### PR TITLE
Add support for bedrock qwen 2 imported model

### DIFF
--- a/docs/my-website/docs/providers/bedrock.md
+++ b/docs/my-website/docs/providers/bedrock.md
@@ -7,7 +7,7 @@ ALL Bedrock models (Anthropic, Meta, Deepseek, Mistral, Amazon, etc.) are Suppor
 | Property | Details |
 |-------|-------|
 | Description | Amazon Bedrock is a fully managed service that offers a choice of high-performing foundation models (FMs). |
-| Provider Route on LiteLLM | `bedrock/`, [`bedrock/converse/`](#set-converse--invoke-route), [`bedrock/invoke/`](#set-invoke-route), [`bedrock/converse_like/`](#calling-via-internal-proxy), [`bedrock/llama/`](#deepseek-not-r1), [`bedrock/deepseek_r1/`](#deepseek-r1), [`bedrock/qwen3/`](#qwen3-imported-models), [`bedrock/openai/`](./bedrock_imported.md#openai-compatible-imported-models-qwen-25-vl-etc) |
+| Provider Route on LiteLLM | `bedrock/`, [`bedrock/converse/`](#set-converse--invoke-route), [`bedrock/invoke/`](#set-invoke-route), [`bedrock/converse_like/`](#calling-via-internal-proxy), [`bedrock/llama/`](#deepseek-not-r1), [`bedrock/deepseek_r1/`](#deepseek-r1), [`bedrock/qwen3/`](#qwen3-imported-models), [`bedrock/qwen2/`](./bedrock_imported.md#qwen2-imported-models), [`bedrock/openai/`](./bedrock_imported.md#openai-compatible-imported-models-qwen-25-vl-etc) |
 | Provider Doc | [Amazon Bedrock ↗](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) |
 | Supported OpenAI Endpoints | `/chat/completions`, `/completions`, `/embeddings`, `/images/generations` |
 | Rerank Endpoint | `/rerank` |

--- a/docs/my-website/docs/providers/bedrock_imported.md
+++ b/docs/my-website/docs/providers/bedrock_imported.md
@@ -203,6 +203,71 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 </TabItem>
 </Tabs>
 
+### Qwen2 Imported Models
+
+| Property | Details |
+|----------|---------|
+| Provider Route | `bedrock/qwen2/{model_arn}` |
+| Provider Documentation | [Bedrock Imported Models](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html) |
+| Note | Qwen2 and Qwen3 architectures are mostly similar. The main difference is in the response format: Qwen2 uses "text" field while Qwen3 uses "generation" field. |
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+import os
+
+response = completion(
+    model="bedrock/qwen2/arn:aws:bedrock:us-east-1:086734376398:imported-model/your-qwen2-model",  # bedrock/qwen2/{your-model-arn}
+    messages=[{"role": "user", "content": "Tell me a joke"}],
+    max_tokens=100,
+    temperature=0.7
+)
+```
+
+</TabItem>
+
+<TabItem value="proxy" label="Proxy">
+
+**1. Add to config**
+
+```yaml
+model_list:
+    - model_name: Qwen2-72B
+      litellm_params:
+        model: bedrock/qwen2/arn:aws:bedrock:us-east-1:086734376398:imported-model/your-qwen2-model
+
+```
+
+**2. Start proxy**
+
+```bash
+litellm --config /path/to/config.yaml
+
+# RUNNING at http://0.0.0.0:4000
+```
+
+**3. Test it!**
+
+```bash
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+      --header 'Authorization: Bearer sk-1234' \
+      --header 'Content-Type: application/json' \
+      --data '{
+            "model": "Qwen2-72B", # 👈 the 'model_name' in config
+            "messages": [
+                {
+                "role": "user",
+                "content": "what llm are you"
+                }
+            ],
+        }'
+```
+
+</TabItem>
+</Tabs>
+
 ### OpenAI-Compatible Imported Models (Qwen 2.5 VL, etc.)
 
 Use this route for Bedrock imported models that follow the **OpenAI Chat Completions API spec**. This includes models like Qwen 2.5 VL that accept OpenAI-formatted messages with support for vision (images), tool calling, and other OpenAI features.

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1163,6 +1163,9 @@ from .llms.bedrock.chat.invoke_transformations.amazon_ai21_transformation import
 from .llms.bedrock.chat.invoke_transformations.amazon_nova_transformation import (
     AmazonInvokeNovaConfig,
 )
+from .llms.bedrock.chat.invoke_transformations.amazon_qwen2_transformation import (
+    AmazonQwen2Config,
+)
 from .llms.bedrock.chat.invoke_transformations.amazon_qwen3_transformation import (
     AmazonQwen3Config,
 )

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -876,6 +876,7 @@ BEDROCK_INVOKE_PROVIDERS_LITERAL = Literal[
     "nova",
     "deepseek_r1",
     "qwen3",
+    "qwen2",
     "twelvelabs",
     "openai",
 ]

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_qwen2_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_qwen2_transformation.py
@@ -1,0 +1,98 @@
+"""
+Handles transforming requests for `bedrock/invoke/{qwen2} models`
+
+Inherits from `AmazonQwen3Config` since Qwen2 and Qwen3 architectures are mostly similar.
+The main difference is in the response format: Qwen2 uses "text" field while Qwen3 uses "generation" field.
+
+Qwen2 + Invoke API Tutorial: https://docs.aws.amazon.com/bedrock/latest/userguide/invoke-imported-model.html
+"""
+
+from typing import Any, List, Optional
+
+import httpx
+
+from litellm.llms.bedrock.chat.invoke_transformations.amazon_qwen3_transformation import (
+    AmazonQwen3Config,
+)
+from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
+    LiteLLMLoggingObj,
+)
+from litellm.types.llms.openai import AllMessageValues
+from litellm.types.utils import ModelResponse
+
+
+class AmazonQwen2Config(AmazonQwen3Config):
+    """
+    Config for sending `qwen2` requests to `/bedrock/invoke/`
+    
+    Inherits from AmazonQwen3Config since Qwen2 and Qwen3 architectures are mostly similar.
+    The main difference is in the response format: Qwen2 uses "text" field while Qwen3 uses "generation" field.
+    
+    Reference: https://docs.aws.amazon.com/bedrock/latest/userguide/invoke-imported-model.html
+    """
+
+    def transform_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: ModelResponse,
+        logging_obj: LiteLLMLoggingObj,
+        request_data: dict,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        encoding: Any,
+        api_key: Optional[str] = None,
+        json_mode: Optional[bool] = None,
+    ) -> ModelResponse:
+        """
+        Transform Qwen2 Bedrock response to OpenAI format
+        
+        Qwen2 uses "text" field, but we also support "generation" field for compatibility.
+        """
+        try:
+            if hasattr(raw_response, 'json'):
+                response_data = raw_response.json()
+            else:
+                response_data = raw_response
+            
+            # Extract the generated text - Qwen2 uses "text" field, but also support "generation" for compatibility
+            generated_text = response_data.get("generation", "") or response_data.get("text", "")
+            
+            # Clean up the response (remove assistant start token if present)
+            if generated_text.startswith("<|im_start|>assistant\n"):
+                generated_text = generated_text[len("<|im_start|>assistant\n"):]
+            if generated_text.endswith("<|im_end|>"):
+                generated_text = generated_text[:-len("<|im_end|>")]
+            
+            # Set the content in the existing model_response structure
+            if hasattr(model_response, 'choices') and len(model_response.choices) > 0:
+                choice = model_response.choices[0]
+                if hasattr(choice, 'message'):
+                    choice.message.content = generated_text
+                    choice.finish_reason = "stop"
+                else:
+                    # Handle streaming choices
+                    choice.delta.content = generated_text
+                    choice.finish_reason = "stop"
+            
+            # Set usage information if available in response
+            if "usage" in response_data:
+                usage_data = response_data["usage"]
+                if hasattr(model_response, 'usage'):
+                    model_response.usage.prompt_tokens = usage_data.get("prompt_tokens", 0)
+                    model_response.usage.completion_tokens = usage_data.get("completion_tokens", 0)
+                    model_response.usage.total_tokens = usage_data.get("total_tokens", 0)
+            
+            return model_response
+            
+        except Exception as e:
+            if logging_obj:
+                logging_obj.post_call(
+                    input=messages,
+                    api_key=api_key,
+                    original_response=raw_response,
+                    additional_args={"error": str(e)},
+                )
+            raise e
+

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -635,6 +635,8 @@ def get_bedrock_chat_config(model: str):
         return litellm.AmazonInvokeNovaConfig()
     elif bedrock_invoke_provider == "qwen3":
         return litellm.AmazonQwen3Config()
+    elif bedrock_invoke_provider == "qwen2":
+        return litellm.AmazonQwen2Config()
     elif bedrock_invoke_provider == "twelvelabs":
         return litellm.AmazonTwelveLabsPegasusConfig()
     else:

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_amazon_qwen2_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_amazon_qwen2_transformation.py
@@ -1,0 +1,292 @@
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+# Ensure the project root is on the import path so `litellm` can be imported when
+# tests are executed from any working directory.
+sys.path.insert(0, os.path.abspath("../../../../../.."))
+
+from litellm.llms.bedrock.chat.invoke_transformations.amazon_qwen2_transformation import (
+    AmazonQwen2Config,
+)
+from litellm.types.utils import ModelResponse
+
+
+def test_qwen2_get_supported_params():
+    """Test that Qwen2 config returns correct supported parameters"""
+    config = AmazonQwen2Config()
+    params = config.get_supported_openai_params(model="qwen2/test-model")
+    
+    expected_params = ["max_tokens", "temperature", "top_p", "top_k", "stop", "stream"]
+    for param in expected_params:
+        assert param in params
+
+
+def test_qwen2_map_openai_params():
+    """Test that OpenAI parameters are correctly mapped to Qwen2 format"""
+    config = AmazonQwen2Config()
+    non_default_params = {
+        "max_tokens": 100,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "top_k": 40,
+        "stop": ["</s>", "<|im_end|>"],
+        "stream": True
+    }
+    optional_params = {}
+    
+    result = config.map_openai_params(
+        non_default_params=non_default_params,
+        optional_params=optional_params,
+        model="qwen2/test-model",
+        drop_params=False
+    )
+    
+    assert result["max_tokens"] == 100
+    assert result["temperature"] == 0.7
+    assert result["top_p"] == 0.9
+    assert result["top_k"] == 40
+    assert result["stop"] == ["</s>", "<|im_end|>"]
+    assert result["stream"] is True
+
+
+def test_qwen2_convert_messages_to_prompt():
+    """Test that messages are correctly converted to Qwen2 prompt format"""
+    config = AmazonQwen2Config()
+    
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+        {"role": "assistant", "content": "I'm doing well, thank you!"},
+        {"role": "user", "content": "What's the weather like?"}
+    ]
+    
+    prompt = config._convert_messages_to_prompt(messages)
+    
+    expected_prompt = """<|im_start|>system
+You are a helpful assistant.<|im_end|>
+<|im_start|>user
+Hello, how are you?<|im_end|>
+<|im_start|>assistant
+I'm doing well, thank you!<|im_end|>
+<|im_start|>user
+What's the weather like?<|im_end|>
+<|im_start|>assistant
+"""
+    
+    assert prompt == expected_prompt
+
+
+def test_qwen2_transform_request():
+    """Test that the request is correctly transformed to Qwen2 format"""
+    config = AmazonQwen2Config()
+    
+    messages = [
+        {"role": "user", "content": "Hello, world!"}
+    ]
+    
+    optional_params = {
+        "max_tokens": 50,
+        "temperature": 0.8,
+        "top_p": 0.9
+    }
+    
+    request_body = config.transform_request(
+        model="qwen2/test-model",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={}
+    )
+    
+    assert "prompt" in request_body
+    assert request_body["max_gen_len"] == 50
+    assert request_body["temperature"] == 0.8
+    assert request_body["top_p"] == 0.9
+    
+    # Check that the prompt contains the expected format
+    assert "<|im_start|>user" in request_body["prompt"]
+    assert "Hello, world!" in request_body["prompt"]
+    assert "<|im_end|>" in request_body["prompt"]
+
+
+def test_qwen2_transform_response_with_text_field():
+    """Test that Qwen2 response with 'text' field is correctly transformed to OpenAI format"""
+    config = AmazonQwen2Config()
+    
+    # Mock response data with 'text' field (Qwen2 format)
+    mock_response_data = {
+        "text": "<|im_start|>assistant\nHello! How can I help you today?<|im_end|>",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 15,
+            "total_tokens": 25
+        }
+    }
+    
+    # Mock the raw response
+    mock_raw_response = Mock()
+    mock_raw_response.json.return_value = mock_response_data
+    
+    model_response = ModelResponse()
+    messages = [{"role": "user", "content": "Hello!"}]
+    
+    result = config.transform_response(
+        model="qwen2/test-model",
+        messages=messages,
+        raw_response=mock_raw_response,
+        model_response=model_response,
+        logging_obj=Mock(),
+        optional_params={},
+        litellm_params={},
+        api_key="test-key",
+        request_data={},
+        encoding=None
+    )
+    
+    # Check that the response is correctly formatted
+    assert len(result.choices) == 1
+    assert result.choices[0]["message"]["role"] == "assistant"
+    assert result.choices[0]["message"]["content"] == "Hello! How can I help you today?"
+    assert result.choices[0]["finish_reason"] == "stop"
+    
+    # Check usage information
+    assert result.usage["prompt_tokens"] == 10
+    assert result.usage["completion_tokens"] == 15
+    assert result.usage["total_tokens"] == 25
+
+
+def test_qwen2_transform_response_with_generation_field():
+    """Test that Qwen2 response also supports 'generation' field for compatibility"""
+    config = AmazonQwen2Config()
+    
+    # Mock response data with 'generation' field (Qwen3 format, but Qwen2 should handle it)
+    mock_response_data = {
+        "generation": "<|im_start|>assistant\nHello! How can I help you today?<|im_end|>",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 15,
+            "total_tokens": 25
+        }
+    }
+    
+    # Mock the raw response
+    mock_raw_response = Mock()
+    mock_raw_response.json.return_value = mock_response_data
+    
+    model_response = ModelResponse()
+    messages = [{"role": "user", "content": "Hello!"}]
+    
+    result = config.transform_response(
+        model="qwen2/test-model",
+        messages=messages,
+        raw_response=mock_raw_response,
+        model_response=model_response,
+        logging_obj=Mock(),
+        optional_params={},
+        litellm_params={},
+        api_key="test-key",
+        request_data={},
+        encoding=None
+    )
+    
+    # Check that the response is correctly formatted
+    assert len(result.choices) == 1
+    assert result.choices[0]["message"]["role"] == "assistant"
+    assert result.choices[0]["message"]["content"] == "Hello! How can I help you today?"
+    assert result.choices[0]["finish_reason"] == "stop"
+
+
+def test_qwen2_transform_response_prefers_generation_over_text():
+    """Test that Qwen2 prefers 'generation' field over 'text' when both are present"""
+    config = AmazonQwen2Config()
+    
+    # Mock response data with both fields
+    mock_response_data = {
+        "generation": "This is from generation field",
+        "text": "This is from text field",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 15,
+            "total_tokens": 25
+        }
+    }
+    
+    # Mock the raw response
+    mock_raw_response = Mock()
+    mock_raw_response.json.return_value = mock_response_data
+    
+    model_response = ModelResponse()
+    messages = [{"role": "user", "content": "Hello!"}]
+    
+    result = config.transform_response(
+        model="qwen2/test-model",
+        messages=messages,
+        raw_response=mock_raw_response,
+        model_response=model_response,
+        logging_obj=Mock(),
+        optional_params={},
+        litellm_params={},
+        api_key="test-key",
+        request_data={},
+        encoding=None
+    )
+    
+    # Should prefer 'generation' field
+    assert result.choices[0]["message"]["content"] == "This is from generation field"
+
+
+def test_qwen2_transform_response_without_usage():
+    """Test response transformation when usage information is not provided"""
+    config = AmazonQwen2Config()
+    
+    # Mock response data without usage
+    mock_response_data = {
+        "text": "Hello! How can I help you today?"
+    }
+    
+    # Mock the raw response
+    mock_raw_response = Mock()
+    mock_raw_response.json.return_value = mock_response_data
+    
+    model_response = ModelResponse()
+    messages = [{"role": "user", "content": "Hello!"}]
+    
+    result = config.transform_response(
+        model="qwen2/test-model",
+        messages=messages,
+        raw_response=mock_raw_response,
+        model_response=model_response,
+        logging_obj=Mock(),
+        optional_params={},
+        litellm_params={},
+        api_key="test-key",
+        request_data={},
+        encoding=None
+    )
+    
+    # Check that the response is correctly formatted
+    assert len(result.choices) == 1
+    assert result.choices[0]["message"]["role"] == "assistant"
+    assert result.choices[0]["message"]["content"] == "Hello! How can I help you today?"
+    assert result.choices[0]["finish_reason"] == "stop"
+
+
+def test_qwen2_provider_detection():
+    """Test that Qwen2 provider is correctly detected from model names"""
+    from litellm.utils import ProviderConfigManager
+    from litellm.types.utils import LlmProviders
+    
+    # Test with qwen2/ prefix
+    config = ProviderConfigManager.get_provider_chat_config(
+        model="qwen2/arn:aws:bedrock:us-east-1:123456789012:imported-model/test-qwen2",
+        provider=LlmProviders.BEDROCK
+    )
+    
+    assert config is not None
+    assert isinstance(config, AmazonQwen2Config)
+


### PR DESCRIPTION
## Title

Add support for bedrock qwen 2 imported model

## Relevant issues



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
🐛 Bug Fix
## Changes

<img width="722" height="134" alt="image" src="https://github.com/user-attachments/assets/398b6d53-3baa-4d62-a3c6-60f50681a398" />

