### PR TITLE
fix(router): add minimum request threshold for error rate cooldown

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -54,6 +54,9 @@ MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB = int(
 SINGLE_DEPLOYMENT_TRAFFIC_FAILURE_THRESHOLD = int(
     os.getenv("SINGLE_DEPLOYMENT_TRAFFIC_FAILURE_THRESHOLD", 1000)
 )  # Minimum number of requests to consider "reasonable traffic". Used for single-deployment cooldown logic.
+DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS = int(
+    os.getenv("DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS", 5)
+)  # Minimum number of requests before applying error rate cooldown. Prevents cooldown from triggering on first failure.
 
 DEFAULT_REASONING_EFFORT_DISABLE_THINKING_BUDGET = int(
     os.getenv("DEFAULT_REASONING_EFFORT_DISABLE_THINKING_BUDGET", 0)

--- a/litellm/router_utils/cooldown_handlers.py
+++ b/litellm/router_utils/cooldown_handlers.py
@@ -14,6 +14,7 @@ import litellm
 from litellm._logging import verbose_router_logger
 from litellm.constants import (
     DEFAULT_COOLDOWN_TIME_SECONDS,
+    DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS,
     DEFAULT_FAILURE_THRESHOLD_PERCENT,
     SINGLE_DEPLOYMENT_TRAFFIC_FAILURE_THRESHOLD,
 )
@@ -231,8 +232,10 @@ def _should_cooldown_deployment(
             return True
         elif (
             percent_fails > DEFAULT_FAILURE_THRESHOLD_PERCENT
+            and total_requests_this_minute >= DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS
             and not is_single_deployment_model_group  # by default we should avoid cooldowns on single deployment model groups
         ):
+            # Only apply error rate cooldown when we have enough requests to make the percentage meaningful
             return True
 
         elif (

--- a/tests/router_unit_tests/test_router_cooldown_utils.py
+++ b/tests/router_unit_tests/test_router_cooldown_utils.py
@@ -414,3 +414,58 @@ def test_is_cooldown_required_empty_string_exception_status(testing_litellm_rout
     assert (
         result is False
     ), "Should not require cooldown when exception_status is empty string"
+
+
+def test_should_cooldown_deployment_minimum_request_threshold(testing_litellm_router):
+    """
+    Test that error rate cooldown does NOT trigger on first failure.
+
+    Fixes GitHub issue #17418: Error Rate Cooldown Triggers on First Failed Request
+
+    The problem: With DEFAULT_FAILURE_THRESHOLD_PERCENT=0.5 (50%), a deployment
+    gets cooled down after just 1 failed request because 1/1 = 100% > 50%.
+
+    The fix: Add a minimum request threshold (DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS)
+    before applying error rate cooldown.
+    """
+    from litellm.constants import DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS
+
+    # Get a deployment that's not a single-deployment model group
+    # (test_deployment_2 and test_deployment_3 are both for "test_deployment" model)
+    available_deployment = testing_litellm_router.get_available_deployment(
+        model="test_deployment"
+    )
+    assert available_deployment is not None
+    deployment_id = available_deployment["model_info"]["id"]
+
+    # Simulate only 1 failure (below minimum threshold)
+    # This should NOT trigger cooldown even though 100% > 50%
+    increment_deployment_failures_for_current_minute(
+        litellm_router_instance=testing_litellm_router, deployment_id=deployment_id
+    )
+
+    _exception = litellm.exceptions.InternalServerError(
+        "Internal error", "openai", "gpt-3.5-turbo"
+    )
+
+    # With only 1 request, should NOT cooldown (below minimum threshold)
+    should_cooldown = _should_cooldown_deployment(
+        testing_litellm_router, deployment_id, 500, _exception
+    )
+    assert (
+        should_cooldown is False
+    ), f"Should NOT cooldown with only 1 failed request (below minimum threshold of {DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS})"
+
+    # Now add more failures to reach the minimum threshold
+    for _ in range(DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS - 1):
+        increment_deployment_failures_for_current_minute(
+            litellm_router_instance=testing_litellm_router, deployment_id=deployment_id
+        )
+
+    # Now with enough requests (all failures), it SHOULD trigger cooldown
+    should_cooldown = _should_cooldown_deployment(
+        testing_litellm_router, deployment_id, 500, _exception
+    )
+    assert (
+        should_cooldown is True
+    ), f"Should cooldown when we have {DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS} failed requests (100% failure rate)"


### PR DESCRIPTION
Fixes #17418

  ## Pre-Submission checklist

  - [x] I have Added testing in the tests/litellm/ directory
  - [x] I have added a screenshot of my new test passing locally
  - [x] My PR passes all unit tests on make test-unit
  - [x] My PR's scope is as isolated as possible

  ## Type

  🐛 Bug Fix
  ✅ Test

  ## Changes

  **Problem:** With `DEFAULT_FAILURE_THRESHOLD_PERCENT=0.5` (50%), a deployment gets cooled down after just 1 failed request because 1/1 = 100% > 50%.

  **Fix:** Added `DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS` constant (default: 5) to require a minimum number of requests before applying error rate-based cooldown. This prevents cooldown from triggering on the first failure.

  **Files changed:**
  - `litellm/constants.py` - Added new configurable constant
  - `litellm/router_utils/cooldown_handlers.py` - Added threshold check to cooldown condition
  - `tests/router_unit_tests/test_router_cooldown_utils.py` - Added test for new behavior

  **Test screenshot:**
<img width="1504" height="353" alt="Screenshot 2025-12-04 at 1 22 20 AM" src="https://github.com/user-attachments/assets/6325e5b7-d2f0-45f5-9cfb-e116a39b8f11" />
