### PR TITLE
fix(bedrock): anthropics beta headers for qwen

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -960,7 +960,10 @@ class AmazonConverseConfig(BaseConfig):
             bedrock_tools = _bedrock_tools_pt(filtered_tools)
 
         # Set anthropic_beta in additional_request_params if we have any beta features
-        if anthropic_beta_list:
+        # ONLY apply to Anthropic/Claude models - other models (e.g., Qwen, Llama) don't support this field
+        # and will error with "unknown variant anthropic_beta" if included
+        base_model = BedrockModelInfo.get_base_model(model)
+        if anthropic_beta_list and base_model.startswith("anthropic"):
             # Remove duplicates while preserving order
             unique_betas = []
             seen = set()


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

Fixes an issue where non-Anthropic models (Qwen, Llama, Nova, etc.) on Bedrock Converse API 
fail with "unknown variant anthropic_beta" error when called via `/v1/messages` endpoint.

The problems:
The `_process_tools_and_beta()` method in `AmazonConverseConfig` was adding `anthropic_beta` 
to `additionalModelRequestFields` for ALL models, but this field is only supported by 
Anthropic/Claude models on Bedrock.


## Relevant issues

<!-- e.g. "Fixes #000" -->
https://github.com/BerriAI/litellm/issues/17133

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem



## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix

### Before fixing

<img width="2106" height="1854" alt="image" src="https://github.com/user-attachments/assets/d3f9d5a4-579f-4895-9dc7-1f09ce1feb42" />

### After fixing
<img width="1960" height="1868" alt="image" src="https://github.com/user-attachments/assets/fbe451ca-c610-4730-9000-52f5cf7f1f41" />



## Changes

Added a check to only include `anthropic_beta` when the model starts with "anthropic".



