### PR TITLE
Add document ingest support for Ragflow

### DIFF
--- a/litellm/llms/ragflow/chat/transformation.py
+++ b/litellm/llms/ragflow/chat/transformation.py
@@ -8,6 +8,14 @@ RAGFlow provides OpenAI-compatible APIs with unique path structures:
 Model name format:
 - Chat: ragflow/chat/{chat_id}/{model_name}
 - Agent: ragflow/agent/{agent_id}/{model_name}
+
+Dynamic ID support:
+You can pass chat_id or agent_id dynamically via extra_body:
+- extra_body={"ragflow_chat_id": "1234"} for chat endpoints
+- extra_body={"ragflow_agent_id": "5678"} for agent endpoints
+
+This allows using model names like "ragflow-chat-gpt4" or "ragflow/chat/gpt-4o-mini"
+without hardcoding the chat_id/agent_id in the model name.
 """
 
 from typing import List, Optional, Tuple
@@ -25,23 +33,39 @@ class RAGFlowConfig(OpenAIConfig):
     Handles both chat and agent endpoints by parsing the model name format:
     - ragflow/chat/{chat_id}/{model_name} for chat endpoints
     - ragflow/agent/{agent_id}/{model_name} for agent endpoints
+    
+    Supports dynamic chat_id and agent_id via extra_body:
+    - extra_body={"ragflow_chat_id": "1234"} for chat endpoints
+    - extra_body={"ragflow_agent_id": "5678"} for agent endpoints
+    
+    This allows using generic model names in the proxy config and passing
+    the chat_id/agent_id dynamically per request.
     """
 
-    def _parse_ragflow_model(self, model: str) -> Tuple[str, str, str]:
+    def _parse_ragflow_model(self, model: str, allow_missing_id: bool = False) -> Tuple[str, Optional[str], str]:
         """
         Parse RAGFlow model name format: ragflow/{endpoint_type}/{id}/{model_name}
         
         Args:
             model: Model name in format ragflow/chat/{chat_id}/{model} or ragflow/agent/{agent_id}/{model}
+                  Also supports ragflow/chat/{model} or ragflow/agent/{model} when allow_missing_id=True
+            allow_missing_id: If True, allows models without ID (for dynamic ID support)
             
         Returns:
-            Tuple of (endpoint_type, id, model_name)
+            Tuple of (endpoint_type, id, model_name) where id can be None if allow_missing_id=True
             
         Raises:
             ValueError: If model format is invalid
         """
         parts = model.split("/")
-        if len(parts) < 4:
+        
+        # Handle model names that start with "ragflow-{type}-" (e.g., "ragflow-chat-gpt4")
+        if not model.startswith("ragflow/") and model.startswith("ragflow-"):
+            # Convert "ragflow-chat-gpt4" to "ragflow/chat/gpt4"
+            model = model.replace("ragflow-", "ragflow/", 1).replace("-", "/", 1)
+            parts = model.split("/")
+        
+        if len(parts) < 2:
             raise ValueError(
                 f"Invalid RAGFlow model format: {model}. "
                 f"Expected format: ragflow/chat/{{chat_id}}/{{model}} or ragflow/agent/{{agent_id}}/{{model}}"
@@ -49,7 +73,7 @@ class RAGFlowConfig(OpenAIConfig):
         
         if parts[0] != "ragflow":
             raise ValueError(
-                f"Invalid RAGFlow model format: {model}. Must start with 'ragflow/'"
+                f"Invalid RAGFlow model format: {model}. Must start with 'ragflow/' or 'ragflow-'"
             )
         
         endpoint_type = parts[1]
@@ -58,8 +82,26 @@ class RAGFlowConfig(OpenAIConfig):
                 f"Invalid RAGFlow endpoint type: {endpoint_type}. Must be 'chat' or 'agent'"
             )
         
-        entity_id = parts[2]
-        model_name = "/".join(parts[3:])  # Handle model names that might contain slashes
+        # If we have 3+ parts, check if part[2] looks like an ID or model name
+        if len(parts) >= 3:
+            # If allow_missing_id and we only have 3 parts, treat part[2] as model name
+            if allow_missing_id and len(parts) == 3:
+                entity_id = None
+                model_name = parts[2]
+            else:
+                # Assume part[2] is the entity_id
+                entity_id = parts[2]
+                model_name = "/".join(parts[3:]) if len(parts) > 3 else "gpt-4o-mini"  # Default model if not specified
+        else:
+            # Only 2 parts: ragflow/{type}
+            if allow_missing_id:
+                entity_id = None
+                model_name = "gpt-4o-mini"  # Default model
+            else:
+                raise ValueError(
+                    f"Invalid RAGFlow model format: {model}. "
+                    f"Expected format: ragflow/chat/{{chat_id}}/{{model}} or ragflow/agent/{{agent_id}}/{{model}}"
+                )
         
         return endpoint_type, entity_id, model_name
 
@@ -79,11 +121,15 @@ class RAGFlowConfig(OpenAIConfig):
         - Chat: /api/v1/chats_openai/{chat_id}/chat/completions
         - Agent: /api/v1/agents_openai/{agent_id}/chat/completions
         
+        Supports dynamic chat_id and agent_id via extra_body:
+        - extra_body={"ragflow_chat_id": "1234"} for chat endpoints
+        - extra_body={"ragflow_agent_id": "5678"} for agent endpoints
+        
         Args:
             api_base: Base API URL (e.g., http://ragflow-server:port or http://ragflow-server:port/v1)
             api_key: API key (not used in URL construction)
-            model: Model name in format ragflow/{endpoint_type}/{id}/{model}
-            optional_params: Optional parameters
+            model: Model name in format ragflow/{endpoint_type}/{id}/{model} or ragflow/{endpoint_type}/{model}
+            optional_params: Optional parameters (may contain extra_body with ragflow_chat_id or ragflow_agent_id)
             litellm_params: LiteLLM parameters (may contain api_base)
             stream: Whether streaming is enabled
             
@@ -104,8 +150,37 @@ class RAGFlowConfig(OpenAIConfig):
         if api_base is None:
             raise ValueError("api_base is required for RAGFlow provider. Set it via api_base parameter, RAGFLOW_API_BASE environment variable, or litellm.api_base")
         
-        # Parse model name to extract endpoint type and ID
-        endpoint_type, entity_id, _ = self._parse_ragflow_model(model)
+        # Parse model name to extract endpoint type and ID (allow missing ID for dynamic support)
+        endpoint_type, entity_id, _ = self._parse_ragflow_model(model, allow_missing_id=True)
+        
+        # Check for dynamic chat_id or agent_id in extra_body
+        extra_body = optional_params.get("extra_body", {})
+        if isinstance(extra_body, dict):
+            if endpoint_type == "chat":
+                # Check for ragflow_chat_id in extra_body
+                dynamic_chat_id = extra_body.get("ragflow_chat_id")
+                if dynamic_chat_id:
+                    entity_id = str(dynamic_chat_id)
+            elif endpoint_type == "agent":
+                # Check for ragflow_agent_id in extra_body
+                dynamic_agent_id = extra_body.get("ragflow_agent_id")
+                if dynamic_agent_id:
+                    entity_id = str(dynamic_agent_id)
+        
+        # If entity_id is still None, raise an error
+        if entity_id is None:
+            if endpoint_type == "chat":
+                raise ValueError(
+                    f"chat_id is required for RAGFlow chat endpoint. "
+                    f"Either include it in the model name (ragflow/chat/{{chat_id}}/{{model}}) "
+                    f"or pass it via extra_body={{'ragflow_chat_id': 'your_chat_id'}}"
+                )
+            else:
+                raise ValueError(
+                    f"agent_id is required for RAGFlow agent endpoint. "
+                    f"Either include it in the model name (ragflow/agent/{{agent_id}}/{{model}}) "
+                    f"or pass it via extra_body={{'ragflow_agent_id': 'your_agent_id'}}"
+                )
         
         # Remove trailing slash from api_base if present
         api_base = api_base.rstrip("/")
@@ -150,7 +225,7 @@ class RAGFlowConfig(OpenAIConfig):
         """
         # Parse model to extract the actual model name
         # The model name will be stored in litellm_params for use in requests
-        _, _, actual_model = self._parse_ragflow_model(model)
+        _, _, actual_model = self._parse_ragflow_model(model, allow_missing_id=True)
         
         # Get api_base from multiple sources: input param, environment, or global litellm setting
         dynamic_api_base = (
@@ -215,7 +290,7 @@ class RAGFlowConfig(OpenAIConfig):
         # Parse model to extract actual model name and store it
         # The actual model name should be used in the request body
         try:
-            _, _, actual_model = self._parse_ragflow_model(model)
+            _, _, actual_model = self._parse_ragflow_model(model, allow_missing_id=True)
             # Store the actual model name in litellm_params for use in transform_request
             litellm_params["_ragflow_actual_model"] = actual_model
         except ValueError:
@@ -252,7 +327,7 @@ class RAGFlowConfig(OpenAIConfig):
         if actual_model is None:
             # Fallback: try to parse the model name
             try:
-                _, _, actual_model = self._parse_ragflow_model(model)
+                _, _, actual_model = self._parse_ragflow_model(model, allow_missing_id=True)
             except ValueError:
                 # If parsing fails, use the original model name
                 actual_model = model

--- a/litellm/rag/ingestion/__init__.py
+++ b/litellm/rag/ingestion/__init__.py
@@ -5,10 +5,12 @@ RAG Ingestion classes for different providers.
 from litellm.rag.ingestion.base_ingestion import BaseRAGIngestion
 from litellm.rag.ingestion.bedrock_ingestion import BedrockRAGIngestion
 from litellm.rag.ingestion.openai_ingestion import OpenAIRAGIngestion
+from litellm.rag.ingestion.ragflow_ingestion import RAGFlowRAGIngestion
 
 __all__ = [
     "BaseRAGIngestion",
     "BedrockRAGIngestion",
     "OpenAIRAGIngestion",
+    "RAGFlowRAGIngestion",
 ]
 

--- a/litellm/rag/ingestion/ragflow_ingestion.py
+++ b/litellm/rag/ingestion/ragflow_ingestion.py
@@ -1,0 +1,347 @@
+"""
+RAGFlow-specific RAG Ingestion implementation.
+
+RAGFlow handles embedding and chunking internally when documents are uploaded to datasets,
+so this implementation skips the embedding step and directly uploads documents.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
+
+from litellm._logging import verbose_logger
+from litellm.llms.custom_httpx.http_handler import (
+    get_async_httpx_client,
+    httpxSpecialProvider,
+)
+from litellm.rag.ingestion.base_ingestion import BaseRAGIngestion
+from litellm.secret_managers.main import get_secret_str
+
+if TYPE_CHECKING:
+    from litellm import Router
+    from litellm.types.rag import RAGIngestOptions
+
+
+class RAGFlowRAGIngestion(BaseRAGIngestion):
+    """
+    RAGFlow-specific RAG ingestion.
+
+    Key differences from base:
+    - Embedding is handled by RAGFlow when documents are parsed
+    - Documents are uploaded using multipart/form-data
+    - Chunking is done by RAGFlow's parser (configurable via chunk_method and parser_config)
+    - Supports automatic parsing trigger after upload
+    """
+
+    def __init__(
+        self,
+        ingest_options: "RAGIngestOptions",
+        router: Optional["Router"] = None,
+    ):
+        super().__init__(ingest_options=ingest_options, router=router)
+
+    async def embed(
+        self,
+        chunks: List[str],
+    ) -> Optional[List[List[float]]]:
+        """
+        RAGFlow handles embedding internally - skip this step.
+
+        Returns:
+            None (RAGFlow embeds when documents are parsed)
+        """
+        # RAGFlow handles embedding when documents are parsed
+        return None
+
+    async def store(
+        self,
+        file_content: Optional[bytes],
+        filename: Optional[str],
+        content_type: Optional[str],
+        chunks: List[str],
+        embeddings: Optional[List[List[float]]],
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Store content in RAGFlow dataset.
+
+        RAGFlow workflow:
+        1. Upload document using POST /api/v1/datasets/{dataset_id}/documents
+        2. Optionally update document configuration (chunk_method, parser_config)
+        3. Optionally trigger parsing using POST /api/v1/datasets/{dataset_id}/chunks
+
+        Args:
+            file_content: Raw file bytes
+            filename: Name of the file
+            content_type: MIME type
+            chunks: Ignored - RAGFlow handles chunking
+            embeddings: Ignored - RAGFlow handles embedding
+
+        Returns:
+            Tuple of (dataset_id, document_id)
+        """
+        vector_store_config = cast(Dict[str, Any], self.vector_store_config)
+        
+        # Validate required fields
+        dataset_id = vector_store_config.get("vector_store_id")
+        if not dataset_id:
+            raise ValueError("vector_store_id (dataset_id) is required for RAGFlow ingestion")
+
+        # Get API credentials
+        api_key = (
+            vector_store_config.get("api_key")
+            or get_secret_str("RAGFLOW_API_KEY")
+        )
+        if not api_key:
+            raise ValueError("RAGFLOW_API_KEY is required (set env var or pass in vector_store config)")
+
+        api_base = (
+            vector_store_config.get("api_base")
+            or get_secret_str("RAGFLOW_API_BASE")
+            or "http://localhost:9380"
+        )
+        api_base = api_base.rstrip("/")
+
+        # Get RAGFlow-specific options
+        chunk_method = vector_store_config.get("chunk_method")
+        parser_config = vector_store_config.get("parser_config")
+        auto_parse = vector_store_config.get("auto_parse", True)  # Default to True
+
+        # Upload document
+        if not file_content or not filename:
+            raise ValueError("file_content and filename are required for RAGFlow document upload")
+
+        document_id = await self._upload_document(
+            api_base=api_base,
+            api_key=api_key,
+            dataset_id=dataset_id,
+            filename=filename,
+            file_content=file_content,
+            content_type=content_type,
+        )
+
+        # Update document configuration if chunk_method or parser_config is provided
+        if chunk_method or parser_config:
+            await self._update_document_config(
+                api_base=api_base,
+                api_key=api_key,
+                dataset_id=dataset_id,
+                document_id=document_id,
+                chunk_method=chunk_method,
+                parser_config=parser_config,
+            )
+
+        # Trigger parsing if auto_parse is True
+        if auto_parse:
+            await self._trigger_parsing(
+                api_base=api_base,
+                api_key=api_key,
+                dataset_id=dataset_id,
+                document_ids=[document_id],
+            )
+
+        return dataset_id, document_id
+
+    async def _upload_document(
+        self,
+        api_base: str,
+        api_key: str,
+        dataset_id: str,
+        filename: str,
+        file_content: bytes,
+        content_type: Optional[str],
+    ) -> str:
+        """
+        Upload a document to RAGFlow dataset.
+
+        Args:
+            api_base: RAGFlow API base URL
+            api_key: RAGFlow API key
+            dataset_id: Dataset ID
+            filename: Name of the file
+            file_content: File content bytes
+            content_type: MIME type
+
+        Returns:
+            Document ID
+        """
+        url = f"{api_base}/api/v1/datasets/{dataset_id}/documents"
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+        }
+
+        # Prepare multipart/form-data
+        files = {
+            "file": (filename, file_content, content_type or "application/octet-stream")
+        }
+
+        verbose_logger.debug(f"Uploading document to RAGFlow: {url}")
+
+        client = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.RAG,
+            params={"timeout": 300.0},  # Longer timeout for large files
+        )
+
+        try:
+            response = await client.post(
+                url,
+                files=files,
+                headers=headers,
+            )
+
+            if response.status_code != 200:
+                error_msg = f"Failed to upload document: {response.text}"
+                verbose_logger.error(error_msg)
+                raise Exception(error_msg)
+
+            response_data = response.json()
+
+            # Check for RAGFlow error response
+            if response_data.get("code") != 0:
+                error_message = response_data.get("message", "Unknown error")
+                raise Exception(f"RAGFlow error: {error_message}")
+
+            # Extract document ID from response
+            data = response_data.get("data", [])
+            if not data or not isinstance(data, list) or len(data) == 0:
+                raise Exception("RAGFlow response missing document data")
+
+            document_id = data[0].get("id")
+            if not document_id:
+                raise Exception("RAGFlow response missing document id")
+
+            verbose_logger.debug(f"Document uploaded successfully. Document ID: {document_id}")
+            return document_id
+
+        except Exception as e:
+            verbose_logger.exception(f"Error uploading document to RAGFlow: {e}")
+            raise
+
+    async def _update_document_config(
+        self,
+        api_base: str,
+        api_key: str,
+        dataset_id: str,
+        document_id: str,
+        chunk_method: Optional[str],
+        parser_config: Optional[Dict[str, Any]],
+    ) -> None:
+        """
+        Update document configuration (chunk_method, parser_config).
+
+        Args:
+            api_base: RAGFlow API base URL
+            api_key: RAGFlow API key
+            dataset_id: Dataset ID
+            document_id: Document ID
+            chunk_method: Chunking method
+            parser_config: Parser configuration
+        """
+        url = f"{api_base}/api/v1/datasets/{dataset_id}/documents/{document_id}"
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        # Build request body
+        request_body: Dict[str, Any] = {}
+        if chunk_method:
+            request_body["chunk_method"] = chunk_method
+        if parser_config:
+            request_body["parser_config"] = parser_config
+
+        if not request_body:
+            return  # Nothing to update
+
+        verbose_logger.debug(f"Updating document configuration: {url}")
+
+        client = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.RAG,
+            params={"timeout": 60.0},
+        )
+
+        try:
+            response = await client.put(
+                url,
+                json=request_body,
+                headers=headers,
+            )
+
+            if response.status_code != 200:
+                error_msg = f"Failed to update document configuration: {response.text}"
+                verbose_logger.error(error_msg)
+                raise Exception(error_msg)
+
+            response_data = response.json()
+
+            # Check for RAGFlow error response
+            if response_data.get("code") != 0:
+                error_message = response_data.get("message", "Unknown error")
+                raise Exception(f"RAGFlow error: {error_message}")
+
+            verbose_logger.debug("Document configuration updated successfully")
+
+        except Exception as e:
+            verbose_logger.exception(f"Error updating document configuration: {e}")
+            raise
+
+    async def _trigger_parsing(
+        self,
+        api_base: str,
+        api_key: str,
+        dataset_id: str,
+        document_ids: List[str],
+    ) -> None:
+        """
+        Trigger parsing for documents.
+
+        Args:
+            api_base: RAGFlow API base URL
+            api_key: RAGFlow API key
+            dataset_id: Dataset ID
+            document_ids: List of document IDs to parse
+        """
+        url = f"{api_base}/api/v1/datasets/{dataset_id}/chunks"
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        request_body = {
+            "document_ids": document_ids,
+        }
+
+        verbose_logger.debug(f"Triggering parsing for documents: {url}")
+
+        client = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.RAG,
+            params={"timeout": 60.0},
+        )
+
+        try:
+            response = await client.post(
+                url,
+                json=request_body,
+                headers=headers,
+            )
+
+            if response.status_code != 200:
+                error_msg = f"Failed to trigger parsing: {response.text}"
+                verbose_logger.error(error_msg)
+                raise Exception(error_msg)
+
+            response_data = response.json()
+
+            # Check for RAGFlow error response
+            if response_data.get("code") != 0:
+                error_message = response_data.get("message", "Unknown error")
+                raise Exception(f"RAGFlow error: {error_message}")
+
+            verbose_logger.debug("Parsing triggered successfully")
+
+        except Exception as e:
+            verbose_logger.exception(f"Error triggering parsing: {e}")
+            raise
+

--- a/litellm/rag/main.py
+++ b/litellm/rag/main.py
@@ -21,6 +21,7 @@ from litellm.rag.ingestion.base_ingestion import BaseRAGIngestion
 from litellm.rag.ingestion.bedrock_ingestion import BedrockRAGIngestion
 from litellm.rag.ingestion.gemini_ingestion import GeminiRAGIngestion
 from litellm.rag.ingestion.openai_ingestion import OpenAIRAGIngestion
+from litellm.rag.ingestion.ragflow_ingestion import RAGFlowRAGIngestion
 from litellm.types.rag import RAGIngestOptions, RAGIngestResponse
 from litellm.utils import client
 
@@ -33,6 +34,7 @@ INGESTION_REGISTRY: Dict[str, Type[BaseRAGIngestion]] = {
     "openai": OpenAIRAGIngestion,
     "bedrock": BedrockRAGIngestion,
     "gemini": GeminiRAGIngestion,
+    "ragflow": RAGFlowRAGIngestion,
 }
 
 

--- a/litellm/types/rag.py
+++ b/litellm/types/rag.py
@@ -127,9 +127,48 @@ class VertexAIVectorStoreOptions(TypedDict, total=False):
     import_timeout: Optional[int]  # Timeout in seconds (default: 600)
 
 
+class RAGFlowVectorStoreOptions(TypedDict, total=False):
+    """
+    RAGFlow dataset configuration.
+
+    Example (use existing dataset):
+        {"custom_llm_provider": "ragflow", "vector_store_id": "dataset_id_123"}
+
+    Example (with chunk method and parser config):
+        {
+            "custom_llm_provider": "ragflow",
+            "vector_store_id": "dataset_id_123",
+            "chunk_method": "naive",
+            "parser_config": {
+                "chunk_token_num": 256,
+                "layout_recognize": True
+            },
+            "auto_parse": True
+        }
+
+    Requires:
+    - RAGFlow API key (set RAGFLOW_API_KEY env var or pass api_key)
+    - RAGFlow API base URL (set RAGFLOW_API_BASE env var or pass api_base, default: http://localhost:9380)
+    - Existing dataset ID (vector_store_id is required)
+    """
+
+    custom_llm_provider: Literal["ragflow"]
+    vector_store_id: str  # Dataset ID (required - must be an existing RAGFlow dataset)
+
+    # RAGFlow-specific options
+    chunk_method: Optional[str]  # Parsing method: naive, manual, qa, table, paper, book, laws, presentation, picture, one, email
+    parser_config: Optional[Dict[str, Any]]  # Parser configuration (chunk_token_num, delimiter, layout_recognize, html4excel, raptor, etc.)
+    auto_parse: Optional[bool]  # Whether to automatically trigger parsing after upload (default: True)
+
+    # Credentials (loaded from litellm.credential_list if litellm_credential_name is provided)
+    litellm_credential_name: Optional[str]  # Credential name to load from litellm.credential_list
+    api_key: Optional[str]  # Direct API key (alternative to litellm_credential_name)
+    api_base: Optional[str]  # Direct API base (alternative to litellm_credential_name, default: http://localhost:9380)
+
+
 # Union type for vector store options
 RAGIngestVectorStoreOptions = Union[
-    OpenAIVectorStoreOptions, BedrockVectorStoreOptions, VertexAIVectorStoreOptions
+    OpenAIVectorStoreOptions, BedrockVectorStoreOptions, VertexAIVectorStoreOptions, RAGFlowVectorStoreOptions
 ]
 
 


### PR DESCRIPTION
## Title

Add document ingest support for Ragflow

## Relevant issues

FIxes  #17112


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature


## Changes
- Added support for providing dynamic chat id/ agent id
- Added support for ingesting doucments of ragflow via rag/ingest API

