### PR TITLE
Fix tag management to preserve encrypted fields in litellm_params

### DIFF
--- a/litellm/proxy/management_endpoints/tag_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tag_management_endpoints.py
@@ -200,15 +200,36 @@ async def _add_tag_to_deployment(deployment: "Deployment", tag: str):
     if prisma_client is None:
         raise HTTPException(status_code=500, detail="Database not connected")
 
-    litellm_params = deployment.litellm_params
-    if "tags" not in litellm_params:
-        litellm_params["tags"] = []
-    litellm_params["tags"].append(tag)
-
     try:
+        # Get current model from database to preserve encrypted fields
+        db_model = await prisma_client.db.litellm_proxymodeltable.find_unique(
+            where={"model_id": deployment.model_info.id}
+        )
+
+        if db_model is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Model {deployment.model_info.id} not found in database"
+            )
+
+        # Prisma returns litellm_params as dict (already parsed from JSON)
+        existing_params = db_model.litellm_params
+        if isinstance(existing_params, str):
+            # If it's a string, parse it
+            existing_params = json.loads(existing_params)
+        elif not isinstance(existing_params, dict):
+            raise Exception(f"Unexpected litellm_params type: {type(existing_params)}")
+
+        # Add tag to tags array (preserve encryption of other fields)
+        if "tags" not in existing_params:
+            existing_params["tags"] = []
+        if tag not in existing_params["tags"]:
+            existing_params["tags"].append(tag)
+
+        # Update database with modified params (keeps encrypted fields encrypted)
         await prisma_client.db.litellm_proxymodeltable.update(
             where={"model_id": deployment.model_info.id},
-            data={"litellm_params": safe_dumps(litellm_params)},
+            data={"litellm_params": json.dumps(existing_params)},
         )
     except Exception as e:
         verbose_proxy_logger.exception(f"Error adding tag to deployment: {str(e)}")


### PR DESCRIPTION
## Title

Fix tag management to preserve encrypted fields in litellm_params

## Relevant issues

None previously filed that I could find.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="2206" height="399" alt="image" src="https://github.com/user-attachments/assets/9720c309-1b5a-45a6-94ce-a24db7e5dcd2" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

The _add_tag_to_deployment function was directly modifying the deployment's litellm_params in memory and writing it back to the database, which caused encrypted API keys and other sensitive fields to be lost. This fix retrieves the model from the database first, preserves all existing fields including encrypted ones, adds only the new tag to the tags array, and updates the database with the modified params while keeping encrypted fields intact.

Added comprehensive unit tests covering preservation of encrypted fields, handling of both string and dict litellm_params formats, duplicate tag prevention, and error handling for missing models.

