### PR TITLE
fix(token-counting): resolve os.environ/ prefix and include system/tools in Anthropic API

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -428,13 +428,17 @@ class AnthropicTokenCounter(BaseTokenCounter):
         contents: Optional[List[Dict[str, Any]]],
         deployment: Optional[Dict[str, Any]] = None,
         request_model: str = "",
+        system: Optional[str] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
     ) -> Optional[TokenCountResponse]:
         from litellm.proxy.utils import count_tokens_with_anthropic_api
-        
+
         result = await count_tokens_with_anthropic_api(
             model_to_use=model_to_use,
             messages=messages,
             deployment=deployment,
+            system=system,
+            tools=tools,
         )
         
         if result is not None:

--- a/litellm/llms/base_llm/base_utils.py
+++ b/litellm/llms/base_llm/base_utils.py
@@ -24,6 +24,8 @@ class BaseTokenCounter(ABC):
         contents: Optional[List[Dict[str, Any]]],
         deployment: Optional[Dict[str, Any]] = None,
         request_model: str = "",
+        system: Optional[str] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
     ) -> Optional[TokenCountResponse]:
         pass
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2432,6 +2432,16 @@ class TokenCountRequest(LiteLLMPydanticObjectBase):
     Google /countTokens endpoint expects contents to be a list of dicts with the following structure:
     """
 
+    system: Optional[str] = None
+    """
+    System prompt for Anthropic token counting
+    """
+
+    tools: Optional[List[dict]] = None
+    """
+    Tool definitions for Anthropic token counting
+    """
+
 
 class CallInfo(LiteLLMPydanticObjectBase):
     """Used for slack budget alerting"""

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -141,6 +141,8 @@ async def count_tokens(
         # Extract required fields
         model_name = data.get("model")
         messages = data.get("messages", [])
+        system = data.get("system")
+        tools = data.get("tools")
 
         if not model_name:
             raise HTTPException(
@@ -155,7 +157,12 @@ async def count_tokens(
         # Create TokenCountRequest for the internal endpoint
         from litellm.proxy._types import TokenCountRequest
 
-        token_request = TokenCountRequest(model=model_name, messages=messages)
+        token_request = TokenCountRequest(
+            model=model_name,
+            messages=messages,
+            system=system,
+            tools=tools,
+        )
 
         # Call the internal token counter function with direct request flag set to False
         token_response = await internal_token_counter(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6612,6 +6612,8 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
     prompt = request.prompt
     messages = request.messages
     contents = request.contents
+    system = request.system
+    tools = request.tools
 
     #########################################################
     # Validate request
@@ -6672,6 +6674,8 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
                 contents=contents,
                 deployment=deployment,
                 request_model=request.model,
+                system=system,
+                tools=tools,
             )
             #########################################################
             # Transfrom the Response to the well known format


### PR DESCRIPTION
## Relevant issues

Fixes token counting inaccuracies for deployments using `os.environ/` prefix syntax in API key configuration.

## Pre-Submission checklist

- [x] I have added testing in the `tests/` directory
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

Bug Fix

## Changes

This PR fixes three bugs in `count_tokens_with_anthropic_api` that cause inaccurate token counting for Anthropic models:

1. **os.environ/ prefix not resolved**: When deployment config uses `api_key: os.environ/ANTHROPIC_API_KEY`, the literal string was passed to the Anthropic SDK, causing authentication failure and silent fallback to tiktoken.

2. **system prompt ignored**: The system prompt was not passed to the Anthropic count_tokens API.

3. **tools ignored**: Tool definitions were not passed to the Anthropic count_tokens API.

## Files changed

- `litellm/proxy/utils.py`: Added os.environ/ resolution via get_secret_str, added system and tools parameters
- `litellm/proxy/_types.py`: Added system and tools fields to TokenCountRequest
- `litellm/proxy/anthropic_endpoints/endpoints.py`: Extract system/tools from request
- `litellm/proxy/proxy_server.py`: Pass system/tools through to provider counter
- `litellm/llms/anthropic/common_utils.py`: Accept system/tools in AnthropicTokenCounter
- `litellm/llms/base_llm/base_utils.py`: Updated BaseTokenCounter interface

## Tests

Added 3 new tests in `tests/proxy_unit_tests/test_proxy_token_counter.py`:
- `test_count_tokens_with_anthropic_api_resolves_os_environ_prefix`
- `test_count_tokens_with_anthropic_api_passes_system_and_tools`
- `test_anthropic_endpoint_extracts_system_and_tools`

```
tests/proxy_unit_tests/test_proxy_token_counter.py::test_anthropic_endpoint_extracts_system_and_tools PASSED
tests/proxy_unit_tests/test_proxy_token_counter.py::test_count_tokens_with_anthropic_api_passes_system_and_tools PASSED
tests/proxy_unit_tests/test_proxy_token_counter.py::test_count_tokens_with_anthropic_api_resolves_os_environ_prefix PASSED
======================== 3 passed in 4.17s =========================
```

Verified with real conversation (195 messages):

| Test | Ground Truth | Broken | Fixed |
|------|-------------|--------|-------|
| Messages only | 185,049 | 180,674 (tiktoken) | 185,049 |
| Messages + System | 185,065 | 180,674 (tiktoken) | 185,065 |
| Messages + System + Tools | 185,719 | 180,674 (tiktoken) | 185,719 |

Fixed version matches direct Anthropic API exactly. Broken version undercounts by 5,045 tokens (2.7%).