### PR TITLE
fix(anthropic): handle partial JSON chunks in streaming responses

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -10,6 +10,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Union,
@@ -500,6 +501,11 @@ class ModelResponseIterator:
         # Track if we've converted any response_format tools (affects finish_reason)
         self.converted_response_format_tool: bool = False
 
+        # For handling partial JSON chunks from fragmentation
+        # See: https://github.com/BerriAI/litellm/issues/17473
+        self.accumulated_json: str = ""
+        self.chunk_type: Literal["valid_json", "accumulated_json"] = "valid_json"
+
     def check_empty_tool_call_args(self) -> bool:
         """
         Check if the tool call block so far has been an empty string
@@ -870,42 +876,105 @@ class ModelResponseIterator:
         usage = self._handle_usage(anthropic_usage_chunk=message_delta["usage"])
         return finish_reason, usage
 
+    def _handle_accumulated_json_chunk(
+        self, data_str: str
+    ) -> Optional[GenericStreamingChunk]:
+        """
+        Handle partial JSON chunks by accumulating them until valid JSON is received.
+
+        This fixes network fragmentation issues where SSE data chunks may be split
+        across TCP packets. See: https://github.com/BerriAI/litellm/issues/17473
+
+        Args:
+            data_str: The JSON string to parse (without "data:" prefix)
+
+        Returns:
+            GenericStreamingChunk if JSON is complete, None if still accumulating
+        """
+        # Accumulate JSON data
+        self.accumulated_json += data_str
+
+        # Try to parse the accumulated JSON
+        try:
+            data_json = json.loads(self.accumulated_json)
+            self.accumulated_json = ""  # Reset after successful parsing
+            return self.chunk_parser(chunk=data_json)
+        except json.JSONDecodeError:
+            # If it's not valid JSON yet, continue to the next chunk
+            return None
+
+    def _parse_sse_data(self, str_line: str) -> Optional[GenericStreamingChunk]:
+        """
+        Parse SSE data line, handling both complete and partial JSON chunks.
+
+        Args:
+            str_line: The SSE line starting with "data:"
+
+        Returns:
+            GenericStreamingChunk if parsing succeeded, None if accumulating partial JSON
+        """
+        data_str = str_line[5:]  # Remove "data:" prefix
+
+        if self.chunk_type == "accumulated_json":
+            # Already in accumulation mode, keep accumulating
+            return self._handle_accumulated_json_chunk(data_str)
+
+        # Try to parse as valid JSON first
+        try:
+            data_json = json.loads(data_str)
+            return self.chunk_parser(chunk=data_json)
+        except json.JSONDecodeError:
+            # Switch to accumulation mode and start accumulating
+            self.chunk_type = "accumulated_json"
+            return self._handle_accumulated_json_chunk(data_str)
+
     # Sync iterator
     def __iter__(self):
         return self
 
     def __next__(self):
-        try:
-            chunk = self.response_iterator.__next__()
-        except StopIteration:
-            raise StopIteration
-        except ValueError as e:
-            raise RuntimeError(f"Error receiving chunk from stream: {e}")
+        while True:
+            try:
+                chunk = self.response_iterator.__next__()
+            except StopIteration:
+                # If we have accumulated JSON when stream ends, try to parse it
+                if self.accumulated_json:
+                    try:
+                        data_json = json.loads(self.accumulated_json)
+                        self.accumulated_json = ""
+                        return self.chunk_parser(chunk=data_json)
+                    except json.JSONDecodeError:
+                        pass
+                raise StopIteration
+            except ValueError as e:
+                raise RuntimeError(f"Error receiving chunk from stream: {e}")
 
-        try:
-            str_line = chunk
-            if isinstance(chunk, bytes):  # Handle binary data
-                str_line = chunk.decode("utf-8")  # Convert bytes to string
-                index = str_line.find("data:")
-                if index != -1:
-                    str_line = str_line[index:]
+            try:
+                str_line = chunk
+                if isinstance(chunk, bytes):  # Handle binary data
+                    str_line = chunk.decode("utf-8")  # Convert bytes to string
+                    index = str_line.find("data:")
+                    if index != -1:
+                        str_line = str_line[index:]
 
-            if str_line.startswith("data:"):
-                data_json = json.loads(str_line[5:])
-                return self.chunk_parser(chunk=data_json)
-            else:
-                return GenericStreamingChunk(
-                    text="",
-                    is_finished=False,
-                    finish_reason="",
-                    usage=None,
-                    index=0,
-                    tool_use=None,
-                )
-        except StopIteration:
-            raise StopIteration
-        except ValueError as e:
-            raise RuntimeError(f"Error parsing chunk: {e},\nReceived chunk: {chunk}")
+                if str_line.startswith("data:"):
+                    result = self._parse_sse_data(str_line)
+                    if result is not None:
+                        return result
+                    # If None, continue loop to get more chunks for accumulation
+                else:
+                    return GenericStreamingChunk(
+                        text="",
+                        is_finished=False,
+                        finish_reason="",
+                        usage=None,
+                        index=0,
+                        tool_use=None,
+                    )
+            except StopIteration:
+                raise StopIteration
+            except ValueError as e:
+                raise RuntimeError(f"Error parsing chunk: {e},\nReceived chunk: {chunk}")
 
     # Async iterator
     def __aiter__(self):
@@ -913,37 +982,48 @@ class ModelResponseIterator:
         return self
 
     async def __anext__(self):
-        try:
-            chunk = await self.async_response_iterator.__anext__()
-        except StopAsyncIteration:
-            raise StopAsyncIteration
-        except ValueError as e:
-            raise RuntimeError(f"Error receiving chunk from stream: {e}")
+        while True:
+            try:
+                chunk = await self.async_response_iterator.__anext__()
+            except StopAsyncIteration:
+                # If we have accumulated JSON when stream ends, try to parse it
+                if self.accumulated_json:
+                    try:
+                        data_json = json.loads(self.accumulated_json)
+                        self.accumulated_json = ""
+                        return self.chunk_parser(chunk=data_json)
+                    except json.JSONDecodeError:
+                        pass
+                raise StopAsyncIteration
+            except ValueError as e:
+                raise RuntimeError(f"Error receiving chunk from stream: {e}")
 
-        try:
-            str_line = chunk
-            if isinstance(chunk, bytes):  # Handle binary data
-                str_line = chunk.decode("utf-8")  # Convert bytes to string
-                index = str_line.find("data:")
-                if index != -1:
-                    str_line = str_line[index:]
+            try:
+                str_line = chunk
+                if isinstance(chunk, bytes):  # Handle binary data
+                    str_line = chunk.decode("utf-8")  # Convert bytes to string
+                    index = str_line.find("data:")
+                    if index != -1:
+                        str_line = str_line[index:]
 
-            if str_line.startswith("data:"):
-                data_json = json.loads(str_line[5:])
-                return self.chunk_parser(chunk=data_json)
-            else:
-                return GenericStreamingChunk(
-                    text="",
-                    is_finished=False,
-                    finish_reason="",
-                    usage=None,
-                    index=0,
-                    tool_use=None,
-                )
-        except StopAsyncIteration:
-            raise StopAsyncIteration
-        except ValueError as e:
-            raise RuntimeError(f"Error parsing chunk: {e},\nReceived chunk: {chunk}")
+                if str_line.startswith("data:"):
+                    result = self._parse_sse_data(str_line)
+                    if result is not None:
+                        return result
+                    # If None, continue loop to get more chunks for accumulation
+                else:
+                    return GenericStreamingChunk(
+                        text="",
+                        is_finished=False,
+                        finish_reason="",
+                        usage=None,
+                        index=0,
+                        tool_use=None,
+                    )
+            except StopAsyncIteration:
+                raise StopAsyncIteration
+            except ValueError as e:
+                raise RuntimeError(f"Error parsing chunk: {e},\nReceived chunk: {chunk}")
 
     def convert_str_chunk_to_generic_chunk(self, chunk: str) -> ModelResponseStream:
         """


### PR DESCRIPTION
## Title

fix(anthropic): handle partial JSON chunks in streaming responses

## Relevant issues

Fixes #17473

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement**
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Anthropic streaming fails with `JSONDecodeError` when network fragmentation causes SSE data to arrive in partial chunks.

The `ModelResponseIterator` in `handler.py` tries to parse JSON immediately with `json.loads()` without handling the case where a chunk arrives incomplete due to TCP packet fragmentation.

### Solution
 Added JSON accumulation logic, following the same pattern already used in the Gemini handler (`handle_accumulated_json_chunk`):
 
- Added `accumulated_json` buffer and `chunk_type` to `ModelResponseIterator.__init__`
- Added `_handle_accumulated_json_chunk()` to accumulate partial JSON until valid
- Added `_parse_sse_data()` to handle both complete and partial chunks
- Modified `__next__` and `__anext__` to use accumulation logic with a loop
- Added 3 unit tests for partial chunk handling

 ### How it works

  When streaming, Anthropic sends SSE like:
  `data: {"type":"content_block_delta","text":"Hello"}`

 Network can fragment TCP packets, so you receive:
```python
data: {"type":"content_block_delta","te # Chunk 1: 
xt":"Hello"} # Chunk 2
```

  **Before :**
```python
  # Chunk 1 arrives 
  → json.loads('{"type":"content_block_delta","te  → 💥 JSONDecodeError
```

  **After (fix):**
```python
# Chunk 1 arrives 
→ json.loads fails → save to buffer
# Chunk 2 arrives 
→ buffer + chunk2 → json.loads('{"type":"content_block_delta","text":"Hello"}') → ✅
```

### Tests added
- `test_partial_json_chunk_accumulation` - verifies partial chunks accumulate
- `test_complete_json_chunk_no_accumulation` - verifies complete chunks parse immediately  
- `test_multiple_partial_chunks_accumulation` - verifies 3+ parts accumulate correctly