### PR TITLE
fix(publicai): use correct API endpoint (api.publicai.co)

### DIFF
--- a/docs/my-website/docs/providers/publicai.md
+++ b/docs/my-website/docs/providers/publicai.md
@@ -10,13 +10,13 @@ import TabItem from '@theme/TabItem';
 | Description | PublicAI provides large language models including essential models like the swiss-ai apertus model. |
 | Provider Route on LiteLLM | `publicai/` |
 | Link to Provider Doc | [PublicAI ↗](https://platform.publicai.co/) |
-| Base URL | `https://platform.publicai.co/` |
+| Base URL | `https://api.publicai.co/` |
 | Supported Operations | [`/chat/completions`](#sample-usage) |
 
 <br />
 <br />
 
-https://platform.publicai.co/
+https://api.publicai.co/
 
 **We support ALL PublicAI models, just set `publicai/` as a prefix when sending completion requests**
 
@@ -29,7 +29,7 @@ os.environ["PUBLICAI_API_KEY"] = ""  # your PublicAI API key
 You can overwrite the base url with:
 
 ```
-os.environ["PUBLICAI_API_BASE"] = "https://platform.publicai.co/v1"
+os.environ["PUBLICAI_API_BASE"] = "https://api.publicai.co/v1"
 ```
 
 ## Usage - LiteLLM Python SDK

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -543,7 +543,7 @@ openai_compatible_endpoints: List = [
     "api.studio.nebius.ai/v1",
     "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
     "https://api.moonshot.ai/v1",
-    "https://platform.publicai.co/v1",
+    "https://api.publicai.co/v1",
     "https://api.v0.dev/v1",
     "https://api.morphllm.com/v1",
     "https://api.lambda.ai/v1",

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -252,7 +252,7 @@ def get_llm_provider(  # noqa: PLR0915
                     elif endpoint == "api.moonshot.ai/v1":
                         custom_llm_provider = "moonshot"
                         dynamic_api_key = get_secret_str("MOONSHOT_API_KEY")
-                    elif endpoint == "platform.publicai.co/v1":
+                    elif endpoint == "api.publicai.co/v1":
                         custom_llm_provider = "publicai"
                         dynamic_api_key = get_secret_str("PUBLICAI_API_KEY")
                     elif endpoint == "https://api.v0.dev/v1":

--- a/litellm/llms/publicai/chat/transformation.py
+++ b/litellm/llms/publicai/chat/transformation.py
@@ -51,7 +51,7 @@ class PublicAIChatConfig(OpenAIGPTConfig):
         api_base = (
             api_base
             or get_secret_str("PUBLICAI_API_BASE")
-            or "https://platform.publicai.co/v1"
+            or "https://api.publicai.co/v1"
         )  # type: ignore
         dynamic_api_key = api_key or get_secret_str("PUBLICAI_API_KEY")
         return api_base, dynamic_api_key
@@ -69,7 +69,7 @@ class PublicAIChatConfig(OpenAIGPTConfig):
         If api_base is not provided, use the default PublicAI /chat/completions endpoint.
         """
         if not api_base:
-            api_base = "https://platform.publicai.co/v1"
+            api_base = "https://api.publicai.co/v1"
 
         if not api_base.endswith("/chat/completions"):
             api_base = f"{api_base}/chat/completions"

--- a/tests/test_litellm/llms/publicai/test_publicai_chat_transformation.py
+++ b/tests/test_litellm/llms/publicai/test_publicai_chat_transformation.py
@@ -120,7 +120,7 @@ class TestPublicAIConfig:
             stream=False
         )
         
-        assert url == "https://platform.publicai.co/v1/chat/completions"
+        assert url == "https://api.publicai.co/v1/chat/completions"
 
     def test_get_complete_url_with_custom_base(self):
         """


### PR DESCRIPTION
## Title

fix(publicai): use correct API endpoint (api.publicai.co)

## Relevant issues

Fixes #17218

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

The PublicAI provider was configured with the wrong API endpoint:
- ❌ `platform.publicai.co` - returns 404 (not the API endpoint)
- ✅ `api.publicai.co` - the correct API endpoint

This caused all PublicAI requests to fail with "Your request was blocked" error.

### Files changed:
- `litellm/llms/publicai/chat/transformation.py` - fixed default endpoint
- `litellm/constants.py` - fixed endpoint in openai_compatible_endpoints list
- `litellm/litellm_core_utils/get_llm_provider_logic.py` - fixed provider detection
- `tests/test_litellm/llms/publicai/test_publicai_chat_transformation.py` - updated test
- `docs/my-website/docs/providers/publicai.md` - updated documentation

### Test passing:
```
======================== 6 passed, 4 warnings in 0.04s =========================
```