### PR TITLE
Add type validation to general settings loaded by config

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1920,6 +1920,75 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="Fine-grained control over which object types to load from the database when store_model_in_db is True. Available types: 'models', 'mcp', 'guardrails', 'vector_stores', 'pass_through_endpoints', 'prompts', 'model_cost_map'. If not set, all objects are loaded (default behavior).",
     )
+    key_management_settings: Optional[Dict] = Field(
+        None, description="Key management configuration settings"
+    )
+    user_api_key_cache_ttl: Optional[float] = Field(
+        None, description="TTL in seconds for in-memory user API key cache"
+    )
+    store_model_in_db: Optional[bool] = Field(
+        None, description="Feature flag for /model/new endpoint to store models in database"
+    )
+    custom_key_generate: Optional[str] = Field(
+        None, description="Path to custom key generation function"
+    )
+    custom_sso: Optional[str] = Field(
+        None, description="Path to custom SSO authentication function"
+    )
+    custom_ui_sso_sign_in_handler: Optional[str] = Field(
+        None, description="Path to custom UI SSO sign-in handler function"
+    )
+    allowed_ips: Optional[List[str]] = Field(
+        None, description="IP whitelist for proxy access (Enterprise feature)"
+    )
+    proxy_budget_rescheduler_min_time: Optional[int] = Field(
+        None, description="Minimum time in seconds to wait before checking database for budget resets"
+    )
+    proxy_budget_rescheduler_max_time: Optional[int] = Field(
+        None, description="Maximum time in seconds to wait before checking database for budget resets"
+    )
+    proxy_batch_polling_interval: Optional[int] = Field(
+        None, description="Time in seconds to wait before polling a batch to check if it's completed"
+    )
+    proxy_batch_write_at: Optional[int] = Field(
+        None, description="Time in seconds to wait before batch writing spend logs to the database"
+    )
+    disable_spend_logs: Optional[bool] = Field(
+        None, description="Disable spend logging for performance improvement"
+    )
+    use_shared_health_check: Optional[bool] = Field(
+        None, description="Enable shared health check state across pods (requires Redis)"
+    )
+    health_check_details: Optional[bool] = Field(
+        None, description="Include detailed information in health check responses"
+    )
+    role_permissions: Optional[Dict] = Field(
+        None, description="RBAC role permissions configuration"
+    )
+    enforced_params: Optional[Dict] = Field(
+        None, description="Enforced parameters for all requests (Enterprise feature)"
+    )
+    disable_retry_on_max_parallel_request_limit_error: Optional[bool] = Field(
+        None, description="Disable retry when max parallel request limit is reached"
+    )
+    litellm_jwtauth: Optional[Dict] = Field(
+        None, description="JWT authentication configuration"
+    )
+    disable_reset_budget: Optional[bool] = Field(
+        None, description="Disable automatic budget reset functionality"
+    )
+    spend_report_frequency: Optional[str] = Field(
+        None, description="Frequency for spend reports (e.g., '7d' for 7 days, '30d' for 30 days)"
+    )
+    maximum_spend_logs_retention_period: Optional[int] = Field(
+        None, description="Maximum retention period in days for spend logs"
+    )
+    moderation_model: Optional[str] = Field(
+        None, description="Default model to use for moderation requests"
+    )
+    auth_header_name: Optional[str] = Field(
+        None, description="Custom authentication header name"
+    )
 
 
 class ConfigYAML(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1096,7 +1096,7 @@ experimental = False
 #### GLOBAL VARIABLES ####
 llm_router: Optional[Router] = None
 llm_model_list: Optional[list] = None
-general_settings: dict = {}
+general_settings = ConfigGeneralSettings()
 config_passthrough_endpoints: Optional[List[Dict[str, Any]]] = None
 log_file = "api_log.json"
 worker_config = None
@@ -2357,9 +2357,10 @@ class ProxyConfig:
                     setattr(litellm, key, value)
 
         ## GENERAL SERVER SETTINGS (e.g. master key,..) # do this after initializing litellm, to ensure sentry logging works for proxylogging
-        general_settings = config.get("general_settings", {})
-        if general_settings is None:
-            general_settings = {}
+        general_settings_dict = config.get("general_settings", {})
+        if general_settings_dict is None:
+            general_settings_dict = {}
+        general_settings = ConfigGeneralSettings(**general_settings_dict)
         if general_settings:
             ### LOAD KEY MANAGEMENT SETTINGS FIRST (needed for custom secret manager) ###
             key_management_settings = general_settings.get(
@@ -3159,7 +3160,7 @@ class ProxyConfig:
 
         Args:
             config_data: dict
-            general_settings: dict - global general_settings currently in use
+            general_settings: ConfigGeneralSettings - global general_settings currently in use
             proxy_logging_obj: ProxyLogging
         """
         _general_settings = config_data.get("general_settings", {})
@@ -3188,7 +3189,7 @@ class ProxyConfig:
                 proxy_logging_obj.slack_alerting_instance.alerting = general_settings[
                     "alerting"
                 ]
-            elif isinstance(general_settings, dict):
+            else:
                 general_settings["alerting"] = _general_settings["alerting"]
                 proxy_logging_obj.alerting = general_settings["alerting"]
                 proxy_logging_obj.slack_alerting_instance.alerting = general_settings[

--- a/litellm/types/llms/base.py
+++ b/litellm/types/llms/base.py
@@ -42,7 +42,12 @@ class LiteLLMPydanticObjectBase(BaseModel):
 
     def __contains__(self, key: str) -> bool:
         """Dict-style 'key in settings' checks"""
-        return hasattr(self, key)
+        # Match dict behavior: return False if value is None (like missing key)
+        try:
+            value = getattr(self, key)
+            return value is not None
+        except AttributeError:
+            return False
 
     def keys(self):
         """Dict-style .keys() method"""

--- a/litellm/types/llms/base.py
+++ b/litellm/types/llms/base.py
@@ -23,7 +23,44 @@ class LiteLLMPydanticObjectBase(BaseModel):
             # if using pydantic v1
             return self.__fields_set__
 
-    model_config = ConfigDict(protected_namespaces=())
+    def get(self, key: str, default: Any = None) -> Any:
+        """Dict-style get() for backward compatibility"""
+        value = getattr(self, key, default)
+        # Return default if value is None (matches dict behavior for missing keys)
+        return default if value is None else value
+
+    def __getitem__(self, key: str) -> Any:
+        """Dict-style ['key'] access"""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Dict-style ['key'] = value assignment"""
+        setattr(self, key, value)
+
+    def __contains__(self, key: str) -> bool:
+        """Dict-style 'key in settings' checks"""
+        return hasattr(self, key)
+
+    def keys(self):
+        """Dict-style .keys() method"""
+        return self.model_fields.keys()
+
+    def items(self):
+        """Dict-style .items() method"""
+        return self.model_dump().items()
+
+    def update(self, other: Any) -> None:
+        """Dict-style .update() method"""
+        if isinstance(other, dict):
+            for key, value in other.items():
+                setattr(self, key, value)
+        else:
+            raise TypeError(f"update() argument must be dict, not {type(other).__name__}")
+
+    model_config = ConfigDict(protected_namespaces=(), extra="allow")
 
 
 class BaseLiteLLMOpenAIResponseObject(BaseModel):

--- a/tests/proxy_unit_tests/test_config_general_settings_type_coercion.py
+++ b/tests/proxy_unit_tests/test_config_general_settings_type_coercion.py
@@ -1,0 +1,196 @@
+"""
+Tests for ConfigGeneralSettings type coercion and dict compatibility.
+
+This test ensures that the ConfigGeneralSettings Pydantic model properly
+coerces types from YAML/dict input, providing consistent behavior with
+environment variable type coercion.
+"""
+
+import pytest
+from litellm.proxy._types import ConfigGeneralSettings
+
+
+def test_config_general_settings_integer_type_coercion():
+    """Test that integer fields are properly coerced from string values."""
+    config_dict = {
+        "proxy_batch_write_at": "10",  # String should be coerced to int
+        "proxy_batch_polling_interval": "6000",
+        "proxy_budget_rescheduler_min_time": "597",
+        "proxy_budget_rescheduler_max_time": "605",
+        "health_check_interval": "300",
+        "alerting_threshold": "600",
+        "max_parallel_requests": "100",
+        "maximum_spend_logs_retention_period": "30",
+    }
+
+    settings = ConfigGeneralSettings(**config_dict)
+
+    # Verify integers are properly coerced
+    assert settings.proxy_batch_write_at == 10
+    assert isinstance(settings.proxy_batch_write_at, int)
+    assert settings.proxy_batch_polling_interval == 6000
+    assert isinstance(settings.proxy_batch_polling_interval, int)
+    assert settings.proxy_budget_rescheduler_min_time == 597
+    assert isinstance(settings.proxy_budget_rescheduler_min_time, int)
+    assert settings.health_check_interval == 300
+    assert isinstance(settings.health_check_interval, int)
+    assert settings.alerting_threshold == 600
+    assert settings.max_parallel_requests == 100
+    assert settings.maximum_spend_logs_retention_period == 30
+
+
+def test_config_general_settings_boolean_type_coercion():
+    """Test that boolean fields are properly coerced from string values."""
+    config_dict = {
+        "disable_spend_logs": "true",
+        "store_model_in_db": "false",
+        "use_shared_health_check": "True",
+        "disable_reset_budget": "False",
+        "health_check_details": "yes",  # Pydantic accepts yes/no
+        "infer_model_from_keys": "1",  # Pydantic accepts 1/0
+    }
+
+    settings = ConfigGeneralSettings(**config_dict)
+
+    # Verify booleans are properly coerced
+    assert settings.disable_spend_logs is True
+    assert isinstance(settings.disable_spend_logs, bool)
+    assert settings.store_model_in_db is False
+    assert isinstance(settings.store_model_in_db, bool)
+    assert settings.use_shared_health_check is True
+    assert settings.disable_reset_budget is False
+    assert settings.health_check_details is True
+    assert settings.infer_model_from_keys is True
+
+
+def test_config_general_settings_float_type_coercion():
+    """Test that float fields are properly coerced from string values."""
+    config_dict = {
+        "user_api_key_cache_ttl": "60.5",
+        "database_connection_timeout": "120",
+    }
+
+    settings = ConfigGeneralSettings(**config_dict)
+
+    assert settings.user_api_key_cache_ttl == 60.5
+    assert isinstance(settings.user_api_key_cache_ttl, float)
+    assert settings.database_connection_timeout == 120.0
+    assert isinstance(settings.database_connection_timeout, float)
+
+
+def test_config_general_settings_get_method_with_none():
+    """Test that .get() method returns default when value is None."""
+    settings = ConfigGeneralSettings()
+
+    # When field is None, .get() should return the default
+    assert settings.get("proxy_batch_write_at", 10) == 10
+    assert settings.get("master_key", "default_key") == "default_key"
+    assert settings.get("disable_spend_logs", True) is True
+    assert settings.get("moderation_model", "gpt-4") == "gpt-4"
+
+
+def test_config_general_settings_get_method_with_values():
+    """Test that .get() method returns actual value when set."""
+    settings = ConfigGeneralSettings(
+        proxy_batch_write_at=15,
+        master_key="test_key",
+        disable_spend_logs=False,
+    )
+
+    assert settings.get("proxy_batch_write_at", 10) == 15
+    assert settings.get("master_key", "default_key") == "test_key"
+    assert settings.get("disable_spend_logs", True) is False
+
+
+def test_config_general_settings_extra_fields_allowed():
+    """Test that extra fields (not defined in model) are allowed and preserved."""
+    config_dict = {
+        "proxy_batch_write_at": 10,
+        "custom_field_not_in_model": "some_value",
+        "another_custom_field": 123,
+    }
+
+    settings = ConfigGeneralSettings(**config_dict)
+
+    # Defined field should work
+    assert settings.proxy_batch_write_at == 10
+
+    # Extra fields should be accessible
+    assert settings.get("custom_field_not_in_model") == "some_value"
+    assert settings.get("another_custom_field") == 123
+
+
+def test_config_general_settings_dict_style_access():
+    """Test dict-style access methods work correctly."""
+    settings = ConfigGeneralSettings(proxy_batch_write_at=20, master_key="test")
+
+    # __getitem__
+    assert settings["proxy_batch_write_at"] == 20
+    assert settings["master_key"] == "test"
+
+    # __contains__
+    assert "proxy_batch_write_at" in settings
+    assert "master_key" in settings
+    assert "nonexistent_field" not in settings
+
+    # __setitem__
+    settings["new_field"] = "new_value"
+    assert settings.get("new_field") == "new_value"
+
+    # items()
+    items = dict(settings.items())
+    assert "proxy_batch_write_at" in items
+    assert items["proxy_batch_write_at"] == 20
+
+
+def test_config_general_settings_update_method():
+    """Test that .update() method works like dict.update()."""
+    settings = ConfigGeneralSettings(proxy_batch_write_at=10)
+
+    # Update with dict
+    settings.update({"proxy_batch_write_at": 20, "master_key": "new_key"})
+
+    assert settings.proxy_batch_write_at == 20
+    assert settings.master_key == "new_key"
+
+    # Update should raise TypeError for non-dict
+    with pytest.raises(TypeError):
+        settings.update("not a dict")
+
+
+def test_config_general_settings_end_to_end_yaml_simulation():
+    """
+    End-to-end test simulating loading from YAML config.
+    This is the key test that validates the original issue is fixed.
+    """
+    # Simulate YAML config being loaded as dict (YAML parsers return strings)
+    yaml_config = {
+        "general_settings": {
+            "proxy_batch_write_at": "10",  # String from YAML
+            "master_key": "sk-1234",
+            "disable_spend_logs": "false",  # String from YAML
+            "user_api_key_cache_ttl": "60.5",  # String from YAML
+        }
+    }
+
+    # Instantiate ConfigGeneralSettings from the dict
+    general_settings = ConfigGeneralSettings(**yaml_config["general_settings"])
+
+    # Verify type coercion happened correctly
+    assert general_settings.proxy_batch_write_at == 10
+    assert isinstance(general_settings.proxy_batch_write_at, int)
+
+    # This is the critical part - can be used in arithmetic without errors
+    # (Original issue was that strings from YAML weren't coerced)
+    batch_interval = general_settings.proxy_batch_write_at + 5
+    assert batch_interval == 15
+
+    # Verify other coercions
+    assert general_settings.disable_spend_logs is False
+    assert isinstance(general_settings.disable_spend_logs, bool)
+    assert general_settings.user_api_key_cache_ttl == 60.5
+    assert isinstance(general_settings.user_api_key_cache_ttl, float)
+
+    # Verify .get() works with fallback to defaults
+    assert general_settings.get("proxy_batch_write_at", 999) == 10
+    assert general_settings.get("nonexistent", "default") == "default"

--- a/tests/test_litellm/llms/__init__.py
+++ b/tests/test_litellm/llms/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for LLM provider implementations."""

--- a/tests/test_litellm/llms/ragflow/__init__.py
+++ b/tests/test_litellm/llms/ragflow/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for RAGFlow provider."""


### PR DESCRIPTION
## Title

Adds formal type validation for a variety of general_settings loaded from config.

## Relevant issues

Fixes #17505 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

There are four failing unit tests when I run `make test-unit`, however, those same four tests appear to fail when running tests on the main branch and I don't believe them to be related to this PR.

<img width="1524" height="188" alt="Screenshot 2025-12-04 at 5 32 55 PM" src="https://github.com/user-attachments/assets/b073ded9-c084-4a86-bba2-8cbc412669f9" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring

## Changes

* Adds various general_settings fields referenced from the `general_settings` dict in `proxy` to the typed `ConfigGeneralSettings`
* Spoofs dict access patterns on pydantic config settings for backwards compatibility with the previous dict implementation.
* Pushes general_settings dict through config loading to enforce type validation on load.



