### PR TITLE
(fix): empty response + vllm streaming

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -444,7 +444,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             else:
                 headers = {}
             response = raw_response.parse()
-            if not hasattr(response, "model_dump"):
+            if not data.get("stream") and not hasattr(response, "model_dump"):
                 raise OpenAIError(
                     status_code=500,
                     message=f"Empty or invalid response from LLM endpoint. Received: {response!r}. Check the reverse proxy or model server configuration.",
@@ -482,7 +482,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             else:
                 headers = {}
             response = raw_response.parse()
-            if not hasattr(response, "model_dump"):
+            if not data.get("stream") and not hasattr(response, "model_dump"):
                 raise OpenAIError(
                     status_code=500,
                     message=f"Empty or invalid response from LLM endpoint. Received: {response!r}. Check the reverse proxy or model server configuration.",


### PR DESCRIPTION
## Title

Fix vLLM with latest upcoming LiteLLM changes.

## Relevant issues

A commit from yesterday to handle empty responses breaks all streaming responses from vLLM models. vLLM itself returns a 200, but after a few retries LiteLLM spits out the following:

```
ERROR TYPE: litellm.InternalServerError

MESSAGE:
Empty or invalid response from LLM endpoint. Received: <openai.AsyncStream object at 0x7f45c8093570>. Check the reverse proxy or model server configuration.

MODEL GROUP: gpt-oss-120b
AVAILABLE FALLBACKS: None
RETRIES: 1 of 2

STACK TRACE:
File "/usr/lib/python3.13/site-packages/litellm/main.py", line 601
File "/usr/lib/python3.13/site-packages/litellm/llms/openai/openai.py", line 1029
File "/usr/lib/python3.13/site-packages/litellm/llms/openai/openai.py", line 1003
File "/usr/lib/python3.13/site-packages/litellm/llms/openai/openai.py", line 459
File "/usr/lib/python3.13/site-packages/litellm/proxy/proxy_server.py", line 4883
File "/usr/lib/python3.13/site-packages/litellm/proxy/common_request_processing.py", line 539
File "/usr/lib/python3.13/site-packages/litellm/router.py", line 1289
File "/usr/lib/python3.13/site-packages/litellm/router.py", line 1265
File "/usr/lib/python3.13/site-packages/litellm/router.py", line 4293
File "/usr/lib/python3.13/site-packages/litellm/router.py", line 4251
File "/usr/lib/python3.13/site-packages/litellm/router.py", line 4285
File "/usr/lib/python3.13/site-packages/litellm/router.py", line 4490
File "/usr/lib/python3.13/site-packages/litellm/router.py", line 4381
File "/usr/lib/python3.13/site-packages/litellm/router.py", line 4501
File "/usr/lib/python3.13/site-packages/litellm/router.py", line 1571
File "/usr/lib/python3.13/site-packages/litellm/router.py", line 1523
File "/usr/lib/python3.13/site-packages/litellm/utils.py", line 1643
File "/usr/lib/python3.13/site-packages/litellm/utils.py", line 1489
File "/usr/lib/python3.13/site-packages/litellm/main.py", line 620
```

QUESTIONS:
What commit is causing this recently?
https://github.com/BerriAI/litellm/commit/a6ce1189899912581714bd80cbf7785b20d1e093

When was this added and by who and how?

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ Yes ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ Yes ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ Yes ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Adds another conditional to check for if we are streaming or not to the empty message check.
