### PR TITLE
fix(streaming): add length validation for empty tool_calls in delta

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -737,6 +737,7 @@ class CustomStreamWrapper:
             or (
                 "tool_calls" in model_response.choices[0].delta
                 and model_response.choices[0].delta["tool_calls"] is not None
+                and len(model_response.choices[0].delta["tool_calls"]) > 0
             )
             or (
                 "function_call" in model_response.choices[0].delta


### PR DESCRIPTION
 ## fix(streaming): add length validation for empty tool_calls in delta

  Fixes #17425

  ## Pre-Submission checklist

  - [x] I have Added testing in the tests/litellm/ directory
  - [x] I have added a screenshot of my new test passing locally
  - [x] My PR passes all unit tests on make test-unit
  - [x] My PR's scope is as isolated as possible

  ## Type

  🐛 Bug Fix
  ✅ Test

  ## Changes

  **Problem:** Empty tool call objects appear in streaming responses when using parallel tool calls with Anthropic Claude models. This regression was introduced in v1.80.0 (PR #15962).

  **Root Cause:** The `is_chunk_non_empty` function in `streaming_handler.py` checks for `tool_calls` in `model_response.choices[0].delta` but doesn't validate that the list is non-empty, unlike the existing 
  check for `completion_obj["tool_calls"]` which includes a length validation.

  **Fix:** Added `len(model_response.choices[0].delta["tool_calls"]) > 0` check to filter out empty tool_calls lists.

  **Test screenshot:**
<img width="1510" height="463" alt="Screenshot 2025-12-05 at 12 56 18 AM" src="https://github.com/user-attachments/assets/8f33de00-3c62-4618-90bb-9a58dce68738" />

