### PR TITLE
[fix] parse <budget:thinking> blocks for opus 4.5

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1071,7 +1071,7 @@ def _parse_content_for_reasoning(
         return None, message_text
 
     reasoning_match = re.match(
-        r"<(?:think|thinking)>(.*?)</(?:think|thinking)>(.*)", message_text, re.DOTALL
+        r"<(?:think|thinking|budget:thinking)>(.*?)</(?:think|thinking|budget:thinking)>(.*)", message_text, re.DOTALL
     )
 
     if reasoning_match:

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -1043,6 +1043,11 @@ def test_convert_model_response_object():
             "I am thinking here",
             "The sky is a canvas of blue",
         ),
+        (
+            "<budget:thinking>\nLet me work through this step by step.\n</budget:thinking>\n\nYou have **8 fruits** remaining.",
+            "\nLet me work through this step by step.\n",
+            "\n\nYou have **8 fruits** remaining.",
+        ),
         ("I am a regular response", None, "I am a regular response"),
     ],
 )

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -1044,9 +1044,9 @@ def test_convert_model_response_object():
             "The sky is a canvas of blue",
         ),
         (
-            "<budget:thinking>\nLet me work through this step by step.\n</budget:thinking>\n\nYou have **8 fruits** remaining.",
-            "\nLet me work through this step by step.\n",
-            "\n\nYou have **8 fruits** remaining.",
+            "<budget:thinking>I am thinking here</budget:thinking>The sky is a canvas of blue",
+            "I am thinking here",
+            "The sky is a canvas of blue",
         ),
         ("I am a regular response", None, "I am a regular response"),
     ],


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

[fix] parse <budget:thinking> blocks for opus 4.5

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

bedrock opus 4.5 returns `<budget:thinking>` blocks which arent parsed correctly by litellm 

ex for chat completion

curl

```
curl -v http://localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-master' \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "claude-opus-4.5",
    "messages": [
      {
        "role": "user",
        "content": "I have 5 apples and 6 oranges. I ate 2 apples and threw away 1 orange. How many fruits do I have?"
      }
    ]
  }'
```

output before fix

notice the `<budget:thinking>`

```json
 "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "<budget:thinking>\nLet me work through this step by step.\n\nStarting fruits:\n- 5 apples\n- 6 oranges\n- Total: 11 fruits\n\nWhat happened:\n- Ate 2 apples: 5 - 2 = 3 apples remaining\n- Threw away 1 orange: 6 - 1 = 5 oranges remaining\n\nFinal count: 3 + 5 = 8 fruits\n</budget:thinking>\n\nYou have **8 fruits** remaining.\n\n- Apples: 5 - 2 = **3 apples**\n- Oranges: 6 - 1 = **5 oranges**\n\nTotal: 3 + 5 = **8 fruits**",
        "role": "assistant",
        "provider_specific_fields": {
          "citations": null,
          "thinking_blocks": null
        }
      }
    }
  ],
```

output after fix

```json
"message": {
        "content": "\n\nYou have **8 fruits** remaining.\n\n- Apples: 5 - 2 = **3 apples**\n- Oranges: 6 - 1 = **5 oranges**\n\nTotal: 3 + 5 = **8 fruits**",
        "role": "assistant",
        "reasoning_content": "\nLet me work through this step by step.\n\nStarting fruits:\n- 5 apples\n- 6 oranges\n- Total: 11 fruits\n\nWhat happened:\n- Ate 2 apples: 5 - 2 = 3 apples remaining\n- Threw away 1 orange: 6 - 1 = 5 oranges remaining\n\nFinal count: 3 + 5 = 8 fruits\n",
        "thinking_blocks": [
          {
            "type": "thinking",
            "thinking": "\nLet me work through this step by step.\n\nStarting fruits:\n- 5 apples\n- 6 oranges\n- Total: 11 fruits\n\nWhat happened:\n- Ate 2 apples: 5 - 2 = 3 apples remaining\n- Threw away 1 orange: 6 - 1 = 5 oranges remaining\n\nFinal count: 3 + 5 = 8 fruits\n"
          }
```

## Tests
Added <budget:thinking> to existing `test_parse_content_for_reasoning` test
ran
`poetry run pytest tests/litellm_utils_tests/test_utils.py::test_parse_content_for_reasoning -v`
<img width="889" height="107" alt="Screenshot 2025-12-05 at 11 05 22 AM" src="https://github.com/user-attachments/assets/182a4b6a-5849-4621-8a5e-b3aa45259fd8" />



