### PR TITLE
Helm Chart: Add possibility to override command, args and add deployment labels

### DIFF
--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.9
+version: 0.4.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ include "litellm.fullname" . }}
   labels:
     {{- include "litellm.labels" . | nindent 4 }}
+    {{- if .Values.deploymentLabels }}
     {{- toYaml .Values.deploymentLabels | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "litellm.fullname" . }}
   labels:
     {{- include "litellm.labels" . | nindent 4 }}
+    {{- toYaml .Values.deploymentLabels | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -126,6 +127,12 @@ spec:
             - configMapRef:
                 name: {{ . }}
           {{- end }}
+          {{- if .Values.command }}
+          command: {{ toYaml .Values.command | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{ toYaml .Values.args | nindent 12 }}
+          {{- else }}
           args:
             - --config
             - /etc/litellm/config.yaml
@@ -133,6 +140,7 @@ spec:
             - --num_workers
             - {{ .Values.numWorkers | quote }}
             {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/deploy/charts/litellm-helm/tests/deployment_command_args_labels_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_command_args_labels_tests.yaml
@@ -1,0 +1,67 @@
+suite: test deployment command, args, and deploymentLabels
+templates:
+  - deployment.yaml
+tests:
+  - it: should override args when custom args specified
+    template: deployment.yaml
+    set:
+      args:
+        - --custom-arg1
+        - value1
+        - --custom-arg2
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - --custom-arg1
+            - value1
+            - --custom-arg2
+  - it: should set custom command when specified
+    template: deployment.yaml
+    set:
+      command:
+        - /bin/sh
+        - -c
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /bin/sh
+            - -c
+  - it: should set custom command and args together
+    template: deployment.yaml
+    set:
+      command:
+        - python
+        - -u
+      args:
+        - my_script.py
+        - --verbose
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - python
+            - -u
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - my_script.py
+            - --verbose
+  - it: should add deploymentLabels to deployment metadata
+    template: deployment.yaml
+    set:
+      deploymentLabels:
+        environment: production
+        team: platform
+        version: v1.2.3
+    asserts:
+      - equal:
+          path: metadata.labels.environment
+          value: production
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.labels.version
+          value: v1.2.3

--- a/deploy/charts/litellm-helm/tests/deployment_command_args_labels_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_command_args_labels_tests.yaml
@@ -1,6 +1,7 @@
 suite: test deployment command, args, and deploymentLabels
 templates:
   - deployment.yaml
+  - configmap-litellm.yaml
 tests:
   - it: should override args when custom args specified
     template: deployment.yaml

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -30,6 +30,7 @@ serviceAccount:
 
 # annotations for litellm deployment
 deploymentAnnotations: {}
+deploymentLabels: {}
 # annotations for litellm pods
 podAnnotations: {}
 podLabels: {}
@@ -252,6 +253,11 @@ envVars: {}
 # USE_DDTRACE: "true"
 # Additional environment variables to be added to the deployment as a list of k8s env vars
 extraEnvVars: {}
+
+# if you want to override the container command, you can do so here
+command: {}
+# if you want to override the container args, you can do so here
+args: {}
 
 # - name: EXTRA_ENV_VAR
 #   value: EXTRA_ENV_VAR_VALUE


### PR DESCRIPTION
## Title
Add possibility to override command, args and add deployment labels in the Helm Chart. This is something we need to support injecting secrets at runtime using the Vault sidecar, to load secrets into ENV and then starting up litellm proxy.

## Pre-Submission checklist
- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="921" height="371" alt="image" src="https://github.com/user-attachments/assets/e25cdf59-7550-4c40-b9b1-7e389635d0cb" />

## Type
🆕 New Feature
✅ Test

## Changes

This PR adds three new configuration options to the Helm chart for greater flexibility in deployment customization:

New Values:
- `command` - Override the container command (entrypoint). Useful for custom initialization scripts or debugging.
- `args` - Override the default container arguments. By default, the chart passes `--config /etc/litellm/config.yaml` (and optionally `--num_workers`), but this can now be fully customized.
- `deploymentLabels` - Add custom labels to the Deployment metadata. Useful for organization-specific labeling conventions, compliance requirements, or tooling integration.