### PR TITLE
Fix: Presidio guardrail test TypeError and license base64 decoding error

### DIFF
--- a/litellm/proxy/auth/litellm_license.py
+++ b/litellm/proxy/auth/litellm_license.py
@@ -162,7 +162,12 @@ class LicenseCheck:
 
             from litellm.proxy._types import EnterpriseLicenseData
 
-            # Decode the license key
+            # Decode the license key - add padding if needed for base64
+            # Base64 strings need to be a multiple of 4 characters
+            padding_needed = len(license_key) % 4
+            if padding_needed:
+                license_key += "=" * (4 - padding_needed)
+            
             decoded = base64.b64decode(license_key)
             message, signature = decoded.split(b".", 1)
 

--- a/tests/guardrails_tests/test_presidio_pii.py
+++ b/tests/guardrails_tests/test_presidio_pii.py
@@ -76,16 +76,20 @@ async def test_presidio_apply_guardrail():
         presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE")
     )
 
-
+    test_text = "My credit card number is 4111-1111-1111-1111 and my email is test@example.com"
     response = await presidio_guardrail.apply_guardrail(
-        text="My credit card number is 4111-1111-1111-1111 and my email is test@example.com",
-        language="en",
+        inputs={"texts": [test_text]},
+        request_data={},
+        input_type="request",
     )
     print("response from apply guardrail for presidio: ", response)
 
-    # assert tthe default config masks the credit card and email
-    assert "4111-1111-1111-1111" not in response
-    assert "test@example.com" not in response
+    # Extract the modified text from the response
+    modified_text = response["texts"][0] if response.get("texts") else ""
+
+    # assert the default config masks the credit card and email
+    assert "4111-1111-1111-1111" not in modified_text
+    assert "test@example.com" not in modified_text
 
 @pytest.mark.asyncio
 async def test_presidio_with_blocked_entities():


### PR DESCRIPTION
## Title

Fix: Presidio guardrail test TypeError and license base64 decoding error

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Fixed two issues:

1. Presidio guardrail test TypeError:
   - Issue: test_presidio_apply_guardrail() was calling apply_guardrail() with incorrect arguments (text=, language=) instead of the correct signature (inputs=, request_data=, input_type=)
   - Fix: Updated test to use correct method signature:
     - Changed from: apply_guardrail(text=..., language=...)
     - Changed to: apply_guardrail(inputs={'texts': [...]}, request_data={}, input_type='request')
   - Also updated assertions to extract text from response['texts'][0]

2. License verification base64 decoding error:
   - Issue: verify_license_without_api_request() was failing with 'Invalid base64-encoded string: number of data characters (185) cannot be 1 more than a multiple of 4' when license keys lacked proper base64 padding
   - Root cause: Base64 strings must be a multiple of 4 characters. Some license keys were missing padding characters (=) needed for proper decoding
   - Fix: Added automatic padding before base64 decoding:
     - Calculate padding needed: len(license_key) % 4
     - Add '=' characters to make length a multiple of 4 - This makes license verification robust to keys with or without padding

Both fixes ensure the code handles edge cases properly and tests use correct APIs.

