### PR TITLE
feat: Add gpt-5.1-codex-max model pricing and configuration

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -3316,6 +3316,36 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "azure/gpt-5.1-codex-max": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "azure",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure/gpt-5.1-codex-mini": {
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 2.5e-07,
@@ -16324,6 +16354,36 @@
         "mode": "responses",
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_priority": 2e-05,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "gpt-5.1-codex-max": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/responses"
         ],

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3316,6 +3316,36 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "azure/gpt-5.1-codex-max": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "azure",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure/gpt-5.1-codex-mini": {
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 2.5e-07,
@@ -16324,6 +16354,36 @@
         "mode": "responses",
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_priority": 2e-05,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "gpt-5.1-codex-max": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/responses"
         ],

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -216,6 +216,7 @@ def test_gpt5_1_model_detection(gpt5_config: OpenAIGPT5Config):
     """Test that GPT-5.1 models are correctly detected."""
     assert gpt5_config.is_model_gpt_5_1_model("gpt-5.1")
     assert gpt5_config.is_model_gpt_5_1_model("gpt-5.1-codex")
+    assert gpt5_config.is_model_gpt_5_1_model("gpt-5.1-codex-max")
     assert gpt5_config.is_model_gpt_5_1_model("gpt-5.1-chat")
     assert not gpt5_config.is_model_gpt_5_1_model("gpt-5")
     assert not gpt5_config.is_model_gpt_5_1_model("gpt-5-mini")


### PR DESCRIPTION
## Title

Add gpt-5.1-codex-max model pricing and configuration

## Relevant issues

Closes #16998
Closes #17509

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Add support for OpenAI's **gpt-5.1-codex-max** model - their most intelligent coding model optimized for long-horizon, agentic coding tasks.

### Model Specifications (from [OpenAI docs](https://platform.openai.com/docs/models/gpt-5.1-codex-max)):

| Property | Value |
|----------|-------|
| Context window | 400,000 tokens |
| Max output tokens | 128,000 tokens |
| Input cost | $1.25 / 1M tokens |
| Cached input cost | $0.125 / 1M tokens |
| Output cost | $10.00 / 1M tokens |
| Knowledge cutoff | Sep 30, 2024 |
| Endpoint | /v1/responses only |

### Features supported:
- Vision (text + image input)
- Function calling
- Reasoning tokens
- Prompt caching
- Structured outputs
- Streaming

### Files changed:
- `model_prices_and_context_window.json` - Added `gpt-5.1-codex-max` and `azure/gpt-5.1-codex-max`
- `litellm/model_prices_and_context_window_backup.json` - Same additions
- `tests/test_litellm/llms/openai/test_gpt5_transformation.py` - Added model detection test

### Test passing locally:
```
tests/test_litellm/llms/openai/test_gpt5_transformation.py::test_gpt5_1_model_detection PASSED
```