### PR TITLE
[Bug fix] WatsonX audio transcriptions, don't force content type in request headers

### DIFF
--- a/litellm/llms/watsonx/audio_transcription/transformation.py
+++ b/litellm/llms/watsonx/audio_transcription/transformation.py
@@ -8,7 +8,10 @@ from typing import Any, Dict, List, Optional
 
 import litellm
 from litellm.litellm_core_utils.audio_utils.utils import process_audio_file
-from litellm.types.llms.openai import OpenAIAudioTranscriptionOptionalParams
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    OpenAIAudioTranscriptionOptionalParams,
+)
 from litellm.types.llms.watsonx import WatsonXAudioTranscriptionRequestBody
 from litellm.types.utils import FileTypes
 
@@ -31,6 +34,35 @@ class IBMWatsonXAudioTranscriptionConfig(
     inherits from OpenAIWhisperAudioTranscriptionConfig and uses IBMWatsonXMixin
     for authentication and URL construction.
     """
+
+    def validate_environment(
+        self,
+        headers: Dict,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: Dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> Dict:
+        """
+        Validate environment for audio transcription.
+        
+        Removes Content-Type header so httpx can set multipart/form-data automatically.
+        """
+        result = IBMWatsonXMixin.validate_environment(
+            self,
+            headers=headers,
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            api_key=api_key,
+            api_base=api_base,
+        )
+        # Remove Content-Type so httpx sets multipart/form-data automatically
+        result.pop("Content-Type", None)
+        return result
 
     def get_supported_openai_params(
         self, model: str

--- a/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
@@ -63,6 +63,9 @@ class TestWatsonXAudioTranscription:
         assert "Authorization" in captured_request["headers"]
         assert "Bearer test-bearer-token" in captured_request["headers"]["Authorization"]
         
+        # Validate Content-Type is NOT set (httpx sets multipart/form-data automatically)
+        assert "Content-Type" not in captured_request["headers"]
+        
         # Validate project_id is in form data, not URL
         assert captured_request["data"].get("project_id") == "test-project-123"
         


### PR DESCRIPTION
## [Bug fix] WatsonX audio transcriptions, don't force content type in request headers

WatsonX audio transcription was failing because requests were being sent as JSON instead of multipart/form-data.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


