### PR TITLE
feat: add Mistral Large 3 model support

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5134,6 +5134,19 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "azure_ai/mistral-large-3": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "source": "https://azure.microsoft.com/en-us/blog/introducing-mistral-large-3-in-microsoft-foundry-open-capable-and-ready-for-production-workloads/",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure_ai/mistral-medium-2505": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "azure_ai",
@@ -18684,6 +18697,21 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
+    },
+    "mistral/mistral-large-3": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "source": "https://docs.mistral.ai/models/mistral-large-3-25-12",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "mistral/mistral-medium": {
         "input_cost_per_token": 2.7e-06,


### PR DESCRIPTION
## Title

Add Mistral Large 3 model to model catalog

## Relevant issues

Fixes #17527

## Pre-Submission checklist

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

> Note: No tests needed - this is a model catalog addition only (JSON config). The model uses existing Mistral transformation which already supports vision (via Pixtral models).

## Type

🆕 New Feature

## Changes

Add Mistral Large 3 (675B MoE) to model catalog for both providers:

| Model | Provider | Input | Output | Context |
|-------|----------|-------|--------|---------|
| `mistral/mistral-large-3` | Mistral | $0.50/1M | $1.50/1M | 256k |
| `azure_ai/mistral-large-3` | Azure AI Foundry | $0.50/1M | $1.50/1M | 256k |

**Capabilities enabled:**
- `supports_vision: true` (multimodal)
- `supports_function_calling: true`
- `supports_tool_choice: true`
- `supports_response_schema: true`
- `supports_assistant_prefill: true` (mistral provider)

**Sources:**
- https://docs.mistral.ai/models/mistral-large-3-25-12
- https://azure.microsoft.com/en-us/blog/introducing-mistral-large-3-in-microsoft-foundry-open-capable-and-ready-for-production-workloads/