### PR TITLE
[Fix] Mock server_root_path for v2/login test

### DIFF
--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -91,6 +91,7 @@ def test_login_v2_returns_redirect_url_and_sets_cookie(monkeypatch):
     monkeypatch.setattr("litellm.proxy.proxy_server.general_settings", {})
     monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", False)
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    monkeypatch.setattr("litellm.proxy.utils.get_server_root_path", lambda: "")
 
     client = TestClient(app)
     response = client.post(


### PR DESCRIPTION
## [Fix] Mock server_root_path for v2/login test

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The v2/login redirect_url depends on server_root_path. The current test does not mock the value, leading it to use the actual value and flaky test. Mocking the implementation to stabilize the test.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

✅ Test

## Changes
<img width="797" height="341" alt="image" src="https://github.com/user-attachments/assets/6eed5ce0-8d8a-49b3-8f8f-d8a5582f31a3" />


