### PR TITLE
Fix Cerebras context window errors not recognized

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -82,6 +82,14 @@ class ExceptionCheckers:
         for substring in known_exception_substrings:
             if substring in _error_str_lowercase:
                 return True
+
+        # Cerebras pattern: "Current length is X while limit is Y"
+        if (
+            "current length is" in _error_str_lowercase
+            and "while limit is" in _error_str_lowercase
+        ):
+            return True
+
         return False
     
     @staticmethod

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -42,6 +42,16 @@ context_window_test_cases = [
     ),
     # Test case insensitivity
     ("ERROR: THIS MODEL'S MAXIMUM CONTEXT LENGTH IS 1024.", True),
+    # Cerebras context window error format
+    # See: https://github.com/BerriAI/litellm/issues/XXXX
+    (
+        "Current length is 132784 while limit is 131000",
+        True,
+    ),
+    (
+        "CerebrasException - Please reduce the length of the messages or completion. Current length is 50000 while limit is 40000",
+        True,
+    ),
     # Negative cases (should return False)
     ("A generic API error occurred.", False),
     ("Invalid API Key provided.", False),


### PR DESCRIPTION

## Title

Add detection for Cerebras's context window exceeded error format: "Current length is X while limit is Y"

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ x ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) 
- [ x ] I have added a screenshot of my new test passing locally 
 ![Screenshot 2025-12-06 at 14 44 37](https://github.com/user-attachments/assets/2de32151-a012-4b98-b583-fc0765d8d6e7)

- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

I see a few errors on main on my machine in `ERROR collecting tests/test_litellm/containers/test_container_api.py`which I also see after the patch. 

- [ x ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

 Add detection for Cerebras's context window exceeded error format: "Current length is X while limit is Y"

This ensures LiteLLM raises ContextWindowExceededError instead of generic BadRequestError when Cerebras API calls exceed the model's context limit, enabling downstream libraries like DSPy to properly catch and handle these errors for automatic context management.
