### PR TITLE
Fix: Langfuse logger test mock setup

### DIFF
--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -35,8 +35,11 @@ class TestLangfuseUsageDetails(unittest.TestCase):
 
         # Create mock objects
         self.mock_langfuse_client = MagicMock()
+        # Mock the client attribute to prevent errors during logger initialization
+        self.mock_langfuse_client.client = MagicMock()
         self.mock_langfuse_trace = MagicMock()
         self.mock_langfuse_generation = MagicMock()
+        self.mock_langfuse_generation.trace_id = "test-trace-id"
 
         # Setup the trace and generation chain
         self.mock_langfuse_trace.generation.return_value = self.mock_langfuse_generation
@@ -63,22 +66,13 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         sys.modules["langfuse"] = self.mock_langfuse
         sys.modules["langfuse"].Langfuse = self.mock_langfuse_class
 
-        # Mock the Langfuse client
-        self.mock_langfuse_client = MagicMock()
-        self.mock_langfuse_trace = MagicMock()
-        self.mock_langfuse_generation = MagicMock()
-
-        # Setup the trace and generation chain
-        self.mock_langfuse_trace.generation.return_value = self.mock_langfuse_generation
-        self.mock_langfuse_client.trace.return_value = self.mock_langfuse_trace
-
-        # Mock the Langfuse class
-        self.mock_langfuse_class = MagicMock()
-        self.mock_langfuse_class.return_value = self.mock_langfuse_client
-        self.mock_langfuse.Langfuse = self.mock_langfuse_class
-
         # Create the logger
         self.logger = LangFuseLogger()
+        
+        # Explicitly set the Langfuse client to our mock
+        self.logger.Langfuse = self.mock_langfuse_client
+        # Ensure langfuse_sdk_version is set correctly for _supports_* methods
+        self.logger.langfuse_sdk_version = "3.0.0"
 
         # Add the log_event_on_langfuse method to the instance
         def log_event_on_langfuse(


### PR DESCRIPTION
## Title

Fix: Langfuse logger test mock setup

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Add mock_langfuse_client.client attribute to prevent errors during init
- Add trace_id to mock_langfuse_generation for proper return value handling
- Remove redundant mock setup code
- Explicitly set logger.Langfuse to mock client after initialization
- Set logger.langfuse_sdk_version to ensure _supports_* methods work correctly
