### PR TITLE
Fix: Ensure guardrail metadata is preserved in request_data

### DIFF
--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -385,6 +385,8 @@ def add_guardrail_to_applied_guardrails_header(
         _metadata["applied_guardrails"].append(guardrail_name)
     else:
         _metadata["applied_guardrails"] = [guardrail_name]
+    # Ensure metadata is set back to request_data (important when metadata didn't exist)
+    request_data["metadata"] = _metadata
 
 
 def add_guardrail_response_to_standard_logging_object(


### PR DESCRIPTION
## Title

Fix: Ensure guardrail metadata is preserved in request_data

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Fixed bug in add_guardrail_to_applied_guardrails_header where guardrail information was lost when request_data didn't have a metadata key. The function would create a new metadata dict but never assign it back to request_data, causing the x-litellm-applied-guardrails header to be missing from responses.

This fixes the failing test_guardrails_with_api_key_controls test.

