### PR TITLE
[Feature] UI - Add Info Banner for Customer Usage

### DIFF
--- a/ui/litellm-dashboard/src/components/new_usage.tsx
+++ b/ui/litellm-dashboard/src/components/new_usage.tsx
@@ -92,6 +92,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({
   const [isCloudZeroModalOpen, setIsCloudZeroModalOpen] = useState(false);
   const [isGlobalExportModalOpen, setIsGlobalExportModalOpen] = useState(false);
   const [showOrganizationBanner, setShowOrganizationBanner] = useState(true);
+  const [showCustomerBanner, setShowCustomerBanner] = useState(true);
 
   const getAllTags = async () => {
     if (!accessToken) {
@@ -803,6 +804,17 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({
 
               {/* Customer Usage Panel */}
               <TabPanel>
+                {showCustomerBanner && (
+                  <Alert
+                    banner
+                    type="info"
+                    message="Customer usage is a new feature."
+                    description="Spend is tracked from feature launch and previous data isn't backfilled, so only future usage appears here."
+                    closable
+                    onClose={() => setShowCustomerBanner(false)}
+                    className="mb-5"
+                  />
+                )}
                 <EntityUsage
                   accessToken={accessToken}
                   entityType="customer"


### PR DESCRIPTION
## [Fix] UI - Add Info Banner for Customer Usage

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This PR adds the info banner for customer usage, notifying the user Customer Usage is a new feature, and previous data is not backfilled

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<img width="780" height="254" alt="image" src="https://github.com/user-attachments/assets/17f6a3be-c454-42b7-93e9-df0846cfd1b2" />
<img width="1268" height="183" alt="image" src="https://github.com/user-attachments/assets/5fc0195c-895e-4636-ae64-669f53863738" />

