### PR TITLE
feat: add script to create branches with litellm_ prefix

### DIFF
--- a/scripts/create_litellm_branch.ps1
+++ b/scripts/create_litellm_branch.ps1
@@ -1,0 +1,134 @@
+# PowerShell script to create a branch with litellm_ prefix from a contributor's branch
+# Usage: .\create_litellm_branch.ps1 [source_branch] [new_branch_name]
+# If no arguments provided, uses current branch as source
+
+param(
+    [string]$SourceBranch = "",
+    [string]$NewBranchName = ""
+)
+
+# Function to print colored output
+function Write-Info {
+    param([string]$Message)
+    Write-Host "ℹ $Message" -ForegroundColor Cyan
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "✓ $Message" -ForegroundColor Green
+}
+
+function Write-Warning {
+    param([string]$Message)
+    Write-Host "⚠ $Message" -ForegroundColor Yellow
+}
+
+function Write-Error {
+    param([string]$Message)
+    Write-Host "✗ $Message" -ForegroundColor Red
+}
+
+# Get source branch (default to current branch)
+if ([string]::IsNullOrEmpty($SourceBranch)) {
+    $SourceBranch = git branch --show-current
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to get current branch"
+        exit 1
+    }
+}
+
+# Get new branch name
+if ([string]::IsNullOrEmpty($NewBranchName)) {
+    $NewBranchName = $SourceBranch
+}
+
+# Remove litellm_ prefix if it already exists
+if ($NewBranchName -like "litellm_*") {
+    $NewBranchName = $NewBranchName -replace "^litellm_", ""
+    Write-Warning "Removed existing litellm_ prefix from branch name"
+}
+
+# Add litellm_ prefix
+$NewBranchName = "litellm_$NewBranchName"
+
+# Validate branch name (Git branch naming rules)
+if ($NewBranchName -notmatch '^[a-zA-Z0-9/._-]+$') {
+    Write-Error "Invalid branch name: $NewBranchName"
+    Write-Info "Branch names can only contain alphanumeric characters, /, ., _, and -"
+    exit 1
+}
+
+# Check if source branch exists
+$sourceExists = $false
+git show-ref --verify --quiet "refs/heads/$SourceBranch" 2>$null
+if ($LASTEXITCODE -eq 0) {
+    $sourceExists = $true
+} else {
+    git show-ref --verify --quiet "refs/remotes/origin/$SourceBranch" 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        $sourceExists = $true
+    }
+}
+
+if (-not $sourceExists) {
+    Write-Error "Source branch '$SourceBranch' does not exist locally or remotely"
+    exit 1
+}
+
+# Check if new branch already exists
+git show-ref --verify --quiet "refs/heads/$NewBranchName" 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Warning "Branch '$NewBranchName' already exists locally"
+    $response = Read-Host "Do you want to switch to it? (y/n)"
+    if ($response -eq 'y' -or $response -eq 'Y') {
+        git checkout $NewBranchName
+        if ($LASTEXITCODE -eq 0) {
+            Write-Success "Switched to existing branch '$NewBranchName'"
+        } else {
+            Write-Error "Failed to switch to branch '$NewBranchName'"
+            exit 1
+        }
+        exit 0
+    } else {
+        Write-Info "Aborted"
+        exit 1
+    }
+}
+
+# Check if we're on the source branch or need to fetch it
+$CurrentBranch = git branch --show-current
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to get current branch"
+    exit 1
+}
+
+if ($CurrentBranch -ne $SourceBranch) {
+    # Check if source branch exists locally
+    git show-ref --verify --quiet "refs/heads/$SourceBranch" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Info "Fetching source branch '$SourceBranch' from remote..."
+        git fetch origin "$SourceBranch`:$SourceBranch"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to fetch branch '$SourceBranch' from remote"
+            exit 1
+        }
+    }
+}
+
+# Create new branch from source
+Write-Info "Creating branch '$NewBranchName' from '$SourceBranch'..."
+git checkout -b $NewBranchName $SourceBranch
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to create branch '$NewBranchName'"
+    exit 1
+}
+
+Write-Success "Created and switched to branch '$NewBranchName'"
+Write-Info "Source branch: $SourceBranch"
+Write-Info "New branch: $NewBranchName"
+
+# Show branch status
+Write-Host ""
+Write-Info "Branch status:"
+git status --short
+

--- a/scripts/create_litellm_branch.sh
+++ b/scripts/create_litellm_branch.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# Script to create a branch with litellm_ prefix from a contributor's branch
+# Usage: ./create_litellm_branch.sh [source_branch] [new_branch_name]
+# If no arguments provided, uses current branch as source
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_info() {
+    echo -e "${BLUE}ℹ${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}✗${NC} $1"
+}
+
+# Get source branch (default to current branch)
+SOURCE_BRANCH="${1:-$(git branch --show-current)}"
+
+# Get new branch name
+if [ -n "$2" ]; then
+    NEW_BRANCH_NAME="$2"
+else
+    # Auto-generate from source branch name
+    NEW_BRANCH_NAME="$SOURCE_BRANCH"
+fi
+
+# Remove litellm_ prefix if it already exists
+if [[ "$NEW_BRANCH_NAME" == litellm_* ]]; then
+    NEW_BRANCH_NAME="${NEW_BRANCH_NAME#litellm_}"
+    print_warning "Removed existing litellm_ prefix from branch name"
+fi
+
+# Add litellm_ prefix
+NEW_BRANCH_NAME="litellm_${NEW_BRANCH_NAME}"
+
+# Validate branch name (Git branch naming rules)
+if ! [[ "$NEW_BRANCH_NAME" =~ ^[a-zA-Z0-9/._-]+$ ]]; then
+    print_error "Invalid branch name: $NEW_BRANCH_NAME"
+    print_info "Branch names can only contain alphanumeric characters, /, ., _, and -"
+    exit 1
+fi
+
+# Check if source branch exists
+if ! git show-ref --verify --quiet refs/heads/"$SOURCE_BRANCH" && ! git show-ref --verify --quiet refs/remotes/origin/"$SOURCE_BRANCH"; then
+    print_error "Source branch '$SOURCE_BRANCH' does not exist locally or remotely"
+    exit 1
+fi
+
+# Check if new branch already exists
+if git show-ref --verify --quiet refs/heads/"$NEW_BRANCH_NAME"; then
+    print_warning "Branch '$NEW_BRANCH_NAME' already exists locally"
+    read -p "Do you want to switch to it? (y/n) " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        git checkout "$NEW_BRANCH_NAME"
+        print_success "Switched to existing branch '$NEW_BRANCH_NAME'"
+        exit 0
+    else
+        print_info "Aborted"
+        exit 1
+    fi
+fi
+
+# Check if we're on the source branch or need to fetch it
+CURRENT_BRANCH=$(git branch --show-current)
+
+if [ "$CURRENT_BRANCH" != "$SOURCE_BRANCH" ]; then
+    # Check if source branch exists locally
+    if git show-ref --verify --quiet refs/heads/"$SOURCE_BRANCH"; then
+        print_info "Source branch '$SOURCE_BRANCH' exists locally"
+    else
+        print_info "Fetching source branch '$SOURCE_BRANCH' from remote..."
+        git fetch origin "$SOURCE_BRANCH":"$SOURCE_BRANCH" || {
+            print_error "Failed to fetch branch '$SOURCE_BRANCH' from remote"
+            exit 1
+        }
+    fi
+fi
+
+# Create new branch from source
+print_info "Creating branch '$NEW_BRANCH_NAME' from '$SOURCE_BRANCH'..."
+git checkout -b "$NEW_BRANCH_NAME" "$SOURCE_BRANCH"
+
+print_success "Created and switched to branch '$NEW_BRANCH_NAME'"
+print_info "Source branch: $SOURCE_BRANCH"
+print_info "New branch: $NEW_BRANCH_NAME"
+
+# Show branch status
+echo
+print_info "Branch status:"
+git status --short
+


### PR DESCRIPTION
## Title

feat: add script to create branches with litellm_ prefix

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

✅ Test

## Changes

Add utility scripts to create branches with litellm_ prefix from contributor branches. This helps maintain consistent branch naming conventions for CI/CD.

- scripts/create_litellm_branch.sh (Bash for macOS/Linux)
- scripts/create_litellm_branch.ps1 (PowerShell for Windows)

## Usage

**Linux/Mac:**
```bash
./scripts/create_litellm_branch.sh [source_branch] [new_branch_name]
# Example:
./scripts/create_litellm_branch.sh main feature/new-guardrails
```

**Windows (PowerShell):**
```powershell
./scripts/create_litellm_branch.ps1 [source_branch] [new_branch_name]
# Example:
./scripts/create_litellm_branch.ps1 main feature/new-guardrails
```

Features:
- Auto-prefixes branch names with litellm_
- Handles existing branches gracefully
- Validates branch names
- Supports local and remote source branches
