### PR TITLE
fix: resolve UI session MCP permissions across real teams

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
@@ -1,0 +1,86 @@
+"""Helpers to resolve real team contexts for UI session tokens."""
+
+from __future__ import annotations
+
+from typing import List
+
+from litellm._logging import verbose_logger
+from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+def clone_user_api_key_auth_with_team(
+    user_api_key_auth: UserAPIKeyAuth,
+    team_id: str,
+) -> UserAPIKeyAuth:
+    """Return a deep copy of the auth context with a different team id."""
+
+    try:
+        cloned_auth = user_api_key_auth.model_copy(deep=True)
+    except AttributeError:
+        cloned_auth = user_api_key_auth.copy(deep=True)  # type: ignore[attr-defined]
+    cloned_auth.team_id = team_id
+    return cloned_auth
+
+
+async def resolve_ui_session_team_ids(
+    user_api_key_auth: UserAPIKeyAuth,
+) -> List[str]:
+    """Resolve the real team ids backing a UI session token."""
+
+    if (
+        user_api_key_auth.team_id != UI_SESSION_TOKEN_TEAM_ID
+        or not user_api_key_auth.user_id
+    ):
+        return []
+
+    from litellm.proxy.auth.auth_checks import get_user_object
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
+
+    if prisma_client is None:
+        verbose_logger.debug("Cannot resolve UI session team ids without DB access")
+        return []
+
+    try:
+        user_obj = await get_user_object(
+            user_id=user_api_key_auth.user_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            user_id_upsert=False,
+            parent_otel_span=user_api_key_auth.parent_otel_span,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging
+        verbose_logger.warning(
+            "Failed to load teams for UI session token user=%s: %s",
+            user_api_key_auth.user_id,
+            exc,
+        )
+        return []
+
+    if user_obj is None or not user_obj.teams:
+        return []
+
+    resolved_team_ids: List[str] = []
+    for team_id in user_obj.teams:
+        if team_id and team_id not in resolved_team_ids:
+            resolved_team_ids.append(team_id)
+    return resolved_team_ids
+
+
+async def build_effective_auth_contexts(
+    user_api_key_auth: UserAPIKeyAuth,
+) -> List[UserAPIKeyAuth]:
+    """Return auth contexts that reflect the actual teams for UI session tokens."""
+
+    resolved_team_ids = await resolve_ui_session_team_ids(user_api_key_auth)
+    if resolved_team_ids:
+        return [
+            clone_user_api_key_auth_with_team(user_api_key_auth, team_id)
+            for team_id in resolved_team_ids
+        ]
+    return [user_api_key_auth]

--- a/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
@@ -56,8 +56,7 @@ async def resolve_ui_session_team_ids(
         )
     except Exception as exc:  # pragma: no cover - defensive logging
         verbose_logger.warning(
-            "Failed to load teams for UI session token user=%s: %s",
-            user_api_key_auth.user_id,
+            "Failed to load teams for UI session token user.",
             exc,
         )
         return []

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
@@ -1,0 +1,92 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+from litellm.proxy._types import UserAPIKeyAuth
+
+from litellm.proxy._experimental.mcp_server.ui_session_utils import (
+    build_effective_auth_contexts,
+    clone_user_api_key_auth_with_team,
+    resolve_ui_session_team_ids,
+)
+
+
+def test_clone_user_api_key_auth_with_team_creates_independent_copy():
+    original = UserAPIKeyAuth(team_id="team-original", user_id="user-123")
+
+    cloned = clone_user_api_key_auth_with_team(original, "team-override")
+
+    assert cloned is not original
+    assert cloned.team_id == "team-override"
+    assert original.team_id == "team-original"
+
+
+@pytest.mark.asyncio
+async def test_resolve_ui_session_team_ids_returns_unique_ids(monkeypatch):
+    user_auth = UserAPIKeyAuth(
+        team_id=UI_SESSION_TOKEN_TEAM_ID,
+        user_id="user-1",
+    )
+
+    fake_user = SimpleNamespace(
+        teams=["team-a", "team-b", "team-a", "", None, "team-c"]
+    )
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        AsyncMock(return_value=fake_user),
+    )
+
+    import litellm.proxy.proxy_server as proxy_server
+
+    monkeypatch.setattr(proxy_server, "prisma_client", object())
+    monkeypatch.setattr(proxy_server, "proxy_logging_obj", None)
+    monkeypatch.setattr(proxy_server, "user_api_key_cache", None)
+
+    team_ids = await resolve_ui_session_team_ids(user_auth)
+
+    assert team_ids == ["team-a", "team-b", "team-c"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_ui_session_team_ids_short_circuits_when_not_ui_session():
+    normal_user = UserAPIKeyAuth(team_id="regular-team", user_id="user-1")
+
+    result = await resolve_ui_session_team_ids(normal_user)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_build_effective_auth_contexts_returns_cloned_contexts(monkeypatch):
+    user_auth = UserAPIKeyAuth(team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="user-42")
+
+    mock_resolve = AsyncMock(return_value=["team-one", "team-two"])
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.ui_session_utils.resolve_ui_session_team_ids",
+        mock_resolve,
+    )
+
+    contexts = await build_effective_auth_contexts(user_auth)
+
+    assert [ctx.team_id for ctx in contexts] == ["team-one", "team-two"]
+    assert all(ctx is not user_auth for ctx in contexts)
+    mock_resolve.assert_awaited_once_with(user_auth)
+
+
+@pytest.mark.asyncio
+async def test_build_effective_auth_contexts_returns_original_when_no_resolution(monkeypatch):
+    user_auth = UserAPIKeyAuth(team_id="existing-team", user_id="user-7")
+
+    mock_resolve = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.ui_session_utils.resolve_ui_session_team_ids",
+        mock_resolve,
+    )
+
+    contexts = await build_effective_auth_contexts(user_auth)
+
+    assert contexts == [user_auth]
+    mock_resolve.assert_awaited_once_with(user_auth)
+


### PR DESCRIPTION
## Title

fix: resolve UI session MCP permissions across real teams

## Relevant issues

Related #17360

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes

@krrishdholakia 
I limited the change to mcp_management_endpoints.py to reduce the risk and impact.
Is this aligned with what you had in mind?

### Details of the approach
I considered three possible strategies for this fix:

1. Determine the actual team directly inside `user_api_key_auth_mcp.py` (#17360)
However, as you pointed out earlier, this approach touches multiple MCP call paths and introduces higher risk.

2. Add something like `team_mcp_servers` to user_api_key_dict, similar to `/model/info`
This would require modifying the logic for populating user_api_key_dict, which also affects many areas — making it a riskier change.

3. Fetch the actual team inside the endpoint (like `/v2/model/info`) — this PR
References:
https://github.com/BerriAI/litellm/blob/4eb9f8036f16a286618f0783f8bef075daf64246/litellm/proxy/proxy_server.py#L7111
https://github.com/BerriAI/litellm/blob/4eb9f8036f16a286618f0783f8bef075daf64246/litellm/proxy/proxy_server.py#L7002

For this PR, I chose option 3 since `mcp_management_endpoints.py` is only called from the UI — keeping the impact surface small.
Additionally, the actual DB fetch logic is placed in `ui_session_utils`, making it reusable if REST-based MCP calls require it in the future.