### PR TITLE
[Feature] Logs Spend Enhancements

### DIFF
--- a/ui/litellm-dashboard/src/components/entity_usage.test.tsx
+++ b/ui/litellm-dashboard/src/components/entity_usage.test.tsx
@@ -245,9 +245,9 @@ describe("EntityUsage", () => {
       expect(mockTagDailyActivityCall).toHaveBeenCalled();
     });
 
-    await waitFor(() => {
-      expect(screen.getByText("$0.00")).toBeInTheDocument();
-      expect(screen.getByText("Total Spend")).toBeInTheDocument();
-    });
+    expect(await screen.findByText("Tag Spend Overview")).toBeInTheDocument();
+    expect(await screen.findByText("$-")).toBeInTheDocument();
+    expect(screen.getByText("Total Spend")).toBeInTheDocument();
+    expect(screen.getAllByText("0")[0]).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/new_usage.tsx
+++ b/ui/litellm-dashboard/src/components/new_usage.tsx
@@ -424,7 +424,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({
       <div className="flex items-end justify-between gap-6 mb-6">
         <div className="flex-1">
           <TabGroup>
-            <div className="flex items-end justify-start gap-6 mb-6">
+            <div className="flex items-end justify-between gap-6 mb-6 w-full">
               <TabList variant="solid">
                 {all_admin_roles.includes(userRole || "") ? <Tab>Global Usage</Tab> : <Tab>Your Usage</Tab>}
                 {all_admin_roles.includes(userRole || "") ? (

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -1,10 +1,10 @@
+import { getSpendString } from "@/utils/dataUtils";
 import type { ColumnDef } from "@tanstack/react-table";
+import { Badge, Button } from "@tremor/react";
+import { Tooltip } from "antd";
 import React, { useState } from "react";
 import { getProviderLogoAndName } from "../provider_info_helpers";
-import { Tooltip } from "antd";
 import { TimeCell } from "./time_cell";
-import { Button, Badge } from "@tremor/react";
-import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 // Helper to get the appropriate logo URL
 const getLogoUrl = (row: LogEntry, provider: string) => {
@@ -145,7 +145,11 @@ export const columns: ColumnDef<LogEntry>[] = [
   {
     header: "Cost",
     accessorKey: "spend",
-    cell: (info: any) => <span>${formatNumberWithCommas(info.getValue() || 0, 6)}</span>,
+    cell: (info: any) => (
+      <Tooltip title={`$${String(info.getValue() || 0)} `}>
+        <span>{getSpendString(info.getValue() || 0)}</span>
+      </Tooltip>
+    ),
   },
   {
     header: "Duration (s)",

--- a/ui/litellm-dashboard/src/utils/dataUtils.ts
+++ b/ui/litellm-dashboard/src/utils/dataUtils.ts
@@ -17,7 +17,7 @@ export const formatNumberWithCommas = (
   decimals: number = 0,
   abbreviate: boolean = false,
 ): string => {
-  if (value === null || value === undefined || !Number.isFinite(value)) {
+  if (value === null || value === undefined || !Number.isFinite(value) || value === 0) {
     return "-";
   }
 
@@ -44,6 +44,22 @@ export const formatNumberWithCommas = (
   }
 
   return `${sign}${scaled.toLocaleString("en-US", opts)}${suffix}`;
+};
+
+export const getSpendString = (value: number | null | undefined, decimals: number = 6): string => {
+  if (value === null || value === undefined || !Number.isFinite(value) || value === 0) {
+    return "-";
+  }
+
+  const formatted = formatNumberWithCommas(value, decimals);
+  const numericFormatted = Number(formatted.replace(/,/g, ""));
+
+  if (numericFormatted === 0) {
+    const threshold = (1 / 10 ** decimals).toFixed(decimals);
+    return `< $${threshold}`;
+  }
+
+  return `$${formatted}`;
 };
 
 export const copyToClipboard = async (


### PR DESCRIPTION
## [Feature] Logs Spend Enhancements

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The current spend log spend field truncates the spend to 6 digits precision. This was an issue for minuscule spend that was less than this threshold, so the spend will show $0.00000, which can be interpreted as no spend, which is inaccurate. This PR changes the display from $0.00000 to < $0.00001 to tell the user the spend is tracked. Hovering on the spend values will show a tooltip of the raw spend value from the backend. 0 Spend is now shown as "-" for distinction

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<img width="274" height="162" alt="Screenshot 2025-12-06 at 4 19 38 PM" src="https://github.com/user-attachments/assets/5d955f10-9f20-4aff-a0ed-db202d2aadd1" />
<img width="275" height="305" alt="image" src="https://github.com/user-attachments/assets/2bbd9a6b-821b-49c4-8b5b-3773e5739fb4" />

