### PR TITLE
[Fix] Fix links + old login page deprecation message

### DIFF
--- a/litellm/proxy/common_utils/html_forms/ui_login.py
+++ b/litellm/proxy/common_utils/html_forms/ui_login.py
@@ -1,10 +1,13 @@
 import os
 
+from litellm.proxy.utils import get_custom_url
+
 url_to_redirect_to = os.getenv("PROXY_BASE_URL", "")
 server_root_path = os.getenv("SERVER_ROOT_PATH", "")
 if server_root_path != "":
     url_to_redirect_to += server_root_path
 url_to_redirect_to += "/login"
+new_ui_login_url = get_custom_url("", "ui/login")
 html_form = f"""
 <!DOCTYPE html>
 <html lang="en">
@@ -185,10 +188,32 @@ html_form = f"""
             margin-top: -12px;
             margin-bottom: 20px;
         }}
+
+        .deprecation-banner {{
+            background-color: #fee2e2;
+            border: 1px solid #ef4444;
+            color: #991b1b;
+            padding: 14px 16px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            font-size: 14px;
+            line-height: 1.5;
+        }}
+
+        .deprecation-banner a {{
+            color: #991b1b;
+            font-weight: 600;
+            text-decoration: underline;
+        }}
     </style>
 </head>
 <body>
     <form action="{url_to_redirect_to}" method="post">
+        <div class="deprecation-banner">
+            <strong>Deprecated:</strong> Logging in with username and password on this page is deprecated.
+            Please use the <a href="{new_ui_login_url}">new login page</a> instead.
+            This page will be dedicated to signing in via SSO in the future.
+        </div>
         <div class="logo-container">
             <div class="logo">
                 🚅 LiteLLM

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -568,7 +568,7 @@ ui_message = (
 )
 ui_message += "\n\n💸 [```LiteLLM Model Cost Map```](https://models.litellm.ai/)."
 
-ui_message += f"\n\n🔎 [```LiteLLM Model Hub```]({model_hub_link}). See available models on the proxy. [**Docs**](https://docs.litellm.ai/docs/proxy/model_hub)"
+ui_message += f"\n\n🔎 [```LiteLLM Model Hub```]({model_hub_link}). See available models on the proxy. [**Docs**](https://docs.litellm.ai/docs/proxy/ai_hub)"
 
 custom_swagger_message = "[**Customize Swagger Docs**](https://docs.litellm.ai/docs/proxy/enterprise#swagger-docs---custom-routes--branding)"
 


### PR DESCRIPTION
## [Fix] Fix links + old login page deprecation message

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Fixed the Docs link that pointed to the old model_hub page, the page has been renamed to ai_hub. Add a deprecation message to /sso/key/generate for logging in via this page using username and password.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

<img width="798" height="159" alt="image" src="https://github.com/user-attachments/assets/e2246566-ac2a-4014-a52d-cb27c1f74f13" />
<img width="579" height="809" alt="image" src="https://github.com/user-attachments/assets/3d759b99-7b9f-4b74-87dd-426403056089" />

