### PR TITLE
fix: Return 403 exception when calling GET responses api

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -402,13 +402,14 @@ def _allowed_routes_check(user_route: str, allowed_routes: list) -> bool:
     - user_route: str - the route the user is trying to call
     - allowed_routes: List[str|LiteLLMRoutes] - the list of allowed routes for the user.
     """
+    from starlette.routing import compile_path
 
     for allowed_route in allowed_routes:
-        if (
-            allowed_route in LiteLLMRoutes.__members__
-            and user_route in LiteLLMRoutes[allowed_route].value
-        ):
-            return True
+        if allowed_route in LiteLLMRoutes.__members__:
+            for template in LiteLLMRoutes[allowed_route].value:
+                regex, _, _ = compile_path(template)
+                if regex.match(user_route):
+                    return True
         elif allowed_route == user_route:
             return True
     return False


### PR DESCRIPTION
## Title

Fix: Return 403 exception when calling GET responses api

## Relevant issues

"Fixes #17628 "

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
https://github.com/BerriAI/litellm/blob/321ffd7258dc283134660dc97e67d74b5fdd89d2/litellm/proxy/auth/auth_checks.py#L409
The condition in this line is for an exact match, but it doesn't consider values ​​defined using templates, such as responses apis(GET).
https://github.com/BerriAI/litellm/blob/321ffd7258dc283134660dc97e67d74b5fdd89d2/litellm/proxy/_types.py#L332-L337


