### PR TITLE
Native Webhook Integration Sumologic

### DIFF
--- a/litellm/integrations/generic_api/generic_api_compatible_callbacks.json
+++ b/litellm/integrations/generic_api/generic_api_compatible_callbacks.json
@@ -16,5 +16,12 @@
             "Authorization": "Bearer {{environment_variables.RUBRIK_API_KEY}}"
         },
         "environment_variables": ["RUBRIK_API_KEY", "RUBRIK_WEBHOOK_URL"]
+    },
+    "sumologic": {
+        "endpoint": "{{environment_variables.SUMOLOGIC_WEBHOOK_URL}}",
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "environment_variables": ["SUMOLOGIC_WEBHOOK_URL"]
     }
 }


### PR DESCRIPTION
## Fix: Support generic_api_compatible_callbacks.json + Add SumoLogic integration

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
<img width="1551" height="639" alt="Screenshot 2025-12-07 at 7 58 50 PM" src="https://github.com/user-attachments/assets/653bb9b1-2f4c-4117-9ebc-9554fa0d93a7" />

- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix
🆕 New Feature

## Changes

### Bug Fix

**Problem:**
The `_add_custom_callback_generic_api_str()` function in `litellm/litellm_core_utils/logging_callback_manager.py` only checked `litellm.callback_settings` for callbacks, completely ignoring callbacks defined in `generic_api_compatible_callbacks.json`. This meant the documented contribution workflow (just adding a callback to the JSON file and using `callbacks: ["name"]`) didn't work - it would fail with `ImportError: Could not find module file`.

**Root Cause:**
Documentation contradiction between:
- **Contribution guide** (`docs/my-website/docs/contribute_integration/custom_webhook_api.md`): Says you only need to add to JSON and use `callbacks: ["rubrik"]`

**Solution:**
Modified `_add_custom_callback_generic_api_str()` to:
1. First check `callback_settings` (existing behavior - no breaking changes)
2. Then check `generic_api_compatible_callbacks.json` using `is_callback_compatible()`
3. If found in JSON, create `GenericAPILogger(callback_name=callback)` with caching

### New Feature: SumoLogic Integration

Added native SumoLogic HTTP Source webhook integration to `generic_api_compatible_callbacks.json`:
- Simple configuration: just `callbacks: ["sumologic"]` + `SUMOLOGIC_WEBHOOK_URL` env var
- No separate API key required (auth is embedded in the SumoLogic URL)
- Sends [LiteLLM Standard Logging Payload](https://docs.litellm.ai/docs/proxy/logging_spec)

### Testing

Added 3 comprehensive unit tests in `tests/litellm_utils_tests/test_logging_callback_manager.py`:
1. `test_generic_api_compatible_callbacks_json()` - Verifies SumoLogic loads from JSON correctly
2. `test_generic_api_compatible_callbacks_json_rubrik()` - Verifies Rubrik with API key works
3. `test_generic_api_compatible_callbacks_json_unknown_callback()` - Verifies graceful fallback for unknown callbacks

## Files Modified

- `litellm/litellm_core_utils/logging_callback_manager.py` - Fixed callback loading logic
- `litellm/integrations/generic_api/generic_api_compatible_callbacks.json` - Added SumoLogic entry
- `tests/litellm_utils_tests/test_logging_callback_manager.py` - Added 4 unit tests

## Usage Example

After this fix, users can now use SumoLogic (or any callback in the JSON) simply:

```yaml
litellm_settings:
  callbacks: ["sumologic"]

environment_variables:
  SUMOLOGIC_WEBHOOK_URL: https://collectors.sumologic.com/receiver/v1/http/your-token-here
  
  
  