### PR TITLE
Add New Bedrock OSS Models to Model List

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -270,6 +270,7 @@
         "supports_vision": true
     },
     "amazon.nova-2-lite-v1:0": {
+        "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
@@ -286,7 +287,8 @@
         "supports_vision": true
     },
     "apac.amazon.nova-2-lite-v1:0": {
-        "input_cost_per_token": 6e-08,
+        "cache_read_input_token_cost": 8.25e-08,
+        "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
@@ -302,7 +304,8 @@
         "supports_vision": true
     },
     "eu.amazon.nova-2-lite-v1:0": {
-        "input_cost_per_token": 6e-08,
+        "cache_read_input_token_cost": 8.25e-08,
+        "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
@@ -318,7 +321,8 @@
         "supports_vision": true
     },
     "us.amazon.nova-2-lite-v1:0": {
-        "input_cost_per_token": 6e-08,
+        "cache_read_input_token_cost": 8.25e-08,
+        "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
@@ -15016,6 +15020,23 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
+    },
+    "global.amazon.nova-2-lite-v1:0": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_video_input": true,
+        "supports_vision": true
     },
     "gpt-3.5-turbo": {
         "input_cost_per_token": 0.5e-06,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14897,6 +14897,39 @@
             "video"
         ]
     },
+    "google.gemma-3-12b-it": {
+        "input_cost_per_token": 9e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.9e-07,
+        "supports_system_messages": true,
+        "supports_vision": true
+    },
+    "google.gemma-3-27b-it": {
+        "input_cost_per_token": 2.3e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 3.8e-07,
+        "supports_system_messages": true,
+        "supports_vision": true
+    },
+    "google.gemma-3-4b-it": {
+        "input_cost_per_token": 4e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 8e-08,
+        "supports_system_messages": true,
+        "supports_vision": true
+    },
     "google_pse/search": {
         "input_cost_per_query": 0.005,
         "litellm_provider": "google_pse",
@@ -18517,6 +18550,61 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "minimax.minimax-m2": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_system_messages": true
+    },
+    "mistral.magistral-small-2509": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true
+    },
+    "mistral.ministral-3-14b-instruct": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
+    "mistral.ministral-3-3b-instruct": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
+    "mistral.ministral-3-8b-instruct": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
     "mistral.mistral-7b-instruct-v0:2": {
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock",
@@ -18548,6 +18636,17 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "mistral.mistral-large-3-675b-instruct": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
     "mistral.mistral-small-2402-v1:0": {
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock",
@@ -18567,6 +18666,28 @@
         "mode": "chat",
         "output_cost_per_token": 7e-07,
         "supports_tool_choice": true
+    },
+    "mistral.voxtral-mini-3b-2507": {
+        "input_cost_per_token": 4e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 4e-08,
+        "supports_audio_input": true,
+        "supports_system_messages": true
+    },
+    "mistral.voxtral-small-24b-2507": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 3e-07,
+        "supports_audio_input": true,
+        "supports_system_messages": true
     },
     "mistral/codestral-2405": {
         "input_cost_per_token": 1e-06,
@@ -19034,6 +19155,17 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
+    },
+    "moonshot.kimi-k2-thinking": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "supports_reasoning": true,
+        "supports_system_messages": true
     },
     "moonshot/kimi-k2-0711-preview": {
         "cache_read_input_token_cost": 1.5e-07,
@@ -19514,6 +19646,27 @@
         "supported_endpoints": [
             "/v1/images/generations"
         ]
+    },
+    "nvidia.nemotron-nano-12b-v2": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_system_messages": true,
+        "supports_vision": true
+    },
+    "nvidia.nemotron-nano-9b-v2": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.3e-07,
+        "supports_system_messages": true
     },
     "o1": {
         "cache_read_input_token_cost": 7.5e-06,
@@ -20499,6 +20652,26 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
+    },
+    "openai.gpt-oss-safeguard-120b": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_system_messages": true
+    },
+    "openai.gpt-oss-safeguard-20b": {
+        "input_cost_per_token": 7e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "supports_system_messages": true
     },
     "openrouter/anthropic/claude-2": {
         "input_cost_per_token": 1.102e-05,
@@ -22430,6 +22603,29 @@
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
+    },
+    "qwen.qwen3-next-80b-a3b": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
+    "qwen.qwen3-vl-235b-a22b": {
+        "input_cost_per_token": 5.3e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.66e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_vision": true
     },
     "recraft/recraftv2": {
         "litellm_provider": "recraft",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -270,6 +270,7 @@
         "supports_vision": true
     },
     "amazon.nova-2-lite-v1:0": {
+        "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
@@ -286,7 +287,8 @@
         "supports_vision": true
     },
     "apac.amazon.nova-2-lite-v1:0": {
-        "input_cost_per_token": 6e-08,
+        "cache_read_input_token_cost": 8.25e-08,
+        "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
@@ -302,7 +304,8 @@
         "supports_vision": true
     },
     "eu.amazon.nova-2-lite-v1:0": {
-        "input_cost_per_token": 6e-08,
+        "cache_read_input_token_cost": 8.25e-08,
+        "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
@@ -318,7 +321,8 @@
         "supports_vision": true
     },
     "us.amazon.nova-2-lite-v1:0": {
-        "input_cost_per_token": 6e-08,
+        "cache_read_input_token_cost": 8.25e-08,
+        "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
@@ -15016,6 +15020,23 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
+    },
+    "global.amazon.nova-2-lite-v1:0": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_video_input": true,
+        "supports_vision": true
     },
     "gpt-3.5-turbo": {
         "input_cost_per_token": 0.5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14897,6 +14897,39 @@
             "video"
         ]
     },
+    "google.gemma-3-12b-it": {
+        "input_cost_per_token": 9e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.9e-07,
+        "supports_system_messages": true,
+        "supports_vision": true
+    },
+    "google.gemma-3-27b-it": {
+        "input_cost_per_token": 2.3e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 3.8e-07,
+        "supports_system_messages": true,
+        "supports_vision": true
+    },
+    "google.gemma-3-4b-it": {
+        "input_cost_per_token": 4e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 8e-08,
+        "supports_system_messages": true,
+        "supports_vision": true
+    },
     "google_pse/search": {
         "input_cost_per_query": 0.005,
         "litellm_provider": "google_pse",
@@ -18517,6 +18550,61 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "minimax.minimax-m2": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_system_messages": true
+    },
+    "mistral.magistral-small-2509": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true
+    },
+    "mistral.ministral-3-14b-instruct": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
+    "mistral.ministral-3-3b-instruct": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
+    "mistral.ministral-3-8b-instruct": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
     "mistral.mistral-7b-instruct-v0:2": {
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock",
@@ -18548,6 +18636,17 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "mistral.mistral-large-3-675b-instruct": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
     "mistral.mistral-small-2402-v1:0": {
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock",
@@ -18567,6 +18666,28 @@
         "mode": "chat",
         "output_cost_per_token": 7e-07,
         "supports_tool_choice": true
+    },
+    "mistral.voxtral-mini-3b-2507": {
+        "input_cost_per_token": 4e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 4e-08,
+        "supports_audio_input": true,
+        "supports_system_messages": true
+    },
+    "mistral.voxtral-small-24b-2507": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 3e-07,
+        "supports_audio_input": true,
+        "supports_system_messages": true
     },
     "mistral/codestral-2405": {
         "input_cost_per_token": 1e-06,
@@ -19034,6 +19155,17 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
+    },
+    "moonshot.kimi-k2-thinking": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "supports_reasoning": true,
+        "supports_system_messages": true
     },
     "moonshot/kimi-k2-0711-preview": {
         "cache_read_input_token_cost": 1.5e-07,
@@ -19514,6 +19646,27 @@
         "supported_endpoints": [
             "/v1/images/generations"
         ]
+    },
+    "nvidia.nemotron-nano-12b-v2": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_system_messages": true,
+        "supports_vision": true
+    },
+    "nvidia.nemotron-nano-9b-v2": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.3e-07,
+        "supports_system_messages": true
     },
     "o1": {
         "cache_read_input_token_cost": 7.5e-06,
@@ -20499,6 +20652,26 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
+    },
+    "openai.gpt-oss-safeguard-120b": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_system_messages": true
+    },
+    "openai.gpt-oss-safeguard-20b": {
+        "input_cost_per_token": 7e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "supports_system_messages": true
     },
     "openrouter/anthropic/claude-2": {
         "input_cost_per_token": 1.102e-05,
@@ -22430,6 +22603,29 @@
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
+    },
+    "qwen.qwen3-next-80b-a3b": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
+    "qwen.qwen3-vl-235b-a22b": {
+        "input_cost_per_token": 5.3e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.66e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_vision": true
     },
     "recraft/recraftv2": {
         "litellm_provider": "recraft",


### PR DESCRIPTION
## Title

Adding the following new OSS models announced at re:Invent. 

Also fixing the pricing for global & geo/regional endpoints for the new amazon.nova-2-lite model

## New Bedrock Models Added

### Mistral Models
- `mistral.ministral-3-3b-instruct`
- `mistral.ministral-3-8b-instruct`
- `mistral.ministral-3-14b-instruct`
- `mistral.mistral-large-3-675b-instruct`
- `mistral.magistral-small-2509`
- `mistral.voxtral-mini-3b-2507`
- `mistral.voxtral-small-24b-2507`

### Google Models
- `google.gemma-3-4b-it`
- `google.gemma-3-12b-it`
- `google.gemma-3-27b-it`

### Qwen Models
- `qwen.qwen3-next-80b-a3b`
- `qwen.qwen3-vl-235b-a22b`

### Other Models
- `minimax.minimax-m2`
- `moonshot.kimi-k2-thinking`
- `nvidia.nemotron-nano-9b-v2`
- `nvidia.nemotron-nano-12b-v2`
- `openai.gpt-oss-safeguard-20b`
- `openai.gpt-oss-safeguard-120b`

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
