### PR TITLE
Add DeepSeek thinking/tool-call guidance with reasoning_content

### DIFF
--- a/docs/my-website/docs/providers/deepseek.md
+++ b/docs/my-website/docs/providers/deepseek.md
@@ -123,7 +123,7 @@ for tool_call in assistant_msg.tool_calls or []:
 resp = completion(
     model="deepseek/deepseek-reasoner",
     messages=messages,
-    extra_body={"thinking": {"type": "enabled"}},
+  thinking={"type": "enabled"}
 )
 print(resp.choices[0].message.content)
 

--- a/docs/my-website/docs/providers/deepseek.md
+++ b/docs/my-website/docs/providers/deepseek.md
@@ -93,7 +93,7 @@ resp = completion(
     model="deepseek/deepseek-reasoner",
     messages=messages,
     tools=tools,
-    extra_body={"thinking": {"type": "enabled"}},
+    thinking={"type": "enabled"}
 )
 assistant_msg = resp.choices[0].message
 

--- a/docs/my-website/docs/providers/deepseek.md
+++ b/docs/my-website/docs/providers/deepseek.md
@@ -123,7 +123,7 @@ for tool_call in assistant_msg.tool_calls or []:
 resp = completion(
     model="deepseek/deepseek-reasoner",
     messages=messages,
-  thinking={"type": "enabled"}
+    thinking={"type": "enabled"}
 )
 print(resp.choices[0].message.content)
 


### PR DESCRIPTION
## Title

Add DeepSeek thinking/tool-call guidance with reasoning_content

## Relevant issues

N/A (docs-only guidance for DeepSeek thinking mode)

## Pre-Submission checklist

- [ ] I have Added testing in the tests/litellm/ (https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, Adding at least 1 test is a hard requirement - see details (https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally
- [ ] My PR passes all unit tests on make test-unit (https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

- Update DeepSeek provider docs with a “Tool calling with thinking / reasoning_content” section explaining that DeepSeek requires echoing reasoning_content on assistant tool-call messages when thinking is enabled, linking to the official guide.
- Add a full Python example showing how to enable thinking, replay reasoning_content, send tool outputs, and optionally strip reasoning content before a new user turn.