### PR TITLE
fix(responses): streaming tool_calls being dropped when text + tool_calls

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -871,8 +871,10 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                     usage=None,
                 )
             elif output_item.get("type") == "message":
+                # Don't emit is_finished=True here - there may be more output items
+                # (e.g., tool_calls) coming after the message. Wait for response.completed.
                 return GenericStreamingChunk(
-                    finish_reason="stop", is_finished=True, usage=None, text=""
+                    finish_reason="", is_finished=False, usage=None, text=""
                 )
 
         elif event_type == "response.output_text.delta":
@@ -905,6 +907,12 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                         )
                     ]
                 )
+        elif event_type == "response.completed":
+            # Response is fully complete - now we can signal is_finished=True
+            # This ensures we don't prematurely end the stream before tool_calls arrive
+            return GenericStreamingChunk(
+                text="", tool_use=None, is_finished=True, finish_reason="stop", usage=None
+            )
         else:
             pass
         # For any unhandled event types, create a minimal valid chunk or skip


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/17246

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

### Summary
When OpenAI Responses API returns both **text AND tool_calls** in streaming mode, the bridge transformation (`OpenAiResponsesToChatCompletionStreamIterator`) was emitting `is_finished=True` after the text message completed, causing subsequent tool_call chunks to be dropped.

**Before:**
```
Chunk 4-14: text='¡Hola!...'
Chunk 15: is_finished=True, finish_reason='stop'  ← CLIENT STOPS HERE
Chunk 16-25: tool_calls  ← DROPPED!
```
In `transformation.py:873-876`, when `response.output_item.done` arrived for a message, it immediately emitted `is_finished=True`. However, OpenAI Responses API can have multiple output items (text at index 0, tool_calls at index 1).

### Fix
1. `response.output_item.done` for messages no longer emits `is_finished=True`
2. Added handler for `response.completed` event to properly signal stream end

```
Chunk 4-14: text='¡Hola!...'
Chunk 15: is_finished=False  ← No longer stops here
Chunk 16-25: tool_calls  ← Now received!
Chunk 26: is_finished=True, finish_reason='stop'
```

### Tests Added
4 new tests in `test_completion_extras_litellm_responses_transformation_transformation.py`:
- `test_message_done_does_not_emit_is_finished`
- `test_response_completed_emits_is_finished`
- `test_function_call_done_emits_is_finished`
- `test_text_plus_tool_calls_sequence`