### PR TITLE
fix Azure AI Anthropic api-key header and passthrough cost calculation

### DIFF
--- a/litellm/llms/azure_ai/anthropic/messages_transformation.py
+++ b/litellm/llms/azure_ai/anthropic/messages_transformation.py
@@ -48,12 +48,7 @@ class AzureAnthropicMessagesConfig(AnthropicMessagesConfig):
         headers = BaseAzureLLM._base_validate_azure_environment(
             headers=headers, litellm_params=litellm_params_obj
         )
-
-        # Azure Anthropic uses x-api-key header (not api-key)
-        # Convert api-key to x-api-key if present
-        if "api-key" in headers and "x-api-key" not in headers:
-            headers["x-api-key"] = headers.pop("api-key")
-
+        
         # Set anthropic-version header
         if "anthropic-version" not in headers:
             headers["anthropic-version"] = "2023-06-01"

--- a/litellm/llms/azure_ai/anthropic/transformation.py
+++ b/litellm/llms/azure_ai/anthropic/transformation.py
@@ -55,11 +55,6 @@ class AzureAnthropicConfig(AnthropicConfig):
         headers = BaseAzureLLM._base_validate_azure_environment(
             headers=headers, litellm_params=litellm_params_obj
         )
-        
-        # Azure Anthropic uses x-api-key header (not api-key)
-        # Convert api-key to x-api-key if present
-        if "api-key" in headers and "x-api-key" not in headers:
-            headers["x-api-key"] = headers.pop("api-key")
 
         # Get tools and other anthropic-specific setup
         tools = optional_params.get("tools")

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -96,9 +96,20 @@ class AnthropicPassthroughLoggingHandler:
         handles streaming and non-streaming responses
         """
         try:
+            # Get custom_llm_provider from logging object if available (e.g., azure_ai for Azure Anthropic)
+            custom_llm_provider = logging_obj.model_call_details.get(
+                "custom_llm_provider"
+            )
+
+            # Prepend custom_llm_provider to model if not already present
+            model_for_cost = model
+            if custom_llm_provider and not model.startswith(f"{custom_llm_provider}/"):
+                model_for_cost = f"{custom_llm_provider}/{model}"
+
             response_cost = litellm.completion_cost(
                 completion_response=litellm_model_response,
-                model=model,
+                model=model_for_cost,
+                custom_llm_provider=custom_llm_provider,
             )
 
             kwargs["response_cost"] = response_cost
@@ -157,19 +168,14 @@ class AnthropicPassthroughLoggingHandler:
         """
 
         model = request_body.get("model", "")
-        # Dheck if it's available in the logging object
+        # Check if it's available in the logging object
         if (
             not model
             and hasattr(litellm_logging_obj, "model_call_details")
             and litellm_logging_obj.model_call_details.get("model")
         ):
             model = cast(str, litellm_logging_obj.model_call_details.get("model"))
-            custom_llm_provider = litellm_logging_obj.model_call_details.get(
-                "custom_llm_provider"
-            )
 
-            if custom_llm_provider and not model.startswith(custom_llm_provider):
-                model = f"{custom_llm_provider}/{model}"
         complete_streaming_response = (
             AnthropicPassthroughLoggingHandler._build_complete_streaming_response(
                 all_chunks=all_chunks,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7362,12 +7362,19 @@ class ProviderConfigManager:
 
             return BedrockModelInfo.get_bedrock_provider_config_for_messages_api(model)
         elif litellm.LlmProviders.VERTEX_AI == provider:
-            if "claude" in model:
+            if "claude" in model.lower():
                 from litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation import (
                     VertexAIPartnerModelsAnthropicMessagesConfig,
                 )
 
                 return VertexAIPartnerModelsAnthropicMessagesConfig()
+        elif litellm.LlmProviders.AZURE_AI == provider:
+            if "claude" in model.lower():
+                from litellm.llms.azure_ai.anthropic.messages_transformation import (
+                    AzureAnthropicMessagesConfig,
+                )
+
+                return AzureAnthropicMessagesConfig()
         return None
 
     @staticmethod

--- a/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_transformation.py
@@ -103,8 +103,8 @@ class TestAzureAnthropicConfig:
             call_args = mock_validate.call_args
             assert call_args[1]["litellm_params"].api_key == "provided-api-key"
 
-    def test_validate_environment_converts_api_key_to_x_api_key(self):
-        """Test that api-key header is converted to x-api-key (Azure Anthropic uses x-api-key)"""
+    def test_validate_environment_preserves_api_key_header(self):
+        """Test that api-key header is preserved as-is (Azure handles the header internally)"""
         config = AzureAnthropicConfig()
         headers = {}
         model = "claude-sonnet-4-5"
@@ -127,10 +127,9 @@ class TestAzureAnthropicConfig:
                     litellm_params=litellm_params,
                 )
 
-                # Verify api-key was converted to x-api-key
-                assert "x-api-key" in result
-                assert result["x-api-key"] == "test-api-key"
-                assert "api-key" not in result
+                # Verify api-key header is preserved as-is
+                assert "api-key" in result
+                assert result["api-key"] == "test-api-key"
 
     def test_validate_environment_sets_anthropic_version(self):
         """Test that anthropic-version header is set"""


### PR DESCRIPTION
## Title

Fix Azure AI Anthropic api-key header and passthrough cost calculation

## Relevant issues

Fixes #17655

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
<img width="1904" height="762" alt="image" src="https://github.com/user-attachments/assets/b732ec33-aabd-4409-97ab-4395f40c9e6d" />


## Type

🐛 Bug Fix

## Changes

- **Remove incorrect `api-key` to `x-api-key` header conversion** for Azure AI Anthropic
  - [Microsoft's documentation](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/use-foundry-models-claude) incorrectly states `x-api-key` should be used, but the [Anthropic SDK](https://github.com/anthropics/anthropic-sdk-python/commit/4721bd52f42357d8040a488e39f0f48f05d75b5c#diff-9ec93c40ddef442037c22f22a02c889dc1f2e3133427afa87a83f3e0061a50c3) uses `api-key`

- **Fix cost calculation for Azure AI Anthropic passthrough endpoints**
  - Pass `custom_llm_provider` to `completion_cost` function
  - Prepend provider prefix to model name for correct cost lookup

- **Add `AzureAnthropicMessagesConfig` to `ProviderConfigManager`**
  - Return correct config for Azure AI provider with Claude models

- **Add unit tests** for the above fixes
