### PR TITLE
mitigate PydanticDeprecatedSince20 warnings

### DIFF
--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, Iterable, List, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing_extensions import Literal, Required, TypedDict
 
 from .openai import (
@@ -535,8 +535,7 @@ class AnthropicResponseContentBlockToolUse(BaseModel):
     input: dict
     provider_specific_fields: Optional[Dict[str, Any]] = None
 
-    class Config:
-        extra = "allow"  # Allow provider_specific_fields
+    model_config = ConfigDict(extra="allow") # Allow provider_specific_fields
 
 
 class AnthropicResponseContentBlockThinking(BaseModel):

--- a/litellm/types/rag.py
+++ b/litellm/types/rag.py
@@ -4,7 +4,7 @@ Type definitions for RAG (Retrieval Augmented Generation) Ingest API.
 
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing_extensions import TypedDict
 
 
@@ -185,6 +185,5 @@ class RAGIngestRequest(BaseModel):
     file_id: Optional[str] = None  # Existing file ID
     ingest_options: Dict[str, Any]  # RAGIngestOptions as dict for flexibility
 
-    class Config:
-        extra = "allow"  # Allow additional fields
+    model_config = ConfigDict(extra="allow")  # Allow additional fields
 


### PR DESCRIPTION
## Title

Mitigate PydanticDeprecatedSince20 warnings

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

I did not implement unit tests, as the existing unit tests cover this functionality.

## Type

🐛 Bug Fix

## Changes

When using litellm with a recent pydantic, the following deprecation warnings are shown

```
litellm/types/llms/anthropic.py:531: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
  class AnthropicResponseContentBlockToolUse(BaseModel):
litellm/types/rag.py:181: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
  class RAGIngestRequest(BaseModel):
```

This aligns with multiple existing places within the litellm codebase that uses ConfigDict to configure pydantic model behavior.
