### PR TITLE
Update litellm docs drop_params

### DIFF
--- a/docs/my-website/docs/completion/drop_params.md
+++ b/docs/my-website/docs/completion/drop_params.md
@@ -5,6 +5,14 @@ import TabItem from '@theme/TabItem';
 
 Drop unsupported OpenAI params by your LLM Provider.
 
+## Default Behavior
+
+**By default, LiteLLM raises an exception** if you send a parameter to a model that doesn't support it. 
+
+For example, if you send `temperature=0.2` to a model that doesn't support the `temperature` parameter, LiteLLM will raise an exception.
+
+**When `drop_params=True` is set**, LiteLLM will drop the unsupported parameter instead of raising an exception. This allows your code to work seamlessly across different providers without having to customize parameters for each one.
+
 ## Quick Start 
 
 ```python 


### PR DESCRIPTION
## Title

Clarify default behavior for `drop_params` in documentation

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

Added a "Default Behavior" section to the `drop_params` documentation. This clarifies that LiteLLM, by default, raises an exception for unsupported parameters, and explains how `drop_params=True` changes this to silently drop them. This aims to resolve common confusion regarding parameter handling across different LLM providers.

---
[Slack Thread](https://berriaillm.slack.com/archives/C098S45EALW/p1765209543276399?thread_ts=1765209543.276399&cid=C098S45EALW)

<a href="https://cursor.com/background-agent?bcId=bc-19367439-fa40-4b6a-b3c4-e171ee56fa55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19367439-fa40-4b6a-b3c4-e171ee56fa55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

