### PR TITLE
Move query params to create_pass_through_route call in Langfuse passthrough

### DIFF
--- a/litellm/proxy/vertex_ai_endpoints/langfuse_endpoints.py
+++ b/litellm/proxy/vertex_ai_endpoints/langfuse_endpoints.py
@@ -128,12 +128,12 @@ async def langfuse_proxy_route(
         endpoint=endpoint,
         target=str(updated_url),
         custom_headers={"Authorization": langfuse_combined_key},
+        query_params=dict(request.query_params),  # type: ignore
     )  # dynamically construct pass-through endpoint based on incoming path
     received_value = await endpoint_func(
         request,
         fastapi_response,
         user_api_key_dict,
-        query_params=dict(request.query_params),  # type: ignore
     )
 
     return received_value


### PR DESCRIPTION
## Title

Fix an error when using the Langfuse passthrough by moving an argument to the correct function invocation.

## Issue

This error:

```
create_pass_through_route.<locals>.endpoint_func() got an unexpected keyword argument 'query_params' in litellm/proxy/vertex_ai_endpoints/langfuse_endpoints.py in langfuse_proxy_route at line 132
```

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

query_params appears to now be expected as an argument to `create_pass_through_route` rather than the returned `endpoint_func`.  It is properly merged into the final request query params when passed there, so I've just moved the argument.
