### PR TITLE
feat: propagate Langfuse trace_id

### DIFF
--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -371,6 +371,8 @@ export LANGFUSE_PUBLIC_KEY="pk_kk"
 export LANGFUSE_SECRET_KEY="sk_ss"
 # Optional, defaults to https://cloud.langfuse.com
 export LANGFUSE_HOST="https://xxx.langfuse.com"
+# Optional - When True, forwards LiteLLM's logging trace_id to Langfuse
+LANGFUSE_PROPAGATE_TRACE_ID=True
 ```
 
 **Step 4**: Start the proxy, make a test request

--- a/litellm/integrations/langfuse/langfuse_prompt_management.py
+++ b/litellm/integrations/langfuse/langfuse_prompt_management.py
@@ -12,6 +12,7 @@ from typing_extensions import TypeAlias
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.prompt_management_base import PromptManagementClient
 from litellm.litellm_core_utils.asyncify import run_async_function
+from litellm.secret_managers.main import str_to_bool
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionSystemMessage
 from litellm.types.utils import StandardCallbackDynamicParams, StandardLoggingPayload
 
@@ -124,6 +125,7 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
             langfuse_host=langfuse_host,
             flush_interval=flush_interval,
         )
+        self.langfuse_propagate_trace_id  = str_to_bool(os.getenv("LANGFUSE_PROPAGATE_TRACE_ID", "False")) is True
 
     @property
     def integration_name(self):

--- a/tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py
+++ b/tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py
@@ -15,18 +15,40 @@ class TestLangfusePromptManagement:
             langfuse_prompt_management, "_get_prompt_from_id"
         ) as mock_get_prompt_from_id:
             mock_should_run_prompt_management.return_value = True
-            chat_completion_prompt = (
-                langfuse_prompt_management.get_chat_completion_prompt(
-                    model="langfuse/langfuse-model",
-                    messages=[{"role": "user", "content": "Hello, how are you?"}],
-                    non_default_params={},
-                    prompt_id="test-chat-prompt",
-                    prompt_variables={},
-                    dynamic_callback_params={},
-                    prompt_version=4,
-                )
+            langfuse_prompt_management.get_chat_completion_prompt(
+                model="langfuse/langfuse-model",
+                messages=[{"role": "user", "content": "Hello, how are you?"}],
+                non_default_params={},
+                prompt_id="test-chat-prompt",
+                prompt_variables={},
+                dynamic_callback_params={},
+                prompt_version=4,
             )
 
             mock_get_prompt_from_id.assert_called_once()
-            print(mock_get_prompt_from_id.call_args.kwargs)
             assert mock_get_prompt_from_id.call_args.kwargs["prompt_version"] == 4
+
+    def test_trace_id_propagation_flag_from_env(self):
+        with patch.dict(
+            os.environ,
+            {
+                "LANGFUSE_SECRET_KEY": "secret",
+                "LANGFUSE_PUBLIC_KEY": "public",
+                "LANGFUSE_PROPAGATE_TRACE_ID": "True",
+            },
+            clear=True,
+        ):
+            pm = LangfusePromptManagement()
+            assert pm.langfuse_propagate_trace_id is True
+
+        with patch.dict(
+            os.environ,
+            {
+                "LANGFUSE_SECRET_KEY": "secret",
+                "LANGFUSE_PUBLIC_KEY": "public",
+                "LANGFUSE_PROPAGATE_TRACE_ID": "False",
+            },
+            clear=True,
+        ):
+            pm2 = LangfusePromptManagement()
+            assert pm2.langfuse_propagate_trace_id is False

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -1,8 +1,7 @@
-import asyncio
 import datetime
-import json
 import os
 import sys
+import types
 import unittest
 from typing import Optional
 from unittest.mock import MagicMock, patch
@@ -48,7 +47,13 @@ class TestLangfuseUsageDetails(unittest.TestCase):
 
         # Setup the trace and generation chain
         self.mock_langfuse_trace.generation.return_value = self.mock_langfuse_generation
-        self.mock_langfuse_client.trace.return_value = self.mock_langfuse_trace
+        self.last_trace_kwargs = {}
+
+        def _trace_side_effect(*args, **kwargs):
+            self.last_trace_kwargs = kwargs
+            return self.mock_langfuse_trace
+
+        self.mock_langfuse_client.trace.side_effect = _trace_side_effect
 
         # Mock the langfuse module that's imported locally in methods
         self.langfuse_module_patcher = patch.dict(
@@ -108,8 +113,6 @@ class TestLangfuseUsageDetails(unittest.TestCase):
             )
 
         # Bind the method to the instance
-        import types
-
         self.logger.log_event_on_langfuse = types.MethodType(
             log_event_on_langfuse, self.logger
         )
@@ -342,6 +345,110 @@ class TestLangfuseUsageDetails(unittest.TestCase):
             self.assertEqual(usage_details_arg["cache_read_input_tokens"], 0)
 
             mock_add_prompt_params.assert_called_once()
+
+    def _build_standard_logging_payload(self, trace_id: Optional[str] = None):
+        payload = {
+            "id": "payload-id",
+            "call_type": "completion",
+            "response_cost": 0.0,
+            "status": "success",
+            "total_tokens": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "startTime": 0.0,
+            "endTime": 0.0,
+            "completionStartTime": 0.0,
+            "model": "gpt-4",
+            "model_id": "model-123",
+            "model_group": "openai",
+            "api_base": "https://api.openai.com",
+            "metadata": {
+                "user_api_key_end_user_id": None,
+                "prompt_management_metadata": None,
+                "session_id": None,
+                "trace_name": None,
+                "trace_version": None,
+                "headers": None,
+                "endpoint": None,
+                "caching_groups": None,
+                "previous_models": None,
+            },
+            "hidden_params": {},
+            "request_tags": [],
+            "messages": [],
+            "response": {"id": "resp"},
+            "model_parameters": {},
+            "guardrail_information": None,
+            "standard_built_in_tools_params": None,
+        }
+        if trace_id is not None:
+            payload["trace_id"] = trace_id
+        return payload
+
+    def _build_langfuse_kwargs(self, standard_logging_payload):
+        return {
+            "standard_logging_object": standard_logging_payload,
+            "model": standard_logging_payload["model"],
+            "call_type": standard_logging_payload["call_type"],
+            "cache_hit": False,
+            "messages": [],
+        }
+
+    def test_log_langfuse_v2_propagates_standard_trace_id_when_enabled(self):
+        self.logger.langfuse_propagate_trace_id = True
+        payload = self._build_standard_logging_payload(trace_id="std-trace-id")
+        kwargs = self._build_langfuse_kwargs(payload)
+        self.last_trace_kwargs = {}
+
+        with patch(
+            "litellm.integrations.langfuse.langfuse._add_prompt_to_generation_params",
+            side_effect=lambda generation_params, **kwargs: generation_params,
+            create=True,
+        ):
+            self.logger._log_langfuse_v2(
+                user_id="user-1",
+                metadata={},
+                litellm_params={"metadata": {}},
+                output=None,
+                start_time=datetime.datetime.utcnow(),
+                end_time=datetime.datetime.utcnow(),
+                kwargs=kwargs,
+                optional_params={},
+                input=None,
+                response_obj=None,
+                level="INFO",
+                litellm_call_id="call-id-xyz",
+            )
+
+        assert self.last_trace_kwargs.get("id") == "std-trace-id"
+
+    def test_log_langfuse_v2_defaults_to_call_id_when_propagation_disabled(self):
+        self.logger.langfuse_propagate_trace_id = False
+        payload = self._build_standard_logging_payload(trace_id="std-trace-id")
+        kwargs = self._build_langfuse_kwargs(payload)
+        self.last_trace_kwargs = {}
+
+        with patch(
+            "litellm.integrations.langfuse.langfuse._add_prompt_to_generation_params",
+            side_effect=lambda generation_params, **kwargs: generation_params,
+            create=True,
+        ):
+            self.logger._log_langfuse_v2(
+                user_id="user-1",
+                metadata={},
+                litellm_params={"metadata": {}},
+                output=None,
+                start_time=datetime.datetime.utcnow(),
+                end_time=datetime.datetime.utcnow(),
+                kwargs=kwargs,
+                optional_params={},
+                input=None,
+                response_obj=None,
+                level="INFO",
+                litellm_call_id="call-id-xyz",
+            )
+
+        assert self.last_trace_kwargs.get("id") == "call-id-xyz"
 
 
 def test_max_langfuse_clients_limit():


### PR DESCRIPTION
## Title

feat: propagate Langfuse trace_id

## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
📖 Documentation
✅ Test

## Changes

When `LANGFUSE_PROPAGATE_TRACE_ID` is `True`, forwards LiteLLM's logging trace_id to Langfuse.

LiteLLM
<img width="1450" height="378" alt="image" src="https://github.com/user-attachments/assets/94bb153c-23b1-48e4-9cf2-d1cb4daf4a2c" />

Langfuse
<img width="1231" height="266" alt="image" src="https://github.com/user-attachments/assets/a262c468-1bc1-4cb3-a926-35640a5fb32e" />
