### PR TITLE
docs(json): make it clearer how to get Pydantic model output

### DIFF
--- a/docs/my-website/docs/completion/json_mode.md
+++ b/docs/my-website/docs/completion/json_mode.md
@@ -126,6 +126,8 @@ resp = completion(
 )
 
 print("Received={}".format(resp))
+
+events_list = EventsList.model_validate_json(resp.choices[0].message.content)
 ```
 </TabItem>
 <TabItem value="proxy" label="PROXY">


### PR DESCRIPTION
## Title

Update docs to make it clearer how to get Pydantic output

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [docs only] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [docs only] I have added a screenshot of my new test passing locally 
- [docs only] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [docs only] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

It wasn't clear from the docs how to actually get the structured output out from LiteLLM's response.
