### PR TITLE
fix: add semver prerelease suffix to helm chart versions

### DIFF
--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -338,7 +338,9 @@ jobs:
           if [ -z "${CHART_LIST}" ]; then
             echo "current-version=0.1.0" | tee -a $GITHUB_OUTPUT
           else
-            printf '%s' "${CHART_LIST}" | grep '^version:' | awk 'BEGIN{FS=":"}{print "current-version="$2}' | tr -d " " | tee -a $GITHUB_OUTPUT
+            # Extract version and strip any prerelease suffix (e.g., 0.1.827-latest -> 0.1.827)
+            VERSION=$(printf '%s' "${CHART_LIST}" | grep '^version:' | awk 'BEGIN{FS=":"}{print $2}' | tr -d " " | cut -d'-' -f1)
+            echo "current-version=${VERSION}" | tee -a $GITHUB_OUTPUT
           fi
         env:
           HELM_EXPERIMENTAL_OCI: '1'
@@ -351,11 +353,24 @@ jobs:
           current-version: ${{ steps.current_version.outputs.current-version || '0.1.0' }}
           version-fragment: 'bug'
 
+      # Add suffix for non-stable releases (semantic versioning)
+      - name: Calculate chart version with prerelease suffix
+        id: chart_version
+        shell: bash
+        run: |
+          BASE_VERSION="${{ steps.bump_version.outputs.next-version || '0.1.0' }}"
+          RELEASE_TYPE="${{ github.event.inputs.release_type }}"
+          if [ "$RELEASE_TYPE" = "stable" ]; then
+            echo "version=${BASE_VERSION}" | tee -a $GITHUB_OUTPUT
+          else
+            echo "version=${BASE_VERSION}-${RELEASE_TYPE}" | tee -a $GITHUB_OUTPUT
+          fi
+
       - uses: ./.github/actions/helm-oci-chart-releaser
         with:
           name: ${{ env.CHART_NAME }}
           repository: ${{ env.REPO_OWNER }}
-          tag: ${{ github.event.inputs.chartVersion || steps.bump_version.outputs.next-version || '0.1.0' }}
+          tag: ${{ github.event.inputs.chartVersion || steps.chart_version.outputs.version || '0.1.0' }}
           app_version: ${{ steps.current_app_tag.outputs.latest_tag }}
           path: deploy/charts/${{ env.CHART_NAME }}
           registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
## Title

Add semantic versioning prerelease suffix to Helm chart versions for non-stable releases

## Relevant issues

Users upgrading Helm charts couldn't distinguish stable from nightly and rc releases.

## Pre-Submission checklist

- [x] Testing: N/A - GitHub Actions workflow change, bash logic tested locally (see below)
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🚄 Infrastructure

## Summary

Previously, Helm chart versions were published like this:

```
0.1.826  → stable
0.1.827  → nightly (but its the same versioning)
0.1.828  → nightly (same)
0.1.829  → nightly ...
```

Users had no way to know which version was stable, nightly or rc just by looking at the version number. 

**This didn't follow [Helm's SemVer 2 convention](https://helm.sh/docs/topics/charts/#charts-and-versioning):**

> "A prerelease may be a version such as `1.2.3-beta.1` while the stable release would be `1.2.3`. Pre-releases come before their associated releases in order of precedence."
> — [Helm Template Functions Docs](https://helm.sh/docs/chart_template_guide/function_list/)

> "SemVer comparisons using constraints without a prerelease comparator will skip prerelease versions."
> — [Helm Dependencies Docs](https://helm.sh/docs/chart_best_practices/dependencies/)

## Solution

Now Helm chart versions include a prerelease suffix based on `release_type`:

```
0.1.826           → stable (no suffix)
0.1.827-rc        → release candidate
0.1.828-latest    → nightly
0.1.829           → next stable
```

| release_type | Chart version | Published? |
|--------------|---------------|------------|
| `stable` | `0.1.830` | ✅ |
| `rc` | `0.1.830-rc` | ✅ |
| `latest` | `0.1.830-latest` | ✅ |
| `dev` | — | ❌ |

## Benefits for Kubernetes users

1. **Clear identification**: Version without `-` = stable, with `-` = prerelease
2. **Helm default behavior**: `helm search repo` hides prerelease versions by default
3. **Explicit opt-in**: Users must use `--devel` flag to see/install prerelease versions

```bash
# Only shows stable versions
helm search repo litellm
# NAME      VERSION
# litellm   0.1.830

# Shows all versions (including prereleases)
helm search repo litellm --devel
# NAME      VERSION
# litellm   0.1.830
# litellm   0.1.830-latest
# litellm   0.1.830-rc
```