### PR TITLE
[Fix] Change deprecation banner to only show on /sso/key/generate

### DIFF
--- a/litellm/proxy/common_utils/html_forms/ui_login.py
+++ b/litellm/proxy/common_utils/html_forms/ui_login.py
@@ -8,7 +8,22 @@ if server_root_path != "":
     url_to_redirect_to += server_root_path
 url_to_redirect_to += "/login"
 new_ui_login_url = get_custom_url("", "ui/login")
-html_form = f"""
+
+
+def build_ui_login_form(show_deprecation_banner: bool = False) -> str:
+    banner_html = (
+        f"""
+        <div class="deprecation-banner">
+            <strong>Deprecated:</strong> Logging in with username and password on this page is deprecated.
+            Please use the <a href="{new_ui_login_url}">new login page</a> instead.
+            This page will be dedicated to signing in via SSO in the future.
+        </div>
+        """
+        if show_deprecation_banner
+        else ""
+    )
+
+    return f"""
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -209,11 +224,7 @@ html_form = f"""
 </head>
 <body>
     <form action="{url_to_redirect_to}" method="post">
-        <div class="deprecation-banner">
-            <strong>Deprecated:</strong> Logging in with username and password on this page is deprecated.
-            Please use the <a href="{new_ui_login_url}">new login page</a> instead.
-            This page will be dedicated to signing in via SSO in the future.
-        </div>
+        {banner_html}
         <div class="logo-container">
             <div class="logo">
                 🚅 LiteLLM
@@ -253,3 +264,6 @@ html_form = f"""
 </body>
 </html>
 """
+
+
+html_form = build_ui_login_form(show_deprecation_banner=True)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -236,7 +236,7 @@ from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     decrypt_value_helper,
     encrypt_value_helper,
 )
-from litellm.proxy.common_utils.html_forms.ui_login import html_form
+from litellm.proxy.common_utils.html_forms.ui_login import build_ui_login_form
 from litellm.proxy.common_utils.http_parsing_utils import (
     _read_request_body,
     check_file_size_under_limit,
@@ -8306,11 +8306,15 @@ async def fallback_login(request: Request):
         # Use UI Credentials set in .env
         from fastapi.responses import HTMLResponse
 
-        return HTMLResponse(content=html_form, status_code=200)
+        return HTMLResponse(
+            content=build_ui_login_form(show_deprecation_banner=False), status_code=200
+        )
     else:
         from fastapi.responses import HTMLResponse
 
-        return HTMLResponse(content=html_form, status_code=200)
+        return HTMLResponse(
+            content=build_ui_login_form(show_deprecation_banner=False), status_code=200
+        )
 
 
 @router.post(


### PR DESCRIPTION
## [Fix] Change deprecation banner to only show on /sso/key/generate

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The login page on /sso/key/generate is deprecated, but the /fallback/login is not. These routes both use the same common file, so adding some logic to show the deprecation banner only on /sso/key/generate. /fallback/login will continue to serve as a fallback.

Will remove the deprecation banner entirely when /sso/key/generate login page is fully removed.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<img width="706" height="143" alt="image" src="https://github.com/user-attachments/assets/817ed4a4-a62b-4783-a5be-0041cbf06539" />
<img width="915" height="891" alt="image" src="https://github.com/user-attachments/assets/0dbf86ae-3293-4a60-9fc3-f02e38d2c39a" />
<img width="935" height="875" alt="image" src="https://github.com/user-attachments/assets/07b8a141-4e7f-433b-8e15-5eac041a1dae" />

