### PR TITLE
feat: add Cerebras zai-glm-4.6 model support

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -6202,6 +6202,19 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "cerebras/zai-glm-4.6": {
+        "input_cost_per_token": 2.25e-06,
+        "litellm_provider": "cerebras",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-06,
+        "source": "https://www.cerebras.ai/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "chat-bison": {
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6202,6 +6202,19 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "cerebras/zai-glm-4.6": {
+        "input_cost_per_token": 2.25e-06,
+        "litellm_provider": "cerebras",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-06,
+        "source": "https://www.cerebras.ai/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "chat-bison": {
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,


### PR DESCRIPTION
## Title

Add Cerebras Z.ai GLM 4.6 model to model registry

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/17677

## Pre-Submission checklist

- [ ] I have Added testing - Manually tested with Cerebras API key, model works correctly
- [x] My PR passes all unit tests on `make test-unit` - No code changes, only JSON config
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Adds support for the new Cerebras `zai-glm-4.6` reasoning model:

- **Input cost**: $2.25/M tokens
- **Output cost**: $2.75/M tokens  
- **Context window**: 128K tokens
- **Capabilities**: function_calling, tool_choice, reasoning

This is a reasoning model (similar to o1/o3) - responses include `reasoning_content` before the final `content`.

**Testing:**
```python
import litellm

response = litellm.completion(
    model='cerebras/zai-glm-4.6',
    messages=[{'role': 'user', 'content': 'Say hi'}],
    max_tokens=2000
)
print(response.choices[0].message.content)
# Output: "Hi there! How can I help you today?"
```

Note: The model is currently in preview status per Cerebras documentation.