### PR TITLE
fix(router): handle tools=None in completion requests

### DIFF
--- a/litellm/router_utils/common_utils.py
+++ b/litellm/router_utils/common_utils.py
@@ -110,7 +110,7 @@ def filter_web_search_deployments(
         return healthy_deployments
 
     is_web_search_request = False
-    tools = request_kwargs.get("tools", [])
+    tools = request_kwargs.get("tools") or []
     for tool in tools:
         # These are the two websearch tools for OpenAI / Azure. 
         if tool.get("type") == "web_search" or tool.get("type") == "web_search_preview":

--- a/tests/test_litellm/router_utils/test_router_utils_common_utils.py
+++ b/tests/test_litellm/router_utils/test_router_utils_common_utils.py
@@ -248,6 +248,11 @@ class TestFilterWebSearchDeployments:
         result = filter_web_search_deployments(sample_deployments, {"tools": []})
         assert result == sample_deployments
 
+    def test_none_tools_returns_all(self, sample_deployments):
+        """When tools is explicitly None, return all deployments (regression test for #17672)"""
+        result = filter_web_search_deployments(sample_deployments, {"tools": None})
+        assert result == sample_deployments
+
     def test_non_web_search_tools_returns_all(self, sample_deployments):
         """When tools don't include web_search, return all deployments"""
         request_kwargs = {"tools": [{"type": "function", "function": {}}]}


### PR DESCRIPTION
## Title

fix(router): handle tools=None in completion requests

## Relevant issues

Fixes #17672

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement**
- [ ] I have added a screenshot of my new test passing locally (see below)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Changed `request_kwargs.get("tools", [])` to `request_kwargs.get("tools") or []` in `filter_web_search_deployments()` to handle the case where `tools` is explicitly set to `None`.

```python
from litellm import Router

  router = Router(model_list=[
      {"model_name": "gpt-4", "litellm_params": {"model": "openai/gpt-4"}},
  ])

  # broken in main
  response = router.completion(
      model="gpt-4",
      messages=[{"role": "user", "content": "Hello"}],
      tools=None  # ❌ TypeError
  )
  print(response)
```

- `dict.get("tools", [])` returns `[]` only if the key doesn't exist
- If `tools=None` is passed explicitly, the key exists with value `None`, so `.get()` returns `None`
- Iterating over `None` causes `TypeError: 'NoneType' is not iterable`

**The fix:**
- Using `or []` ensures both missing keys AND explicit `None` values are converted to empty list

**Test output:**
```
tests/test_litellm/router_utils/test_router_utils_common_utils.py::TestFilterWebSearchDeployments::test_none_tools_returns_all PASSED
```