### PR TITLE
[Fix] Missing content in Anthropic to OpenAI conversion

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -613,7 +613,14 @@ class LiteLLMAnthropicMessagesAdapter:
                             )
                         )
 
-            # Handle tool calls
+            # Handle text content
+            if choice.message.content is not None:
+                new_content.append(
+                    AnthropicResponseContentBlockText(
+                        type="text", text=choice.message.content
+                    )
+                )
+            # Handle tool calls (in parallel to text content)
             if (
                 choice.message.tool_calls is not None
                 and len(choice.message.tool_calls) > 0
@@ -642,13 +649,6 @@ class LiteLLMAnthropicMessagesAdapter:
                             provider_specific_fields
                         )
                     new_content.append(tool_use_block)
-            # Handle text content
-            elif choice.message.content is not None:
-                new_content.append(
-                    AnthropicResponseContentBlockText(
-                        type="text", text=choice.message.content
-                    )
-                )
 
         return new_content
 


### PR DESCRIPTION
## Title

Text content could be missing from the final response (Anthropic client, OpenAI backend) when there is a co-existing tool call in the raw response, which is a very common case for Claude Code.

## Relevant issues

https://github.com/microsoft/agent-lightning/pull/376

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1853" height="128" alt="image" src="https://github.com/user-attachments/assets/a661e251-ca7d-4511-a908-3642c8574eb1" />

## Type

🐛 Bug Fix

## Changes

Thanks @zxgx for pinpointing the root cause of the issue.