### PR TITLE
Fix Opus 4.5 reasoning_effort mapping

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -759,14 +759,11 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             if param == "thinking":
                 optional_params["thinking"] = value
             elif param == "reasoning_effort" and isinstance(value, str):
-                # For Claude Opus 4.5, map reasoning_effort to output_config
+                thinking_param = AnthropicConfig._map_reasoning_effort(value)
+                optional_params["thinking"] = thinking_param
+                # For Claude Opus 4.5, also map reasoning_effort to output_config
                 if self._is_claude_opus_4_5(model):
                     optional_params["output_config"] = {"effort": value}
-                else:
-                    # For other models, map to thinking parameter
-                    optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
-                        value
-                    )
             elif param == "web_search_options" and isinstance(value, dict):
                 hosted_web_search_tool = self.map_web_search_tool(
                     cast(OpenAIWebSearchOptions, value)


### PR DESCRIPTION
  ## Title

  Fix Opus 4.5 reasoning_effort mapping

  ## Relevant issues

  None

  ## Pre-Submission checklist

  - [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://
  docs.litellm.ai/docs/extras/contributing_code)
  - [ ] I have added a screenshot of my new test passing locally
  - [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  (Notes: Ran targeted pytest selection: `python3 -m pytest tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py -k reasoning_effort --maxfail=1`. Did not run full `make test-
  unit` here. Installed local dev deps to run the targeted tests.)

  ## Type

  🐛 Bug Fix

  ## Changes

  - Adjust Anthropic reasoning mapping: `reasoning_effort` now always sets `thinking` (to ensure reasoning blocks are returned) and, for Claude Opus 4.5, also sets `output_config={"effort": ...}` to
  honor the new effort parameter.
  - This fixes the previous gap where Opus 4.5 requests mapped `reasoning_effort` only to `output_config`, resulting in missing `thinking`/reasoning content in responses unless callers manually set
  `thinking`. The new behavior restores OpenAI-style `reasoning_effort` semantics while still enabling the Opus 4.5 effort control.
  - Added tests to verify:
    - Opus 4.5: `reasoning_effort` yields both `thinking` (correct budget) and `output_config`.
    - Non-Opus Claude models: `reasoning_effort` yields `thinking` only and no `output_config`.
  - Imported `DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET` in tests for precise assertions.