### PR TITLE
fix(docs): Supported Endpoints page

### DIFF
--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -171,7 +171,7 @@ const sidebars = {
             {
               type: "link",
               label: "All Supported Endpoints →",
-              href: "/docs/supported_endpoints",
+              href: "https://docs.litellm.ai/docs/supported_endpoints",
             },
           ],
         },


### PR DESCRIPTION
## Title

Fix Supported Endpoints page showing SDK Functions instead of actual endpoints

## Relevant issues

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - N/A (docs-only change)
- [x] I have added a screenshot of my new test passing locally - N/A (docs-only change)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) - N/A (docs-only change)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix
📖 Documentation

## Changes

The `/docs/supported_endpoints` page was incorrectly showing SDK Functions (completion(), embedding(), etc.) instead of the actual supported endpoints (/a2a, /audio, /batches, etc.).

**Root cause:** Docusaurus has a bug where internal links (`/docs/...`) inside a sidebar category can conflict with `generated-index` pages that have the same slug. The link in SDK Functions pointing to `/docs/supported_endpoints` was causing Docusaurus to associate that page with SDK Functions context.

**Fix:** Changed the link from relative (`/docs/supported_endpoints`) to absolute URL (`https://docs.litellm.ai/docs/supported_endpoints`). This makes Docusaurus treat it as an external link, avoiding the slug conflict with the `generated-index`.

Reference: https://github.com/facebook/docusaurus/issues/11612