### PR TITLE
[Fix] Change credential encryption to only affect db credentials

### DIFF
--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -24,10 +24,16 @@ class CredentialHelperUtils:
     def encrypt_credential_values(credential: CredentialItem) -> CredentialItem:
         """Encrypt values in credential.credential_values and add to DB"""
         encrypted_credential_values = {}
-        for key, value in credential.credential_values.items():
+        for key, value in (credential.credential_values or {}).items():
             encrypted_credential_values[key] = encrypt_value_helper(value)
-        credential.credential_values = encrypted_credential_values
-        return credential
+
+        # Return a new object to avoid mutating the caller's credential, which
+        # is kept in memory and should remain unencrypted.
+        return CredentialItem(
+            credential_name=credential.credential_name,
+            credential_values=encrypted_credential_values,
+            credential_info=credential.credential_info or {},
+        )
 
 
 @router.post(

--- a/tests/test_litellm/proxy/client/test_credentials.py
+++ b/tests/test_litellm/proxy/client/test_credentials.py
@@ -13,6 +13,8 @@ import responses
 
 from litellm.proxy.client.credentials import CredentialsManagementClient
 from litellm.proxy.client.exceptions import UnauthorizedError
+from litellm.proxy.credential_endpoints.endpoints import CredentialHelperUtils
+from litellm.types.utils import CredentialItem
 
 
 @pytest.fixture
@@ -263,3 +265,19 @@ def test_get_unauthorized_error(client):
 
     with pytest.raises(UnauthorizedError):
         client.get(credential_name="azure1")
+
+
+def test_encrypt_credential_values_does_not_mutate_original(monkeypatch):
+    """Ensure encrypt_credential_values returns a new encrypted object"""
+    monkeypatch.setenv("LITELLM_SALT_KEY", "test-key")
+    credential = CredentialItem(
+        credential_name="azure1",
+        credential_values={"api_key": "sk-123"},
+        credential_info={"api_type": "azure"},
+    )
+
+    encrypted = CredentialHelperUtils.encrypt_credential_values(credential)
+
+    assert encrypted.credential_values["api_key"] != "sk-123"
+    assert credential.credential_values["api_key"] == "sk-123"
+    assert encrypted.credential_name == credential.credential_name


### PR DESCRIPTION
## [Fix] Change credential encryption to only affect db credentials

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The previous credential encryption workflow directly modified the credentials in memory, causing subsequent GET requests to return the encrypted version of the credentials. This PR changes the workflow to return a new encrypted credential object to prevent affect the credentials already in memory. subsequent GET requests should now return the correct credentials fields

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<img width="650" height="279" alt="image" src="https://github.com/user-attachments/assets/0179b0de-19af-4092-accc-76c6f78a8822" />


