### PR TITLE
Support model names with slashes on Gemini endpoints

### DIFF
--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -13,11 +13,11 @@ router = APIRouter(
 
 
 @router.post(
-    "/v1beta/models/{model_name}:generateContent",
+    "/v1beta/models/{model_name:path}:generateContent",
     dependencies=[Depends(user_api_key_auth)],
 )
 @router.post(
-    "/models/{model_name}:generateContent", dependencies=[Depends(user_api_key_auth)]
+    "/models/{model_name:path}:generateContent", dependencies=[Depends(user_api_key_auth)]
 )
 async def google_generate_content(
     request: Request,
@@ -50,11 +50,11 @@ async def google_generate_content(
 
 
 @router.post(
-    "/v1beta/models/{model_name}:streamGenerateContent",
+    "/v1beta/models/{model_name:path}:streamGenerateContent",
     dependencies=[Depends(user_api_key_auth)],
 )
 @router.post(
-    "/models/{model_name}:streamGenerateContent",
+    "/models/{model_name:path}:streamGenerateContent",
     dependencies=[Depends(user_api_key_auth)],
 )
 async def google_stream_generate_content(
@@ -95,12 +95,12 @@ async def google_stream_generate_content(
 
 
 @router.post(
-    "/v1beta/models/{model_name}:countTokens",
+    "/v1beta/models/{model_name:path}:countTokens",
     dependencies=[Depends(user_api_key_auth)],
     response_model=TokenCountDetailsResponse,
 )
 @router.post(
-    "/models/{model_name}:countTokens",
+    "/models/{model_name:path}:countTokens",
     dependencies=[Depends(user_api_key_auth)],
     response_model=TokenCountDetailsResponse,
 )

--- a/tests/proxy_unit_tests/test_google_endpoint_routing.py
+++ b/tests/proxy_unit_tests/test_google_endpoint_routing.py
@@ -1,0 +1,69 @@
+import json
+import os
+import sys
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.proxy_server import app, initialize
+
+# Create a TestClient
+client = TestClient(app)
+
+@pytest.fixture
+def mock_user_api_key_dict():
+    """Mock user API key dictionary."""
+    return UserAPIKeyAuth(
+        api_key="test_api_key",
+        user_id="test_user_id",
+        user_email="test@example.com",
+        team_id="test_team_id",
+        max_budget=100.0,
+        spend=0.0,
+        user_role="internal_user",
+        allowed_cache_controls=[],
+        metadata={},
+        tpm_limit=None,
+        rpm_limit=None,
+    )
+
+def mock_user_api_key_auth_dependency(mock_user_api_key_dict):
+    async def override():
+        return mock_user_api_key_dict
+    return override
+
+@pytest.mark.asyncio
+async def test_google_generate_content_with_slashes_in_model_name(mock_user_api_key_dict):
+    """
+    Test that the google_generate_content endpoint correctly handles model names with slashes.
+    """
+    with patch("litellm.proxy.proxy_server.llm_router") as mock_llm_router:
+        mock_llm_router.agenerate_content = AsyncMock()
+        
+        # Override the dependency
+        app.dependency_overrides[UserAPIKeyAuth] = mock_user_api_key_auth_dependency(mock_user_api_key_dict)
+
+        # Initialize the router
+        await initialize(model_list=[
+            {
+                "model_name": "bedrock/claude-sonnet-3.7",
+                "litellm_params": {
+                    "model": "bedrock/claude-3-sonnet-20240229-v1:0",
+                },
+            }
+        ])
+
+        response = client.post("/v1beta/models/bedrock/claude-sonnet-3.7:generateContent", json={})
+        
+        # Reset the dependency override
+        app.dependency_overrides = {}
+        
+        mock_llm_router.agenerate_content.assert_called_once()
+        call_args = mock_llm_router.agenerate_content.call_args[1]
+        assert call_args["model"] == "bedrock/claude-sonnet-3.7"

--- a/tests/proxy_unit_tests/test_google_endpoint_routing.py
+++ b/tests/proxy_unit_tests/test_google_endpoint_routing.py
@@ -4,7 +4,6 @@ import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
 import pytest
 import asyncio
 import yaml

--- a/tests/proxy_unit_tests/test_google_endpoint_routing.py
+++ b/tests/proxy_unit_tests/test_google_endpoint_routing.py
@@ -13,7 +13,7 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.google_endpoints.endpoints import google_generate_content
 from fastapi import Request, Response
 from fastapi.datastructures import Headers
-from litellm.proxy.proxy_server import initialize, app, user_api_key_auth
+from litellm.proxy.proxy_server import initialize
 from litellm.router import Router
 from litellm.utils import ModelResponse
 

--- a/tests/proxy_unit_tests/test_google_endpoint_routing.py
+++ b/tests/proxy_unit_tests/test_google_endpoint_routing.py
@@ -14,7 +14,6 @@ from litellm.proxy.google_endpoints.endpoints import google_generate_content
 from fastapi import Request, Response
 from fastapi.datastructures import Headers
 from litellm.proxy.proxy_server import initialize
-from litellm.router import Router
 from litellm.utils import ModelResponse
 
 @pytest.fixture

--- a/tests/proxy_unit_tests/test_google_endpoint_routing.py
+++ b/tests/proxy_unit_tests/test_google_endpoint_routing.py
@@ -2,7 +2,6 @@
 import json
 import os
 import sys
-from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/tests/proxy_unit_tests/test_google_endpoint_routing.py
+++ b/tests/proxy_unit_tests/test_google_endpoint_routing.py
@@ -5,7 +5,6 @@ import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import asyncio
 import yaml
 
 sys.path.insert(0, os.path.abspath("../.."))

--- a/tests/proxy_unit_tests/test_google_endpoint_routing.py
+++ b/tests/proxy_unit_tests/test_google_endpoint_routing.py
@@ -82,19 +82,22 @@ async def test_google_generate_content_with_slashes_in_model_name(
     with open(config_fp, "w") as f:
         yaml.dump(config, f)
 
-    await initialize(config=config_fp)
+    try:
+        await initialize(config=config_fp)
 
-    with patch("litellm.proxy.proxy_server.llm_router.agenerate_content", new_callable=AsyncMock) as mock_agenerate_content:
-        mock_agenerate_content.return_value = ModelResponse()
-        
-        await google_generate_content(
-            request=mock_request,
-            model_name="bedrock/claude-sonnet-3.7",
-            fastapi_response=mock_response,
-            user_api_key_dict=mock_user_api_key_dict,
-        )
+        with patch("litellm.proxy.proxy_server.llm_router.agenerate_content", new_callable=AsyncMock) as mock_agenerate_content:
+            mock_agenerate_content.return_value = ModelResponse()
+            
+            await google_generate_content(
+                request=mock_request,
+                model_name="bedrock/claude-sonnet-3.7",
+                fastapi_response=mock_response,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
 
-        mock_agenerate_content.assert_called_once()
-        _, call_kwargs = mock_agenerate_content.call_args
-        assert call_kwargs["model"] == "bedrock/claude-sonnet-3.7"
-        os.remove(config_fp)
+            mock_agenerate_content.assert_called_once()
+            _, call_kwargs = mock_agenerate_content.call_args
+            assert call_kwargs["model"] == "bedrock/claude-sonnet-3.7"
+    finally:
+        if os.path.exists(config_fp):
+            os.remove(config_fp)


### PR DESCRIPTION
## Title
This allows model names with slashes (i.e. `bedrock/claude-sonnet-4.5`) when using Gemini endpoints.

## Relevant issues
N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
This allows model names with slashes (i.e. `bedrock/claude-sonnet-4.5`) when using Gemini endpoints.

Some tests are failing, though it seems to be the same ones affecting other PRs.

<img width="2879" height="568" alt="image" src="https://github.com/user-attachments/assets/01160b58-4277-4e7a-b05f-5ff014e4b06b" />

