### PR TITLE
Fix: Extract service_tier from response/usage for OpenAI flex pricing

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -836,6 +836,22 @@ def completion_cost(  # noqa: PLR0915
         if service_tier is None and optional_params is not None:
             service_tier = optional_params.get("service_tier")
 
+        # Extract service_tier from completion_response if not provided
+        if service_tier is None and completion_response is not None:
+            if isinstance(completion_response, BaseModel):
+                service_tier = getattr(completion_response, "service_tier", None)
+            elif isinstance(completion_response, dict):
+                service_tier = completion_response.get("service_tier")
+
+        # Extract service_tier from usage object if not provided
+        if service_tier is None and cost_per_token_usage_object is not None:
+            if isinstance(cost_per_token_usage_object, BaseModel):
+                service_tier = getattr(
+                    cost_per_token_usage_object, "service_tier", None
+                )
+            elif isinstance(cost_per_token_usage_object, dict):
+                service_tier = cost_per_token_usage_object.get("service_tier")
+
         selected_model = _select_model_name_for_cost_calc(
             model=model,
             completion_response=completion_response,


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ✅] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [✅ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [✅ ] I did manual testing for the change. See SS below.

<img width="994" height="809" alt="Screenshot 2025-12-09 at 6 07 32 PM" src="https://github.com/user-attachments/assets/b5972af9-8145-4f92-8e83-ed3ffac9f25b" />




🐛 Bug Fix
✅ Test

## Changes
OpenAI can include service_tier in the response or usage object. Without extracting it, the cost calculation defaulted to standard pricing even when flex was used, leading to incorrect costs. This fix ensures the correct pricing tier is applied based on what was actually used.
