### PR TITLE
fix: Avoid error when we have just the tool_calls in input

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -1270,14 +1270,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             Exception: If content is blocked by Bedrock guardrail
         """
         texts = inputs.get("texts", [])
-
-        # Add the function name and arguments to guardrails validation
-        for tool in inputs.get("tool_calls", []):
-            if tool.get("type") != "function":
-                continue
-            func = tool.get("function", {})
-            texts.extend(filter(None, [func.get("name"), func.get("arguments")]))
-
         try:
             verbose_proxy_logger.debug(
                 f"Bedrock Guardrail: Applying guardrail to {len(texts)} text(s)"


### PR DESCRIPTION
## Title

fix: Avoid error when we have just the tool_calls in input

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Tests
This is the prompt I am using for testing
```
{
    "messages": [
        {
            "content": "What is the weather in São Paulo?",
            "role": "user"
        }
    ],
    "model": "gpt-4.1",
    "parallel_tool_calls": false,
    "stream": false,
    "temperature": 0,
    "tools": [
        {
        "type": "function",
        "function": {
            "name": "get_weather",
            "description": "Get the current weather",
            "parameters": {
            "type": "object",
            "properties": {
                "location": {"type": "string"}
            }
            }
        }
        }
    ],
    "service_tier": "priority",
    "guardrails": [
        "bedrock-post-guard"
    ]
}
```
The error we received
<img width="1160" height="244" alt="image" src="https://github.com/user-attachments/assets/8ba6649b-e139-424f-afef-9bd70fa94fe4" />

Note: The error message it's not so helpful, but it happens because bedrock is receiving an empty message to validate.

After the fix
<img width="1160" height="379" alt="image" src="https://github.com/user-attachments/assets/5125a2ce-880f-4e7f-a4cf-c0fc29e4e8c0" />

Unit test
<img width="1047" height="322" alt="image" src="https://github.com/user-attachments/assets/cf3cfedf-6d41-4967-b2ba-f20c27b27790" />

## Changes
I add the "if filtered_messages" to avoid errors in make_bedrock_api_request. Depending the prompt with tools, it's possible that in the input variable the texts are empty (But have tools). Sending an empty message do bedrock will throw an error

