### PR TITLE
fix(github_copilot): Consolidate duplicate tool_result blocks for Cla…

### DIFF
--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Tuple, cast, List
+from typing import Any, Dict, Optional, Tuple, cast, List, Union
 
 from litellm.exceptions import AuthenticationError
 from litellm.llms.openai.openai import OpenAIConfig
@@ -52,7 +52,276 @@ class GithubCopilotConfig(OpenAIConfig):
             for message in messages:
                 if "role" in message and message["role"] == "system":
                     cast(Any, message)["role"] = "assistant"
+
+        # Consolidate duplicate tool results for Claude models on GitHub Copilot
+        # GitHub Copilot's Claude API expects each tool_use to have exactly one tool_result
+        messages = self._consolidate_tool_results(messages)
+
         return messages
+
+    def _consolidate_tool_results(
+        self,
+        messages: List[AllMessageValues],
+    ) -> List[AllMessageValues]:
+        """
+        Consolidate multiple tool results with the same tool_call_id/tool_use_id into a single result.
+
+        GitHub Copilot's Claude API expects each tool_use to have exactly one tool_result.
+        When multiple tool_result blocks have the same ID, their content is merged into a single block.
+
+        Handles both:
+        - OpenAI format: multiple 'tool' role messages with the same tool_call_id
+        - Anthropic format: content arrays with multiple tool_result blocks with the same tool_use_id
+        """
+        # First, consolidate OpenAI-style tool messages
+        messages = self._consolidate_openai_tool_messages(messages)
+
+        # Then, consolidate Anthropic-style tool_result blocks within message content
+        messages = self._consolidate_anthropic_tool_results(messages)
+
+        return messages
+
+    def _consolidate_openai_tool_messages(
+        self,
+        messages: List[AllMessageValues],
+    ) -> List[AllMessageValues]:
+        """
+        Consolidate multiple OpenAI-style 'tool' role messages with the same tool_call_id.
+
+        When multiple tool messages have the same tool_call_id, their content is merged
+        into a single tool message.
+        """
+        # Find all tool messages and group by tool_call_id
+        tool_messages_by_id: Dict[str, List[Dict[str, Any]]] = {}
+        non_tool_messages: List[Tuple[int, AllMessageValues]] = []
+        tool_message_first_indices: Dict[str, int] = {}
+
+        for idx, message in enumerate(messages):
+            if message.get("role") == "tool":
+                tool_call_id = message.get("tool_call_id")
+                if tool_call_id:
+                    if tool_call_id not in tool_messages_by_id:
+                        tool_messages_by_id[tool_call_id] = []
+                        tool_message_first_indices[tool_call_id] = idx
+                    tool_messages_by_id[tool_call_id].append(message)  # type: ignore
+                else:
+                    non_tool_messages.append((idx, message))
+            else:
+                non_tool_messages.append((idx, message))
+
+        # If no tool messages or no duplicates found, return original messages
+        if not tool_messages_by_id or all(len(msgs) == 1 for msgs in tool_messages_by_id.values()):
+            return messages
+
+        # Build new message list with consolidated tool messages
+        consolidated_messages: List[AllMessageValues] = []
+        processed_tool_ids: set = set()
+
+        for idx, message in enumerate(messages):
+            if message.get("role") == "tool":
+                tool_call_id = message.get("tool_call_id")
+                if tool_call_id and tool_call_id not in processed_tool_ids:
+                    # Consolidate all messages with this tool_call_id
+                    tool_msgs = tool_messages_by_id[tool_call_id]
+                    if len(tool_msgs) == 1:
+                        consolidated_messages.append(tool_msgs[0])  # type: ignore
+                    else:
+                        consolidated_msg = self._merge_tool_messages(tool_msgs)
+                        consolidated_messages.append(consolidated_msg)  # type: ignore
+                    processed_tool_ids.add(tool_call_id)
+                elif not tool_call_id:
+                    consolidated_messages.append(message)
+            else:
+                consolidated_messages.append(message)
+
+        return consolidated_messages
+
+    def _merge_tool_messages(
+        self,
+        tool_messages: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """
+        Merge multiple tool messages with the same tool_call_id into a single message.
+
+        The content from all messages is concatenated with newlines.
+        """
+        if not tool_messages:
+            raise ValueError("Cannot merge empty list of tool messages")
+
+        first_msg = tool_messages[0]
+        merged_content_parts: List[str] = []
+
+        for msg in tool_messages:
+            content = msg.get("content")
+            if isinstance(content, str):
+                merged_content_parts.append(content)
+            elif isinstance(content, list):
+                # Handle list content (extract text parts)
+                for item in content:
+                    if isinstance(item, dict) and item.get("type") == "text":
+                        merged_content_parts.append(item.get("text", ""))
+                    elif isinstance(item, str):
+                        merged_content_parts.append(item)
+
+        merged_msg: Dict[str, Any] = {
+            "role": "tool",
+            "tool_call_id": first_msg.get("tool_call_id"),
+            "content": "\n".join(merged_content_parts),
+        }
+
+        # Preserve name if present
+        if "name" in first_msg:
+            merged_msg["name"] = first_msg["name"]
+
+        return merged_msg
+
+    def _consolidate_anthropic_tool_results(
+        self,
+        messages: List[AllMessageValues],
+    ) -> List[AllMessageValues]:
+        """
+        Consolidate multiple Anthropic-style tool_result blocks with the same tool_use_id
+        within message content arrays.
+
+        When multiple tool_result blocks have the same tool_use_id, their content is merged
+        into a single tool_result block.
+        """
+        result_messages: List[AllMessageValues] = []
+
+        for message in messages:
+            content = message.get("content")
+            if isinstance(content, list):
+                # Check if this message has tool_result blocks that need consolidation
+                consolidated_content = self._consolidate_content_tool_results(content)
+                if consolidated_content is not content:
+                    # Content was modified, create new message
+                    new_message = dict(message)
+                    new_message["content"] = consolidated_content
+                    result_messages.append(new_message)  # type: ignore
+                else:
+                    result_messages.append(message)
+            else:
+                result_messages.append(message)
+
+        return result_messages
+
+    def _consolidate_content_tool_results(
+        self,
+        content: List[Any],
+    ) -> List[Any]:
+        """
+        Consolidate tool_result blocks in a content array by tool_use_id.
+
+        Returns the original content list if no consolidation is needed,
+        or a new list with consolidated tool_results.
+        """
+        # Group tool_results by tool_use_id
+        tool_results_by_id: Dict[str, List[Dict[str, Any]]] = {}
+        tool_result_first_indices: Dict[str, int] = {}
+        other_content: List[Tuple[int, Any]] = []
+
+        for idx, item in enumerate(content):
+            if isinstance(item, dict) and item.get("type") == "tool_result":
+                tool_use_id = item.get("tool_use_id")
+                if tool_use_id:
+                    if tool_use_id not in tool_results_by_id:
+                        tool_results_by_id[tool_use_id] = []
+                        tool_result_first_indices[tool_use_id] = idx
+                    tool_results_by_id[tool_use_id].append(item)
+                else:
+                    other_content.append((idx, item))
+            else:
+                other_content.append((idx, item))
+
+        # If no tool_results or no duplicates, return original content
+        if not tool_results_by_id or all(len(results) == 1 for results in tool_results_by_id.values()):
+            return content
+
+        # Build new content list with consolidated tool_results
+        consolidated_content: List[Any] = []
+        processed_tool_ids: set = set()
+
+        for idx, item in enumerate(content):
+            if isinstance(item, dict) and item.get("type") == "tool_result":
+                tool_use_id = item.get("tool_use_id")
+                if tool_use_id and tool_use_id not in processed_tool_ids:
+                    # Consolidate all tool_results with this tool_use_id
+                    tool_results = tool_results_by_id[tool_use_id]
+                    if len(tool_results) == 1:
+                        consolidated_content.append(tool_results[0])
+                    else:
+                        consolidated_result = self._merge_tool_results(tool_results)
+                        consolidated_content.append(consolidated_result)
+                    processed_tool_ids.add(tool_use_id)
+                elif not tool_use_id:
+                    consolidated_content.append(item)
+            else:
+                consolidated_content.append(item)
+
+        return consolidated_content
+
+    def _merge_tool_results(
+        self,
+        tool_results: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """
+        Merge multiple tool_result blocks with the same tool_use_id into a single block.
+
+        The content from all blocks is merged:
+        - String content is concatenated with newlines
+        - List content is flattened into a single list
+        """
+        if not tool_results:
+            raise ValueError("Cannot merge empty list of tool results")
+
+        first_result = tool_results[0]
+        merged_content: Union[str, List[Any]]
+
+        # Collect all content
+        all_string_content: List[str] = []
+        all_list_content: List[Any] = []
+        has_string_content = False
+        has_list_content = False
+
+        for result in tool_results:
+            result_content = result.get("content")
+            if isinstance(result_content, str):
+                all_string_content.append(result_content)
+                has_string_content = True
+            elif isinstance(result_content, list):
+                all_list_content.extend(result_content)
+                has_list_content = True
+
+        # Determine merged content format
+        if has_list_content and not has_string_content:
+            # All list content
+            merged_content = all_list_content
+        elif has_string_content and not has_list_content:
+            # All string content
+            merged_content = "\n".join(all_string_content)
+        else:
+            # Mixed content - convert strings to text blocks and combine
+            merged_list: List[Any] = []
+            for s in all_string_content:
+                merged_list.append({"type": "text", "text": s})
+            merged_list.extend(all_list_content)
+            merged_content = merged_list
+
+        merged_result: Dict[str, Any] = {
+            "type": "tool_result",
+            "tool_use_id": first_result.get("tool_use_id"),
+            "content": merged_content,
+        }
+
+        # Preserve is_error if any result has it set to True
+        if any(r.get("is_error") for r in tool_results):
+            merged_result["is_error"] = True
+
+        # Preserve cache_control from first result if present
+        if "cache_control" in first_result:
+            merged_result["cache_control"] = first_result["cache_control"]
+
+        return merged_result
 
     def validate_environment(
         self,


### PR DESCRIPTION
…ude models

GitHub Copilot's Claude API expects each tool_use to have exactly one tool_result block. When multiple tool_result blocks have the same tool_use_id, the API returns an error:
"each tool_use must have a single result"

This fix adds consolidation logic to the GitHub Copilot chat transformation that merges multiple tool results with the same ID into a single result.

The consolidation handles both:
- OpenAI format: multiple 'tool' role messages with the same tool_call_id
- Anthropic format: content arrays with multiple tool_result blocks with the same tool_use_id

When merging:
- String content is concatenated with newlines
- List content is flattened into a single list
- The is_error flag is preserved if any result has it True
- cache_control is preserved from the first result

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


