### PR TITLE
Upgrade grpcio dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ polars = {version = "^1.31.0", optional = true, python = ">=3.10"}
 semantic-router = {version = ">=0.1.12", optional = true, python = ">=3.9,<3.14"}
 mlflow = {version = ">3.1.4", optional = true, python = ">=3.10"}
 soundfile = {version = "^0.12.1", optional = true}
-grpcio = ">=1.62.3,<1.68.0"  # Constrain to < 1.68.0 to avoid resource exhausted bug (https://github.com/grpc/grpc/issues/38290). Minimum 1.62.3 required by grpcio-status.
+grpcio = ">=1.73.1"  # Constrain to >=1.73.1 to avoid resource exhausted bug (https://github.com/grpc/grpc/issues/38290)
 
 [tool.poetry.extras]
 proxy = [


### PR DESCRIPTION
## Title

Upgrade grpcio dependency version

## Relevant issues

The stated bug was fixed in 1.73.1 https://github.com/grpc/grpc/issues/38290#issuecomment-3014966368

We've not able to upgrade to the latest litellm since we use the latest grpcio due to CVE upgrades

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring

## Changes

Just upgrading the grpcio version
