### PR TITLE
[Perf] - Cut memory leak in half

### DIFF
--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -6,6 +6,7 @@ Module responsible for
 """
 
 import asyncio
+import copy
 import json
 import os
 import random
@@ -162,14 +163,14 @@ class DBSpendUpdateWriter:
             asyncio.create_task(
                 self._update_tag_db(
                     response_cost=response_cost,
-                    request_tags=payload.get("request_tags"),
+                    request_tags=copy.deepcopy(payload.get("request_tags")),
                     prisma_client=prisma_client,
                 )
             )
 
             if disable_spend_logs is False:
                 await self._insert_spend_log_to_db(
-                    payload=payload,
+                    payload=copy.deepcopy(payload),
                     prisma_client=prisma_client,
                 )
             else:
@@ -179,34 +180,34 @@ class DBSpendUpdateWriter:
 
             asyncio.create_task(
                 self.add_spend_log_transaction_to_daily_user_transaction(
-                    payload=payload,
+                    payload=copy.deepcopy(payload),
                     prisma_client=prisma_client,
                 )
             )
 
             asyncio.create_task(
                 self.add_spend_log_transaction_to_daily_end_user_transaction(
-                    payload=payload,
+                    payload=copy.deepcopy(payload),
                     prisma_client=prisma_client,
                 )
             )
 
             asyncio.create_task(
                 self.add_spend_log_transaction_to_daily_team_transaction(
-                    payload=payload,
+                    payload=copy.deepcopy(payload),
                     prisma_client=prisma_client,
                 )
             )
             asyncio.create_task(
                 self.add_spend_log_transaction_to_daily_org_transaction(
-                    payload=payload,
+                    payload=copy.deepcopy(payload),
                     org_id=org_id,
                     prisma_client=prisma_client,
                 )
             )
             asyncio.create_task(
                 self.add_spend_log_transaction_to_daily_tag_transaction(
-                    payload=payload,
+                    payload=copy.deepcopy(payload),
                     prisma_client=prisma_client,
                 )
             )

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1,6 +1,5 @@
 import asyncio
 import copy
-import gc
 import hashlib
 import json
 import os
@@ -3379,7 +3378,6 @@ class ProxyUpdateSpend:
                             headers={"Content-Type": "application/json"},
                         )
                         del json_data
-                        gc.collect()
                         if response.status_code == 200:
                             prisma_client.spend_log_transactions = (
                                 prisma_client.spend_log_transactions[
@@ -3401,9 +3399,6 @@ class ProxyUpdateSpend:
                             )
                             # Explicitly clear batch memory
                             del batch, batch_with_dates
-                            # Only run gc every 5 batches to reduce overhead
-                            if j % (BATCH_SIZE * 5) == 0:
-                                gc.collect()
 
                         prisma_client.spend_log_transactions = (
                             prisma_client.spend_log_transactions[len(logs_to_process) :]
@@ -3429,7 +3424,6 @@ class ProxyUpdateSpend:
         finally:
             # Clean up logs_to_process after all processing is complete
             del logs_to_process
-            gc.collect()
 
     @staticmethod
     def disable_spend_updates() -> bool:


### PR DESCRIPTION

## Title

[Perf] - Cut memory leak in half

## Relevant issues

Addresses #12685

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- Remove references from being passed to fire-and-forget tasks.


## Results

* The memory leak is now reduced by more than half.
* There's still one small memory leak remaining 

**Before**
<img width="1434" height="269" alt="Screenshot 2025-12-10 at 11 19 46 AM" src="https://github.com/user-attachments/assets/4b4e7dd7-8a10-41be-a26f-1feb3001754a" />


**After**

<img width="1371" height="198" alt="Screenshot 2025-12-10 at 12 09 44 PM" src="https://github.com/user-attachments/assets/539d72c8-d8d3-4a43-a87a-5eeeb8081ce1" />


## How to look for memory leaks ?

1. Start the proxy server with a single worker.
2. In a separate terminal, run:

   ```bash
   memray attach --trace-python-allocators <ProxyServer's PID>
   ```
3. Run a load test against the proxy server.
4. Stop the load test.
5. Let the process sit for 5–10 minutes and observe what memory remains.
6. Sort by `% Own`
