### PR TITLE
fix: MCP OAuth callback routing and URL handling

### DIFF
--- a/ui/litellm-dashboard/src/app/mcp/oauth/callback/page.tsx
+++ b/ui/litellm-dashboard/src/app/mcp/oauth/callback/page.tsx
@@ -6,6 +6,21 @@ import { useSearchParams } from "next/navigation";
 const RESULT_STORAGE_KEY = "litellm-mcp-oauth-result";
 const RETURN_URL_STORAGE_KEY = "litellm-mcp-oauth-return-url";
 
+const resolveDefaultRedirect = () => {
+  if (typeof window === "undefined") {
+    return "/ui";
+  }
+
+  const path = window.location.pathname || "";
+  const uiIndex = path.indexOf("/ui");
+  if (uiIndex >= 0) {
+    const prefix = path.slice(0, uiIndex + 3);
+    return prefix.endsWith("/") ? prefix : `${prefix}`;
+  }
+
+  return "/";
+};
+
 const McpOAuthCallbackPage = () => {
   const searchParams = useSearchParams();
 
@@ -33,11 +48,8 @@ const McpOAuthCallbackPage = () => {
 
     const returnUrl = window.sessionStorage.getItem(RETURN_URL_STORAGE_KEY);
     console.info("[MCP OAuth callback] returnUrl", returnUrl);
-    if (returnUrl) {
-      window.location.replace(returnUrl);
-    } else {
-      window.location.replace("/");
-    }
+    const destination = returnUrl || resolveDefaultRedirect();
+    window.location.replace(destination);
   }, [payload]);
 
   return (

--- a/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
+++ b/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
@@ -8,6 +8,7 @@ import {
   exchangeMcpOAuthToken,
   getProxyBaseUrl,
   registerMcpOAuthClient,
+  serverRootPath,
 } from "@/components/networking";
 
 export type McpOAuthStatus = "idle" | "authorizing" | "exchanging" | "success" | "error";
@@ -87,12 +88,21 @@ export const useMcpOAuthFlow = ({
     }
   };
 
-  const callbackUrl = () => {
-    if (typeof window === "undefined") {
-      return `${getProxyBaseUrl()}/v1/mcp/oauth/callback`;
+  const buildCallbackUrl = () => {
+    if (typeof window !== "undefined") {
+      const path = window.location.pathname || "";
+      const uiIndex = path.indexOf("/ui");
+      const uiPrefix = uiIndex >= 0 ? path.slice(0, uiIndex + 3) : "";
+      const normalizedPrefix = uiPrefix.replace(/\/+$/, "");
+      return `${window.location.origin}${normalizedPrefix}/mcp/oauth/callback`;
     }
-    return `${window.location.origin}/mcp/oauth/callback`;
+
+    const base = (getProxyBaseUrl() || "").replace(/\/+$/, "");
+    const rootPrefix = serverRootPath && serverRootPath !== "/" ? serverRootPath : "";
+    return `${base}${rootPrefix}/ui/mcp/oauth/callback`;
   };
+
+  const callbackUrl = () => buildCallbackUrl();
 
   const startOAuthFlow = useCallback(async () => {
     const credentials = getCredentials() || {};


### PR DESCRIPTION
## Title

fix: MCP OAuth callback routing and URL handling

## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

This PR addresses two issues with the MCP OAuth callback flow:

1. The proxy’s UI restructuring logic only converted top-level *.html files into `<route>/index.html`. 
Nested routes like `mcp/oauth/callback` stayed as callback.html, so /ui/mcp/oauth/callback 404’d once the dashboard bundle was mounted behind the Python server. The fix walks the entire exported UI tree and moves every non-index HTML file into a matching folder, restoring nested routes automatically.

2. Callback URLs generated in useMcpOAuthFlow (and the callback page itself) didn’t honor the /ui prefix or custom server_root_path, so they returned to / or the proxy root regardless of environment.
The new logic inspects the current pathname to prepend /ui whenever the UI is being served from that path, ensuring both dev (npm run dev on port 3000) and proxy deployments redirect back to the correct dashboard entry point.

https://www.loom.com/share/84bfd182579e4cc69bd815f0755d4d20