### PR TITLE
chore: prefer standard trace id for Langfuse logging

### DIFF
--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -371,8 +371,6 @@ export LANGFUSE_PUBLIC_KEY="pk_kk"
 export LANGFUSE_SECRET_KEY="sk_ss"
 # Optional, defaults to https://cloud.langfuse.com
 export LANGFUSE_HOST="https://xxx.langfuse.com"
-# Optional - When True, forwards LiteLLM's logging trace_id to Langfuse
-LANGFUSE_PROPAGATE_TRACE_ID=True
 ```
 
 **Step 4**: Start the proxy, make a test request

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -70,7 +70,6 @@ class LangFuseLogger:
         self.langfuse_flush_interval = LangFuseLogger._get_langfuse_flush_interval(
             flush_interval
         )
-        self.langfuse_propagate_trace_id  = str_to_bool(os.getenv("LANGFUSE_PROPAGATE_TRACE_ID", "False")) is True
         http_client = _get_httpx_client()
         self.langfuse_client = http_client.client
 
@@ -538,11 +537,7 @@ class LangFuseLogger:
             session_id = clean_metadata.pop("session_id", None)
             trace_name = cast(Optional[str], clean_metadata.pop("trace_name", None))
             trace_id = clean_metadata.pop("trace_id", None)
-            if (
-                trace_id is None
-                and self.langfuse_propagate_trace_id is True
-                and standard_logging_object is not None
-            ):
+            if trace_id is None and standard_logging_object is not None:
                 trace_id = cast(Optional[str], standard_logging_object.get("trace_id"))
             if trace_id is None:
                 trace_id = litellm_call_id

--- a/litellm/integrations/langfuse/langfuse_prompt_management.py
+++ b/litellm/integrations/langfuse/langfuse_prompt_management.py
@@ -12,7 +12,6 @@ from typing_extensions import TypeAlias
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.prompt_management_base import PromptManagementClient
 from litellm.litellm_core_utils.asyncify import run_async_function
-from litellm.secret_managers.main import str_to_bool
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionSystemMessage
 from litellm.types.utils import StandardCallbackDynamicParams, StandardLoggingPayload
 
@@ -125,7 +124,6 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
             langfuse_host=langfuse_host,
             flush_interval=flush_interval,
         )
-        self.langfuse_propagate_trace_id  = str_to_bool(os.getenv("LANGFUSE_PROPAGATE_TRACE_ID", "False")) is True
 
     @property
     def integration_name(self):
@@ -138,7 +136,6 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
     ) -> PROMPT_CLIENT:
-
         prompt_client = langfuse_client.get_prompt(
             langfuse_prompt_id, label=prompt_label, version=prompt_version
         )
@@ -189,11 +186,7 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
         tools: Optional[List[Dict]] = None,
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
-    ) -> Tuple[
-        str,
-        List[AllMessageValues],
-        dict,
-    ]:
+    ) -> Tuple[str, List[AllMessageValues], dict,]:
         return self.get_chat_completion_prompt(
             model,
             messages,

--- a/tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py
+++ b/tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py
@@ -27,28 +27,3 @@ class TestLangfusePromptManagement:
 
             mock_get_prompt_from_id.assert_called_once()
             assert mock_get_prompt_from_id.call_args.kwargs["prompt_version"] == 4
-
-    def test_trace_id_propagation_flag_from_env(self):
-        with patch.dict(
-            os.environ,
-            {
-                "LANGFUSE_SECRET_KEY": "secret",
-                "LANGFUSE_PUBLIC_KEY": "public",
-                "LANGFUSE_PROPAGATE_TRACE_ID": "True",
-            },
-            clear=True,
-        ):
-            pm = LangfusePromptManagement()
-            assert pm.langfuse_propagate_trace_id is True
-
-        with patch.dict(
-            os.environ,
-            {
-                "LANGFUSE_SECRET_KEY": "secret",
-                "LANGFUSE_PUBLIC_KEY": "public",
-                "LANGFUSE_PROPAGATE_TRACE_ID": "False",
-            },
-            clear=True,
-        ):
-            pm2 = LangfusePromptManagement()
-            assert pm2.langfuse_propagate_trace_id is False

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -394,8 +394,7 @@ class TestLangfuseUsageDetails(unittest.TestCase):
             "messages": [],
         }
 
-    def test_log_langfuse_v2_propagates_standard_trace_id_when_enabled(self):
-        self.logger.langfuse_propagate_trace_id = True
+    def test_log_langfuse_v2_uses_standard_trace_id_when_available(self):
         payload = self._build_standard_logging_payload(trace_id="std-trace-id")
         kwargs = self._build_langfuse_kwargs(payload)
         self.last_trace_kwargs = {}
@@ -422,9 +421,8 @@ class TestLangfuseUsageDetails(unittest.TestCase):
 
         assert self.last_trace_kwargs.get("id") == "std-trace-id"
 
-    def test_log_langfuse_v2_defaults_to_call_id_when_propagation_disabled(self):
-        self.logger.langfuse_propagate_trace_id = False
-        payload = self._build_standard_logging_payload(trace_id="std-trace-id")
+    def test_log_langfuse_v2_defaults_to_call_id_without_standard_trace_id(self):
+        payload = self._build_standard_logging_payload()
         kwargs = self._build_langfuse_kwargs(payload)
         self.last_trace_kwargs = {}
 


### PR DESCRIPTION
## Title

chore: prefer standard trace id for Langfuse logging

## Relevant issues

Related #17669

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

Addressing https://github.com/BerriAI/litellm/pull/17669/files#r2600856384 – Langfuse now always prefers standard_logging_object.trace_id, falling back to litellm_call_id when it’s missing.
If this change isn’t needed, feel free to close.

