### PR TITLE
[Feat] Agent Gateway - Track `agent_id` in SpendLogs 

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -315,6 +315,7 @@ model LiteLLM_SpendLogs {
   session_id          String?
   status              String?
   mcp_namespaced_tool_name String? 
+  agent_id            String?
   proxy_server_request Json?     @default("{}")
   @@index([startTime])
   @@index([end_user])

--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -208,10 +208,14 @@ async def asend_message(
         return LiteLLMSendMessageResponse.from_dict(response_dict)
 
     # Standard A2A client flow
-    if a2a_client is None:
-        raise ValueError("a2a_client is required for standard A2A flow")
     if request is None:
         raise ValueError("request is required")
+
+    # Create A2A client if not provided but api_base is available
+    if a2a_client is None:
+        if api_base is None:
+            raise ValueError("Either a2a_client or api_base is required for standard A2A flow")
+        a2a_client = await create_a2a_client(base_url=api_base)
 
     agent_name = _get_a2a_model_info(a2a_client, kwargs)
 
@@ -347,10 +351,14 @@ async def asend_message_streaming(
         return
 
     # Standard A2A client flow
-    if a2a_client is None:
-        raise ValueError("a2a_client is required for standard A2A flow")
     if request is None:
         raise ValueError("request is required")
+
+    # Create A2A client if not provided but api_base is available
+    if a2a_client is None:
+        if api_base is None:
+            raise ValueError("Either a2a_client or api_base is required for standard A2A flow")
+        a2a_client = await create_a2a_client(base_url=api_base)
 
     verbose_logger.info(f"A2A send_message_streaming request_id={request.id}")
 

--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -68,7 +68,7 @@ def _set_agent_id_on_logging_obj(
     agent_id: Optional[str],
 ) -> None:
     """
-    Set agent_id on litellm_logging_obj metadata for SpendLogs tracking.
+    Set agent_id on litellm_logging_obj for SpendLogs tracking.
 
     Args:
         kwargs: The kwargs dict containing litellm_logging_obj
@@ -79,10 +79,8 @@ def _set_agent_id_on_logging_obj(
 
     litellm_logging_obj = kwargs.get("litellm_logging_obj")
     if litellm_logging_obj is not None:
-        # Set agent_id in metadata for spend logs
-        if "metadata" not in litellm_logging_obj.model_call_details:
-            litellm_logging_obj.model_call_details["metadata"] = {}
-        litellm_logging_obj.model_call_details["metadata"]["agent_id"] = agent_id
+        # Set agent_id directly on model_call_details (same pattern as custom_llm_provider)
+        litellm_logging_obj.model_call_details["agent_id"] = agent_id
 
 
 def _get_a2a_model_info(a2a_client: Any, kwargs: Dict[str, Any]) -> str:

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2677,6 +2677,7 @@ class SpendLogsPayload(TypedDict):
     model_id: Optional[str]
     model_group: Optional[str]
     mcp_namespaced_tool_name: Optional[str]
+    agent_id: Optional[str]
     api_base: str
     user: str
     metadata: str  # json str

--- a/litellm/proxy/agent_endpoints/a2a_endpoints.py
+++ b/litellm/proxy/agent_endpoints/a2a_endpoints.py
@@ -50,6 +50,7 @@ async def _handle_stream_message(
     request_id: str,
     params: dict,
     litellm_params: Optional[dict] = None,
+    agent_id: Optional[str] = None,
 ) -> StreamingResponse:
     """Handle message/stream method via SDK functions."""
     from a2a.types import MessageSendParams, SendStreamingMessageRequest
@@ -66,6 +67,7 @@ async def _handle_stream_message(
                 request=a2a_request,
                 api_base=api_base,
                 litellm_params=litellm_params,
+                agent_id=agent_id,
             ):
                 # Chunk may be dict or object depending on bridge vs standard path
                 if hasattr(chunk, "model_dump"):
@@ -241,6 +243,7 @@ async def invoke_agent_a2a(
                 request=a2a_request,
                 api_base=agent_url,
                 litellm_params=litellm_params,
+                agent_id=agent.agent_id,
                 metadata=data.get("metadata", {}),
                 proxy_server_request=data.get("proxy_server_request"),
             )
@@ -252,6 +255,7 @@ async def invoke_agent_a2a(
                 request_id=request_id,
                 params=params,
                 litellm_params=litellm_params,
+                agent_id=agent.agent_id,
             )
         else:
             return _jsonrpc_error(request_id, -32601, f"Method '{method}' not found")

--- a/litellm/proxy/agent_endpoints/a2a_endpoints.py
+++ b/litellm/proxy/agent_endpoints/a2a_endpoints.py
@@ -51,6 +51,8 @@ async def _handle_stream_message(
     params: dict,
     litellm_params: Optional[dict] = None,
     agent_id: Optional[str] = None,
+    metadata: Optional[dict] = None,
+    proxy_server_request: Optional[dict] = None,
 ) -> StreamingResponse:
     """Handle message/stream method via SDK functions."""
     from a2a.types import MessageSendParams, SendStreamingMessageRequest
@@ -68,6 +70,8 @@ async def _handle_stream_message(
                 api_base=api_base,
                 litellm_params=litellm_params,
                 agent_id=agent_id,
+                metadata=metadata,
+                proxy_server_request=proxy_server_request,
             ):
                 # Chunk may be dict or object depending on bridge vs standard path
                 if hasattr(chunk, "model_dump"):
@@ -256,6 +260,8 @@ async def invoke_agent_a2a(
                 params=params,
                 litellm_params=litellm_params,
                 agent_id=agent.agent_id,
+                metadata=data.get("metadata", {}),
+                proxy_server_request=data.get("proxy_server_request"),
             )
         else:
             return _jsonrpc_error(request_id, -32601, f"Method '{method}' not found")

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -315,6 +315,7 @@ model LiteLLM_SpendLogs {
   session_id          String?
   status              String?
   mcp_namespaced_tool_name String? 
+  agent_id            String?
   proxy_server_request Json?     @default("{}")
   @@index([startTime])
   @@index([end_user])

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -225,13 +225,16 @@ def get_logging_payload(  # noqa: PLR0915
         response_obj_dict = {}
 
     # Handle OCR responses which use usage_info instead of usage
+    usage: dict = {}
     if call_type in ["ocr", "aocr"]:
         usage = _extract_usage_for_ocr_call(response_obj, response_obj_dict)
     else:
         # Use response_obj_dict instead of response_obj to avoid calling .get() on Pydantic models
-        usage = response_obj_dict.get("usage", None) or {}
-        if isinstance(usage, litellm.Usage):
-            usage = dict(usage)
+        _usage = response_obj_dict.get("usage", None) or {}
+        if isinstance(_usage, litellm.Usage):
+            usage = dict(_usage)
+        elif isinstance(_usage, dict):
+            usage = _usage
 
     id = get_spend_logs_id(call_type or "acompletion", response_obj_dict, kwargs)
     standard_logging_payload = cast(
@@ -369,6 +372,9 @@ def get_logging_payload(  # noqa: PLR0915
             "namespaced_tool_name", None
         )
 
+    # Extract agent_id for A2A requests (set directly on model_call_details)
+    agent_id: Optional[str] = kwargs.get("agent_id")
+
     try:
         payload: SpendLogsPayload = SpendLogsPayload(
             request_id=str(id),
@@ -396,6 +402,7 @@ def get_logging_payload(  # noqa: PLR0915
             model_group=_model_group,
             model_id=_model_id,
             mcp_namespaced_tool_name=mcp_namespaced_tool_name,
+            agent_id=agent_id,
             requester_ip_address=clean_metadata.get("requester_ip_address", None),
             custom_llm_provider=kwargs.get("custom_llm_provider", ""),
             messages=_get_messages_for_spend_logs_payload(

--- a/schema.prisma
+++ b/schema.prisma
@@ -315,6 +315,7 @@ model LiteLLM_SpendLogs {
   session_id          String?
   status              String?
   mcp_namespaced_tool_name String? 
+  agent_id            String?
   proxy_server_request Json?     @default("{}")
   @@index([startTime])
   @@index([end_user])

--- a/tests/test_litellm/a2a_protocol/test_cost_calculator.py
+++ b/tests/test_litellm/a2a_protocol/test_cost_calculator.py
@@ -224,6 +224,80 @@ async def test_asend_message_passes_agent_id_to_callback():
     assert agent_id_logger.agent_id == test_agent_id, f"Expected agent_id '{test_agent_id}', got '{agent_id_logger.agent_id}'"
 
 
+class MetadataLogger(CustomLogger):
+    """Custom logger to capture metadata from kwargs for proxy spend tracking."""
+
+    def __init__(self):
+        self.metadata: Optional[dict] = None
+        self.litellm_params: Optional[dict] = None
+        self.user_api_key: Optional[str] = None
+        self.user_id: Optional[str] = None
+        self.team_id: Optional[str] = None
+        super().__init__()
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.litellm_params = kwargs.get("litellm_params", {})
+        self.metadata = self.litellm_params.get("metadata", {})
+        self.user_api_key = self.metadata.get("user_api_key")
+        self.user_id = self.metadata.get("user_api_key_user_id")
+        self.team_id = self.metadata.get("user_api_key_team_id")
+
+
+@pytest.mark.asyncio
+async def test_asend_message_streaming_propagates_metadata():
+    """
+    Test that asend_message_streaming propagates metadata to logging object.
+    This ensures user_api_key, user_id, team_id are available for SpendLogs.
+    """
+    from litellm.a2a_protocol import asend_message_streaming
+
+    # Setup logger
+    litellm.logging_callback_manager._reset_all_callbacks()
+    metadata_logger = MetadataLogger()
+    litellm.logging_callback_manager.add_litellm_async_success_callback(metadata_logger)
+
+    # Mock A2A client
+    mock_client = MagicMock()
+    mock_client._litellm_agent_card = MagicMock()
+    mock_client._litellm_agent_card.name = "test-agent"
+
+    # Mock streaming response
+    async def mock_stream():
+        yield MagicMock(model_dump=lambda mode, exclude_none: {"chunk": 1})
+        yield MagicMock(model_dump=lambda mode, exclude_none: {"chunk": 2})
+
+    mock_client.send_message_streaming = MagicMock(return_value=mock_stream())
+
+    # Mock request
+    mock_request = MagicMock()
+    mock_request.id = "test-stream-metadata"
+    mock_request.params = MagicMock()
+    mock_request.params.message = {"role": "user", "parts": [{"kind": "text", "text": "Hello"}]}
+
+    # Metadata from proxy (contains user_api_key, user_id, team_id for SpendLogs)
+    test_metadata = {
+        "user_api_key": "sk-test-key-hash-12345",
+        "user_api_key_user_id": "user-uuid-123",
+        "user_api_key_team_id": "team-uuid-456",
+    }
+
+    # Consume streaming response with metadata
+    chunks = []
+    async for chunk in asend_message_streaming(
+        a2a_client=mock_client,
+        request=mock_request,
+        metadata=test_metadata,
+    ):
+        chunks.append(chunk)
+
+    await asyncio.sleep(0.2)
+
+    # Verify metadata was propagated to callback
+    assert metadata_logger.user_api_key == "sk-test-key-hash-12345"
+    assert metadata_logger.user_id == "user-uuid-123"
+    assert metadata_logger.team_id == "team-uuid-456"
+
+
 @pytest.mark.asyncio
 async def test_asend_message_streaming_triggers_callbacks():
     """


### PR DESCRIPTION
## [Feat] Track `agent_id` in SpendLogs 

<img width="1411" height="606" alt="Screenshot 2025-12-10 at 3 15 53 PM" src="https://github.com/user-attachments/assets/26cbfca5-5b80-4ad6-bef9-163e7ec9b380" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


