### PR TITLE
fix(completion): transform image content in tool results for Responses API

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -165,11 +165,18 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     )
             elif role == "tool":
                 # Convert tool message to function call output format
+                # Transform content if it's multimodal (list with images, etc.)
+                if isinstance(content, list):
+                    transformed_output = self._convert_content_to_responses_format(
+                        content, "tool"
+                    )
+                else:
+                    transformed_output = content
                 input_items.append(
                     {
                         "type": "function_call_output",
                         "call_id": tool_call_id,
-                        "output": content,
+                        "output": transformed_output,
                     }
                 )
             elif role == "assistant" and tool_calls and isinstance(tool_calls, list):


### PR DESCRIPTION
## Relevant issues

Fixes #17762 and #17507

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

When using `litellm.completion()` with `model="openai/responses/..."`, images in tool message content were not being transformed from Chat Completion format to Responses API format.

### Example Request

```python
import litellm

messages = [
    {"role": "user", "content": "Fetch the image"},
    {
        "role": "assistant",
        "content": None,
        "tool_calls": [
            {
                "id": "call_abc123",
                "type": "function",
                "function": {
                    "name": "fetch_image",
                    "arguments": '{"url": "https://example.com/image.png"}'
                }
            }
        ]
    },
    {
        "role": "tool",
        "tool_call_id": "call_abc123",
        "content": [
            {
                "type": "image_url",
                "image_url": {
                    "url": "data:image/png;base64,iVBORw0KGgo..."
                }
            }
        ]
    },
    {"role": "user", "content": "What color is the image?"}
]

response = litellm.completion(
    model="openai/responses/gpt-4.1",
    messages=messages,
    tools=[{
        "type": "function",
        "function": {
            "name": "fetch_image",
            "parameters": {"type": "object", "properties": {"url": {"type": "string"}}}
        }
    }]
)
```

The tool message content was being passed directly without transformation:

**Chat Completion format (what user sends):**
```python
{"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
```

**Responses API format (what OpenAI expects):**
```python
{"type": "input_image", "image_url": "data:image/png;base64,..."}
```

 OpenAI reject the request with error 400:
```
Invalid value: 'image_url'. Supported values are: 'input_text', 'input_image', 'output_text', ...
```

### Fix

Transform tool message content using `_convert_content_to_responses_format()` when the content is a list (multimodal content with images).

 ### Tests Added

   **File:** `tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py`

   Added `test_convert_chat_completion_messages_to_responses_api_tool_result_with_image()` which verifies:
   - Tool messages with `image_url` content are correctly transformed
   - Output type is `input_image` (not `image_url`)
   - Output `image_url` is a flat string (not nested object)
   - `detail` field is preserved"