### PR TITLE
feat(bedrock): add serviceTier support for Converse API

### DIFF
--- a/docs/my-website/docs/providers/bedrock.md
+++ b/docs/my-website/docs/providers/bedrock.md
@@ -957,6 +957,65 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 </TabItem>
 </Tabs>
 
+## Usage - Service Tier
+
+Control the processing tier for your Bedrock requests using `serviceTier`. Valid values are `priority`, `default`, or `flex`.
+
+- `priority`: Higher priority processing with guaranteed capacity
+- `default`: Standard processing tier
+- `flex`: Cost-optimized processing for batch workloads
+
+[Bedrock ServiceTier API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ServiceTier.html)
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+
+response = completion(
+    model="bedrock/converse/qwen.qwen3-235b-a22b-2507-v1:0",
+    messages=[{"role": "user", "content": "What is the capital of France?"}],
+    serviceTier={"type": "priority"},
+)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+1. Setup config.yaml
+
+```yaml
+model_list:
+  - model_name: qwen3-235b-priority
+    litellm_params:
+      model: bedrock/converse/qwen.qwen3-235b-a22b-2507-v1:0
+      aws_region_name: ap-northeast-1
+      serviceTier:
+        type: priority
+```
+
+2. Start proxy
+
+```bash
+litellm --config /path/to/config.yaml
+```
+
+3. Test it!
+
+```bash
+curl http://0.0.0.0:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LITELLM_KEY" \
+  -d '{
+    "model": "qwen3-235b-priority",
+    "messages": [{"role": "user", "content": "What is the capital of France?"}],
+    "serviceTier": {"type": "priority"}
+  }'
+```
+
+</TabItem>
+</Tabs>
 ## Usage - Bedrock Guardrails
 
 Example of using [Bedrock Guardrails with LiteLLM](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-use-converse-api.html)

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -100,6 +100,7 @@ class AmazonConverseConfig(BaseConfig):
         return {
             "guardrailConfig": GuardrailConfigBlock,
             "performanceConfig": PerformanceConfigBlock,
+            "serviceTier": ServiceTierBlock,
         }
 
     @staticmethod

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -216,6 +216,10 @@ class PerformanceConfigBlock(TypedDict):
     latency: Literal["optimized", "throughput"]
 
 
+class ServiceTierBlock(TypedDict):
+    type: Literal["priority", "default", "flex"]
+
+
 class CommonRequestObject(
     TypedDict, total=False
 ):  # common request object across sync + async flows
@@ -226,6 +230,7 @@ class CommonRequestObject(
     toolConfig: ToolConfigBlock
     guardrailConfig: Optional[GuardrailConfigBlock]
     performanceConfig: Optional[PerformanceConfigBlock]
+    serviceTier: Optional[ServiceTierBlock]
     requestMetadata: Optional[Dict[str, str]]
 
 

--- a/tests/test_litellm/llms/bedrock/chat/test_service_tier.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_service_tier.py
@@ -1,0 +1,149 @@
+"""
+Tests for Bedrock Converse API serviceTier support.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+from litellm.types.llms.bedrock import ServiceTierBlock
+
+
+def test_service_tier_block_type():
+    """Test that ServiceTierBlock is properly defined."""
+    # Test valid service tier values
+    priority_tier: ServiceTierBlock = {"type": "priority"}
+    default_tier: ServiceTierBlock = {"type": "default"}
+    flex_tier: ServiceTierBlock = {"type": "flex"}
+
+    assert priority_tier["type"] == "priority"
+    assert default_tier["type"] == "default"
+    assert flex_tier["type"] == "flex"
+
+
+def test_service_tier_in_config_blocks():
+    """Test that serviceTier is included in get_config_blocks()."""
+    config_blocks = AmazonConverseConfig.get_config_blocks()
+
+    assert "serviceTier" in config_blocks
+    assert config_blocks["serviceTier"] == ServiceTierBlock
+
+
+def test_transform_request_with_service_tier():
+    """Test that serviceTier is properly included in the transformed request."""
+    config = AmazonConverseConfig()
+
+    messages = [{"role": "user", "content": "Hello!"}]
+    optional_params = {
+        "serviceTier": {"type": "priority"},
+    }
+
+    result = config.transform_request(
+        model="bedrock/converse/qwen.qwen3-235b-a22b-2507-v1:0",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    # serviceTier should be a top-level parameter, not in additionalModelRequestFields
+    assert "serviceTier" in result
+    assert result["serviceTier"]["type"] == "priority"
+
+    # Verify it's NOT in additionalModelRequestFields
+    additional_fields = result.get("additionalModelRequestFields", {})
+    assert "serviceTier" not in additional_fields
+    assert "service_tier" not in additional_fields
+
+
+def test_transform_request_with_default_tier():
+    """Test serviceTier with default value."""
+    config = AmazonConverseConfig()
+
+    messages = [{"role": "user", "content": "Hello!"}]
+    optional_params = {
+        "serviceTier": {"type": "default"},
+    }
+
+    result = config.transform_request(
+        model="bedrock/converse/anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert "serviceTier" in result
+    assert result["serviceTier"]["type"] == "default"
+
+
+def test_transform_request_with_flex_tier():
+    """Test serviceTier with flex value."""
+    config = AmazonConverseConfig()
+
+    messages = [{"role": "user", "content": "Hello!"}]
+    optional_params = {
+        "serviceTier": {"type": "flex"},
+    }
+
+    result = config.transform_request(
+        model="bedrock/converse/anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert "serviceTier" in result
+    assert result["serviceTier"]["type"] == "flex"
+
+
+def test_transform_request_without_service_tier():
+    """Test that requests without serviceTier work correctly."""
+    config = AmazonConverseConfig()
+
+    messages = [{"role": "user", "content": "Hello!"}]
+    optional_params = {}
+
+    result = config.transform_request(
+        model="bedrock/converse/anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    # serviceTier should not be present if not specified
+    assert "serviceTier" not in result
+
+
+def test_service_tier_with_other_config_blocks():
+    """Test serviceTier works alongside other config blocks like performanceConfig."""
+    config = AmazonConverseConfig()
+
+    messages = [{"role": "user", "content": "Hello!"}]
+    optional_params = {
+        "serviceTier": {"type": "priority"},
+        "performanceConfig": {"latency": "optimized"},
+    }
+
+    result = config.transform_request(
+        model="bedrock/converse/anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    # Both should be top-level parameters
+    assert "serviceTier" in result
+    assert result["serviceTier"]["type"] == "priority"
+    assert "performanceConfig" in result
+    assert result["performanceConfig"]["latency"] == "optimized"


### PR DESCRIPTION
## Relevant issues

Fixes #17808

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally (see below)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="2732" height="532" alt="CleanShot 2025-12-11 at 16 06 21@2x" src="https://github.com/user-attachments/assets/bb5be613-c37b-4353-aa84-341e7c83fd5d" />

## Type

🆕 New Feature

## Changes

### Summary

Add support for the Bedrock Converse API `serviceTier` parameter to allow users to specify processing tier (`priority`, `default`, or `flex`).

### Problem

Currently, when passing `serviceTier` via LiteLLM config or request params, it gets placed in `additionalModelRequestFields` instead of as a top-level parameter. Bedrock ignores `serviceTier` when it's in `additionalModelRequestFields`.

**Current behavior (incorrect):**

```json
{
  "additionalModelRequestFields": {
    "service_tier": "priority"
  }
}
```

**Expected behavior (correct):**

```json
{
  "serviceTier": {
    "type": "priority"
  }
}
```

### Solution

1. Added `ServiceTierBlock` type in `litellm/types/llms/bedrock.py`
2. Added `serviceTier` to `CommonRequestObject` TypedDict
3. Added `serviceTier` to `get_config_blocks()` in `AmazonConverseConfig` (similar to `guardrailConfig` and `performanceConfig`)

### Files Changed

- `litellm/types/llms/bedrock.py` - Added `ServiceTierBlock` type and updated `CommonRequestObject`
- `litellm/llms/bedrock/chat/converse_transformation.py` - Added `serviceTier` to `get_config_blocks()`
- `tests/test_litellm/llms/bedrock/chat/test_service_tier.py` - Added 7 comprehensive tests

### Usage

**Proxy config:**

```yaml
model_list:
  - model_name: qwen3-235b-priority
    litellm_params:
      model: bedrock/converse/qwen.qwen3-235b-a22b-2507-v1:0
      aws_region_name: ap-northeast-1
      serviceTier:
        type: priority
```

**SDK:**

```python
response = litellm.completion(
    model="bedrock/converse/qwen.qwen3-235b-a22b-2507-v1:0",
    messages=[{"role": "user", "content": "Hello"}],
    serviceTier={"type": "priority"}
)
```

### Test Results Screenshot

```
===== test session starts =====
collected 7 items

tests/test_litellm/llms/bedrock/chat/test_service_tier.py::test_service_tier_block_type PASSED           [ 14%]
tests/test_litellm/llms/bedrock/chat/test_service_tier.py::test_service_tier_in_config_blocks PASSED     [ 28%]
tests/test_litellm/llms/bedrock/chat/test_service_tier.py::test_service_tier_with_other_config_blocks PASSED [ 42%]
tests/test_litellm/llms/bedrock/chat/test_service_tier.py::test_transform_request_with_default_tier PASSED [ 57%]
tests/test_litellm/llms/bedrock/chat/test_service_tier.py::test_transform_request_with_flex_tier PASSED  [ 71%]
tests/test_litellm/llms/bedrock/chat/test_service_tier.py::test_transform_request_with_service_tier PASSED [ 85%]
tests/test_litellm/llms/bedrock/chat/test_service_tier.py::test_transform_request_without_service_tier PASSED [100%]

===== 7 passed =====
```

### Verified with CloudWatch Logs

Tested with Bedrock model invocation logging enabled. The log confirms `serviceTier` is now correctly placed as a top-level parameter:

```json
{
  "timestamp": "2025-12-11T08:10:27Z",
  "accountId": "[REDACTED]",
  "identity": {
    "arn": "arn:aws:iam::[REDACTED]:user/[REDACTED]"
  },
  "region": "ap-northeast-1",
  "requestId": "7e89531a-b625-4cdb-a640-571246c43daa",
  "operation": "Converse",
  "modelId": "qwen.qwen3-235b-a22b-2507-v1:0",
  "input": {
    "inputContentType": "application/json",
    "inputBodyJson": {
      "messages": [
        {
          "role": "user",
          "content": [
            {
              "text": "today is 2025-dec-11. what date is today?"
            }
          ]
        }
      ],
      "system": [],
      "inferenceConfig": {
        "maxTokens": 50
      },
      "additionalModelRequestFields": {},
      "serviceTier": {
        "type": "priority"
      }
    },
    "inputTokenCount": 26
  },
  "output": {
    "outputContentType": "application/json",
    "outputBodyJson": {
      "output": {
        "message": {
          "role": "assistant",
          "content": [
            {
              "text": "Today is December 11, 2025."
            }
          ]
        }
      },
      "stopReason": "end_turn",
      "usage": {
        "inputTokens": 26,
        "outputTokens": 14,
        "totalTokens": 40
      }
    },
    "outputTokenCount": 14
  },
  "serviceTier": {
    "type": "priority"
  },
  "schemaType": "ModelInvocationLog",
  "schemaVersion": "1.0"
}
```

Key points:

- `serviceTier` is at the top level in `inputBodyJson` ✅
- `serviceTier` is confirmed in the response at root level ✅
- `additionalModelRequestFields` is empty (not containing service_tier) ✅

### References

- [Bedrock ServiceTier API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ServiceTier.html)
