### PR TITLE
feat: Improve ollama_chat structured-output resilience for mixed text+JSON responses

### DIFF
--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import os
 import sys
 from typing import cast
@@ -11,6 +12,7 @@ sys.path.insert(
 )
 
 from litellm.llms.ollama.chat.transformation import OllamaChatConfig
+import litellm.llms.ollama_chat as ollama_chat_module
 from litellm.types.llms.openai import AllMessageValues
 from litellm.utils import get_optional_params
 
@@ -328,3 +330,10 @@ class TestOllamaChatConfigResponseFormat:
         # and the code checks "if images is not None", an empty list will still be set
         assert "images" in result["messages"][0]
         assert result["messages"][0]["images"] == []
+
+    def test_coerce_content_to_json_string_handles_mixed_text(self):
+        """Ensure best-effort JSON coercion works when model returns mixed natural text + JSON."""
+        raw = 'Sure, here you go:\\n{"reasoning": "ok", "accept": true}\\nThanks!'
+        coerced = ollama_chat_module._coerce_content_to_json_string(raw)
+        assert coerced is not None
+        assert json.loads(coerced) == {"reasoning": "ok", "accept": True}


### PR DESCRIPTION
Fixes  #17807  (Ollama /api/chat returns non-JSON, breaking structured output/tool calls)

  ## Pre-Submission checklist

- [ ] I have Added testing in the tests/litellm/ (https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, Adding at least 1 test is a hard requirement - see details (https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally
- [ ] My PR passes all unit tests on make test-unit (https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## Type

  🐛 Bug Fix

  ## Changes

  - Add a best-effort JSON coercion in ollama_chat when format/structured output is requested but /api/chat returns mixed natural text + JSON; applies to sync/async paths.
  - Add a regression test covering mixed text + JSON to ensure coercion extracts a valid JSON object.
  - Goal: prevent structured-output/tool-call parsing from failing when the model includes a JSON fragment in otherwise natural-language replies.
