### PR TITLE
Fix responses function_call_output reordering and add regression corage

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -251,14 +251,6 @@ class LiteLLMCompletionResponsesConfig:
                 ChatCompletionResponseMessage,
             ]
         ] = []
-        tool_call_output_messages: List[
-            Union[
-                AllMessageValues,
-                GenericChatCompletionMessage,
-                ChatCompletionMessageToolCall,
-                ChatCompletionResponseMessage,
-            ]
-        ] = []
 
         if isinstance(input, str):
             messages.append(ChatCompletionUserMessage(role="user", content=input))
@@ -269,16 +261,10 @@ class LiteLLMCompletionResponsesConfig:
                 )
 
                 #########################################################
-                # If Input Item is a Tool Call Output, add it to the tool_call_output_messages list
+                # If Input Item is a Tool Call Output, add it directly to messages
                 #########################################################
-                if LiteLLMCompletionResponsesConfig._is_input_item_tool_call_output(
-                    input_item=_input
-                ):
-                    tool_call_output_messages.extend(chat_completion_messages)
-                else:
-                    messages.extend(chat_completion_messages)
+                messages.extend(chat_completion_messages)
 
-        messages.extend(tool_call_output_messages)
         return messages
 
     @staticmethod


### PR DESCRIPTION
Fixes Vertex AI BadRequestError: "Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn." (caused by misordered
  function_call / function_call_output)

- stop buffering `function_call_output` in `LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message`, so tool outputs stay at their original position
- prevent assistant `tool_calls` from being merged into one turn and misaligning subsequent tool responses
- add regression test to ensure function calls and outputs remain adjacent and ordered (`tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py`)

## Title

Fix Responses transform `function_call_output` ordering and add regression test

## Relevant issues

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`]
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Stop reordering `function_call_output` (fixes Vertex AI BadRequestError)

#### Before: `function_call_output` was buffered to the end, so the sequence below got rearranged:

Input:
```
      1) user
      2) assistant (text)
      3) function_call fill (id=142)
      4) function_call_output (id=142)
      5) assistant (text)
      6) function_call click (id=1250)
      7) function_call_output (id=1250)
```
Old transform (problem):
```
      1 user
      2 assistant text
      3 assistant tool_call fill
      4 assistant text
      5 assistant tool_call click     ← both calls merged into same assistant turn
      6 tool response for fill        ← misaligned
      7 tool response for click
```

This triggered Vertex AI: “Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn.”

#### After: append `function_call_output` in-place; calls and outputs stay adjacent:

```
      1 user
      2 assistant text
      3 assistant tool_call fill
      4 tool response for fill
      5 assistant text
      6 assistant tool_call click
      7 tool response for click
```

### 2) Regression coverage

- Added a test for the above sequence to assert that function calls and outputs remain adjacent and ordered.

Files changed

- `litellm/responses/litellm_completion_transformation/transformation.py` — remove buffering, keep original order
- `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py` — new regression test

<img width="1440" height="761" alt="image" src="https://github.com/user-attachments/assets/f788d94f-57de-4b3c-b293-7aae4213a3ef" />
