### PR TITLE
fix(azure_ai): Remove unsupported params from Azure AI Anthropic requests

### DIFF
--- a/litellm/llms/azure_ai/anthropic/transformation.py
+++ b/litellm/llms/azure_ai/anthropic/transformation.py
@@ -98,8 +98,8 @@ class AzureAnthropicConfig(AnthropicConfig):
         headers: dict,
     ) -> dict:
         """
-        Transform request using parent AnthropicConfig, then remove extra_body if present.
-        Azure Anthropic doesn't support extra_body parameter.
+        Transform request using parent AnthropicConfig, then remove unsupported params.
+        Azure Anthropic doesn't support extra_body, max_retries, or stream_options parameters.
         """
         # Call parent transform_request
         data = super().transform_request(
@@ -109,9 +109,11 @@ class AzureAnthropicConfig(AnthropicConfig):
             litellm_params=litellm_params,
             headers=headers,
         )
-        
-        # Remove extra_body if present (Azure Anthropic doesn't support it)
+
+        # Remove unsupported parameters for Azure AI Anthropic
         data.pop("extra_body", None)
-        
+        data.pop("max_retries", None)
+        data.pop("stream_options", None)
+
         return data
 


### PR DESCRIPTION
## Title

fix(azure_ai): Remove unsupported params (max_retries, stream_options) from Azure AI Anthropic requests

## Relevant issues

Fixes the issue reported in Slack where Azure AI Anthropic endpoint rejects requests with:
- `max_retries: Extra inputs are not permitted`
- `stream_options: Extra inputs are not permitted`

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Symmary
When using Azure AI Anthropic (e.g., `azure_ai/claude-sonnet-4-5`), LiteLLM internally adds parameters like `max_retries` and `stream_options` to `optional_params`. These get spread into the request body via `**optional_params` in `transform_request()`, causing the Azure AI Anthropic endpoint to reject the request with 400 Bad Request.

### Solution
Updated `AzureAnthropicConfig.transform_request()` to remove unsupported parameters before sending to Azure AI Anthropic:
- `max_retries` - LiteLLM internal retry config
- `stream_options` - LiteLLM internal streaming config  
- `extra_body` - Already was being removed

This follows the same pattern used by other providers like `azure_ai/chat`, `groq`, `huggingface`, etc.

### Tests added