### PR TITLE
feat(langfuse): Add support for custom masking function

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -551,6 +551,12 @@ class LangFuseLogger:
             debug = clean_metadata.pop("debug_langfuse", None)
             mask_input = clean_metadata.pop("mask_input", False)
             mask_output = clean_metadata.pop("mask_output", False)
+            masking_function = clean_metadata.pop("langfuse_masking_function", None)
+
+            # Apply custom masking function if provided
+            if masking_function is not None and callable(masking_function):
+                input = self._apply_masking_function(input, masking_function)
+                output = self._apply_masking_function(output, masking_function)
 
             clean_metadata = redact_user_api_key_info(metadata=clean_metadata)
 
@@ -876,6 +882,45 @@ class LangFuseLogger:
     def _supports_completion_start_time(self):
         """Check if current langfuse version supports completion start time"""
         return Version(self.langfuse_sdk_version) >= Version("2.7.3")
+
+    @staticmethod
+    def _apply_masking_function(data: Any, masking_function: callable) -> Any:
+        """
+        Apply a masking function to data, handling different data types.
+
+        Args:
+            data: The data to mask (can be str, dict, list, or None)
+            masking_function: A callable that takes data and returns masked data
+
+        Returns:
+            The masked data
+        """
+        if data is None:
+            return None
+
+        try:
+            if isinstance(data, str):
+                return masking_function(data)
+            elif isinstance(data, dict):
+                masked_dict = {}
+                for key, value in data.items():
+                    masked_dict[key] = LangFuseLogger._apply_masking_function(
+                        value, masking_function
+                    )
+                return masked_dict
+            elif isinstance(data, list):
+                return [
+                    LangFuseLogger._apply_masking_function(item, masking_function)
+                    for item in data
+                ]
+            else:
+                # For other types, try to apply the function directly
+                return masking_function(data)
+        except Exception as e:
+            verbose_logger.warning(
+                f"Failed to apply masking function: {e}. Returning original data."
+            )
+            return data
 
     @staticmethod
     def _get_langfuse_flush_interval(flush_interval: int) -> int:

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -551,7 +551,9 @@ class LangFuseLogger:
             debug = clean_metadata.pop("debug_langfuse", None)
             mask_input = clean_metadata.pop("mask_input", False)
             mask_output = clean_metadata.pop("mask_output", False)
-            masking_function = clean_metadata.pop("langfuse_masking_function", None)
+            # Look for masking function in the dedicated location first (set by scrub_sensitive_keys_in_metadata)
+            # Fall back to metadata for backwards compatibility
+            masking_function = litellm_params.get("_langfuse_masking_function") or clean_metadata.pop("langfuse_masking_function", None)
 
             # Apply custom masking function if provided
             if masking_function is not None and callable(masking_function):

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5096,6 +5096,15 @@ def scrub_sensitive_keys_in_metadata(litellm_params: Optional[dict]):
 
     metadata = litellm_params.get("metadata", {}) or {}
 
+    ## Extract provider-specific callable values (like langfuse_masking_function)
+    ## Store them separately so only the intended logger can access them
+    ## This prevents callables from leaking to other logging integrations
+    if "langfuse_masking_function" in metadata:
+        masking_fn = metadata.pop("langfuse_masking_function", None)
+        if callable(masking_fn):
+            litellm_params["_langfuse_masking_function"] = masking_fn
+        litellm_params["metadata"] = metadata
+
     ## check user_api_key_metadata for sensitive logging keys
     cleaned_user_api_key_metadata = {}
     if "user_api_key_metadata" in metadata and isinstance(


### PR DESCRIPTION
## Title

feat(langfuse): Add support for custom masking function

## Relevant issues

Implements custom masking function support for Langfuse integration as discussed in internal thread.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

### Summary
Currently, LiteLLM's Langfuse integration only supports boolean `mask_input`/`mask_output` which completely redacts all data with "redacted-by-litellm". Users cannot selectively mask sensitive data (credit cards, emails, PII) while keeping the rest of the context visible for debugging.

### Solution
Added support for `langfuse_masking_function` parameter in metadata that allows users to pass a custom function to selectively redact sensitive information.

### Usage

```python
import litellm
import re

def mask_pii(data):
    if isinstance(data, 
        data = re.sub(r'\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b', '[CARD]', data)
        data = re.sub(r'[\w\.-]+@[\w\.-]+', '[EMAIL]', data)
    return data

response = litellm.completion(
    model="gpt-4",
    messages=[{"role": "user", "content": "Card example number is 4532-1234-5678-9012"}],
    metadata={"langfuse_masking_function": mask_pii}
)
# In Langfuse: "Card example number is [CARD]"
```

### Files changed
- `litellm/integrations/langfuse/langfuse.py` - Added `_apply_masking_function` method and integration
- `tests/logging_callback_tests/test_langfuse_unit_tests.py` - Added 4 unit tests for the new functionality