### PR TITLE
 fix(bedrock): Fix URL construction for qwen3/qwen2 imported models

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -345,26 +345,13 @@ class BaseAWSLLM:
             model_id = model
 
         model_id = model_id.replace("invoke/", "", 1)
-        if provider == "llama" and "llama/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="llama"
-            )
-        elif provider == "deepseek_r1" and "deepseek_r1/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="deepseek_r1"
-            )
-        elif provider == "openai" and "openai/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="openai"
-            )
-        elif provider == "qwen3" and "qwen3/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="qwen3"
-            )
-        elif provider == "qwen2" and "qwen2/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="qwen2"
-            )
+        provider_specs = ["llama", "deepseek_r1", "openai", "qwen3", "qwen2"]
+        for spec in provider_specs:
+            if provider == spec and f"{spec}/" in model_id:
+                model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                    model_id, spec=spec
+                )
+                break
         return model_id
 
     @staticmethod

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -357,6 +357,14 @@ class BaseAWSLLM:
             model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
                 model_id, spec="openai"
             )
+        elif provider == "qwen3" and "qwen3/" in model_id:
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                model_id, spec="qwen3"
+            )
+        elif provider == "qwen2" and "qwen2/" in model_id:
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                model_id, spec="qwen2"
+            )
         return model_id
 
     @staticmethod

--- a/tests/litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/litellm/llms/bedrock/test_base_aws_llm.py
@@ -1,0 +1,111 @@
+"""
+Tests for BaseAWSLLM class, specifically model ID extraction for imported models.
+
+Fixes: https://github.com/BerriAI/litellm/issues/17763
+"""
+
+import pytest
+from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+
+class TestBedrockModelIdExtraction:
+    """Test model ID extraction and encoding for imported Bedrock models."""
+
+    def test_qwen3_imported_model_strips_prefix(self):
+        """
+        Test that qwen3/ prefix is stripped from imported model ARN.
+
+        Fixes: https://github.com/BerriAI/litellm/issues/17763
+        """
+        model = "qwen3/arn:aws:bedrock:eu-central-1:123456789012:imported-model/test-model-123"
+        provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
+
+        assert provider == "qwen3"
+
+        model_id = BaseAWSLLM.get_bedrock_model_id(
+            model=model,
+            provider=provider,
+            optional_params={}
+        )
+
+        # The ARN should be URL encoded
+        assert "arn" in model_id
+        assert "imported-model" in model_id
+        # Ensure the qwen3/ prefix was stripped (this was the bug)
+        assert "qwen3%2F" not in model_id
+        assert "qwen3/" not in model_id
+
+    def test_qwen2_imported_model_strips_prefix(self):
+        """Test that qwen2/ prefix is stripped from imported model ARN."""
+        model = "qwen2/arn:aws:bedrock:us-west-2:123456789012:imported-model/test-model-456"
+        provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
+
+        assert provider == "qwen2"
+
+        model_id = BaseAWSLLM.get_bedrock_model_id(
+            model=model,
+            provider=provider,
+            optional_params={}
+        )
+
+        # The ARN should be URL encoded
+        assert "arn" in model_id
+        assert "imported-model" in model_id
+        # Ensure the qwen2/ prefix was stripped
+        assert "qwen2%2F" not in model_id
+        assert "qwen2/" not in model_id
+
+    def test_openai_imported_model_strips_prefix(self):
+        """Test that openai/ prefix is stripped from imported model ARN."""
+        model = "openai/arn:aws:bedrock:us-east-1:123456789012:imported-model/test-model-789"
+        provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
+
+        assert provider == "openai"
+
+        model_id = BaseAWSLLM.get_bedrock_model_id(
+            model=model,
+            provider=provider,
+            optional_params={}
+        )
+
+        # The ARN should be URL encoded
+        assert "arn" in model_id
+        assert "imported-model" in model_id
+        # Ensure the openai/ prefix was stripped
+        assert "openai%2F" not in model_id
+        assert "openai/" not in model_id
+
+    def test_llama_imported_model_strips_prefix(self):
+        """Test that llama/ prefix is stripped from imported model ARN."""
+        model = "llama/arn:aws:bedrock:us-east-1:123456789012:imported-model/test-model-abc"
+        provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
+
+        assert provider == "llama"
+
+        model_id = BaseAWSLLM.get_bedrock_model_id(
+            model=model,
+            provider=provider,
+            optional_params={}
+        )
+
+        # The ARN should be URL encoded
+        assert "arn" in model_id
+        assert "imported-model" in model_id
+        # Ensure the llama/ prefix was stripped
+        assert "llama%2F" not in model_id
+        assert "llama/" not in model_id
+
+    def test_native_model_unchanged(self):
+        """Test that native Bedrock model IDs are not modified."""
+        model = "qwen.qwen3-30b-v1:0"
+        provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
+
+        model_id = BaseAWSLLM.get_bedrock_model_id(
+            model=model,
+            provider=provider,
+            optional_params={}
+        )
+
+        # Native model should remain unchanged (just URL encoded)
+        assert "qwen" in model_id
+        assert "30b" in model_id

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -3568,7 +3568,64 @@ def test_bedrock_openai_model_id_extraction():
     # The ARN should be double URL encoded
     assert "arn" in model_id
     assert "imported-model" in model_id
+    # Ensure the openai/ prefix was stripped
+    assert "openai%2F" not in model_id
+    assert "openai/" not in model_id
     print(f"✓ Model ID extracted and encoded: {model_id}")
+
+
+def test_bedrock_qwen3_model_id_extraction():
+    """
+    Test that the model ID (ARN) is correctly extracted and encoded for Qwen3 imported models.
+
+    Fixes: https://github.com/BerriAI/litellm/issues/17763
+    """
+    from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+    model = "qwen3/arn:aws:bedrock:eu-central-1:123456789012:imported-model/test-model-123"
+    provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
+
+    assert provider == "qwen3"
+
+    model_id = BaseAWSLLM.get_bedrock_model_id(
+        model=model,
+        provider=provider,
+        optional_params={}
+    )
+
+    # The ARN should be URL encoded
+    assert "arn" in model_id
+    assert "imported-model" in model_id
+    # Ensure the qwen3/ prefix was stripped (this was the bug)
+    assert "qwen3%2F" not in model_id
+    assert "qwen3/" not in model_id
+    print(f"✓ Qwen3 Model ID extracted and encoded: {model_id}")
+
+
+def test_bedrock_qwen2_model_id_extraction():
+    """
+    Test that the model ID (ARN) is correctly extracted and encoded for Qwen2 imported models.
+    """
+    from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+    model = "qwen2/arn:aws:bedrock:us-west-2:123456789012:imported-model/test-model-456"
+    provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
+
+    assert provider == "qwen2"
+
+    model_id = BaseAWSLLM.get_bedrock_model_id(
+        model=model,
+        provider=provider,
+        optional_params={}
+    )
+
+    # The ARN should be URL encoded
+    assert "arn" in model_id
+    assert "imported-model" in model_id
+    # Ensure the qwen2/ prefix was stripped
+    assert "qwen2%2F" not in model_id
+    assert "qwen2/" not in model_id
+    print(f"✓ Qwen2 Model ID extracted and encoded: {model_id}")
 
 
 def test_bedrock_openai_convert_messages_to_prompt():


### PR DESCRIPTION
## Title

fix(bedrock): Strip qwen3/qwen2 prefix from imported model ARN URLs

## Relevant issues

Fixes #17763

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

When using imported Bedrock models with `qwen3/` or `qwen2/` provider prefix, the prefix was incorrectly included in the API URL.

<details>
<summary>What is an ARN for imported models?</summary>

AWS Bedrock allows users to import custom models (fine-tuned or from sources like Hugging Face) via the **Custom Model Import** feature. These imported models are identified by an ARN (Amazon Resource Name) instead of a standard model ID:

```
arn:aws:bedrock:{region}:{account-id}:imported-model/{model-id}
```

When using LiteLLM with an imported model, users specify the provider prefix (e.g., `qwen3/`) to indicate which prompt format to use, since AWS doesn't know the chat template for custom models:

```
bedrock/qwen3/arn:aws:bedrock:eu-central-1:123456789:imported-model/my-model
        ^^^^^
        Provider prefix (tells LiteLLM which prompt format to use)
```

This prefix should be stripped before constructing the AWS API URL.

</details>

### Example request

```python
from litellm import completion

response = completion(
    model="bedrock/qwen3/arn:aws:bedrock:eu-central-1:123456789:imported-model/my-model",
    messages=[{"role": "user", "content": "Hello!"}]
)
```

**Before:**
```
URL: /model/qwen3/arn:aws:bedrock:.../invoke
```

**After (fix):**
```
URL: /model/arn:aws:bedrock:.../invoke
```

The fix adds `qwen3` and `qwen2` to the list of providers whose prefix gets stripped from the `model_id` in `get_bedrock_model_id()`, matching existing behavior for `llama`, `deepseek_r1`, and `openai` providers.

### Tests added

`tests/litellm/llms/bedrock/test_base_aws_llm.py`