### PR TITLE
[Fix] Create Team Model Dropdown Honors Organization's Models

### DIFF
--- a/ui/litellm-dashboard/src/components/OldTeams.test.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.test.tsx
@@ -616,13 +616,13 @@ describe("OldTeams - Default Team Settings tab visibility", () => {
   });
 });
 
-describe("OldTeams - all-proxy-models dropdown visibility", () => {
+describe("OldTeams - models dropdown options", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(fetchAvailableModelsForTeamOrKey).mockResolvedValue(["gpt-4", "gpt-3.5-turbo"]);
   });
 
-  it("should not show all-proxy-models option when user has no access to it", async () => {
+  it("should not render all-proxy-models option in models select", async () => {
     vi.mocked(fetchAvailableModelsForTeamOrKey).mockResolvedValue(["gpt-4", "gpt-3.5-turbo"]);
 
     render(

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -1158,11 +1158,6 @@ const Teams: React.FC<TeamProps> = ({
                     name="models"
                   >
                     <Select2 mode="multiple" placeholder="Select models" style={{ width: "100%" }}>
-                      {(isProxyAdminRole(userRole || "") || userModels.includes("all-proxy-models")) && (
-                        <Select2.Option key="all-proxy-models" value="all-proxy-models">
-                          All Proxy Models
-                        </Select2.Option>
-                      )}
                       <Select2.Option key="no-default-models" value="no-default-models">
                         No Default Models
                       </Select2.Option>

--- a/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.test.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { getModelDisplayName } from "./fetch_available_models_team_key";
+
+describe("getModelDisplayName", () => {
+  it("should return display label for all proxy models", () => {
+    expect(getModelDisplayName("all-proxy-models")).toBe("All Proxy Models");
+  });
+
+  it("should return provider-wide label for wildcard models", () => {
+    expect(getModelDisplayName("openai/*")).toBe("All openai models");
+  });
+});

--- a/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.tsx
@@ -36,6 +36,9 @@ export const fetchAvailableModelsForTeamOrKey = async (
 };
 
 export const getModelDisplayName = (model: string) => {
+  if (model === "all-proxy-models") {
+    return "All Proxy Models";
+  }
   if (model.endsWith("/*")) {
     const provider = model.replace("/*", "");
     return `All ${provider} models`;


### PR DESCRIPTION
## [Fix] Create Team Model Dropdown Honors Organization's Models

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
In the Create Team Modal, when an organization is selected, it is now the source of truth for all models shown in the model dropdown. Previously if the user is the proxy admin, they can select All Proxy Models for the org even when the org does not have access to All Proxy Models

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="650" height="178" alt="image" src="https://github.com/user-attachments/assets/36b84a4f-ba7f-4f27-9015-bff9a63021cf" />


<img width="1010" height="430" alt="image" src="https://github.com/user-attachments/assets/e755b74d-ec82-4b4f-b3fe-93d1e6373c3c" />


