### PR TITLE
Add gpt-5.2-2025-12-11 and gpt-5.2-pro-2025-12-11 model entries

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16300,6 +16300,38 @@
         "supports_tool_choice": false,
         "supports_vision": true
     },
+    "gpt-5.2-2025-12-11": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "input_cost_per_token": 1.75e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "gpt-5-pro": {
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
@@ -16345,6 +16377,36 @@
         "output_cost_per_token_batches": 6e-05,
         "supported_endpoints": [
             "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": false,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
+    "gpt-5.2-pro-2025-12-11": {
+        "input_cost_per_token": 2.1e-05,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1.68e-04,
+        "supported_endpoints": [
             "/v1/responses"
         ],
         "supported_modalities": [


### PR DESCRIPTION
This PR adds model entries for:
- gpt-5.2-2025-12-11: Input $1.75/M tokens, Output $14/M tokens, 400K context window
- gpt-5.2-pro-2025-12-11: Input $21/M tokens, Output $168/M tokens, 400K context window

Both models support reasoning, vision, function calling, and are accessible via chat/responses APIs.

References:
- https://platform.openai.com/docs/models/gpt-5.2
- https://platform.openai.com/docs/models/gpt-5.2-pro