### PR TITLE
feat(proxy): add max_parallel_requests for model/user/team levels

### DIFF
--- a/docs/my-website/docs/proxy/model_max_parallel_requests.md
+++ b/docs/my-website/docs/proxy/model_max_parallel_requests.md
@@ -1,0 +1,233 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Model-Specific Max Parallel Requests
+
+Set different concurrent request limits for each model on a virtual key.
+
+Use this to:
+- Protect expensive models (GPT-4) while allowing more throughput on cheaper models
+- Prevent capacity exhaustion on rate-limited model deployments
+- Implement tiered access controls per model
+
+## Quick Start
+
+### Step 1. Create a key with model-specific limits
+
+Use `metadata.model_max_parallel_requests` to set per-model concurrent request limits:
+
+```shell
+curl --location 'http://0.0.0.0:4000/key/generate' \
+--header 'Authorization: Bearer sk-1234' \
+--header 'Content-Type: application/json' \
+--data '{
+  "max_parallel_requests": 20,
+  "metadata": {
+    "model_max_parallel_requests": {
+      "gpt-4": 2,
+      "gpt-3.5-turbo": 5
+    }
+  }
+}'
+```
+
+[**See Swagger**](https://litellm-api.up.railway.app/#/key%20management/generate_key_fn_key_generate_post)
+
+This creates a key where:
+- Overall key limit: 20 concurrent requests
+- `gpt-4`: max 2 concurrent requests
+- `gpt-3.5-turbo`: max 5 concurrent requests
+
+**Expected Response**
+
+```json
+{
+  "key": "sk-abc123...",
+  "max_parallel_requests": 20,
+  "metadata": {
+    "model_max_parallel_requests": {
+      "gpt-4": 2,
+      "gpt-3.5-turbo": 5
+    }
+  }
+}
+```
+
+### Step 2. Test the limits
+
+**Request within limit (succeeds):**
+
+```shell
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+--header 'Authorization: Bearer sk-abc123...' \
+--header 'Content-Type: application/json' \
+--data '{
+  "model": "gpt-4",
+  "messages": [{"role": "user", "content": "Hello"}]
+}'
+```
+
+**Request exceeding model limit (returns 429):**
+
+When you exceed the model's concurrent limit:
+
+```json
+{
+  "error": {
+    "message": "Max parallel request limit reached for model gpt-4. Limit: 2, current: 2",
+    "type": "rate_limit_error",
+    "code": 429
+  }
+}
+```
+
+## Setting Limits at Different Levels
+
+Model-specific parallel request limits can be set at the key level, team level, or via `model_max_budget`.
+
+**Priority order:**
+
+1. Key metadata (highest priority)
+2. model_max_budget configuration
+3. Team metadata (lowest priority)
+
+```mermaid
+flowchart TD
+    A["Incoming Request<br/>model=gpt-4"] --> B{"Key metadata<br/>has model limit?"}
+    B -->|Yes| C["Use key limit"]
+    B -->|No| D{"model_max_budget<br/>has limit?"}
+    D -->|Yes| E["Use model_max_budget limit"]
+    D -->|No| F{"Team metadata<br/>has model limit?"}
+    F -->|Yes| G["Use team limit"]
+    F -->|No| H["No model limit<br/>(use key overall limit)"]
+
+    style C fill:#ccffcc
+    style E fill:#ccffcc
+    style G fill:#ccffcc
+```
+
+<Tabs>
+<TabItem value="key" label="Per Key">
+
+Set limits directly on a virtual key:
+
+```shell
+curl --location 'http://0.0.0.0:4000/key/generate' \
+--header 'Authorization: Bearer sk-1234' \
+--header 'Content-Type: application/json' \
+--data '{
+  "metadata": {
+    "model_max_parallel_requests": {
+      "gpt-4": 2,
+      "claude-3-opus": 1
+    }
+  }
+}'
+```
+
+</TabItem>
+<TabItem value="team" label="Per Team">
+
+Set limits at the team level. All keys in the team inherit these limits.
+
+```shell
+curl --location 'http://0.0.0.0:4000/team/new' \
+--header 'Authorization: Bearer sk-1234' \
+--header 'Content-Type: application/json' \
+--data '{
+  "team_alias": "production-team",
+  "max_parallel_requests": 50,
+  "metadata": {
+    "model_max_parallel_requests": {
+      "gpt-4": 10,
+      "gpt-3.5-turbo": 30
+    }
+  }
+}'
+```
+
+[**See Swagger**](https://litellm-api.up.railway.app/#/team%20management/new_team_team_new_post)
+
+Then create keys for the team:
+
+```shell
+curl --location 'http://0.0.0.0:4000/key/generate' \
+--header 'Authorization: Bearer sk-1234' \
+--header 'Content-Type: application/json' \
+--data '{"team_id": "<team-id-from-above>"}'
+```
+
+</TabItem>
+<TabItem value="priority" label="Priority Override">
+
+Key metadata overrides team metadata. Useful for giving specific users different limits.
+
+```shell
+# Team has gpt-4 limit of 3
+# But this key overrides to limit of 1
+curl --location 'http://0.0.0.0:4000/key/generate' \
+--header 'Authorization: Bearer sk-1234' \
+--header 'Content-Type: application/json' \
+--data '{
+  "team_id": "<team-id>",
+  "metadata": {
+    "model_max_parallel_requests": {
+      "gpt-4": 1
+    }
+  }
+}'
+```
+
+The key-level limit of 1 takes precedence over the team-level limit of 3.
+
+</TabItem>
+</Tabs>
+
+## How It Works
+
+Model limits are enforced **independently** from the overall key limit:
+
+| Check | Behavior |
+|-------|----------|
+| Overall key `max_parallel_requests` | Limits total concurrent requests across all models |
+| Per-model `model_max_parallel_requests` | Limits concurrent requests for that specific model |
+
+**Example:** A key with `max_parallel_requests: 20` and `model_max_parallel_requests: {"gpt-4": 2}` can have:
+- Up to 2 concurrent GPT-4 requests
+- Up to 20 total concurrent requests (including GPT-4)
+- Hitting the GPT-4 limit doesn't block requests to other models
+
+## Combining with RPM/TPM Limits
+
+Combine `model_max_parallel_requests` with `model_rpm_limit` and `model_tpm_limit`:
+
+```shell
+curl --location 'http://0.0.0.0:4000/key/generate' \
+--header 'Authorization: Bearer sk-1234' \
+--header 'Content-Type: application/json' \
+--data '{
+  "model_rpm_limit": {"gpt-4": 10},
+  "model_tpm_limit": {"gpt-4": 10000},
+  "metadata": {
+    "model_max_parallel_requests": {
+      "gpt-4": 2
+    }
+  }
+}'
+```
+
+This key has:
+- Max 2 concurrent GPT-4 requests
+- Max 10 GPT-4 requests per minute
+- Max 10,000 GPT-4 tokens per minute
+
+## Demo Video
+
+<!-- TODO: Add Loom embed after recording -->
+<!-- <iframe width="840" height="500" src="https://www.loom.com/embed/VIDEO_ID" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe> -->
+
+## Related
+
+- [Set Rate Limits (RPM/TPM)](/docs/proxy/users#set-rate-limits)
+- [Dynamic Rate Limiting](/docs/proxy/dynamic_rate_limit)
+- [Virtual Keys](/docs/proxy/virtual_keys)

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2014,6 +2014,7 @@ class LiteLLM_VerificationTokenView(LiteLLM_VerificationToken):
     team_alias: Optional[str] = None
     team_tpm_limit: Optional[int] = None
     team_rpm_limit: Optional[int] = None
+    team_max_parallel_requests: Optional[int] = None
     team_max_budget: Optional[float] = None
     team_models: List = []
     team_blocked: bool = False
@@ -2076,6 +2077,7 @@ class UserAPIKeyAuth(
     tpm_limit_per_model: Optional[Dict[str, int]] = None
     user_tpm_limit: Optional[int] = None
     user_rpm_limit: Optional[int] = None
+    user_max_parallel_requests: Optional[int] = None
     user_email: Optional[str] = None
     request_route: Optional[str] = None
 

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -461,6 +461,44 @@ def get_key_model_tpm_limit(
     return None
 
 
+def get_key_model_max_parallel_requests(
+    user_api_key_dict: UserAPIKeyAuth,
+) -> Optional[Dict[str, int]]:
+    """
+    Get the max_parallel_requests per model for a given API key.
+
+    Checks in order:
+    1. Key metadata (model_max_parallel_requests)
+    2. Key model_max_budget (max_parallel_requests per model)
+    3. Team metadata (model_max_parallel_requests)
+
+    Note: Uses `(dict or {}).get()` pattern to avoid short-circuit issues where
+    an empty dict would skip fallback checks in if/elif chains.
+    """
+    # Check key metadata
+    result = (user_api_key_dict.metadata or {}).get("model_max_parallel_requests")
+    if result is not None:
+        return result
+
+    # Check model_max_budget
+    if user_api_key_dict.model_max_budget:
+        model_limits: Dict[str, int] = {}
+        for model, budget in user_api_key_dict.model_max_budget.items():
+            if isinstance(budget, dict):
+                limit = budget.get("max_parallel_requests")
+                if limit is not None:
+                    model_limits[model] = limit
+        if model_limits:
+            return model_limits
+
+    # Check team metadata
+    result = (user_api_key_dict.team_metadata or {}).get("model_max_parallel_requests")
+    if result is not None:
+        return result
+
+    return None
+
+
 def get_model_rate_limit_from_metadata(
     user_api_key_dict: UserAPIKeyAuth,
     metadata_accessor_key: Literal["team_metadata", "organization_metadata"],

--- a/tests/test_litellm/proxy/auth/test_max_parallel_requests.py
+++ b/tests/test_litellm/proxy/auth/test_max_parallel_requests.py
@@ -1,0 +1,130 @@
+"""
+Tests for max_parallel_requests per model/user/team support.
+
+Tests the helper function and rate limiter integration.
+"""
+
+import pytest
+from typing import Dict, Optional
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.auth_utils import get_key_model_max_parallel_requests
+
+
+class TestGetKeyModelMaxParallelRequests:
+    """Tests for get_key_model_max_parallel_requests helper function."""
+
+    def test_returns_none_when_no_limits_set(self):
+        """Should return None when no max_parallel_requests limits are configured."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-test",
+            metadata={},
+        )
+        result = get_key_model_max_parallel_requests(user_api_key_dict)
+        assert result is None
+
+    def test_extracts_from_metadata(self):
+        """Should extract limits from key metadata."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-test",
+            metadata={
+                "model_max_parallel_requests": {
+                    "gpt-4": 5,
+                    "gpt-3.5-turbo": 10,
+                }
+            },
+        )
+        result = get_key_model_max_parallel_requests(user_api_key_dict)
+        assert result == {"gpt-4": 5, "gpt-3.5-turbo": 10}
+
+    def test_extracts_from_model_max_budget(self):
+        """Should extract limits from model_max_budget when metadata not set."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-test",
+            metadata={},  # Empty dict, not None
+            model_max_budget={
+                "gpt-4": {"max_parallel_requests": 3, "budget": 100.0},
+                "gpt-3.5-turbo": {"budget": 50.0},  # No max_parallel_requests
+            },
+        )
+        result = get_key_model_max_parallel_requests(user_api_key_dict)
+        assert result == {"gpt-4": 3}
+
+    def test_extracts_from_team_metadata(self):
+        """Should extract limits from team_metadata as fallback."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-test",
+            metadata={},  # Empty dict, not None
+            team_metadata={
+                "model_max_parallel_requests": {
+                    "gpt-4": 8,
+                }
+            },
+        )
+        result = get_key_model_max_parallel_requests(user_api_key_dict)
+        assert result == {"gpt-4": 8}
+
+    def test_metadata_takes_precedence(self):
+        """Key metadata should take precedence over team_metadata."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-test",
+            metadata={"model_max_parallel_requests": {"gpt-4": 5}},
+            team_metadata={"model_max_parallel_requests": {"gpt-4": 10}},
+        )
+        result = get_key_model_max_parallel_requests(user_api_key_dict)
+        assert result == {"gpt-4": 5}
+
+    def test_skips_none_values_in_model_max_budget(self):
+        """Should skip models with None max_parallel_requests in budget."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-test",
+            metadata={},  # Empty dict, not None
+            model_max_budget={
+                "gpt-4": {"max_parallel_requests": None},
+                "gpt-3.5-turbo": {"max_parallel_requests": 5},
+            },
+        )
+        result = get_key_model_max_parallel_requests(user_api_key_dict)
+        assert result == {"gpt-3.5-turbo": 5}
+
+
+class TestUserMaxParallelRequests:
+    """Tests for user-level max_parallel_requests field."""
+
+    def test_field_exists_on_user_api_key_auth(self):
+        """UserAPIKeyAuth should have user_max_parallel_requests field."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-test",
+            user_id="user-123",
+            user_max_parallel_requests=10,
+        )
+        assert user_api_key_dict.user_max_parallel_requests == 10
+
+    def test_field_defaults_to_none(self):
+        """user_max_parallel_requests should default to None."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-test",
+            user_id="user-123",
+        )
+        assert user_api_key_dict.user_max_parallel_requests is None
+
+
+class TestTeamMaxParallelRequests:
+    """Tests for team-level max_parallel_requests field."""
+
+    def test_field_exists_on_user_api_key_auth(self):
+        """UserAPIKeyAuth should have team_max_parallel_requests field."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-test",
+            team_id="team-456",
+            team_max_parallel_requests=50,
+        )
+        assert user_api_key_dict.team_max_parallel_requests == 50
+
+    def test_field_defaults_to_none(self):
+        """team_max_parallel_requests should default to None."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-test",
+            team_id="team-456",
+        )
+        assert user_api_key_dict.team_max_parallel_requests is None


### PR DESCRIPTION
## Summary

Implements per-model, per-user, and per-team `max_parallel_requests` limits in the proxy rate limiter, addressing three TODOs in `parallel_request_limiter.py`.

- **Model-level**: Configurable via key metadata (`model_max_parallel_requests`) or `model_max_budget`
- **User-level**: New `user_max_parallel_requests` field on `UserAPIKeyAuth`
- **Team-level**: New `team_max_parallel_requests` field on `UserAPIKeyAuth`

## Changes

| File | Change |
|------|--------|
| `auth_utils.py` | Added `get_key_model_max_parallel_requests()` helper |
| `_types.py` | Added `user_max_parallel_requests` and `team_max_parallel_requests` fields |
| `parallel_request_limiter.py` | Wired all 3 TODO locations (v1 limiter) |
| `parallel_request_limiter_v3.py` | Added model-level support to v3 limiter |
| `test_max_parallel_requests.py` | 10 unit tests |

## Documentation

📄 **[Model-Specific Max Parallel Requests](docs/my-website/docs/proxy/model_max_parallel_requests.md)** - New doc with:
- Quick start guide
- Key, team, and priority override examples
- Mermaid flowchart showing priority resolution

## Config Examples

**Model-level** (via API key metadata):
```json
{
  "model_max_parallel_requests": {
    "gpt-4": 5,
    "gpt-3.5-turbo": 20
  }
}
```

**User-level**: Set `user_max_parallel_requests` on user record  
**Team-level**: Set `team_max_parallel_requests` on team record

## Test plan

- [x] Unit tests pass (10/10)
- [x] v3 limiter support added
- [x] Documentation added
- [ ] CI passes

Closes #17824