### PR TITLE
[Bug Fix] Watsonx Audio Transcription - ensure only correct params are sent to API 

### DIFF
--- a/litellm/llms/watsonx/audio_transcription/transformation.py
+++ b/litellm/llms/watsonx/audio_transcription/transformation.py
@@ -112,12 +112,6 @@ class IBMWatsonXAudioTranscriptionConfig(
             if key in supported_params and value is not None:
                 form_data[key] = value  # type: ignore
         
-        # Set default response_format for cost calculation
-        if "response_format" not in form_data or (
-            form_data.get("response_format") in ["text", "json"]
-        ):
-            form_data["response_format"] = "verbose_json"
-        
         # Prepare files dict with the audio file
         files = {
             "file": (

--- a/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
@@ -135,3 +135,57 @@ class TestWatsonXAudioTranscription:
         files = captured_request.get("files", {})
         assert "file" in files
         assert isinstance(files["file"], tuple)  # Should be (filename, content, content_type)
+
+    @pytest.mark.asyncio
+    async def test_watsonx_transcription_only_user_params_sent(self):
+        """
+        Test that only user-specified params are sent in request body to WatsonX.
+        
+        LiteLLM should NOT add extra params like response_format if user didn't specify them.
+        """
+        captured_request = {}
+
+        async def mock_post(*args, **kwargs):
+            captured_request["data"] = kwargs.get("data", {})
+            captured_request["files"] = kwargs.get("files", {})
+            
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "text": "test transcription",
+                "duration": 1.0,
+            }
+            mock_response.status_code = 200
+            return mock_response
+
+        with patch("litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post", new=mock_post):
+            try:
+                # Minimal request - only required params
+                await litellm.atranscription(
+                    model="watsonx/whisper-large-v3-turbo",
+                    file=b"fake_audio_data",
+                    api_base="https://us-south.ml.cloud.ibm.com",
+                    api_key="test-api-key",
+                    project_id="test-project-123",
+                    token="test-bearer-token",
+                )
+            except Exception:
+                pass  # We just want to capture the request
+
+        data = captured_request.get("data", {})
+        
+        # These are the ONLY keys that should be in data
+        expected_keys = {"model", "project_id"}
+        actual_keys = set(data.keys())
+        
+        assert actual_keys == expected_keys, (
+            f"Request body should only contain {expected_keys}, "
+            f"but got {actual_keys}. "
+            f"Extra keys: {actual_keys - expected_keys}"
+        )
+        
+        # Specifically verify response_format is NOT added
+        assert "response_format" not in data, "response_format should NOT be added by default"
+        
+        # Verify file is sent separately
+        files = captured_request.get("files", {})
+        assert "file" in files

--- a/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
@@ -128,7 +128,8 @@ class TestWatsonXAudioTranscription:
         # OpenAI params should be in form data
         assert data.get("language") == "en"
         assert data.get("temperature") == 0.5
-        assert data.get("response_format") == "verbose_json"  # Default for cost calculation
+        # response_format should NOT be set by default - only send what user specifies
+        assert "response_format" not in data
         
         # Validate file is in files dict (multipart/form-data)
         files = captured_request.get("files", {})


### PR DESCRIPTION
## [Bug Fix] Watsonx Audio Transcription - ensure only correct params are sent to API 

LiteLLM was automatically adding response_format: "verbose_json" to all WatsonX audio transcription requests, even when the user didn't specify it. WatsonX only supports text or json formats.

Fix
Removed the logic that automatically injects response_format into WatsonX audio transcription requests. Now LiteLLM only sends parameters that the user explicitly provides.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


