### PR TITLE
fix(prometheus): add 'exception_status' to prometheus logger

### DIFF
--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -354,6 +354,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_BASE.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.EXCEPTION_STATUS.value,
     ]
 
     litellm_deployment_successful_fallbacks = [

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
@@ -1051,9 +1051,8 @@ def test_deployment_state_management(prometheus_logger):
 
 def test_increment_deployment_cooled_down(prometheus_logger):
     import inspect
-    from litellm.integrations.prometheus import PrometheusLogger
 
-    method_sig = inspect.signature(PrometheusLogger.increment_deployment_cooled_down)
+    method_sig = inspect.signature(prometheus_logger.increment_deployment_cooled_down)
     expected_label_count = len([p for p in method_sig.parameters.keys() if p != 'self'])
 
     mock_chain = MagicMock()

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
@@ -1050,8 +1050,23 @@ def test_deployment_state_management(prometheus_logger):
 
 
 def test_increment_deployment_cooled_down(prometheus_logger):
+    import inspect
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    method_sig = inspect.signature(PrometheusLogger.increment_deployment_cooled_down)
+    expected_label_count = len([p for p in method_sig.parameters.keys() if p != 'self'])
+
+    mock_chain = MagicMock()
+
+    def validating_labels(*label_values, **label_kwargs):
+        """Validate label count matches metric definition"""
+        total = len(label_values) + len(label_kwargs)
+        if total != expected_label_count:
+            raise ValueError(f"Incorrect label count: expected {expected_label_count}, got {total}")
+        return mock_chain
 
     prometheus_logger.litellm_deployment_cooled_down = MagicMock()
+    prometheus_logger.litellm_deployment_cooled_down.labels = MagicMock(side_effect=validating_labels)
 
     prometheus_logger.increment_deployment_cooled_down(
         litellm_model_name="gpt-3.5-turbo",
@@ -1064,7 +1079,7 @@ def test_increment_deployment_cooled_down(prometheus_logger):
     prometheus_logger.litellm_deployment_cooled_down.labels.assert_called_once_with(
         "gpt-3.5-turbo", "model-123", "https://api.openai.com", "openai", "429"
     )
-    prometheus_logger.litellm_deployment_cooled_down.labels().inc.assert_called_once()
+    mock_chain.inc.assert_called_once()
 
 
 @pytest.mark.parametrize("enable_end_user_cost_tracking_prometheus_only", [True, False])

--- a/tests/enterprise/litellm_enterprise/integrations/test_prometheus_unit_tests.py
+++ b/tests/enterprise/litellm_enterprise/integrations/test_prometheus_unit_tests.py
@@ -327,3 +327,32 @@ async def test_router_cooldown_event_callback_no_prometheus():
 
     # Assert that the router's get_deployment method was called
     mock_router.get_deployment.assert_called_once_with(model_id="test-deployment")
+
+
+def test_deployment_cooled_down_label_count():
+    """
+    Validate that the litellm_deployment_cooled_down metric label definition
+    matches the increment_deployment_cooled_down method signature.
+    """
+
+    import inspect
+    from litellm.types.integrations.prometheus import PrometheusMetricLabels
+
+    metric_labels = PrometheusMetricLabels.litellm_deployment_cooled_down
+
+    from litellm.integrations.prometheus import PrometheusLogger
+    method_sig = inspect.signature(PrometheusLogger.increment_deployment_cooled_down)
+
+    method_params = [p for p in method_sig.parameters.keys() if p != 'self']
+
+    assert len(metric_labels) == len(method_params), (
+        f"Label count mismatch for litellm_deployment_cooled_down: "
+        f"metric has {len(metric_labels)} labels {metric_labels}, "
+        f"but method expects {len(method_params)} parameters {method_params}"
+    )
+
+    expected_labels = ['litellm_model_name', 'model_id', 'api_base', 'api_provider', 'exception_status']
+    assert metric_labels == expected_labels, (
+        f"Label names don't match expected parameters. "
+        f"Expected: {expected_labels}, Got: {metric_labels}"
+    )

--- a/tests/enterprise/litellm_enterprise/integrations/test_prometheus_unit_tests.py
+++ b/tests/enterprise/litellm_enterprise/integrations/test_prometheus_unit_tests.py
@@ -327,32 +327,3 @@ async def test_router_cooldown_event_callback_no_prometheus():
 
     # Assert that the router's get_deployment method was called
     mock_router.get_deployment.assert_called_once_with(model_id="test-deployment")
-
-
-def test_deployment_cooled_down_label_count():
-    """
-    Validate that the litellm_deployment_cooled_down metric label definition
-    matches the increment_deployment_cooled_down method signature.
-    """
-
-    import inspect
-    from litellm.types.integrations.prometheus import PrometheusMetricLabels
-
-    metric_labels = PrometheusMetricLabels.litellm_deployment_cooled_down
-
-    from litellm.integrations.prometheus import PrometheusLogger
-    method_sig = inspect.signature(PrometheusLogger.increment_deployment_cooled_down)
-
-    method_params = [p for p in method_sig.parameters.keys() if p != 'self']
-
-    assert len(metric_labels) == len(method_params), (
-        f"Label count mismatch for litellm_deployment_cooled_down: "
-        f"metric has {len(metric_labels)} labels {metric_labels}, "
-        f"but method expects {len(method_params)} parameters {method_params}"
-    )
-
-    expected_labels = ['litellm_model_name', 'model_id', 'api_base', 'api_provider', 'exception_status']
-    assert metric_labels == expected_labels, (
-        f"Label names don't match expected parameters. "
-        f"Expected: {expected_labels}, Got: {metric_labels}"
-    )


### PR DESCRIPTION
## Title

Fix prometheus logger exception caused by incorrect number of labels in `litellm_deployment_cooled_down`. 

## Relevant issues
Fixes:
- https://github.com/BerriAI/litellm/issues/16773
- https://github.com/BerriAI/litellm/issues/7611

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Adds `UserAPIKeyLabelNames.EXCEPTION_STATUS.value` to the list of expected metric labels for `litellm_deployment_cooled_down`.  Updates tests to use more accurate mocking to catch this error.


<img width="1344" height="826" alt="Screenshot 2025-12-11 at 4 12 15 PM" src="https://github.com/user-attachments/assets/1cef5a4a-37ce-445a-b405-d568dd7a6401" />

<img width="1339" height="505" alt="Screenshot 2025-12-11 at 4 14 10 PM" src="https://github.com/user-attachments/assets/09e2f8ec-05f7-4138-816a-7c724eb8fee5" />

