### PR TITLE
added GenAI sdk resumable files init headers to req/res

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -227,6 +227,13 @@ async def gemini_proxy_route(
     if "stream" in str(updated_url):
         is_streaming_request = True
 
+    custom_headers_dict = {}
+    is_files_init = "/upload/v1beta/files" in encoded_endpoint and request.method == "POST"
+    if is_files_init:
+        custom_headers_dict["x-goog-resumable"] = "start"
+        custom_headers_dict["X-Goog-Upload-Protocol"] = "resumable"
+        custom_headers_dict["X-Goog-Upload-Command"] = "start"
+
     ## CREATE PASS-THROUGH
     endpoint_func = create_pass_through_route(
         endpoint=endpoint,
@@ -241,6 +248,15 @@ async def gemini_proxy_route(
         user_api_key_dict,
     )
 
+    # Map Location -> x-goog-upload-url for SDK compatibility.
+    if is_files_init:
+        # Prefer already-set x-goog-upload-url; otherwise copy from Location if present
+        lower_out_headers = {k.lower(): v for k, v in fastapi_response.headers.items()}
+        if "x-goog-upload-url" not in lower_out_headers:
+            loc = fastapi_response.headers.get("location") or lower_out_headers.get("location")
+            if loc:
+                fastapi_response.headers["x-goog-upload-url"] = loc
+    
     return received_value
 
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -1901,3 +1901,76 @@ class TestMilvusProxyRoute:
             # Verify that the target URL has correct path
             create_route_args = mock_create_route.call_args[1]
             assert "/vectors/search" in create_route_args["target"]
+
+class TestGeminiProxyRoute:
+    """
+    Test cases for Gemini proxy route resumable upload headers
+    """
+
+    @pytest.mark.asyncio
+    async def test_gemini_files_upload_resumable_headers(self):
+        """
+        Test that resumable upload headers are added for Google Files API upload init.
+        
+        Verifies that POST requests to /upload/v1beta/files include:
+        - x-goog-resumable: start
+        - X-Goog-Upload-Protocol: resumable
+        - X-Goog-Upload-Command: start
+        """
+        from unittest.mock import AsyncMock, patch
+        from starlette.datastructures import URL
+        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+            gemini_proxy_route,
+        )
+
+        # Mock request body
+        body = b'{"file": {"display_name": "test.txt"}}'
+        
+        # Create request to files upload endpoint
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/gemini/upload/v1beta/files",
+            "query_string": b"key=sk-test-key",
+            "headers": [(b"content-type", b"application/json")],
+        }
+        
+        async def async_receive():
+            return {"type": "http.request", "body": body, "more_body": False}
+        
+        from fastapi import Request, Response
+        request = Request(scope=scope, receive=async_receive)
+        
+        # Track the headers passed to create_pass_through_route
+        captured_headers = None
+        
+        def capture_create_pass_through_route(*args, **kwargs):
+            nonlocal captured_headers
+            captured_headers = kwargs.get('custom_headers', {})
+            # Return a mock endpoint function
+            async def mock_endpoint_func(req, resp, user_dict, **kw):
+                return Response(content=b'{"name": "files/test"}')
+            return mock_endpoint_func
+        
+        # Mock the necessary functions
+        with patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+            side_effect=capture_create_pass_through_route
+        ), patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.user_api_key_auth",
+            new=AsyncMock(return_value={"user_id": "test_user"})
+        ), patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+            return_value="test-gemini-key"
+        ):
+            response = await gemini_proxy_route(
+                endpoint="upload/v1beta/files",
+                request=request,
+                fastapi_response=Response(),
+            )
+        
+        # Verify the resumable upload headers were added
+        assert captured_headers is not None, "Headers were not captured"
+        assert captured_headers.get("x-goog-resumable") == "start"
+        assert captured_headers.get("X-Goog-Upload-Protocol") == "resumable"
+        assert captured_headers.get("X-Goog-Upload-Command") == "start"


### PR DESCRIPTION
## Title

fix add GenAI resumable Files init headers and Location → x-goog-upload-url mapping

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Add required Google GenAI resumable upload headers and map Location → x-goog-upload-url. Without them the [GenAI sdk](https://github.com/googleapis/js-genai) will break on the files upload through litellm.

<img width="862" height="230" alt="Screen Shot 2025-12-11 at 4 34 24 PM" src="https://github.com/user-attachments/assets/93012465-b197-40e5-81bf-3ecdd723900f" />



