### PR TITLE
fix: add speechConfig to GenerationConfig for Gemini TTS

### DIFF
--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -213,6 +213,7 @@ class GenerationConfig(TypedDict, total=False):
     responseModalities: List[GeminiResponseModalities]
     imageConfig: GeminiImageConfig
     thinkingConfig: GeminiThinkingConfig
+    speechConfig: SpeechConfig
 
 
 class VertexToolName(str, Enum):
@@ -301,7 +302,6 @@ class RequestBody(TypedDict, total=False):
     generationConfig: GenerationConfig
     cachedContent: str
     labels: Dict[str, str]
-    speechConfig: SpeechConfig
 
 
 class CachedContentRequestBody(TypedDict, total=False):


### PR DESCRIPTION
## Summary

Fixes Gemini TTS failing with `400 INVALID_ARGUMENT` when using `/v1/chat/completions` with `modalities: ["audio"]` or `/audio/speech` endpoint.

**Fixes #17735**

## Root Cause

`speechConfig` was being created correctly in `map_openai_params()` but then filtered out in `_transform_request_body()` because `GenerationConfig.__annotations__.keys()` didn't include `speechConfig`.

## Fix

Moved `speechConfig: SpeechConfig` from `RequestBody` TypedDict to `GenerationConfig` TypedDict in `litellm/types/llms/vertex_ai.py`.

## Testing

Added parametrized tests covering:
- Both `vertex_ai` and `gemini` providers
- Preview (`gemini-2.5-flash-preview-tts`) and non-preview (`gemini-2.5-flash-tts`, `gemini-2.5-pro-tts`) model names

All 18 tests pass:
```
pytest tests/test_litellm/llms/gemini/test_gemini_tts.py -v
==================== 18 passed in 0.16s ====================
```

## Files Changed

- `litellm/types/llms/vertex_ai.py` - TypedDict fix
- `tests/test_litellm/llms/gemini/test_gemini_tts.py` - Added integration tests