### PR TITLE
Add support for expires after param in Files endpoint

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1,6 +1,7 @@
 import time
 import types
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Callable,
@@ -10,7 +11,6 @@ from typing import (
     List,
     Literal,
     Optional,
-    TYPE_CHECKING,
     Union,
     cast,
 )
@@ -20,6 +20,7 @@ import httpx
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession
+
 import openai
 from openai import AsyncOpenAI, OpenAI
 from openai.types.beta.assistant_deleted import AssistantDeleted
@@ -1549,7 +1550,7 @@ class OpenAIFilesAPI(BaseLLM):
         create_file_data: CreateFileRequest,
         openai_client: AsyncOpenAI,
     ) -> OpenAIFileObject:
-        response = await openai_client.files.create(**create_file_data)
+        response = await openai_client.files.create(**create_file_data)  # type: ignore[arg-type]
         return OpenAIFileObject(**response.model_dump())
 
     def create_file(
@@ -1585,7 +1586,7 @@ class OpenAIFilesAPI(BaseLLM):
             return self.acreate_file(  # type: ignore
                 create_file_data=create_file_data, openai_client=openai_client
             )
-        response = cast(OpenAI, openai_client).files.create(**create_file_data)
+        response = cast(OpenAI, openai_client).files.create(**create_file_data)  # type: ignore[arg-type]
         return OpenAIFileObject(**response.model_dump())
 
     async def afile_content(

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -39,6 +39,7 @@ from litellm.proxy.utils import ProxyLogging, is_known_model
 from litellm.router import Router
 from litellm.types.llms.openai import (
     CREATE_FILE_REQUESTS_PURPOSE,
+    FileExpiresAfter,
     OpenAIFileObject,
     OpenAIFilesPurpose,
 )
@@ -272,7 +273,8 @@ async def create_file(
         -H "Authorization: Bearer sk-1234" \
         -F purpose="batch" \
         -F file="@mydata.jsonl"
-
+        -F expires_after[anchor]="created_at" \
+        -F expires_after[seconds]=2592000
     ```
     """
     from litellm.proxy.proxy_server import (
@@ -329,6 +331,25 @@ async def create_file(
         if litellm_metadata is not None:
             data["litellm_metadata"] = litellm_metadata
 
+        # Parse expires_after if provided
+        expires_after = None
+        form_data = await request.form()
+        expires_after_anchor = form_data.get("expires_after[anchor]")
+        expires_after_seconds_str = form_data.get("expires_after[seconds]")
+        
+        if expires_after_anchor is not None or expires_after_seconds_str is not None:
+            if expires_after_anchor is None or expires_after_seconds_str is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": "Both expires_after[anchor] and expires_after[seconds] must be provided if expires_after is specified",
+                    },
+                )
+            expires_after = FileExpiresAfter(
+                anchor=expires_after_anchor,
+                seconds=int(expires_after_seconds_str),
+            )
+
         # Include original request and headers in the data
         data = await add_litellm_data_to_request(
             data=data,
@@ -354,7 +375,10 @@ async def create_file(
                 )
 
         _create_file_request = CreateFileRequest(
-            file=file_data, purpose=cast(CREATE_FILE_REQUESTS_PURPOSE, purpose), **data
+            file=file_data, 
+            purpose=cast(CREATE_FILE_REQUESTS_PURPOSE, purpose),
+            expires_after=expires_after,
+            **data
         )
 
         response = await route_create_file(

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -250,7 +250,7 @@ async def route_create_file(
     dependencies=[Depends(user_api_key_auth)],
     tags=["files"],
 )
-async def create_file(
+async def create_file(  # noqa: PLR0915
     request: Request,
     fastapi_response: Response,
     purpose: str = Form(...),

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 import httpx
+from openai import Omit
 from openai._legacy_response import (
     HttpxBinaryResponseContent as _HttpxBinaryResponseContent,
 )
@@ -69,7 +70,7 @@ from openai.types.responses.response_create_params import (
     ToolParam,
 )
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
-from pydantic import BaseModel, ConfigDict, Discriminator, Field, PrivateAttr
+from pydantic import BaseModel, ConfigDict, Discriminator, PrivateAttr
 from typing_extensions import Annotated, Dict, Required, TypedDict, override
 
 from litellm.types.llms.base import BaseLiteLLMOpenAIResponseObject
@@ -346,6 +347,19 @@ class OpenAIFileObject(BaseModel):
 CREATE_FILE_REQUESTS_PURPOSE = Literal["assistants", "batch", "fine-tune"]
 
 
+# File expiration policy
+class FileExpiresAfter(TypedDict):
+    """
+    File expiration policy
+    
+    Properties:
+        anchor: Anchor timestamp after which the expiration policy applies. Supported anchors: created_at.
+        seconds: The number of seconds after the anchor time that the file will expire. Must be between 3600 (1 hour) and 2592000 (30 days).
+    """
+    anchor: Required[Literal["created_at"]]
+    seconds: Required[int]
+
+
 # OpenAI Files Types
 class CreateFileRequest(TypedDict, total=False):
     """
@@ -357,6 +371,7 @@ class CreateFileRequest(TypedDict, total=False):
         purpose: Literal['assistants', 'batch', 'fine-tune']
 
     Optional Params:
+        expires_after: Optional[FileExpiresAfter] - The expiration policy for a file
         extra_headers: Optional[Dict[str, str]]
         extra_body: Optional[Dict[str, str]] = None
         timeout: Optional[float] = None
@@ -364,6 +379,7 @@ class CreateFileRequest(TypedDict, total=False):
 
     file: Required[FileTypes]
     purpose: Required[CREATE_FILE_REQUESTS_PURPOSE]
+    expires_after: Optional[FileExpiresAfter]
     extra_headers: Optional[Dict[str, str]]
     extra_body: Optional[Dict[str, str]]
     timeout: Optional[float]


### PR DESCRIPTION
## Title

Add support for expires after param in Files endpoint

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature
🐛 Bug Fix


## Changes


