### PR TITLE
Fix x-litellm-key-spend header update

### DIFF
--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -114,3 +114,83 @@ class TestResponsesAPIEndpoints(unittest.TestCase):
             # Should not have Responses API structure
             assert "output" not in response_data or "status" not in response_data
 
+    @pytest.mark.asyncio
+    @patch("litellm.proxy.proxy_server.llm_router")
+    @patch("litellm.proxy.proxy_server.user_api_key_auth")
+    async def test_responses_api_key_spend_header_includes_response_cost(
+        self, mock_auth, mock_router
+    ):
+        """
+        Test that x-litellm-key-spend header includes the current request's response_cost
+        for /v1/responses endpoint.
+        
+        This ensures the spend header reflects updated spend including the current request,
+        even though spend tracking updates happen asynchronously after the response.
+        """
+        from litellm.types.llms.openai import ResponsesAPIResponse
+        from litellm.types.utils import ResponseOutputMessage, ResponseOutputText
+
+        # Create mock user API key with initial spend
+        mock_user_api_key_dict = MagicMock()
+        mock_user_api_key_dict.token = "test_token"
+        mock_user_api_key_dict.user_id = "test_user"
+        mock_user_api_key_dict.team_id = None
+        mock_user_api_key_dict.spend = 0.001  # Initial spend: $0.001
+        mock_user_api_key_dict.tpm_limit = None
+        mock_user_api_key_dict.rpm_limit = None
+        mock_user_api_key_dict.max_budget = None
+        mock_user_api_key_dict.allowed_model_region = None
+        mock_user_api_key_dict.api_key = "sk-test-key"
+        mock_user_api_key_dict.metadata = {}
+        
+        mock_auth.return_value = mock_user_api_key_dict
+
+        # Mock response with hidden_params containing response_cost
+        mock_response = ResponsesAPIResponse(
+            id="resp_test123",
+            created_at=1234567890,
+            model="gpt-4o",
+            object="response",
+            output=[
+                ResponseOutputMessage(
+                    type="message",
+                    role="assistant",
+                    content=[
+                        ResponseOutputText(type="output_text", text="Test response")
+                    ],
+                )
+            ],
+        )
+        
+        # Add hidden_params with response_cost to the mock response
+        mock_response._hidden_params = {
+            "response_cost": 0.0005,  # Current request cost: $0.0005
+            "model_id": "test-model-id",
+        }
+        
+        mock_router.aresponses = AsyncMock(return_value=mock_response)
+
+        client = TestClient(app)
+
+        test_data = {"model": "gpt-4o", "input": "Tell me about AI"}
+
+        response = client.post(
+            "/v1/responses",
+            json=test_data,
+            headers={"Authorization": "Bearer sk-test-key"},
+        )
+
+        # Verify the response was successful
+        assert response.status_code == 200
+
+        # Verify x-litellm-key-spend header includes current request cost
+        assert "x-litellm-key-spend" in response.headers
+        key_spend_value = float(response.headers["x-litellm-key-spend"])
+        expected_spend = 0.001 + 0.0005  # Initial spend + current request cost
+        assert key_spend_value == pytest.approx(expected_spend, abs=1e-10)
+
+        # Verify x-litellm-response-cost header is present
+        assert "x-litellm-response-cost" in response.headers
+        response_cost_value = float(response.headers["x-litellm-response-cost"])
+        assert response_cost_value == pytest.approx(0.0005, abs=1e-10)
+


### PR DESCRIPTION
## Title

Fix x-litellm-key-spend header update

## Relevant issues



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix


## Changes
<img width="950" height="746" alt="image" src="https://github.com/user-attachments/assets/4d8bac08-378f-41f3-9096-9a15f3d44772" />


