### PR TITLE
fix: bedrock header forwarding with cutom api

### DIFF
--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -286,11 +286,12 @@ class BedrockEmbedding(BaseAWSLLM):
                     "headers": prepped.headers,
                 },
             )
+            headers_for_request = dict(prepped.headers) if hasattr(prepped, 'headers') else {}
             response = self._make_sync_call(
                 client=client,
                 timeout=timeout,
                 api_base=prepped.url,
-                headers=prepped.headers,  # type: ignore
+                headers=headers_for_request,
                 data=data,
             )
 
@@ -352,11 +353,14 @@ class BedrockEmbedding(BaseAWSLLM):
                     "headers": prepped.headers,
                 },
             )
+            # Convert CaseInsensitiveDict to regular dict for httpx compatibility
+            # This ensures custom headers are properly forwarded, especially with IAM roles and custom api_base
+            headers_for_request = dict(prepped.headers) if hasattr(prepped, 'headers') else {}
             response = await self._make_async_call(
                 client=client,
                 timeout=timeout,
                 api_base=prepped.url,
-                headers=prepped.headers,  # type: ignore
+                headers=headers_for_request,
                 data=data,
             )
 
@@ -562,6 +566,8 @@ class BedrockEmbedding(BaseAWSLLM):
         )
 
         ## ROUTING ##
+        # Convert CaseInsensitiveDict to regular dict for httpx compatibility
+        headers_for_request = dict(prepped.headers) if hasattr(prepped, 'headers') else {}
         return cohere_embedding(
             model=model,
             input=input,
@@ -575,7 +581,7 @@ class BedrockEmbedding(BaseAWSLLM):
             aembedding=aembedding,
             timeout=timeout,
             client=client,
-            headers=prepped.headers,  # type: ignore
+            headers=headers_for_request,
         )
 
     async def _get_async_invoke_status(


### PR DESCRIPTION
## Title
fix: bedrock header forwarding with cutom api
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


