### PR TITLE
feat(openai): add reasoning_effort='xhigh' support for gpt-5.2 models

### DIFF
--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -433,7 +433,7 @@ Expected Response:
 
 ### Advanced: Using `reasoning_effort` with `summary` field
 
-By default, `reasoning_effort` accepts a string value (`"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`—`"xhigh"` is only supported on `gpt-5.1-codex-max`) and only sets the effort level without including a reasoning summary.
+By default, `reasoning_effort` accepts a string value (`"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`—`"xhigh"` is only supported on `gpt-5.1-codex-max` and `gpt-5.2` models) and only sets the effort level without including a reasoning summary.
 
 To opt-in to the `summary` feature, you can pass `reasoning_effort` as a dictionary. **Note:** The `summary` field requires your OpenAI organization to have verification status. Using `summary` without verification will result in a 400 error from OpenAI.
 
@@ -501,11 +501,13 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 | `gpt-5.1-codex` | `adaptive` | `low`, `medium`, `high` (no `minimal`) |
 | `gpt-5.1-codex-mini` | `adaptive` | `low`, `medium`, `high` (no `minimal`) |
 | `gpt-5.1-codex-max` | `adaptive` | `low`, `medium`, `high`, `xhigh` (no `minimal`) |
+| `gpt-5.2` | `medium` | `none`, `low`, `medium`, `high`, `xhigh` |
+| `gpt-5.2-pro` | `high` | `low`, `medium`, `high`, `xhigh` |
 | `gpt-5-pro` | `high` | `high` only |
 
 **Note:**
 - GPT-5.1 introduced a new `reasoning_effort="none"` setting for faster, lower-latency responses. This replaces the `"minimal"` setting from GPT-5.
-- `gpt-5.1-codex-max` is the only model that supports `reasoning_effort="xhigh"`. All other models will reject this value.
+- `gpt-5.1-codex-max` and `gpt-5.2` models support `reasoning_effort="xhigh"`. All other models will reject this value.
 - `gpt-5-pro` only accepts `reasoning_effort="high"`. Other values will return an error.
 - When `reasoning_effort` is not set (None), OpenAI defaults to the value shown in the "Default" column.
 

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -51,6 +51,12 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         model_name = model.split("/")[-1]
         return model_name.startswith("gpt-5.2-pro")
 
+    @classmethod
+    def is_model_gpt_5_2_model(cls, model: str) -> bool:
+        """Check if the model is a gpt-5.2 variant (including pro)."""
+        model_name = model.split("/")[-1]
+        return model_name.startswith("gpt-5.2")
+
     def get_supported_openai_params(self, model: str) -> list:
         from litellm.utils import supports_tool_choice
 
@@ -89,14 +95,14 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         if reasoning_effort is not None and reasoning_effort == "xhigh":
             if not (
                 self.is_model_gpt_5_1_codex_max_model(model)
-                or self.is_model_gpt_5_2_pro_model(model)
+                or self.is_model_gpt_5_2_model(model)
             ):
                 if litellm.drop_params or drop_params:
                     non_default_params.pop("reasoning_effort", None)
                 else:
                     raise litellm.utils.UnsupportedParamsError(
                         message=(
-                            "reasoning_effort='xhigh' is only supported for gpt-5.1-codex-max."
+                            "reasoning_effort='xhigh' is only supported for gpt-5.1-codex-max and gpt-5.2 models."
                         ),
                         status_code=400,
                     )

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -388,11 +388,12 @@ def test_gpt5_2_pro_allows_reasoning_effort_xhigh(config: OpenAIConfig):
     assert params["reasoning_effort"] == "xhigh"
 
 
-def test_gpt5_2_rejects_reasoning_effort_xhigh_for_base_model(config: OpenAIConfig):
-    with pytest.raises(litellm.utils.UnsupportedParamsError):
-        config.map_openai_params(
-            non_default_params={"reasoning_effort": "xhigh"},
-            optional_params={},
-            model="gpt-5.2",
-            drop_params=False,
-        )
+def test_gpt5_2_allows_reasoning_effort_xhigh(config: OpenAIConfig):
+    """Test that gpt-5.2 (base model) also supports reasoning_effort='xhigh'."""
+    params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "xhigh"},
+        optional_params={},
+        model="gpt-5.2",
+        drop_params=False,
+    )
+    assert params["reasoning_effort"] == "xhigh"


### PR DESCRIPTION
## Title

Add reasoning_effort='xhigh' support for gpt-5.2 models

## Relevant issues

<!-- N/A -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Add support for the `reasoning_effort='xhigh'` parameter on all gpt-5.2 model variants, not just gpt-5.2-pro.

### Code changes:
- Added `is_model_gpt_5_2_model()` method to detect all gpt-5.2 variants
- Updated xhigh validation to allow all gpt-5.2 models (not just gpt-5.2-pro)
- Updated error message to reflect new supported models

### Documentation:
- Updated `docs/my-website/docs/providers/openai.md` with gpt-5.2 reasoning_effort support
- Added gpt-5.2 and gpt-5.2-pro to the reasoning_effort values table

### Tests:
- Updated `test_gpt5_2_allows_reasoning_effort_xhigh` to verify gpt-5.2 base model accepts xhigh