### PR TITLE
fix(perplexity): use API-provided cost instead of manual calculation

### DIFF
--- a/litellm/llms/perplexity/cost_calculator.py
+++ b/litellm/llms/perplexity/cost_calculator.py
@@ -20,6 +20,17 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
     Returns:
         Tuple[float, float] - prompt_cost_in_usd, completion_cost_in_usd
     """
+    ## USE PRE-CALCULATED COST FROM PERPLEXITY IF AVAILABLE
+    ## Perplexity returns accurate cost in usage.cost.total_cost including request fees
+    cost_info = getattr(usage, "cost", None)
+    if cost_info is not None and isinstance(cost_info, dict):
+        total_cost = cost_info.get("total_cost")
+        if total_cost is not None:
+            # Return total cost as completion_cost (prompt_cost=0) since Perplexity
+            # doesn't break down by input/output in their cost object
+            return (0.0, float(total_cost))
+
+    ## FALLBACK: Calculate cost manually if Perplexity doesn't provide it
     ## GET MODEL INFO
     model_info = get_model_info(model=model, custom_llm_provider="perplexity")
 


### PR DESCRIPTION
## Title

Fix Perplexity cost calculation - use API-provided cost instead of manual calculation

## Relevant issues

Fixes #15337

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests (61 tests passing)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Summary

Perplexity API returns pre-calculated costs in `usage.cost.total_cost` that include the `request_cost` (fixed per-request fee). LiteLLM was **ignoring this** and calculating costs manually, resulting in **~27x cost underreporting**.

### Example

```python
import litellm

response = litellm.completion(
    model="perplexity/sonar-pro",
    messages=[{"role": "user", "content": "What is the capital of France?"}]
)

print(f"LiteLLM cost: ${response._hidden_params['response_cost']}")
print(f"Perplexity cost: ${response.usage.cost['total_cost']}")
```

**Before (27x cost underreporting):**
```
LiteLLM cost: $0.000216
Perplexity cost: $0.006
```

**After (correct):**
```
LiteLLM cost: $0.006
Perplexity cost: $0.006 ✓
```

### What Perplexity actually returns

```json
"usage": {
  "prompt_tokens": 7,
  "completion_tokens": 149,
  "total_tokens": 156,
  "search_context_size": "low",
  "cost": {
    "input_tokens_cost": 0.0,
    "output_tokens_cost": 0.002,
    "request_cost": 0.006,
    "total_cost": 0.008
  }
}
```

The `request_cost` is a fixed per-request fee that varies by model and is **not in the model_prices JSON** - it can only come from the API response.

### The Fix

10 lines in `cost_calculator.py`:
- Use `usage.cost.total_cost` from Perplexity response when available
- Fall back to manual calculation if cost object not present (backward compatibility)

### Tests Added

- `test_uses_perplexity_provided_cost_when_available` - verifies API cost is used
- `test_falls_back_to_manual_calculation_when_no_cost_provided` - verifies backward compatibility

All 61 tests passing.