### PR TITLE
[Feature] Usage Entity labels

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.test.tsx
@@ -269,4 +269,79 @@ describe("EntityUsage", () => {
     expect(screen.getByText("Total Spend")).toBeInTheDocument();
     expect(screen.getAllByText("0")[0]).toBeInTheDocument();
   });
+
+  it("should use entityList label when entityList is provided and entity exists", async () => {
+    const customEntityList = [
+      { label: "Custom Tag Label", value: "tag-1" },
+      { label: "Tag 2", value: "tag-2" },
+    ];
+
+    render(<EntityUsage {...defaultProps} entityList={customEntityList} />);
+
+    await waitFor(() => {
+      expect(mockTagDailyActivityCall).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Custom Tag Label")).toBeInTheDocument();
+    });
+  });
+
+  it("should fallback to team_alias when entityList is provided but entity does not exist", async () => {
+    const customEntityList = [{ label: "Tag 2", value: "tag-2" }];
+
+    render(<EntityUsage {...defaultProps} entityList={customEntityList} />);
+
+    await waitFor(() => {
+      expect(mockTagDailyActivityCall).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Tag 1")).toBeInTheDocument();
+    });
+  });
+
+  it("should fallback to team_alias when entityList is null", async () => {
+    render(<EntityUsage {...defaultProps} entityList={null} />);
+
+    await waitFor(() => {
+      expect(mockTagDailyActivityCall).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Tag 1")).toBeInTheDocument();
+    });
+  });
+
+  it("should fallback to entity value when no entityList and no team_alias", async () => {
+    const spendDataWithoutAlias = {
+      ...mockSpendData,
+      results: [
+        {
+          ...mockSpendData.results[0],
+          breakdown: {
+            ...mockSpendData.results[0].breakdown,
+            entities: {
+              "tag-1": {
+                ...mockSpendData.results[0].breakdown.entities["tag-1"],
+                metadata: {},
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    mockTagDailyActivityCall.mockResolvedValue(spendDataWithoutAlias);
+
+    render(<EntityUsage {...defaultProps} entityList={null} />);
+
+    await waitFor(() => {
+      expect(mockTagDailyActivityCall).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("tag-1")).toBeInTheDocument();
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.test.tsx
@@ -265,7 +265,7 @@ describe("EntityUsage", () => {
     });
 
     expect(await screen.findByText("Tag Spend Overview")).toBeInTheDocument();
-    expect(await screen.findByText("$-")).toBeInTheDocument();
+    expect(await screen.findByText("$0.00")).toBeInTheDocument();
     expect(screen.getByText("Total Spend")).toBeInTheDocument();
     expect(screen.getAllByText("0")[0]).toBeInTheDocument();
   });

--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
@@ -305,6 +305,20 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
     }
   };
 
+  const getEntityLabel = (entity: string, metadata?: Record<string, any>): string => {
+    if (entityList) {
+      const entityItem = entityList.find((item) => item.value === entity);
+      if (entityItem) {
+        return entityItem.label;
+      }
+    }
+    // Fallback to team_alias for backward compatibility
+    if (metadata?.team_alias) {
+      return metadata.team_alias;
+    }
+    return entity;
+  };
+
   const filterDataByTags = (data: EntityMetricWithMetadata[]) => {
     if (selectedTags.length === 0) return data;
     return data.filter((item) => selectedTags.includes(item.metadata.id));
@@ -328,7 +342,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
               cache_creation_input_tokens: 0,
             },
             metadata: {
-              alias: (data.metadata as any).team_alias || entity,
+              alias: getEntityLabel(entity, data.metadata as any),
               id: entity,
             },
           };
@@ -472,7 +486,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                                 const metrics = entityData as EntityMetrics;
                                 return (
                                   <p key={entity} className="text-sm text-gray-600">
-                                    {metrics.metadata.team_alias || entity}: $
+                                    {getEntityLabel(entity, metrics.metadata)}: $
                                     {formatNumberWithCommas(metrics.metrics.spend, 2)}
                                   </p>
                                 );

--- a/ui/litellm-dashboard/src/utils/dataUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/dataUtils.test.ts
@@ -72,8 +72,8 @@ describe("dataUtils", () => {
     });
 
     it("should handle zero and non-finite values", () => {
-      expect(formatNumberWithCommas(0)).toBe("-");
-      expect(formatNumberWithCommas(0, 2)).toBe("-");
+      expect(formatNumberWithCommas(0)).toBe("0");
+      expect(formatNumberWithCommas(0, 2)).toBe("0.00");
       expect(formatNumberWithCommas(Infinity)).toBe("-");
       expect(formatNumberWithCommas(Number.NaN)).toBe("-");
     });
@@ -82,6 +82,18 @@ describe("dataUtils", () => {
       expect(formatNumberWithCommas(1_234_567, 1, true)).toBe("1.2M");
       expect(formatNumberWithCommas(12_345, 2, true)).toBe("12.35K");
       expect(formatNumberWithCommas(-1_200, 2, true)).toBe("-1.20K");
+    });
+
+    it("should show zero when showZero is true", () => {
+      expect(formatNumberWithCommas(0, 0, false, true)).toBe("0");
+      expect(formatNumberWithCommas(0, 2, false, true)).toBe("0.00");
+      expect(formatNumberWithCommas(0, 0, true, true)).toBe("0");
+    });
+
+    it("should return '-' for zero when showZero is false", () => {
+      expect(formatNumberWithCommas(0, 0, false, false)).toBe("-");
+      expect(formatNumberWithCommas(0, 2, false, false)).toBe("-");
+      expect(formatNumberWithCommas(0, 0, true, false)).toBe("-");
     });
   });
 

--- a/ui/litellm-dashboard/src/utils/dataUtils.ts
+++ b/ui/litellm-dashboard/src/utils/dataUtils.ts
@@ -16,8 +16,9 @@ export const formatNumberWithCommas = (
   value: number | null | undefined,
   decimals: number = 0,
   abbreviate: boolean = false,
+  showZero: boolean = true,
 ): string => {
-  if (value === null || value === undefined || !Number.isFinite(value) || value === 0) {
+  if (value === null || value === undefined || !Number.isFinite(value) || (value === 0 && !showZero)) {
     return "-";
   }
 
@@ -51,7 +52,7 @@ export const getSpendString = (value: number | null | undefined, decimals: numbe
     return "-";
   }
 
-  const formatted = formatNumberWithCommas(value, decimals);
+  const formatted = formatNumberWithCommas(value, decimals, false, false);
   const numericFormatted = Number(formatted.replace(/,/g, ""));
 
   if (numericFormatted === 0) {


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Previously the labels inside all usage views except for teams showed the UUID of resource for the spend. This creates a bad UX experience where the user needs to match the UUID to the alias/name of the resource. This PR changes the labels to be the alias instead.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<img width="1577" height="933" alt="image" src="https://github.com/user-attachments/assets/9c998b0b-3ea3-49a8-a74d-def4a528520e" />

<img width="647" height="210" alt="image" src="https://github.com/user-attachments/assets/47334dac-9c34-46d8-ad90-88fb2acbbf7d" />

