### PR TITLE
adding support for .svg files  in UI logo UI_LOGO param override for admin panel

### DIFF
--- a/litellm/proxy/common_utils/logo_utils.py
+++ b/litellm/proxy/common_utils/logo_utils.py
@@ -1,0 +1,39 @@
+import mimetypes
+from typing import Optional, Tuple
+
+
+def normalize_logo_content_type(content_type: str) -> str:
+    normalized = (content_type or "").split(";", 1)[0].strip().lower()
+    if normalized == "image/svg":
+        return "image/svg+xml"
+    if normalized == "image/jpg":
+        return "image/jpeg"
+    return normalized
+
+
+def infer_logo_content_type(
+    path: str, default: str = "image/jpeg"
+) -> Tuple[str, Optional[str]]:
+    """
+    Infer logo content type + optional content encoding from a path/URL.
+
+    Note: Python's built-in `mimetypes` can be inconsistent across OSes for SVG,
+    so handle it explicitly.
+    """
+    lower_path = (path or "").lower()
+    if lower_path.endswith((".svg", ".svgz")):
+        return "image/svg+xml", "gzip" if lower_path.endswith(".svgz") else None
+
+    media_type, _encoding = mimetypes.guess_type(path)
+    return normalize_logo_content_type(media_type or default), None
+
+
+def cache_extension_for_logo(
+    content_type: str, content_encoding: Optional[str] = None
+) -> str:
+    normalized = normalize_logo_content_type(content_type)
+    if normalized == "image/svg+xml":
+        if (content_encoding or "").lower() == "gzip":
+            return ".svgz"
+        return ".svg"
+    return mimetypes.guess_extension(normalized) or ".img"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12,6 +12,7 @@ import time
 import traceback
 import warnings
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -505,6 +506,11 @@ from fastapi.security.api_key import APIKeyHeader
 from fastapi.staticfiles import StaticFiles
 
 from litellm.types.agents import AgentConfig
+from litellm.proxy.common_utils.logo_utils import (
+    cache_extension_for_logo,
+    infer_logo_content_type,
+    normalize_logo_content_type,
+)
 
 # import enterprise folder
 enterprise_router = APIRouter()
@@ -8772,6 +8778,7 @@ async def login_v2(request: Request):  # noqa: PLR0915
             )
 
 
+
 @app.get("/onboarding/get_token", include_in_schema=False)
 async def onboarding(invite_link: str, request: Request):
     """
@@ -8978,7 +8985,13 @@ def get_logo_url():
 
 @app.get("/get_image", include_in_schema=False)
 def get_image():
-    """Get logo to show on admin UI"""
+    """
+    Get logo to show on admin UI.
+
+    Note: SVG files can contain embedded scripts. This endpoint assumes logos
+    are admin-controlled via UI_LOGO_PATH environment variable.
+    """
+    default_media_type = "image/jpeg"
 
     # get current_dir
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -8997,6 +9010,8 @@ def get_image():
         default_logo = default_site_logo
 
     logo_path = os.getenv("UI_LOGO_PATH", default_logo)
+    if not logo_path or not logo_path.strip():
+        logo_path = default_logo
     verbose_proxy_logger.debug("Reading logo from path: %s", logo_path)
 
     # Check if the logo path is an HTTP/HTTPS URL
@@ -9005,20 +9020,46 @@ def get_image():
         client = HTTPHandler()
         response = client.get(logo_path)
         if response.status_code == 200:
+            url_path = urlparse(logo_path).path
+            inferred_media_type, inferred_encoding = infer_logo_content_type(
+                url_path, default_media_type
+            )
+
+            content_type_header = response.headers.get("Content-Type")
+            media_type = (
+                normalize_logo_content_type(content_type_header)
+                if content_type_header
+                else inferred_media_type
+            )
+            if media_type in {"application/octet-stream", "binary/octet-stream"}:
+                media_type = inferred_media_type
+
+            content_encoding_header = response.headers.get("Content-Encoding")
+            content_encoding = content_encoding_header or inferred_encoding
+
+            cache_ext = cache_extension_for_logo(media_type, content_encoding)
+
             # Save the image to a local file
             cache_dir = assets_dir if is_non_root else current_dir
-            cache_path = os.path.join(cache_dir, "cached_logo.jpg")
+            cache_path = os.path.join(cache_dir, f"cached_logo{cache_ext}")
             with open(cache_path, "wb") as f:
                 f.write(response.content)
 
             # Return the cached image as a FileResponse
-            return FileResponse(cache_path, media_type="image/jpeg")
+            headers = (
+                {"Content-Encoding": content_encoding} if content_encoding else None
+            )
+            return FileResponse(cache_path, media_type=media_type, headers=headers)
         else:
             # Handle the case when the image cannot be downloaded
-            return FileResponse(default_logo, media_type="image/jpeg")
+            return FileResponse(default_logo, media_type=default_media_type)
     else:
         # Return the local image file if the logo path is not an HTTP/HTTPS URL
-        return FileResponse(logo_path, media_type="image/jpeg")
+        media_type, content_encoding = infer_logo_content_type(
+            logo_path, default_media_type
+        )
+        headers = {"Content-Encoding": content_encoding} if content_encoding else None
+        return FileResponse(logo_path, media_type=media_type, headers=headers)
 
 
 #### INVITATION MANAGEMENT ####


### PR DESCRIPTION
##  Title
Add /ui Logo .svg file support

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🧹 Refactoring
✅ Test

## Changes
What this PR changes (SVG logo support)

Adds SVG/SVGZ MIME handling helpers
New litellm/proxy/common_utils/logo_utils.py provides:

infer_logo_content_type() to detect image/svg+xml for .svg / .svgz (and mark .svgz as gzip-encoded).
normalize_logo_content_type() to normalize headers like image/svg → image/svg+xml (and image/jpg → image/jpeg).
cache_extension_for_logo() to choose the right cache filename extension (.svg, .svgz, or a best-effort extension for other image types).
Fixes /get_image to return correct Content-Type for SVG
In litellm/proxy/proxy_server.py, /get_image now:

Returns media_type="image/svg+xml" for local UI_LOGO_PATH pointing to .svg/.svgz instead of always image/jpeg.
For remote logos (HTTP/HTTPS), reads Content-Type from the response when present, otherwise infers it from the URL path.
Caches remote logos using the correct extension (cached_logo.svg / cached_logo.svgz), rather than always writing cached_logo.jpg.
Preserves Content-Encoding: gzip when serving .svgz (so browsers can decode it correctly).
Adds tests for the new behavior
In tests/test_litellm/proxy/test_proxy_server.py, adds mocked tests that verify:



Local Unit Test Passing:
Full file run: 


<img width="1316" height="480" alt="Screenshot 2025-12-12 at 12 41 06 PM" src="https://github.com/user-attachments/assets/a5291c85-bc3c-4182-a1e7-cfb72395b28d" />


Specific unit test added passing: 

<img width="1305" height="55" alt="Screenshot 2025-12-12 at 12 43 00 PM" src="https://github.com/user-attachments/assets/4e961e7d-57ad-4132-960e-2a99171a430a" />



## Evidence of the Update: 

Before SVG ui Handling (overriding UI_LOGO param with a link to a local .svg): 
<img width="284" height="82" alt="Screenshot 2025-12-12 at 11 45 45 AM" src="https://github.com/user-attachments/assets/f6c40c24-342a-42f8-8330-c290acdc33b9" />


After Svg Handling: (the purple circular "LLM" image). 
<img width="652" height="422" alt="Screenshot 2025-12-12 at 11 17 37 AM" src="https://github.com/user-attachments/assets/fdb03a82-a765-47d4-944b-f4224b6b9976" />



### A NOTE TO REVIEWER: 
Locally, linting failed with 
```
proxy/custom_prompt_management.py:40: error: Cannot instantiate abstract class "X42PromptManagement" with abstract attribute "async_compile_prompt_helper"  [abstract]
Found 36 errors in 16 files (checked 1472 source files)
```

I also witnessed this happen in your automation pipeline, as well as running linting in a direct clone from main. I do not believe this failure is related to my change, but, rather, something else in the codebase. 

also, locally running format updated around 673 files. I did not change those 673 files. i witnessed the same behavior when comparing in main. running make format in main resulted in the same (673) files reformatted. Again, i dont believe this is related to my change. 


Additionally, i am noticing the custom prompt management unit tests are failing. 

Primary commit to review: 
435283c6b8c80f8971042a38ccfeda22d64a5552

