### PR TITLE
fix(anthropic): use dynamic max_tokens based on model

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -8,6 +8,7 @@ import httpx
 import litellm
 from litellm.constants import (
     ANTHROPIC_WEB_SEARCH_TOOL_MAX_USES,
+    DEFAULT_ANTHROPIC_CHAT_MAX_TOKENS,
     DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
@@ -122,18 +123,17 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
     def get_max_tokens_for_model(model: Optional[str] = None) -> int:
         """
         Get the max output tokens for a given model.
-        Falls back to 4096 if model is not found.
+        Falls back to DEFAULT_ANTHROPIC_CHAT_MAX_TOKENS (configurable via env var) if model is not found.
         """
-        DEFAULT_MAX_TOKENS = 4096
         if model is None:
-            return DEFAULT_MAX_TOKENS
+            return DEFAULT_ANTHROPIC_CHAT_MAX_TOKENS
         try:
             max_tokens = get_max_tokens(model)
             if max_tokens is None:
-                return DEFAULT_MAX_TOKENS
+                return DEFAULT_ANTHROPIC_CHAT_MAX_TOKENS
             return max_tokens
         except Exception:
-            return DEFAULT_MAX_TOKENS
+            return DEFAULT_ANTHROPIC_CHAT_MAX_TOKENS
 
     @staticmethod
     def convert_tool_use_to_openai_format(


### PR DESCRIPTION
## Title

fix(anthropic): use dynamic max_tokens based on model instead of hardcoded 4096

## Relevant issues

Fixes #8835
Fixes [#552](https://github.com/laude-institute/terminal-bench/issues/552)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Context

In the Anthropic Messages API, the `max_tokens` parameter is **required** (unlike OpenAI where it's optional):

```python
# Direct Anthropic API call - max_tokens is REQUIRED
import anthropic

client = anthropic.Anthropic()
response = client.messages.create(
    model="claude-3-5-sonnet-20241022",
    messages=[{"role": "user", "content": "Hello"}],
    max_tokens=8192  # ← Required, omitting this causes an error
)
```

From [Anthropic's documentation](https://docs.anthropic.com/en/api/messages):

> **max_tokens** (required): The maximum number of tokens to generate before stopping.
> Note that our models may stop before reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.
> **Different models have different maximum values for this parameter.** See models for details.

### Summary

When users call LiteLLM without specifying `max_tokens`, LiteLLM must provide a default value. Previously, it used a **hardcoded 4096** for all Claude models:

```python
# User doesn't specify max_tokens
response = litellm.completion(
    model="claude-3-5-sonnet-20241022",
    messages=[{"role": "user", "content": "Write a long essay..."}]
)
# Before: LiteLLM sent max_tokens=4096 (wrong for Claude 3.5+)
# Result: Responses truncated at 4096 tokens instead of model's actual limit
```

| Model | Hardcoded default | Actual model limit |
|-------|-------------------|-------------------|
| Claude 3 (Opus/Sonnet/Haiku) | 4096 ✓ | 4096 |
| Claude 3.5 (Sonnet/Haiku) | 4096 ❌ | 8192 |
| Claude 3.7 Sonnet | 4096 ❌ | 128000 |
| Claude 4 Sonnet | 4096 ❌ | 64000 |

### Solution

Modified `AnthropicConfig.get_config()` to dynamically read the correct `max_output_tokens` from `model_prices_and_context_window.json` using the existing `get_max_tokens(model)` function.

**Users can still override this** by explicitly passing `max_tokens`:

```python
# Uses dynamic default (8192 for Claude 3.5)
litellm.completion(model="claude-3-5-sonnet-20241022", messages=[...])

# User override - uses 1000
litellm.completion(model="claude-3-5-sonnet-20241022", messages=[...], max_tokens=1000)
```

### Code Changes

1. `AnthropicConfig.get_config()` now accepts optional `model` parameter
2. Added `get_max_tokens_for_model()` static method that reads from model pricing JSON
3. Falls back to 4096 if model not found (backwards compatible)
4. Updated `transform_request()` to pass model to `get_config()`

### Tests Added