### PR TITLE
fix(cost_calculator): correct gpt-image-1 cost calculation using token-based pricing

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -161,6 +161,15 @@ def _get_token_base_cost(
 
     prompt_base_cost = cast(float, _get_cost_per_unit(model_info, input_cost_key))
     completion_base_cost = cast(float, _get_cost_per_unit(model_info, output_cost_key))
+
+    # For image generation models that don't have output_cost_per_token,
+    # use output_cost_per_image_token as the base cost (all output tokens are image tokens)
+    if completion_base_cost == 0.0 or completion_base_cost is None:
+        output_image_cost = _get_cost_per_unit(
+            model_info, "output_cost_per_image_token", None
+        )
+        if output_image_cost is not None:
+            completion_base_cost = cast(float, output_image_cost)
     cache_creation_cost = cast(
         float, _get_cost_per_unit(model_info, cache_creation_cost_key)
     )
@@ -342,6 +351,7 @@ class PromptTokensDetailsResult(TypedDict):
     cache_creation_token_details: Optional[CacheCreationTokenDetails]
     text_tokens: int
     audio_tokens: int
+    image_tokens: int
     character_count: int
     image_count: int
     video_length_seconds: int
@@ -374,6 +384,10 @@ def _parse_prompt_tokens_details(usage: Usage) -> PromptTokensDetailsResult:
         cast(Optional[int], getattr(usage.prompt_tokens_details, "audio_tokens", 0))
         or 0
     )
+    image_tokens = (
+        cast(Optional[int], getattr(usage.prompt_tokens_details, "image_tokens", 0))
+        or 0
+    )
     character_count = (
         cast(
             Optional[int],
@@ -398,6 +412,7 @@ def _parse_prompt_tokens_details(usage: Usage) -> PromptTokensDetailsResult:
         cache_creation_token_details=cache_creation_token_details,
         text_tokens=text_tokens,
         audio_tokens=audio_tokens,
+        image_tokens=image_tokens,
         character_count=character_count,
         image_count=image_count,
         video_length_seconds=video_length_seconds,
@@ -470,6 +485,11 @@ def _calculate_input_cost(
         model_info, "input_cost_per_audio_token", prompt_tokens_details["audio_tokens"]
     )
 
+    ### IMAGE TOKEN COST (for gpt-image-1 and similar models)
+    prompt_cost += calculate_cost_component(
+        model_info, "input_cost_per_image_token", prompt_tokens_details["image_tokens"]
+    )
+
     ### CACHE WRITING COST - Now uses tiered pricing
     prompt_cost += calculate_cache_writing_cost(
         cache_creation_tokens=prompt_tokens_details["cache_creation_tokens"],
@@ -533,6 +553,7 @@ def generic_cost_per_token(
         cache_creation_token_details=None,
         text_tokens=usage.prompt_tokens,
         audio_tokens=0,
+        image_tokens=0,
         character_count=0,
         image_count=0,
         video_length_seconds=0,

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -782,6 +782,50 @@ class CostCalculatorUtils:
                 model=model,
                 image_response=completion_response,
             )
+        elif custom_llm_provider == litellm.LlmProviders.OPENAI.value:
+            # Check if this is a gpt-image model (token-based pricing)
+            model_lower = model.lower()
+            if "gpt-image-1" in model_lower:
+                from litellm.llms.openai.image_generation.cost_calculator import (
+                    cost_calculator as openai_gpt_image_cost_calculator,
+                )
+
+                return openai_gpt_image_cost_calculator(
+                    model=model,
+                    image_response=completion_response,
+                    custom_llm_provider=custom_llm_provider,
+                )
+            # Fall through to default for DALL-E models
+            return default_image_cost_calculator(
+                model=model,
+                quality=quality,
+                custom_llm_provider=custom_llm_provider,
+                n=n,
+                size=size,
+                optional_params=optional_params,
+            )
+        elif custom_llm_provider == litellm.LlmProviders.AZURE.value:
+            # Check if this is a gpt-image model (token-based pricing)
+            model_lower = model.lower()
+            if "gpt-image-1" in model_lower:
+                from litellm.llms.openai.image_generation.cost_calculator import (
+                    cost_calculator as openai_gpt_image_cost_calculator,
+                )
+
+                return openai_gpt_image_cost_calculator(
+                    model=model,
+                    image_response=completion_response,
+                    custom_llm_provider=custom_llm_provider,
+                )
+            # Fall through to default for DALL-E models
+            return default_image_cost_calculator(
+                model=model,
+                quality=quality,
+                custom_llm_provider=custom_llm_provider,
+                n=n,
+                size=size,
+                optional_params=optional_params,
+            )
         else:
             return default_image_cost_calculator(
                 model=model,

--- a/litellm/llms/openai/image_generation/cost_calculator.py
+++ b/litellm/llms/openai/image_generation/cost_calculator.py
@@ -6,15 +6,10 @@ These models use token-based pricing instead of pixel-based pricing like DALL-E.
 
 from typing import Optional
 
-import litellm
 from litellm import verbose_logger
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+from litellm.responses.utils import ResponseAPILoggingUtils
 from litellm.types.utils import ImageResponse
-
-
-def _is_gpt_image_model(model: str) -> bool:
-    """Check if model is a gpt-image model that uses token-based pricing"""
-    model_lower = model.lower()
-    return "gpt-image-1" in model_lower or "gpt-image-1-mini" in model_lower
 
 
 def cost_calculator(
@@ -25,10 +20,8 @@ def cost_calculator(
     """
     Calculate cost for OpenAI gpt-image-1 and gpt-image-1-mini models.
 
-    These models use token-based pricing:
-    - Text input tokens (from prompt)
-    - Image input tokens (from input images for editing)
-    - Image output tokens (for generated images)
+    Uses the same usage format as Responses API, so we reuse the helper
+    to transform to chat completion format and use generic_cost_per_token.
 
     Args:
         model: The model name (e.g., "gpt-image-1", "gpt-image-1-mini")
@@ -37,23 +30,7 @@ def cost_calculator(
 
     Returns:
         float: Total cost in USD
-
-    Pricing (as of 2025):
-        gpt-image-1:
-            - Text Input: $5.00/1M tokens
-            - Image Input: $10.00/1M tokens
-            - Image Output: $40.00/1M tokens
-            - Cached Text: $1.25/1M tokens
-            - Cached Image: $2.50/1M tokens
-
-        gpt-image-1-mini:
-            - Text Input: $2.00/1M tokens
-            - Image Input: $2.50/1M tokens
-            - Image Output: $8.00/1M tokens
-            - Cached Text: $0.20/1M tokens
-            - Cached Image: $0.25/1M tokens
     """
-    # Get usage from response
     usage = getattr(image_response, "usage", None)
 
     if usage is None:
@@ -62,69 +39,24 @@ def cost_calculator(
         )
         return 0.0
 
-    # Get token counts
-    input_tokens = getattr(usage, "input_tokens", 0) or 0
-    output_tokens = getattr(usage, "output_tokens", 0) or 0
+    # Transform ImageUsage to Usage using the existing helper
+    # ImageUsage has the same format as ResponseAPIUsage
+    chat_usage = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+        usage
+    )
 
-    # Get token details for input breakdown
-    input_tokens_details = getattr(usage, "input_tokens_details", None)
-    text_tokens = 0
-    image_tokens = 0
+    # Use generic_cost_per_token for cost calculation
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model=model,
+        usage=chat_usage,
+        custom_llm_provider=custom_llm_provider or "openai",
+    )
 
-    if input_tokens_details:
-        text_tokens = getattr(input_tokens_details, "text_tokens", 0) or 0
-        image_tokens = getattr(input_tokens_details, "image_tokens", 0) or 0
-    else:
-        # If no details, assume all input tokens are text tokens
-        text_tokens = input_tokens
-
-    # Get pricing from model_cost dict (includes all fields unlike get_model_info)
-    model_cost = litellm.model_cost
-
-    # Try different model name variations
-    base_model = model.split("/")[-1] if "/" in model else model
-    provider_prefix = custom_llm_provider or "openai"
-    model_names_to_try = [
-        model,  # as-is
-        f"{provider_prefix}/{base_model}",  # with provider prefix
-        base_model,  # just the model name
-    ]
-
-    cost_info = None
-    for model_name in model_names_to_try:
-        if model_name in model_cost:
-            cost_info = model_cost[model_name]
-            break
-
-    if cost_info is None:
-        verbose_logger.debug(
-            f"Could not find pricing for model {model}. Tried: {model_names_to_try}"
-        )
-        return 0.0
-
-    # Get cost rates from model_cost dict
-    input_cost_per_token = cost_info.get("input_cost_per_token", 0) or 0
-    input_cost_per_image_token = cost_info.get("input_cost_per_image_token", 0) or 0
-    output_cost_per_image_token = cost_info.get("output_cost_per_image_token", 0) or 0
-
-    # If no image token cost is defined, fall back to regular token cost
-    if input_cost_per_image_token == 0:
-        input_cost_per_image_token = input_cost_per_token
-    if output_cost_per_image_token == 0:
-        output_cost_per_image_token = cost_info.get("output_cost_per_token", 0) or 0
-
-    # Calculate costs
-    text_input_cost = text_tokens * input_cost_per_token
-    image_input_cost = image_tokens * input_cost_per_image_token
-    output_cost = output_tokens * output_cost_per_image_token
-
-    total_cost = text_input_cost + image_input_cost + output_cost
+    total_cost = prompt_cost + completion_cost
 
     verbose_logger.debug(
         f"OpenAI gpt-image cost calculation for {model}: "
-        f"text_tokens={text_tokens} (${text_input_cost:.6f}), "
-        f"image_tokens={image_tokens} (${image_input_cost:.6f}), "
-        f"output_tokens={output_tokens} (${output_cost:.6f}), "
+        f"prompt_cost=${prompt_cost:.6f}, completion_cost=${completion_cost:.6f}, "
         f"total=${total_cost:.6f}"
     )
 

--- a/litellm/llms/openai/image_generation/cost_calculator.py
+++ b/litellm/llms/openai/image_generation/cost_calculator.py
@@ -1,0 +1,131 @@
+"""
+Cost calculator for OpenAI image generation models (gpt-image-1, gpt-image-1-mini)
+
+These models use token-based pricing instead of pixel-based pricing like DALL-E.
+"""
+
+from typing import Optional
+
+import litellm
+from litellm import verbose_logger
+from litellm.types.utils import ImageResponse
+
+
+def _is_gpt_image_model(model: str) -> bool:
+    """Check if model is a gpt-image model that uses token-based pricing"""
+    model_lower = model.lower()
+    return "gpt-image-1" in model_lower or "gpt-image-1-mini" in model_lower
+
+
+def cost_calculator(
+    model: str,
+    image_response: ImageResponse,
+    custom_llm_provider: Optional[str] = None,
+) -> float:
+    """
+    Calculate cost for OpenAI gpt-image-1 and gpt-image-1-mini models.
+
+    These models use token-based pricing:
+    - Text input tokens (from prompt)
+    - Image input tokens (from input images for editing)
+    - Image output tokens (for generated images)
+
+    Args:
+        model: The model name (e.g., "gpt-image-1", "gpt-image-1-mini")
+        image_response: The ImageResponse containing usage data
+        custom_llm_provider: Optional provider name
+
+    Returns:
+        float: Total cost in USD
+
+    Pricing (as of 2025):
+        gpt-image-1:
+            - Text Input: $5.00/1M tokens
+            - Image Input: $10.00/1M tokens
+            - Image Output: $40.00/1M tokens
+            - Cached Text: $1.25/1M tokens
+            - Cached Image: $2.50/1M tokens
+
+        gpt-image-1-mini:
+            - Text Input: $2.00/1M tokens
+            - Image Input: $2.50/1M tokens
+            - Image Output: $8.00/1M tokens
+            - Cached Text: $0.20/1M tokens
+            - Cached Image: $0.25/1M tokens
+    """
+    # Get usage from response
+    usage = getattr(image_response, "usage", None)
+
+    if usage is None:
+        verbose_logger.debug(
+            f"No usage data available for {model}, cannot calculate token-based cost"
+        )
+        return 0.0
+
+    # Get token counts
+    input_tokens = getattr(usage, "input_tokens", 0) or 0
+    output_tokens = getattr(usage, "output_tokens", 0) or 0
+
+    # Get token details for input breakdown
+    input_tokens_details = getattr(usage, "input_tokens_details", None)
+    text_tokens = 0
+    image_tokens = 0
+
+    if input_tokens_details:
+        text_tokens = getattr(input_tokens_details, "text_tokens", 0) or 0
+        image_tokens = getattr(input_tokens_details, "image_tokens", 0) or 0
+    else:
+        # If no details, assume all input tokens are text tokens
+        text_tokens = input_tokens
+
+    # Get pricing from model_cost dict (includes all fields unlike get_model_info)
+    model_cost = litellm.model_cost
+
+    # Try different model name variations
+    base_model = model.split("/")[-1] if "/" in model else model
+    provider_prefix = custom_llm_provider or "openai"
+    model_names_to_try = [
+        model,  # as-is
+        f"{provider_prefix}/{base_model}",  # with provider prefix
+        base_model,  # just the model name
+    ]
+
+    cost_info = None
+    for model_name in model_names_to_try:
+        if model_name in model_cost:
+            cost_info = model_cost[model_name]
+            break
+
+    if cost_info is None:
+        verbose_logger.debug(
+            f"Could not find pricing for model {model}. Tried: {model_names_to_try}"
+        )
+        return 0.0
+
+    # Get cost rates from model_cost dict
+    input_cost_per_token = cost_info.get("input_cost_per_token", 0) or 0
+    input_cost_per_image_token = cost_info.get("input_cost_per_image_token", 0) or 0
+    output_cost_per_image_token = cost_info.get("output_cost_per_image_token", 0) or 0
+
+    # If no image token cost is defined, fall back to regular token cost
+    if input_cost_per_image_token == 0:
+        input_cost_per_image_token = input_cost_per_token
+    if output_cost_per_image_token == 0:
+        output_cost_per_image_token = cost_info.get("output_cost_per_token", 0) or 0
+
+    # Calculate costs
+    text_input_cost = text_tokens * input_cost_per_token
+    image_input_cost = image_tokens * input_cost_per_image_token
+    output_cost = output_tokens * output_cost_per_image_token
+
+    total_cost = text_input_cost + image_input_cost + output_cost
+
+    verbose_logger.debug(
+        f"OpenAI gpt-image cost calculation for {model}: "
+        f"text_tokens={text_tokens} (${text_input_cost:.6f}), "
+        f"image_tokens={image_tokens} (${image_input_cost:.6f}), "
+        f"output_tokens={output_tokens} (${output_cost:.6f}), "
+        f"total=${total_cost:.6f}"
+    )
+
+    return total_cost

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -3591,12 +3591,16 @@
         "supports_web_search": true
     },
     "azure/gpt-image-1": {
-        "input_cost_per_pixel": 4.0054321e-08,
+        "cache_read_input_image_token_cost": 2.5e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 1e-05,
+        "input_cost_per_token": 5e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
-        "output_cost_per_pixel": 0.0,
+        "output_cost_per_image_token": 4e-05,
         "supported_endpoints": [
-            "/v1/images/generations"
+            "/v1/images/generations",
+            "/v1/images/edits"
         ]
     },
     "azure/hd/1024-x-1024/dall-e-3": {
@@ -3699,12 +3703,16 @@
         ]
     },
     "azure/gpt-image-1-mini": {
-        "input_cost_per_pixel": 8.0566406e-09,
+        "cache_read_input_image_token_cost": 2.5e-07,
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_image_token": 2.5e-06,
+        "input_cost_per_token": 2e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
-        "output_cost_per_pixel": 0.0,
+        "output_cost_per_image_token": 8e-06,
         "supported_endpoints": [
-            "/v1/images/generations"
+            "/v1/images/generations",
+            "/v1/images/edits"
         ]
     },
     "azure/low/1024-x-1024/gpt-image-1-mini": {
@@ -17643,16 +17651,16 @@
         "supports_vision": true
     },
     "gpt-image-1": {
-        "input_cost_per_image": 0.042,
-        "input_cost_per_pixel": 4.0054321e-08,
-        "input_cost_per_token": 0.000005,
-        "input_cost_per_image_token": 0.00001,
+        "cache_read_input_image_token_cost": 2.5e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 1e-05,
+        "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
         "mode": "image_generation",
-        "output_cost_per_pixel": 0.0,
-        "output_cost_per_token": 0.00004,
+        "output_cost_per_image_token": 4e-05,
         "supported_endpoints": [
-            "/v1/images/generations"
+            "/v1/images/generations",
+            "/v1/images/edits"
         ]
     },
     "gpt-image-1-mini": {

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -142,6 +142,7 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     ]  # only for vertex ai models
     input_cost_per_query: Optional[float]  # only for rerank models
     input_cost_per_image: Optional[float]  # only for vertex ai models
+    input_cost_per_image_token: Optional[float]  # for gpt-image-1 and similar models
     input_cost_per_audio_per_second: Optional[float]  # only for vertex ai models
     input_cost_per_video_per_second: Optional[float]  # only for vertex ai models
     input_cost_per_second: Optional[float]  # for OpenAI Speech models
@@ -1300,7 +1301,7 @@ class CacheCreationTokenDetails(BaseModel):
 
 class PromptTokensDetailsWrapper(
     PromptTokensDetails
-):  # wrapper for older openai versions
+):  # extends with image generation fields (text_tokens, image_tokens)
     text_tokens: Optional[int] = None
     """Text tokens sent to the model."""
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5059,6 +5059,9 @@ def _get_model_info_helper(  # noqa: PLR0915
                 input_cost_per_audio_token=_model_info.get(
                     "input_cost_per_audio_token", None
                 ),
+                input_cost_per_image_token=_model_info.get(
+                    "input_cost_per_image_token", None
+                ),
                 input_cost_per_token_batches=_model_info.get(
                     "input_cost_per_token_batches"
                 ),

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3591,12 +3591,16 @@
         "supports_web_search": true
     },
     "azure/gpt-image-1": {
-        "input_cost_per_pixel": 4.0054321e-08,
+        "cache_read_input_image_token_cost": 2.5e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 1e-05,
+        "input_cost_per_token": 5e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
-        "output_cost_per_pixel": 0.0,
+        "output_cost_per_image_token": 4e-05,
         "supported_endpoints": [
-            "/v1/images/generations"
+            "/v1/images/generations",
+            "/v1/images/edits"
         ]
     },
     "azure/hd/1024-x-1024/dall-e-3": {
@@ -3699,12 +3703,16 @@
         ]
     },
     "azure/gpt-image-1-mini": {
-        "input_cost_per_pixel": 8.0566406e-09,
+        "cache_read_input_image_token_cost": 2.5e-07,
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_image_token": 2.5e-06,
+        "input_cost_per_token": 2e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
-        "output_cost_per_pixel": 0.0,
+        "output_cost_per_image_token": 8e-06,
         "supported_endpoints": [
-            "/v1/images/generations"
+            "/v1/images/generations",
+            "/v1/images/edits"
         ]
     },
     "azure/low/1024-x-1024/gpt-image-1-mini": {
@@ -17643,16 +17651,16 @@
         "supports_vision": true
     },
     "gpt-image-1": {
-        "input_cost_per_image": 0.042,
-        "input_cost_per_pixel": 4.0054321e-08,
-        "input_cost_per_token": 0.000005,
-        "input_cost_per_image_token": 0.00001,
+        "cache_read_input_image_token_cost": 2.5e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 1e-05,
+        "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
         "mode": "image_generation",
-        "output_cost_per_pixel": 0.0,
-        "output_cost_per_token": 0.00004,
+        "output_cost_per_image_token": 4e-05,
         "supported_endpoints": [
-            "/v1/images/generations"
+            "/v1/images/generations",
+            "/v1/images/edits"
         ]
     },
     "gpt-image-1-mini": {

--- a/tests/test_litellm/test_gpt_image_cost_calculator.py
+++ b/tests/test_litellm/test_gpt_image_cost_calculator.py
@@ -1,0 +1,269 @@
+"""
+Tests for OpenAI gpt-image-1 cost calculator
+
+This tests the fix for GitHub issue #13847:
+https://github.com/BerriAI/litellm/issues/13847
+
+gpt-image-1 cost calculation was incomplete - it only calculated output image
+cost using pixel-based pricing and completely ignored input token costs.
+
+The correct pricing structure for gpt-image-1 is token-based:
+- Text Input: $5.00/1M tokens
+- Image Input: $10.00/1M tokens
+- Image Output: $40.00/1M tokens
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import pytest
+
+import litellm
+from litellm.types.utils import ImageResponse, ImageObject
+
+
+class TestGPTImageCostCalculator:
+    """Test the OpenAI gpt-image-1 cost calculator"""
+
+    def test_gpt_image_1_cost_with_text_only(self):
+        """Test cost calculation with only text input tokens"""
+        from litellm.llms.openai.image_generation.cost_calculator import cost_calculator
+
+        # Create mock ImageResponse with usage data
+        usage = MagicMock()
+        usage.input_tokens = 100
+        usage.output_tokens = 5000
+        usage.input_tokens_details = MagicMock()
+        usage.input_tokens_details.text_tokens = 100
+        usage.input_tokens_details.image_tokens = 0
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(url="http://example.com/image.jpg")],
+        )
+        image_response.usage = usage
+
+        cost = cost_calculator(
+            model="gpt-image-1",
+            image_response=image_response,
+            custom_llm_provider="openai",
+        )
+
+        # Expected cost calculation:
+        # Text input: 100 tokens * $5.00/1M = 100 * 5e-06 = 0.0005
+        # Image input: 0 tokens * $10.00/1M = 0
+        # Image output: 5000 tokens * $40.00/1M = 5000 * 4e-05 = 0.2
+        # Total: 0.0005 + 0 + 0.2 = 0.2005
+        expected_cost = 0.0005 + 0.2
+        assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
+
+    def test_gpt_image_1_cost_with_image_input(self):
+        """Test cost calculation with both text and image input tokens"""
+        from litellm.llms.openai.image_generation.cost_calculator import cost_calculator
+
+        # Create mock ImageResponse with usage data including image input
+        usage = MagicMock()
+        usage.input_tokens = 600  # 100 text + 500 image
+        usage.output_tokens = 5000
+        usage.input_tokens_details = MagicMock()
+        usage.input_tokens_details.text_tokens = 100
+        usage.input_tokens_details.image_tokens = 500
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(url="http://example.com/image.jpg")],
+        )
+        image_response.usage = usage
+
+        cost = cost_calculator(
+            model="gpt-image-1",
+            image_response=image_response,
+            custom_llm_provider="openai",
+        )
+
+        # Expected cost calculation:
+        # Text input: 100 tokens * $5.00/1M = 100 * 5e-06 = 0.0005
+        # Image input: 500 tokens * $10.00/1M = 500 * 1e-05 = 0.005
+        # Image output: 5000 tokens * $40.00/1M = 5000 * 4e-05 = 0.2
+        # Total: 0.0005 + 0.005 + 0.2 = 0.2055
+        expected_cost = 0.0005 + 0.005 + 0.2
+        assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
+
+    def test_gpt_image_1_mini_cost(self):
+        """Test cost calculation for gpt-image-1-mini model"""
+        from litellm.llms.openai.image_generation.cost_calculator import cost_calculator
+
+        # Create mock ImageResponse with usage data
+        usage = MagicMock()
+        usage.input_tokens = 100
+        usage.output_tokens = 5000
+        usage.input_tokens_details = MagicMock()
+        usage.input_tokens_details.text_tokens = 100
+        usage.input_tokens_details.image_tokens = 0
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(url="http://example.com/image.jpg")],
+        )
+        image_response.usage = usage
+
+        cost = cost_calculator(
+            model="gpt-image-1-mini",
+            image_response=image_response,
+            custom_llm_provider="openai",
+        )
+
+        # Expected cost calculation for gpt-image-1-mini:
+        # Text input: 100 tokens * $2.00/1M = 100 * 2e-06 = 0.0002
+        # Image input: 0 tokens * $2.50/1M = 0
+        # Image output: 5000 tokens * $8.00/1M = 5000 * 8e-06 = 0.04
+        # Total: 0.0002 + 0 + 0.04 = 0.0402
+        expected_cost = 0.0002 + 0.04
+        assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
+
+    def test_gpt_image_1_cost_no_usage(self):
+        """Test that cost returns 0 when no usage data is available"""
+        from litellm.llms.openai.image_generation.cost_calculator import cost_calculator
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(url="http://example.com/image.jpg")],
+        )
+        # No usage attribute set
+
+        cost = cost_calculator(
+            model="gpt-image-1",
+            image_response=image_response,
+            custom_llm_provider="openai",
+        )
+
+        assert cost == 0.0
+
+    def test_gpt_image_1_cost_no_input_details(self):
+        """Test cost calculation when input_tokens_details is not available"""
+        from litellm.llms.openai.image_generation.cost_calculator import cost_calculator
+
+        # Create mock ImageResponse with usage data but no details
+        usage = MagicMock()
+        usage.input_tokens = 100
+        usage.output_tokens = 5000
+        usage.input_tokens_details = None  # No details
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(url="http://example.com/image.jpg")],
+        )
+        image_response.usage = usage
+
+        cost = cost_calculator(
+            model="gpt-image-1",
+            image_response=image_response,
+            custom_llm_provider="openai",
+        )
+
+        # When no details, all input tokens are assumed to be text tokens
+        # Text input: 100 tokens * $5.00/1M = 100 * 5e-06 = 0.0005
+        # Image output: 5000 tokens * $40.00/1M = 5000 * 4e-05 = 0.2
+        # Total: 0.0005 + 0.2 = 0.2005
+        expected_cost = 0.0005 + 0.2
+        assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
+
+
+class TestGPTImageCostRouting:
+    """Test that gpt-image models are properly routed to the token-based calculator"""
+
+    def test_openai_gpt_image_routes_to_token_calculator(self):
+        """Test that OpenAI gpt-image-1 routes to token-based calculator"""
+        from litellm.litellm_core_utils.llm_cost_calc.utils import CostCalculatorUtils
+
+        # Create mock ImageResponse with usage data
+        usage = MagicMock()
+        usage.input_tokens = 100
+        usage.output_tokens = 5000
+        usage.input_tokens_details = MagicMock()
+        usage.input_tokens_details.text_tokens = 100
+        usage.input_tokens_details.image_tokens = 0
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(url="http://example.com/image.jpg")],
+        )
+        image_response.usage = usage
+
+        cost = CostCalculatorUtils.route_image_generation_cost_calculator(
+            model="gpt-image-1",
+            completion_response=image_response,
+            custom_llm_provider="openai",
+        )
+
+        # Should be > 0 (token-based calculation)
+        assert cost > 0, f"Expected positive cost, got {cost}"
+
+        # Verify it's using token-based pricing, not pixel-based
+        # Pixel-based would give a very different result
+        expected_cost = 0.0005 + 0.2  # text + output
+        assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
+
+    def test_openai_dalle_routes_to_pixel_calculator(self):
+        """Test that OpenAI DALL-E still routes to pixel-based calculator"""
+        from litellm.litellm_core_utils.llm_cost_calc.utils import CostCalculatorUtils
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(url="http://example.com/image.jpg")],
+        )
+        image_response.size = "1024x1024"
+        image_response.quality = "standard"
+
+        # DALL-E should use pixel-based calculation
+        cost = CostCalculatorUtils.route_image_generation_cost_calculator(
+            model="dall-e-3",
+            completion_response=image_response,
+            custom_llm_provider="openai",
+            size="1024x1024",
+            quality="standard",
+            n=1,
+        )
+
+        # DALL-E cost should be calculated (pixel-based)
+        assert cost >= 0
+
+
+class TestCompletionCostIntegration:
+    """Test the full completion_cost integration for gpt-image-1"""
+
+    def test_completion_cost_gpt_image_1(self):
+        """Test completion_cost correctly calculates gpt-image-1 costs"""
+        # Create mock ImageResponse with usage data
+        usage = MagicMock()
+        usage.input_tokens = 100
+        usage.output_tokens = 5000
+        usage.total_tokens = 5100
+        usage.input_tokens_details = MagicMock()
+        usage.input_tokens_details.text_tokens = 100
+        usage.input_tokens_details.image_tokens = 0
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(url="http://example.com/image.jpg")],
+        )
+        image_response.usage = usage
+        image_response._hidden_params = {"custom_llm_provider": "openai"}
+
+        cost = litellm.completion_cost(
+            completion_response=image_response,
+            model="gpt-image-1",
+            call_type="image_generation",
+            custom_llm_provider="openai",
+        )
+
+        # Expected cost: text input + output image tokens
+        expected_cost = 0.0005 + 0.2
+        assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_litellm/test_gpt_image_cost_calculator.py
+++ b/tests/test_litellm/test_gpt_image_cost_calculator.py
@@ -4,10 +4,7 @@ Tests for OpenAI gpt-image-1 cost calculator
 This tests the fix for GitHub issue #13847:
 https://github.com/BerriAI/litellm/issues/13847
 
-gpt-image-1 cost calculation was incomplete - it only calculated output image
-cost using pixel-based pricing and completely ignored input token costs.
-
-The correct pricing structure for gpt-image-1 is token-based:
+gpt-image-1 uses token-based pricing:
 - Text Input: $5.00/1M tokens
 - Image Input: $10.00/1M tokens
 - Image Output: $40.00/1M tokens
@@ -15,14 +12,18 @@ The correct pricing structure for gpt-image-1 is token-based:
 
 import os
 import sys
-from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath("../.."))
 
 import pytest
 
 import litellm
-from litellm.types.utils import ImageResponse, ImageObject
+from litellm.types.utils import (
+    ImageResponse,
+    ImageObject,
+    ImageUsage,
+    ImageUsageInputTokensDetails,
+)
 
 
 class TestGPTImageCostCalculator:
@@ -32,13 +33,15 @@ class TestGPTImageCostCalculator:
         """Test cost calculation with only text input tokens"""
         from litellm.llms.openai.image_generation.cost_calculator import cost_calculator
 
-        # Create mock ImageResponse with usage data
-        usage = MagicMock()
-        usage.input_tokens = 100
-        usage.output_tokens = 5000
-        usage.input_tokens_details = MagicMock()
-        usage.input_tokens_details.text_tokens = 100
-        usage.input_tokens_details.image_tokens = 0
+        usage = ImageUsage(
+            input_tokens=100,
+            output_tokens=5000,
+            total_tokens=5100,
+            input_tokens_details=ImageUsageInputTokensDetails(
+                text_tokens=100,
+                image_tokens=0,
+            ),
+        )
 
         image_response = ImageResponse(
             created=1234567890,
@@ -52,25 +55,26 @@ class TestGPTImageCostCalculator:
             custom_llm_provider="openai",
         )
 
-        # Expected cost calculation:
-        # Text input: 100 tokens * $5.00/1M = 100 * 5e-06 = 0.0005
-        # Image input: 0 tokens * $10.00/1M = 0
-        # Image output: 5000 tokens * $40.00/1M = 5000 * 4e-05 = 0.2
-        # Total: 0.0005 + 0 + 0.2 = 0.2005
+        # Expected cost:
+        # Text input: 100 * $5/1M = 0.0005
+        # Image output: 5000 * $40/1M = 0.2
+        # Total: 0.2005
         expected_cost = 0.0005 + 0.2
         assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
 
     def test_gpt_image_1_cost_with_image_input(self):
-        """Test cost calculation with both text and image input tokens"""
+        """Test cost calculation with both text and image input tokens (for edits)"""
         from litellm.llms.openai.image_generation.cost_calculator import cost_calculator
 
-        # Create mock ImageResponse with usage data including image input
-        usage = MagicMock()
-        usage.input_tokens = 600  # 100 text + 500 image
-        usage.output_tokens = 5000
-        usage.input_tokens_details = MagicMock()
-        usage.input_tokens_details.text_tokens = 100
-        usage.input_tokens_details.image_tokens = 500
+        usage = ImageUsage(
+            input_tokens=600,
+            output_tokens=5000,
+            total_tokens=5600,
+            input_tokens_details=ImageUsageInputTokensDetails(
+                text_tokens=100,
+                image_tokens=500,
+            ),
+        )
 
         image_response = ImageResponse(
             created=1234567890,
@@ -84,11 +88,11 @@ class TestGPTImageCostCalculator:
             custom_llm_provider="openai",
         )
 
-        # Expected cost calculation:
-        # Text input: 100 tokens * $5.00/1M = 100 * 5e-06 = 0.0005
-        # Image input: 500 tokens * $10.00/1M = 500 * 1e-05 = 0.005
-        # Image output: 5000 tokens * $40.00/1M = 5000 * 4e-05 = 0.2
-        # Total: 0.0005 + 0.005 + 0.2 = 0.2055
+        # Expected cost:
+        # Text input: 100 * $5/1M = 0.0005
+        # Image input: 500 * $10/1M = 0.005
+        # Image output: 5000 * $40/1M = 0.2
+        # Total: 0.2055
         expected_cost = 0.0005 + 0.005 + 0.2
         assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
 
@@ -96,13 +100,15 @@ class TestGPTImageCostCalculator:
         """Test cost calculation for gpt-image-1-mini model"""
         from litellm.llms.openai.image_generation.cost_calculator import cost_calculator
 
-        # Create mock ImageResponse with usage data
-        usage = MagicMock()
-        usage.input_tokens = 100
-        usage.output_tokens = 5000
-        usage.input_tokens_details = MagicMock()
-        usage.input_tokens_details.text_tokens = 100
-        usage.input_tokens_details.image_tokens = 0
+        usage = ImageUsage(
+            input_tokens=100,
+            output_tokens=5000,
+            total_tokens=5100,
+            input_tokens_details=ImageUsageInputTokensDetails(
+                text_tokens=100,
+                image_tokens=0,
+            ),
+        )
 
         image_response = ImageResponse(
             created=1234567890,
@@ -116,11 +122,10 @@ class TestGPTImageCostCalculator:
             custom_llm_provider="openai",
         )
 
-        # Expected cost calculation for gpt-image-1-mini:
-        # Text input: 100 tokens * $2.00/1M = 100 * 2e-06 = 0.0002
-        # Image input: 0 tokens * $2.50/1M = 0
-        # Image output: 5000 tokens * $8.00/1M = 5000 * 8e-06 = 0.04
-        # Total: 0.0002 + 0 + 0.04 = 0.0402
+        # Expected cost for gpt-image-1-mini:
+        # Text input: 100 * $2/1M = 0.0002
+        # Image output: 5000 * $8/1M = 0.04
+        # Total: 0.0402
         expected_cost = 0.0002 + 0.04
         assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
 
@@ -132,7 +137,6 @@ class TestGPTImageCostCalculator:
             created=1234567890,
             data=[ImageObject(url="http://example.com/image.jpg")],
         )
-        # No usage attribute set
 
         cost = cost_calculator(
             model="gpt-image-1",
@@ -142,35 +146,6 @@ class TestGPTImageCostCalculator:
 
         assert cost == 0.0
 
-    def test_gpt_image_1_cost_no_input_details(self):
-        """Test cost calculation when input_tokens_details is not available"""
-        from litellm.llms.openai.image_generation.cost_calculator import cost_calculator
-
-        # Create mock ImageResponse with usage data but no details
-        usage = MagicMock()
-        usage.input_tokens = 100
-        usage.output_tokens = 5000
-        usage.input_tokens_details = None  # No details
-
-        image_response = ImageResponse(
-            created=1234567890,
-            data=[ImageObject(url="http://example.com/image.jpg")],
-        )
-        image_response.usage = usage
-
-        cost = cost_calculator(
-            model="gpt-image-1",
-            image_response=image_response,
-            custom_llm_provider="openai",
-        )
-
-        # When no details, all input tokens are assumed to be text tokens
-        # Text input: 100 tokens * $5.00/1M = 100 * 5e-06 = 0.0005
-        # Image output: 5000 tokens * $40.00/1M = 5000 * 4e-05 = 0.2
-        # Total: 0.0005 + 0.2 = 0.2005
-        expected_cost = 0.0005 + 0.2
-        assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
-
 
 class TestGPTImageCostRouting:
     """Test that gpt-image models are properly routed to the token-based calculator"""
@@ -179,13 +154,15 @@ class TestGPTImageCostRouting:
         """Test that OpenAI gpt-image-1 routes to token-based calculator"""
         from litellm.litellm_core_utils.llm_cost_calc.utils import CostCalculatorUtils
 
-        # Create mock ImageResponse with usage data
-        usage = MagicMock()
-        usage.input_tokens = 100
-        usage.output_tokens = 5000
-        usage.input_tokens_details = MagicMock()
-        usage.input_tokens_details.text_tokens = 100
-        usage.input_tokens_details.image_tokens = 0
+        usage = ImageUsage(
+            input_tokens=100,
+            output_tokens=5000,
+            total_tokens=5100,
+            input_tokens_details=ImageUsageInputTokensDetails(
+                text_tokens=100,
+                image_tokens=0,
+            ),
+        )
 
         image_response = ImageResponse(
             created=1234567890,
@@ -199,12 +176,7 @@ class TestGPTImageCostRouting:
             custom_llm_provider="openai",
         )
 
-        # Should be > 0 (token-based calculation)
-        assert cost > 0, f"Expected positive cost, got {cost}"
-
-        # Verify it's using token-based pricing, not pixel-based
-        # Pixel-based would give a very different result
-        expected_cost = 0.0005 + 0.2  # text + output
+        expected_cost = 0.0005 + 0.2
         assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
 
     def test_openai_dalle_routes_to_pixel_calculator(self):
@@ -218,7 +190,6 @@ class TestGPTImageCostRouting:
         image_response.size = "1024x1024"
         image_response.quality = "standard"
 
-        # DALL-E should use pixel-based calculation
         cost = CostCalculatorUtils.route_image_generation_cost_calculator(
             model="dall-e-3",
             completion_response=image_response,
@@ -228,7 +199,6 @@ class TestGPTImageCostRouting:
             n=1,
         )
 
-        # DALL-E cost should be calculated (pixel-based)
         assert cost >= 0
 
 
@@ -237,14 +207,15 @@ class TestCompletionCostIntegration:
 
     def test_completion_cost_gpt_image_1(self):
         """Test completion_cost correctly calculates gpt-image-1 costs"""
-        # Create mock ImageResponse with usage data
-        usage = MagicMock()
-        usage.input_tokens = 100
-        usage.output_tokens = 5000
-        usage.total_tokens = 5100
-        usage.input_tokens_details = MagicMock()
-        usage.input_tokens_details.text_tokens = 100
-        usage.input_tokens_details.image_tokens = 0
+        usage = ImageUsage(
+            input_tokens=100,
+            output_tokens=5000,
+            total_tokens=5100,
+            input_tokens_details=ImageUsageInputTokensDetails(
+                text_tokens=100,
+                image_tokens=0,
+            ),
+        )
 
         image_response = ImageResponse(
             created=1234567890,
@@ -260,7 +231,6 @@ class TestCompletionCostIntegration:
             custom_llm_provider="openai",
         )
 
-        # Expected cost: text input + output image tokens
         expected_cost = 0.0005 + 0.2
         assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
 


### PR DESCRIPTION
## Title

fix(cost_calculator): correct gpt-image-1 cost calculation using token-based pricing

## Relevant issues

Fixes #13847
Fixes #18141

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Summary

The current cost calculator for `gpt-image-1` uses **pixel-based pricing** (inherited from DALL-E), but OpenAI's `gpt-image-1` actually uses **token-based pricing**.

### Example

```python
import litellm

response = litellm.image_generation(
    model="gpt-image-1",
    prompt="A cat sitting on a windowsill",
    size="1024x1024",
    quality="medium",
)

# Response includes usage data:
# response.usage.input_tokens = 150
# response.usage.output_tokens = 8000
# response.usage.input_tokens_details.text_tokens = 150
# response.usage.input_tokens_details.image_tokens = 0

# Cost with this fix is calculated correctly using tokens
cost = litellm.completion_cost(completion_response=response)
# Returns: $0.32075 (not $0.042 as before)
```


**calculation**
```
cost = input_cost_per_pixel × width × height × n
cost = 4.0054321e-08 × 1024 × 1024 × 1 = $0.042
```

**New calculation (token-based):**
```python
# OpenAI gpt-image-1 pricing:
# - Text Input: $5.00/1M tokens
# - Image Input: $10.00/1M tokens  
# - Image Output: $40.00/1M tokens
```
### Solution

1. **Updated pricing JSON**: Changed `gpt-image-1` entries from `input_cost_per_pixel` to token-based fields:
   - `input_cost_per_token`: 5e-06 ($5/1M)
   - `input_cost_per_image_token`: 1e-05 ($10/1M)
   - `output_cost_per_image_token`: 4e-05 ($40/1M)

2. **New cost calculator**: `litellm/llms/openai/image_generation/cost_calculator.py`
   - Uses `usage` data from the API response
   - Calculates: text_input + image_input + image_output costs

3. **Updated router**: Routes `gpt-image-1` models to the new token-based calculator while DALL-E continues to use pixel-based calculation


### Files changed

- `model_prices_and_context_window.json` - Updated gpt-image-1 pricing
- `litellm/model_prices_and_context_window_backup.json` - Same
- `litellm/llms/openai/image_generation/cost_calculator.py` - New calculator
- `litellm/litellm_core_utils/llm_cost_calc/utils.py` - Router update
- `tests/test_litellm/test_gpt_image_cost_calculator.py` - 8 new tests