### PR TITLE
Litellm fix mcp tool name prefix

### DIFF
--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -494,9 +494,21 @@ class LiteLLM_Proxy_MCP_Handler:
 
                 server_name = tool_server_map[tool_name]
 
+                # Remove the server name prefix if the tool name includes it.
+                sanitized_tool_name = tool_name
+                unprefixed_name, prefixed_server_name = split_server_prefix_from_name(
+                    tool_name
+                )
+                if (
+                    prefixed_server_name
+                    and prefixed_server_name == server_name
+                    and unprefixed_name
+                ):
+                    sanitized_tool_name = unprefixed_name
+
                 result = await global_mcp_server_manager.call_tool(
                     server_name=server_name,
-                    name=tool_name,
+                    name=sanitized_tool_name,
                     arguments=parsed_arguments,
                     user_api_key_auth=user_api_key_auth,
                     mcp_auth_header=mcp_auth_header,

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -638,9 +638,7 @@ class LiteLLM_Proxy_MCP_Handler:
         function_calls: List[Dict[str, Any]] = []
 
         for output_item in response.output:
-            if not isinstance(output_item, dict) and hasattr(
-                output_item, "model_dump"
-            ):
+            if not isinstance(output_item, dict) and hasattr(output_item, "model_dump"):
                 output_item = output_item.model_dump()
 
             if isinstance(output_item, dict):

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -638,6 +638,11 @@ class LiteLLM_Proxy_MCP_Handler:
         function_calls: List[Dict[str, Any]] = []
 
         for output_item in response.output:
+            if not isinstance(output_item, dict) and hasattr(
+                output_item, "model_dump"
+            ):
+                output_item = output_item.model_dump()
+
             if isinstance(output_item, dict):
                 if output_item.get("type") == "function_call":
                     call_id = output_item.get("call_id") or output_item.get("id")


### PR DESCRIPTION
## Title

Litellm fix mcp tool name prefix

## Relevant issues

Fixes #17404 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes

Two bugs in the responses flow were addressed:

1. Tool names that arrived with a server-name prefix (e.g., deepwiki-read_wiki_structure) caused MCP execution to fail.
We now strip the matching prefix before invoking the actual tool on the server.

2. After an MCP tool run, follow-up responses calls failed because the tool-call message wasn’t forwarded—OutputFunctionToolCall objects aren’t dicts, so _create_follow_up_input ignored them. 


