### PR TITLE
[Fix] CI/CD - mypy &  check_code_and_doc_quality & mcp_testing 

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -487,6 +487,7 @@ router_settings:
 | DEFAULT_CRON_JOB_LOCK_TTL_SECONDS | Time-to-live for cron job locks in seconds. Default is 60 (1 minute)
 | DEFAULT_DATAFORSEO_LOCATION_CODE | Default location code for DataForSEO search API. Default is 2250 (France)
 | DEFAULT_FAILURE_THRESHOLD_PERCENT | Threshold percentage of failures to cool down a deployment. Default is 0.5 (50%)
+| DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS | Minimum number of requests before applying error rate cooldown. Prevents cooldown from triggering on first failure. Default is 5
 | DEFAULT_FLUSH_INTERVAL_SECONDS | Default interval in seconds for flushing operations. Default is 5
 | DEFAULT_HEALTH_CHECK_INTERVAL | Default interval in seconds for health checks. Default is 300 (5 minutes)
 | DEFAULT_HEALTH_CHECK_PROMPT | Default prompt used during health checks for non-image models. Default is "test from litellm"

--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -7,7 +7,7 @@ Users can define
 """
 
 import copy
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
@@ -20,6 +20,11 @@ from litellm.types.integrations.anthropic_cache_control_hook import (
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionCachedContent
 from litellm.types.prompts.init_prompts import PromptSpec
 from litellm.types.utils import StandardCallbackDynamicParams
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
 
 
 class AnthropicCacheControlHook(CustomPromptManagement):
@@ -198,11 +203,13 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         prompt_id: Optional[str],
         prompt_variables: Optional[dict],
         dynamic_callback_params: StandardCallbackDynamicParams,
-        litellm_logging_obj: Any,
+        litellm_logging_obj: LiteLLMLoggingObj,
         prompt_spec: Optional[PromptSpec] = None,
         tools: Optional[List[Dict]] = None,
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
+        ignore_prompt_manager_model: Optional[bool] = False,
+        ignore_prompt_manager_optional_params: Optional[bool] = False,
     ) -> Tuple[str, List[AllMessageValues], dict]:
         """Async version - delegates to sync since no async operations needed."""
         return self.get_chat_completion_prompt(
@@ -212,8 +219,11 @@ class AnthropicCacheControlHook(CustomPromptManagement):
             prompt_id=prompt_id,
             prompt_variables=prompt_variables,
             dynamic_callback_params=dynamic_callback_params,
+            prompt_spec=prompt_spec,
             prompt_label=prompt_label,
             prompt_version=prompt_version,
+            ignore_prompt_manager_model=ignore_prompt_manager_model,
+            ignore_prompt_manager_optional_params=ignore_prompt_manager_optional_params,
         )
 
     @staticmethod

--- a/litellm/integrations/bitbucket/bitbucket_prompt_manager.py
+++ b/litellm/integrations/bitbucket/bitbucket_prompt_manager.py
@@ -3,11 +3,16 @@ BitBucket prompt manager that integrates with LiteLLM's prompt management system
 Fetches .prompt files from BitBucket repositories and provides team-based access control.
 """
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from jinja2 import DictLoader, Environment, select_autoescape
 
 from litellm.integrations.custom_prompt_management import CustomPromptManagement
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
 from litellm.integrations.prompt_management_base import (
     PromptManagementBase,
     PromptManagementClient,
@@ -550,11 +555,13 @@ class BitBucketPromptManager(CustomPromptManagement):
         prompt_id: Optional[str],
         prompt_variables: Optional[dict],
         dynamic_callback_params: StandardCallbackDynamicParams,
-        litellm_logging_obj: Any,
+        litellm_logging_obj: LiteLLMLoggingObj,
         prompt_spec: Optional[PromptSpec] = None,
         tools: Optional[List[Dict]] = None,
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
+        ignore_prompt_manager_model: Optional[bool] = False,
+        ignore_prompt_manager_optional_params: Optional[bool] = False,
     ) -> Tuple[str, List[AllMessageValues], dict]:
         """
         Async version - delegates to PromptManagementBase async implementation.
@@ -572,4 +579,6 @@ class BitBucketPromptManager(CustomPromptManagement):
             tools=tools,
             prompt_label=prompt_label,
             prompt_version=prompt_version,
+            ignore_prompt_manager_model=ignore_prompt_manager_model,
+            ignore_prompt_manager_optional_params=ignore_prompt_manager_optional_params,
         )

--- a/litellm/integrations/custom_prompt_management.py
+++ b/litellm/integrations/custom_prompt_management.py
@@ -68,3 +68,16 @@ class CustomPromptManagement(CustomLogger, PromptManagementBase):
         raise NotImplementedError(
             "Custom prompt management does not support compile prompt helper"
         )
+
+    async def async_compile_prompt_helper(
+        self,
+        prompt_id: Optional[str],
+        prompt_variables: Optional[dict],
+        dynamic_callback_params: StandardCallbackDynamicParams,
+        prompt_spec: Optional[PromptSpec] = None,
+        prompt_label: Optional[str] = None,
+        prompt_version: Optional[int] = None,
+    ) -> PromptManagementClient:
+        raise NotImplementedError(
+            "Custom prompt management does not support async compile prompt helper"
+        )

--- a/litellm/integrations/dotprompt/dotprompt_manager.py
+++ b/litellm/integrations/dotprompt/dotprompt_manager.py
@@ -4,13 +4,18 @@ Builds on top of PromptManagementBase to provide .prompt file support.
 """
 
 import json
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from litellm.integrations.custom_prompt_management import CustomPromptManagement
 from litellm.integrations.prompt_management_base import PromptManagementClient
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.prompts.init_prompts import PromptSpec
 from litellm.types.utils import StandardCallbackDynamicParams
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
 
 from .prompt_manager import PromptManager, PromptTemplate
 
@@ -224,11 +229,13 @@ class DotpromptManager(CustomPromptManagement):
         prompt_id: Optional[str],
         prompt_variables: Optional[dict],
         dynamic_callback_params: StandardCallbackDynamicParams,
-        litellm_logging_obj: Any,
+        litellm_logging_obj: LiteLLMLoggingObj,
         prompt_spec: Optional[PromptSpec] = None,
         tools: Optional[List[Dict]] = None,
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
+        ignore_prompt_manager_model: Optional[bool] = False,
+        ignore_prompt_manager_optional_params: Optional[bool] = False,
     ) -> Tuple[str, List[AllMessageValues], dict]:
         """
         Async version - delegates to PromptManagementBase async implementation.
@@ -248,6 +255,8 @@ class DotpromptManager(CustomPromptManagement):
             tools=tools,
             prompt_label=prompt_label,
             prompt_version=prompt_version,
+            ignore_prompt_manager_model=ignore_prompt_manager_model,
+            ignore_prompt_manager_optional_params=ignore_prompt_manager_optional_params,
         )
 
     def _convert_to_messages(self, rendered_content: str) -> List[AllMessageValues]:

--- a/litellm/integrations/gitlab/gitlab_prompt_manager.py
+++ b/litellm/integrations/gitlab/gitlab_prompt_manager.py
@@ -2,11 +2,16 @@
 GitLab prompt manager with configurable prompts folder.
 """
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from jinja2 import DictLoader, Environment, select_autoescape
 
 from litellm.integrations.custom_prompt_management import CustomPromptManagement
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
 from litellm.integrations.gitlab.gitlab_client import GitLabClient
 from litellm.integrations.prompt_management_base import (
     PromptManagementBase,
@@ -571,11 +576,13 @@ class GitLabPromptManager(CustomPromptManagement):
         prompt_id: Optional[str],
         prompt_variables: Optional[dict],
         dynamic_callback_params: StandardCallbackDynamicParams,
-        litellm_logging_obj: Any,
+        litellm_logging_obj: LiteLLMLoggingObj,
         prompt_spec: Optional[PromptSpec] = None,
         tools: Optional[List[Dict]] = None,
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
+        ignore_prompt_manager_model: Optional[bool] = False,
+        ignore_prompt_manager_optional_params: Optional[bool] = False,
     ) -> Tuple[str, List[AllMessageValues], dict]:
         """
         Async version - delegates to PromptManagementBase async implementation.
@@ -593,6 +600,8 @@ class GitLabPromptManager(CustomPromptManagement):
             tools=tools,
             prompt_label=prompt_label,
             prompt_version=prompt_version,
+            ignore_prompt_manager_model=ignore_prompt_manager_model,
+            ignore_prompt_manager_optional_params=ignore_prompt_manager_optional_params,
         )
 
 

--- a/litellm/integrations/humanloop.py
+++ b/litellm/integrations/humanloop.py
@@ -14,6 +14,7 @@ from litellm.caching import DualCache
 from litellm.llms.custom_httpx.http_handler import _get_httpx_client
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
+from litellm.types.prompts.init_prompts import PromptSpec
 from litellm.types.utils import StandardCallbackDynamicParams
 
 from .custom_logger import CustomLogger
@@ -156,6 +157,7 @@ class HumanloopLogger(CustomLogger):
         prompt_id: Optional[str],
         prompt_variables: Optional[dict],
         dynamic_callback_params: StandardCallbackDynamicParams,
+        prompt_spec: Optional[PromptSpec] = None,
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
         ignore_prompt_manager_model: Optional[bool] = False,
@@ -180,6 +182,7 @@ class HumanloopLogger(CustomLogger):
                 prompt_id=prompt_id,
                 prompt_variables=prompt_variables,
                 dynamic_callback_params=dynamic_callback_params,
+                prompt_spec=prompt_spec,
             )
 
         prompt_template = prompt_manager._get_prompt_from_id(

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -3,7 +3,7 @@
 import os
 import traceback
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 from packaging.version import Version
 
@@ -894,7 +894,7 @@ class LangFuseLogger:
         return Version(self.langfuse_sdk_version) >= Version("2.7.3")
 
     @staticmethod
-    def _apply_masking_function(data: Any, masking_function: callable) -> Any:
+    def _apply_masking_function(data: Any, masking_function: Callable[[Any], Any]) -> Any:
         """
         Apply a masking function to data, handling different data types.
 

--- a/litellm/integrations/langfuse/langfuse_prompt_management.py
+++ b/litellm/integrations/langfuse/langfuse_prompt_management.py
@@ -188,6 +188,8 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
         tools: Optional[List[Dict]] = None,
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
+        ignore_prompt_manager_model: Optional[bool] = False,
+        ignore_prompt_manager_optional_params: Optional[bool] = False,
     ) -> Tuple[str, List[AllMessageValues], dict,]:
         return self.get_chat_completion_prompt(
             model,
@@ -196,8 +198,11 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
             prompt_id,
             prompt_variables,
             dynamic_callback_params,
+            prompt_spec=prompt_spec,
             prompt_label=prompt_label,
             prompt_version=prompt_version,
+            ignore_prompt_manager_model=ignore_prompt_manager_model,
+            ignore_prompt_manager_optional_params=ignore_prompt_manager_optional_params,
         )
 
     def should_run_prompt_management(

--- a/litellm/integrations/vector_store_integrations/vector_store_pre_call_hook.py
+++ b/litellm/integrations/vector_store_integrations/vector_store_pre_call_hook.py
@@ -12,6 +12,7 @@ import litellm.vector_stores
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionUserMessage
+from litellm.types.prompts.init_prompts import PromptSpec
 from litellm.types.utils import StandardCallbackDynamicParams
 from litellm.types.vector_stores import (
     LiteLLM_ManagedVectorStore,
@@ -23,7 +24,7 @@ from litellm.types.vector_stores import (
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 else:
-    LiteLLMLoggingObj = None
+    LiteLLMLoggingObj = Any
 
 
 class VectorStorePreCallHook(CustomLogger):
@@ -49,9 +50,12 @@ class VectorStorePreCallHook(CustomLogger):
         prompt_variables: Optional[dict],
         dynamic_callback_params: StandardCallbackDynamicParams,
         litellm_logging_obj: LiteLLMLoggingObj,
+        prompt_spec: Optional[PromptSpec] = None,
         tools: Optional[List[Dict]] = None,
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
+        ignore_prompt_manager_model: Optional[bool] = False,
+        ignore_prompt_manager_optional_params: Optional[bool] = False,
     ) -> Tuple[str, List[AllMessageValues], dict]:
         """
         Perform vector store search and append results as context to messages.

--- a/litellm/llms/sap/embed/transformation.py
+++ b/litellm/llms/sap/embed/transformation.py
@@ -5,10 +5,8 @@ Translates from OpenAI's `/v1/embeddings` to IBM's `/text/embeddings` route.
 from typing import Optional, List, Dict, Literal, Union
 from pydantic import BaseModel, Field
 from functools import cached_property
-from typing import Dict, List, Literal, Optional, Union
 
 import httpx
-from pydantic import BaseModel, Field
 
 from litellm.llms.base_llm.embedding.transformation import (
     BaseEmbeddingConfig,

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1280,6 +1280,11 @@ if MCP_AVAILABLE:
                 standard_logging_mcp_tool_call["mcp_server_cost_info"] = (
                     mcp_server.mcp_info or {}
                 ).get("mcp_server_cost_info")
+                # Update model_call_details with the cost info
+                if litellm_logging_obj:
+                    litellm_logging_obj.model_call_details[
+                        "mcp_tool_call_metadata"
+                    ] = standard_logging_mcp_tool_call
                 response = await _handle_managed_mcp_tool(
                     server_name=server_name,
                     name=original_tool_name,  # Pass the full name (potentially prefixed)
@@ -1316,6 +1321,20 @@ if MCP_AVAILABLE:
                 response_obj=response,
                 start_time=start_time,
                 end_time=end_time,
+            )
+            # Set call_type to call_mcp_tool so cost calculator recognizes it
+            from litellm.types.utils import CallTypes
+
+            litellm_logging_obj.call_type = CallTypes.call_mcp_tool.value
+            # Trigger success logging to build standard_logging_object and call callbacks
+            # async_success_handler will:
+            # 1. Call _success_handler_helper_fn which recognizes call_mcp_tool
+            # 2. Call _process_hidden_params_and_response_cost which:
+            #    - Calculates cost via _response_cost_calculator -> MCPCostCalculator
+            #    - Builds standard_logging_object
+            # 3. Call async_log_success_event on all callbacks
+            await litellm_logging_obj.async_success_handler(
+                result=response, start_time=start_time, end_time=end_time
             )
         return response
 

--- a/litellm/proxy/custom_prompt_management.py
+++ b/litellm/proxy/custom_prompt_management.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_prompt_management import CustomPromptManagement
 from litellm.types.llms.openai import AllMessageValues
+from litellm.types.prompts.init_prompts import PromptSpec
 from litellm.types.utils import StandardCallbackDynamicParams
 
 
@@ -15,6 +16,7 @@ class X42PromptManagement(CustomPromptManagement):
         prompt_id: Optional[str],
         prompt_variables: Optional[dict],
         dynamic_callback_params: StandardCallbackDynamicParams,
+        prompt_spec: Optional[PromptSpec] = None,
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
         ignore_prompt_manager_model: Optional[bool] = False,

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -724,6 +724,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         )
 
         for choice in response.choices:
+            # Type narrowing: StreamingChoices doesn't have .message attribute
+            if not hasattr(choice, "message"):
+                continue
             content = getattr(choice.message, "content", None)
             if content is None:
                 continue

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -380,16 +380,15 @@ async def create_file(  # noqa: PLR0915
                 )
             
             # Validate expires_after[seconds] is a string (not UploadFile)
-            if isinstance(expires_after_seconds_str, UploadFile):
+            # Use positive isinstance check for proper type narrowing (matches codebase pattern)
+            if not isinstance(expires_after_seconds_str, str):
                 raise HTTPException(
                     status_code=400,
                     detail={
                         "error": "expires_after[seconds] must be a string, not a file upload",
                     },
                 )
-            
-            # Type narrowing: assert it's str after validation (mypy understands assert for narrowing)
-            assert not isinstance(expires_after_seconds_str, UploadFile), "Already validated above"
+            # After this check, mypy knows expires_after_seconds_str is str
             expires_after_seconds_str_validated: str = expires_after_seconds_str
             
             # Validate anchor is "created_at"

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -388,6 +388,10 @@ async def create_file(  # noqa: PLR0915
                     },
                 )
             
+            # Type narrowing: assert it's str after validation (mypy understands assert for narrowing)
+            assert not isinstance(expires_after_seconds_str, UploadFile), "Already validated above"
+            expires_after_seconds_str_validated: str = expires_after_seconds_str
+            
             # Validate anchor is "created_at"
             if expires_after_anchor != "created_at":
                 raise HTTPException(
@@ -399,7 +403,7 @@ async def create_file(  # noqa: PLR0915
             
             # Convert seconds to int
             try:
-                expires_after_seconds = int(expires_after_seconds_str)
+                expires_after_seconds = int(expires_after_seconds_str_validated)
             except (ValueError, TypeError) as e:
                 raise HTTPException(
                     status_code=400,

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -369,9 +369,49 @@ async def create_file(  # noqa: PLR0915
                         "error": "Both expires_after[anchor] and expires_after[seconds] must be provided if expires_after is specified",
                     },
                 )
+            
+            # Validate expires_after[anchor] is a string (not UploadFile)
+            if isinstance(expires_after_anchor, UploadFile):
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": "expires_after[anchor] must be a string, not a file upload",
+                    },
+                )
+            
+            # Validate expires_after[seconds] is a string (not UploadFile)
+            if isinstance(expires_after_seconds_str, UploadFile):
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": "expires_after[seconds] must be a string, not a file upload",
+                    },
+                )
+            
+            # Validate anchor is "created_at"
+            if expires_after_anchor != "created_at":
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": f"expires_after[anchor] must be 'created_at', got '{expires_after_anchor}'",
+                    },
+                )
+            
+            # Convert seconds to int
+            try:
+                expires_after_seconds = int(expires_after_seconds_str)
+            except (ValueError, TypeError) as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": f"expires_after[seconds] must be a valid integer, got '{expires_after_seconds_str}': {e}",
+                    },
+                )
+            
+            # Use literal "created_at" (not variable) for TypedDict to satisfy Literal type
             expires_after = FileExpiresAfter(
-                anchor=expires_after_anchor,
-                seconds=int(expires_after_seconds_str),
+                anchor="created_at",  # Literal, not expires_after_anchor variable
+                seconds=expires_after_seconds,
             )
 
         # Include original request and headers in the data

--- a/litellm/proxy/openai_files_endpoints/storage_backend_service.py
+++ b/litellm/proxy/openai_files_endpoints/storage_backend_service.py
@@ -15,7 +15,7 @@ from litellm.llms.base_llm.files.storage_backend_factory import get_storage_back
 from litellm.llms.base_llm.files.transformation import BaseFileEndpoints
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.utils import ProxyLogging
-from litellm.types.llms.openai import OpenAIFileObject
+from litellm.types.llms.openai import OpenAIFileObject, OpenAIFilesPurpose
 from litellm.types.utils import SpecialEnums
 
 
@@ -35,7 +35,7 @@ class StorageBackendFileService:
         file_data: Mapping[str, Any],
         target_storage: str,
         target_model_names: List[str],
-        purpose: str,
+        purpose: OpenAIFilesPurpose,
         proxy_logging_obj: ProxyLogging,
         user_api_key_dict: UserAPIKeyAuth,
     ) -> OpenAIFileObject:
@@ -112,7 +112,7 @@ class StorageBackendFileService:
     def _create_file_object_with_storage_metadata(
         file_content: bytes,
         filename: str,
-        purpose: str,
+        purpose: OpenAIFilesPurpose,
         target_storage: str,
         storage_url: str,
     ) -> OpenAIFileObject:

--- a/litellm/types/services.py
+++ b/litellm/types/services.py
@@ -37,6 +37,7 @@ class ServiceTypes(str, enum.Enum):
     REDIS_DAILY_END_USER_SPEND_UPDATE_QUEUE = "redis_daily_end_user_spend_update_queue"
     REDIS_DAILY_ORG_SPEND_UPDATE_QUEUE = "redis_daily_org_spend_update_queue"
     REDIS_DAILY_TEAM_SPEND_UPDATE_QUEUE = "redis_daily_team_spend_update_queue"
+    REDIS_DAILY_AGENT_SPEND_UPDATE_QUEUE = "redis_daily_agent_spend_update_queue"
     REDIS_DAILY_TAG_SPEND_UPDATE_QUEUE = "redis_daily_tag_spend_update_queue"
     # spend update queue - current spend of key, user, team
     IN_MEMORY_SPEND_UPDATE_QUEUE = "in_memory_spend_update_queue"
@@ -91,6 +92,9 @@ DEFAULT_SERVICE_CONFIGS = {
         "metrics": [ServiceMetrics.GAUGE]
     },
     ServiceTypes.REDIS_DAILY_END_USER_SPEND_UPDATE_QUEUE.value: {
+        "metrics": [ServiceMetrics.GAUGE]
+    },
+    ServiceTypes.REDIS_DAILY_AGENT_SPEND_UPDATE_QUEUE.value: {
         "metrics": [ServiceMetrics.GAUGE]
     },
     ServiceTypes.IN_MEMORY_SPEND_UPDATE_QUEUE.value: {


### PR DESCRIPTION
## Title

[Fix] CI/CD - mypy & check_code_and_doc_quality & mcp_testing

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

This PR fixes multiple CI/CD issues related to mypy type checking, code quality checks, and MCP testing:

### Mypy Type Fixes

1. **Type hints for `LiteLLMLoggingObj`**: Added proper `TYPE_CHECKING` imports and type aliases in multiple prompt management integrations:
   - `AnthropicCacheControlHook`
   - `BitBucketPromptManager`
   - `DotpromptManager`
   - `GitLabPromptManager`
   - `VectorStorePreCallHook` (fixed from `None` to `Any`)

2. **Type narrowing improvements**:
   - Fixed `expires_after_seconds_str` type narrowing in `files_endpoints.py` using positive `isinstance` check
   - Added type narrowing for Presidio guardrail hook to handle `StreamingChoices` vs regular choices

3. **Callable type annotation**: Changed `callable` to `Callable[[Any], Any]` in `LangFuseLogger._apply_masking_function`

4. **Azure files handler**: 
   - Added `_prepare_create_file_data` method to handle `expires_after=None` case properly
   - Fixed type issues with `expires_after` parameter handling

5. **Storage backend service**: Changed `purpose` parameter type from `str` to `OpenAIFilesPurpose` for proper type safety

### Prompt Management Fixes

1. **Missing parameters in async methods**: Added missing parameters to `async_get_chat_completion_prompt` methods across multiple prompt managers:
   - `prompt_spec: Optional[PromptSpec]`
   - `ignore_prompt_manager_model: Optional[bool]`
   - `ignore_prompt_manager_optional_params: Optional[bool]`

2. **Arize Phoenix prompt manager**:
   - Fixed `should_run_prompt_management` and `_compile_prompt_helper` to accept `prompt_spec` parameter
   - Added `async_compile_prompt_helper` method
   - Added proper `prompt_id` None checks

3. **Custom prompt management**: Added `async_compile_prompt_helper` method to base class

4. **Humanloop logger**: Added missing `prompt_spec` parameter to `get_chat_completion_prompt` method

### MCP Testing Fixes

1. **Cost tracking for MCP tool calls**: 
   - Added `mcp_tool_call_metadata` to `model_call_details` in logging object
   - Set `call_type` to `CallTypes.call_mcp_tool.value` to enable proper cost calculation
   - Trigger `async_success_handler` for MCP tool calls to enable cost tracking and logging via `MCPCostCalculator`

### Other Fixes

1. **ServiceTypes enum**: Added missing `REDIS_DAILY_AGENT_SPEND_UPDATE_QUEUE` to `ServiceTypes` enum and `DEFAULT_SERVICE_CONFIGS`

2. **Files endpoint validation**: Added proper validation for `expires_after` form fields to handle `UploadFile | str` type and ensure proper type conversion

3. **Documentation**: Added missing `DEFAULT_FAILURE_THRESHOLD_MINIMUM_REQUESTS` environment variable documentation

### Files Changed

- 18 files modified
- 202 insertions, 24 deletions
- Changes span across integrations, proxy server, type definitions, and documentation

