### PR TITLE
fix gemini web search requests count

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1553,9 +1553,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             for grounding_metadata_item in grounding_metadata:
                 web_search_queries = grounding_metadata_item.get("webSearchQueries")
                 if web_search_queries and web_search_requests:
-                    web_search_requests += len(web_search_queries)
+                    web_search_requests += len([q for q in web_search_queries if q])
                 elif web_search_queries:
-                    web_search_requests = len(web_search_queries)
+                    web_search_requests = len([q for q in web_search_queries if q])
         return web_search_requests
 
     @staticmethod

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1555,7 +1555,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 if web_search_queries and web_search_requests:
                     web_search_requests += len(web_search_queries)
                 elif web_search_queries:
-                    web_search_requests = len(grounding_metadata)
+                    web_search_requests = len(web_search_queries)
         return web_search_requests
 
     @staticmethod

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -806,7 +806,7 @@ def test_vertex_ai_streaming_usage_web_search_calculation():
             {
                 "content": {"parts": [{"text": "Hello"}]},
                 "groundingMetadata": [
-                    {"webSearchQueries": ["What is the capital of France?"]}
+                    {"webSearchQueries": ["What is the capital of France?", "Captial of France"]}
                 ],
             }
         ],
@@ -821,7 +821,7 @@ def test_vertex_ai_streaming_usage_web_search_calculation():
 
     usage: Usage = completed_response.usage
     assert usage.prompt_tokens_details.web_search_requests is not None
-    assert usage.prompt_tokens_details.web_search_requests == 1
+    assert usage.prompt_tokens_details.web_search_requests == 2
 
 
 def test_vertex_ai_transform_parts():

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -806,7 +806,7 @@ def test_vertex_ai_streaming_usage_web_search_calculation():
             {
                 "content": {"parts": [{"text": "Hello"}]},
                 "groundingMetadata": [
-                    {"webSearchQueries": ["What is the capital of France?", "Captial of France"]}
+                    {"webSearchQueries": ["", "What is the capital of France?", "Capital of France"]}
                 ],
             }
         ],


### PR DESCRIPTION
## Summary

Fix incorrect `web_search_requests` count in Gemini streaming responses.

## Bug

In `_calculate_web_search_requests`, the code used `len(grounding_metadata)` (always 1) instead of `len(web_search_queries)` (actual query count).

Example: Gemini returns `['weather in NYC', 'current weather New York City']` → should report `web_search_requests=2`, but was reporting `1`.

## Changes

- `vertex_and_google_ai_studio_gemini.py`: Fix calculation to use `len(web_search_queries)` and filter out empty strings (Google's API sometimes returns empty strings in `webSearchQueries` array, e.g., `['', 'current weather in NYC']`)
- Updated test to verify multiple queries are counted correctly

## Note on Gemini 3 billing

The billing will be different for different Gemini models starting next month. Maybe it still makes sense to update it with this PR, and have downstream apps decide how to handle how to use this data?

> When you use Grounding with Google Search with Gemini 3, your project is billed for each search query that the model decides to execute. If the model decides to execute multiple search queries to answer a single prompt (for example, searching for "UEFA Euro 2024 winner" and "Spain vs England Euro 2024 final score" within the same API call), this counts as two billable uses of the tool for that request. This only applies to Gemini 3 models; when you use search grounding with Gemini 2.5 or older models, your project is billed per prompt.

## Reproduce

You can see that even with `gemini-3-pro-preview`, `web_search_requests=1` when it should be higher:

```python
import sys

captured_queries = []

def trace_chunk_parser(frame, event, arg):
    if event == 'call' and frame.f_code.co_name == 'chunk_parser':
        def local_tracer(frame, event, arg):
            if event == 'line' and 'chunk' in frame.f_locals:
                chunk = frame.f_locals['chunk']
                if 'candidates' in chunk:
                    for cand in chunk.get('candidates', []):
                        gm = cand.get('groundingMetadata', {})
                        queries = gm.get('webSearchQueries')
                        if queries and not captured_queries:
                            captured_queries.extend(queries)
            return local_tracer
        return local_tracer
    return None

sys.settrace(trace_chunk_parser)

chat = Chat("gemini/gemini-3-pro-preview")
res = chat("What is the weather like in NYC? Search web at least with 2 queries.", search="m", stream=True, stream_options={"include_usage": True})
for o in res: pass

sys.settrace(None)

print(f"Captured queries: {captured_queries}")
print(f"Total unique query sets: {len(captured_queries)}")
print(f"Reported web_search_requests: {o.usage.prompt_tokens_details.web_search_requests if o.usage.prompt_tokens_details else None}")
```

```
Captured queries: ['', 'current weather in NYC', 'NYC weather forecast today']
Total unique query sets: 3
Reported web_search_requests: 1
```

## Note on empty strings

Google's Gemini API sometimes returns empty strings in the `webSearchQueries` array (e.g., `['', 'current weather in NYC']`). This fix filters them out when counting. This appears to be an upstream Google issue.

Fixes #17919