### PR TITLE
[Fix] CI/CD - Fix failing proxy and core integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1391,6 +1391,7 @@ jobs:
       - run:
           name: Run proxy tests
           command: |
+            prisma generate
             python -m pytest tests/test_litellm/proxy --cov=litellm --cov-report=xml --junitxml=test-results/junit-proxy.xml --durations=10 -n 16 --maxfail=5 --timeout=300 -vv --log-cli-level=WARNING
           no_output_timeout: 120m
       - run:

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -753,6 +753,25 @@ class OpenTelemetry(CustomLogger):
         )
         self._record_response_duration_metric(kwargs, end_time, common_attrs)
 
+    @staticmethod
+    def _to_timestamp(val: Optional[Union[datetime, float, str]]) -> Optional[float]:
+        """Convert datetime/float/string to timestamp."""
+        if val is None:
+            return None
+        if isinstance(val, datetime):
+            return val.timestamp()
+        if isinstance(val, (int, float)):
+            return float(val)
+        if isinstance(val, str):
+            try:
+                return datetime.strptime(val, '%Y-%m-%d %H:%M:%S.%f').timestamp()
+            except ValueError:
+                try:
+                    return datetime.strptime(val, '%Y-%m-%d %H:%M:%S').timestamp()
+                except ValueError:
+                    return None
+        return None
+
     def _record_time_to_first_token_metric(self, kwargs: dict, common_attrs: dict):
         """Record Time to First Token (TTFT) metric for streaming requests."""
         optional_params = kwargs.get("optional_params", {})
@@ -767,16 +786,12 @@ class OpenTelemetry(CustomLogger):
         completion_start_time = kwargs.get("completion_start_time", None)
         
         if api_call_start_time is not None and completion_start_time is not None:
-            # Convert to timestamps if needed (handles both datetime and float)
-            if isinstance(api_call_start_time, datetime):
-                api_call_start_ts = api_call_start_time.timestamp()
-            else:
-                api_call_start_ts = api_call_start_time
+            # Convert to timestamps if needed (handles datetime, float, and string)
+            api_call_start_ts = self._to_timestamp(api_call_start_time)
+            completion_start_ts = self._to_timestamp(completion_start_time)
             
-            if isinstance(completion_start_time, datetime):
-                completion_start_ts = completion_start_time.timestamp()
-            else:
-                completion_start_ts = completion_start_time
+            if api_call_start_ts is None or completion_start_ts is None:
+                return  # Skip recording if conversion failed
             
             time_to_first_token_seconds = completion_start_ts - api_call_start_ts
             self._time_to_first_token_histogram.record(
@@ -812,29 +827,35 @@ class OpenTelemetry(CustomLogger):
         completion_start_time = kwargs.get("completion_start_time", None)
         api_call_start_time = kwargs.get("api_call_start_time", None)
         
-        # Convert end_time to timestamp
-        if isinstance(end_time, datetime):
-            end_time_ts = end_time.timestamp()
-        else:
-            end_time_ts = end_time
+        # Convert end_time to timestamp (handles datetime, float, and string)
+        end_time_ts = self._to_timestamp(end_time)
+        if end_time_ts is None:
+            # Fallback to duration_s if conversion failed
+            generation_time_seconds = duration_s
+            if generation_time_seconds > 0:
+                time_per_output_token_seconds = generation_time_seconds / completion_tokens
+                self._time_per_output_token_histogram.record(
+                    time_per_output_token_seconds, attributes=common_attrs
+                )
+            return
         
         if completion_start_time is not None:
             # Streaming: use completion_start_time (when first token arrived)
             # This measures time to generate all tokens after the first one
-            if isinstance(completion_start_time, datetime):
-                completion_start_ts = completion_start_time.timestamp()
+            completion_start_ts = self._to_timestamp(completion_start_time)
+            if completion_start_ts is None:
+                # Fallback to duration_s if conversion failed
+                generation_time_seconds = duration_s
             else:
-                completion_start_ts = completion_start_time
-            
-            generation_time_seconds = end_time_ts - completion_start_ts
+                generation_time_seconds = end_time_ts - completion_start_ts
         elif api_call_start_time is not None:
             # Non-streaming: use api_call_start_time (total generation time)
-            if isinstance(api_call_start_time, datetime):
-                api_call_start_ts = api_call_start_time.timestamp()
+            api_call_start_ts = self._to_timestamp(api_call_start_time)
+            if api_call_start_ts is None:
+                # Fallback to duration_s if conversion failed
+                generation_time_seconds = duration_s
             else:
-                api_call_start_ts = api_call_start_time
-            
-            generation_time_seconds = end_time_ts - api_call_start_ts
+                generation_time_seconds = end_time_ts - api_call_start_ts
         else:
             # Fallback: use duration_s (already calculated as (end_time - start_time).total_seconds())
             generation_time_seconds = duration_s
@@ -874,16 +895,12 @@ class OpenTelemetry(CustomLogger):
         if _end_time is None:
             _end_time = datetime.now()
         
-        # Convert to timestamps if needed (handles both datetime and float)
-        if isinstance(api_call_start_time, datetime):
-            api_call_start_ts = api_call_start_time.timestamp()
-        else:
-            api_call_start_ts = api_call_start_time
+        # Convert to timestamps if needed (handles datetime, float, and string)
+        api_call_start_ts = self._to_timestamp(api_call_start_time)
+        end_time_ts = self._to_timestamp(_end_time)
         
-        if isinstance(_end_time, datetime):
-            end_time_ts = _end_time.timestamp()
-        else:
-            end_time_ts = _end_time
+        if api_call_start_ts is None or end_time_ts is None:
+            return  # Skip recording if conversion failed
         
         response_duration_seconds = end_time_ts - api_call_start_ts
         

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -762,15 +762,14 @@ class OpenTelemetry(CustomLogger):
             return val.timestamp()
         if isinstance(val, (int, float)):
             return float(val)
-        if isinstance(val, str):
+        # isinstance(val, str) - parse datetime string (with or without microseconds)
+        try:
+            return datetime.strptime(val, '%Y-%m-%d %H:%M:%S.%f').timestamp()
+        except ValueError:
             try:
-                return datetime.strptime(val, '%Y-%m-%d %H:%M:%S.%f').timestamp()
+                return datetime.strptime(val, '%Y-%m-%d %H:%M:%S').timestamp()
             except ValueError:
-                try:
-                    return datetime.strptime(val, '%Y-%m-%d %H:%M:%S').timestamp()
-                except ValueError:
-                    return None
-        return None
+                return None
 
     def _record_time_to_first_token_metric(self, kwargs: dict, common_attrs: dict):
         """Record Time to First Token (TTFT) metric for streaming requests."""

--- a/tests/test_litellm/integrations/test_custom_prompt_management.py
+++ b/tests/test_litellm/integrations/test_custom_prompt_management.py
@@ -16,6 +16,7 @@ import litellm
 from litellm.integrations.custom_prompt_management import CustomPromptManagement
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 from litellm.types.llms.openai import AllMessageValues
+from litellm.types.prompts.init_prompts import PromptSpec
 from litellm.types.utils import StandardCallbackDynamicParams
 
 
@@ -33,6 +34,7 @@ class TestCustomPromptManagement(CustomPromptManagement):
         prompt_id: Optional[str],
         prompt_variables: Optional[dict],
         dynamic_callback_params: StandardCallbackDynamicParams,
+        prompt_spec: Optional[PromptSpec] = None,
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
         ignore_prompt_manager_model: Optional[bool] = False,


### PR DESCRIPTION
## Title

[Fix] CI/CD - Fix failing proxy and core integration tests

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [ ] I have added a screenshot of my new test passing locally

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

This PR fixes failing CI/CD tests in both proxy and core test suites:

### 1. Prisma Client Generation Fix

Affected tests: `test_health_liveliness_endpoint`, `test_health_liveness_endpoint`, `test_health_readiness`

**Problem**: Three health endpoint tests were failing with `RuntimeError: The Client hasn't been generated yet, you must run 'prisma generate' before you can use the client.`

**Root Cause**: The Prisma client binaries were not being generated before running proxy tests. When tests tried to initialize `PrismaClient` during proxy startup, the client wasn't available, causing setup failures.

**Solution**: Added `prisma generate` command to the `litellm_mapped_tests_proxy` job in `.circleci/config.yml` before running pytest, matching the pattern already used in `litellm_mapped_enterprise_tests` job.

**File Changed**: `.circleci/config.yml`

### 2. Custom Prompt Management Parameter Fix

Affected tests: `test_custom_prompt_management_with_prompt_id`, `test_custom_prompt_management_with_prompt_id_and_prompt_variables`

**Problem**: Two tests were failing with `TypeError: TestCustomPromptManagement.get_chat_completion_prompt() got an unexpected keyword argument 'prompt_spec'`.

**Root Cause**: The `TestCustomPromptManagement.get_chat_completion_prompt()` method signature was missing the `prompt_spec` parameter that was being passed by the calling code in `litellm/litellm_core_utils/litellm_logging.py:629`. The test mock didn't match the base class method signature from `CustomPromptManagement`.

**Solution**: Added `prompt_spec: Optional[PromptSpec] = None` parameter to the method signature and imported `PromptSpec` from `litellm.types.prompts.init_prompts` to align the test mock with the base class interface.

**File Changed**: `tests/test_litellm/integrations/test_custom_prompt_management.py`

### 3. OpenTelemetry Timestamp Conversion Fix

Affected test: `test_handle_success_spans_and_metrics`

**Problem**: Test was failing with `TypeError: unsupported operand type(s) for -: 'float' and 'str'` when trying to calculate time differences for OpenTelemetry metrics.

**Root Cause**: The `completion_start_time` and other timestamp values from `kwargs` were sometimes strings (e.g., `'2025-06-22 10:59:08.399523'`) due to JSON deserialization, but the code assumed they were always `datetime` objects or float timestamps. When strings were passed, the subtraction operations failed.

**Solution**:

1. Created a `_to_timestamp()` static helper method that handles multiple input types:

   - `datetime` objects → converted to timestamp
   - `float`/`int` → returned as-is (already timestamps)
   - `str` → parsed as datetime strings with two format attempts:
     - With microseconds: `'%Y-%m-%d %H:%M:%S.%f'`
     - Without microseconds: `'%Y-%m-%d %H:%M:%S'`
   - Returns `None` if conversion fails

2. Applied the helper to all timestamp conversions in three metric recording methods:

   - `_record_time_to_first_token_metric()`
   - `_record_time_per_output_token_metric()`
   - `_record_response_duration_metric()`

3. Added proper fallback logic when timestamp conversion returns `None`

**File Changed**: `litellm/integrations/opentelemetry.py`

## Technical Details

**Prisma Fix**:

- Prisma client must be generated before tests that require database access
- The `prisma generate` command creates the necessary binaries for the Prisma ORM client
- This ensures `PrismaClient` can be initialized during proxy startup events

**Custom Prompt Management Fix**:

- Test mocks must match the interface of the base classes they're testing
- The `prompt_spec` parameter was added to the `CustomPromptManagement` base class but not reflected in the test implementation
- This fix ensures test mocks stay in sync with the actual interface

**OpenTelemetry Timestamp Conversion**:

- JSON serialization/deserialization can convert `datetime` objects to strings
- The helper function robustly handles all possible timestamp formats
- Two string format attempts ensure compatibility with timestamps that include or exclude microseconds
- Proper `None` handling prevents type errors while maintaining metric accuracy