### PR TITLE
optional Automatic chunking for embedding inputs exceeding context limits

### DIFF
--- a/docs/my-website/docs/embedding/embedding_chunking.md
+++ b/docs/my-website/docs/embedding/embedding_chunking.md
@@ -98,7 +98,7 @@ LiteLLM uses a fast approximation for token counting:
 - **Base formula**: `tokens ≈ characters / 4`
 - **Safety factor**: 1.1x multiplier to account for tokenizer variations
 
-This conservative estimate ensures chunks won't exceed the actual token limit.
+This conservative estimate ensures chunks won't exceed the actual token limit (for English language).
 
 ### Chunking Strategy
 

--- a/docs/my-website/docs/embedding/embedding_chunking.md
+++ b/docs/my-website/docs/embedding/embedding_chunking.md
@@ -1,0 +1,195 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Embedding Context Limit Handling
+
+LiteLLM Router can automatically handle large embedding inputs that exceed a model's context limit by chunking the text and merging the resulting embeddings.
+
+## Overview
+
+Many embedding models have token limits (e.g., 512 tokens for some models, 8192 for others). When you have text that exceeds these limits, LiteLLM can:
+
+1. **Automatically chunk** the input text into smaller pieces
+2. **Embed each chunk** separately (with concurrent processing)
+3. **Merge the embeddings** by averaging the vectors
+
+This is useful for:
+- Processing long documents without manual chunking
+- Ensuring consistent embedding dimensions regardless of input length
+- Avoiding "context length exceeded" errors
+
+## Quick Start
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import Router
+
+router = Router(
+    model_list=[
+        {
+            "model_name": "text-embedding-ada-002",
+            "litellm_params": {"model": "text-embedding-ada-002"},
+        }
+    ],
+    # Enable automatic chunking for large inputs
+    enforce_embedding_context_limit=True,
+    embedding_chunk_size=512,  # tokens per chunk
+)
+
+# This will automatically chunk if the text exceeds 512 tokens
+response = router.embedding(
+    model="text-embedding-ada-002",
+    input="Your very long text here..."
+)
+
+# Works with async too
+response = await router.aembedding(
+    model="text-embedding-ada-002",
+    input="Your very long text here..."
+)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```yaml
+# config.yaml
+model_list:
+  - model_name: text-embedding-ada-002
+    litellm_params:
+      model: text-embedding-ada-002
+
+router_settings:
+  enforce_embedding_context_limit: true
+  embedding_chunk_size: 512
+```
+
+```bash
+$ litellm --config /path/to/config.yaml
+```
+
+```shell
+curl --location 'http://0.0.0.0:4000/v1/embeddings' \
+--header 'Authorization: Bearer sk-1234' \
+--header 'Content-Type: application/json' \
+--data '{
+    "input": "Your very long text here...",
+    "model": "text-embedding-ada-002"
+}'
+```
+
+</TabItem>
+</Tabs>
+
+## Configuration Options
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `enforce_embedding_context_limit` | `bool` | `False` | When `True`, automatically chunks inputs that exceed `embedding_chunk_size` |
+| `embedding_chunk_size` | `int` | `512` | Maximum tokens per chunk. Set based on your model's context limit |
+
+## How It Works
+
+### Token Estimation
+
+LiteLLM uses a fast approximation for token counting:
+- **Base formula**: `tokens ≈ characters / 4`
+- **Safety factor**: 1.1x multiplier to account for tokenizer variations
+
+This conservative estimate ensures chunks won't exceed the actual token limit.
+
+### Chunking Strategy
+
+1. Text is split into chunks of approximately `embedding_chunk_size` tokens
+2. Chunks break at word boundaries when possible (searches last 10% for spaces)
+3. A 0.9x safety margin is applied to chunk sizes
+
+### Embedding Merging
+
+When text is chunked, the resulting embeddings are merged by **element-wise averaging**:
+
+```
+merged_embedding[i] = mean(chunk_1[i], chunk_2[i], ..., chunk_n[i])
+```
+
+This produces a single embedding vector with the same dimensions as individual chunk embeddings.
+
+## Common Chunk Sizes
+
+| Model | Recommended `embedding_chunk_size` |
+|-------|-----------------------------------|
+| OpenAI text-embedding-ada-002 | 8191 |
+| OpenAI text-embedding-3-small | 8191 |
+| OpenAI text-embedding-3-large | 8191 |
+| Cohere embed-english-v3.0 | 512 |
+| Most other models | 512 (safe default) |
+
+## Example: Processing Long Documents
+
+```python
+from litellm import Router
+
+router = Router(
+    model_list=[
+        {
+            "model_name": "embeddings",
+            "litellm_params": {"model": "text-embedding-ada-002"},
+        }
+    ],
+    enforce_embedding_context_limit=True,
+    embedding_chunk_size=2048,  # Use larger chunks for ada-002
+)
+
+# Process a long document
+long_document = open("research_paper.txt").read()  # e.g., 50,000 characters
+
+response = router.embedding(
+    model="embeddings",
+    input=long_document
+)
+
+# Single embedding vector returned, regardless of document length
+embedding = response.data[0]["embedding"]
+print(f"Embedding dimensions: {len(embedding)}")
+```
+
+## Example: Batch Processing
+
+```python
+# Multiple inputs - each will be chunked independently if needed
+inputs = [
+    "Short text",
+    "A" * 10000,  # Very long text - will be chunked
+    "Medium length text here",
+]
+
+response = router.embedding(
+    model="embeddings",
+    input=inputs
+)
+
+# Returns one embedding per input
+for i, item in enumerate(response.data):
+    print(f"Input {i}: embedding dimensions = {len(item['embedding'])}")
+```
+
+## Performance Considerations
+
+- **Concurrent Processing**: Chunks are processed concurrently for better performance
+- **Token Estimation**: Uses fast character-based estimation (no tokenizer overhead)
+- **Memory**: Large inputs are processed in chunks, reducing peak memory usage
+
+## When to Use This Feature
+
+✅ **Use when:**
+- Processing documents of unknown/variable length
+- You want to avoid "context length exceeded" errors
+- You need consistent embedding dimensions for any input size
+- Document classification or clustering (understanding general topic/theme)
+
+❌ **Don't use when:**
+- **Precise Retrieval (RAG)**: If you need to retrieve specific facts or passages, averaging the chunk vectors will "smear" the meaning across the entire document. For RAG applications, you should manually chunk your documents and store each chunk as a separate vector record in your database.
+- You need precise control over how text is chunked (use manual chunking)
+- Your text is always within the model's context limit

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -791,6 +791,7 @@ const sidebars = {
         "completion/audio",
         "completion/document_understanding",
         "completion/drop_params",
+        "embedding/embedding_chunking",
         "completion/image_generation_chat",
         "completion/json_mode",
         "completion/knowledgebase",

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3427,7 +3427,7 @@ class Router:
         prepared_kwargs = kwargs.copy()
         # Deep copy metadata to avoid mutating the original kwargs
         if "metadata" in prepared_kwargs:
-            prepared_kwargs["metadata"] = prepared_kwargs["metadata"].copy()
+            prepared_kwargs["metadata"] = copy.deepcopy(prepared_kwargs["metadata"])
         prepared_kwargs.update(
             {
                 "model": model,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1856,8 +1856,8 @@ class Router:
                         _async_completion_no_exceptions_return_idx(
                             model=model,
                             idx=idx,
-                            messages=message,
-                            **kwargs,  # type: ignore
+                            messages=message,  # type: ignore[arg-type]
+                            **kwargs,
                         )
                     )
             responses = await asyncio.gather(*_tasks)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3640,7 +3640,6 @@ class Router:
             prepared_kwargs["input"] = input  # Preserve original format
             return await self.async_function_with_fallbacks(**prepared_kwargs)
         except Exception as e:
-
             asyncio.create_task(
                 send_llm_exception_alert(
                     litellm_router_instance=self,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3275,12 +3275,25 @@ class Router:
         Returns:
             A single averaged embedding vector. Returns empty list if input is empty,
             or the single vector unchanged if only one is provided.
+
+        Note:
+            If vectors have mismatched dimensions, a warning is logged and the
+            result is truncated to the shortest vector length.
         """
         if not embeddings:
             return []
 
         if len(embeddings) == 1:
             return embeddings[0]
+
+        # Check for dimension mismatches
+        dimensions = [len(emb) for emb in embeddings]
+        if len(set(dimensions)) > 1:
+            verbose_router_logger.warning(
+                f"Embedding dimension mismatch detected during merge: {dimensions}. "
+                f"Result will be truncated to shortest dimension ({min(dimensions)}). "
+                "This may indicate API issues or model inconsistencies."
+            )
 
         num_vecs = len(embeddings)
 

--- a/tests/router_unit_tests/test_router_embedding_chunking.py
+++ b/tests/router_unit_tests/test_router_embedding_chunking.py
@@ -61,7 +61,7 @@ class TestEmbeddingChunkingHelpers:
     def test_chunk_text_large_input(self):
         """Test that large inputs are properly chunked."""
         # Create text that's ~1100 tokens (4000 chars)
-        text = "word " * 800  # 4000 chars = 1100 tokens (with 1.1 safty margin) 
+        text = "word " * 800  # 4000 chars = 1100 tokens (with 1.1 safety margin) 
         chunks = self.router._chunk_text(text, chunk_size=512)
 
         # Should create multiple chunks

--- a/tests/router_unit_tests/test_router_embedding_chunking.py
+++ b/tests/router_unit_tests/test_router_embedding_chunking.py
@@ -1,0 +1,355 @@
+"""
+Tests for Router embedding chunking functionality.
+
+This tests the enforce_embedding_context_limit feature which automatically
+chunks large embedding inputs that exceed the model's context limit.
+"""
+
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+from litellm import Router
+from litellm.types.utils import Usage
+from litellm.utils import EmbeddingResponse
+
+
+class TestEmbeddingChunkingHelpers:
+    """Test the helper methods for embedding chunking."""
+
+    def setup_method(self):
+        """Set up a router instance for testing."""
+        self.router = Router(
+            model_list=[
+                {
+                    "model_name": "test-embedding",
+                    "litellm_params": {"model": "text-embedding-ada-002"},
+                }
+            ],
+            enforce_embedding_context_limit=True,
+            embedding_chunk_size=512,
+        )
+
+    def test_approx_token_count_short_text(self):
+        """Test token count estimation for short text."""
+        text = "Hello world"  # 11 chars -> ~2-3 tokens
+        count = self.router._approx_token_count(text)
+        assert count == 2  # 11 // 4 = 2
+
+    def test_approx_token_count_long_text(self):
+        """Test token count estimation for long text."""
+        text = "a" * 4000  # 4000 chars -> ~1000 tokens
+        count = self.router._approx_token_count(text)
+        assert count == 1000
+
+    def test_chunk_text_small_input(self):
+        """Test that small inputs are not chunked."""
+        text = "This is a short text"  # Well under 512 tokens
+        chunks = self.router._chunk_text(text, chunk_size=512)
+        assert len(chunks) == 1
+        assert chunks[0] == text
+
+    def test_chunk_text_large_input(self):
+        """Test that large inputs are properly chunked."""
+        # Create text that's ~1000 tokens (4000 chars)
+        text = "word " * 800  # 4000 chars = 1000 tokens
+        chunks = self.router._chunk_text(text, chunk_size=512)
+
+        # Should create multiple chunks
+        assert len(chunks) >= 2
+
+        # Each chunk should be under the limit (512 tokens * 4 chars = 2048 chars)
+        for chunk in chunks:
+            assert len(chunk) <= 512 * 4 + 100  # Allow some buffer for word boundary
+
+    def test_chunk_text_preserves_content(self):
+        """Test that chunking doesn't lose content."""
+        text = "word " * 800
+        chunks = self.router._chunk_text(text, chunk_size=512)
+
+        # Rejoined chunks should contain all words
+        rejoined = "".join(chunks)
+        # Account for potential whitespace differences
+        assert rejoined.replace(" ", "").replace("\n", "") == text.replace(" ", "")
+
+    def test_chunk_text_breaks_on_word_boundary(self):
+        """Test that chunks break on word boundaries when possible."""
+        text = "hello world " * 500  # Long text with clear word boundaries
+        chunks = self.router._chunk_text(text, chunk_size=512)
+
+        # Each chunk (except possibly last) should end with space or be at word boundary
+        for chunk in chunks[:-1]:
+            # Should not break in middle of "hello" or "world"
+            stripped = chunk.rstrip()
+            assert stripped.endswith("hello") or stripped.endswith("world")
+
+    def test_merge_embeddings_single(self):
+        """Test merging a single embedding returns it unchanged."""
+        embedding = [0.1, 0.2, 0.3, 0.4]
+        result = self.router._merge_embeddings([embedding])
+        assert result == embedding
+
+    def test_merge_embeddings_multiple(self):
+        """Test merging multiple embeddings averages them."""
+        embeddings = [
+            [1.0, 2.0, 3.0],
+            [3.0, 4.0, 5.0],
+        ]
+        result = self.router._merge_embeddings(embeddings)
+
+        # Average of [1,3], [2,4], [3,5] = [2, 3, 4]
+        assert result == [2.0, 3.0, 4.0]
+
+    def test_merge_embeddings_empty(self):
+        """Test merging empty list returns empty list."""
+        result = self.router._merge_embeddings([])
+        assert result == []
+
+
+class TestEmbeddingChunkingIntegration:
+    """Integration tests for embedding chunking with mocked API calls."""
+
+    def _create_mock_embedding_response(
+        self, embedding: List[float]
+    ) -> EmbeddingResponse:
+        """Helper to create a mock embedding response."""
+        return EmbeddingResponse(
+            model="text-embedding-ada-002",
+            data=[{"object": "embedding", "embedding": embedding, "index": 0}],
+            usage=Usage(prompt_tokens=10, total_tokens=10),
+        )
+
+    @patch.object(Router, "function_with_fallbacks")
+    def test_embedding_chunking_triggered_for_large_input(self, mock_fallbacks):
+        """Test that chunking is triggered for inputs exceeding chunk size."""
+        # Setup
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test-embedding",
+                    "litellm_params": {"model": "text-embedding-ada-002"},
+                }
+            ],
+            enforce_embedding_context_limit=True,
+            embedding_chunk_size=100,  # Small chunk size to trigger chunking
+        )
+
+        # Use a callable that returns incrementing embeddings
+        call_count = [0]
+
+        def mock_response(*args, **kwargs):
+            call_count[0] += 1
+            # Return different embedding each call
+            base = call_count[0] * 0.1
+            return self._create_mock_embedding_response([base, base + 0.1, base + 0.2])
+
+        mock_fallbacks.side_effect = mock_response
+
+        # Create input that exceeds 100 tokens (~400 chars)
+        # 1000 chars / 4 = 250 tokens, with chunk_size=100, this creates 3 chunks
+        large_input = "test " * 200  # 1000 chars = ~250 tokens
+
+        # Execute
+        response = router.embedding(model="test-embedding", input=large_input)
+
+        # Verify chunking happened (multiple API calls)
+        assert call_count[0] >= 2, f"Expected at least 2 chunks, got {call_count[0]}"
+
+        # Verify response structure
+        assert len(response.data) == 1
+        assert "embedding" in response.data[0]
+
+        # Verify we got a merged embedding (list of floats)
+        merged = response.data[0]["embedding"]
+        assert isinstance(merged, list)
+        assert len(merged) == 3
+        assert all(isinstance(v, float) for v in merged)
+
+    @patch.object(Router, "function_with_fallbacks")
+    def test_embedding_no_chunking_for_small_input(self, mock_fallbacks):
+        """Test that small inputs are not chunked."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test-embedding",
+                    "litellm_params": {"model": "text-embedding-ada-002"},
+                }
+            ],
+            enforce_embedding_context_limit=True,
+            embedding_chunk_size=512,
+        )
+
+        mock_fallbacks.return_value = self._create_mock_embedding_response(
+            [0.1, 0.2, 0.3]
+        )
+
+        # Small input
+        small_input = "hello world"
+
+        response = router.embedding(model="test-embedding", input=small_input)
+
+        # Should only make one call
+        assert mock_fallbacks.call_count == 1
+        assert response.data[0]["embedding"] == [0.1, 0.2, 0.3]
+
+    @patch.object(Router, "function_with_fallbacks")
+    def test_embedding_chunking_disabled(self, mock_fallbacks):
+        """Test that chunking can be disabled."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test-embedding",
+                    "litellm_params": {"model": "text-embedding-ada-002"},
+                }
+            ],
+            enforce_embedding_context_limit=False,  # Disabled
+            embedding_chunk_size=100,
+        )
+
+        mock_fallbacks.return_value = self._create_mock_embedding_response(
+            [0.1, 0.2, 0.3]
+        )
+
+        # Large input that would normally be chunked
+        large_input = "test " * 200
+
+        _ = router.embedding(model="test-embedding", input=large_input)
+
+        # Should only make one call (no chunking)
+        assert mock_fallbacks.call_count == 1
+
+    @patch.object(Router, "function_with_fallbacks")
+    def test_embedding_list_input_with_chunking(self, mock_fallbacks):
+        """Test chunking with list of inputs."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test-embedding",
+                    "litellm_params": {"model": "text-embedding-ada-002"},
+                }
+            ],
+            enforce_embedding_context_limit=True,
+            embedding_chunk_size=100,
+        )
+
+        # Use callable to handle variable number of calls
+        call_count = [0]
+
+        def mock_response(*args, **kwargs):
+            call_count[0] += 1
+            base = call_count[0] * 0.1
+            return self._create_mock_embedding_response([base, base + 0.1])
+
+        mock_fallbacks.side_effect = mock_response
+
+        inputs = [
+            "test " * 200,  # Large - needs chunking (~250 tokens)
+            "small text",  # Small - no chunking
+        ]
+
+        response = router.embedding(model="test-embedding", input=inputs)
+
+        # Should have 2 embeddings in response (one per input)
+        assert len(response.data) == 2
+
+        # Verify both are valid embeddings
+        assert isinstance(response.data[0]["embedding"], list)
+        assert isinstance(response.data[1]["embedding"], list)
+
+        # Multiple calls should have been made (at least 2 for large + 1 for small)
+        assert call_count[0] >= 3, f"Expected at least 3 calls, got {call_count[0]}"
+
+
+class TestEmbeddingChunkingAsync:
+    """Test async embedding chunking."""
+
+    def _create_mock_embedding_response(
+        self, embedding: List[float]
+    ) -> EmbeddingResponse:
+        """Helper to create a mock embedding response."""
+        return EmbeddingResponse(
+            model="text-embedding-ada-002",
+            data=[{"object": "embedding", "embedding": embedding, "index": 0}],
+            usage=Usage(prompt_tokens=10, total_tokens=10),
+        )
+
+    @pytest.mark.asyncio
+    @patch.object(Router, "async_function_with_fallbacks")
+    async def test_aembedding_chunking(self, mock_async_fallbacks):
+        """Test async embedding with chunking."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test-embedding",
+                    "litellm_params": {"model": "text-embedding-ada-002"},
+                }
+            ],
+            enforce_embedding_context_limit=True,
+            embedding_chunk_size=100,
+        )
+
+        # Use async callable that returns incrementing embeddings
+        call_count = [0]
+
+        async def mock_response(*args, **kwargs):
+            call_count[0] += 1
+            base = call_count[0] * 0.1
+            return self._create_mock_embedding_response([base, base + 0.1, base + 0.2])
+
+        mock_async_fallbacks.side_effect = mock_response
+
+        large_input = "test " * 200
+
+        response = await router.aembedding(model="test-embedding", input=large_input)
+
+        # Verify chunking happened
+        assert call_count[0] >= 2, f"Expected at least 2 chunks, got {call_count[0]}"
+
+        # Verify response structure
+        assert len(response.data) == 1
+        merged = response.data[0]["embedding"]
+        assert isinstance(merged, list)
+        assert len(merged) == 3
+
+
+class TestRouterEmbeddingDefaults:
+    """Test default configuration for embedding chunking."""
+
+    def test_default_enforce_embedding_context_limit_is_false(self):
+        """Test that enforce_embedding_context_limit defaults to False (opt-in feature)."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test",
+                    "litellm_params": {"model": "text-embedding-ada-002"},
+                }
+            ]
+        )
+        # Default is False - users must opt-in to chunking
+        assert router.enforce_embedding_context_limit is False
+
+    def test_default_embedding_chunk_size_is_512(self):
+        """Test that embedding_chunk_size defaults to 512."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test",
+                    "litellm_params": {"model": "text-embedding-ada-002"},
+                }
+            ]
+        )
+        assert router.embedding_chunk_size == 512
+
+    def test_custom_embedding_chunk_size(self):
+        """Test that embedding_chunk_size can be customized."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test",
+                    "litellm_params": {"model": "text-embedding-ada-002"},
+                }
+            ],
+            embedding_chunk_size=2048,
+        )
+        assert router.embedding_chunk_size == 2048

--- a/tests/router_unit_tests/test_router_embedding_chunking.py
+++ b/tests/router_unit_tests/test_router_embedding_chunking.py
@@ -32,16 +32,24 @@ class TestEmbeddingChunkingHelpers:
         )
 
     def test_approx_token_count_short_text(self):
-        """Test token count estimation for short text."""
-        text = "Hello world"  # 11 chars -> ~2-3 tokens
+        """Test token count estimation for short text.
+
+        With safety factor of 1.1, the estimate is conservative (higher):
+        11 chars / 4 * 1.1 = 3 (rounded)
+        """
+        text = "Hello world"  # 11 chars
         count = self.router._approx_token_count(text)
-        assert count == 2  # 11 // 4 = 2
+        assert count == 3  # int((11 / 4) * 1.1) = 3
 
     def test_approx_token_count_long_text(self):
-        """Test token count estimation for long text."""
-        text = "a" * 4000  # 4000 chars -> ~1000 tokens
+        """Test token count estimation for long text.
+
+        With safety factor of 1.1, the estimate is conservative (higher):
+        4000 chars / 4 * 1.1 = 1100
+        """
+        text = "a" * 4000  # 4000 chars
         count = self.router._approx_token_count(text)
-        assert count == 1000
+        assert count == 1100  # int((4000 / 4) * 1.1) = 1100
 
     def test_chunk_text_small_input(self):
         """Test that small inputs are not chunked."""


### PR DESCRIPTION
## Title

<!--  automatic chunking for embedding inputs exceeding context limits -->

## Relevant issues

<!-- Fixes #17869  -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

-  I have Added testing in the tests/router_unit_tests/test_router_embedding_chunking.py
-  I have added a screenshot of my new test passing locally
<img width="2556" height="1530" alt="locally_passed_test" src="https://github.com/user-attachments/assets/d4504f7d-19af-4687-a931-4f6b3b810996" />

- My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature
🐛 Bug Fix

## Changes
Added automatic chunking support for embedding inputs that exceed the embedding model's context limit.

## Problem
When using Router with embedding models which  have 512-8k token limits large inputs fail with:
`Internal_litellm_router API call failed. Error: litellm.InternalServerError: InternalServerError: OpenAIException - Error code: 500 - {'error': {'code': 500, 'message': 'input is too large to process. increase the physical batch size', 'type': 'server_error'}}. Received Model Group=embedding
Available Model Group Fallbacks=None LiteLLM Retried: 1 times, LiteLLM Max Retries: 2`
as in issue #17869 

## Solution:
Added enforce_embedding_context_limit (bool, default: False) - Opt-in flag to enable chunking
Added embedding_chunk_size (int, default: 512) - Configurable max tokens per chunk
Large inputs are automatically split at word boundaries, embedded separately, and merged by averaging vectors

##Tests:
Added 17 unit tests in test_router_embedding_chunking.py covering chunking logic, embedding merging, sync/async calls, and default configuration.
