### PR TITLE
[Fix] Add extra_headers and allowed_tools to UpdateMCPServerRequest

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1070,6 +1070,8 @@ class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
     url: Optional[str] = None
     mcp_info: Optional[MCPInfo] = None
     mcp_access_groups: List[str] = Field(default_factory=list)
+    allowed_tools: Optional[List[str]] = None
+    extra_headers: Optional[List[str]] = None
     static_headers: Optional[Dict[str, str]] = None
     # Stdio-specific fields
     command: Optional[str] = None


### PR DESCRIPTION
## [Fix] Add extra_headers and allowed_tools to UpdateMCPServerRequest

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Adding `extra_headers` and `allowed_tools` into the UpdateMCPServerRequest type. These were missing from the types, so when an update from the UI came in with these values, they were not updated.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<img width="718" height="168" alt="image" src="https://github.com/user-attachments/assets/2b134669-8efc-41fd-8ac3-ce62376e6d77" />
<img width="1782" height="250" alt="image" src="https://github.com/user-attachments/assets/3e80c8c6-775e-4ee4-a5b5-04e1b10850bc" />
<img width="1905" height="282" alt="image" src="https://github.com/user-attachments/assets/d8ed9a80-ba2e-449f-8dde-d8a97060a8af" />

