### PR TITLE
[Fix] Filter internal params in fallback code

### DIFF
--- a/litellm/litellm_core_utils/fallback_utils.py
+++ b/litellm/litellm_core_utils/fallback_utils.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import litellm
 from litellm._logging import verbose_logger
-from litellm.litellm_core_utils.core_helpers import safe_deep_copy
+from litellm.litellm_core_utils.core_helpers import safe_deep_copy, filter_internal_params
 
 from .asyncify import run_async_function
 
@@ -48,6 +48,9 @@ async def async_completion_with_fallbacks(**kwargs):
                 completion_kwargs.update(fallback)
             else:
                 model = fallback
+
+            # Filter out internal parameters that shouldn't be sent to provider APIs
+            completion_kwargs = filter_internal_params(completion_kwargs)
 
             response = await litellm.acompletion(
                 **completion_kwargs,

--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -3118,8 +3118,9 @@ async def test_completion_bedrock_httpx_models(sync_mode, model):
 
 def test_completion_bedrock_titan_null_response():
     try:
+        # amazon.titan-text-lite-v1 is deprecated, using titan-text-express-v1 instead
         response = completion(
-            model="bedrock/amazon.titan-text-lite-v1",
+            model="bedrock/amazon.titan-text-express-v1",
             messages=[
                 {
                     "role": "user",

--- a/tests/local_testing/test_gcs_bucket.py
+++ b/tests/local_testing/test_gcs_bucket.py
@@ -108,7 +108,6 @@ async def test_aaabasic_gcs_logger():
             },
             "endpoint": "http://localhost:4000/chat/completions",
             "model_group": "gpt-3.5-turbo",
-            "deployment": "azure/gpt-4.1-mini",
             "model_info": {
                 "id": "4bad40a1eb6bebd1682800f16f44b9f06c52a6703444c99c7f9f32e9de3693b4",
                 "db_model": False,
@@ -216,7 +215,6 @@ async def test_basic_gcs_logger_failure():
                 },
                 "endpoint": "http://localhost:4000/chat/completions",
                 "model_group": "gpt-3.5-turbo",
-                "deployment": "azure/gpt-4.1-mini",
                 "model_info": {
                     "id": "4bad40a1eb6bebd1682800f16f44b9f06c52a6703444c99c7f9f32e9de3693b4",
                     "db_model": False,
@@ -626,7 +624,6 @@ async def test_basic_gcs_logger_with_folder_in_bucket_name():
             },
             "endpoint": "http://localhost:4000/chat/completions",
             "model_group": "gpt-3.5-turbo",
-            "deployment": "azure/gpt-4.1-mini",
             "model_info": {
                 "id": "4bad40a1eb6bebd1682800f16f44b9f06c52a6703444c99c7f9f32e9de3693b4",
                 "db_model": False,


### PR DESCRIPTION
## Title

[Fix] Filter internal params in fallback code

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

This PR fixes issues with internal parameters being passed to provider APIs in fallback code and resolves test failures:

### Fallback Code Fixes

1. **Filter internal parameters in fallback utils**:
   - Added `filter_internal_params` call in `async_completion_with_fallbacks` before calling `acompletion`
   - Prevents internal parameters like `skip_mcp_handler` from being passed to provider APIs, which was causing errors
   - Imported `filter_internal_params` from `core_helpers`

### Test Fixes

1. **GCS bucket logger tests**:

   - Removed `deployment` field from test metadata in multiple test cases
   - Fixes model name mismatch where deployment field was overriding the model in logging
   - Updated tests: `test_aaabasic_gcs_logger`, `test_basic_gcs_logger_failure`, and `test_basic_gcs_logger_with_folder_in_bucket_name`

2. **Bedrock Titan test**:
   - Updated test to use non-deprecated model `titan-text-express-v1` instead of deprecated `amazon.titan-text-lite-v1`
   - Fixes test failure due to deprecated model