### PR TITLE
fix: Change extra_headers to additional_headers

### DIFF
--- a/litellm/llms/azure/realtime/handler.py
+++ b/litellm/llms/azure/realtime/handler.py
@@ -94,7 +94,7 @@ class AzureOpenAIRealtime(AzureChatCompletion):
             ssl_context = get_shared_realtime_ssl_context()
             async with websockets.connect(  # type: ignore
                 url,
-                extra_headers={
+                additional_headers={
                     "api-key": api_key,  # type: ignore
                 },
                 max_size=REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -3646,7 +3646,7 @@ class BaseLLMHTTPHandler:
             ssl_context = get_shared_realtime_ssl_context()
             async with websockets.connect(  # type: ignore
                 url,
-                extra_headers=headers,
+                additional_headers=headers,
                 max_size=REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
                 ssl=ssl_context,
             ) as backend_ws:

--- a/litellm/llms/openai/realtime/handler.py
+++ b/litellm/llms/openai/realtime/handler.py
@@ -59,7 +59,7 @@ class OpenAIRealtime(OpenAIChatCompletion):
             ssl_context = get_shared_realtime_ssl_context()
             async with websockets.connect(  # type: ignore
                 url,
-                extra_headers={
+                additional_headers={
                     "Authorization": f"Bearer {api_key}",  # type: ignore
                     "OpenAI-Beta": "realtime=v1",
                 },

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -196,7 +196,7 @@ async def _realtime_health_check(
     ssl_context = get_shared_realtime_ssl_context()
     async with websockets.connect(  # type: ignore
         url,
-        extra_headers={
+        additional_headers={
             "api-key": api_key,  # type: ignore
         },
         max_size=REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,

--- a/tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py
+++ b/tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py
@@ -195,10 +195,10 @@ async def test_async_realtime_url_contains_model():
         
         # Verify proper headers were set
         called_kwargs = mock_ws_connect.call_args[1]
-        assert "extra_headers" in called_kwargs
-        extra_headers = called_kwargs["extra_headers"]
-        assert extra_headers["Authorization"] == f"Bearer {api_key}"
-        assert extra_headers["OpenAI-Beta"] == "realtime=v1"
+        assert "additional_headers" in called_kwargs
+        additional_headers = called_kwargs["additional_headers"]
+        assert additional_headers["Authorization"] == f"Bearer {api_key}"
+        assert additional_headers["OpenAI-Beta"] == "realtime=v1"
         assert called_kwargs["ssl"] is shared_context
         
         mock_realtime_streaming.assert_called_once()


### PR DESCRIPTION
## Title

fix: Change extra_headers to additional_headers

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
We have a breaking change since websockets 14+ with the "extra_headers" parameters. You can see a issue [here](https://github.com/camect/camect-py/issues/20)

Because of it we're getting an internal server error saying "extra_headers" it's an unexpected argument
<img width="998" height="672" alt="Screenshot 2025-12-14 at 02 37 24" src="https://github.com/user-attachments/assets/0a0630ca-606f-4207-9e31-1e78d6cba90a" />

Here, it's after the fix
<img width="596" height="139" alt="Screenshot 2025-12-14 at 02 38 48" src="https://github.com/user-attachments/assets/8e3a7319-1968-4cc9-bea6-3d04f8b218d8" />

This is necessary because we have this [PR](https://github.com/BerriAI/litellm/pull/16734) updating the websockets version to 15. Despite having this update, the codes were not updated correctly.

## Notes
I search for every `websockets.connect` code with `extra_headers` and updated it. But, honestly beyond the unit tests I just test the OpenAI WS connection. We can rollback some changes if necessary :) 

## Tests

<img width="1086" height="415" alt="Screenshot 2025-12-14 at 02 51 00" src="https://github.com/user-attachments/assets/8afd8a3b-3672-41d2-ae0a-4d3ff1c0cabe" />
