### PR TITLE
feat(pillar): add masking support and MCP call support

### DIFF
--- a/tests/test_litellm/proxy/guardrails/test_pillar_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/test_pillar_guardrails.py
@@ -1142,6 +1142,305 @@ def test_get_config_model():
     assert hasattr(config_model, "ui_friendly_name")
 
 
+# ============================================================================
+# MASKING TESTS
+# ============================================================================
+
+
+@pytest.fixture
+def pillar_masked_response():
+    """Fixture providing a Pillar API response with masked messages."""
+    return Response(
+        json={
+            "session_id": "test-session-123",
+            "flagged": True,
+            "masked_session_messages": [
+                {"role": "user", "content": "My email is [MASKED_EMAIL]"}
+            ],
+            "evidence": [
+                {
+                    "category": "pii",
+                    "type": "email",
+                    "evidence": "test@example.com",
+                }
+            ],
+            "scanners": {
+                "jailbreak": False,
+                "prompt_injection": False,
+                "pii": True,
+                "toxic_language": False,
+            },
+        },
+        status_code=200,
+        request=Request(
+            method="POST", url="https://api.pillar.security/api/v1/protect"
+        ),
+    )
+
+
+@pytest.fixture
+def pillar_mask_guardrail(env_setup):
+    """Fixture providing a PillarGuardrail instance in mask mode."""
+    return PillarGuardrail(
+        guardrail_name="pillar-mask",
+        api_key="test-pillar-key",
+        api_base="https://api.pillar.security",
+        on_flagged_action="mask",
+    )
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_masking_mode(
+    pillar_mask_guardrail,
+    sample_request_data,
+    user_api_key_dict,
+    dual_cache,
+    pillar_masked_response,
+):
+    """Test pre-call hook masks content when action is 'mask'."""
+    original_messages = sample_request_data["messages"].copy()
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=pillar_masked_response,
+    ):
+        result = await pillar_mask_guardrail.async_pre_call_hook(
+            data=sample_request_data,
+            cache=dual_cache,
+            user_api_key_dict=user_api_key_dict,
+            call_type="completion",
+        )
+
+    # Messages should be replaced with masked messages
+    assert result["messages"] == pillar_masked_response.json()["masked_session_messages"]
+    assert result["messages"] != original_messages
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_masking_no_masked_messages(
+    pillar_mask_guardrail,
+    sample_request_data,
+    user_api_key_dict,
+    dual_cache,
+):
+    """Test masking mode when API doesn't return masked_session_messages."""
+    response_no_mask = Response(
+        json={
+            "session_id": "test-session-123",
+            "flagged": True,
+            # No masked_session_messages
+        },
+        status_code=200,
+        request=Request(
+            method="POST", url="https://api.pillar.security/api/v1/protect"
+        ),
+    )
+
+    original_messages = sample_request_data["messages"].copy()
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=response_no_mask,
+    ):
+        result = await pillar_mask_guardrail.async_pre_call_hook(
+            data=sample_request_data,
+            cache=dual_cache,
+            user_api_key_dict=user_api_key_dict,
+            call_type="completion",
+        )
+
+    # Messages should remain unchanged if no masked messages provided
+    assert result["messages"] == original_messages
+
+
+# ============================================================================
+# CONDITIONAL EXCEPTION DETAILS TESTS
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_exception_without_scanners(
+    sample_request_data,
+    user_api_key_dict,
+    dual_cache,
+    pillar_flagged_response,
+):
+    """Test exception excludes scanners when include_scanners is False."""
+    guardrail = PillarGuardrail(
+        guardrail_name="pillar-no-scanners",
+        api_key="test-pillar-key",
+        api_base="https://api.pillar.security",
+        on_flagged_action="block",
+        include_scanners=False,
+        include_evidence=True,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            return_value=pillar_flagged_response,
+        ):
+            await guardrail.async_pre_call_hook(
+                data=sample_request_data,
+                cache=dual_cache,
+                user_api_key_dict=user_api_key_dict,
+                call_type="completion",
+            )
+
+    error_detail = excinfo.value.detail
+    assert "pillar_response" in error_detail
+    assert "scanners" not in error_detail["pillar_response"]
+    assert "evidence" in error_detail["pillar_response"]
+
+
+@pytest.mark.asyncio
+async def test_exception_without_evidence(
+    sample_request_data,
+    user_api_key_dict,
+    dual_cache,
+    pillar_flagged_response,
+):
+    """Test exception excludes evidence when include_evidence is False."""
+    guardrail = PillarGuardrail(
+        guardrail_name="pillar-no-evidence",
+        api_key="test-pillar-key",
+        api_base="https://api.pillar.security",
+        on_flagged_action="block",
+        include_scanners=True,
+        include_evidence=False,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            return_value=pillar_flagged_response,
+        ):
+            await guardrail.async_pre_call_hook(
+                data=sample_request_data,
+                cache=dual_cache,
+                user_api_key_dict=user_api_key_dict,
+                call_type="completion",
+            )
+
+    error_detail = excinfo.value.detail
+    assert "pillar_response" in error_detail
+    assert "scanners" in error_detail["pillar_response"]
+    assert "evidence" not in error_detail["pillar_response"]
+
+
+@pytest.mark.asyncio
+async def test_exception_without_scanners_or_evidence(
+    sample_request_data,
+    user_api_key_dict,
+    dual_cache,
+    pillar_flagged_response,
+):
+    """Test exception excludes both scanners and evidence when both are False."""
+    guardrail = PillarGuardrail(
+        guardrail_name="pillar-minimal",
+        api_key="test-pillar-key",
+        api_base="https://api.pillar.security",
+        on_flagged_action="block",
+        include_scanners=False,
+        include_evidence=False,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            return_value=pillar_flagged_response,
+        ):
+            await guardrail.async_pre_call_hook(
+                data=sample_request_data,
+                cache=dual_cache,
+                user_api_key_dict=user_api_key_dict,
+                call_type="completion",
+            )
+
+    error_detail = excinfo.value.detail
+    assert "pillar_response" in error_detail
+    pillar_response = error_detail["pillar_response"]
+    assert "scanners" not in pillar_response
+    assert "evidence" not in pillar_response
+    assert "session_id" in pillar_response  # session_id should always be present
+
+
+# ============================================================================
+# MCP CALL SUPPORT TESTS
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_mcp_call(
+    pillar_guardrail_instance,
+    sample_request_data,
+    user_api_key_dict,
+    dual_cache,
+    pillar_clean_response,
+):
+    """Test pre-call hook works with MCP call type."""
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=pillar_clean_response,
+    ):
+        result = await pillar_guardrail_instance.async_pre_call_hook(
+            data=sample_request_data,
+            cache=dual_cache,
+            user_api_key_dict=user_api_key_dict,
+            call_type="mcp_call",
+        )
+
+    assert result == sample_request_data
+
+
+@pytest.mark.asyncio
+async def test_moderation_hook_mcp_call(
+    pillar_guardrail_instance,
+    sample_request_data,
+    user_api_key_dict,
+    pillar_clean_response,
+):
+    """Test moderation hook works with MCP call type."""
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=pillar_clean_response,
+    ):
+        result = await pillar_guardrail_instance.async_moderation_hook(
+            data=sample_request_data,
+            user_api_key_dict=user_api_key_dict,
+            call_type="mcp_call",
+        )
+
+    assert result == sample_request_data
+
+
+@pytest.mark.asyncio
+async def test_mcp_call_masking(
+    pillar_mask_guardrail,
+    sample_request_data,
+    user_api_key_dict,
+    dual_cache,
+    pillar_masked_response,
+):
+    """Test masking works with MCP call type."""
+    original_messages = sample_request_data["messages"].copy()
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        return_value=pillar_masked_response,
+    ):
+        result = await pillar_mask_guardrail.async_pre_call_hook(
+            data=sample_request_data,
+            cache=dual_cache,
+            user_api_key_dict=user_api_key_dict,
+            call_type="mcp_call",
+        )
+
+    # Messages should be replaced with masked messages
+    assert result["messages"] == pillar_masked_response.json()["masked_session_messages"]
+    assert result["messages"] != original_messages
+
+
 if __name__ == "__main__":
     # Run the tests
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Title

feat(pillar): add masking support and MCP call support

## Relevant issues

Fixes #17958 - Add Masking Support and MCP Call Support to Pillar Security Guardrail

## Pre-Submission checklist

<img width="1419" height="615" alt="image" src="https://github.com/user-attachments/assets/26151749-a72a-4d9c-bed4-b6c226101092" />


- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

This PR adds three key enhancements to the Pillar Security guardrail:

### 1. Masking Support
- Add `"mask"` to `SUPPORTED_ON_FLAGGED_ACTIONS`
- When `on_flagged_action: "mask"`, automatically replace messages with `masked_session_messages` from Pillar API
- Allows requests to proceed with sanitized content instead of blocking

### 2. MCP Call Support  
- Add `pre_mcp_call` and `during_mcp_call` to supported event hooks
- Enable Pillar scanning for MCP (Model Context Protocol) tool calls
- Extends security coverage to all LLM endpoints including agent workflows

### 3. Conditional Exception Details
- Control exception payload size by conditionally including `scanners` and `evidence`
- Only include details when `include_scanners`/`include_evidence` are `true`
- Always include `session_id` for traceability

### Testing
Added comprehensive test coverage:
- ✅ 3 tests for masking functionality (with/without masked messages, MCP calls)
- ✅ 3 tests for conditional exception details
- ✅ 2 tests for MCP call support
- ✅ All 34 tests passing

### Documentation
- Added Mask section with configuration examples
- Added MCP call protection examples
- Updated modes table to include MCP modes
- Clarified exception details control

### Backward Compatibility
✅ All changes maintain backward compatibility:
- Default values unchanged (`include_scanners=True`, `include_evidence=True`)
- Existing `block` and `monitor` actions work as before
- New `mask` action is additive

## Configuration Example

```yaml
guardrails:
  - guardrail_name: "pillar-security"
    litellm_params:
      guardrail: "pillar"
      mode: "pre_call"  # or "pre_mcp_call", "during_mcp_call"
      on_flagged_action: "mask"  # Options: "block", "monitor", "mask"
      include_scanners: true      # Include in exception when blocking
      include_evidence: true      # Include in exception when blocking
```

## Related Issues/PRs

- Related to PR #17206 (feat/pillar-masking) which was closed
- PR #17812 was merged before this work
- Similar to issue #17809