### PR TITLE
fix: Support Signed URLs with Query Parameters in Image Processing

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -689,7 +689,14 @@ def _get_image_mime_type_from_url(url: str) -> Optional[str]:
     video/mpegps
     video/flv
     """
+    from urllib.parse import urlparse
+    
     url = url.lower()
+    
+    # Parse URL to extract path without query parameters
+    # This handles URLs like: https://example.com/image.jpg?signature=...
+    parsed = urlparse(url)
+    path = parsed.path
 
     # Map file extensions to mime types
     mime_types = {
@@ -717,7 +724,7 @@ def _get_image_mime_type_from_url(url: str) -> Optional[str]:
 
     # Check each extension group against the URL
     for extensions, mime_type in mime_types.items():
-        if any(url.endswith(ext) for ext in extensions):
+        if any(path.endswith(ext) for ext in extensions):
             return mime_type
 
     return None


### PR DESCRIPTION
# Fix: Support Signed URLs with Query Parameters in Image Processing

## Problem Summary

This PR fixes a critical bug in image URL handling that affects all providers using signed URLs (e.g., Tencent Cloud COS, etc.).

### Issue 1: MIME Type Detection Failure for URLs with Query Parameters

**File**: `litellm/litellm_core_utils/prompt_templates/common_utils.py`

**Function**: `_get_image_mime_type_from_url()`

The original implementation fails to detect MIME types for image URLs containing query parameters:

```python
# Original code - fails for signed URLs
def _get_image_mime_type_from_url(url: str) -> Optional[str]:
    url = url.lower()
    if any(url.endswith(ext) for ext in extensions):  # ❌ Fails: "image.jpg?signature=..." doesn't end with ".jpg"
        return mime_type
    return None
```

**Impact**: 
- URLs like `https://example.com/image.jpg?signature=abc123` are not recognized as images
- Returns `None` instead of the correct MIME type
- Triggers unnecessary base64 conversion for valid image URLs
- Breaks signed URL workflows across all cloud providers

## Root Cause

The function checks if the entire URL string ends with an image extension (`.jpg`, `.png`, etc.), but signed URLs include query parameters after the file extension:

```
❌ url.endswith('.jpg')  # False for "image.jpg?signature=xyz"
✅ Should check path only  # True for path part "image.jpg"
```

## Solution

Parse the URL to extract only the path component, excluding query parameters:

```python
from urllib.parse import urlparse

def _get_image_mime_type_from_url(url: str) -> Optional[str]:
    """
    Extract MIME type from image URL based on file extension.
    Handles URLs with query parameters (e.g., signed URLs).
    
    Args:
        url: Image URL (may contain query parameters)
        
    Returns:
        MIME type string or None if not recognized
        
    Examples:
        'https://example.com/photo.jpg' → 'image/jpeg'
        'https://example.com/photo.jpg?signature=abc' → 'image/jpeg'
    """
    url = url.lower()
    
    # Parse URL to extract path, ignoring query parameters
    parsed = urlparse(url)
    path = parsed.path  # Only check the path component
    
    mime_types = {
        ('.jpg', '.jpeg'): 'image/jpeg',
        ('.png',): 'image/png',
        ('.gif',): 'image/gif',
        ('.webp',): 'image/webp',
    }
    
    for extensions, mime_type in mime_types.items():
        if any(path.endswith(ext) for ext in extensions):
            return mime_type
    
    return None
```

## Benefits

1. **Universal Fix**: Solves the problem for all cloud storage providers using signed URLs
2. **Better Performance**: Avoids unnecessary base64 encoding/decoding
3. **Correct Behavior**: Preserves original URL format when the model supports it
4. **Backward Compatible**: No breaking changes - only improves existing behavior

## Test Cases

```python
# All should correctly return 'image/jpeg'
assert _get_image_mime_type_from_url('https://example.com/image.jpg') == 'image/jpeg'
assert _get_image_mime_type_from_url('https://example.com/image.jpg?signature=abc') == 'image/jpeg'
assert _get_image_mime_type_from_url('https://example.com/image.jpg?q-sign-algorithm=sha1&q-ak=...') == 'image/jpeg'
assert _get_image_mime_type_from_url('https://example.com/photo.png?expires=1234567890') == 'image/png'
```

## Related Files

This PR focuses on the MIME type detection fix in `common_utils.py`. A companion fix for HTTPHandler query parameter handling is addressed separately to maintain clear separation of concerns.

## Verification

Tested with:
- ✅ Tencent Cloud COS signed URLs
- ✅ Plain image URLs without parameters

The fix is designed to work with any URL containing query parameters, including signed URLs from other cloud storage providers (AWS S3, Google Cloud Storage, Azure Blob Storage, etc.).
