### PR TITLE
fix(anthropic): claude-3-7-sonnet max_tokens to 64K default

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -6723,8 +6723,8 @@
         "input_cost_per_token": 3e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
         "search_context_cost_per_query": {
@@ -6752,8 +6752,8 @@
         "input_cost_per_token": 3e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
         "search_context_cost_per_query": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6723,8 +6723,8 @@
         "input_cost_per_token": 3e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
         "search_context_cost_per_query": {
@@ -6752,8 +6752,8 @@
         "input_cost_per_token": 3e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
         "search_context_cost_per_query": {

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1651,15 +1651,16 @@ def test_get_max_tokens_for_model_claude_35():
 def test_get_max_tokens_for_model_claude_37():
     """
     Test that get_max_tokens_for_model returns correct value for Claude 3.7 models.
-    Claude 3.7 Sonnet has max_output_tokens of 128000 (128K with extended thinking).
+    Claude 3.7 Sonnet has max_output_tokens of 64000 by default.
+    128K output requires the beta header 'output-128k-2025-02-19'.
 
     Fixes: https://github.com/BerriAI/litellm/issues/8835
     """
     config = AnthropicConfig()
 
-    # Claude 3.7 Sonnet should return 128000 (128K)
+    # Claude 3.7 Sonnet should return 64000 (64K default, 128K requires beta header)
     max_tokens = config.get_max_tokens_for_model("claude-3-7-sonnet-20250219")
-    assert max_tokens == 128000
+    assert max_tokens == 64000
 
 
 def test_get_max_tokens_for_model_unknown():
@@ -1698,9 +1699,9 @@ def test_get_config_with_model_uses_dynamic_max_tokens():
     config_claude35 = AnthropicConfig.get_config(model="claude-3-5-sonnet-20241022")
     assert config_claude35["max_tokens"] == 8192
 
-    # Claude 3.7 model should get 128000 (128K with extended thinking)
+    # Claude 3.7 model should get 64000 (64K default, 128K requires beta header)
     config_claude37 = AnthropicConfig.get_config(model="claude-3-7-sonnet-20250219")
-    assert config_claude37["max_tokens"] == 128000
+    assert config_claude37["max_tokens"] == 64000
 
 
 def test_get_config_without_model_uses_fallback():


### PR DESCRIPTION
## Title

fix(anthropic): correct claude-3-7-sonnet max_tokens to 64K default

## Relevant issues

Fixes failing `test_multiturn_tool_calls` integration test (reported in PR #17900 comments)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - Updated existing tests in `test_anthropic_chat_transformation.py`
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Claude 3.7 Sonnet's default `max_output_tokens` is **64000**. The 128K output limit requires the beta header `output-128k-2025-02-19`.

This fixes the integration test `test_multiturn_tool_calls` which was failing because requests with `max_tokens=128000` were being rejected by the Anthropic API with:
```
max_tokens: 128000 > 64000, which is the maximum allowed number of output tokens for claude-3-7-sonnet-20250219
```