### PR TITLE
Add provider specific tools support in responses api

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -697,6 +697,8 @@ class LiteLLMCompletionResponsesConfig:
                 chat_completion_tools.append(tool)
             elif tool.get("type") == "computer_use":
                 chat_completion_tools.append(tool)
+            elif tool.get("name") == "tool_search_tool_regex" or tool.get("name") == "tool_search_tool_bm25" or tool.get("type") == "code_execution_20250825":
+                chat_completion_tools.append(tool)
             else:
                 typed_tool = cast(FunctionToolParam, tool)
                 # Ensure parameters has "type": "object" as required by providers like Anthropic

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -695,6 +695,8 @@ class LiteLLMCompletionResponsesConfig:
                 )
             elif len(tool) == 1 and next(iter(tool)) in {e.value for e in VertexToolName}:
                 chat_completion_tools.append(tool)
+            elif tool.get("type") == "computer_use":
+                chat_completion_tools.append(tool)
             else:
                 typed_tool = cast(FunctionToolParam, tool)
                 # Ensure parameters has "type": "object" as required by providers like Anthropic

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -39,7 +39,6 @@ from litellm.types.llms.openai import (
     ValidChatCompletionMessageContentTypes,
     ValidChatCompletionMessageContentTypesLiteral,
 )
-from litellm.types.llms.vertex_ai import VertexToolName
 from litellm.types.responses.main import (
     GenericResponseOutputItem,
     GenericResponseOutputItemContentAnnotation,
@@ -692,13 +691,7 @@ class LiteLLMCompletionResponsesConfig:
                     search_context_size=_search_context_size,
                     user_location=_user_location,
                 )
-            elif len(tool) == 1 and next(iter(tool)) in {e.value for e in VertexToolName}:
-                chat_completion_tools.append(cast(Union[ChatCompletionToolParam, OpenAIMcpServerTool], tool))
-            elif tool.get("type") == "computer_use":
-                chat_completion_tools.append(cast(Union[ChatCompletionToolParam, OpenAIMcpServerTool], tool))
-            elif tool.get("name") == "tool_search_tool_regex" or tool.get("name") == "tool_search_tool_bm25" or tool.get("type") == "code_execution_20250825":
-                chat_completion_tools.append(cast(Union[ChatCompletionToolParam, OpenAIMcpServerTool], tool))
-            else:
+            elif tool.get("type") == "function":
                 typed_tool = cast(FunctionToolParam, tool)
                 # Ensure parameters has "type": "object" as required by providers like Anthropic
                 parameters = dict(typed_tool.get("parameters", {}) or {})
@@ -724,6 +717,8 @@ class LiteLLMCompletionResponsesConfig:
                 chat_completion_tools.append(
                     cast(ChatCompletionToolParam, chat_completion_tool)
                 )
+            else:
+                chat_completion_tools.append(cast(Union[ChatCompletionToolParam, OpenAIMcpServerTool], tool))
         return chat_completion_tools, web_search_options
 
     @staticmethod

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -22,7 +22,6 @@ from litellm.types.llms.openai import (
     ChatCompletionToolCallFunctionChunk,
     ChatCompletionToolMessage,
     ChatCompletionToolParam,
-    ChatCompletionToolParamFunctionChunk,
     ChatCompletionUserMessage,
     GenericChatCompletionMessage,
     InputTokensDetails,

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -716,6 +716,12 @@ class LiteLLMCompletionResponsesConfig:
                     )
                 if tool.get("cache_control"):
                     chat_completion_tool["cache_control"] = tool.get("cache_control")
+                if tool.get("defer_loading"):
+                    chat_completion_tool["defer_loading"] = tool.get("defer_loading")
+                if tool.get("allowed_callers"):
+                    chat_completion_tool["allowed_callers"] = tool.get("allowed_callers")
+                if tool.get("input_examples"):
+                    chat_completion_tool["input_examples"] = tool.get("input_examples")
                 chat_completion_tools.append(
                     chat_completion_tool
                 )

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -705,8 +705,7 @@ class LiteLLMCompletionResponsesConfig:
                 parameters = dict(typed_tool.get("parameters", {}) or {})
                 if not parameters or "type" not in parameters:
                     parameters["type"] = "object"
-                chat_completion_tools.append(
-                    ChatCompletionToolParam(
+                chat_completion_tool = ChatCompletionToolParam(
                         type="function",
                         function=ChatCompletionToolParamFunctionChunk(
                             name=typed_tool.get("name") or "",
@@ -715,6 +714,10 @@ class LiteLLMCompletionResponsesConfig:
                             strict=typed_tool.get("strict", False) or False,
                         ),
                     )
+                if tool.get("cache_control"):
+                    chat_completion_tool["cache_control"] = tool.get("cache_control")
+                chat_completion_tools.append(
+                    chat_completion_tool
                 )
         return chat_completion_tools, web_search_options
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -55,6 +55,8 @@ from litellm.types.utils import (
     ModelResponse,
     Usage,
 )
+from litellm.types.llms.vertex_ai import VertexToolName
+
 
 ########### Initialize Classes used for Responses API  ###########
 TOOL_CALLS_CACHE = InMemoryCache()
@@ -691,6 +693,8 @@ class LiteLLMCompletionResponsesConfig:
                     search_context_size=_search_context_size,
                     user_location=_user_location,
                 )
+            elif len(tool) == 1 and next(iter(tool)) in {e.value for e in VertexToolName}:
+                chat_completion_tools.append(tool)
             else:
                 typed_tool = cast(FunctionToolParam, tool)
                 # Ensure parameters has "type": "object" as required by providers like Anthropic

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -736,6 +736,373 @@ class TestContentTypeTransformation:
         assert result[1]["text"] == "another valid"
 
 
+class TestToolTransformation:
+    """Test cases for tool transformation from Responses API to Chat Completion format"""
+
+    def test_transform_vertex_ai_tools(self):
+        """Test that Vertex AI tools are passed through as-is"""
+        from litellm.types.llms.vertex_ai import VertexToolName
+
+        # Create a Vertex AI tool using the enum value
+        vertex_tool = {VertexToolName.CODE_EXECUTION.value: {}}
+        
+        tools = [vertex_tool]
+        
+        # Execute
+        result_tools, web_search_options = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 1
+        assert result_tools[0] == vertex_tool
+        assert web_search_options is None
+
+    def test_transform_mcp_tools(self):
+        """Test that MCP tools are passed through as-is"""
+        mcp_tool = {
+            "type": "mcp",
+            "server_label": "zapier",
+            "server_url": "https://mcp.zapier.com/api/mcp/mcp",
+            "headers": {
+                "Authorization": "Bearer token123"
+            },
+        }
+        
+        tools = [mcp_tool]
+        
+        # Execute
+        result_tools, web_search_options = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 1
+        assert result_tools[0] == mcp_tool
+        assert result_tools[0]["type"] == "mcp"
+        assert web_search_options is None
+
+    def test_transform_computer_use_tools(self):
+        """Test that computer_use tools are passed through as-is"""
+        computer_use_tool = {
+            "type": "computer_use",
+            "display_width_px": 1024,
+            "display_height_px": 768
+        }
+        
+        tools = [computer_use_tool]
+        
+        # Execute
+        result_tools, web_search_options = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 1
+        assert result_tools[0] == computer_use_tool
+        assert result_tools[0]["type"] == "computer_use"
+        assert web_search_options is None
+
+    def test_transform_web_search_tools_to_web_search_options(self):
+        """Test that web_search tools are converted to web_search_options"""
+        web_search_tool = {
+            "type": "web_search_preview",
+            "search_context_size": "medium",
+            "user_location": {"country": "US"}
+        }
+        
+        tools = [web_search_tool]
+        
+        # Execute
+        result_tools, web_search_options = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 0  # Web search is not added to tools
+        assert web_search_options is not None
+        assert web_search_options.get("search_context_size") == "medium"
+        assert web_search_options.get("user_location") == {"country": "US"}
+
+    def test_transform_function_tools_with_anthropic_specific_fields(self):
+        """Test that Anthropic-specific fields are preserved in function tools"""
+        function_tool = {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"}
+                },
+                "required": ["location"]
+            },
+            "cache_control": {"type": "ephemeral"},
+            "defer_loading": True,
+            "allowed_callers": ["user"],
+            "input_examples": [{"location": "San Francisco"}]
+        }
+        
+        tools = [function_tool]
+        
+        # Execute
+        result_tools, web_search_options = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 1
+        result_tool = result_tools[0]
+        assert result_tool["type"] == "function"
+        assert result_tool["function"]["name"] == "get_weather"
+        assert result_tool["function"]["description"] == "Get weather for a location"
+        assert result_tool["cache_control"] == {"type": "ephemeral"}
+        assert result_tool["defer_loading"] is True
+        assert result_tool["allowed_callers"] == ["user"]
+        assert result_tool["input_examples"] == [{"location": "San Francisco"}]
+        assert web_search_options is None
+
+    def test_transform_function_tools_with_cache_control_only(self):
+        """Test that cache_control field is preserved when present"""
+        function_tool = {
+            "type": "function",
+            "name": "search",
+            "description": "Search function",
+            "parameters": {"type": "object"},
+            "cache_control": {"type": "ephemeral"}
+        }
+        
+        tools = [function_tool]
+        
+        # Execute
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 1
+        result_tool = result_tools[0]
+        assert "cache_control" in result_tool
+        assert result_tool["cache_control"]["type"] == "ephemeral"
+
+    def test_transform_function_tools_without_anthropic_fields(self):
+        """Test that function tools work when anthropic-specific fields are not present"""
+        function_tool = {
+            "type": "function",
+            "name": "simple_function",
+            "description": "A simple function",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "param": {"type": "string"}
+                }
+            }
+        }
+        
+        tools = [function_tool]
+        
+        # Execute
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 1
+        result_tool = result_tools[0]
+        assert result_tool["type"] == "function"
+        assert result_tool["function"]["name"] == "simple_function"
+        # Anthropic-specific fields should not be present
+        assert "cache_control" not in result_tool
+        assert "defer_loading" not in result_tool
+        assert "allowed_callers" not in result_tool
+        assert "input_examples" not in result_tool
+
+    def test_transform_code_execution_tools(self):
+        """Test that code_execution tools are passed through as-is"""
+        code_execution_tool = {
+            "type": "code_execution_20250825",
+            "name": "python_code_execution"
+        }
+        
+        tools = [code_execution_tool]
+        
+        # Execute
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 1
+        assert result_tools[0]["type"] == "code_execution_20250825"
+
+    def test_transform_tool_search_tools(self):
+        """Test that tool_search tools are passed through as-is"""
+        tool_search_regex = {
+            "name": "tool_search_tool_regex",
+            "description": "Search tools using regex"
+        }
+        
+        tool_search_bm25 = {
+            "name": "tool_search_tool_bm25",
+            "description": "Search tools using BM25"
+        }
+        
+        tools = [tool_search_regex, tool_search_bm25]
+        
+        # Execute
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 2
+        assert result_tools[0]["name"] == "tool_search_tool_regex"
+        assert result_tools[1]["name"] == "tool_search_tool_bm25"
+
+    def test_transform_mixed_tools_list(self):
+        """Test transforming a mixed list of different tool types"""
+        from litellm.types.llms.vertex_ai import VertexToolName
+        
+        tools = [
+            # Regular function tool with anthropic fields
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object"},
+                "cache_control": {"type": "ephemeral"}
+            },
+            # MCP tool
+            {
+                "type": "mcp",
+                "server_label": "zapier"
+            },
+            # Web search tool
+            {
+                "type": "web_search_preview",
+                "search_context_size": "high"
+            },
+            # Vertex AI tool
+            {VertexToolName.CODE_EXECUTION.value: {}}
+        ]
+        
+        # Execute
+        result_tools, web_search_options = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 3  # function, mcp, vertex (web_search becomes options)
+        assert web_search_options is not None
+        
+        # Check function tool
+        func_tools = [t for t in result_tools if t.get("type") == "function"]
+        assert len(func_tools) == 1
+        assert func_tools[0]["cache_control"]["type"] == "ephemeral"
+        
+        # Check MCP tool
+        mcp_tools = [t for t in result_tools if t.get("type") == "mcp"]
+        assert len(mcp_tools) == 1
+        
+        # Check web search was converted to options
+        assert web_search_options.get("search_context_size") == "high"
+
+    def test_transform_function_tools_parameters_with_missing_type(self):
+        """Test that parameters get 'type': 'object' added if missing"""
+        function_tool = {
+            "type": "function",
+            "name": "test_function",
+            "description": "Test function",
+            "parameters": {
+                "properties": {
+                    "arg": {"type": "string"}
+                }
+            }
+        }
+        
+        tools = [function_tool]
+        
+        # Execute
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 1
+        result_tool = result_tools[0]
+        assert result_tool["function"]["parameters"]["type"] == "object"
+        assert "properties" in result_tool["function"]["parameters"]
+
+    def test_transform_function_tools_empty_parameters(self):
+        """Test that empty parameters get 'type': 'object' added"""
+        function_tool = {
+            "type": "function",
+            "name": "test_function",
+            "description": "Test function",
+            "parameters": {}
+        }
+        
+        tools = [function_tool]
+        
+        # Execute
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 1
+        result_tool = result_tools[0]
+        assert result_tool["function"]["parameters"]["type"] == "object"
+
+    def test_transform_function_tools_missing_parameters(self):
+        """Test that missing parameters get default 'type': 'object' added"""
+        function_tool = {
+            "type": "function",
+            "name": "test_function",
+            "description": "Test function"
+        }
+        
+        tools = [function_tool]
+        
+        # Execute
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 1
+        result_tool = result_tools[0]
+        assert result_tool["function"]["parameters"]["type"] == "object"
+
+    def test_transform_function_tools_preserves_existing_type(self):
+        """Test that existing 'type': 'object' in parameters is preserved"""
+        function_tool = {
+            "type": "function",
+            "name": "test_function",
+            "description": "Test function",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "arg": {"type": "string"}
+                }
+            }
+        }
+        
+        tools = [function_tool]
+        
+        # Execute
+        result_tools, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            tools=tools
+        )
+        
+        # Assert
+        assert len(result_tools) == 1
+        result_tool = result_tools[0]
+        assert result_tool["function"]["parameters"]["type"] == "object"
+        assert "properties" in result_tool["function"]["parameters"]
+        assert result_tool["function"]["parameters"]["properties"]["arg"]["type"] == "string"
+
+
 class TestUsageTransformation:
     """Test cases for usage transformation from Chat Completion to Responses API format"""
 


### PR DESCRIPTION
## Title

Add provider specific tools support in responses api

## Relevant issues

Fixes #17871

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix
🧹 Refactoring

## Changes
- Added provider specific tools handling in responses to completion transfromation class'


## Testing

<img width="1108" height="404" alt="image" src="https://github.com/user-attachments/assets/85c0671c-f299-44c6-b4e9-8c722767b38f" />


