### PR TITLE
Fix: VertexAI "Exception occured - api_base is required. Unable to determine the correct api_base for the request."

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -26,9 +26,9 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
 
         Validate the environment for the request
         """
-            vertex_ai_project = VertexBase.get_vertex_ai_project(litellm_params)
-            vertex_credentials = VertexBase.get_vertex_ai_credentials(litellm_params)
-            vertex_ai_location = VertexBase.get_vertex_ai_location(litellm_params)
+        vertex_ai_project = VertexBase.get_vertex_ai_project(litellm_params)
+        vertex_credentials = VertexBase.get_vertex_ai_credentials(litellm_params)
+        vertex_ai_location = VertexBase.get_vertex_ai_location(litellm_params)
         
         if "Authorization" not in headers:
             access_token, project_id = self._ensure_access_token(

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -26,11 +26,11 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
 
         Validate the environment for the request
         """
-        if "Authorization" not in headers:
             vertex_ai_project = VertexBase.get_vertex_ai_project(litellm_params)
             vertex_credentials = VertexBase.get_vertex_ai_credentials(litellm_params)
             vertex_ai_location = VertexBase.get_vertex_ai_location(litellm_params)
-
+        
+        if "Authorization" not in headers:
             access_token, project_id = self._ensure_access_token(
                 credentials=vertex_credentials,
                 project_id=vertex_ai_project,
@@ -38,7 +38,9 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
             )
 
             headers["Authorization"] = f"Bearer {access_token}"
-
+        
+        if api_base is None:
+            
             api_base = self.get_complete_vertex_url(
                 custom_api_base=api_base,
                 vertex_location=vertex_ai_location,


### PR DESCRIPTION
## Title

Fixing a bug that we appeared today after we upgraded from 1.80.5-stable to 1.80.8-stable.

Our config:
```yaml
  - model_name: claude-opus-4-5-20251101
    litellm_params:
      model: vertex_ai/claude-opus-4-5@20251101
      vertex_credentials: "/mnt/vertex.json" 
      vertex_project: "vertex-ai-poc-415000"
      vertex_location: "us-east5"
      extra_headers: {"anthropic-beta": "web-search-2025-03-05"}
      web_search_options: {}  # Enables web search with default setting

```

The error we have is `Exception occured - api_base is required. Unable to determine the correct api_base for the request."`

From a quick analysis of the stack trace, it seems the logic on how headers are read has changed between the 2 versions and the api is no longer. 

Let me know if you think this is the right approach.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->

🐛 Bug Fix

## Changes


