### PR TITLE
Propagate token usage when generating images with Gemini

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
@@ -141,7 +141,22 @@ class TestVertexAIGeminiImageGenerationConfig:
                         ]
                     }
                 }
-            ]
+            ],
+            "usageMetadata": {
+                "promptTokenCount": 93,
+                "promptTokensDetails": [
+                    {
+                        "modality": "TEXT",
+                        "tokenCount": 54,
+                    },
+                    {
+                        "modality": "IMAGE",
+                        "tokenCount": 39,
+                    }
+                ],
+                "candidatesTokenCount": 17,
+                "totalTokenCount": 110,
+            }
         }
         mock_response.headers = {}
 
@@ -162,6 +177,12 @@ class TestVertexAIGeminiImageGenerationConfig:
         assert len(result.data) == 1
         assert result.data[0].b64_json == "base64_encoded_image_data"
         assert result.data[0].url is None
+        assert result.usage.input_tokens == 93
+        assert result.usage.input_tokens_details.text_tokens == 54
+        assert result.usage.input_tokens_details.image_tokens == 39
+        assert result.usage.output_tokens == 17
+        assert result.usage.total_tokens == 110
+
 
     def test_transform_image_generation_response_multiple_images(self):
         """Test response transformation with multiple images"""


### PR DESCRIPTION
## Title

Propagate token usage details when generating images with Gemini

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1496" height="224" alt="Screenshot 2025-12-15 at 4 44 54 PM" src="https://github.com/user-attachments/assets/29d536f2-280e-4cb7-97a3-18abe56ca680" />

## Type

🧹 Refactoring

## Changes

Gemini responds with sufficient token usage information that can be propagated down the stream. This PR attempts to map those values to OpenAI format
