### PR TITLE
fix: add headers to metadata for guardrails on pass-through endpoints

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -843,6 +843,11 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
         )
     )
 
+    # Add headers to metadata for guardrails to access (fixes #17477)
+    # Guardrails use metadata["headers"] to access request headers (e.g., User-Agent)
+    if _metadata_variable_name in data and isinstance(data[_metadata_variable_name], dict):
+        data[_metadata_variable_name]["headers"] = _headers
+
     # check for forwardable headers
     data = LiteLLMProxyRequestSetup.add_headers_to_llm_call_by_model_group(
         data=data, headers=_headers, user_api_key_dict=user_api_key_dict


### PR DESCRIPTION
## Summary
Fixes #17477

Guardrails couldn't access request headers (like User-Agent) on Bedrock pass-through endpoints because headers were only stored in `data["proxy_server_request"]["headers"]` but not in `data["metadata"]["headers"]` where guardrails typically look for them.

This fix adds headers to metadata in `add_litellm_data_to_request()` so guardrails can access User-Agent, API keys, and other header-based checks on all endpoints including Bedrock pass-through.

## Changes
- Added headers to `data[metadata]["headers"]` in `litellm/proxy/litellm_pre_call_utils.py`
- Added test to verify headers are available in metadata for guardrails

## Test plan
- [x] Unit test added: `test_add_litellm_data_to_request_adds_headers_to_metadata`
- [x] Manual testing confirmed guardrails can now access User-Agent on Bedrock pass-through