### PR TITLE
feat(custom_llm): add image_edit and aimage_edit support

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -702,6 +702,59 @@ def image_edit(
             custom_llm_provider=custom_llm_provider,
         )
 
+        # Check for custom provider
+        if custom_llm_provider in litellm._custom_providers:
+            custom_handler: Optional[CustomLLM] = None
+            for item in litellm.custom_provider_map:
+                if item["provider"] == custom_llm_provider:
+                    custom_handler = item["custom_handler"]
+
+            if custom_handler is None:
+                raise LiteLLMUnknownProvider(
+                    model=model, custom_llm_provider=custom_llm_provider
+                )
+
+            model_response = ImageResponse()
+
+            if _is_async:
+                async_custom_client: Optional[AsyncHTTPHandler] = None
+                if kwargs.get("client") is not None and isinstance(
+                    kwargs.get("client"), AsyncHTTPHandler
+                ):
+                    async_custom_client = kwargs.get("client")
+
+                return custom_handler.aimage_edit(
+                    model=model,
+                    image=images,
+                    prompt=prompt,
+                    model_response=model_response,
+                    api_key=kwargs.get("api_key"),
+                    api_base=kwargs.get("api_base"),
+                    optional_params=kwargs,
+                    logging_obj=litellm_logging_obj,
+                    timeout=timeout,
+                    client=async_custom_client,
+                )
+            else:
+                custom_client: Optional[HTTPHandler] = None
+                if kwargs.get("client") is not None and isinstance(
+                    kwargs.get("client"), HTTPHandler
+                ):
+                    custom_client = kwargs.get("client")
+
+                return custom_handler.image_edit(
+                    model=model,
+                    image=images,
+                    prompt=prompt,
+                    model_response=model_response,
+                    api_key=kwargs.get("api_key"),
+                    api_base=kwargs.get("api_base"),
+                    optional_params=kwargs,
+                    logging_obj=litellm_logging_obj,
+                    timeout=timeout,
+                    client=custom_client,
+                )
+
         # get provider config
         image_edit_provider_config: Optional[BaseImageEditConfig] = (
             ProviderConfigManager.get_provider_image_edit_config(

--- a/litellm/llms/custom_llm.py
+++ b/litellm/llms/custom_llm.py
@@ -197,6 +197,36 @@ class CustomLLM(BaseLLM):
     ) -> EmbeddingResponse:
         raise CustomLLMError(status_code=500, message="Not implemented yet!")
 
+    def image_edit(
+        self,
+        model: str,
+        image: Any,
+        prompt: str,
+        model_response: ImageResponse,
+        api_key: Optional[str],
+        api_base: Optional[str],
+        optional_params: dict,
+        logging_obj: Any,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
+        client: Optional[HTTPHandler] = None,
+    ) -> ImageResponse:
+        raise CustomLLMError(status_code=500, message="Not implemented yet!")
+
+    async def aimage_edit(
+        self,
+        model: str,
+        image: Any,
+        prompt: str,
+        model_response: ImageResponse,
+        api_key: Optional[str],
+        api_base: Optional[str],
+        optional_params: dict,
+        logging_obj: Any,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
+        client: Optional[AsyncHTTPHandler] = None,
+    ) -> ImageResponse:
+        raise CustomLLMError(status_code=500, message="Not implemented yet!")
+
 
 def custom_chat_llm_router(
     async_fn: bool, stream: Optional[bool], custom_llm: CustomLLM

--- a/tests/local_testing/test_custom_llm.py
+++ b/tests/local_testing/test_custom_llm.py
@@ -309,6 +309,44 @@ class MyCustomLLM(CustomLLM):
 
         return model_response
 
+    def image_edit(
+        self,
+        model: str,
+        image: Any,
+        prompt: str,
+        model_response: ImageResponse,
+        api_key: Optional[str],
+        api_base: Optional[str],
+        optional_params: dict,
+        logging_obj: Any,
+        timeout=None,
+        client: Optional[HTTPHandler] = None,
+    ) -> ImageResponse:
+        return ImageResponse(
+            created=int(time.time()),
+            data=[ImageObject(url="https://example.com/edited-image.png")],
+            response_ms=1000,
+        )
+
+    async def aimage_edit(
+        self,
+        model: str,
+        image: Any,
+        prompt: str,
+        model_response: ImageResponse,
+        api_key: Optional[str],
+        api_base: Optional[str],
+        optional_params: dict,
+        logging_obj: Any,
+        timeout=None,
+        client: Optional[AsyncHTTPHandler] = None,
+    ) -> ImageResponse:
+        return ImageResponse(
+            created=int(time.time()),
+            data=[ImageObject(url="https://example.com/edited-image.png")],
+            response_ms=1000,
+        )
+
 
 def test_get_llm_provider():
     """"""
@@ -449,6 +487,69 @@ async def test_image_generation_async_additional_params():
         mock_client.call_args.kwargs["optional_params"] == {
             "my_custom_param": "my-custom-param"
         }
+
+
+def test_simple_image_edit():
+    """Test sync image_edit with custom handler"""
+    my_custom_llm = MyCustomLLM()
+    litellm.custom_provider_map = [
+        {"provider": "custom_llm", "custom_handler": my_custom_llm}
+    ]
+    resp = litellm.image_edit(
+        model="custom_llm/my-fake-model",
+        image=b"fake_image_bytes",
+        prompt="Edit this image",
+    )
+
+    print(resp)
+    assert resp.data[0].url == "https://example.com/edited-image.png"
+
+
+@pytest.mark.asyncio
+async def test_simple_image_edit_async():
+    """Test async image_edit with custom handler"""
+    my_custom_llm = MyCustomLLM()
+    litellm.custom_provider_map = [
+        {"provider": "custom_llm", "custom_handler": my_custom_llm}
+    ]
+    resp = await litellm.aimage_edit(
+        model="custom_llm/my-fake-model",
+        image=b"fake_image_bytes",
+        prompt="Edit this image",
+    )
+
+    print(resp)
+    assert resp.data[0].url == "https://example.com/edited-image.png"
+
+
+@pytest.mark.asyncio
+async def test_image_edit_async_additional_params():
+    """Test that additional params are passed to custom handler"""
+    my_custom_llm = MyCustomLLM()
+    litellm.custom_provider_map = [
+        {"provider": "custom_llm", "custom_handler": my_custom_llm}
+    ]
+
+    with patch.object(
+        my_custom_llm, "aimage_edit", new=AsyncMock(return_value=ImageResponse(
+            created=int(time.time()),
+            data=[ImageObject(url="https://example.com/edited-image.png")],
+        ))
+    ) as mock_client:
+        resp = await litellm.aimage_edit(
+            model="custom_llm/my-fake-model",
+            image=b"fake_image_bytes",
+            prompt="Edit this image",
+            api_key="my-api-key",
+            api_base="my-api-base",
+            my_custom_param="my-custom-param",
+        )
+
+        print(resp)
+
+        mock_client.assert_awaited_once()
+        assert mock_client.call_args.kwargs["api_key"] == "my-api-key"
+        assert mock_client.call_args.kwargs["api_base"] == "my-api-base"
 
 
 def test_get_supported_openai_params():


### PR DESCRIPTION
## Title

Add image_edit and aimage_edit support to CustomLLM

## Relevant issues

Closes #17982

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

This PR adds support for `image_edit` and `aimage_edit` methods in the `CustomLLM` class, allowing users to implement custom image editing providers (like Stability AI, Black Forest Labs, etc.) without modifying LiteLLM's core code.

### What was added:

1. **`litellm/llms/custom_llm.py`**
   - Added `image_edit()` method signature
   - Added `aimage_edit()` method signature

2. **`litellm/images/main.py`**
   - Added custom provider detection in `image_edit()` function
   - Routes to custom handler when provider is in `litellm._custom_providers`

3. **`tests/local_testing/test_custom_llm.py`**
   - Added `image_edit` and `aimage_edit` methods to `MyCustomLLM` test class
   - Added `test_simple_image_edit()` test
   - Added `test_simple_image_edit_async()` test
   - Added `test_image_edit_async_additional_params()` test

4. **`docs/my-website/docs/providers/custom_llm_server.md`**
   - Added `/v1/images/edits` to supported routes
   - Added "Image Edit" section with usage example
   - Updated "Custom Handler Spec" with `image_edit` and `aimage_edit` methods

### Example usage:

```python
from litellm import CustomLLM, ImageResponse
from litellm.types.utils import ImageObject

class MyImageEditHandler(CustomLLM):
    def image_edit(self, model, image, prompt, **kwargs):
        # Your custom logic here
        return ImageResponse(
            created=123,
            data=[ImageObject(url="https://...")]
        )

litellm.custom_provider_map = [
    {"provider": "my_provider", "custom_handler": MyImageEditHandler()}
]

response = litellm.image_edit(
    model="my_provider/my-model",
    image=open("image.png", "rb"),
    prompt="Edit this image",
)
```

### Test results:

```
$ poetry run pytest tests/local_testing/test_custom_llm.py::test_simple_image_edit tests/local_testing/test_custom_llm.py::test_simple_image_edit_async tests/local_testing/test_custom_llm.py::test_image_edit_async_additional_params -v

tests/local_testing/test_custom_llm.py::test_image_edit_async_additional_params PASSED [ 33%]
tests/local_testing/test_custom_llm.py::test_simple_image_edit PASSED            [ 66%]
tests/local_testing/test_custom_llm.py::test_simple_image_edit_async PASSED      [100%]

======================== 3 passed in 0.11s ========================
```