### PR TITLE
fix(text_completion): support token IDs (list of integers) as prompt

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5460,11 +5460,9 @@ def text_completion(  # noqa: PLR0915
         )
         and isinstance(prompt, list)
         and len(prompt) > 0
-        and isinstance(prompt[0], list)
+        and (isinstance(prompt[0], list) or isinstance(prompt[0], int))
     ):
-        verbose_logger.warning(
-            msg="List of lists being passed. If this is for tokens, then it might not work across all models."
-        )
+        # Support for token IDs as prompt (list of integers or list of lists of integers)
         messages = [{"role": "user", "content": prompt}]  # type: ignore
     else:
         raise Exception(

--- a/tests/local_testing/test_text_completion.py
+++ b/tests/local_testing/test_text_completion.py
@@ -3917,6 +3917,28 @@ def test_completion_text_003_prompt_array():
 # test_completion_text_003_prompt_array()
 
 
+def test_completion_prompt_token_ids():
+    """
+    Test text_completion with a list of token IDs (integers).
+    This tests the fix for https://github.com/BerriAI/litellm/issues/17118
+    """
+    try:
+        # Token IDs for "Hello world" in GPT tokenizer
+        token_ids = [15496, 995]
+        response = text_completion(
+            model="gpt-3.5-turbo-instruct",
+            prompt=token_ids,
+            max_tokens=5,
+        )
+        print("\n\n response for token IDs prompt")
+        print(response)
+        assert response is not None
+        assert response.choices[0].text is not None
+        assert response.usage.prompt_tokens == 2
+    except Exception as e:
+        pytest.fail(f"Error occurred: {e}")
+
+
 # not including this in our ci cd pipeline, since we don't want to fail tests due to an unstable replit
 # def test_text_completion_with_proxy():
 #     try:

--- a/tests/local_testing/test_text_completion.py
+++ b/tests/local_testing/test_text_completion.py
@@ -3917,28 +3917,6 @@ def test_completion_text_003_prompt_array():
 # test_completion_text_003_prompt_array()
 
 
-def test_completion_prompt_token_ids():
-    """
-    Test text_completion with a list of token IDs (integers).
-    This tests the fix for https://github.com/BerriAI/litellm/issues/17118
-    """
-    try:
-        # Token IDs for "Hello world" in GPT tokenizer
-        token_ids = [15496, 995]
-        response = text_completion(
-            model="gpt-3.5-turbo-instruct",
-            prompt=token_ids,
-            max_tokens=5,
-        )
-        print("\n\n response for token IDs prompt")
-        print(response)
-        assert response is not None
-        assert response.choices[0].text is not None
-        assert response.usage.prompt_tokens == 2
-    except Exception as e:
-        pytest.fail(f"Error occurred: {e}")
-
-
 # not including this in our ci cd pipeline, since we don't want to fail tests due to an unstable replit
 # def test_text_completion_with_proxy():
 #     try:

--- a/tests/test_litellm/llms/openai/completion/test_text_completion_token_ids.py
+++ b/tests/test_litellm/llms/openai/completion/test_text_completion_token_ids.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for text_completion with token IDs (list of integers) as prompt.
+Tests the fix for https://github.com/BerriAI/litellm/issues/17118
+"""
+
+import os
+import sys
+
+import pytest
+import respx
+from httpx import Response
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+import litellm
+from litellm import text_completion
+
+
+@pytest.fixture(autouse=True)
+def setup_env(monkeypatch):
+    """Set up test environment variables."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-key")
+
+
+@pytest.fixture
+def text_completion_response():
+    """Mock response for text completion API."""
+    return {
+        "id": "cmpl-test123",
+        "object": "text_completion",
+        "created": 1677652288,
+        "model": "gpt-3.5-turbo-instruct",
+        "choices": [
+            {
+                "text": " is a greeting",
+                "index": 0,
+                "logprobs": None,
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 2, "completion_tokens": 4, "total_tokens": 6},
+    }
+
+
+class TestTextCompletionTokenIds:
+    """Test text_completion with token IDs as prompt."""
+
+    @respx.mock
+    def test_completion_prompt_token_ids(
+        self, text_completion_response, monkeypatch
+    ):
+        """
+        Test text_completion with a list of token IDs (integers).
+        This tests the fix for https://github.com/BerriAI/litellm/issues/17118
+        """
+        # Token IDs for "Hello world" in GPT tokenizer
+        token_ids = [15496, 995]
+
+        # Mock the OpenAI completions endpoint
+        respx.post("https://api.openai.com/v1/completions").mock(
+            return_value=Response(200, json=text_completion_response)
+        )
+
+        response = text_completion(
+            model="gpt-3.5-turbo-instruct",
+            prompt=token_ids,
+            max_tokens=5,
+        )
+
+        assert response is not None
+        assert response.choices[0].text is not None
+        assert response.usage.prompt_tokens == 2
+
+    @respx.mock
+    def test_completion_prompt_token_ids_batch(
+        self, text_completion_response, monkeypatch
+    ):
+        """
+        Test text_completion with multiple prompts as token IDs.
+        """
+        # Multiple token ID lists (batch)
+        token_ids_batch = [[15496, 995], [9906, 0]]
+
+        # Update mock response for batch
+        batch_response = {
+            **text_completion_response,
+            "choices": [
+                {
+                    "text": " is a greeting",
+                    "index": 0,
+                    "logprobs": None,
+                    "finish_reason": "stop",
+                },
+                {
+                    "text": " is another",
+                    "index": 1,
+                    "logprobs": None,
+                    "finish_reason": "stop",
+                },
+            ],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 6, "total_tokens": 10},
+        }
+
+        respx.post("https://api.openai.com/v1/completions").mock(
+            return_value=Response(200, json=batch_response)
+        )
+
+        response = text_completion(
+            model="gpt-3.5-turbo-instruct",
+            prompt=token_ids_batch,
+            max_tokens=5,
+        )
+
+        assert response is not None
+        assert len(response.choices) == 2


### PR DESCRIPTION
## Title

fix(text_completion): support token IDs (list of integers) as prompt

## Relevant issues

Fixes #17118

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Summary

Added support for passing token IDs (list of integers) to the `/v1/completions` endpoint for OpenAI-compatible providers.
Users couldn't pass token IDs as prompt to the text_completion endpoint. 

### Example Request

```python
import litellm

response = litellm.text_completion(
    model="gpt-3.5-turbo-instruct",
    prompt=[15496, 995],  # Token IDs for "Hello world"
    max_tokens=10
)
print(response.choices[0].text)
```

```
Unmapped prompt format. Your prompt is neither a list of strings nor a string.
```
### Solution
Extended the existing condition that handles `list[list]` (array of token arrays) to also handle `list[int]` (array of tokens):
This only affects OpenAI-compatible providers (openai, azure, azure_text, text-completion-codestral, text-completion-openai) which includes vLLM and other compatible backends.