### PR TITLE
fix(gemini): use JSON instead of form-data for image edit requests

### DIFF
--- a/litellm/llms/base_llm/image_edit/transformation.py
+++ b/litellm/llms/base_llm/image_edit/transformation.py
@@ -109,6 +109,15 @@ class BaseImageEditConfig(ABC):
     ) -> ImageResponse:
         pass
 
+    def use_multipart_form_data(self) -> bool:
+        """
+        Return True if the provider uses multipart/form-data for image edit requests.
+        Return False if the provider uses JSON requests.
+
+        Default is True for backwards compatibility with OpenAI-style providers.
+        """
+        return True
+
     def get_error_class(
         self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
     ) -> BaseLLMException:

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -3768,13 +3768,24 @@ class BaseLLMHTTPHandler:
         )
 
         try:
-            response = sync_httpx_client.post(
-                url=api_base,
-                headers=headers,
-                data=data,
-                files=files,
-                timeout=timeout,
-            )
+            # Check if provider uses multipart/form-data or JSON
+            if image_edit_provider_config.use_multipart_form_data():
+                # Use form-data (OpenAI style)
+                response = sync_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    data=data,
+                    files=files,
+                    timeout=timeout,
+                )
+            else:
+                # Use JSON (Gemini style)
+                response = sync_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    json=data,
+                    timeout=timeout,
+                )
 
         except Exception as e:
             raise self._handle_error(
@@ -3853,13 +3864,24 @@ class BaseLLMHTTPHandler:
         )
 
         try:
-            response = await async_httpx_client.post(
-                url=api_base,
-                headers=headers,
-                data=data,
-                files=files,
-                timeout=timeout,
-            )
+            # Check if provider uses multipart/form-data or JSON
+            if image_edit_provider_config.use_multipart_form_data():
+                # Use form-data (OpenAI style)
+                response = await async_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    data=data,
+                    files=files,
+                    timeout=timeout,
+                )
+            else:
+                # Use JSON (Gemini style)
+                response = await async_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    json=data,
+                    timeout=timeout,
+                )
 
         except Exception as e:
             raise self._handle_error(

--- a/litellm/llms/gemini/image_edit/transformation.py
+++ b/litellm/llms/gemini/image_edit/transformation.py
@@ -63,6 +63,10 @@ class GeminiImageEditConfig(BaseImageEditConfig):
         headers["Content-Type"] = "application/json"
         return headers
 
+    def use_multipart_form_data(self) -> bool:
+        """Gemini uses JSON requests, not multipart/form-data."""
+        return False
+
     def get_complete_url(
         self,
         model: str,

--- a/tests/test_litellm/llms/gemini/image_edit/test_gemini_image_edit_transformation.py
+++ b/tests/test_litellm/llms/gemini/image_edit/test_gemini_image_edit_transformation.py
@@ -147,3 +147,14 @@ class TestGeminiImageEditTransformation:
                 headers={},
             )
 
+    def test_use_multipart_form_data_returns_false(self) -> None:
+        """
+        Gemini uses JSON requests, not multipart/form-data.
+        This is critical because httpx sends data differently:
+        - data=dict sends form-encoded
+        - json=dict sends JSON
+
+        Without this, Gemini returns: "Invalid JSON payload received. Unexpected token."
+        """
+        assert self.config.use_multipart_form_data() is False
+


### PR DESCRIPTION
## Title

Fix Gemini image edit - use JSON instead of form-data

## Relevant issues

Fixes #17189

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Gemini's image edit API expects a JSON body, but the handler was sending form-encoded data, causing 400 errors:

```
Invalid JSON payload received. Unexpected token.
contents=%7B%27parts
```
### Usage

```python
import litellm

response = litellm.image_edit(
    model="gemini/gemini-2.0-flash-exp",
    image=open("image.png", "rb").read(),
    prompt="Add a red hat",
)
```

### Fix

- Add `use_multipart_form_data()` method to `BaseImageEditConfig` (defaults to `True` for backwards compatibility)
- Modify `image_edit_handler` to use `json=data` when `use_multipart_form_data()` returns `False`
- Override in `GeminiImageEditConfig` to return `False`