### PR TITLE
[Feature] Add LiteLLM Overhead to Logs

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2664,6 +2664,9 @@ class SpendLogsMetadata(TypedDict):
     cold_storage_object_key: Optional[
         str
     ]  # S3/GCS object key for cold storage retrieval
+    litellm_overhead_time_ms: Optional[
+        float
+    ]  # LiteLLM overhead time in milliseconds
 
 
 class SpendLogsPayload(TypedDict):

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1680,7 +1680,7 @@ async def ui_view_spend_logs(  # noqa: PLR0915
     ),
 ):
     """
-    View spend logs with pagination support
+    View spend logs with pagination support.
     Available at both `/spend/logs/v2` (public API) and `/spend/logs/ui` (internal UI).
 
     Returns paginated response with data, total, page, page_size, and total_pages.

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1680,7 +1680,7 @@ async def ui_view_spend_logs(  # noqa: PLR0915
     ),
 ):
     """
-    View spend logs with pagination support.
+    View spend logs with pagination support
     Available at both `/spend/logs/v2` (public API) and `/spend/logs/ui` (internal UI).
 
     Returns paginated response with data, total, page, page_size, and total_pages.

--- a/tests/logging_callback_tests/test_gcs_pub_sub.py
+++ b/tests/logging_callback_tests/test_gcs_pub_sub.py
@@ -39,6 +39,7 @@ ignored_keys = [
     "metadata.model_map_information",
     "metadata.usage_object",
     "metadata.cold_storage_object_key",
+    "metadata.litellm_overhead_time_ms",
 ]
 
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -201,6 +201,7 @@ ignored_keys = [
     "metadata.usage_object",
     "metadata.cold_storage_object_key",
     "metadata.additional_usage_values.prompt_tokens_details.cache_creation_tokens",
+    "metadata.litellm_overhead_time_ms",
 ]
 
 MODEL_LIST = [


### PR DESCRIPTION
## Relevant issues
LiteLLM already calculates the overhead, but this information is not included anywhere inside of the logs page. This PR includes the changes needed for the backend to surface logs with litellm_overhead_ms in the metadata of /spend/logs/ui

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/51748/workflows/bac7be12-2fa1-4588-9fe0-1867284b6a10

- [ ] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/51854/workflows/04c8d64b-1df7-47f4-b2d1-1a79a95a92bd

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="727" height="179" alt="image" src="https://github.com/user-attachments/assets/90943418-fb9a-4d49-a437-280515f4ded4" />
