### PR TITLE
Add custom headers in responses API

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -430,6 +430,18 @@ def convert_to_model_response_object(  # noqa: PLR0915
 
     if hidden_params is None:
         hidden_params = {}
+    
+    # Preserve existing additional_headers if they contain important provider headers
+    # For responses API, additional_headers may already be set with LLM provider headers
+    existing_additional_headers = hidden_params.get("additional_headers", {})
+    if existing_additional_headers and _response_headers is None:
+        # Keep existing headers when _response_headers is None (responses API case)
+        additional_headers = existing_additional_headers
+    else:
+        # Merge new headers with existing ones
+        if existing_additional_headers:
+            additional_headers.update(existing_additional_headers)
+    
     hidden_params["additional_headers"] = additional_headers
 
     ### CHECK IF ERROR IN RESPONSE ### - openrouter returns these in the dictionary

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.core_helpers import process_response_headers
 from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
     _safe_convert_created_field,
 )
@@ -15,7 +16,7 @@ from litellm.types.llms.openai import *
 from litellm.types.responses.main import *
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
-from litellm.litellm_core_utils.core_helpers import process_response_headers
+
 from ..common_utils import OpenAIError
 
 if TYPE_CHECKING:
@@ -181,6 +182,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
             )
             response = ResponsesAPIResponse.model_construct(**raw_response_json)
         
+        # Store processed headers in additional_headers so they get returned to the client
         response._hidden_params["additional_headers"] = processed_headers
         response._hidden_params["headers"] = raw_response_headers
         return response

--- a/tests/llm_responses_api_testing/test_azure_responses_api.py
+++ b/tests/llm_responses_api_testing/test_azure_responses_api.py
@@ -182,3 +182,94 @@ async def test_azure_responses_api_status_error():
         f"Expected: {json.dumps(expected_input, indent=2)}\n"
         f"Got: {json.dumps(captured_request_body['input'], indent=2)}"
     )
+
+
+@pytest.mark.asyncio
+async def test_azure_responses_api_headers_with_llm_provider_prefix():
+    """
+    Test that Azure-specific headers like 'x-request-id' and 'apim-request-id'
+    are properly forwarded with 'llm_provider-' prefix in response._hidden_params["headers"].
+    
+    Issue: https://github.com/BerriAI/litellm/issues/16538
+    
+    The fix ensures that processed headers (with llm_provider- prefix) are stored
+    in response._hidden_params["headers"] instead of additional_headers, making them
+    accessible via completion.headers in the same way as the completion API.
+    """
+    import json
+    import httpx
+
+    mock_response_data = {
+        "id": "resp_123",
+        "object": "response",
+        "created_at": 1234567890,
+        "model": "gpt-5-codex",
+        "status": "completed",
+        "output": [
+            {
+                "id": "msg_123",
+                "role": "assistant",
+                "type": "message",
+                "content": [{"type": "output_text", "text": "Hello!"}],
+            }
+        ],
+    }
+
+    # Mock headers that Azure returns - exactly like in the issue
+    mock_headers = {
+        "date": "Wed, 12 Nov 2025 15:31:28 GMT",
+        "server": "uvicorn",
+        "content-type": "application/json",
+        "x-ratelimit-remaining-tokens": "5010000",
+        "x-ratelimit-limit-tokens": "5010000",
+        # These are the Azure-specific headers that should be forwarded with llm_provider- prefix
+        "x-request-id": "12086715-aca3-4006-a29f-2f1e1d552043",
+        "apim-request-id": "25664b0d-cf4b-4e10-8d27-c7272e7efd49",
+        "x-ms-region": "Sweden Central",
+    }
+
+    async def mock_post(*args, **kwargs):
+        response_content = json.dumps(mock_response_data).encode("utf-8")
+        response = httpx.Response(
+            status_code=200,
+            headers=mock_headers,
+            content=response_content,
+            request=httpx.Request(method="POST", url="https://test.openai.azure.com"),
+        )
+        return response
+
+    with patch.object(AsyncHTTPHandler, "post", new=mock_post):
+        response = await litellm.aresponses(
+            model="azure/gpt-5-codex",
+            api_version="2025-03-01-preview",
+            api_base="https://test.openai.azure.com",
+            api_key="test-key",
+            input="Hello, can you tell me a short joke?",
+        )
+
+    # Check that the response has the expected headers structure
+    assert hasattr(response, "_hidden_params"), "Response should have _hidden_params"
+    assert "additional_headers" in response._hidden_params, (
+        "Response _hidden_params should contain 'additional_headers' with the LLM provider headers"
+    )
+
+    headers = response._hidden_params["additional_headers"]
+    
+    # Verify that Azure-specific headers are present with llm_provider- prefix
+    assert "llm_provider-x-request-id" in headers, (
+        f"Response should contain 'llm_provider-x-request-id' header. "
+        f"Headers: {list(headers.keys())}"
+    )
+    assert "llm_provider-apim-request-id" in headers, (
+        f"Response should contain 'llm_provider-apim-request-id' header. "
+        f"Headers: {list(headers.keys())}"
+    )
+    
+    # Verify the header values match
+    assert headers["llm_provider-x-request-id"] == "12086715-aca3-4006-a29f-2f1e1d552043"
+    assert headers["llm_provider-apim-request-id"] == "25664b0d-cf4b-4e10-8d27-c7272e7efd49"
+    assert headers["llm_provider-x-ms-region"] == "Sweden Central"
+    
+    # Also verify openai-compatible headers are included
+    assert "x-ratelimit-limit-tokens" in headers
+    assert "x-ratelimit-remaining-tokens" in headers


### PR DESCRIPTION
## Relevant issues

Fixes #16538

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix


## Changes
-  Additonal headers were not getting passed in chat completion responses bridge

<img width="1073" height="729" alt="image" src="https://github.com/user-attachments/assets/547460a7-2f47-4fd5-aaca-65e898c578f8" />
