### PR TITLE
Fix/add team member org restriction

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1742,6 +1742,64 @@ async def add_internal_user_to_organization(
         raise Exception(f"Failed to add user to organization: {str(e)}")
 
 
+async def _filter_users_by_organization(
+    prisma_client,
+    organization_id: str,
+    user_id: Optional[str],
+    user_email: Optional[str],
+    skip: int,
+    page_size: int,
+) -> List[LiteLLM_UserTableFiltered]:
+    """
+    Filter users by organization membership.
+
+    Queries the organization membership table to get user IDs in the organization,
+    then filters and returns user details from the user table.
+    """
+    # Get organization memberships
+    org_memberships = await prisma_client.db.litellm_organizationmembership.find_many(
+        where={"organization_id": organization_id}
+    )
+
+    if not org_memberships:
+        return []
+
+    # Extract user IDs from memberships
+    org_user_ids = [m.user_id for m in org_memberships]
+
+    # Build where conditions for user filtering
+    where_conditions: dict = {"user_id": {"in": org_user_ids}}
+
+    if user_id:
+        # Filter by user_id within org members
+        where_conditions["user_id"] = {
+            "in": org_user_ids,
+            "contains": user_id,
+            "mode": "insensitive",
+        }
+
+    if user_email:
+        where_conditions["user_email"] = {
+            "contains": user_email,
+            "mode": "insensitive",
+        }
+
+    # Query users with pagination and filters
+    users: Optional[
+        List[BaseModel]
+    ] = await prisma_client.db.litellm_usertable.find_many(
+        where=where_conditions,
+        skip=skip,
+        take=page_size,
+        order={"created_at": "desc"},
+    )
+
+    if not users:
+        return []
+
+    return [LiteLLM_UserTableFiltered(**user.model_dump()) for user in users]
+
+
 @router.get(
     "/user/filter/ui",
     tags=["Internal User management"],
@@ -1758,6 +1816,10 @@ async def ui_view_users(
     user_email: Optional[str] = fastapi.Query(
         default=None, description="User email in the request parameters"
     ),
+    organization_id: Optional[str] = fastapi.Query(
+        default=None,
+        description="Organization ID to filter users by membership. When provided, only returns users who are members of this organization.",
+    ),
     page: int = fastapi.Query(
         default=1, description="Page number for pagination", ge=1
     ),
@@ -1772,6 +1834,7 @@ async def ui_view_users(
     Args:
         user_id (Optional[str]): Partial user ID to search for
         user_email (Optional[str]): Partial email to search for
+        organization_id (Optional[str]): Filter by organization membership
         page (int): Page number for pagination (starts at 1)
         page_size (int): Number of items per page (max 100)
         user_api_key_dict (UserAPIKeyAuth): User authentication information
@@ -1787,6 +1850,17 @@ async def ui_view_users(
     try:
         # Calculate offset for pagination
         skip = (page - 1) * page_size
+
+        # If organization_id is provided, filter users by organization membership
+        if organization_id:
+            return await _filter_users_by_organization(
+                prisma_client=prisma_client,
+                organization_id=organization_id,
+                user_id=user_id,
+                user_email=user_email,
+                skip=skip,
+                page_size=page_size,
+            )
 
         # Build where conditions based on provided parameters
         where_conditions = {}

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1558,6 +1558,90 @@ async def _validate_team_member_add_permissions(
         )
 
 
+async def _validate_organization_membership(
+    data: TeamMemberAddRequest,
+    complete_team_data: LiteLLM_TeamTable,
+    prisma_client: PrismaClient,
+    user_api_key_cache,
+    proxy_logging_obj,
+) -> None:
+    """
+    Validate that users being added to an organization-scoped team are members of that organization.
+
+    For teams with organization_id set, only users who are members of that organization can be added.
+    For standalone teams (organization_id = None), any proxy user can be added.
+    """
+    # Skip validation for standalone teams
+    if complete_team_data.organization_id is None:
+        return
+
+    # Extract members being added (handle both single Member and List[Member])
+    members_to_check = [data.member] if isinstance(data.member, Member) else data.member
+
+    # Separate IDs and Emails to check
+    user_ids_to_check = set()
+    emails_to_check = set()
+
+    for member in members_to_check:
+        # Skip the default_user_id (global proxy admin)
+        if member.user_id == SpecialProxyStrings.default_user_id.value:
+            continue
+
+        if member.user_id:
+            user_ids_to_check.add(member.user_id)
+        elif member.user_email:
+            emails_to_check.add(member.user_email)
+
+    if not user_ids_to_check and not emails_to_check:
+        return
+
+    valid_ids = set()
+    if user_ids_to_check:
+        memberships = await prisma_client.db.litellm_organizationmembership.find_many(
+            where={
+                "organization_id": complete_team_data.organization_id,
+                "user_id": {"in": list(user_ids_to_check)},
+            }
+        )
+        valid_ids = {m.user_id for m in memberships}
+
+    valid_emails = set()
+    if emails_to_check:
+        # We need to find users who have these emails AND are in the org
+        users = await prisma_client.db.litellm_usertable.find_many(
+            where={
+                "user_email": {"in": list(emails_to_check)},
+                "organization_memberships": {
+                    "some": {"organization_id": complete_team_data.organization_id}
+                },
+            }
+        )
+        valid_emails = {u.user_email for u in users if u.user_email}
+
+    # Validate each member
+    for member in members_to_check:
+        # Skip the default_user_id (global proxy admin)
+        if member.user_id == SpecialProxyStrings.default_user_id.value:
+            continue
+
+        if member.user_id:
+            if member.user_id not in valid_ids:
+                raise HTTPException(
+                    status_code=403,
+                    detail={
+                        "error": f"User ID {member.user_id} is not a member of organization {complete_team_data.organization_id}. Only users who are members of the organization can be added to organization-scoped teams."
+                    },
+                )
+        elif member.user_email:
+            if member.user_email not in valid_emails:
+                raise HTTPException(
+                    status_code=403,
+                    detail={
+                        "error": f"User Email {member.user_email} is not a member of organization {complete_team_data.organization_id}. Only users who are members of the organization can be added to organization-scoped teams."
+                    },
+                )
+
+
 async def _process_team_members(
     data: TeamMemberAddRequest,
     complete_team_data: LiteLLM_TeamTable,
@@ -1792,14 +1876,25 @@ async def team_member_add(
         complete_team_data=complete_team_data,
     )
 
-    updated_team, updated_users, updated_team_memberships = (
-        await _add_team_members_to_team(
-            data=data,
-            complete_team_data=complete_team_data,
-            prisma_client=prisma_client,
-            user_api_key_dict=user_api_key_dict,
-            litellm_proxy_admin_name=litellm_proxy_admin_name,
-        )
+    # Validate organization membership for org-scoped teams
+    await _validate_organization_membership(
+        data=data,
+        complete_team_data=complete_team_data,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
+    )
+
+    (
+        updated_team,
+        updated_users,
+        updated_team_memberships,
+    ) = await _add_team_members_to_team(
+        data=data,
+        complete_team_data=complete_team_data,
+        prisma_client=prisma_client,
+        user_api_key_dict=user_api_key_dict,
+        litellm_proxy_admin_name=litellm_proxy_admin_name,
     )
 
     # Check if updated_team is None

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -62,6 +62,7 @@ async def test_ui_view_users_with_null_email(mocker, caplog):
         user_api_key_dict=UserAPIKeyAuth(user_id="test_user"),
         user_id="test_user",
         user_email=None,
+        organization_id=None,
         page=1,
         page_size=50,
     )

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints_filtering.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints_filtering.py
@@ -1,0 +1,171 @@
+
+import pytest
+from litellm.proxy.management_endpoints.internal_user_endpoints import ui_view_users
+from litellm.proxy._types import UserAPIKeyAuth
+
+@pytest.mark.asyncio
+async def test_ui_view_users_filter_by_organization(mocker):
+    """
+    Test that /user/filter/ui endpoint correctly filters users by organization_id
+    """
+    # Mock the prisma client
+    mock_prisma_client = mocker.MagicMock()
+    
+    # Setup mock organization memberships
+    mock_membership_1 = mocker.MagicMock()
+    mock_membership_1.user_id = "user-in-org-1"
+    
+    mock_membership_2 = mocker.MagicMock()
+    mock_membership_2.user_id = "user-in-org-2"
+
+    async def mock_find_many_memberships(*args, **kwargs):
+        # Verify we're looking for the correct organization
+        assert kwargs.get("where", {}).get("organization_id") == "test-org-id"
+        return [mock_membership_1, mock_membership_2]
+
+    mock_prisma_client.db.litellm_organizationmembership.find_many = mock_find_many_memberships
+
+    # Setup mock users
+    mock_user_1 = mocker.MagicMock()
+    mock_user_1.model_dump.return_value = {
+        "user_id": "user-in-org-1",
+        "user_email": "user1@example.com",
+        "user_role": "internal_user",
+        "created_at": "2024-01-01T00:00:00Z"
+    }
+    
+    mock_user_2 = mocker.MagicMock()
+    mock_user_2.model_dump.return_value = {
+        "user_id": "user-in-org-2",
+        "user_email": "user2@example.com",
+        "user_role": "internal_user",
+        "created_at": "2024-01-01T00:00:00Z"
+    }
+
+    async def mock_find_many_users(*args, **kwargs):
+        # Verify the user filtering logic
+        where = kwargs.get("where", {})
+        
+        # Should filter by user_id IN [org_members]
+        assert "user_id" in where
+        assert "in" in where["user_id"]
+        assert set(where["user_id"]["in"]) == {"user-in-org-1", "user-in-org-2"}
+        
+        return [mock_user_1, mock_user_2]
+
+    mock_prisma_client.db.litellm_usertable.find_many = mock_find_many_users
+
+    # Patch the prisma client import in the endpoint
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    # Call ui_view_users function with organization_id
+    response = await ui_view_users(
+        user_api_key_dict=UserAPIKeyAuth(user_id="admin"),
+        user_id=None,
+        user_email=None,
+        organization_id="test-org-id",
+        page=1,
+        page_size=50
+    )
+
+    # Verify response
+    assert len(response) == 2
+    user_ids = [user.user_id for user in response]
+    assert "user-in-org-1" in user_ids
+    assert "user-in-org-2" in user_ids
+
+@pytest.mark.asyncio
+async def test_ui_view_users_filter_by_organization_empty(mocker):
+    """
+    Test that /user/filter/ui endpoint returns empty list when organization has no members
+    """
+    # Mock the prisma client
+    mock_prisma_client = mocker.MagicMock()
+    
+    # Return empty list for memberships
+    async def mock_find_many_memberships(*args, **kwargs):
+        return []
+
+    mock_prisma_client.db.litellm_organizationmembership.find_many = mock_find_many_memberships
+    
+    # Mock users find_many (should not be called if no memberships, but just in case)
+    mock_prisma_client.db.litellm_usertable.find_many = mocker.AsyncMock(return_value=[])
+
+    # Patch the prisma client import in the endpoint
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    # Call ui_view_users function
+    response = await ui_view_users(
+        user_api_key_dict=UserAPIKeyAuth(user_id="admin"),
+        user_id=None,
+        user_email=None,
+        organization_id="empty-org-id",
+        page=1,
+        page_size=50
+    )
+
+    assert response == []
+
+@pytest.mark.asyncio
+async def test_ui_view_users_filter_by_organization_and_user_id(mocker):
+    """
+    Test that /user/filter/ui endpoint correctly combines organization filter with user_id search
+    """
+    # Mock the prisma client
+    mock_prisma_client = mocker.MagicMock()
+    
+    # Setup mock organization memberships
+    mock_membership_1 = mocker.MagicMock()
+    mock_membership_1.user_id = "user-in-org-1"
+    
+    mock_membership_2 = mocker.MagicMock()
+    mock_membership_2.user_id = "user-in-org-2"
+
+    async def mock_find_many_memberships(*args, **kwargs):
+        return [mock_membership_1, mock_membership_2]
+
+    mock_prisma_client.db.litellm_organizationmembership.find_many = mock_find_many_memberships
+
+    # Setup mock users
+    mock_user_1 = mocker.MagicMock()
+    mock_user_1.model_dump.return_value = {
+        "user_id": "user-in-org-1",
+        "user_email": "user1@example.com",
+        "user_role": "internal_user",
+        "created_at": "2024-01-01T00:00:00Z"
+    }
+
+    async def mock_find_many_users(*args, **kwargs):
+        # Verify the user filtering logic
+        where = kwargs.get("where", {})
+        
+        assert "user_id" in where
+        user_id_condition = where["user_id"]
+        
+        # Check combined conditions
+        assert "in" in user_id_condition
+        assert set(user_id_condition["in"]) == {"user-in-org-1", "user-in-org-2"}
+        
+        assert "contains" in user_id_condition
+        assert user_id_condition["contains"] == "user-in-org-1"
+        
+        return [mock_user_1]
+
+    mock_prisma_client.db.litellm_usertable.find_many = mock_find_many_users
+
+    # Patch the prisma client import in the endpoint
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    # Call ui_view_users function with organization_id AND user_id search
+    response = await ui_view_users(
+        user_api_key_dict=UserAPIKeyAuth(user_id="admin"),
+        user_id="user-in-org-1",
+        user_email=None,
+        organization_id="test-org-id",
+        page=1,
+        page_size=50
+    )
+
+    # Verify response
+    assert len(response) == 1
+    assert response[0].user_id == "user-in-org-1"

--- a/tests/test_litellm/proxy/management_endpoints/test_org_member_edge_cases.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_org_member_edge_cases.py
@@ -1,0 +1,360 @@
+"""
+Test cases specifically for edge cases around organization membership validation
+with varying numbers of members (1 vs 2+) to catch object vs list handling bugs.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi import HTTPException
+
+from litellm.proxy._types import (
+    LiteLLM_TeamTable,
+    LitellmUserRoles,
+    TeamMemberAddRequest,
+    UserAPIKeyAuth,
+)
+
+
+@pytest.mark.asyncio
+async def test_team_member_add_org_with_single_member_reject():
+    """
+    Test rejection when org has EXACTLY 1 member and we try to add someone else.
+
+    This catches bugs where single-item lists might be handled differently than multi-item lists.
+
+    Scenario:
+    - Organization has exactly 1 member: "only-member"
+    - Team belongs to that organization
+    - Try to add "different-user" who is NOT the only member
+    - Expected: 403 Forbidden
+    """
+    from litellm.proxy._types import (
+        LiteLLM_OrganizationTable,
+        LiteLLM_TeamMembership,
+        LiteLLM_UserTable,
+        Member,
+    )
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_add
+
+    team_admin = UserAPIKeyAuth(
+        user_id="only-member",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        team_id="single-member-org-team",
+    )
+
+    # Try to add a user who is NOT the single org member
+    request_data = TeamMemberAddRequest(
+        team_id="single-member-org-team",
+        member=Member(
+            user_id="different-user",
+            role="user",
+        ),
+    )
+
+    mock_team = MagicMock(spec=LiteLLM_TeamTable)
+    mock_team.team_id = "single-member-org-team"
+    mock_team.organization_id = "single-member-org"
+    mock_team.members_with_roles = [
+        Member(user_id="only-member", role="admin"),
+    ]
+    mock_team.metadata = None
+    mock_team.model_dump.return_value = {
+        "team_id": "single-member-org-team",
+        "organization_id": "single-member-org",
+        "members_with_roles": [{"user_id": "only-member", "role": "admin"}],
+        "metadata": None,
+        "spend": 0.0,
+    }
+
+    # Mock Membership finding: No members found for "different-user"
+    mock_memberships = []
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma, patch(
+        "litellm.proxy.proxy_server.user_api_key_cache"
+    ), patch("litellm.proxy.proxy_server.proxy_logging_obj"), patch(
+        "litellm.proxy.proxy_server.premium_user", True
+    ), patch(
+        "litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+        new_callable=AsyncMock,
+        return_value=mock_team,
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints._is_user_team_admin",
+        return_value=True,
+    ):
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_organizationmembership.find_many = AsyncMock(
+            return_value=mock_memberships
+        )
+        mock_prisma.db.litellm_usertable.find_many = AsyncMock(return_value=[])
+
+        # Expected: Should reject because different-user is not in the single-member org
+        with pytest.raises(HTTPException) as exc_info:
+            await team_member_add(
+                data=request_data,
+                user_api_key_dict=team_admin,
+            )
+        assert exc_info.value.status_code == 403
+        assert "organization" in str(exc_info.value.detail).lower()
+        assert "different-user" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_team_member_add_org_with_single_member_allow():
+    """
+    Test success when org has EXACTLY 1 member and we add that same member to another team.
+
+    This catches bugs where single-item lists might be handled differently than multi-item lists.
+
+    Scenario:
+    - Organization has exactly 1 member: "only-member"
+    - Team belongs to that organization
+    - Try to add "only-member" (the same user)
+    - Expected: Success
+    """
+    from litellm.proxy._types import (
+        LiteLLM_OrganizationTable,
+        LiteLLM_TeamMembership,
+        LiteLLM_UserTable,
+        Member,
+    )
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_add
+
+    team_admin = UserAPIKeyAuth(
+        user_id="admin-user",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+
+    # Try to add the only member of the org to a team
+    request_data = TeamMemberAddRequest(
+        team_id="single-member-org-team",
+        member=Member(
+            user_id="only-member",
+            role="user",
+        ),
+    )
+
+    mock_team = MagicMock(spec=LiteLLM_TeamTable)
+    mock_team.team_id = "single-member-org-team"
+    mock_team.organization_id = "single-member-org"
+    mock_team.members_with_roles = []
+    mock_team.metadata = None
+    mock_team.model_dump.return_value = {
+        "team_id": "single-member-org-team",
+        "organization_id": "single-member-org",
+        "members_with_roles": [],
+        "metadata": None,
+        "spend": 0.0,
+    }
+
+    # Mock Membership finding: "only-member" IS a member
+    mock_membership_record = MagicMock()
+    mock_membership_record.user_id = "only-member"
+    mock_memberships = [mock_membership_record]
+
+    mock_updated_team = MagicMock(spec=LiteLLM_TeamTable)
+    mock_updated_team.team_id = "single-member-org-team"
+    mock_updated_team.organization_id = "single-member-org"
+    mock_updated_team.model_dump.return_value = {
+        "team_id": "single-member-org-team",
+        "organization_id": "single-member-org",
+        "spend": 0.0,
+    }
+
+    mock_user = MagicMock(spec=LiteLLM_UserTable)
+    mock_user.user_id = "only-member"
+    mock_user.model_dump.return_value = {"user_id": "only-member"}
+
+    mock_membership = MagicMock(spec=LiteLLM_TeamMembership)
+    mock_membership.model_dump.return_value = {
+        "user_id": "only-member",
+        "team_id": "single-member-org-team",
+    }
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma, patch(
+        "litellm.proxy.proxy_server.user_api_key_cache"
+    ), patch("litellm.proxy.proxy_server.proxy_logging_obj"), patch(
+        "litellm.proxy.proxy_server.premium_user", True
+    ), patch(
+        "litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+        new_callable=AsyncMock,
+        return_value=mock_team,
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints._is_user_team_admin",
+        return_value=True,
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints._add_team_members_to_team",
+        new_callable=AsyncMock,
+        return_value=(mock_updated_team, [mock_user], [mock_membership]),
+    ):
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_organizationmembership.find_many = AsyncMock(
+            return_value=mock_memberships
+        )
+
+        # Should succeed - only-member is in the single-member org
+        result = await team_member_add(
+            data=request_data,
+            user_api_key_dict=team_admin,
+        )
+
+        assert result.team_id == "single-member-org-team"
+        assert len(result.updated_users) == 1
+
+
+@pytest.mark.asyncio
+async def test_team_member_add_org_with_empty_users_list():
+    """
+    Test rejection when org exists but has NO members (empty users list).
+    """
+    from litellm.proxy._types import (
+        LiteLLM_OrganizationTable,
+        Member,
+    )
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_add
+
+    team_admin = UserAPIKeyAuth(
+        user_id="admin-user",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+
+    request_data = TeamMemberAddRequest(
+        team_id="empty-org-team",
+        member=Member(
+            user_id="some-user",
+            role="user",
+        ),
+    )
+
+    mock_team = MagicMock(spec=LiteLLM_TeamTable)
+    mock_team.team_id = "empty-org-team"
+    mock_team.organization_id = "empty-org"
+    mock_team.members_with_roles = []
+    mock_team.metadata = None
+    mock_team.model_dump.return_value = {
+        "team_id": "empty-org-team",
+        "organization_id": "empty-org",
+        "members_with_roles": [],
+        "metadata": None,
+        "spend": 0.0,
+    }
+
+    # Mock Membership finding: No members
+    mock_memberships = []
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma, patch(
+        "litellm.proxy.proxy_server.user_api_key_cache"
+    ), patch("litellm.proxy.proxy_server.proxy_logging_obj"), patch(
+        "litellm.proxy.proxy_server.premium_user", True
+    ), patch(
+        "litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+        new_callable=AsyncMock,
+        return_value=mock_team,
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints._is_user_team_admin",
+        return_value=True,
+    ):
+        mock_prisma.db = MagicMock()
+        mock_prisma.db.litellm_organizationmembership.find_many = AsyncMock(
+            return_value=mock_memberships
+        )
+        mock_prisma.db.litellm_usertable.find_many = AsyncMock(return_value=[])
+
+        # Expected: Should reject because org has no members matching the request
+        with pytest.raises(HTTPException) as exc_info:
+            await team_member_add(
+                data=request_data,
+                user_api_key_dict=team_admin,
+            )
+        assert exc_info.value.status_code == 403
+        assert "organization" in str(exc_info.value.detail).lower()
+
+
+@pytest.mark.asyncio
+async def test_team_member_add_org_with_email_validation():
+    """
+    Test that email-based member addition validates against organization membership correctly.
+    """
+    from litellm.proxy._types import (
+        LiteLLM_TeamMembership,
+        LiteLLM_UserTable,
+        Member,
+    )
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_add
+
+    team_admin = UserAPIKeyAuth(
+        user_id="admin-user",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+
+    # Try to add a user by email
+    request_data = TeamMemberAddRequest(
+        team_id="email-org-team",
+        member=Member(
+            user_email="valid@example.com",
+            role="user",
+        ),
+    )
+
+    mock_team = MagicMock(spec=LiteLLM_TeamTable)
+    mock_team.team_id = "email-org-team"
+    mock_team.organization_id = "email-org"
+    mock_team.members_with_roles = []
+    mock_team.metadata = None
+    mock_team.model_dump.return_value = {
+        "team_id": "email-org-team",
+        "organization_id": "email-org",
+        "members_with_roles": [],
+        "metadata": None,
+        "spend": 0.0,
+    }
+
+    # Mock finding user by email in org
+    mock_user = MagicMock(spec=LiteLLM_UserTable)
+    mock_user.user_email = "valid@example.com"
+    mock_user.user_id = "valid-user-id"
+    mock_user.model_dump.return_value = {
+        "user_id": "valid-user-id",
+        "user_email": "valid@example.com",
+    }
+
+    mock_updated_team = MagicMock(spec=LiteLLM_TeamTable)
+    mock_updated_team.team_id = "email-org-team"
+    mock_updated_team.organization_id = "email-org"
+    mock_updated_team.model_dump.return_value = {"team_id": "email-org-team"}
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma, patch(
+        "litellm.proxy.proxy_server.user_api_key_cache"
+    ), patch("litellm.proxy.proxy_server.proxy_logging_obj"), patch(
+        "litellm.proxy.proxy_server.premium_user", True
+    ), patch(
+        "litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+        new_callable=AsyncMock,
+        return_value=mock_team,
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints._is_user_team_admin",
+        return_value=True,
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints._add_team_members_to_team",
+        new_callable=AsyncMock,
+        return_value=(mock_updated_team, [mock_user], []),
+    ):
+        mock_prisma.db = MagicMock()
+        # ID check returns empty
+        mock_prisma.db.litellm_organizationmembership.find_many = AsyncMock(
+            return_value=[]
+        )
+        # Email check returns the user
+        mock_prisma.db.litellm_usertable.find_many = AsyncMock(return_value=[mock_user])
+
+        result = await team_member_add(
+            data=request_data,
+            user_api_key_dict=team_admin,
+        )
+        assert result.team_id == "email-org-team"

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints_org_validation.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints_org_validation.py
@@ -1,0 +1,179 @@
+
+import pytest
+from fastapi import HTTPException
+from litellm.proxy.management_endpoints.team_endpoints import team_member_add
+from litellm.proxy._types import TeamMemberAddRequest, Member, UserAPIKeyAuth
+
+@pytest.mark.asyncio
+async def test_team_member_add_org_validation_failure(mocker):
+    """
+    Test that adding a user to an org-scoped team fails if the user is not in the org.
+    """
+    # Mock dependencies
+    mock_prisma_client = mocker.MagicMock()
+    
+    # Mock team with organization_id
+    mock_team_data = {
+        "team_id": "org-team-id",
+        "organization_id": "test-org-id",
+        "team_alias": "test-team",
+        "admins": [],
+        "members": [],
+        "metadata": {}
+    }
+    mock_team_row = mocker.MagicMock()
+    mock_team_row.model_dump.return_value = mock_team_data
+    
+    # Mock get_team_object to return our team
+    mocker.patch(
+        "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+        return_value=mock_team_row
+    )
+    
+    # Mock validation checks
+    mocker.patch("litellm.proxy.management_endpoints.team_endpoints.team_call_validation_checks")
+    mocker.patch("litellm.proxy.management_endpoints.team_endpoints._validate_team_member_add_permissions")
+    
+    # Mock organization membership check to return EMPTY list (user not in org)
+    mock_prisma_client.db.litellm_organizationmembership.find_many = mocker.AsyncMock(return_value=[])
+    
+    # Patch prisma client
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    
+    # Request data
+    data = TeamMemberAddRequest(
+        team_id="org-team-id",
+        member=Member(user_id="outsider-user", role="user")
+    )
+    
+    # Call endpoint and expect 403
+    with pytest.raises(HTTPException) as exc_info:
+        await team_member_add(
+            data=data,
+            user_api_key_dict=UserAPIKeyAuth(user_id="admin", user_role="proxy_admin")
+        )
+    
+    assert exc_info.value.status_code == 403
+    assert "is not a member of organization" in str(exc_info.value.detail)
+
+@pytest.mark.asyncio
+async def test_team_member_add_org_validation_success(mocker):
+    """
+    Test that adding a user to an org-scoped team succeeds if the user is in the org.
+    """
+    # Mock dependencies
+    mock_prisma_client = mocker.MagicMock()
+    
+    # Mock team with organization_id
+    mock_team_data = {
+        "team_id": "org-team-id",
+        "organization_id": "test-org-id",
+        "team_alias": "test-team",
+        "admins": [],
+        "members": [],
+        "metadata": {}
+    }
+    mock_team_row = mocker.MagicMock()
+    mock_team_row.model_dump.return_value = mock_team_data
+    
+    # Mock get_team_object
+    mocker.patch(
+        "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+        return_value=mock_team_row
+    )
+    
+    # Mock validation checks
+    mocker.patch("litellm.proxy.management_endpoints.team_endpoints.team_call_validation_checks")
+    mocker.patch("litellm.proxy.management_endpoints.team_endpoints._validate_team_member_add_permissions")
+    
+    # Mock organization membership check to return match
+    mock_membership = mocker.MagicMock()
+    mock_membership.user_id = "insider-user"
+    mock_prisma_client.db.litellm_organizationmembership.find_many = mocker.AsyncMock(return_value=[mock_membership])
+    
+    # Mock successful addition
+    mock_updated_team = mocker.MagicMock()
+    mock_updated_team.model_dump.return_value = mock_team_data
+    
+    mocker.patch(
+        "litellm.proxy.management_endpoints.team_endpoints._add_team_members_to_team",
+        return_value=(mock_updated_team, [], [])
+    )
+    
+    # Patch prisma client
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    
+    # Request data
+    data = TeamMemberAddRequest(
+        team_id="org-team-id",
+        member=Member(user_id="insider-user", role="user")
+    )
+    
+    # Call endpoint
+    response = await team_member_add(
+        data=data,
+        user_api_key_dict=UserAPIKeyAuth(user_id="admin", user_role="proxy_admin")
+    )
+    
+    assert response.team_id == "org-team-id"
+
+@pytest.mark.asyncio
+async def test_team_member_add_no_org_validation_skipped(mocker):
+    """
+    Test that organization validation is skipped for teams without organization_id.
+    """
+    # Mock dependencies
+    mock_prisma_client = mocker.MagicMock()
+    
+    # Mock team WITHOUT organization_id
+    mock_team_data = {
+        "team_id": "standalone-team-id",
+        "organization_id": None,
+        "team_alias": "test-team",
+        "admins": [],
+        "members": [],
+        "metadata": {}
+    }
+    mock_team_row = mocker.MagicMock()
+    mock_team_row.model_dump.return_value = mock_team_data
+    
+    # Mock get_team_object
+    mocker.patch(
+        "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+        return_value=mock_team_row
+    )
+    
+    # Mock validation checks
+    mocker.patch("litellm.proxy.management_endpoints.team_endpoints.team_call_validation_checks")
+    mocker.patch("litellm.proxy.management_endpoints.team_endpoints._validate_team_member_add_permissions")
+    
+    # Mock organization membership check (Should NOT be called, but if it is, let's fail to prove it wasn't used for validation)
+    mock_prisma_client.db.litellm_organizationmembership.find_many = mocker.AsyncMock(return_value=[])
+    
+    # Mock successful addition
+    mock_updated_team = mocker.MagicMock()
+    mock_updated_team.model_dump.return_value = mock_team_data
+    
+    mocker.patch(
+        "litellm.proxy.management_endpoints.team_endpoints._add_team_members_to_team",
+        return_value=(mock_updated_team, [], [])
+    )
+    
+    # Patch prisma client
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    
+    # Request data
+    data = TeamMemberAddRequest(
+        team_id="standalone-team-id",
+        member=Member(user_id="any-user", role="user")
+    )
+    
+    # Call endpoint
+    response = await team_member_add(
+        data=data,
+        user_api_key_dict=UserAPIKeyAuth(user_id="admin", user_role="proxy_admin")
+    )
+    
+    # Assert success despite empty membership return
+    assert response.team_id == "standalone-team-id"
+

--- a/ui/litellm-dashboard/src/components/common_components/user_search_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/user_search_modal.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, waitFor } from "../../../tests/test-utils";
+import UserSearchModal from "./user_search_modal";
+import * as networking from "@/components/networking";
+
+// Mock the networking module
+vi.mock("@/components/networking", () => ({
+  userFilterUICall: vi.fn(),
+}));
+
+describe("UserSearchModal", () => {
+  const defaultProps = {
+    isVisible: true,
+    onCancel: vi.fn(),
+    onSubmit: vi.fn(),
+    accessToken: "test-token",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(networking.userFilterUICall).mockResolvedValue([]);
+  });
+
+  it("renders the modal with default title", () => {
+    const { getByText } = renderWithProviders(<UserSearchModal {...defaultProps} />);
+    expect(getByText("Add Team Member")).toBeInTheDocument();
+  });
+
+  it("renders with custom title", () => {
+    const { getByText } = renderWithProviders(<UserSearchModal {...defaultProps} title="Add Organization Member" />);
+    expect(getByText("Add Organization Member")).toBeInTheDocument();
+  });
+
+  it("passes organization_id to userFilterUICall when searching and organizationId is provided", async () => {
+    const user = userEvent.setup();
+    const organizationId = "org-123";
+
+    vi.mocked(networking.userFilterUICall).mockResolvedValue([
+      { user_id: "user-1", user_email: "user1@example.com" },
+    ]);
+
+    renderWithProviders(<UserSearchModal {...defaultProps} organizationId={organizationId} />);
+
+    // Get the email input by its id (Ant Design Select uses id for the input)
+    const emailInput = document.getElementById("user_email") as HTMLInputElement;
+    expect(emailInput).not.toBeNull();
+
+    await user.click(emailInput);
+    await user.type(emailInput, "user1");
+
+    await waitFor(() => {
+      expect(networking.userFilterUICall).toHaveBeenCalled();
+    });
+
+    // Verify the URLSearchParams include organization_id
+    const callArgs = vi.mocked(networking.userFilterUICall).mock.calls[0];
+    const params = callArgs[1] as URLSearchParams;
+    expect(params.get("organization_id")).toBe(organizationId);
+    expect(params.get("user_email")).toBe("user1");
+  });
+
+  it("does not pass organization_id when organizationId is not provided", async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(networking.userFilterUICall).mockResolvedValue([
+      { user_id: "user-1", user_email: "user1@example.com" },
+    ]);
+
+    renderWithProviders(<UserSearchModal {...defaultProps} />);
+
+    // Get the email input by its id
+    const emailInput = document.getElementById("user_email") as HTMLInputElement;
+    expect(emailInput).not.toBeNull();
+
+    await user.click(emailInput);
+    await user.type(emailInput, "user1");
+
+    await waitFor(() => {
+      expect(networking.userFilterUICall).toHaveBeenCalled();
+    });
+
+    // Verify the URLSearchParams do NOT include organization_id
+    const callArgs = vi.mocked(networking.userFilterUICall).mock.calls[0];
+    const params = callArgs[1] as URLSearchParams;
+    expect(params.get("organization_id")).toBeNull();
+    expect(params.get("user_email")).toBe("user1");
+  });
+
+  it("does not pass organization_id when organizationId is null", async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(networking.userFilterUICall).mockResolvedValue([
+      { user_id: "user-1", user_email: "user1@example.com" },
+    ]);
+
+    renderWithProviders(<UserSearchModal {...defaultProps} organizationId={null} />);
+
+    // Get the email input by its id
+    const emailInput = document.getElementById("user_email") as HTMLInputElement;
+    expect(emailInput).not.toBeNull();
+
+    await user.click(emailInput);
+    await user.type(emailInput, "user1");
+
+    await waitFor(() => {
+      expect(networking.userFilterUICall).toHaveBeenCalled();
+    });
+
+    // Verify the URLSearchParams do NOT include organization_id
+    const callArgs = vi.mocked(networking.userFilterUICall).mock.calls[0];
+    const params = callArgs[1] as URLSearchParams;
+    expect(params.get("organization_id")).toBeNull();
+  });
+
+  it("passes organization_id when searching by user_id", async () => {
+    const user = userEvent.setup();
+    const organizationId = "org-456";
+
+    vi.mocked(networking.userFilterUICall).mockResolvedValue([
+      { user_id: "user-1", user_email: "user1@example.com" },
+    ]);
+
+    renderWithProviders(<UserSearchModal {...defaultProps} organizationId={organizationId} />);
+
+    // Get the user_id input by its id
+    const userIdInput = document.getElementById("user_id") as HTMLInputElement;
+    expect(userIdInput).not.toBeNull();
+
+    await user.click(userIdInput);
+    await user.type(userIdInput, "user-1");
+
+    await waitFor(() => {
+      expect(networking.userFilterUICall).toHaveBeenCalled();
+    });
+
+    // Verify the URLSearchParams include organization_id
+    const callArgs = vi.mocked(networking.userFilterUICall).mock.calls[0];
+    const params = callArgs[1] as URLSearchParams;
+    expect(params.get("organization_id")).toBe(organizationId);
+    expect(params.get("user_id")).toBe("user-1");
+  });
+});

--- a/ui/litellm-dashboard/src/components/common_components/user_search_modal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/user_search_modal.tsx
@@ -34,6 +34,7 @@ interface UserSearchModalProps {
   title?: string;
   roles?: Role[];
   defaultRole?: string;
+  organizationId?: string | null;
 }
 
 const UserSearchModal: React.FC<UserSearchModalProps> = ({
@@ -51,13 +52,14 @@ const UserSearchModal: React.FC<UserSearchModalProps> = ({
     { label: "user", value: "user", description: "User role. Can view team info, but not manage it." },
   ],
   defaultRole = "user",
+  organizationId,
 }) => {
   const [form] = Form.useForm<FormValues>();
   const [userOptions, setUserOptions] = useState<UserOption[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [selectedField, setSelectedField] = useState<"user_email" | "user_id">("user_email");
 
-  const fetchUsers = async (searchText: string, fieldName: "user_email" | "user_id"): Promise<void> => {
+  const fetchUsers = useCallback(async (searchText: string, fieldName: "user_email" | "user_id"): Promise<void> => {
     if (!searchText) {
       setUserOptions([]);
       return;
@@ -67,6 +69,9 @@ const UserSearchModal: React.FC<UserSearchModalProps> = ({
     try {
       const params = new URLSearchParams();
       params.append(fieldName, searchText);
+      if (organizationId) {
+        params.append("organization_id", organizationId);
+      }
       if (accessToken == null) {
         return;
       }
@@ -84,11 +89,11 @@ const UserSearchModal: React.FC<UserSearchModalProps> = ({
     } finally {
       setLoading(false);
     }
-  };
+  }, [organizationId, accessToken]);
 
   const debouncedSearch = useCallback(
     debounce((text: string, fieldName: "user_email" | "user_id") => fetchUsers(text, fieldName), 300),
-    [],
+    [fetchUsers],
   );
 
   const handleSearch = (value: string, fieldName: "user_email" | "user_id"): void => {

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2604,11 +2604,9 @@ export const userFilterUICall = async (accessToken: string, params: URLSearchPar
   try {
     let url = proxyBaseUrl ? `${proxyBaseUrl}/user/filter/ui` : `/user/filter/ui`;
 
-    if (params.get("user_email")) {
-      url += `?user_email=${params.get("user_email")}`;
-    }
-    if (params.get("user_id")) {
-      url += `?user_id=${params.get("user_id")}`;
+    const queryString = params.toString();
+    if (queryString) {
+      url += `?${queryString}`;
     }
 
     const response = await fetch(url, {

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -1047,6 +1047,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         onCancel={() => setIsAddMemberModalVisible(false)}
         onSubmit={handleMemberCreate}
         accessToken={accessToken}
+        organizationId={teamData?.team_info?.organization_id}
       />
 
       {/* Delete Member Confirmation Modal */}


### PR DESCRIPTION
## Relevant issues

Fixes #17544

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
Unrelated unit tests failures:
```bash
================================================================================================================= short test summary info ==================================================================================================================
FAILED tests/test_litellm/test_utils.py::test_aaamodel_prices_and_context_window_json_is_valid - jsonschema.exceptions.ValidationError: None is not of type 'number'
FAILED tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_header_forwarding.py::test_bedrock_rerank_extra_headers_and_headers_merge - Failed: Failed to merge and forward headers: litellm.APIConnectionError: Unable to locate credentials
FAILED tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_header_forwarding.py::test_bedrock_rerank_header_forwarding_async[bedrock/arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0] - Failed: Failed to forward headers to bedrock/arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0: litellm.APIConnectionError: Unable to locate credentials
FAILED tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_header_forwarding.py::test_bedrock_rerank_header_forwarding_async[bedrock/arn:aws:bedrock:us-west-2::foundation-model/amazon.rerank-v1:0] - Failed: Failed to forward headers to bedrock/arn:aws:bedrock:us-west-2::foundation-model/amazon.rerank-v1:0: litellm.APIConnectionError: Unable to locate credentials
FAILED tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_header_forwarding.py::test_bedrock_rerank_header_forwarding_sync[bedrock/arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0] - Failed: Failed to forward headers to bedrock/arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0: litellm.APIConnectionError: Unable to locate credentials
FAILED tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_header_forwarding.py::test_bedrock_rerank_header_forwarding_sync[bedrock/arn:aws:bedrock:us-west-2::foundation-model/amazon.rerank-v1:0] - Failed: Failed to forward headers to bedrock/arn:aws:bedrock:us-west-2::foundation-model/amazon.rerank-v1:0: litellm.APIConnectionError: Unable to locate credentials
FAILED tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py::test_get_supported_openai_params_reasoning_effort - AssertionError: assert 'reasoning_effort' in ['stream', 'max_completion_tokens', 'max_tokens', 'temperature', 'top_p', 'top_k', ...]
FAILED tests/test_litellm/litellm_core_utils/test_token_counter.py::test_img_url_token_counter[https://blog.purpureus.net/assets/blog/personal_key_rotation/simplified-asset-graph.jpg] - ValueError: not enough values to unpack (expected 2, got 1)
FAILED tests/test_litellm/caching/test_s3_cache.py::test_s3_cache_async_set_cache_pipeline - AssertionError: assert 'key2' == 'key1'
FAILED tests/test_litellm/caching/test_s3_cache.py::test_s3_cache_concurrent_async_operations - AssertionError: assert 'concurrent_key_0' == 'concurrent_key_2'
FAILED tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py::test_supports_reasoning_effort - AssertionError: fireworks_ai/accounts/fireworks/models/qwen3-8b should support reasoning_effort
FAILED tests/test_litellm/litellm_core_utils/test_duration_parser.py::TestStandardizedResetTime::test_timezone_handling - zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key US/Eastern'
ERROR tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_sendgrid_email.py
====================================================================================== 12 failed, 5848 passed, 55 skipped, 191 warnings, 1 error in 402.21s (0:06:42) ======================================================================================
```

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

litellm/proxy/management_endpoints/internal_user_endpoints.py
litellm/proxy/management_endpoints/team_endpoints.py
tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints_filtering.py
tests/test_litellm/proxy/management_endpoints/test_org_member_edge_cases.py
tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
tests/test_litellm/proxy/management_endpoints/test_team_endpoints_org_validation.py
ui/litellm-dashboard/src/components/common_components/user_search_modal.test.tsx
ui/litellm-dashboard/src/components/common_components/user_search_modal.tsx
ui/litellm-dashboard/src/components/networking.tsx
ui/litellm-dashboard/src/components/team/team_info.tsx

### Description

    fix: Validate organization membership when adding team members
    
    Prevent cross-organization team member addition by enforcing that only
    users who are members of an organization can be added to org-scoped teams.
    Standalone teams remain unaffected.

    test: Add tests for cross-organization team member addition validation
    
    Add comprehensive test coverage for organization boundary enforcement
    when adding members to org-scoped teams, covering both backend API
    and frontend UI components.
    
    Backend tests:
    - test_internal_user_endpoints.py: Add organization_id parameter to
      existing test
    - test_internal_user_endpoints_filtering.py: Tests for /user/filter/ui
      endpoint to filter users by organization_id
    - test_org_member_edge_cases.py: Edge case tests for single-member orgs,
      empty user lists, and email-based member addition
    - test_team_endpoints.py: Tests verifying team_member_add and
      bulk_team_member_add reject users not in team's organization
    - test_team_endpoints_org_validation.py: Focused tests for org validation
      success/failure cases and standalone team bypass
    
    Frontend tests:
    - user_search_modal.test.tsx: Tests verifying UserSearchModal passes
      organization_id to userFilterUICall when searching for users to add
      to org-scoped teams
    
    These tests document the expected behavior that users outside an
    organization cannot be added to org-scoped teams, enforcing multi-tenancy
    isolation at both API and UI levels.