### PR TITLE
fix: remove deprecated Groq models and update model registry

### DIFF
--- a/docs/my-website/docs/providers/groq.md
+++ b/docs/my-website/docs/providers/groq.md
@@ -150,15 +150,15 @@ We support ALL Groq models, just set `groq/` as a prefix when sending completion
 
 | Model Name         | Usage                                           |
 |--------------------|---------------------------------------------------------|
-| llama-3.1-8b-instant     | `completion(model="groq/llama-3.1-8b-instant", messages)`     | 
-| llama-3.1-70b-versatile    | `completion(model="groq/llama-3.1-70b-versatile", messages)`    | 
-| llama3-8b-8192     | `completion(model="groq/llama3-8b-8192", messages)`     | 
-| llama3-70b-8192    | `completion(model="groq/llama3-70b-8192", messages)`    | 
-| llama2-70b-4096    | `completion(model="groq/llama2-70b-4096", messages)`    | 
-| mixtral-8x7b-32768 | `completion(model="groq/mixtral-8x7b-32768", messages)` |
-| gemma-7b-it        | `completion(model="groq/gemma-7b-it", messages)`        |
-| moonshotai/kimi-k2-instruct | `completion(model="groq/moonshotai/kimi-k2-instruct", messages)` |
-| qwen3-32b       | `completion(model="groq/qwen/qwen3-32b", messages)`       |
+| llama-3.3-70b-versatile     | `completion(model="groq/llama-3.3-70b-versatile", messages)`     |
+| llama-3.1-8b-instant     | `completion(model="groq/llama-3.1-8b-instant", messages)`     |
+| meta-llama/llama-4-scout-17b-16e-instruct | `completion(model="groq/meta-llama/llama-4-scout-17b-16e-instruct", messages)` |
+| meta-llama/llama-4-maverick-17b-128e-instruct | `completion(model="groq/meta-llama/llama-4-maverick-17b-128e-instruct", messages)` |
+| meta-llama/llama-guard-4-12b | `completion(model="groq/meta-llama/llama-guard-4-12b", messages)` |
+| qwen/qwen3-32b       | `completion(model="groq/qwen/qwen3-32b", messages)`       |
+| moonshotai/kimi-k2-instruct-0905 | `completion(model="groq/moonshotai/kimi-k2-instruct-0905", messages)` |
+| openai/gpt-oss-120b | `completion(model="groq/openai/gpt-oss-120b", messages)` |
+| openai/gpt-oss-20b | `completion(model="groq/openai/gpt-oss-20b", messages)` |
 
 ## Groq - Tool / Function Calling Example
 
@@ -261,31 +261,28 @@ if tool_calls:
     print("second response\n", second_response)
 ```
 
-## Groq - Vision Example    
+## Groq - Vision Example
 
-Select Groq models support vision. Check out their [model list](https://console.groq.com/docs/vision) for more details.
+Groq's Llama 4 models support vision. Check out their [model list](https://console.groq.com/docs/vision) for more details.
 
 <Tabs>
 <TabItem value="sdk" label="SDK">
 
 ```python
-from litellm import completion
-
-import os 
+import os
 from litellm import completion
 
 os.environ["GROQ_API_KEY"] = "your-api-key"
 
-# openai call
 response = completion(
-    model = "groq/llama-3.2-11b-vision-preview", 
+    model = "groq/meta-llama/llama-4-scout-17b-16e-instruct",
     messages=[
         {
             "role": "user",
             "content": [
                             {
                                 "type": "text",
-                                "text": "What’s in this image?"
+                                "text": "What's in this image?"
                             },
                             {
                                 "type": "image_url",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -17509,75 +17509,6 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
-    "groq/deepseek-r1-distill-llama-70b": {
-        "input_cost_per_token": 7.5e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 9.9e-07,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/distil-whisper-large-v3-en": {
-        "input_cost_per_second": 5.56e-06,
-        "litellm_provider": "groq",
-        "mode": "audio_transcription",
-        "output_cost_per_second": 0.0
-    },
-    "groq/gemma-7b-it": {
-        "deprecation_date": "2024-12-18",
-        "input_cost_per_token": 7e-08,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 7e-08,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/gemma2-9b-it": {
-        "input_cost_per_token": 2e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 2e-07,
-        "supports_function_calling": false,
-        "supports_response_schema": false,
-        "supports_tool_choice": false
-    },
-    "groq/llama-3.1-405b-reasoning": {
-        "input_cost_per_token": 5.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 7.9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.1-70b-versatile": {
-        "deprecation_date": "2025-01-24",
-        "input_cost_per_token": 5.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 7.9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
     "groq/llama-3.1-8b-instant": {
         "input_cost_per_token": 5e-08,
         "litellm_provider": "groq",
@@ -17588,97 +17519,6 @@
         "output_cost_per_token": 8e-08,
         "supports_function_calling": true,
         "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.2-11b-text-preview": {
-        "deprecation_date": "2024-10-28",
-        "input_cost_per_token": 1.8e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.8e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.2-11b-vision-preview": {
-        "deprecation_date": "2025-04-14",
-        "input_cost_per_token": 1.8e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.8e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "groq/llama-3.2-1b-preview": {
-        "deprecation_date": "2025-04-14",
-        "input_cost_per_token": 4e-08,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 4e-08,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.2-3b-preview": {
-        "deprecation_date": "2025-04-14",
-        "input_cost_per_token": 6e-08,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 6e-08,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.2-90b-text-preview": {
-        "deprecation_date": "2024-11-25",
-        "input_cost_per_token": 9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.2-90b-vision-preview": {
-        "deprecation_date": "2025-04-14",
-        "input_cost_per_token": 9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "groq/llama-3.3-70b-specdec": {
-        "deprecation_date": "2025-04-14",
-        "input_cost_per_token": 5.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 9.9e-07,
         "supports_tool_choice": true
     },
     "groq/llama-3.3-70b-versatile": {
@@ -17693,7 +17533,7 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
-    "groq/llama-guard-3-8b": {
+    "groq/meta-llama/llama-guard-4-12b": {
         "input_cost_per_token": 2e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 8192,
@@ -17701,44 +17541,6 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 2e-07
-    },
-    "groq/llama2-70b-4096": {
-        "input_cost_per_token": 7e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 8e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama3-groq-70b-8192-tool-use-preview": {
-        "deprecation_date": "2025-01-06",
-        "input_cost_per_token": 8.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 8.9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama3-groq-8b-8192-tool-use-preview": {
-        "deprecation_date": "2025-01-06",
-        "input_cost_per_token": 1.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
     },
     "groq/meta-llama/llama-4-maverick-17b-128e-instruct": {
         "input_cost_per_token": 2e-07,
@@ -17750,7 +17552,8 @@
         "output_cost_per_token": 6e-07,
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "groq/meta-llama/llama-4-scout-17b-16e-instruct": {
         "input_cost_per_token": 1.1e-07,
@@ -17762,41 +17565,8 @@
         "output_cost_per_token": 3.4e-07,
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_tool_choice": true
-    },
-    "groq/mistral-saba-24b": {
-        "input_cost_per_token": 7.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 32000,
-        "max_output_tokens": 32000,
-        "max_tokens": 32000,
-        "mode": "chat",
-        "output_cost_per_token": 7.9e-07
-    },
-    "groq/mixtral-8x7b-32768": {
-        "deprecation_date": "2025-03-20",
-        "input_cost_per_token": 2.4e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 2.4e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/moonshotai/kimi-k2-instruct": {
-        "input_cost_per_token": 1e-06,
-        "litellm_provider": "groq",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 16384,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 3e-06,
-        "supports_function_calling": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "groq/moonshotai/kimi-k2-instruct-0905": {
         "input_cost_per_token": 1e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -17509,75 +17509,6 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
-    "groq/deepseek-r1-distill-llama-70b": {
-        "input_cost_per_token": 7.5e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 9.9e-07,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/distil-whisper-large-v3-en": {
-        "input_cost_per_second": 5.56e-06,
-        "litellm_provider": "groq",
-        "mode": "audio_transcription",
-        "output_cost_per_second": 0.0
-    },
-    "groq/gemma-7b-it": {
-        "deprecation_date": "2024-12-18",
-        "input_cost_per_token": 7e-08,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 7e-08,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/gemma2-9b-it": {
-        "input_cost_per_token": 2e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 2e-07,
-        "supports_function_calling": false,
-        "supports_response_schema": false,
-        "supports_tool_choice": false
-    },
-    "groq/llama-3.1-405b-reasoning": {
-        "input_cost_per_token": 5.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 7.9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.1-70b-versatile": {
-        "deprecation_date": "2025-01-24",
-        "input_cost_per_token": 5.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 7.9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
     "groq/llama-3.1-8b-instant": {
         "input_cost_per_token": 5e-08,
         "litellm_provider": "groq",
@@ -17588,97 +17519,6 @@
         "output_cost_per_token": 8e-08,
         "supports_function_calling": true,
         "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.2-11b-text-preview": {
-        "deprecation_date": "2024-10-28",
-        "input_cost_per_token": 1.8e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.8e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.2-11b-vision-preview": {
-        "deprecation_date": "2025-04-14",
-        "input_cost_per_token": 1.8e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.8e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "groq/llama-3.2-1b-preview": {
-        "deprecation_date": "2025-04-14",
-        "input_cost_per_token": 4e-08,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 4e-08,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.2-3b-preview": {
-        "deprecation_date": "2025-04-14",
-        "input_cost_per_token": 6e-08,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 6e-08,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.2-90b-text-preview": {
-        "deprecation_date": "2024-11-25",
-        "input_cost_per_token": 9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama-3.2-90b-vision-preview": {
-        "deprecation_date": "2025-04-14",
-        "input_cost_per_token": 9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "groq/llama-3.3-70b-specdec": {
-        "deprecation_date": "2025-04-14",
-        "input_cost_per_token": 5.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 9.9e-07,
         "supports_tool_choice": true
     },
     "groq/llama-3.3-70b-versatile": {
@@ -17693,7 +17533,7 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
-    "groq/llama-guard-3-8b": {
+    "groq/meta-llama/llama-guard-4-12b": {
         "input_cost_per_token": 2e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 8192,
@@ -17701,44 +17541,6 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 2e-07
-    },
-    "groq/llama2-70b-4096": {
-        "input_cost_per_token": 7e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 8e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama3-groq-70b-8192-tool-use-preview": {
-        "deprecation_date": "2025-01-06",
-        "input_cost_per_token": 8.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 8.9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/llama3-groq-8b-8192-tool-use-preview": {
-        "deprecation_date": "2025-01-06",
-        "input_cost_per_token": 1.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.9e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
     },
     "groq/meta-llama/llama-4-maverick-17b-128e-instruct": {
         "input_cost_per_token": 2e-07,
@@ -17750,7 +17552,8 @@
         "output_cost_per_token": 6e-07,
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "groq/meta-llama/llama-4-scout-17b-16e-instruct": {
         "input_cost_per_token": 1.1e-07,
@@ -17762,41 +17565,8 @@
         "output_cost_per_token": 3.4e-07,
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_tool_choice": true
-    },
-    "groq/mistral-saba-24b": {
-        "input_cost_per_token": 7.9e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 32000,
-        "max_output_tokens": 32000,
-        "max_tokens": 32000,
-        "mode": "chat",
-        "output_cost_per_token": 7.9e-07
-    },
-    "groq/mixtral-8x7b-32768": {
-        "deprecation_date": "2025-03-20",
-        "input_cost_per_token": 2.4e-07,
-        "litellm_provider": "groq",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 2.4e-07,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/moonshotai/kimi-k2-instruct": {
-        "input_cost_per_token": 1e-06,
-        "litellm_provider": "groq",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 16384,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 3e-06,
-        "supports_function_calling": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "groq/moonshotai/kimi-k2-instruct-0905": {
         "input_cost_per_token": 1e-06,

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -870,8 +870,6 @@ SKIP_MODELS = [
     "jamba",
     "deepinfra",
     "mistral.",
-    "groq/llama-guard-3-8b",
-    "groq/gemma2-9b-it",
 ]
 
 # Bedrock models to block - organized by type


### PR DESCRIPTION
## Title

Remove deprecated Groq models and update model registry

## Relevant issues

Fixes #18043

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory - N/A (model registry update, no code changes)
- [ ] I have added a screenshot of my new test passing locally - N/A
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) - N/A (JSON/docs only)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix
📖 Documentation

## Changes

### Removed deprecated models (20 total)
Per [Groq's deprecation page](https://console.groq.com/docs/deprecations):
- `groq/gemma-7b-it` (deprecated 2024-12-18)
- `groq/llama-3.2-11b-text-preview` (deprecated 2024-10-28)
- `groq/llama-3.2-90b-text-preview` (deprecated 2024-11-25)
- `groq/llama3-groq-70b-8192-tool-use-preview` (deprecated 2025-01-06)
- `groq/llama3-groq-8b-8192-tool-use-preview` (deprecated 2025-01-06)
- `groq/llama-3.1-70b-versatile` (deprecated 2025-01-24)
- `groq/mixtral-8x7b-32768` (deprecated 2025-03-20)
- `groq/llama-3.2-11b-vision-preview` (deprecated 2025-04-14)
- `groq/llama-3.2-1b-preview` (deprecated 2025-04-14)
- `groq/llama-3.2-3b-preview` (deprecated 2025-04-14)
- `groq/llama-3.2-90b-vision-preview` (deprecated 2025-04-14)
- `groq/llama-3.3-70b-specdec` (deprecated 2025-04-14)
- `groq/llama-guard-3-8b` (deprecated 2025-06-06)
- `groq/mistral-saba-24b` (deprecated 2025-07-30)
- `groq/distil-whisper-large-v3-en` (deprecated 2025-08-23)
- `groq/deepseek-r1-distill-llama-70b` (deprecated 2025-10-02)
- `groq/gemma2-9b-it` (deprecated 2025-10-08)
- `groq/moonshotai/kimi-k2-instruct` (deprecated 2025-10-10)
- `groq/llama-3.1-405b-reasoning` (no longer available)
- `groq/llama2-70b-4096` (no longer available)

### Added new model
- `groq/meta-llama/llama-guard-4-12b` - New safety/moderation model

### Updated existing models
- Added `supports_vision: true` to `groq/meta-llama/llama-4-maverick-17b-128e-instruct`
- Added `supports_vision: true` to `groq/meta-llama/llama-4-scout-17b-16e-instruct`

### Updated documentation
- Updated `docs/my-website/docs/providers/groq.md` with current model list
- Updated vision example to use Llama 4 model instead of deprecated preview model

### Current Groq models 
```
groq/llama-3.1-8b-instant
groq/llama-3.3-70b-versatile
groq/meta-llama/llama-guard-4-12b
groq/meta-llama/llama-4-maverick-17b-128e-instruct
groq/meta-llama/llama-4-scout-17b-16e-instruct
groq/moonshotai/kimi-k2-instruct-0905
groq/openai/gpt-oss-120b
groq/openai/gpt-oss-20b
groq/playai-tts
groq/qwen/qwen3-32b
groq/whisper-large-v3
groq/whisper-large-v3-turbo
```