### PR TITLE
[Refactor] litellm/init.py: lazy load GuardrailItem

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1,4 +1,6 @@
 ### Hide pydantic namespace conflict warnings globally ###
+from __future__ import annotations
+
 import warnings
 
 warnings.filterwarnings("ignore", message=".*conflict with protected namespace.*")
@@ -72,7 +74,6 @@ from litellm.constants import (
     DEFAULT_SOFT_BUDGET,
     DEFAULT_ALLOWED_FAILS,
 )
-from litellm.types.guardrails import GuardrailItem
 from litellm.types.secret_managers.main import (
     KeyManagementSystem,
     KeyManagementSettings,
@@ -1506,6 +1507,7 @@ if TYPE_CHECKING:
         PriorityReservationDict,
         StandardKeyGenerationConfig,
     )
+    from litellm.types.guardrails import GuardrailItem
 
     # Cost calculator functions
     cost_per_token: Callable[..., Tuple[float, float]]
@@ -1568,6 +1570,7 @@ def __getattr__(name: str) -> Any:
         HTTP_HANDLER_NAMES,
         DOTPROMPT_NAMES,
         LLM_CONFIG_NAMES,
+        TYPES_NAMES,
     )
     
     # Lazy load cost_calculator functions
@@ -1627,6 +1630,12 @@ def __getattr__(name: str) -> Any:
         from ._lazy_imports import _lazy_import_llm_configs
 
         return _lazy_import_llm_configs(name)
+
+    # Lazy load types
+    if name in TYPES_NAMES:
+        from ._lazy_imports import _lazy_import_types
+
+        return _lazy_import_types(name)
 
     # Lazy load encoding from main.py to avoid heavy tiktoken import
     if name == "encoding":

--- a/litellm/_lazy_imports.py
+++ b/litellm/_lazy_imports.py
@@ -159,6 +159,11 @@ LLM_CONFIG_NAMES = (
     "AmazonConverseConfig",
 )
 
+# Types that support lazy loading via _lazy_import_types
+TYPES_NAMES = (
+    "GuardrailItem",
+)
+
 # Lazy import for utils module - imports only the requested item by name.
 # Note: PLR0915 (too many statements) is suppressed because the many if statements
 # are intentional - each attribute is imported individually only when requested,
@@ -617,6 +622,21 @@ def _lazy_import_dotprompt(name: str) -> Any:
         return _set_global_prompt_directory
 
     raise AttributeError(f"Dotprompt lazy import: unknown attribute {name!r}")
+
+
+def _lazy_import_types(name: str) -> Any:
+    """Lazy import for type classes."""
+    _globals = _get_litellm_globals()
+
+    if name == "GuardrailItem":
+        from litellm.types.guardrails import (
+            GuardrailItem as _GuardrailItem,
+        )
+
+        _globals["GuardrailItem"] = _GuardrailItem
+        return _GuardrailItem
+
+    raise AttributeError(f"Types lazy import: unknown attribute {name!r}")
 
 
 def _lazy_import_llm_configs(name: str) -> Any:

--- a/tests/test_litellm/test_lazy_imports.py
+++ b/tests/test_litellm/test_lazy_imports.py
@@ -31,6 +31,8 @@ from litellm._lazy_imports import (
     _lazy_import_dotprompt,
     LLM_CONFIG_NAMES,
     _lazy_import_llm_configs,
+    TYPES_NAMES,
+    _lazy_import_types,
 )
 
 
@@ -213,6 +215,9 @@ def test_unknown_attribute_raises_error():
     with pytest.raises(AttributeError):
         _lazy_import_llm_configs("unknown")
 
+    with pytest.raises(AttributeError):
+        _lazy_import_types("unknown")
+
 
 def test_llm_config_lazy_imports():
     """Test that LLM config classes can be lazy imported."""
@@ -226,4 +231,18 @@ def test_llm_config_lazy_imports():
         assert isinstance(obj, type), f"{name} should be a class"
 
         _verify_only_requested_name_imported(name, LLM_CONFIG_NAMES)
+
+
+def test_types_lazy_imports():
+    """Test that type classes can be lazy imported."""
+    for name in TYPES_NAMES:
+        _clear_names_from_globals(TYPES_NAMES)
+
+        obj = _lazy_import_types(name)
+        assert obj is not None
+        assert name in litellm.__dict__
+        # Type classes should be classes/types
+        assert isinstance(obj, type), f"{name} should be a class"
+
+        _verify_only_requested_name_imported(name, TYPES_NAMES)
 


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: [Baseline](https://app.circleci.com/pipelines/github/BerriAI/litellm/51841/workflows/9a96ca07-db2b-437a-b214-ef5350b2f848)

- [x] **CI run for the last commit**  
       Link: [Last Commit](https://app.circleci.com/pipelines/github/BerriAI/litellm/51844/workflows/93784ef3-be83-420a-8eab-47be197a99ab)

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- Add TYPES_NAMES tuple and _lazy_import_types function in _lazy_imports.py
- Remove direct import of GuardrailItem from __init__.py
- Add lazy loading handler in __getattr__ to dispatch type imports
- Add type stub for GuardrailItem in TYPE_CHECKING block
- Add test_types_lazy_imports test to verify lazy loading works
- Use from __future__ import annotations for forward reference support
- Follows same pattern as DOTPROMPT_NAMES and LLM_CONFIG_NAMES for consistency

## Test Results

<img width="1440" height="900" alt="Screenshot 2025-12-16 at 11 41 11 AM" src="https://github.com/user-attachments/assets/3998a074-2f11-415e-a83e-30a329baecd4" />

<img width="1416" height="204" alt="Screenshot 2025-12-16 at 11 45 08 AM" src="https://github.com/user-attachments/assets/d6d8d27b-d8a4-4c42-b8c7-f3b500187e3e" />

- Failures seem unrelated.



