### PR TITLE
Lazy load OpenAILikeChatConfig to avoid heavy import

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1056,7 +1056,6 @@ from .utils import client
 
 from .llms.bytez.chat.transformation import BytezChatConfig
 from .llms.custom_llm import CustomLLM
-from .llms.openai_like.chat.handler import OpenAILikeChatConfig
 from .llms.aiohttp_openai.chat.transformation import AiohttpOpenAIChatConfig
 from .llms.galadriel.chat.transformation import GaladrielChatConfig
 from .llms.github.chat.transformation import GithubChatConfig
@@ -1554,6 +1553,7 @@ if TYPE_CHECKING:
 
     # LLM config classes - lazy loaded only
     AmazonConverseConfig: Type[Any]
+    OpenAILikeChatConfig: Type[Any]
 
 
 def __getattr__(name: str) -> Any:

--- a/litellm/_lazy_imports.py
+++ b/litellm/_lazy_imports.py
@@ -157,6 +157,7 @@ DOTPROMPT_NAMES = (
 # LLM config classes that support lazy loading via _lazy_import_llm_configs
 LLM_CONFIG_NAMES = (
     "AmazonConverseConfig",
+    "OpenAILikeChatConfig",
 )
 
 # Types that support lazy loading via _lazy_import_types
@@ -650,5 +651,13 @@ def _lazy_import_llm_configs(name: str) -> Any:
 
         _globals["AmazonConverseConfig"] = _AmazonConverseConfig
         return _AmazonConverseConfig
+
+    if name == "OpenAILikeChatConfig":
+        from .llms.openai_like.chat.handler import (
+            OpenAILikeChatConfig as _OpenAILikeChatConfig,
+        )
+
+        _globals["OpenAILikeChatConfig"] = _OpenAILikeChatConfig
+        return _OpenAILikeChatConfig
 
     raise AttributeError(f"LLM config lazy import: unknown attribute {name!r}")


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: [Baseline](https://app.circleci.com/pipelines/github/BerriAI/litellm/51849/workflows/99c289ef-709b-43de-ab68-dac999c9ae82)

- [x] **CI run for the last commit**  
       Link: [Last Commit](https://app.circleci.com/pipelines/github/BerriAI/litellm/51850/workflows/6f48513a-f274-423f-8730-747c5cb6f568)

- [ ] **Merge / cherry-pick CI run**  
       Links: None

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- Remove direct import of OpenAILikeChatConfig from llms.openai_like.chat.handler
- Add OpenAILikeChatConfig to LLM_CONFIG_NAMES for lazy loading
- Add handler in _lazy_import_llm_configs() to lazy load when accessed
- Add OpenAILikeChatConfig to TYPE_CHECKING block for type hints

This defers the import until OpenAILikeChatConfig is actually needed, improving import time.

## Test Results

<img width="1437" height="434" alt="Screenshot 2025-12-16 at 12 38 35 PM" src="https://github.com/user-attachments/assets/6d7ea86e-69e4-4071-9aef-d2953629278a" />

<img width="1440" height="234" alt="Screenshot 2025-12-16 at 12 42 20 PM" src="https://github.com/user-attachments/assets/f8c70f6d-d23e-4aaa-b34c-c49d90c23714" />

- Failures seem unrelated
