### PR TITLE
[Fix] Redact user API key info in S3 logger metadata

### DIFF
--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -14,6 +14,7 @@ import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.constants import DEFAULT_S3_BATCH_SIZE, DEFAULT_S3_FLUSH_INTERVAL_SECONDS
 from litellm.integrations.s3 import get_s3_object_key
+from litellm.litellm_core_utils.redact_messages import redact_user_api_key_info
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.llms.custom_httpx.http_handler import (
@@ -425,8 +426,13 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
 
         s3_object_download_filename = f"time-{start_time.strftime('%Y-%m-%dT%H-%M-%S-%f')}_{standard_logging_payload['id']}.json"
 
+        # Redact user API key info from metadata before creating payload
+        payload_dict = dict(standard_logging_payload)
+        if "metadata" in payload_dict and isinstance(payload_dict["metadata"], dict):
+            payload_dict["metadata"] = redact_user_api_key_info(metadata=payload_dict["metadata"])
+
         return s3BatchLoggingElement(
-            payload=dict(standard_logging_payload),
+            payload=payload_dict,
             s3_object_key=s3_object_key,
             s3_object_download_filename=s3_object_download_filename,
         )

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -616,3 +616,122 @@ async def test_combined_prefix_reflects_in_s3_object_key():
     result = logger.create_s3_batch_logging_element(datetime.utcnow(), payload)
     key = result.s3_object_key
     assert "myteam/apikey/" in key, f"Expected both prefixes in key: {key}"
+
+
+# --------------------------------------------------------------
+# Test API key redaction
+# --------------------------------------------------------------
+def test_redact_user_api_key_info_when_enabled():
+    """
+    Test that user_api_key fields are redacted from metadata when redact_user_api_key_info is True.
+    """
+    import litellm
+    
+    # Enable redaction
+    original_value = litellm.redact_user_api_key_info
+    litellm.redact_user_api_key_info = True
+    
+    try:
+        logger = S3Logger()
+        payload = StandardLoggingPayload(
+            id="redact-test",
+            metadata={
+                "user_api_key_team_alias": "team-redact",
+                "user_api_key_alias": "key-redact",
+                "user_api_key_user_id": "user-123",
+                "user_api_key_hash": "hash-abc",
+                "other_metadata": "should-remain",
+                "normal_field": "normal-value",
+            },
+            messages=[],
+        )
+        
+        result = logger.create_s3_batch_logging_element(datetime.utcnow(), payload)
+        assert result is not None
+        
+        # Verify that user_api_key fields are removed
+        metadata = result.payload.get("metadata", {})
+        assert "user_api_key_team_alias" not in metadata, "user_api_key_team_alias should be redacted"
+        assert "user_api_key_alias" not in metadata, "user_api_key_alias should be redacted"
+        assert "user_api_key_user_id" not in metadata, "user_api_key_user_id should be redacted"
+        assert "user_api_key_hash" not in metadata, "user_api_key_hash should be redacted"
+        
+        # Verify that other fields remain
+        assert "other_metadata" in metadata, "other_metadata should remain"
+        assert metadata["other_metadata"] == "should-remain"
+        assert "normal_field" in metadata, "normal_field should remain"
+        assert metadata["normal_field"] == "normal-value"
+    finally:
+        # Restore original value
+        litellm.redact_user_api_key_info = original_value
+
+
+def test_redact_user_api_key_info_when_disabled():
+    """
+    Test that user_api_key fields are NOT redacted when redact_user_api_key_info is False or None.
+    """
+    import litellm
+    
+    # Disable redaction
+    original_value = litellm.redact_user_api_key_info
+    litellm.redact_user_api_key_info = False
+    
+    try:
+        logger = S3Logger()
+        payload = StandardLoggingPayload(
+            id="no-redact-test",
+            metadata={
+                "user_api_key_team_alias": "team-keep",
+                "user_api_key_alias": "key-keep",
+                "other_metadata": "should-remain",
+            },
+            messages=[],
+        )
+        
+        result = logger.create_s3_batch_logging_element(datetime.utcnow(), payload)
+        assert result is not None
+        
+        # Verify that user_api_key fields are NOT removed
+        metadata = result.payload.get("metadata", {})
+        assert "user_api_key_team_alias" in metadata, "user_api_key_team_alias should NOT be redacted when flag is False"
+        assert metadata["user_api_key_team_alias"] == "team-keep"
+        assert "user_api_key_alias" in metadata, "user_api_key_alias should NOT be redacted when flag is False"
+        assert metadata["user_api_key_alias"] == "key-keep"
+        assert "other_metadata" in metadata, "other_metadata should remain"
+    finally:
+        # Restore original value
+        litellm.redact_user_api_key_info = original_value
+
+
+def test_redact_user_api_key_info_with_no_metadata():
+    """
+    Test that redaction works correctly when metadata is None or empty.
+    """
+    import litellm
+    
+    original_value = litellm.redact_user_api_key_info
+    litellm.redact_user_api_key_info = True
+    
+    try:
+        logger = S3Logger()
+        
+        # Test with None metadata
+        payload1 = StandardLoggingPayload(
+            id="no-metadata-test",
+            metadata=None,
+            messages=[],
+        )
+        result1 = logger.create_s3_batch_logging_element(datetime.utcnow(), payload1)
+        assert result1 is not None
+        
+        # Test with empty metadata
+        payload2 = StandardLoggingPayload(
+            id="empty-metadata-test",
+            metadata={},
+            messages=[],
+        )
+        result2 = logger.create_s3_batch_logging_element(datetime.utcnow(), payload2)
+        assert result2 is not None
+        assert result2.payload.get("metadata") == {}
+    finally:
+        litellm.redact_user_api_key_info = original_value


### PR DESCRIPTION
## Relevant issues
The S3 logger was not redacting user API key information from metadata before uploading logs to S3 when redact_user_api_key_info was true. 
## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes
- Applied the same redaction logic used in Langfuse to the S3 logger.
- Applied redaction to metadata in `create_s3_batch_logging_element` method before payload creation
- Added unit tests to verify redaction behavior when enabled/disabled