### PR TITLE
Feature/lakera monitor mode

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/lakera_ai.md
+++ b/docs/my-website/docs/proxy/guardrails/lakera_ai.md
@@ -29,6 +29,13 @@ guardrails:
       mode: "pre_call"
       api_key: os.environ/LAKERA_API_KEY
       api_base: os.environ/LAKERA_API_BASE
+  - guardrail_name: "lakera-monitor"
+    litellm_params:
+      guardrail: lakera_v2
+      mode: "pre_call"
+      on_flagged: "monitor"  # Log violations but don't block
+      api_key: os.environ/LAKERA_API_KEY
+      api_base: os.environ/LAKERA_API_BASE
   
 ```
 
@@ -144,6 +151,7 @@ guardrails:
       # breakdown: Optional[bool] = True,
       # metadata: Optional[Dict] = None,
       # dev_info: Optional[bool] = True,
+      # on_flagged: Optional[str] = "block",  # "block" or "monitor"
 ```
 
 - `api_base`: (Optional[str]) The base of the Lakera integration. Defaults to `https://api.lakera.ai` 
@@ -153,3 +161,6 @@ guardrails:
 - `breakdown`: (Optional[bool]) When true the response will return a breakdown list of the detectors that were run, as defined in the policy, and whether each of them detected something or not.
 - `metadata`: (Optional[Dict]) Metadata tags can be attached to screening requests as an object that can contain any arbitrary key-value pairs. 
 - `dev_info`: (Optional[bool]) When true the response will return an object with developer information about the build of Lakera Guard.
+- `on_flagged`: (Optional[str]) Action to take when content is flagged. Defaults to `"block"`. 
+  - `"block"`: Raises an HTTP 400 exception when violations are detected (default behavior)
+  - `"monitor"`: Logs violations but allows the request to proceed. Useful for tuning security policies without blocking legitimate requests.

--- a/litellm/proxy/guardrails/guardrail_initializers.py
+++ b/litellm/proxy/guardrails/guardrail_initializers.py
@@ -65,6 +65,7 @@ def initialize_lakera_v2(litellm_params: LitellmParams, guardrail: Guardrail):
         breakdown=litellm_params.breakdown,
         metadata=litellm_params.metadata,
         dev_info=litellm_params.dev_info,
+        on_flagged=litellm_params.on_flagged,
     )
     litellm.logging_callback_manager.add_litellm_callback(_lakera_v2_callback)
     return _lakera_v2_callback

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -391,6 +391,10 @@ class LakeraV2GuardrailConfigModel(BaseModel):
         default=True,
         description="Whether to include developer information in the response",
     )
+    on_flagged: Optional[Literal["block", "monitor"]] = Field(
+        default="block",
+        description="Action to take when content is flagged: 'block' (raise exception) or 'monitor' (log only)",
+    )
 
 
 class LassoGuardrailConfigModel(BaseModel):

--- a/tests/guardrails_tests/test_lakera_v2.py
+++ b/tests/guardrails_tests/test_lakera_v2.py
@@ -231,3 +231,132 @@ async def test_lakera_blocks_flagged_content_with_user_scenario():
         assert lakera_response["metadata"]["request_uuid"] == "b7cd4c8a-28aa-4285-a245-2befee514dbf"
         assert len(lakera_response["breakdown"]) == 16  # All the breakdown items from the user's scenario
 
+
+@pytest.mark.asyncio
+async def test_lakera_monitor_mode_allows_flagged_content():
+    """Test that monitor mode logs violations but allows requests to proceed."""
+    
+    lakera_guardrail = LakeraAIGuardrail(
+        api_key="test_key",
+        on_flagged="monitor",  # Monitor mode
+    )
+    
+    # Mock response with violations
+    mock_response = {
+        'payload': [],
+        'flagged': True,
+        'breakdown': [
+            {'detector_type': 'moderated_content/violence', 'detected': True, 'message_id': 0},
+            {'detector_type': 'prompt_attack', 'detected': True, 'message_id': 0},
+        ]
+    }
+    
+    with patch.object(lakera_guardrail, 'call_v2_guard', new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = (mock_response, {})
+        
+        data = {
+            "messages": [
+                {"role": "user", "content": "Some harmful content"}
+            ],
+            "model": "gpt-3.5-turbo",
+            "metadata": {}
+        }
+        
+        user_api_key_dict = UserAPIKeyAuth(api_key="test_key")
+        cache = DualCache()
+        
+        # Should NOT raise an exception in monitor mode
+        result = await lakera_guardrail.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=cache,
+            data=data,
+            call_type="completion"
+        )
+        
+        # Verify request was allowed through
+        assert result is not None
+        assert "messages" in result
+
+
+@pytest.mark.asyncio
+async def test_lakera_block_mode_raises_exception():
+    """Test that block mode (default) raises HTTPException for violations."""
+    
+    lakera_guardrail = LakeraAIGuardrail(
+        api_key="test_key",
+        on_flagged="block",  # Block mode (default)
+    )
+    
+    mock_response = {
+        'payload': [],
+        'flagged': True,
+        'breakdown': [
+            {'detector_type': 'moderated_content/violence', 'detected': True, 'message_id': 0},
+        ]
+    }
+    
+    with patch.object(lakera_guardrail, 'call_v2_guard', new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = (mock_response, {})
+        
+        data = {
+            "messages": [
+                {"role": "user", "content": "Harmful content"}
+            ],
+            "model": "gpt-3.5-turbo",
+            "metadata": {}
+        }
+        
+        user_api_key_dict = UserAPIKeyAuth(api_key="test_key")
+        cache = DualCache()
+        
+        # Should raise HTTPException in block mode
+        with pytest.raises(HTTPException) as exc_info:
+            await lakera_guardrail.async_pre_call_hook(
+                user_api_key_dict=user_api_key_dict,
+                cache=cache,
+                data=data,
+                call_type="completion"
+            )
+        
+        assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_lakera_monitor_mode_during_call():
+    """Test monitor mode works with during_call (moderation_hook)."""
+    
+    lakera_guardrail = LakeraAIGuardrail(
+        api_key="test_key",
+        on_flagged="monitor",
+    )
+    
+    mock_response = {
+        'payload': [],
+        'flagged': True,
+        'breakdown': [
+            {'detector_type': 'prompt_attack', 'detected': True, 'message_id': 0},
+        ]
+    }
+    
+    with patch.object(lakera_guardrail, 'call_v2_guard', new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = (mock_response, {})
+        
+        data = {
+            "messages": [
+                {"role": "user", "content": "Test content"}
+            ],
+            "model": "gpt-3.5-turbo",
+            "metadata": {}
+        }
+        
+        user_api_key_dict = UserAPIKeyAuth(api_key="test_key")
+        
+        # Should NOT raise exception in monitor mode
+        result = await lakera_guardrail.async_moderation_hook(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            call_type="completion"
+        )
+        
+        assert result is not None
+


### PR DESCRIPTION

## Relevant issues

[Feature]: Add monitor mode support to Lakera guardrails #18015

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes
- Add on_flagged parameter to LakeraV2GuardrailConfigModel (default: 'block')
- Support 'monitor' mode that logs violations without blocking requests
- Support 'block' mode (default) that raises HTTPException on violations
- Update async_pre_call_hook and async_moderation_hook to check on_flagged
- Update guardrail initializer to pass on_flagged from config
- Add documentation with monitor mode examples

This allows users to tune Lakera security policies by monitoring violations without blocking legitimate requests.