### PR TITLE
fix(azure_ai): return AzureAnthropicConfig for Claude models in get_provider_chat_config

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7258,6 +7258,8 @@ class ProviderConfigManager:
                 return litellm.AzureOpenAIGPT5Config()
             return litellm.AzureOpenAIConfig()
         elif litellm.LlmProviders.AZURE_AI == provider:
+            if "claude" in model.lower():
+                return litellm.AzureAnthropicConfig()
             return litellm.AzureAIStudioConfig()
         elif litellm.LlmProviders.AZURE_TEXT == provider:
             return litellm.AzureOpenAITextConfig()

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -2602,3 +2602,30 @@ class TestIsCachedMessage:
         """Empty list content should return False."""
         message = {"role": "user", "content": []}
         assert is_cached_message(message) is False
+
+
+def test_azure_ai_claude_provider_config():
+    """Test that Azure AI Claude models return AzureAnthropicConfig for proper tool transformation."""
+    from litellm import AzureAnthropicConfig, AzureAIStudioConfig
+    from litellm.utils import ProviderConfigManager
+
+    # Claude models should return AzureAnthropicConfig
+    config = ProviderConfigManager.get_provider_chat_config(
+        model="claude-sonnet-4-5",
+        provider=LlmProviders.AZURE_AI,
+    )
+    assert isinstance(config, AzureAnthropicConfig)
+
+    # Test case-insensitive matching
+    config = ProviderConfigManager.get_provider_chat_config(
+        model="Claude-Opus-4",
+        provider=LlmProviders.AZURE_AI,
+    )
+    assert isinstance(config, AzureAnthropicConfig)
+
+    # Non-Claude models should return AzureAIStudioConfig
+    config = ProviderConfigManager.get_provider_chat_config(
+        model="mistral-large",
+        provider=LlmProviders.AZURE_AI,
+    )
+    assert isinstance(config, AzureAIStudioConfig)


### PR DESCRIPTION
Claude models on Azure AI were incorrectly using AzureAIStudioConfig, causing tool calls to fail with invalid_request_error because tools remained in OpenAI format instead of being transformed to Anthropic format.

## Relevant issues

(no open bug regarding this issue that I found)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`ProviderConfigManager.get_provider_chat_config()` now returns `AzureAnthropicConfig` for Claude models on the `azure_ai` provider, matching the existing pattern for Vertex AI and `get_provider_anthropic_messages_config()`.

Without this fix, Claude models on Azure AI receive tools in OpenAI format (`type: "function"`) instead of Anthropic format, causing the Azure Anthropic endpoint to reject requests with `invalid_request_error`.