### PR TITLE
feat(openai): add gpt-image-1.5 pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -17459,6 +17459,38 @@
             "/v1/images/edits"
         ]
     },
+    "gpt-image-1.5": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 8e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3.2e-05,
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
+    "gpt-image-1.5-2025-12-16": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 8e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3.2e-05,
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
     "gpt-realtime": {
         "cache_creation_input_audio_token_cost": 4e-07,
         "cache_read_input_token_cost": 4e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -17469,6 +17469,8 @@
         "output_cost_per_image_token": 3.2e-05,
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
             "/v1/images/generations",
             "/v1/images/edits"
         ]
@@ -17483,6 +17485,8 @@
         "output_cost_per_image_token": 3.2e-05,
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
             "/v1/images/generations",
             "/v1/images/edits"
         ]

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -17459,6 +17459,34 @@
             "/v1/images/edits"
         ]
     },
+    "gpt-image-1.5": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 8e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3.2e-05,
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
+    "gpt-image-1.5-2025-12-16": {
+        "cache_read_input_image_token_cost": 2e-06,
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_image_token": 8e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "output_cost_per_image_token": 3.2e-05,
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ]
+    },
     "gpt-realtime": {
         "cache_creation_input_audio_token_cost": 4e-07,
         "cache_read_input_token_cost": 4e-07,


### PR DESCRIPTION
## Relevant issues

Day 0 support for OpenAI's new `gpt-image-1.5` image generation model.

https://platform.openai.com/docs/models/gpt-image-1.5

## Pre-Submission checklist

- [x] I have Added testing - N/A (pricing JSON update only, no code changes)
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Add OpenAI's new `gpt-image-1.5` multimodal image generation model.

### Pricing

| Token Type | Input | Cached | Output |
|------------|-------|--------|--------|
| Text | $5/1M | $1.25/1M | $10/1M |
| Image | $8/1M | $2/1M | $32/1M |

### Supported Endpoints

- `/v1/chat/completions`
- `/v1/responses`
- `/v1/images/generations`
- `/v1/images/edits`

### Models added

- `gpt-image-1.5`
- `gpt-image-1.5-2025-12-16` (dated snapshot)