### PR TITLE
fix: broaden Azure AI rerank URL handling

### DIFF
--- a/litellm/llms/azure_ai/rerank/transformation.py
+++ b/litellm/llms/azure_ai/rerank/transformation.py
@@ -38,8 +38,12 @@ class AzureAIRerankConfig(CohereRerankConfig):
         if normalized_path.endswith("/v1/rerank") or normalized_path.endswith("/v2/rerank"):
             return str(original_url.copy_with(path=normalized_path or "/"))
 
-        # If callers pass just the version path (e.g. ".../v2"), append "/rerank"
-        if normalized_path.endswith("/v1") or normalized_path.endswith("/v2"):
+        # If callers pass just the version path (e.g. ".../v2" or ".../providers/cohere/v2"), append "/rerank"
+        if (
+            normalized_path.endswith("/v1")
+            or normalized_path.endswith("/v2")
+            or normalized_path.endswith("/providers/cohere/v2")
+        ):
             return _add_path_to_api_base(
                 api_base=str(original_url.copy_with(path=normalized_path or "/")),
                 ending_path="/rerank",

--- a/litellm/llms/azure_ai/rerank/transformation.py
+++ b/litellm/llms/azure_ai/rerank/transformation.py
@@ -30,6 +30,12 @@ class AzureAIRerankConfig(CohereRerankConfig):
                 "Azure AI API Base is required. api_base=None. Set in call or via `AZURE_AI_API_BASE` env var."
             )
         original_url = httpx.URL(api_base)
+        if not original_url.is_absolute_url:
+            raise ValueError(
+                "Azure AI API Base must be an absolute URL including scheme (e.g. "
+                "'https://<resource>.services.ai.azure.com'). "
+                f"Got api_base={api_base!r}."
+            )
         normalized_path = original_url.path.rstrip("/")
 
         # Allow callers to pass either full v1/v2 rerank endpoints:

--- a/litellm/llms/azure_ai/rerank/transformation.py
+++ b/litellm/llms/azure_ai/rerank/transformation.py
@@ -11,6 +11,7 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.llms.cohere.rerank.transformation import CohereRerankConfig
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.utils import RerankResponse
+from litellm.utils import _add_path_to_api_base
 
 
 class AzureAIRerankConfig(CohereRerankConfig):
@@ -28,9 +29,24 @@ class AzureAIRerankConfig(CohereRerankConfig):
             raise ValueError(
                 "Azure AI API Base is required. api_base=None. Set in call or via `AZURE_AI_API_BASE` env var."
             )
-        if not api_base.endswith("/v1/rerank"):
-            api_base = f"{api_base}/v1/rerank"
-        return api_base
+        original_url = httpx.URL(api_base)
+        normalized_path = original_url.path.rstrip("/")
+
+        # Allow callers to pass either full v1/v2 rerank endpoints:
+        # - https://<resource>.services.ai.azure.com/v1/rerank
+        # - https://<resource>.services.ai.azure.com/providers/cohere/v2/rerank
+        if normalized_path.endswith("/v1/rerank") or normalized_path.endswith("/v2/rerank"):
+            return str(original_url.copy_with(path=normalized_path or "/"))
+
+        # If callers pass just the version path (e.g. ".../v2"), append "/rerank"
+        if normalized_path.endswith("/v1") or normalized_path.endswith("/v2"):
+            return _add_path_to_api_base(
+                api_base=str(original_url.copy_with(path=normalized_path or "/")),
+                ending_path="/rerank",
+            )
+
+        # Backwards compatible default: Azure AI rerank was originally exposed under /v1/rerank
+        return _add_path_to_api_base(api_base=api_base, ending_path="/v1/rerank")
 
     def validate_environment(
         self,

--- a/tests/test_litellm/llms/azure_ai/rerank/test_azure_ai_rerank_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/rerank/test_azure_ai_rerank_transformation.py
@@ -1,0 +1,100 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.llms.azure_ai.rerank.transformation import AzureAIRerankConfig
+
+
+class TestAzureAIRerankConfigGetCompleteUrl:
+    def setup_method(self):
+        self.config = AzureAIRerankConfig()
+        self.model = "azure_ai/cohere-rerank-v3-english"
+
+    def test_api_base_required(self):
+        with pytest.raises(ValueError) as exc_info:
+            self.config.get_complete_url(api_base=None, model=self.model)
+
+        assert "api_base=None" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "api_base",
+        [
+            "example.com",
+            "example.com/v1",
+            "//example.com/v1",
+            "/v1/rerank",
+        ],
+    )
+    def test_api_base_requires_scheme(self, api_base):
+        with pytest.raises(ValueError) as exc_info:
+            self.config.get_complete_url(api_base=api_base, model=self.model)
+
+        error_message = str(exc_info.value).lower()
+        assert "absolute url" in error_message
+        assert "scheme" in error_message
+
+    @pytest.mark.parametrize(
+        "api_base, expected_url",
+        [
+            (
+                "https://my-resource.services.ai.azure.com/v1/rerank/",
+                "https://my-resource.services.ai.azure.com/v1/rerank",
+            ),
+            (
+                "https://my-resource.services.ai.azure.com/providers/cohere/v2/rerank/",
+                "https://my-resource.services.ai.azure.com/providers/cohere/v2/rerank",
+            ),
+        ],
+    )
+    def test_preserves_full_rerank_endpoint(self, api_base, expected_url):
+        url = self.config.get_complete_url(api_base=api_base, model=self.model)
+        assert url == expected_url
+
+    @pytest.mark.parametrize(
+        "api_base, expected_url",
+        [
+            (
+                "https://my-resource.services.ai.azure.com/v1",
+                "https://my-resource.services.ai.azure.com/v1/rerank",
+            ),
+            (
+                "https://my-resource.services.ai.azure.com/v2/",
+                "https://my-resource.services.ai.azure.com/v2/rerank",
+            ),
+            (
+                "https://my-resource.services.ai.azure.com/providers/cohere/v2",
+                "https://my-resource.services.ai.azure.com/providers/cohere/v2/rerank",
+            ),
+            (
+                "https://my-resource.services.ai.azure.com/providers/cohere/v2/",
+                "https://my-resource.services.ai.azure.com/providers/cohere/v2/rerank",
+            ),
+        ],
+    )
+    def test_appends_rerank_for_version_paths(self, api_base, expected_url):
+        url = self.config.get_complete_url(api_base=api_base, model=self.model)
+        assert url == expected_url
+
+    @pytest.mark.parametrize(
+        "api_base",
+        [
+            "https://my-resource.services.ai.azure.com",
+            "https://my-resource.services.ai.azure.com/",
+        ],
+    )
+    def test_defaults_to_v1_rerank_when_base_has_no_path(self, api_base):
+        url = self.config.get_complete_url(api_base=api_base, model=self.model)
+        assert url == "https://my-resource.services.ai.azure.com/v1/rerank"
+
+    def test_preserves_query_params(self):
+        url = self.config.get_complete_url(
+            api_base="https://my-resource.services.ai.azure.com/v1?r=1",
+            model=self.model,
+        )
+        assert url == "https://my-resource.services.ai.azure.com/v1/rerank?r=1"
+


### PR DESCRIPTION
Expands URL handling to support rerank v2 URIs
Required to support cohere rerank 4.0 models

## Relevant issues

Fixes #18024

## Type
🆕 New Feature
🐛 Bug Fix
