### PR TITLE
feat(bedrock): add OpenAI-compatible service_tier parameter translation

### DIFF
--- a/docs/my-website/docs/providers/bedrock.md
+++ b/docs/my-website/docs/providers/bedrock.md
@@ -967,6 +967,30 @@ Control the processing tier for your Bedrock requests using `serviceTier`. Valid
 
 [Bedrock ServiceTier API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ServiceTier.html)
 
+### OpenAI-compatible `service_tier` parameter
+
+LiteLLM also supports the OpenAI-style `service_tier` parameter, which is automatically translated to Bedrock's native `serviceTier` format:
+
+| OpenAI `service_tier` | Bedrock `serviceTier` |
+|-----------------------|----------------------|
+| `"priority"` | `{"type": "priority"}` |
+| `"default"` | `{"type": "default"}` |
+| `"flex"` | `{"type": "flex"}` |
+| `"auto"` | `{"type": "default"}` |
+
+```python
+from litellm import completion
+
+# Using OpenAI-style service_tier parameter
+response = completion(
+    model="bedrock/converse/anthropic.claude-3-sonnet-20240229-v1:0",
+    messages=[{"role": "user", "content": "Hello!"}],
+    service_tier="priority"  # Automatically translated to serviceTier={"type": "priority"}
+)
+```
+
+### Native Bedrock `serviceTier` parameter
+
 <Tabs>
 <TabItem value="sdk" label="SDK">
 

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -353,6 +353,7 @@ class AmazonConverseConfig(BaseConfig):
             "extra_headers",
             "response_format",
             "requestMetadata",
+            "service_tier",
         ]
 
         if (
@@ -676,6 +677,15 @@ class AmazonConverseConfig(BaseConfig):
                 if value is not None and isinstance(value, dict):
                     self._validate_request_metadata(value)  # type: ignore
                     optional_params["requestMetadata"] = value
+            if param == "service_tier" and isinstance(value, str):
+                # Map OpenAI service_tier (string) to Bedrock serviceTier (object)
+                # OpenAI values: "auto", "default", "flex", "priority"
+                # Bedrock values: "default", "flex", "priority" (no "auto")
+                bedrock_tier = value
+                if value == "auto":
+                    bedrock_tier = "default"  # Bedrock doesn't support "auto"
+                if bedrock_tier in ("default", "flex", "priority"):
+                    optional_params["serviceTier"] = {"type": bedrock_tier}
 
         # Only update thinking tokens for non-GPT-OSS models and non-Nova-Lite-2 models
         # Nova Lite 2 handles token budgeting differently through reasoningConfig

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1545,6 +1545,13 @@ class AmazonConverseConfig(BaseConfig):
         if "trace" in completion_response:
             setattr(model_response, "trace", completion_response["trace"])
 
+        # Add service_tier if present in Bedrock response
+        # Map Bedrock serviceTier (object) to OpenAI service_tier (string)
+        if "serviceTier" in completion_response:
+            service_tier_block = completion_response["serviceTier"]
+            if isinstance(service_tier_block, dict) and "type" in service_tier_block:
+                setattr(model_response, "service_tier", service_tier_block["type"])
+
         return model_response
 
     def get_error_class(

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -128,14 +128,19 @@ class ConverseTokenUsageBlock(TypedDict):
     cacheWriteInputTokens: int
 
 
-class ConverseResponseBlock(TypedDict):
+class ServiceTierBlock(TypedDict):
+    type: Literal["priority", "default", "flex"]
+
+
+class ConverseResponseBlock(TypedDict, total=False):
     additionalModelResponseFields: dict
     metrics: ConverseMetricsBlock
-    output: ConverseResponseOutputBlock
-    stopReason: (
-        str  # end_turn | tool_use | max_tokens | stop_sequence | content_filtered
-    )
-    usage: ConverseTokenUsageBlock
+    output: Required[ConverseResponseOutputBlock]
+    stopReason: Required[
+        str
+    ]  # end_turn | tool_use | max_tokens | stop_sequence | content_filtered
+    usage: Required[ConverseTokenUsageBlock]
+    serviceTier: ServiceTierBlock  # Optional - only present when serviceTier was sent in request
 
 
 class ToolJsonSchemaBlock(TypedDict, total=False):
@@ -214,10 +219,6 @@ class ContentBlockDeltaEvent(TypedDict, total=False):
 
 class PerformanceConfigBlock(TypedDict):
     latency: Literal["optimized", "throughput"]
-
-
-class ServiceTierBlock(TypedDict):
-    type: Literal["priority", "default", "flex"]
 
 
 class CommonRequestObject(

--- a/tests/test_litellm/llms/bedrock/chat/test_service_tier.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_service_tier.py
@@ -147,3 +147,78 @@ def test_service_tier_with_other_config_blocks():
     assert result["serviceTier"]["type"] == "priority"
     assert "performanceConfig" in result
     assert result["performanceConfig"]["latency"] == "optimized"
+
+
+# Tests for OpenAI-compatible service_tier parameter translation
+
+
+def test_service_tier_in_supported_openai_params():
+    """Test that service_tier is in the list of supported OpenAI params."""
+    config = AmazonConverseConfig()
+    supported_params = config.get_supported_openai_params(
+        model="anthropic.claude-3-sonnet-20240229-v1:0"
+    )
+    assert "service_tier" in supported_params
+
+
+def test_map_openai_service_tier_priority():
+    """Test that OpenAI service_tier='priority' maps to Bedrock serviceTier."""
+    config = AmazonConverseConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"service_tier": "priority"},
+        optional_params={},
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        drop_params=False,
+    )
+
+    assert "serviceTier" in result
+    assert result["serviceTier"] == {"type": "priority"}
+
+
+def test_map_openai_service_tier_default():
+    """Test that OpenAI service_tier='default' maps to Bedrock serviceTier."""
+    config = AmazonConverseConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"service_tier": "default"},
+        optional_params={},
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        drop_params=False,
+    )
+
+    assert "serviceTier" in result
+    assert result["serviceTier"] == {"type": "default"}
+
+
+def test_map_openai_service_tier_flex():
+    """Test that OpenAI service_tier='flex' maps to Bedrock serviceTier."""
+    config = AmazonConverseConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"service_tier": "flex"},
+        optional_params={},
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        drop_params=False,
+    )
+
+    assert "serviceTier" in result
+    assert result["serviceTier"] == {"type": "flex"}
+
+
+def test_map_openai_service_tier_auto_maps_to_default():
+    """Test that OpenAI service_tier='auto' maps to Bedrock serviceTier='default'.
+
+    Bedrock doesn't support 'auto', so we map it to 'default'.
+    """
+    config = AmazonConverseConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"service_tier": "auto"},
+        optional_params={},
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        drop_params=False,
+    )
+
+    assert "serviceTier" in result
+    assert result["serviceTier"] == {"type": "default"}

--- a/tests/test_litellm/llms/bedrock/chat/test_service_tier.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_service_tier.py
@@ -222,3 +222,205 @@ def test_map_openai_service_tier_auto_maps_to_default():
 
     assert "serviceTier" in result
     assert result["serviceTier"] == {"type": "default"}
+
+
+# Tests for service_tier in response
+
+
+def test_transform_response_with_service_tier():
+    """Test that serviceTier from Bedrock response is mapped to service_tier in OpenAI format."""
+    from unittest.mock import Mock
+
+    import httpx
+
+    from litellm.types.utils import ModelResponse
+
+    config = AmazonConverseConfig()
+
+    # Mock Bedrock response with serviceTier
+    mock_response_data = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Hello! How can I assist you today?"}],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {
+            "inputTokens": 10,
+            "outputTokens": 20,
+            "totalTokens": 30,
+        },
+        "serviceTier": {"type": "priority"},  # This should be mapped to service_tier
+    }
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.json.return_value = mock_response_data
+    mock_response.text = json.dumps(mock_response_data)
+
+    model_response = ModelResponse()
+    messages = [{"role": "user", "content": "Hello"}]
+
+    result = config.transform_response(
+        model="bedrock/converse/anthropic.claude-3-sonnet-20240229-v1:0",
+        raw_response=mock_response,
+        model_response=model_response,
+        logging_obj=None,
+        request_data={},
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+    )
+
+    # Verify service_tier is present in the response
+    assert hasattr(result, "service_tier")
+    assert result.service_tier == "priority"
+
+
+def test_transform_response_with_service_tier_default():
+    """Test that serviceTier='default' is correctly mapped."""
+    from unittest.mock import Mock
+
+    import httpx
+
+    from litellm.types.utils import ModelResponse
+
+    config = AmazonConverseConfig()
+
+    mock_response_data = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Response text"}],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {
+            "inputTokens": 10,
+            "outputTokens": 20,
+            "totalTokens": 30,
+        },
+        "serviceTier": {"type": "default"},
+    }
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.json.return_value = mock_response_data
+    mock_response.text = json.dumps(mock_response_data)
+
+    model_response = ModelResponse()
+    messages = [{"role": "user", "content": "Hello"}]
+
+    result = config.transform_response(
+        model="bedrock/converse/anthropic.claude-3-sonnet-20240229-v1:0",
+        raw_response=mock_response,
+        model_response=model_response,
+        logging_obj=None,
+        request_data={},
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+    )
+
+    assert hasattr(result, "service_tier")
+    assert result.service_tier == "default"
+
+
+def test_transform_response_with_service_tier_flex():
+    """Test that serviceTier='flex' is correctly mapped."""
+    from unittest.mock import Mock
+
+    import httpx
+
+    from litellm.types.utils import ModelResponse
+
+    config = AmazonConverseConfig()
+
+    mock_response_data = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Response text"}],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {
+            "inputTokens": 10,
+            "outputTokens": 20,
+            "totalTokens": 30,
+        },
+        "serviceTier": {"type": "flex"},
+    }
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.json.return_value = mock_response_data
+    mock_response.text = json.dumps(mock_response_data)
+
+    model_response = ModelResponse()
+    messages = [{"role": "user", "content": "Hello"}]
+
+    result = config.transform_response(
+        model="bedrock/converse/anthropic.claude-3-sonnet-20240229-v1:0",
+        raw_response=mock_response,
+        model_response=model_response,
+        logging_obj=None,
+        request_data={},
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+    )
+
+    assert hasattr(result, "service_tier")
+    assert result.service_tier == "flex"
+
+
+def test_transform_response_without_service_tier():
+    """Test that responses without serviceTier don't have service_tier attribute."""
+    from unittest.mock import Mock
+
+    import httpx
+
+    from litellm.types.utils import ModelResponse
+
+    config = AmazonConverseConfig()
+
+    # Mock Bedrock response WITHOUT serviceTier
+    mock_response_data = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Hello! How can I assist you today?"}],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {
+            "inputTokens": 10,
+            "outputTokens": 20,
+            "totalTokens": 30,
+        },
+        # No serviceTier field
+    }
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.json.return_value = mock_response_data
+    mock_response.text = json.dumps(mock_response_data)
+
+    model_response = ModelResponse()
+    messages = [{"role": "user", "content": "Hello"}]
+
+    result = config.transform_response(
+        model="bedrock/converse/anthropic.claude-3-sonnet-20240229-v1:0",
+        raw_response=mock_response,
+        model_response=model_response,
+        logging_obj=None,
+        request_data={},
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+    )
+
+    # service_tier should not be present if not in Bedrock response
+    assert not hasattr(result, "service_tier")


### PR DESCRIPTION
## Relevant issues

Related to #17911 and #17810

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

### Summary

Adds OpenAI-compatible `service_tier` parameter support for Bedrock Converse API, translating it to Bedrock's native `serviceTier` format.

Currently, using the OpenAI-style `service_tier` parameter with Bedrock models throws `UnsupportedParamsError`:

```python
# This fails with UnsupportedParamsError
litellm.completion(
    model="bedrock/converse/anthropic.claude-3-sonnet-20240229-v1:0",
    messages=[{"role": "user", "content": "Hi"}],
    service_tier="priority"
)
```

### Solution

1. Added `service_tier` to `supported_params` in `get_supported_openai_params()`
2. Added translation in `map_openai_params()` that converts:
   - `service_tier="priority"` → `serviceTier={"type": "priority"}`
   - `service_tier="default"` → `serviceTier={"type": "default"}`
   - `service_tier="flex"` → `serviceTier={"type": "flex"}`
   - `service_tier="auto"` → `serviceTier={"type": "default"}` (Bedrock doesn't support "auto")

### Usage

```python
# Now works with OpenAI-style parameter
litellm.completion(
    model="bedrock/converse/anthropic.claude-3-sonnet-20240229-v1:0",
    messages=[{"role": "user", "content": "Hi"}],
    service_tier="priority"  # OpenAI format, automatically translated
)
```

### Tests

Added 5 new tests in `tests/test_litellm/llms/bedrock/chat/test_service_tier.py`:
- `test_service_tier_in_supported_openai_params`
- `test_map_openai_service_tier_priority`
- `test_map_openai_service_tier_default`
- `test_map_openai_service_tier_flex`
- `test_map_openai_service_tier_auto_maps_to_default`

12 tests passing:
```
======================== 12 passed in 0.04s ========================
```