### PR TITLE
fix(docker): add libsndfile to Alpine image for ARM64 audio processing

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -34,8 +34,8 @@ RUN pip wheel --no-cache-dir --wheel-dir=/wheels/ -r requirements.txt
 # Runtime stage
 FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
-# Update dependencies and clean up
-RUN apk upgrade --no-cache
+# Update dependencies and clean up, install libsndfile for audio processing
+RUN apk upgrade --no-cache && apk add --no-cache libsndfile
 
 WORKDIR /app
 


### PR DESCRIPTION
## Relevant issues

Fixes #16920

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - N/A (Dockerfile change, not testable with unit tests)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Adds `libsndfile` system library to the Alpine Docker image (`docker/Dockerfile.alpine`).

The ARM64 Alpine image was missing the `libsndfile` native library, causing the Python `soundfile` module to fail with:

```
cannot load library 'libsndfile.so': libsndfile.so: cannot open shared object file
```

This affects users running LiteLLM on ARM64 infrastructure (Apple Silicon Macs via Docker, AWS Graviton, etc.) who need audio processing features (STT/TTS).

When you `pip install soundfile`:

```
macOS / Windows / Linux x86_64 (glibc)
   │
   └─ PyPI has pre-built .whl with libsndfile bundled inside
         │
         └─ Downloads .whl → extracts → works ✅


Alpine ARM64 (musl)
   │
   └─ PyPI has NO .whl for musllinux_aarch64
         │
         └─ Downloads .tar.gz (source) → compiles → needs libsndfile from system
                                                          │
                                                          └─ Not installed ❌
```

- Alpine Linux uses `musl` libc instead of `glibc` (standard)
- Binaries compiled for `glibc` don't work on `musl` and vice versa
- The `soundfile` maintainers don't publish wheels for `musllinux` (Alpine)
- So pip falls back to source compilation, which requires `libsndfile` system library

### Solution

Added `apk add --no-cache libsndfile` to the runtime stage of `Dockerfile.alpine`.

This is the standard solution - the `soundfile` documentation states: "On Linux, you need to install libsndfile using your distribution's package manager."