### PR TITLE
Fix get_model_from_request() to extract model ID from Vertex AI passthrough URLs

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -616,6 +616,14 @@ def get_model_from_request(
         if match:
             model = match.group(1)
 
+    # If still not found, extract from Vertex AI passthrough route
+    # Pattern: /vertex_ai/.../models/{model_id}:*
+    # Example: /vertex_ai/v1/.../models/gemini-1.5-pro:generateContent
+    if model is None and "/vertex" in route.lower():
+        vertex_match = re.search(r"/models/([^/:]+)", route)
+        if vertex_match:
+            model = vertex_match.group(1)
+
     return model
 
 

--- a/tests/local_testing/test_auth_utils.py
+++ b/tests/local_testing/test_auth_utils.py
@@ -311,3 +311,56 @@ def test_get_internal_user_header_from_mapping_no_internal_returns_none():
     single_mapping = {"header_name": "X-Only-Customer", "litellm_user_role": "customer"}
     result = LiteLLMProxyRequestSetup.get_internal_user_header_from_mapping(single_mapping)
     assert result is None
+
+
+@pytest.mark.parametrize(
+    "request_data, route, expected_model",
+    [
+        # Vertex AI passthrough URL patterns
+        (
+            {},
+            "/vertex_ai/v1/projects/my-project/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent",
+            "gemini-1.5-pro"
+        ),
+        (
+            {},
+            "/vertex_ai/v1beta1/projects/my-project/locations/us-central1/publishers/google/models/gemini-1.0-pro:streamGenerateContent",
+            "gemini-1.0-pro"
+        ),
+        (
+            {},
+            "/vertex_ai/v1/projects/my-project/locations/asia-southeast1/publishers/google/models/gemini-2.0-flash:generateContent",
+            "gemini-2.0-flash"
+        ),
+        # Model without method suffix (no colon) - should still extract
+        (
+            {},
+            "/vertex_ai/v1/projects/my-project/locations/us-central1/publishers/google/models/gemini-pro",
+            "gemini-pro"  # Should match even without colon
+        ),
+        # Request body model takes precedence over URL
+        (
+            {"model": "gpt-4o"},
+            "/vertex_ai/v1/projects/my-project/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent",
+            "gpt-4o"
+        ),
+        # Non-vertex route should not extract from vertex pattern
+        (
+            {},
+            "/openai/v1/chat/completions",
+            None
+        ),
+        # Azure deployment pattern should still work
+        (
+            {},
+            "/openai/deployments/my-deployment/chat/completions",
+            "my-deployment"
+        ),
+    ],
+)
+def test_get_model_from_request_vertex_ai_passthrough(request_data, route, expected_model):
+    """Test that get_model_from_request correctly extracts Vertex AI model from URL"""
+    from litellm.proxy.auth.auth_utils import get_model_from_request
+
+    model = get_model_from_request(request_data, route)
+    assert model == expected_model


### PR DESCRIPTION
## Title

Fix get_model_from_request() to extract model ID from Vertex AI passthrough URLs

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="3504" height="548" alt="image" src="https://github.com/user-attachments/assets/0814b1f7-c530-40be-a6d7-004419f17c2c" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

### Summary
This PR enhances the model extraction logic in the proxy authentication module to properly handle Vertex AI passthrough routes. Previously, the `get_model_from_request()` function could not extract model IDs from Vertex AI passthrough URLs, which follows a distinct pattern compared to OpenAI deployments.

### Problem
Vertex AI passthrough endpoints have a URL structure like:
```
/vertex_ai/v1/projects/{project}/locations/{location}/publishers/google/models/{model_id}:{method}
```

The existing model extraction logic only handled OpenAI deployments (`/openai/deployments/{model}/`), leaving Vertex AI models unidentified.

### Solution
Added regex-based model extraction for Vertex AI routes:
- Pattern: `/vertex_ai/.../models/{model_id}:*`
- Extracts model ID using the regex pattern: `/models/([^/:]+)`
- Handles both versioned endpoints (v1, v1beta1) and different Google Cloud regions
- Maintains precedence: request body model > extracted from URL
- Does not interfere with existing OpenAI deployment extraction

### Testing
Added comprehensive test coverage with 7 parametrized test cases in `test_get_model_from_request_vertex_ai_passthrough()`:
1. ✅ Vertex AI v1 endpoint with generateContent method
2. ✅ Vertex AI v1beta1 endpoint with streamGenerateContent method
3. ✅ Different region locations (us-central1, asia-southeast1)
4. ✅ Model extraction without method suffix (no colon)
5. ✅ Request body model takes precedence over URL pattern
6. ✅ Non-Vertex routes are not affected
7. ✅ Azure deployment pattern still works as expected

### Files Changed
- `litellm/proxy/auth/auth_utils.py`: Added Vertex AI model extraction logic
- `tests/local_testing/test_auth_utils.py`: Added parametrized test cases
