### PR TITLE
Update headings for fallback sections in reliability.md

### DIFF
--- a/docs/my-website/docs/proxy/reliability.md
+++ b/docs/my-website/docs/proxy/reliability.md
@@ -416,7 +416,7 @@ print(response)
 </TabItem>
 </Tabs>
 
-## Content Policy Violation Fallback
+### Content Policy Violation Fallback
 
 Key change: 
 
@@ -480,7 +480,7 @@ litellm --config /path/to/config.yaml
 </TabItem>
 </Tabs>
 
-## Context Window Exceeded Fallback
+### Context Window Exceeded Fallback
 
 Key change: 
 


### PR DESCRIPTION
## Relevant issues


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


📖 Documentation

## Changes

Both "Content Policy Violation Fallback" and "Context Window Exceeded Fallback" belong to "Client Side Fallbacks", so they should be set as three-level headings
