### PR TITLE
Add support for bedrock image gaurdrails

### DIFF
--- a/litellm/llms/bedrock/image/image_handler.py
+++ b/litellm/llms/bedrock/image/image_handler.py
@@ -170,6 +170,21 @@ class BedrockImageGeneration(BaseAWSLLM):
         )
         return model_response
 
+    def _extract_headers_from_optional_params(self, optional_params: dict) -> dict:
+        """
+        Extract guardrail parameters from optional_params and convert them to headers.
+        """
+        headers = {}
+        guardrail_identifier = optional_params.pop("guardrailIdentifier", None)
+        guardrail_version = optional_params.pop("guardrailVersion", None)
+        
+        if guardrail_identifier is not None:
+            headers["x-amz-bedrock-guardrail-identifier"] = guardrail_identifier
+        if guardrail_version is not None:
+            headers["x-amz-bedrock-guardrail-version"] = guardrail_version
+            
+        return headers
+
     def _prepare_request(
         self,
         model: str,
@@ -227,6 +242,10 @@ class BedrockImageGeneration(BaseAWSLLM):
         headers = {"Content-Type": "application/json"}
         if extra_headers is not None:
             headers = {"Content-Type": "application/json", **extra_headers}
+
+        # Extract guardrail parameters and add them as headers
+        guardrail_headers = self._extract_headers_from_optional_params(optional_params)
+        headers.update(guardrail_headers)
 
         prepped = self.get_request_headers(
             credentials=boto3_credentials_info.credentials,

--- a/tests/image_gen_tests/test_bedrock_image_gen_unit_tests.py
+++ b/tests/image_gen_tests/test_bedrock_image_gen_unit_tests.py
@@ -541,3 +541,28 @@ def test_amazon_titan_image_gen():
     print(f"response cost: {response._hidden_params['response_cost']}")
 
     assert response._hidden_params["response_cost"] > 0
+
+
+def test_extract_headers_from_optional_params_with_guardrails():
+    """Test that guardrail parameters are correctly extracted from optional_params and converted to headers"""
+    handler = BedrockImageGeneration()
+    
+    # Test with both guardrail parameters
+    optional_params = {
+        "guardrailIdentifier": "4cf5knqaeq15",
+        "guardrailVersion": "1",
+        "someOtherParam": "value",
+    }
+    
+    headers = handler._extract_headers_from_optional_params(optional_params)
+    
+    # Verify headers are correctly set
+    assert headers["x-amz-bedrock-guardrail-identifier"] == "4cf5knqaeq15"
+    assert headers["x-amz-bedrock-guardrail-version"] == "1"
+    
+    # Verify guardrail params are removed from optional_params
+    assert "guardrailIdentifier" not in optional_params
+    assert "guardrailVersion" not in optional_params
+    
+    # Verify other params remain in optional_params
+    assert optional_params["someOtherParam"] == "value"


### PR DESCRIPTION
## Relevant issues

Fixes LIT-1558

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
- Added conversion for gaurdrails params into bedrock headers

<img width="1286" height="276" alt="image" src="https://github.com/user-attachments/assets/c642640f-19c9-4ef4-b729-dfdab9cfbb5e" />
