### PR TITLE
fix: remove fake keys causing security scans to fail

### DIFF
--- a/litellm/proxy/_super_secret_config.yaml
+++ b/litellm/proxy/_super_secret_config.yaml
@@ -81,13 +81,13 @@ model_list:
 #   # default_team_settings: 
 #   #   - team_id: proj1
 #   #     success_callback: ["langfuse"]
-#   #     langfuse_public_key: pk-lf-a65841e9-5192-4397-a679-cfff029fd5b0
-#   #     langfuse_secret: sk-lf-d58c2891-3717-4f98-89dd-df44826215fd
+#   #     langfuse_public_key: os.environ/LANGFUSE_PUBLIC_KEY
+#   #     langfuse_secret: os.environ/LANGFUSE_SECRET
 #   #     langfuse_host: https://us.cloud.langfuse.com
 #   #   - team_id: proj2
 #   #     success_callback: ["langfuse"]
-#   #     langfuse_public_key: pk-lf-3d789fd1-f49f-4e73-a7d9-1b4e11acbf9a
-#   #     langfuse_secret: sk-lf-11b13aca-b0d4-4cde-9d54-721479dace6d
+#   #     langfuse_public_key: os.environ/LANGFUSE_PUBLIC_KEY
+#   #     langfuse_secret: os.environ/LANGFUSE_SECRET
 #   #     langfuse_host: https://us.cloud.langfuse.com
 
 assistant_settings:

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -20,8 +20,8 @@ Object.defineProperty(window, "matchMedia", {
 
 describe("KeyEditView", () => {
   const MOCK_KEY_DATA: KeyResponse = {
-    token: "40b7608ea43423400d5b82bb5ee11042bfb2ed4655f05b5992b5abbc2f294931",
-    token_id: "40b7608ea43423400d5b82bb5ee11042bfb2ed4655f05b5992b5abbc2f294931",
+    token: "test-token-123",
+    token_id: "test-token-123",
     key_name: "sk-...TUuw",
     key_alias: "asdasdas",
     spend: 0,

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -5,8 +5,8 @@ import KeyInfoView from "./key_info_view";
 
 describe("KeyInfoView", () => {
   const MOCK_KEY_DATA: KeyResponse = {
-    token: "40b7608ea43423400d5b82bb5ee11042bfb2ed4655f05b5992b5abbc2f294931",
-    token_id: "40b7608ea43423400d5b82bb5ee11042bfb2ed4655f05b5992b5abbc2f294931",
+    token: "test-token-123",
+    token_id: "test-token-123",
     key_name: "sk-...TUuw",
     key_alias: "asdasdas",
     spend: 0,


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: **Not Needed**

- [ ] **CI run for the last commit**  
       Link:  **Not Needed**

- [ ] **Merge / cherry-pick CI run**  
       Links:  **Not Needed**

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Remove fake keys being flagged on security scans.

## Test Results

**Before**
<img width="3839" height="1956" alt="Screenshot 2025-12-17 095522" src="https://github.com/user-attachments/assets/1ee633d3-da0f-4c21-b020-a13ed7d1e760" />

**After**
<img width="3574" height="627" alt="Screenshot 2025-12-17 095607" src="https://github.com/user-attachments/assets/690a9155-25cf-402a-a5e9-4c19a02435d1" />

