### PR TITLE
feat(gemini): add opt-in support for responseJsonSchema

### DIFF
--- a/docs/my-website/docs/completion/json_mode.md
+++ b/docs/my-website/docs/completion/json_mode.md
@@ -343,11 +343,11 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 </TabItem>
 </Tabs>
 
-## Gemini - Use Native JSON Schema Format (Gemini 2.0+)
+## Gemini - Native JSON Schema Format (Gemini 2.0+)
 
-Gemini 2.0+ models support a native `responseJsonSchema` parameter that uses standard JSON Schema format. This provides better compatibility with Pydantic schemas and supports `additionalProperties`.
+Gemini 2.0+ models automatically use the native `responseJsonSchema` parameter, which provides better compatibility with standard JSON Schema format.
 
-### Benefits of `use_json_schema: True`:
+### Benefits (Gemini 2.0+):
 - Standard JSON Schema format (lowercase types like `string`, `object`)
 - Supports `additionalProperties: false` for stricter validation
 - Better compatibility with Pydantic's `model_json_schema()`
@@ -380,10 +380,9 @@ response = completion(
                     "age": {"type": "integer"}
                 },
                 "required": ["name", "age"],
-                "additionalProperties": False  # Now works with use_json_schema!
+                "additionalProperties": False  # Supported on Gemini 2.0+
             }
-        },
-        "use_json_schema": True  # Opt-in to native JSON Schema format
+        }
     }
 )
 ```
@@ -413,8 +412,7 @@ curl http://0.0.0.0:4000/v1/chat/completions \
                 "required": ["name", "age"],
                 "additionalProperties": false
             }
-        },
-        "use_json_schema": true
+        }
     }
   }'
 ```
@@ -422,12 +420,11 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 </TabItem>
 </Tabs>
 
-### Supported Models
+### Model Behavior
 
-`use_json_schema: True` is supported on Gemini 2.0+ models:
-- `gemini-2.0-flash`
-- `gemini-2.0-flash-lite`
-- `gemini-2.5-pro`
-- `gemini-2.5-flash`
+| Model | Format Used | `additionalProperties` Support |
+|-------|-------------|-------------------------------|
+| Gemini 2.0+ | `responseJsonSchema` (JSON Schema) | ✅ Yes |
+| Gemini 1.5 | `responseSchema` (OpenAPI) | ❌ No |
 
-For older models (e.g., `gemini-1.5-flash`), the parameter is ignored and falls back to the default `responseSchema` format.
+LiteLLM automatically selects the appropriate format based on the model version.

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -150,6 +150,34 @@ def get_supports_response_schema(
     return _supports_response_schema
 
 
+def supports_response_json_schema(model: str) -> bool:
+    """
+    Check if the model supports responseJsonSchema (JSON Schema format).
+
+    responseJsonSchema is supported by Gemini 2.0+ models and uses standard
+    JSON Schema format with lowercase types (string, object, etc.) instead of
+    the OpenAPI-style responseSchema with uppercase types (STRING, OBJECT, etc.).
+
+    Benefits of responseJsonSchema:
+    - Supports additionalProperties for stricter schema validation
+    - Uses standard JSON Schema format (no type conversion needed)
+    - Better compatibility with Pydantic's model_json_schema()
+
+    Args:
+        model: The model name (e.g., "gemini-2.0-flash", "gemini-2.5-pro")
+
+    Returns:
+        True if the model supports responseJsonSchema, False otherwise
+    """
+    model_lower = model.lower()
+
+    # Gemini 2.0+ and 2.5+ models support responseJsonSchema
+    # Pattern matches: gemini-2.0-*, gemini-2.5-*, gemini-3-*, etc.
+    gemini_2_plus_pattern = re.compile(r"gemini-([2-9]|[1-9]\d+)\.")
+
+    return bool(gemini_2_plus_pattern.search(model_lower))
+
+
 from typing import Literal, Optional
 
 all_gemini_url_modes = Literal[
@@ -463,6 +491,44 @@ def _build_vertex_schema(parameters: dict, add_property_ordering: bool = False):
 
     if add_property_ordering:
         set_schema_property_ordering(parameters)
+
+    return parameters
+
+
+def _build_json_schema(parameters: dict) -> dict:
+    """
+    Build a JSON Schema for use with Gemini's responseJsonSchema parameter.
+
+    Unlike _build_vertex_schema (used for responseSchema), this function:
+    - Does NOT convert types to uppercase (keeps standard JSON Schema format)
+    - Does NOT add propertyOrdering
+    - Does NOT filter fields (allows additionalProperties)
+    - Still unpacks $defs/$ref (Gemini doesn't support JSON Schema references)
+
+    Parameters:
+        parameters: dict - the JSON schema to process
+
+    Returns:
+        dict - the processed schema in standard JSON Schema format
+    """
+    # Unpack $defs references (Gemini doesn't support $ref)
+    defs = parameters.pop("$defs", {})
+    for name, value in defs.items():
+        unpack_defs(value, defs)
+    unpack_defs(parameters, defs)
+
+    # Convert anyOf with null to nullable
+    convert_anyof_null_to_nullable(parameters)
+
+    # Handle empty strings in enum values - Gemini doesn't accept empty strings in enums
+    _fix_enum_empty_strings(parameters)
+
+    # Remove enums for non-string typed fields (Gemini requires enum only on strings)
+    _fix_enum_types(parameters)
+
+    # Handle empty items objects
+    process_items(parameters)
+    add_object_type(parameters)
 
     return parameters
 

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -92,7 +92,12 @@ from litellm.utils import (
 )
 
 from ....utils import _remove_additional_properties, _remove_strict_from_schema
-from ..common_utils import VertexAIError, _build_vertex_schema
+from ..common_utils import (
+    VertexAIError,
+    _build_json_schema,
+    _build_vertex_schema,
+    supports_response_json_schema,
+)
 from ..vertex_llm_base import VertexBase
 from .transformation import (
     _gemini_convert_messages_with_history,
@@ -595,30 +600,61 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             )
         return old_schema
 
-    def apply_response_schema_transformation(self, value: dict, optional_params: dict):
+    def apply_response_schema_transformation(
+        self, value: dict, optional_params: dict, model: str
+    ):
         new_value = deepcopy(value)
-        # remove 'additionalProperties' from json schema
-        new_value = _remove_additional_properties(new_value)
-        # remove 'strict' from json schema
+        # remove 'strict' from json schema (not supported by Gemini)
         new_value = _remove_strict_from_schema(new_value)
-        if new_value["type"] == "json_object":
+
+        # Check if user explicitly opted-in to use responseJsonSchema
+        # This is opt-in to maintain backwards compatibility
+        use_json_schema = new_value.pop("use_json_schema", False)
+
+        # Only allow use_json_schema for models that support it (Gemini 2.0+)
+        if use_json_schema and not supports_response_json_schema(model):
+            verbose_logger.warning(
+                f"Model {model} does not support responseJsonSchema. Falling back to responseSchema."
+            )
+            use_json_schema = False
+
+        if not use_json_schema:
+            # For responseSchema, remove 'additionalProperties' (not supported)
+            new_value = _remove_additional_properties(new_value)
+
+        # Handle response type
+        if new_value.get("type") == "json_object":
             optional_params["response_mime_type"] = "application/json"
-        elif new_value["type"] == "text":
+        elif new_value.get("type") == "text":
             optional_params["response_mime_type"] = "text/plain"
+
+        # Extract schema from response_format
+        schema = None
         if "response_schema" in new_value:
             optional_params["response_mime_type"] = "application/json"
-            optional_params["response_schema"] = new_value["response_schema"]
-        elif new_value["type"] == "json_schema":  # type: ignore
-            if "json_schema" in new_value and "schema" in new_value["json_schema"]:  # type: ignore
+            schema = new_value["response_schema"]
+        elif new_value.get("type") == "json_schema":
+            if "json_schema" in new_value and "schema" in new_value["json_schema"]:
                 optional_params["response_mime_type"] = "application/json"
-                optional_params["response_schema"] = new_value["json_schema"]["schema"]  # type: ignore
+                schema = new_value["json_schema"]["schema"]
 
-        if "response_schema" in optional_params and isinstance(
-            optional_params["response_schema"], dict
-        ):
-            optional_params["response_schema"] = self._map_response_schema(
-                value=optional_params["response_schema"]
-            )
+        if schema and isinstance(schema, dict):
+            if use_json_schema:
+                # Use responseJsonSchema (Gemini 2.0+ only, opt-in)
+                # - Standard JSON Schema format (lowercase types)
+                # - Supports additionalProperties
+                # - No propertyOrdering needed
+                optional_params["response_json_schema"] = _build_json_schema(
+                    deepcopy(schema)
+                )
+            else:
+                # Use responseSchema (default, backwards compatible)
+                # - OpenAPI-style format (uppercase types)
+                # - No additionalProperties support
+                # - Requires propertyOrdering
+                optional_params["response_schema"] = self._map_response_schema(
+                    value=schema
+                )
 
     @staticmethod
     def _map_reasoning_effort_to_thinking_budget(
@@ -868,7 +904,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 optional_params["max_output_tokens"] = value
             elif param == "response_format" and isinstance(value, dict):  # type: ignore
                 self.apply_response_schema_transformation(
-                    value=value, optional_params=optional_params
+                    value=value, optional_params=optional_params, model=model
                 )
             elif param == "frequency_penalty":
                 if self._supports_penalty_parameters(model):

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -607,16 +607,10 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         # remove 'strict' from json schema (not supported by Gemini)
         new_value = _remove_strict_from_schema(new_value)
 
-        # Check if user explicitly opted-in to use responseJsonSchema
-        # This is opt-in to maintain backwards compatibility
-        use_json_schema = new_value.pop("use_json_schema", False)
-
-        # Only allow use_json_schema for models that support it (Gemini 2.0+)
-        if use_json_schema and not supports_response_json_schema(model):
-            verbose_logger.warning(
-                f"Model {model} does not support responseJsonSchema. Falling back to responseSchema."
-            )
-            use_json_schema = False
+        # Automatically use responseJsonSchema for Gemini 2.0+ models
+        # responseJsonSchema uses standard JSON Schema format and supports additionalProperties
+        # For older models (Gemini 1.5), fall back to responseSchema (OpenAPI format)
+        use_json_schema = supports_response_json_schema(model)
 
         if not use_json_schema:
             # For responseSchema, remove 'additionalProperties' (not supported)

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -207,6 +207,7 @@ class GenerationConfig(TypedDict, total=False):
     frequency_penalty: float
     response_mime_type: Literal["text/plain", "application/json"]
     response_schema: dict
+    response_json_schema: dict
     seed: int
     responseLogprobs: bool
     logprobs: int


### PR DESCRIPTION
## Relevant issues

Fixes #16340

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Automatically use Gemini's native `responseJsonSchema` for Gemini 2.0+ models.

### What is `responseJsonSchema`?

Gemini API supports two schema formats for structured outputs:
- `responseSchema` (OpenAPI format) - uppercase types, no additionalProperties support
- `responseJsonSchema` (JSON Schema format) - standard format, supports additionalProperties

### Benefits of `responseJsonSchema` (Gemini 2.0+):
- Standard JSON Schema format (lowercase types like `string`, `object`)
- Supports `additionalProperties: false` for stricter validation
- Better compatibility with Pydantic's `model_json_schema()`
- No `propertyOrdering` required

### Usage:

```python
response = litellm.completion(
    model="gemini/gemini-2.0-flash",
    messages=[{"role": "user", "content": "..."}],
    response_format={
        "type": "json_schema",
        "json_schema": {
            "schema": {
                "type": "object",
                "properties": {"name": {"type": "string"}},
                "additionalProperties": False,  # Now works on Gemini 2.0+!
            }
        }
    }
)
```

### Automatic Model Detection:
| Model | Format Used | `additionalProperties` Support |
|-------|-------------|-------------------------------|
| Gemini 2.0+ | `responseJsonSchema` (JSON Schema) | ✅ Yes |
| Gemini 1.5 | `responseSchema` (OpenAPI) | ❌ No |

LiteLLM automatically selects the appropriate format based on the model version - no provider-specific flags needed.

### Files Changed:
- `litellm/types/llms/vertex_ai.py` - Added `response_json_schema` to GenerationConfig
- `litellm/llms/vertex_ai/common_utils.py` - Added `supports_response_json_schema()` and `_build_json_schema()`
- `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py` - Auto-detect model version for schema format
- `tests/.../test_vertex_and_google_ai_studio_gemini.py` - Updated tests

## Test

- `test_vertex_ai_response_json_schema_for_gemini_2` - Verifies Gemini 2.0+ uses responseJsonSchema automatically
- `test_vertex_ai_response_schema_for_old_models` - Verifies Gemini 1.5 uses responseSchema
- `test_vertex_ai_response_schema_dict` - Verifies legacy format for older models
- `test_vertex_ai_response_schema_defs` - Verifies $defs unpacking for older models
- 51 tests pass