### PR TITLE
Fix VertexAI Anthropic Beta Headers

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -536,3 +536,25 @@ def process_anthropic_headers(headers: Union[httpx.Headers, dict]) -> dict:
 
     additional_headers = {**llm_response_headers, **openai_headers}
     return additional_headers
+
+
+def get_anthropic_beta_from_headers(headers: dict) -> List[str]:
+    """
+    Extract anthropic-beta header values and convert them to a list.
+    Supports comma-separated values from user headers.
+
+    Used by both converse and invoke transformations for consistent handling
+    of anthropic-beta headers that should be passed to AWS Bedrock.
+
+    Args:
+        headers (dict): Request headers dictionary
+
+    Returns:
+        List[str]: List of anthropic beta feature strings, empty list if no header
+    """
+    anthropic_beta_header = headers.get("anthropic-beta")
+    if not anthropic_beta_header:
+        return []
+
+    # Split comma-separated values and strip whitespace
+    return [beta.strip() for beta in anthropic_beta_header.split(",")]

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -55,10 +55,11 @@ from litellm.types.utils import (
 )
 from litellm.utils import add_dummy_tool, has_tool_call_blocks, supports_reasoning
 
+from litellm.llms.anthropic.common_utils import get_anthropic_beta_from_headers
+
 from ..common_utils import (
     BedrockError,
     BedrockModelInfo,
-    get_anthropic_beta_from_headers,
     get_bedrock_tool_name,
 )
 

--- a/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
@@ -3,10 +3,10 @@ from typing import TYPE_CHECKING, Any, List, Optional
 import httpx
 
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+from litellm.llms.anthropic.common_utils import get_anthropic_beta_from_headers
 from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
     AmazonInvokeConfig,
 )
-from litellm.llms.bedrock.common_utils import get_anthropic_beta_from_headers
 from litellm.types.llms.anthropic import ANTHROPIC_TOOL_SEARCH_BETA_HEADER
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import ModelResponse

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -708,28 +708,6 @@ class BedrockEventStreamDecoderBase:
             return chunk.decode()  # type: ignore[no-any-return]
 
 
-def get_anthropic_beta_from_headers(headers: dict) -> List[str]:
-    """
-    Extract anthropic-beta header values and convert them to a list.
-    Supports comma-separated values from user headers.
-
-    Used by both converse and invoke transformations for consistent handling
-    of anthropic-beta headers that should be passed to AWS Bedrock.
-
-    Args:
-        headers (dict): Request headers dictionary
-
-    Returns:
-        List[str]: List of anthropic beta feature strings, empty list if no header
-    """
-    anthropic_beta_header = headers.get("anthropic-beta")
-    if not anthropic_beta_header:
-        return []
-
-    # Split comma-separated values and strip whitespace
-    return [beta.strip() for beta in anthropic_beta_header.split(",")]
-
-
 class CommonBatchFilesUtils:
     """
     Common utilities for Bedrock batch and file operations.

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -12,7 +12,10 @@ from typing import (
 
 import httpx
 
-from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+from litellm.llms.anthropic.common_utils import (
+    AnthropicModelInfo,
+    get_anthropic_beta_from_headers,
+)
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
 )
@@ -23,7 +26,6 @@ from litellm.llms.bedrock.chat.invoke_handler import AWSEventStreamDecoder
 from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
     AmazonInvokeConfig,
 )
-from litellm.llms.bedrock.common_utils import get_anthropic_beta_from_headers
 from litellm.types.llms.anthropic import ANTHROPIC_TOOL_SEARCH_BETA_HEADER
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.router import GenericLiteLLMParams

--- a/tests/test_litellm/llms/bedrock/test_anthropic_beta_support.py
+++ b/tests/test_litellm/llms/bedrock/test_anthropic_beta_support.py
@@ -10,11 +10,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from litellm.llms.anthropic.common_utils import get_anthropic_beta_from_headers
 from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
 from litellm.llms.bedrock.chat.invoke_transformations.anthropic_claude3_transformation import (
     AmazonAnthropicClaudeConfig,
 )
-from litellm.llms.bedrock.common_utils import get_anthropic_beta_from_headers
 from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
     AmazonAnthropicClaudeMessagesConfig,
 )


### PR DESCRIPTION
Don't pass `prompt-caching-2024-07-31` to VertexAI. 

Applies the pattern in https://github.com/BerriAI/litellm/pull/17301/ after https://github.com/BerriAI/litellm/pull/17142

## Relevant issues
Fixes #18145

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix