### PR TITLE
fix(gemini): include IMAGE tokens in input cost calculation

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1480,8 +1480,10 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             for detail in usage_metadata["promptTokensDetails"]:
                 if detail["modality"] == "AUDIO":
                     audio_tokens = detail.get("tokenCount", 0)
-                elif detail["modality"] == "TEXT":
-                    text_tokens = detail.get("tokenCount", 0)
+                elif detail["modality"] in ("TEXT", "IMAGE"):
+                    # Image tokens are priced the same as text tokens for Gemini
+                    # https://ai.google.dev/gemini-api/docs/pricing
+                    text_tokens = (text_tokens or 0) + detail.get("tokenCount", 0)
         if "thoughtsTokenCount" in usage_metadata:
             reasoning_tokens = usage_metadata["thoughtsTokenCount"]
             # Also add reasoning tokens to response_tokens_details


### PR DESCRIPTION
## Relevant issues

Fixes #14285

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

When sending images as input to Gemini, LiteLLM was not counting IMAGE tokens for cost calculation. The API returns `promptTokensDetails` with separate modalities:

```json
{
  "promptTokenCount": 262,
  "promptTokensDetails": [
    {"modality": "TEXT", "tokenCount": 4},
    {"modality": "IMAGE", "tokenCount": 258}
  ]
}
```

LiteLLM only counted TEXT tokens (4), ignoring IMAGE tokens (258), resulting in **~98% undercharged costs** for image inputs.

### Example

```python
response = litellm.completion(
    model="gemini/gemini-2.0-flash",
    messages=[{
        "role": "user",
        "content": [
            {"type": "text", "text": "What is this?"},
            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
        ]
    }]
)
# Before fix: text_tokens=4, cost based on 4 tokens
# After fix: text_tokens=262, cost based on 262 tokens
```

### Solution

According to [Google's Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing), **image input tokens are priced the same as text tokens** for all Gemini models:

> Input price: $0.30 (text / image / video)

The fix adds IMAGE tokens to `text_tokens` in `_calculate_usage()`:

```python
elif detail["modality"] in ("TEXT", "IMAGE"):
    # Image tokens are priced the same as text tokens for Gemini
    text_tokens = (text_tokens or 0) + detail.get("tokenCount", 0)
```

### Tests Added

- `test_vertex_ai_usage_metadata_with_image_input_tokens` - IMAGE tokens in promptTokensDetails
- `test_vertex_ai_usage_metadata_with_image_input_tokens_reverse_order` - Order independence