### PR TITLE
[Feature] UI - Cloudzero Delete Settings

### DIFF
--- a/ui/litellm-dashboard/src/components/CloudZeroCostTracking/CloudZeroIntegrationSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/CloudZeroCostTracking/CloudZeroIntegrationSettings.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CloudZeroIntegrationSettings } from "./CloudZeroIntegrationSettings";
 import { CloudZeroSettings } from "./types";
 
@@ -67,5 +67,16 @@ describe("CloudZeroIntegrationSettings", () => {
     expect(screen.getByText("API Key (Redacted)")).toBeInTheDocument();
     expect(screen.getByText("Connection ID")).toBeInTheDocument();
     expect(screen.getByText("Timezone")).toBeInTheDocument();
+  });
+
+  it("should display the correct values from settings", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CloudZeroIntegrationSettings settings={mockSettings} onSettingsUpdated={vi.fn()} />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText(mockSettings.api_key_masked)).toBeInTheDocument();
+    expect(screen.getByText(mockSettings.connection_id)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Relevant issues
Previously users could not delete their cloudzero settings as there was no route in the backend to support this. This PR adds this functionality and calls the newly created /cloudzero/delete route. The delete pattern is the standard delete with friction pattern that is standard with the rest of the UI.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="985" height="184" alt="image" src="https://github.com/user-attachments/assets/d85febfb-a8a3-4605-a084-e0a8d883e265" />
<img width="643" height="419" alt="image" src="https://github.com/user-attachments/assets/918f4e2b-bb33-488b-a17b-7cf38c75b3c9" />
