### PR TITLE
[Feat] New Search API Provider - LinkUp Search 

### DIFF
--- a/docs/my-website/docs/search/index.md
+++ b/docs/my-website/docs/search/index.md
@@ -2,7 +2,7 @@
 
 | Feature | Supported | 
 |---------|-----------|
-| Supported Providers | `perplexity`, `tavily`, `parallel_ai`, `exa_ai`, `google_pse`, `dataforseo`, `firecrawl`, `searxng` |
+| Supported Providers | `perplexity`, `tavily`, `parallel_ai`, `exa_ai`, `google_pse`, `dataforseo`, `firecrawl`, `searxng`, `linkup` |
 | Cost Tracking | ✅ |
 | Logging | ✅ |
 | Load Balancing | ❌ |
@@ -205,7 +205,7 @@ See the [official Perplexity Search documentation](https://docs.perplexity.ai/ap
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `query` | string or array | Yes | Search query. Can be a single string or array of strings |
-| `search_provider` | string | Yes (SDK) | The search provider to use: `"perplexity"`, `"tavily"`, `"parallel_ai"`, `"exa_ai"`, `"google_pse"`, `"dataforseo"`, `"firecrawl"`, or `"searxng"` |
+| `search_provider` | string | Yes (SDK) | The search provider to use: `"perplexity"`, `"tavily"`, `"parallel_ai"`, `"exa_ai"`, `"google_pse"`, `"dataforseo"`, `"firecrawl"`, `"searxng"`, or `"linkup"` |
 | `search_tool_name` | string | Yes (Proxy) | Name of the search tool configured in `config.yaml` |
 | `max_results` | integer | No | Maximum number of results to return (1-20). Default: 10 |
 | `search_domain_filter` | array | No | List of domains to filter results (max 20 domains) |
@@ -269,6 +269,7 @@ The response follows Perplexity's search format with the following structure:
 | DataForSEO | `DATAFORSEO_LOGIN`, `DATAFORSEO_PASSWORD` | `dataforseo` |
 | Firecrawl | `FIRECRAWL_API_KEY` | `firecrawl` |
 | SearXNG | `SEARXNG_API_BASE` (required) | `searxng` |
+| Linkup | `LINKUP_API_KEY` | `linkup` |
 
 See the individual provider documentation for detailed setup instructions and provider-specific parameters.
 

--- a/docs/my-website/docs/search/linkup.md
+++ b/docs/my-website/docs/search/linkup.md
@@ -1,0 +1,152 @@
+# Linkup Search
+
+**Get API Key:** [https://linkup.so](https://linkup.so)
+
+## LiteLLM Python SDK
+
+```python showLineNumbers title="Linkup Search"
+import os
+from litellm import search
+
+os.environ["LINKUP_API_KEY"] = "..."
+
+response = search(
+    query="latest AI developments",
+    search_provider="linkup",
+    max_results=5
+)
+```
+
+## LiteLLM AI Gateway
+
+### 1. Setup config.yaml
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: gpt-4
+    litellm_params:
+      model: gpt-4
+      api_key: os.environ/OPENAI_API_KEY
+
+search_tools:
+  - search_tool_name: linkup-search
+    litellm_params:
+      search_provider: linkup
+      api_key: os.environ/LINKUP_API_KEY
+```
+
+### 2. Start the proxy
+
+```bash
+litellm --config /path/to/config.yaml
+
+# RUNNING on http://0.0.0.0:4000
+```
+
+### 3. Test the search endpoint
+
+```bash showLineNumbers title="Test Request"
+curl http://0.0.0.0:4000/v1/search/linkup-search \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "latest AI developments",
+    "max_results": 5
+  }'
+```
+
+## Provider-specific Parameters
+
+```python showLineNumbers title="Linkup Search with Provider-specific Parameters"
+import os
+from litellm import search
+
+os.environ["LINKUP_API_KEY"] = "..."
+
+response = search(
+    query="machine learning research",
+    search_provider="linkup",
+    max_results=10,
+    # Linkup-specific parameters
+    depth="deep",                      # "standard" (faster) or "deep" (more comprehensive)
+    outputType="searchResults",        # "searchResults", "sourcedAnswer", or "structured"
+    includeSources=True,               # Include sources in response
+    includeImages=True,                # Include images in results
+    fromDate="2024-01-01",             # Start date filter (YYYY-MM-DD)
+    toDate="2024-12-31",               # End date filter (YYYY-MM-DD)
+    includeDomains=["arxiv.org", "nature.com"],  # Domains to search (max 100)
+    excludeDomains=["wikipedia.com"],  # Domains to exclude
+    includeInlineCitations=True,       # Include inline citations in sourcedAnswer
+)
+```
+
+## Features
+
+Linkup provides powerful web search with context retrieval capabilities:
+
+### Search Depth
+Control the precision and speed of your search:
+- `standard` - Returns results faster
+- `deep` - Takes longer but yields more comprehensive results
+
+### Output Types
+Choose how results are formatted:
+- `searchResults` - Returns a list of search results with URLs and content
+- `sourcedAnswer` - Returns an AI-generated answer with sources
+- `structured` - Returns results in a custom JSON schema format
+
+### Date Filtering
+Filter results by date range:
+```python
+response = search(
+    query="AI developments",
+    search_provider="linkup",
+    fromDate="2024-06-01",
+    toDate="2024-12-31"
+)
+```
+
+### Domain Filtering
+Include or exclude specific domains:
+```python
+response = search(
+    query="research papers",
+    search_provider="linkup",
+    includeDomains=["arxiv.org", "nature.com", "ieee.org"],
+    excludeDomains=["wikipedia.com"]
+)
+```
+
+### Structured Output
+Get results in a custom JSON schema format:
+```python
+response = search(
+    query="Microsoft 2024 revenue",
+    search_provider="linkup",
+    outputType="structured",
+    structuredOutputSchema='{"type": "object", "properties": {"revenue": {"type": "string"}, "year": {"type": "string"}}}'
+)
+```
+
+## Response Format
+
+Linkup returns results in the following format:
+
+```json
+{
+  "results": [
+    {
+      "type": "text",
+      "name": "Microsoft 2024 Annual Report",
+      "url": "https://www.microsoft.com/investor/reports/ar24/index.html",
+      "content": "Highlights from fiscal year 2024..."
+    }
+  ]
+}
+```
+
+LiteLLM transforms this to the standard `SearchResponse` format:
+- `results[].name` → `SearchResult.title`
+- `results[].url` → `SearchResult.url`
+- `results[].content` → `SearchResult.snippet`
+

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -544,6 +544,7 @@ const sidebars = {
             "search/dataforseo",
             "search/firecrawl",
             "search/searxng",
+            "search/linkup",
           ]
         },
         "skills",

--- a/litellm/integrations/SlackAlerting/budget_alert_types.py
+++ b/litellm/integrations/SlackAlerting/budget_alert_types.py
@@ -77,8 +77,9 @@ class ProjectedLimitExceededAlert(BaseBudgetAlertType):
 def get_budget_alert_type(
     type: Literal[
         "token_budget",
-        "soft_budget",
         "user_budget",
+        "soft_budget",
+        "max_budget_alert",
         "team_budget",
         "organization_budget",
         "proxy_budget",
@@ -91,6 +92,7 @@ def get_budget_alert_type(
         "proxy_budget": ProxyBudgetAlert(),
         "soft_budget": SoftBudgetAlert(),
         "user_budget": UserBudgetAlert(),
+        "max_budget_alert": TokenBudgetAlert(),
         "team_budget": TeamBudgetAlert(),
         "organization_budget": OrganizationBudgetAlert(),
         "token_budget": TokenBudgetAlert(),

--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -531,8 +531,9 @@ class SlackAlerting(CustomBatchLogger):
         self,
         type: Literal[
             "token_budget",
-            "soft_budget",
             "user_budget",
+            "soft_budget",
+            "max_budget_alert",
             "team_budget",
             "organization_budget",
             "proxy_budget",

--- a/litellm/llms/linkup/__init__.py
+++ b/litellm/llms/linkup/__init__.py
@@ -1,0 +1,7 @@
+"""
+Linkup API integration module.
+"""
+from litellm.llms.linkup.search.transformation import LinkupSearchConfig
+
+__all__ = ["LinkupSearchConfig"]
+

--- a/litellm/llms/linkup/search/__init__.py
+++ b/litellm/llms/linkup/search/__init__.py
@@ -1,0 +1,7 @@
+"""
+Linkup Search API module.
+"""
+from litellm.llms.linkup.search.transformation import LinkupSearchConfig
+
+__all__ = ["LinkupSearchConfig"]
+

--- a/litellm/llms/linkup/search/transformation.py
+++ b/litellm/llms/linkup/search/transformation.py
@@ -1,0 +1,206 @@
+"""
+Calls Linkup's /search endpoint to search the web.
+
+Linkup API Reference: https://docs.linkup.so/pages/documentation/api-reference/endpoint/post-search
+"""
+from typing import Dict, List, Literal, Optional, TypedDict, Union
+
+import httpx
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.search.transformation import (
+    BaseSearchConfig,
+    SearchResponse,
+    SearchResult,
+)
+from litellm.secret_managers.main import get_secret_str
+
+
+class _LinkupSearchRequestRequired(TypedDict):
+    """Required fields for Linkup Search API request."""
+
+    q: str  # Required - The natural language question for which you want to retrieve context
+    depth: Literal["deep", "standard"]  # Required - Defines the precision of the search
+    outputType: Literal[
+        "searchResults", "sourcedAnswer", "structured"
+    ]  # Required - The type of output
+
+
+class LinkupSearchRequest(_LinkupSearchRequestRequired, total=False):
+    """
+    Linkup Search API request format.
+    Based on: https://docs.linkup.so/pages/documentation/api-reference/endpoint/post-search
+    """
+
+    structuredOutputSchema: str  # Required only when outputType is "structured"
+    includeSources: bool  # Optional - Include sources in response (default false)
+    includeImages: bool  # Optional - Include images in results (default false)
+    fromDate: str  # Optional - Start date for results (YYYY-MM-DD)
+    toDate: str  # Optional - End date for results (YYYY-MM-DD)
+    includeDomains: List[str]  # Optional - Domains to search on (max 100)
+    excludeDomains: List[str]  # Optional - Domains to exclude
+    includeInlineCitations: bool  # Optional - Include inline citations (default false)
+    maxResults: int  # Optional - Maximum number of results to return
+
+
+class LinkupSearchConfig(BaseSearchConfig):
+    LINKUP_API_BASE = "https://api.linkup.so/v1"
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "Linkup"
+
+    def validate_environment(
+        self,
+        headers: Dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        **kwargs,
+    ) -> Dict:
+        """
+        Validate environment and return headers.
+        """
+        api_key = api_key or get_secret_str("LINKUP_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "LINKUP_API_KEY is not set. Set `LINKUP_API_KEY` environment variable."
+            )
+        headers["Authorization"] = f"Bearer {api_key}"
+        headers["Content-Type"] = "application/json"
+        return headers
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        optional_params: dict,
+        data: Optional[Union[Dict, List[Dict]]] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Get complete URL for Search endpoint.
+        """
+        api_base = (
+            api_base or get_secret_str("LINKUP_API_BASE") or self.LINKUP_API_BASE
+        )
+
+        # Append "/search" to the api base if it's not already there
+        if not api_base.endswith("/search"):
+            api_base = f"{api_base}/search"
+
+        return api_base
+
+    def transform_search_request(
+        self,
+        query: Union[str, List[str]],
+        optional_params: dict,
+        **kwargs,
+    ) -> Dict:
+        """
+        Transform Search request to Linkup API format.
+
+        Transforms Perplexity unified spec parameters:
+        - query -> q
+        - max_results -> maxResults
+        - search_domain_filter -> includeDomains
+        - country -> (not directly supported)
+        - max_tokens_per_page -> (not applicable)
+
+        All other Linkup-specific parameters are passed through as-is.
+
+        Args:
+            query: Search query (string or list of strings). Linkup only supports single string queries.
+            optional_params: Optional parameters for the request
+
+        Returns:
+            Dict with typed request data following LinkupSearchRequest spec
+        """
+        if isinstance(query, list):
+            # Linkup only supports single string queries, join with spaces
+            query = " ".join(query)
+
+        request_data: LinkupSearchRequest = {
+            "q": query,
+            "depth": optional_params.get("depth", "standard"),
+            "outputType": optional_params.get("outputType", "searchResults"),
+        }
+
+        # Transform Perplexity unified spec parameters to Linkup format
+        if "max_results" in optional_params:
+            request_data["maxResults"] = optional_params["max_results"]
+
+        if "search_domain_filter" in optional_params:
+            request_data["includeDomains"] = optional_params["search_domain_filter"]
+
+        # Convert to dict before dynamic key assignments
+        result_data = dict(request_data)
+
+        # pass through all other parameters as-is
+        for param, value in optional_params.items():
+            if (
+                param not in self.get_supported_perplexity_optional_params()
+                and param not in result_data
+            ):
+                result_data[param] = value
+
+        return result_data
+
+    def transform_search_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+        **kwargs,
+    ) -> SearchResponse:
+        """
+        Transform Linkup API response to LiteLLM unified SearchResponse format.
+
+        Linkup -> LiteLLM mappings:
+        - results[].name -> SearchResult.title
+        - results[].url -> SearchResult.url
+        - results[].content -> SearchResult.snippet
+        - No date field in results (set to None)
+        - No last_updated field in Linkup response (set to None)
+
+        Args:
+            raw_response: Raw httpx response from Linkup API
+            logging_obj: Logging object for tracking
+
+        Returns:
+            SearchResponse with standardized format
+        """
+        response_json = raw_response.json()
+
+        # Transform results to SearchResult objects
+        results = []
+
+        # Process results array
+        raw_results = response_json.get("results", [])
+
+        for result in raw_results:
+            # Handle both text and image result types
+            result_type = result.get("type", "text")
+
+            if result_type == "text":
+                search_result = SearchResult(
+                    title=result.get("name", ""),
+                    url=result.get("url", ""),
+                    snippet=result.get("content", ""),
+                    date=None,
+                    last_updated=None,
+                )
+                results.append(search_result)
+            elif result_type == "image":
+                # For image results, use the URL as both title and snippet if name not provided
+                search_result = SearchResult(
+                    title=result.get("name", result.get("url", "")),
+                    url=result.get("url", ""),
+                    snippet=result.get("content", ""),
+                    date=None,
+                    last_updated=None,
+                )
+                results.append(search_result)
+
+        return SearchResponse(
+            results=results,
+            object="search",
+        )
+

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -24542,6 +24542,16 @@
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
     },
+    "linkup/search": {
+        "input_cost_per_query": 5.87e-03,
+        "litellm_provider": "linkup",
+        "mode": "search"
+    },
+    "linkup/search-deep": {
+        "input_cost_per_query": 58.67e-03,
+        "litellm_provider": "linkup",
+        "mode": "search"
+    },
     "tavily/search": {
         "input_cost_per_query": 0.008,
         "litellm_provider": "tavily",

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1263,7 +1263,7 @@ async def test_model_connection(
         
         # Look up model configuration from router if model name is provided
         # This gets the litellm_params from proxy config (with resolved env vars)
-        config_litellm_params = {}
+        config_litellm_params: dict = {}
         if model_name and llm_router is not None:
             try:
                 # First try to find by proxy model_name (e.g., "gpt-4o")
@@ -1281,7 +1281,7 @@ async def test_model_connection(
                 if deployments and len(deployments) > 0:
                     # Use the first deployment's litellm_params as base config
                     # These already have resolved environment variables from proxy config
-                    config_litellm_params = deployments[0].get("litellm_params", {}).copy()
+                    config_litellm_params = dict(deployments[0].get("litellm_params", {}))
             except Exception as e:
                 verbose_proxy_logger.debug(
                     f"Could not find model {model_name} in router: {e}. "

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3038,6 +3038,7 @@ class SearchProviders(str, Enum):
     DATAFORSEO = "dataforseo"
     FIRECRAWL = "firecrawl"
     SEARXNG = "searxng"
+    LINKUP = "linkup"
 
 
 # Create a set of all search provider values for quick lookup

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1,15 +1,6 @@
 # from __future__ import annotations must be the first non-comment statement
 from __future__ import annotations
 
-# +-----------------------------------------------+
-# |                                               |
-# |           Give Feedback / Get Help            |
-# | https://github.com/BerriAI/litellm/issues/new |
-# |                                               |
-# +-----------------------------------------------+
-#
-#  Thank you users! We ❤️ you! - Krrish & Ishaan
-
 import ast
 import asyncio
 import base64
@@ -63,6 +54,11 @@ import litellm.litellm_core_utils.audio_utils.utils
 import litellm.litellm_core_utils.json_validation_rule
 import litellm.llms
 import litellm.llms.gemini
+from litellm._lazy_imports import (
+    _get_default_encoding,
+    _get_modified_max_tokens,
+    _get_token_counter_new,
+)
 from litellm._uuid import uuid
 from litellm.caching._internal_lru_cache import lru_cache_wrapper
 from litellm.caching.caching import DualCache
@@ -102,11 +98,6 @@ from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.dot_notation_indexing import (
     delete_nested_value,
     is_nested_path,
-)
-from litellm._lazy_imports import (
-    _get_default_encoding,
-    _get_modified_max_tokens,
-    _get_token_counter_new,
 )
 from litellm.litellm_core_utils.exception_mapping_utils import (
     _get_response_headers,
@@ -217,6 +208,20 @@ from litellm.types.utils import (
     all_litellm_params,
 )
 
+# +-----------------------------------------------+
+# |                                               |
+# |           Give Feedback / Get Help            |
+# | https://github.com/BerriAI/litellm/issues/new |
+# |                                               |
+# +-----------------------------------------------+
+#
+#  Thank you users! We ❤️ you! - Krrish & Ishaan
+
+
+
+
+
+
 try:
     # Python 3.9+
     with resources.files("litellm.litellm_core_utils.tokenizers").joinpath(
@@ -271,6 +276,7 @@ if TYPE_CHECKING:
     # their modules at runtime during `litellm` import.
     from litellm.llms.base_llm.files.transformation import BaseFilesConfig
     from litellm.proxy._types import AllowedModelRegion
+
 from litellm.llms.base_llm.batches.transformation import BaseBatchesConfig
 from litellm.llms.base_llm.chat.transformation import BaseConfig
 from litellm.llms.base_llm.completion.transformation import BaseTextCompletionConfig
@@ -303,7 +309,6 @@ from .caching.caching import (
     RedisSemanticCache,
     S3Cache,
 )
-
 from .exceptions import (
     APIConnectionError,
     APIError,
@@ -7999,6 +8004,7 @@ class ProviderConfigManager:
         from litellm.llms.exa_ai.search.transformation import ExaAISearchConfig
         from litellm.llms.firecrawl.search.transformation import FirecrawlSearchConfig
         from litellm.llms.google_pse.search.transformation import GooglePSESearchConfig
+        from litellm.llms.linkup.search.transformation import LinkupSearchConfig
         from litellm.llms.parallel_ai.search.transformation import (
             ParallelAISearchConfig,
         )
@@ -8015,6 +8021,7 @@ class ProviderConfigManager:
             SearchProviders.DATAFORSEO: DataForSEOSearchConfig,
             SearchProviders.FIRECRAWL: FirecrawlSearchConfig,
             SearchProviders.SEARXNG: SearXNGSearchConfig,
+            SearchProviders.LINKUP: LinkupSearchConfig,
         }
         config_class = PROVIDER_TO_CONFIG_MAP.get(provider, None)
         if config_class is None:
@@ -8403,9 +8410,10 @@ def should_run_mock_completion(
 def __getattr__(name: str) -> Any:
     """Lazy import handler for utils module"""
     if name == "encoding":
-        from litellm.main import encoding as _encoding
         # Cache it in the module's __dict__ for subsequent accesses
         import sys
+
+        from litellm.main import encoding as _encoding
         sys.modules[__name__].__dict__["encoding"] = _encoding
         return _encoding
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -24542,6 +24542,16 @@
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
     },
+    "linkup/search": {
+        "input_cost_per_query": 5.87e-03,
+        "litellm_provider": "linkup",
+        "mode": "search"
+    },
+    "linkup/search-deep": {
+        "input_cost_per_query": 58.67e-03,
+        "litellm_provider": "linkup",
+        "mode": "search"
+    },
     "tavily/search": {
         "input_cost_per_query": 0.008,
         "litellm_provider": "tavily",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -716,6 +716,23 @@
         "search": true
       }
     },
+    "linkup": {
+      "display_name": "Linkup (`linkup`)",
+      "url": "https://docs.litellm.ai/docs/search/linkup",
+      "endpoints": {
+        "chat_completions": false,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "search": true
+      }
+    },
     "friendliai": {
       "display_name": "FriendliAI (`friendliai`)",
       "url": "https://docs.litellm.ai/docs/providers/friendliai",

--- a/tests/search_tests/test_linkup_search.py
+++ b/tests/search_tests/test_linkup_search.py
@@ -1,0 +1,119 @@
+"""
+Tests for Linkup Search API integration.
+"""
+import os
+import sys
+import pytest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from tests.search_tests.base_search_unit_tests import BaseSearchTest
+
+
+@pytest.mark.skip(reason="Local only tested search providers")
+class TestLinkupSearch(BaseSearchTest):
+    """
+    E2E tests for Linkup Search functionality that make real API calls.
+    Inherits from BaseSearchTest to run standard search tests.
+    """
+
+    def get_search_provider(self) -> str:
+        """
+        Return search_provider for Linkup Search.
+        """
+        return "linkup"
+
+
+class TestLinkupSearchTransformation:
+    """
+    Unit tests for Linkup Search request/response transformation with mocked responses.
+    """
+
+    def test_linkup_search_request_transformation(self):
+        """
+        Test that validates the Linkup search request is correctly transformed from
+        unified params to Linkup API format.
+        """
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "type": "text",
+                    "name": "Test Title",
+                    "url": "https://example.com",
+                    "content": "Test content",
+                }
+            ]
+        }
+
+        with patch.dict(os.environ, {"LINKUP_API_KEY": "test-api-key"}):
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.HTTPHandler.post",
+                return_value=mock_response,
+            ) as mock_post:
+                litellm.search(
+                    query="test query",
+                    search_provider="linkup",
+                    max_results=10,
+                    search_domain_filter=["arxiv.org", "nature.com"],
+                )
+
+                assert mock_post.called
+                call_kwargs = mock_post.call_args.kwargs
+                request_body = call_kwargs.get("json")
+
+                # Verify request transformation
+                assert request_body is not None
+                assert request_body["q"] == "test query"
+                assert request_body["maxResults"] == 10
+                assert request_body["depth"] == "standard"
+                assert request_body["outputType"] == "searchResults"
+                assert request_body["includeDomains"] == ["arxiv.org", "nature.com"]
+
+    def test_linkup_search_response_transformation(self):
+        """
+        Test that validates the Linkup API response is correctly transformed to
+        the unified SearchResponse format.
+        """
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "type": "text",
+                    "name": "Microsoft 2024 Annual Report",
+                    "url": "https://www.microsoft.com/investor/reports/ar24/index.html",
+                    "content": "Highlights from fiscal year 2024: Microsoft Cloud revenue increased 23% to $137.4 billion.",
+                },
+                {
+                    "type": "text",
+                    "name": "Another Result",
+                    "url": "https://example.com/page",
+                    "content": "Some other content",
+                },
+            ]
+        }
+
+        with patch.dict(os.environ, {"LINKUP_API_KEY": "test-api-key"}):
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.HTTPHandler.post",
+                return_value=mock_response,
+            ):
+                response = litellm.search(
+                    query="Microsoft revenue", search_provider="linkup"
+                )
+
+                # Verify response transformation
+                assert response.object == "search"
+                assert len(response.results) == 2
+
+                first_result = response.results[0]
+                assert first_result.title == "Microsoft 2024 Annual Report"
+                assert (
+                    first_result.url
+                    == "https://www.microsoft.com/investor/reports/ar24/index.html"
+                )
+                assert "Microsoft Cloud revenue" in first_result.snippet


### PR DESCRIPTION
## [Feat] New Search API Provider - LinkUp Search 


This PR adds Linkup as a new search provider to LiteLLM's unified Search API. Linkup provides web search with context retrieval capabilities, supporting features like search depth control, date filtering, and domain filtering.

## Usage Examples

### Basic Search

```python
import os
from litellm import search

os.environ["LINKUP_API_KEY"] = "..."

response = search(
    query="latest AI developments",
    search_provider="linkup",
    max_results=5
)

for result in response.results:
    print(f"{result.title}: {result.url}")
    print(f"Snippet: {result.snippet}\n")
```

### With Provider-Specific Parameters

```python
response = search(
    query="machine learning research",
    search_provider="linkup",
    max_results=10,
    depth="deep",                      # "standard" (faster) or "deep" (more comprehensive)
    outputType="searchResults",        # "searchResults", "sourcedAnswer", or "structured"
    fromDate="2024-01-01",             # Date filtering
    toDate="2024-12-31",
    includeDomains=["arxiv.org", "nature.com"],  # Domain filtering
)
```

### LiteLLM Proxy Configuration

```yaml
search_tools:
  - search_tool_name: linkup-search
    litellm_params:
      search_provider: linkup
      api_key: os.environ/LINKUP_API_KEY
```

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
