### PR TITLE
added functionality to accept list content handling in bedrock cohere…

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2580,26 +2580,9 @@ def cohere_message_pt(messages: list):
             )
             tool_results.append(tool_result)
         elif message.get("content"):
-            content = message["content"]
-
-            # Support both string content and OpenAI-style list-of-parts content
-            # e.g. [{"type": "text", "text": "Hi"}]
-            if isinstance(content, list):
-                text_parts: List[str] = []
-                for part in content:
-                    if isinstance(part, dict):
-                        # Prefer explicit text field
-                        if part.get("type") == "text" and "text" in part:
-                            text_parts.append(str(part["text"]))
-                        elif "text" in part:
-                            text_parts.append(str(part["text"]))
-                    elif isinstance(part, str):
-                        text_parts.append(part)
-
-                if len(text_parts) > 0:
-                    prompt += "".join(text_parts) + "\n\n"
-            else:
-                prompt += str(content) + "\n\n"
+            text_content = convert_content_list_to_str(message)
+            if text_content:
+                prompt += text_content + "\n\n"
     prompt = prompt.rstrip()
     return prompt, tool_results
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2580,7 +2580,26 @@ def cohere_message_pt(messages: list):
             )
             tool_results.append(tool_result)
         elif message.get("content"):
-            prompt += message["content"] + "\n\n"
+            content = message["content"]
+
+            # Support both string content and OpenAI-style list-of-parts content
+            # e.g. [{"type": "text", "text": "Hi"}]
+            if isinstance(content, list):
+                text_parts: List[str] = []
+                for part in content:
+                    if isinstance(part, dict):
+                        # Prefer explicit text field
+                        if part.get("type") == "text" and "text" in part:
+                            text_parts.append(str(part["text"]))
+                        elif "text" in part:
+                            text_parts.append(str(part["text"]))
+                    elif isinstance(part, str):
+                        text_parts.append(part)
+
+                if len(text_parts) > 0:
+                    prompt += "".join(text_parts) + "\n\n"
+            else:
+                prompt += str(content) + "\n\n"
     prompt = prompt.rstrip()
     return prompt, tool_results
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_cohere_message_pt.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_cohere_message_pt.py
@@ -1,0 +1,32 @@
+import pytest
+
+from litellm.litellm_core_utils.prompt_templates.factory import cohere_message_pt
+
+
+def test_cohere_message_pt_with_string_content():
+    messages = [{"role": "user", "content": "Hi"}]
+
+    prompt, tool_results = cohere_message_pt(messages)
+
+    assert prompt == "Hi"
+    assert tool_results == []
+
+
+def test_cohere_message_pt_with_list_content_text_part():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Hi",
+                }
+            ],
+        }
+    ]
+
+    prompt, tool_results = cohere_message_pt(messages)
+
+    assert prompt == "Hi"
+    assert tool_results == []
+


### PR DESCRIPTION
## Relevant issues
Bedrock Cohere command-r / command-r-plus models crashed when messages used OpenAI-style list content (e.g. [{ "type": "text", "text": "Hi" }]), because cohere_message_pt assumed content was always a string and attempted to concatenate a list with a string.

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->

🐛 Bug Fix
✅ Test

## Changes
Updated cohere_message_pt to gracefully handle both string and list-style content by extracting and joining text parts from lists, and added unit tests to cover both string and list content paths so Bedrock Cohere chat models accept OpenAI-format messages without errors.

List format is supported now.
<img width="852" height="466" alt="Screenshot 2025-12-18 at 2 37 30 AM" src="https://github.com/user-attachments/assets/6051a796-6cdf-4df4-86db-e493fe7e243b" />
