### PR TITLE
fix(gemini): support snake_case for google_search tool parameters

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -479,19 +479,26 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 or tool_name == VertexToolName.CODE_EXECUTION.value
             ):  # code_execution maintained for backwards compatibility
                 code_execution = self.get_tool_value(tool, "codeExecution")
-            elif tool_name and tool_name == VertexToolName.GOOGLE_SEARCH.value:
+            elif tool_name and (
+                tool_name == VertexToolName.GOOGLE_SEARCH.value
+                or tool_name == "google_search"
+            ):
                 googleSearch = self.get_tool_value(
-                    tool, VertexToolName.GOOGLE_SEARCH.value
+                    tool, tool_name
                 )
-            elif (
-                tool_name and tool_name == VertexToolName.GOOGLE_SEARCH_RETRIEVAL.value
+            elif tool_name and (
+                tool_name == VertexToolName.GOOGLE_SEARCH_RETRIEVAL.value
+                or tool_name == "google_search_retrieval"
             ):
                 googleSearchRetrieval = self.get_tool_value(
-                    tool, VertexToolName.GOOGLE_SEARCH_RETRIEVAL.value
+                    tool, tool_name
                 )
-            elif tool_name and tool_name == VertexToolName.ENTERPRISE_WEB_SEARCH.value:
+            elif tool_name and (
+                tool_name == VertexToolName.ENTERPRISE_WEB_SEARCH.value
+                or tool_name == "enterprise_web_search"
+            ):
                 enterpriseWebSearch = self.get_tool_value(
-                    tool, VertexToolName.ENTERPRISE_WEB_SEARCH.value
+                    tool, tool_name
                 )
             elif tool_name and (
                 tool_name == VertexToolName.URL_CONTEXT.value

--- a/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
+++ b/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
@@ -7,6 +7,7 @@ sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 from litellm.llms.vertex_ai.gemini import transformation
+from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexGeminiConfig
 from litellm.types.llms import openai
 from litellm.types import completion
 from litellm.types.llms.vertex_ai import RequestBody
@@ -226,3 +227,64 @@ async def test__transform_request_body_image_config_with_image_size():
     assert "imageConfig" in rb["generationConfig"]
     assert rb["generationConfig"]["imageConfig"]["aspectRatio"] == "16:9"
     assert rb["generationConfig"]["imageConfig"]["imageSize"] == "4K"
+
+
+def test_map_function_google_search_snake_case():
+    """
+    Test that google_search tool (snake_case) is properly mapped to googleSearch.
+    Fixes issue where tools=[{"google_search": {}}] was being stripped.
+    """
+    config = VertexGeminiConfig()
+    optional_params = {}
+
+    # Test snake_case google_search
+    tools = [{"google_search": {}}]
+    result = config._map_function(tools, optional_params)
+
+    assert len(result) == 1
+    assert "googleSearch" in result[0]
+    assert result[0]["googleSearch"] == {}
+
+
+def test_map_function_google_search_camel_case():
+    """
+    Test that googleSearch tool (camelCase) still works.
+    """
+    config = VertexGeminiConfig()
+    optional_params = {}
+
+    # Test camelCase googleSearch
+    tools = [{"googleSearch": {}}]
+    result = config._map_function(tools, optional_params)
+
+    assert len(result) == 1
+    assert "googleSearch" in result[0]
+    assert result[0]["googleSearch"] == {}
+
+
+def test_map_function_google_search_retrieval_snake_case():
+    """
+    Test that google_search_retrieval tool (snake_case) is properly mapped.
+    """
+    config = VertexGeminiConfig()
+    optional_params = {}
+
+    tools = [{"google_search_retrieval": {"dynamic_retrieval_config": {"mode": "MODE_DYNAMIC"}}}]
+    result = config._map_function(tools, optional_params)
+
+    assert len(result) == 1
+    assert "googleSearchRetrieval" in result[0]
+
+
+def test_map_function_enterprise_web_search_snake_case():
+    """
+    Test that enterprise_web_search tool (snake_case) is properly mapped.
+    """
+    config = VertexGeminiConfig()
+    optional_params = {}
+
+    tools = [{"enterprise_web_search": {}}]
+    result = config._map_function(tools, optional_params)
+
+    assert len(result) == 1
+    assert "enterpriseWebSearch" in result[0]


### PR DESCRIPTION
## Relevant issues

Fixes #18171

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Summary

Add snake_case aliases for Gemini tool names to match the pattern already used by other tools (`url_context`, `google_maps`, `code_execution`):
## Example

```python
import litellm

response = litellm.completion(
    model="gemini/gemini-2.0-flash",
    messages=[{"role": "user", "content": "What is the weather in Tokyo?"}],
    tools=[{"google_search": {}}]
)
```

- `google_search` -> `googleSearch`
- `google_search_retrieval` -> `googleSearchRetrieval`
- `enterprise_web_search` -> `enterpriseWebSearch`

When sending `tools=[{"google_search": {}}]` to Gemini models, the tool was being stripped and an empty `{}` was sent to the API, causing a 400 error.

