### PR TITLE
Fix: Claude code responses api bridge errors

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -492,7 +492,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
     def _convert_content_str_to_input_text(
         self, content: str, role: str
     ) -> Dict[str, Any]:
-        if role == "user" or role == "system":
+        if role == "user" or role == "system" or role == "tool":
             return {"type": "input_text", "text": content}
         else:
             return {"type": "output_text", "text": content}

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -96,8 +96,8 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                     validated_input.append(item.model_dump(exclude_none=True))
                 elif isinstance(item, dict):
                     # Handle reasoning items specifically to filter out status=None
-                    verbose_logger.debug(f"Handling reasoning item: {item}")
                     if item.get("type") == "reasoning":
+                        verbose_logger.debug(f"Handling reasoning item: {item}")
                         # Type assertion since we know it's a dict at this point
                         dict_item = cast(Dict[str, Any], item)
                         filtered_item = self._handle_reasoning_item(dict_item)


### PR DESCRIPTION
## Relevant issues

Fixes #16052
[Add thinking to reasoning_effort mapping in v1/messages](https://github.com/BerriAI/litellm/commit/d764b7405d82c44adcca2ccec927b5e29b26ba79)
[Fix : tool calling with response api bridge](https://github.com/BerriAI/litellm/commit/dafd123756214a6d713470658e0d9fa6e3006aef)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix


## Changes
