### PR TITLE
Fix Gemini 3 Flash pricing for Vertex AI

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12970,7 +12970,7 @@
         "supports_web_search": true
     },
     "vertex_ai/gemini-3-flash-preview": {
-        "cache_read_input_token_cost": 1.25e-08,
+        "cache_read_input_token_cost": 5e-08,
         "input_cost_per_token": 5e-07,
         "input_cost_per_audio_token": 1e-06,
         "litellm_provider": "vertex_ai",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12972,7 +12972,7 @@
         "supports_web_search": true
     },
     "vertex_ai/gemini-3-flash-preview": {
-        "cache_read_input_token_cost": 1.25e-08,
+        "cache_read_input_token_cost": 5e-08,
         "input_cost_per_token": 5e-07,
         "input_cost_per_audio_token": 1e-06,
         "litellm_provider": "vertex_ai",


### PR DESCRIPTION
This makes the cache read input token pricing consistent across the 3 different Gemini 3 Flash entry pricing: `gemini-3-flash-preview`, `gemini/gemini-3-flash-preview`, `vertex_ai/gemini-3-flash-preview`

It should be $0.05/1 million tokens for cached read input tokens according to Vertex's pricing table: https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models-3

---

As a side question: why is there two JSON files for model pricing? AFAICT they are the same.

## Type

🐛 Bug Fix

## Changes
