### PR TITLE
[Fix] UI - Usage Page Top Key View Button Visibility

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
@@ -30,10 +30,14 @@ vi.mock("../molecules/notifications_manager", () => {
   return { default: Notifications };
 });
 
-// Roles: ensure 'admin' has write access
-vi.mock("../../utils/roles", () => ({
-  rolesWithWriteAccess: ["admin"],
-}));
+// Roles: ensure 'admin' has write access and include all role helper functions
+vi.mock("../../utils/roles", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../utils/roles")>();
+  return {
+    ...actual,
+    rolesWithWriteAccess: ["admin"],
+  };
+});
 
 // Helpers used in rendering
 vi.mock("@/utils/dataUtils", () => ({
@@ -217,6 +221,40 @@ vi.mock("../common_components/AutoRotationView", async () => {
   (AutoRotationView as any).displayName = "AutoRotationView";
   return { __esModule: true, default: AutoRotationView };
 });
+
+// Mock Next.js router to avoid "invariant expected app router to be mounted" error
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+// Mock useTeams hook
+vi.mock("@/app/(dashboard)/hooks/useTeams", () => ({
+  default: vi.fn(() => ({
+    teams: [],
+    setTeams: vi.fn(),
+  })),
+}));
+
+// Mock useAuthorized hook to avoid Next.js router dependency
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: vi.fn(() => ({
+    accessToken: "access_abc",
+    userId: "user_1",
+    userRole: "admin",
+    premiumUser: true,
+    token: "token_123",
+    userEmail: "test@example.com",
+    disabledPersonalKeyCreation: false,
+    showSSOBanner: false,
+  })),
+}));
 
 // KeyEditView mock: triggers onSubmit with our injected form values
 vi.mock("./key_edit_view", async () => {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -1,9 +1,20 @@
-import { render, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { KeyResponse } from "../key_team_helpers/key_list";
+import { render, waitFor, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { KeyResponse, Team } from "../key_team_helpers/key_list";
 import KeyInfoView from "./key_info_view";
+import useTeams from "@/app/(dashboard)/hooks/useTeams";
+
+vi.mock("@/app/(dashboard)/hooks/useTeams", () => ({
+  default: vi.fn(),
+}));
 
 describe("KeyInfoView", () => {
+  beforeEach(() => {
+    vi.mocked(useTeams).mockReturnValue({
+      teams: [],
+      setTeams: vi.fn(),
+    });
+  });
   const MOCK_KEY_DATA: KeyResponse = {
     token: "test-token-123",
     token_id: "test-token-123",
@@ -112,6 +123,136 @@ describe("KeyInfoView", () => {
       const metadataBlock = container.querySelector("pre");
       expect(metadataBlock).toBeInTheDocument();
       expect(metadataBlock?.textContent?.trim()).toBe("{}");
+    });
+  });
+
+  it("should allow proxy admin to modify key", async () => {
+    vi.mocked(useTeams).mockReturnValue({
+      teams: [],
+      setTeams: vi.fn(),
+    });
+
+    const keyData = { ...MOCK_KEY_DATA, user_id: "other-user-id" };
+    render(
+      <KeyInfoView
+        keyData={keyData}
+        onClose={() => {}}
+        keyId={"test-key-id"}
+        onKeyDataUpdate={() => {}}
+        accessToken={"test-token"}
+        userID={"proxy-admin-user"}
+        userRole={"proxy_admin"}
+        premiumUser={true}
+        teams={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Regenerate Key")).toBeInTheDocument();
+      expect(screen.getByText("Delete Key")).toBeInTheDocument();
+    });
+  });
+
+  it("should allow team admin to modify key", async () => {
+    const teamId = "test-team-id";
+    const teamAdminUserId = "team-admin-user";
+    const mockTeam: Team = {
+      team_id: teamId,
+      team_alias: "Test Team",
+      models: [],
+      max_budget: null,
+      budget_duration: null,
+      tpm_limit: null,
+      rpm_limit: null,
+      organization_id: "org-1",
+      created_at: "2025-01-01T00:00:00Z",
+      keys: [],
+      members_with_roles: [
+        {
+          user_id: teamAdminUserId,
+          role: "admin",
+        },
+      ],
+    };
+
+    vi.mocked(useTeams).mockReturnValue({
+      teams: [mockTeam],
+      setTeams: vi.fn(),
+    });
+
+    const keyData = { ...MOCK_KEY_DATA, team_id: teamId, user_id: "other-user-id" };
+    render(
+      <KeyInfoView
+        keyData={keyData}
+        onClose={() => {}}
+        keyId={"test-key-id"}
+        onKeyDataUpdate={() => {}}
+        accessToken={"test-token"}
+        userID={teamAdminUserId}
+        userRole={"user"}
+        premiumUser={true}
+        teams={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Regenerate Key")).toBeInTheDocument();
+      expect(screen.getByText("Delete Key")).toBeInTheDocument();
+    });
+  });
+
+  it("should allow owner to modify their own key", async () => {
+    vi.mocked(useTeams).mockReturnValue({
+      teams: [],
+      setTeams: vi.fn(),
+    });
+
+    const ownerUserId = "owner-user-id";
+    const keyData = { ...MOCK_KEY_DATA, user_id: ownerUserId };
+    render(
+      <KeyInfoView
+        keyData={keyData}
+        onClose={() => {}}
+        keyId={"test-key-id"}
+        onKeyDataUpdate={() => {}}
+        accessToken={"test-token"}
+        userID={ownerUserId}
+        userRole={"user"}
+        premiumUser={true}
+        teams={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Regenerate Key")).toBeInTheDocument();
+      expect(screen.getByText("Delete Key")).toBeInTheDocument();
+    });
+  });
+
+  it("should not allow other user to modify key", async () => {
+    vi.mocked(useTeams).mockReturnValue({
+      teams: [],
+      setTeams: vi.fn(),
+    });
+
+    const keyData = { ...MOCK_KEY_DATA, user_id: "owner-user-id" };
+    render(
+      <KeyInfoView
+        keyData={keyData}
+        onClose={() => {}}
+        keyId={"test-key-id"}
+        onKeyDataUpdate={() => {}}
+        accessToken={"test-token"}
+        userID={"other-user-id"}
+        userRole={"user"}
+        premiumUser={true}
+        teams={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Regenerate Key")).not.toBeInTheDocument();
+      expect(screen.queryByText("Delete Key")).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Relevant issues
https://github.com/BerriAI/litellm/issues/17969

Tested the 4 cases and all matched the expected outcomes:
1. Proxy admin -> Can see the buttons
2. Team admin of the team -> Can see the buttons
3. User who owns the key -> Can see the buttons
4. Other use who does not own the key -> Can not see the buttons

This was purely a UI issue, the backend checks for proper permission
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="718" height="204" alt="image" src="https://github.com/user-attachments/assets/cb6213a8-fc92-412c-a9e4-7b4971af8058" />
<img width="1244" height="411" alt="image" src="https://github.com/user-attachments/assets/b2f1d8a4-3214-4301-ac0d-06a41697c36c" />
<img width="1239" height="444" alt="image" src="https://github.com/user-attachments/assets/68a2922c-88af-4c40-8ab2-0b182c8acde0" />
