### PR TITLE
docs: update message content types link and add content types table

### DIFF
--- a/docs/my-website/docs/completion/input.md
+++ b/docs/my-website/docs/completion/input.md
@@ -150,10 +150,10 @@ def completion(
 
 | Type | Description | Docs |
 |------|-------------|------|
-| `text` | Text content | - |
+| `text` | Text content | [Type Definition](https://github.com/BerriAI/litellm/blob/main/litellm/types/llms/openai.py#L603) |
 | `image_url` | Images | [Vision](./vision.md) |
 | `input_audio` | Audio input | [Audio](./audio.md) |
-| `video_url` | Video input | - |
+| `video_url` | Video input | [Type Definition](https://github.com/BerriAI/litellm/blob/main/litellm/types/llms/openai.py#L625) |
 | `file` | Files (OpenAI) | [Document Understanding](./document_understanding.md) |
 | `document` | PDFs (Anthropic) | [Document Understanding](./document_understanding.md) |
 

--- a/docs/my-website/docs/completion/input.md
+++ b/docs/my-website/docs/completion/input.md
@@ -142,7 +142,28 @@ def completion(
 - `tool_call_id`: *str (optional)* - Tool call that this message is responding to.
 
 
-[**See All Message Values**](https://github.com/BerriAI/litellm/blob/8600ec77042dacad324d3879a2bd918fc6a719fa/litellm/types/llms/openai.py#L392)
+[**See All Message Values**](https://github.com/BerriAI/litellm/blob/main/litellm/types/llms/openai.py#L664)
+
+#### Content Types
+
+`content` can be a string (text only) or a list of content blocks (multimodal):
+
+| Type | Description | Docs |
+|------|-------------|------|
+| `text` | Text content | - |
+| `image_url` | Images | [Vision](./vision.md) |
+| `input_audio` | Audio input | [Audio](./audio.md) |
+| `video_url` | Video input | - |
+| `file` | Files (OpenAI) | [Document Understanding](./document_understanding.md) |
+| `document` | PDFs (Anthropic) | [Document Understanding](./document_understanding.md) |
+
+**Example (multimodal):**
+```python
+{"role": "user", "content": [
+    {"type": "text", "text": "What's in this image?"},
+    {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+]}
+```
 
 ## Optional Fields
 

--- a/docs/my-website/docs/completion/input.md
+++ b/docs/my-website/docs/completion/input.md
@@ -154,8 +154,8 @@ def completion(
 | `image_url` | Images | [Vision](./vision.md) |
 | `input_audio` | Audio input | [Audio](./audio.md) |
 | `video_url` | Video input | [Type Definition](https://github.com/BerriAI/litellm/blob/main/litellm/types/llms/openai.py#L625) |
-| `file` | Files (OpenAI) | [Document Understanding](./document_understanding.md) |
-| `document` | PDFs (Anthropic) | [Document Understanding](./document_understanding.md) |
+| `file` | Files | [Document Understanding](./document_understanding.md) |
+| `document` | Documents/PDFs | [Document Understanding](./document_understanding.md) |
 
 **Example (multimodal):**
 ```python

--- a/docs/my-website/docs/completion/input.md
+++ b/docs/my-website/docs/completion/input.md
@@ -150,7 +150,7 @@ def completion(
 
 | Type | Description | Docs |
 |------|-------------|------|
-| `text` | Text content | [Type Definition](https://github.com/BerriAI/litellm/blob/main/litellm/types/llms/openai.py#L603) |
+| `text` | Text content | [Type Definition](https://github.com/BerriAI/litellm/blob/main/litellm/types/llms/openai.py#L598) |
 | `image_url` | Images | [Vision](./vision.md) |
 | `input_audio` | Audio input | [Audio](./audio.md) |
 | `video_url` | Video input | [Type Definition](https://github.com/BerriAI/litellm/blob/main/litellm/types/llms/openai.py#L625) |

--- a/docs/my-website/docs/completion/input.md
+++ b/docs/my-website/docs/completion/input.md
@@ -157,12 +157,31 @@ def completion(
 | `file` | Files | [Document Understanding](./document_understanding.md) |
 | `document` | Documents/PDFs | [Document Understanding](./document_understanding.md) |
 
-**Example (multimodal):**
+**Examples:**
 ```python
-{"role": "user", "content": [
-    {"type": "text", "text": "What's in this image?"},
+# Text
+messages=[{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]
+
+# Image
+messages=[{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}]}]
+
+# Audio
+messages=[{"role": "user", "content": [{"type": "input_audio", "input_audio": {"data": "<base64>", "format": "wav"}}]}]
+
+# Video
+messages=[{"role": "user", "content": [{"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}]}]
+
+# File
+messages=[{"role": "user", "content": [{"type": "file", "file": {"file_id": "https://example.com/doc.pdf"}}]}]
+
+# Document
+messages=[{"role": "user", "content": [{"type": "document", "source": {"type": "text", "media_type": "application/pdf", "data": "<base64>"}}]}]
+
+# Combining multiple types (multimodal)
+messages=[{"role": "user", "content": [
+    {"type": "text", "text": "Generate a product description based on this image"},
     {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
-]}
+]}]
 ```
 
 ## Optional Fields


### PR DESCRIPTION
## Relevant issues

Fixes outdated "See All Message Values" link reported by user in Slack.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - N/A - Documentation only change
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

1. Updated "See All Message Values" link from outdated commit `8600ec7` (line 392) to `main` branch (line 664)
2. Added Content Types table documenting all 6 multimodal content types:
   - `text` - Text content
   - `image_url` - Images ([Vision docs](./vision.md))
   - `input_audio` - Audio input ([Audio docs](./audio.md))
   - `video_url` - Video input
   - `file` - Files/OpenAI ([Document Understanding docs](./document_understanding.md))
   - `document` - PDFs/Anthropic ([Document Understanding docs](./document_understanding.md))
3. Added example showing multimodal message format