### PR TITLE
Add Amazon Nova to sidebar and under supported models in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Support for more providers. Missing a provider or LLM Platform, raise a [feature
 | [AI21 (`ai21`)](https://docs.litellm.ai/docs/providers/ai21) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [AI21 Chat (`ai21_chat`)](https://docs.litellm.ai/docs/providers/ai21) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Aleph Alpha](https://docs.litellm.ai/docs/providers/aleph_alpha) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
+| [Amazon Nova](https://docs.litellm.ai/docs/providers/amazon_nova) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |
 | [Anthropic (`anthropic`)](https://docs.litellm.ai/docs/providers/anthropic) | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |  |
 | [Anthropic Text (`anthropic_text`)](https://docs.litellm.ai/docs/providers/anthropic) | ✅ | ✅ | ✅ |  |  |  |  |  | ✅ |  |
 | [Anyscale](https://docs.litellm.ai/docs/providers/anyscale) | ✅ | ✅ | ✅ |  |  |  |  |  |  |  |

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -671,6 +671,7 @@ const sidebars = {
         "providers/ai21",
         "providers/aiml",
         "providers/aleph_alpha",
+        "providers/amazon_nova",
         "providers/anyscale",
         "providers/baseten",
         "providers/bytez",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -84,6 +84,23 @@
         "a2a": true
       }
     },
+    "amazon_nova": {
+      "display_name": "Amazon Nova (`amazon_nova`)",
+      "url": "https://docs.litellm.ai/docs/providers/amazon_nova",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": true
+      }
+    },
     "anthropic": {
       "display_name": "Anthropic (`anthropic`)",
       "url": "https://docs.litellm.ai/docs/providers/anthropic",


### PR DESCRIPTION
📖 Documentation

## Changes
README.md - Added Amazon Nova under Supported Providers
docs/my-website/sidebars.js - Added Amazon Nova to sidebar
provider_endpoints_support.json - Added Amazon to supported endpoints