### PR TITLE
fix(responses-api): fix tool calls transformation in completion bridge

### DIFF
--- a/docs/my-website/docs/providers/openai/responses_api.md
+++ b/docs/my-website/docs/providers/openai/responses_api.md
@@ -623,6 +623,58 @@ display(styled_df)
 </TabItem>
 </Tabs>
 
+## Function Calling
+
+```python showLineNumbers title="Function Calling with Parallel Tool Calls"
+import litellm
+import json
+
+tools = [
+    {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get current weather for a location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"}
+            },
+            "required": ["location"]
+        }
+    }
+]
+
+# Step 1: Request with tools (parallel_tool_calls=True allows multiple calls)
+response = litellm.responses(
+    model="openai/gpt-4o",
+    input=[{"role": "user", "content": "What's the weather in Paris and Tokyo?"}],
+    tools=tools,
+    parallel_tool_calls=True, # Defaults = True
+)
+
+# Step 2: Execute tool calls and collect results
+tool_results = []
+for output in response.output:
+    if output.type == "function_call":
+        result = {"temperature": 15, "condition": "sunny"}  # Your function logic here
+        tool_results.append({
+            "type": "function_call_output",
+            "call_id": output.call_id,
+            "output": json.dumps(result)
+        })
+
+# Step 3: Send results back
+final_response = litellm.responses(
+    model="openai/gpt-4o",
+    input=tool_results,
+    tools=tools,
+)
+
+print(final_response.output)
+```
+
+Set `parallel_tool_calls=False` to ensure zero or one tool is called per turn. [More details](https://platform.openai.com/docs/guides/function-calling#parallel-function-calling).
+
 ## Free-form Function Calling
 
 <Tabs>
@@ -633,7 +685,6 @@ display(styled_df)
 import litellm
 
 response = litellm.responses(
-    response = client.responses.create(
     model="gpt-5-mini",
     input="Please use the code_exec tool to calculate the area of a circle with radius equal to the number of 'r's in strawberry",
     text={"format": {"type": "text"}},

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -167,24 +167,28 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     )
             elif role == "tool":
                 # Convert tool message to function call output format
-                # Transform content to responses format (handles str, list, and other types)
-                # _convert_content_to_responses_format always returns List[Dict[str, Any]]
+                # The Responses API expects 'output' to be a string, not a list
                 if content is None:
-                    transformed_output: list[dict[str, Any]] = []
-                elif isinstance(content, (str, list)):
-                    transformed_output = self._convert_content_to_responses_format(
-                        content, "tool"
-                    )
+                    output_str = ""
+                elif isinstance(content, str):
+                    output_str = content
+                elif isinstance(content, list):
+                    # If content is a list, extract text parts and join them
+                    text_parts = []
+                    for item in content:
+                        if isinstance(item, str):
+                            text_parts.append(item)
+                        elif isinstance(item, dict) and item.get("type") == "text":
+                            text_parts.append(item.get("text", ""))
+                    output_str = " ".join(text_parts) if text_parts else str(content)
                 else:
-                    # Fallback: convert unexpected types to string first
-                    transformed_output = self._convert_content_to_responses_format(
-                        str(content), "tool"
-                    )
+                    # Fallback: convert unexpected types to string
+                    output_str = str(content)
                 input_items.append(
                     {
                         "type": "function_call_output",
                         "call_id": tool_call_id,
-                        "output": transformed_output,
+                        "output": output_str,
                     }
                 )
             elif role == "assistant" and tool_calls and isinstance(tool_calls, list):
@@ -345,6 +349,11 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         index = 0
         reasoning_content: Optional[str] = None
 
+        # Collect all tool calls to put them in a single choice
+        # (Chat Completions API expects all tool calls in one message)
+        accumulated_tool_calls: List[Dict[str, Any]] = []
+        tool_call_index = 0
+
         for item in output_items:
             if isinstance(item, ResponseReasoningItem):
                 for summary_item in item.summary:
@@ -378,20 +387,10 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
                 tool_call_dict = LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
                     tool_call_item=item,
-                    index=index,
+                    index=tool_call_index,
                 )
-
-                msg = Message(
-                    content=None,
-                    tool_calls=[tool_call_dict],
-                    reasoning_content=reasoning_content,
-                )
-
-                choices.append(
-                    Choices(message=msg, finish_reason="tool_calls", index=index)
-                )
-                reasoning_content = None  # flush reasoning content
-                index += 1
+                accumulated_tool_calls.append(tool_call_dict)
+                tool_call_index += 1
 
             elif isinstance(item, dict) and handle_raw_dict_callback is not None:
                 # Handle raw dict responses (e.g., from GPT-5 Codex)
@@ -400,6 +399,18 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     choices.append(choice)
             else:
                 pass  # don't fail request if item in list is not supported
+
+        # If we accumulated tool calls, create a single choice with all of them
+        if accumulated_tool_calls:
+            msg = Message(
+                content=None,
+                tool_calls=accumulated_tool_calls,
+                reasoning_content=reasoning_content,
+            )
+            choices.append(
+                Choices(message=msg, finish_reason="tool_calls", index=index)
+            )
+            reasoning_content = None
 
         return choices
 

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -717,3 +717,213 @@ def test_text_plus_tool_calls_sequence():
     assert (
         completed_result.choices[0].finish_reason == "stop"
     ), "response.completed should have finish_reason='stop'"
+
+
+# =============================================================================
+# Tests for issue #18201: Tool calls transformation fixes
+# =============================================================================
+
+
+def test_tool_message_output_is_string_not_list():
+    """
+    Test that tool message content is converted to a string, not a list.
+
+    This is a regression test for a bug where tool results were transformed to:
+        {"type": "function_call_output", "output": [{"type": "output_text", "text": "..."}]}
+
+    But the Responses API expects:
+        {"type": "function_call_output", "output": "..."}
+
+    The incorrect format caused OpenAI to reject with:
+        "Invalid value: 'output_text'. Supported values are: 'input_text', 'input_image', and 'input_file'."
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    messages = [
+        {"role": "user", "content": "What's the weather?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_abc123",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"location": "Paris"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_abc123",
+            "content": '{"temperature": 15, "condition": "sunny"}',
+        },
+    ]
+
+    response, _ = handler.convert_chat_completion_messages_to_responses_api(messages)
+
+    # Find the function_call_output item
+    function_call_output = None
+    for item in response:
+        if item.get("type") == "function_call_output":
+            function_call_output = item
+            break
+
+    assert function_call_output is not None, "function_call_output not found"
+    assert function_call_output["call_id"] == "call_abc123"
+
+    # The output should be a string, NOT a list
+    output = function_call_output["output"]
+    assert isinstance(output, str), f"output should be a string, got {type(output)}"
+    assert output == '{"temperature": 15, "condition": "sunny"}'
+
+    print("✓ Tool message output is correctly a string, not a list")
+
+
+def test_multiple_tool_calls_in_single_choice():
+    """
+    Test that multiple tool calls are grouped into a single choice.
+
+    This is a regression test for a bug where each tool call was put in its own
+    Choice with separate indices:
+        choices = [
+            {"index": 0, "message": {"tool_calls": [tc1]}},
+            {"index": 1, "message": {"tool_calls": [tc2]}},
+            {"index": 2, "message": {"tool_calls": [tc3]}},
+        ]
+
+    But Chat Completions API expects all tool calls in a single choice:
+        choices = [
+            {"index": 0, "message": {"tool_calls": [tc1, tc2, tc3]}},
+        ]
+    """
+    from unittest.mock import Mock
+
+    from openai.types.responses import ResponseFunctionToolCall
+
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+    from litellm.types.llms.openai import (
+        InputTokensDetails,
+        OutputTokensDetails,
+        ResponseAPIUsage,
+        ResponsesAPIResponse,
+    )
+    from litellm.types.utils import ModelResponse, Usage
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    # Create multiple function tool calls (simulating parallel tool calls)
+    tool_call_1 = ResponseFunctionToolCall(
+        id="fc_1",
+        type="function_call",
+        status="completed",
+        arguments='{"location": "Paris"}',
+        call_id="call_paris",
+        name="get_weather",
+    )
+    tool_call_2 = ResponseFunctionToolCall(
+        id="fc_2",
+        type="function_call",
+        status="completed",
+        arguments='{"location": "Tokyo"}',
+        call_id="call_tokyo",
+        name="get_weather",
+    )
+    tool_call_3 = ResponseFunctionToolCall(
+        id="fc_3",
+        type="function_call",
+        status="completed",
+        arguments='{"sign": "Leo"}',
+        call_id="call_horoscope",
+        name="get_horoscope",
+    )
+
+    usage = ResponseAPIUsage(
+        input_tokens=50,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens=100,
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        total_tokens=150,
+    )
+
+    raw_response = ResponsesAPIResponse(
+        id="resp_test",
+        created_at=1234567890,
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata={},
+        model="gpt-4o",
+        object="response",
+        output=[tool_call_1, tool_call_2, tool_call_3],
+        parallel_tool_calls=True,
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text=None,
+        truncation="disabled",
+        usage=usage,
+        user=None,
+        store=True,
+        background=False,
+    )
+
+    model_response = ModelResponse(
+        id="chatcmpl-test",
+        created=1234567890,
+        model=None,
+        object="chat.completion",
+        choices=[],
+        usage=Usage(completion_tokens=0, prompt_tokens=0, total_tokens=0),
+    )
+
+    logging_obj = Mock()
+
+    result = handler.transform_response(
+        model="gpt-4o",
+        raw_response=raw_response,
+        model_response=model_response,
+        logging_obj=logging_obj,
+        request_data={"model": "gpt-4o"},
+        messages=[{"role": "user", "content": "test"}],
+        optional_params={},
+        litellm_params={},
+        encoding=Mock(),
+    )
+
+    # Should have exactly ONE choice
+    assert len(result.choices) == 1, f"Expected 1 choice, got {len(result.choices)}"
+
+    choice = result.choices[0]
+    assert choice.index == 0
+    assert choice.finish_reason == "tool_calls"
+
+    # That one choice should have ALL THREE tool calls
+    tool_calls = choice.message.tool_calls
+    assert tool_calls is not None, "tool_calls should not be None"
+    assert len(tool_calls) == 3, f"Expected 3 tool_calls, got {len(tool_calls)}"
+
+    # Verify each tool call
+    assert tool_calls[0]["id"] == "call_paris"
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+
+    assert tool_calls[1]["id"] == "call_tokyo"
+    assert tool_calls[1]["function"]["name"] == "get_weather"
+
+    assert tool_calls[2]["id"] == "call_horoscope"
+    assert tool_calls[2]["function"]["name"] == "get_horoscope"
+
+    print("✓ Multiple tool calls are correctly grouped in a single choice")


### PR DESCRIPTION
## Relevant issues

Fixes #18201

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix
📖 Documentation

## Changes

Fixes two bugs in the `openai/responses/...` completion bridge.

### Bug 1: `function_call_output.output` must be a string

When sending tool results back, LiteLLM incorrectly transformed the output to a list instead of a string.

**Code:**
```
USER CODE                      LITELLM BRIDGE                     OPENAI API
─────────────────────────────────────────────────────────────────────────────

messages = [                   Transforms to:                     Receives:
  {                            {                                  {
    "role": "tool",       →      "type": "function_call_output",    "type": "function_call_output",
    "tool_call_id": "x",         "call_id": "x",                    "call_id": "x",
    "content": '{"temp":15}'     "output": [{"type":                "output": [{"type":
  }                                "output_text",                     "output_text", ...}]
]                                  "text": '{"temp":15}'}]        }
                               }
                                                                   ❌ ERROR: Invalid value 'output_text'
```

**After (fixed):**
```
USER CODE                      LITELLM BRIDGE                     OPENAI API
─────────────────────────────────────────────────────────────────────────────

messages = [                   Transforms to:                     Receives:
  {                            {                                  {
    "role": "tool",       →      "type": "function_call_output",    "type": "function_call_output",
    "tool_call_id": "x",         "call_id": "x",                    "call_id": "x",
    "content": '{"temp":15}'     "output": '{"temp":15}'            "output": '{"temp":15}'
  }                            }                                  }
]
                                                                   ✅ OK
```

### Bug 2: Multiple tool calls must be grouped in a single choice

When the model returned multiple tool calls, LiteLLM incorrectly created separate choices instead of grouping them.

**Code:**
```
OPENAI RESPONSES API           LITELLM BRIDGE                     USER CODE RECEIVES
───────────────────────────────────────────────────────────────────────────────────────

Response:                      Transformed to:                    Received:
{                              {                                  {
  "output": [                    "choices": [                       "choices": [
    {type: "function_call",        {index: 0, message:                {index: 0, message:
     name: "get_weather",            {tool_calls: [tc1]}},              {tool_calls: [tc1]}},
     call_id: "call_1"},           {index: 1, message:                {index: 1, message:
    {type: "function_call",          {tool_calls: [tc2]}},              {tool_calls: [tc2]}},
     name: "get_weather",          {index: 2, message:                {index: 2, message:
     call_id: "call_2"},             {tool_calls: [tc3]}}               {tool_calls: [tc3]}}
    {type: "function_call",      ]                                  ]
     name: "get_horoscope",    }                                  }
     call_id: "call_3"}
  ]                            ❌ 3 separate choices              ❌ Incorrect format
}
```

**After (fixed):**
```
OPENAI RESPONSES API           LITELLM BRIDGE                     USER CODE RECEIVES
───────────────────────────────────────────────────────────────────────────────────────

Response:                      Transformed to:                    Received:
{                              {                                  {
  "output": [                    "choices": [                       "choices": [
    {type: "function_call",        {index: 0, message:                {index: 0, message:
     call_id: "call_1"},             {tool_calls: [tc1,                 {tool_calls: [tc1,
    {type: "function_call",                        tc2,                              tc2,
     call_id: "call_2"},                           tc3]}}                            tc3]}}
    {type: "function_call",      ]                                  ]
     call_id: "call_3"}        }                                  }
  ]
}                              ✅ 1 choice with all tool calls    ✅ Correct format
```

### Tests added

- `test_tool_message_output_is_string_not_list`
- `test_multiple_tool_calls_in_single_choice`

### Documentation

Added function calling example with `parallel_tool_calls` to the Responses API docs.