### PR TITLE
fix: not working log_failure_event in langfuse

### DIFF
--- a/litellm/integrations/langfuse/langfuse_prompt_management.py
+++ b/litellm/integrations/langfuse/langfuse_prompt_management.py
@@ -294,6 +294,11 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
             self.async_log_success_event, kwargs, response_obj, start_time, end_time
         )
 
+    def log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        return run_async_function(
+            self.async_log_failure_event, kwargs, response_obj, start_time, end_time
+        )
+
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         standard_callback_dynamic_params = kwargs.get(
             "standard_callback_dynamic_params"

--- a/tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py
+++ b/tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py
@@ -27,3 +27,24 @@ class TestLangfusePromptManagement:
 
             mock_get_prompt_from_id.assert_called_once()
             assert mock_get_prompt_from_id.call_args.kwargs["prompt_version"] == 4
+
+    def test_log_failure_event_runs_async_logger(self):
+        langfuse_prompt_management = LangfusePromptManagement()
+        with patch(
+            "litellm.integrations.langfuse.langfuse_prompt_management.run_async_function"
+        ) as mock_run_async:
+            kwargs = {"standard_callback_dynamic_params": {}}
+            start_time, end_time = 1, 2
+
+            langfuse_prompt_management.log_failure_event(
+                kwargs=kwargs,
+                response_obj=None,
+                start_time=start_time,
+                end_time=end_time,
+            )
+
+            mock_run_async.assert_called_once()
+            assert (
+                mock_run_async.call_args[0][0]
+                == langfuse_prompt_management.async_log_failure_event
+            )


### PR DESCRIPTION
## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/52208/workflows/ad784ee3-8853-4897-b64a-3dcce0643d1d

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/52217/workflows/49ca463c-e0bd-457a-990c-f7238cb4a131/jobs/984564

- [x] **Merge / cherry-pick CI run**  
       Links: https://app.circleci.com/pipelines/github/BerriAI/litellm/52223/workflows/a8906ed0-6921-4052-92c4-8dce64c6b2ec

## Type

🐛 Bug Fix
✅ Test

## Changes

There was an issue where errors returned by the LLM weren’t propagated to Langfuse. This snippet reproduces it:

```
import litellm
import os

os.environ["LANGFUSE_PUBLIC_KEY"] = "pk-**********"
os.environ["LANGFUSE_SECRET_KEY"] = "sk-**********"
os.environ["LANG_HOST"] = "http://localhost:3003"

litellm.success_callback = ["langfuse"]
litellm.failure_callback = ["langfuse"]

response = litellm.completion(
  api_key="***", # use an incorrect key here to trigger a failure
  model="gpt-4o",
  messages=[{"role": "user", "content": "Who are you?"}]
)
```