### PR TITLE
fix:No module named 'fastapi'

### DIFF
--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -2,12 +2,12 @@ import base64
 import mimetypes
 import re
 from dataclasses import dataclass, field
-from typing import List, Literal, Optional, Union
+from typing import TYPE_CHECKING, List, Literal, Optional, Union
 
-from fastapi import Request
-
-from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.types.utils import SpecialEnums
+
+if TYPE_CHECKING:
+    from fastapi import Request
 
 
 def _is_base64_encoded_unified_file_id(b64_uid: str) -> Union[str, Literal[False]]:
@@ -554,7 +554,7 @@ class FileCreationParams:
 
 
 async def extract_file_creation_params(
-    request: Request,
+    request: "Request",
     request_body: Optional[dict] = None,
     target_model_names_form: Optional[str] = None,
     target_storage_form: Optional[str] = None,
@@ -571,6 +571,8 @@ async def extract_file_creation_params(
     Returns:
         FileCreationParams: Structured parameters extracted from the request
     """
+    from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
+    
     if request_body is None:
         request_body = await _read_request_body(request=request) or {}
     
@@ -621,7 +623,7 @@ def _extract_target_model_names_simple(target_model_names_form: Optional[str] = 
     return []
 
 
-def _extract_model_param(request: Request, request_body: dict) -> Optional[str]:
+def _extract_model_param(request: "Request", request_body: dict) -> Optional[str]:
     """
     Extract model parameter from request.
     


### PR DESCRIPTION
## Relevant issues

Fixes #18193

The issue was that litellm/proxy/openai_files_endpoints/common_utils.py had a hard import of fastapi at the module level:
from fastapi import Request
This caused a ModuleNotFoundError when using core library functions like litellm.responses() in environments where fastapi is not installed (since it's an optional dependency).

Not adding any test as I just reordered imports

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix


## Changes
**Before**
<img width="1052" height="779" alt="image" src="https://github.com/user-attachments/assets/d59337cf-909f-46ae-af44-c1d92b3bc553" />

**After**
<img width="1052" height="371" alt="image" src="https://github.com/user-attachments/assets/99ecd031-23f6-41b5-ad4f-93c4696804b7" />
