### PR TITLE
feat: Preserve context in success_handler function

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1,6 +1,7 @@
 # What is this?
 ## Common Utility file for Logging handler
 # Logging function -> log the exact model details + what's being sent | Non-Blocking
+import contextvars
 import copy
 import datetime
 import json
@@ -3064,7 +3065,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if self._should_run_sync_callbacks_for_async_calls() is False:
             return
 
+        ctx = contextvars.copy_context()
         executor.submit(
+            ctx.run,
             self.success_handler,
             result,
             start_time,

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1,7 +1,12 @@
+import contextvars
+import datetime
 import json
 import os
 import sys
-from unittest.mock import MagicMock, patch
+import threading
+from threading import Event
+from typing import Any
+from unittest.mock import MagicMock, patch, Mock
 
 import pytest
 
@@ -929,3 +934,41 @@ def test_append_system_prompt_messages():
         kwargs=None, messages=messages
     )
     assert result == messages
+
+
+@patch.object(LitellmLogging, "success_handler")
+@patch.object(LitellmLogging, "_should_run_sync_callbacks_for_async_calls", return_value=True)
+def test_handle_sync_success_callbacks_for_async_calls_runs_with_context(
+    should_run_sync_callbacks_for_async_calls_mock: Mock,
+    success_handler_mock: Mock,
+    logging_obj: LitellmLogging
+):
+    # Given
+    test_var = contextvars.ContextVar("test_var", default="test_value")
+    side_effect_test_var_value: None | str = None
+    event: Event = threading.Event()
+
+    def side_effect(result, start_time, end_time, cache_hit) -> None:
+        nonlocal side_effect_test_var_value
+
+        side_effect_test_var_value = test_var.get()
+        event.set()
+
+    success_handler_mock.side_effect = side_effect
+
+    args = (
+        "test_result",
+        datetime.datetime(2025, 12, 18, 10, 0 ,0),
+        datetime.datetime(2025, 12, 18, 10, 0, 5),
+        "hit"
+    )
+
+    # When
+    logging_obj.handle_sync_success_callbacks_for_async_calls(*args)
+    event.wait(timeout=1)
+
+    # Then
+    success_handler_mock.assert_called_once_with(*args)
+    should_run_sync_callbacks_for_async_calls_mock.assert_called_once_with()
+
+    assert side_effect_test_var_value == "test_value", "Context variable not preserved in success_handler call"


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

Currently, the async context is not available inside the success_handler function in litellm_logging. This PR makes the context available inside the success_handler function.

After applying this Patch, the context is available in sync custom callback functions.