### PR TITLE
[Fix] Nova model detection for Bedrock provider (#17910)

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -314,6 +314,12 @@ class BaseAWSLLM:
         if model.startswith("invoke/"):
             model = model.replace("invoke/", "", 1)
 
+        # Special case: Check for "nova" in model name first (before "amazon")
+        # This handles amazon.nova-* models which would otherwise match "amazon" (Titan)
+        if "nova" in model.lower():
+            if "nova" in get_args(BEDROCK_INVOKE_PROVIDERS_LITERAL):
+                return cast(BEDROCK_INVOKE_PROVIDERS_LITERAL, "nova")
+
         _split_model = model.split(".")[0]
         if _split_model in get_args(BEDROCK_INVOKE_PROVIDERS_LITERAL):
             return cast(BEDROCK_INVOKE_PROVIDERS_LITERAL, _split_model)
@@ -323,13 +329,9 @@ class BaseAWSLLM:
         if provider is not None:
             return provider
 
-        # check if provider == "nova"
-        if "nova" in model:
-            return "nova"
-        else:
-            for provider in get_args(BEDROCK_INVOKE_PROVIDERS_LITERAL):
-                if provider in model:
-                    return provider
+        for provider in get_args(BEDROCK_INVOKE_PROVIDERS_LITERAL):
+            if provider in model:
+                return provider
         return None
 
     @staticmethod
@@ -364,7 +366,7 @@ class BaseAWSLLM:
         elif provider == "qwen3" and "qwen3/" in model_id:
             model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
                 model_id, spec="qwen3"
-            ) 
+            )
         elif provider == "stability" and "stability/" in model_id:
             model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
                 model_id, spec="stability"
@@ -412,7 +414,7 @@ class BaseAWSLLM:
         if "nova" in model.lower():
             if "nova" in get_args(BEDROCK_EMBEDDING_PROVIDERS_LITERAL):
                 return cast(BEDROCK_EMBEDDING_PROVIDERS_LITERAL, "nova")
-        
+
         # Handle regional models like us.twelvelabs.marengo-embed-2-7-v1:0
         if "." in model:
             parts = model.split(".")
@@ -958,7 +960,9 @@ class BaseAWSLLM:
         return endpoint_url, proxy_endpoint_url
 
     def _select_default_endpoint_url(
-        self, endpoint_type: Optional[Literal["runtime", "agent", "agentcore"]], aws_region_name: str
+        self,
+        endpoint_type: Optional[Literal["runtime", "agent", "agentcore"]],
+        aws_region_name: str,
     ) -> str:
         """
         Select the default endpoint url based on the endpoint type

--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -524,6 +524,12 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
         if model.startswith("invoke/"):
             model = model.replace("invoke/", "", 1)
 
+        # Special case: Check for "nova" in model name first (before "amazon")
+        # This handles amazon.nova-* models which would otherwise match "amazon" (Titan)
+        if "nova" in model.lower():
+            if "nova" in get_args(litellm.BEDROCK_INVOKE_PROVIDERS_LITERAL):
+                return cast(litellm.BEDROCK_INVOKE_PROVIDERS_LITERAL, "nova")
+
         _split_model = model.split(".")[0]
         if _split_model in get_args(litellm.BEDROCK_INVOKE_PROVIDERS_LITERAL):
             return cast(litellm.BEDROCK_INVOKE_PROVIDERS_LITERAL, _split_model)
@@ -532,10 +538,6 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
         provider = AmazonInvokeConfig._get_provider_from_model_path(model)
         if provider is not None:
             return provider
-
-        # check if provider == "nova"
-        if "nova" in model:
-            return "nova"
 
         for provider in get_args(litellm.BEDROCK_INVOKE_PROVIDERS_LITERAL):
             if provider in model:

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -2841,6 +2841,34 @@ def test_bedrock_invoke_provider():
         )
         == "nova"
     )
+    assert (
+        litellm.AmazonInvokeConfig().get_bedrock_invoke_provider("amazon.nova-pro-v1:0")
+        == "nova"
+    )
+    assert (
+        litellm.AmazonInvokeConfig().get_bedrock_invoke_provider(
+            "amazon.nova-lite-v1:0"
+        )
+        == "nova"
+    )
+    assert (
+        litellm.AmazonInvokeConfig().get_bedrock_invoke_provider(
+            "amazon.nova-micro-v1:0"
+        )
+        == "nova"
+    )
+    assert (
+        litellm.AmazonInvokeConfig().get_bedrock_invoke_provider(
+            "amazon.nova-premier-v1:0"
+        )
+        == "nova"
+    )
+    assert (
+        litellm.AmazonInvokeConfig().get_bedrock_invoke_provider(
+            "amazon.nova-2-lite-v1:0"
+        )
+        == "nova"
+    )
 
 
 def test_bedrock_description_param():
@@ -3494,7 +3522,9 @@ def test_bedrock_openai_imported_model():
         url = mock_post.call_args.kwargs["url"]
         print(f"URL: {url}")
         assert "bedrock-runtime.us-east-1.amazonaws.com" in url
-        assert "arn:aws:bedrock:us-east-1:117159858402:imported-model/m4gc1mrfuddy" in url
+        assert (
+            "arn:aws:bedrock:us-east-1:117159858402:imported-model/m4gc1mrfuddy" in url
+        )
         assert "/invoke" in url
 
         # Validate request body follows OpenAI format
@@ -3523,7 +3553,9 @@ def test_bedrock_openai_imported_model():
         # Check image_url content
         assert user_msg["content"][1]["type"] == "image_url"
         assert "image_url" in user_msg["content"][1]
-        assert user_msg["content"][1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+        assert user_msg["content"][1]["image_url"]["url"].startswith(
+            "data:image/jpeg;base64,"
+        )
 
         assert user_msg["content"][2]["type"] == "image_url"
         assert "image_url" in user_msg["content"][2]
@@ -3532,21 +3564,67 @@ def test_bedrock_openai_imported_model():
         assert request_body["max_tokens"] == 300
         assert request_body["temperature"] == 0.5
 
+
+def test_bedrock_nova_provider_detection():
+    """
+    Test that Nova models are correctly detected even when prefixed with "amazon."
+    Regression test for issue #17910 where models like "amazon.nova-pro-v1:0"
+    were incorrectly identified as "amazon" (Titan) instead of "nova".
+    """
+    from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+    # Test various Nova model formats
+    nova_test_cases = [
+        ("us.amazon.nova-pro-v1:0", "nova"),
+        ("us.amazon.nova-lite-v1:0", "nova"),
+        ("us.amazon.nova-micro-v1:0", "nova"),
+        ("amazon.nova-pro-v1:0", "nova"),
+        ("amazon.nova-lite-v1:0", "nova"),
+        ("amazon.nova-micro-v1:0", "nova"),
+        ("amazon.nova-premier-v1:0", "nova"),
+        ("amazon.nova-2-lite-v1:0", "nova"),
+        ("bedrock/amazon.nova-pro-v1:0", "nova"),
+        ("bedrock/invoke/amazon.nova-pro-v1:0", "nova"),
+        ("amazon.Nova-pro-v1:0", "nova"),
+        ("amazon.NOVA-pro-v1:0", "nova"),
+    ]
+
+    for model, expected in nova_test_cases:
+        provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
+        assert (
+            provider == expected
+        ), f"Failed for model: {model}, expected: {expected}, got: {provider}"
+
+    # Verify that Amazon Titan models still return "amazon"
+    titan_test_cases = [
+        ("amazon.titan-text-express-v1", "amazon"),
+        ("us.amazon.titan-text-lite-v1", "amazon"),
+    ]
+
+    for model, expected in titan_test_cases:
+        provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
+        assert (
+            provider == expected
+        ), f"Failed for model: {model}, expected: {expected}, got: {provider}"
+
+
 def test_bedrock_openai_provider_detection():
     """
     Test that the OpenAI provider is correctly detected from model strings.
     """
     from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
-    
+
     # Test various OpenAI model formats
     test_cases = [
         "openai/arn:aws:bedrock:us-east-1:123456789012:imported-model/abc123",
         "bedrock/openai/arn:aws:bedrock:us-east-1:123456789012:imported-model/xyz789",
     ]
-    
+
     for model in test_cases:
         provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
-        assert provider == "openai", f"Failed for model: {model}, got provider: {provider}"
+        assert (
+            provider == "openai"
+        ), f"Failed for model: {model}, got provider: {provider}"
         print(f"✓ Provider detection works for: {model}")
 
 
@@ -3555,16 +3633,16 @@ def test_bedrock_openai_model_id_extraction():
     Test that the model ID (ARN) is correctly extracted and encoded for OpenAI models.
     """
     from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
-    
-    model = "openai/arn:aws:bedrock:us-east-1:123456789012:imported-model/test-model-123"
-    provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
-    
-    model_id = BaseAWSLLM.get_bedrock_model_id(
-        model=model,
-        provider=provider,
-        optional_params={}
+
+    model = (
+        "openai/arn:aws:bedrock:us-east-1:123456789012:imported-model/test-model-123"
     )
-    
+    provider = BaseAWSLLM.get_bedrock_invoke_provider(model)
+
+    model_id = BaseAWSLLM.get_bedrock_model_id(
+        model=model, provider=provider, optional_params={}
+    )
+
     # The ARN should be double URL encoded
     assert "arn" in model_id
     assert "imported-model" in model_id
@@ -3576,20 +3654,17 @@ def test_bedrock_openai_convert_messages_to_prompt():
     Test that convert_messages_to_prompt returns empty string for OpenAI models.
     """
     from litellm.llms.bedrock.chat.invoke_handler import BedrockLLM
-    
+
     bedrock_llm = BedrockLLM()
     messages = [
         {"role": "system", "content": "You are helpful"},
-        {"role": "user", "content": "Hello"}
+        {"role": "user", "content": "Hello"},
     ]
-    
+
     prompt, chat_history = bedrock_llm.convert_messages_to_prompt(
-        model="test-model",
-        messages=messages,
-        provider="openai",
-        custom_prompt_dict={}
+        model="test-model", messages=messages, provider="openai", custom_prompt_dict={}
     )
-    
+
     # OpenAI models use messages directly, no prompt conversion
     assert prompt == ""
     assert chat_history is None
@@ -3604,37 +3679,33 @@ def test_bedrock_openai_response_parsing():
     from litellm import ModelResponse
     from unittest.mock import Mock
     import json
-    
+
     bedrock_llm = BedrockLLM()
-    
+
     # Mock OpenAI-style response
     openai_response = {
         "choices": [
             {
                 "message": {
                     "content": "The capital of France is Paris.",
-                    "role": "assistant"
+                    "role": "assistant",
                 },
                 "finish_reason": "stop",
-                "index": 0
+                "index": 0,
             }
         ],
-        "usage": {
-            "prompt_tokens": 10,
-            "completion_tokens": 8,
-            "total_tokens": 18
-        }
+        "usage": {"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18},
     }
-    
+
     mock_response = Mock()
     mock_response.json.return_value = openai_response
     mock_response.text = json.dumps(openai_response)
     mock_response.status_code = 200
     mock_response.headers = {}
-    
+
     model_response = ModelResponse()
     mock_logging = Mock()
-    
+
     result = bedrock_llm.process_response(
         model="openai/arn:aws:bedrock:us-east-1:123:imported-model/test",
         response=mock_response,
@@ -3646,18 +3717,18 @@ def test_bedrock_openai_response_parsing():
         data={},
         messages=[{"role": "user", "content": "What is the capital of France?"}],
         print_verbose=lambda x: None,
-        encoding=None
+        encoding=None,
     )
-    
+
     # Verify response content
     assert result.choices[0].message.content == "The capital of France is Paris."
     assert result.choices[0].finish_reason == "stop"
-    
+
     # Verify usage
     assert result.usage.prompt_tokens == 10
     assert result.usage.completion_tokens == 8
     assert result.usage.total_tokens == 18
-    
+
     print("✓ OpenAI response parsing works correctly")
 
 
@@ -3665,45 +3736,47 @@ def test_bedrock_openai_request_transformation():
     """
     Test that the request is correctly transformed for OpenAI models.
     """
-    from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import AmazonInvokeConfig
-    
+    from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
+        AmazonInvokeConfig,
+    )
+
     config = AmazonInvokeConfig()
-    
+
     model = "openai/arn:aws:bedrock:us-east-1:123:imported-model/test"
     messages = [
         {"role": "system", "content": "You are helpful"},
-        {"role": "user", "content": "Hello"}
+        {"role": "user", "content": "Hello"},
     ]
-    
+
     optional_params = {
         "max_tokens": 100,
         "temperature": 0.7,
         "top_p": 0.9,
-        "stream": False
+        "stream": False,
     }
-    
+
     litellm_params = {}
     headers = {}
-    
-    with patch.object(config, 'get_bedrock_invoke_provider', return_value="openai"):
+
+    with patch.object(config, "get_bedrock_invoke_provider", return_value="openai"):
         result = config.transform_request(
             model=model,
             messages=messages,
             optional_params=optional_params.copy(),
             litellm_params=litellm_params,
-            headers=headers
+            headers=headers,
         )
-    
+
     # Verify the request uses messages format (not prompt)
     assert "messages" in result
     assert len(result["messages"]) == 2
     assert result["messages"][0]["role"] == "system"
     assert result["messages"][1]["role"] == "user"
-    
+
     # Verify parameters are included
     assert "max_tokens" in result
     assert "temperature" in result
-    
+
     print("✓ Request transformation works correctly")
 
 
@@ -3711,20 +3784,22 @@ def test_bedrock_openai_parameter_filtering():
     """
     Test that only supported OpenAI parameters are included in the request.
     """
-    from litellm.llms.bedrock.chat.invoke_transformations.amazon_openai_transformation import AmazonBedrockOpenAIConfig
-    
+    from litellm.llms.bedrock.chat.invoke_transformations.amazon_openai_transformation import (
+        AmazonBedrockOpenAIConfig,
+    )
+
     config = AmazonBedrockOpenAIConfig()
     model = "test-model"
-    
+
     supported_params = config.get_supported_openai_params(model=model)
-    
+
     # Verify common OpenAI parameters are supported
     assert "max_tokens" in supported_params
     assert "temperature" in supported_params
     assert "top_p" in supported_params
     assert "stream" in supported_params
     assert "stop" in supported_params
-    
+
     print(f"✓ Parameter filtering supports: {len(supported_params)} parameters")
     print(f"  Supported params: {supported_params}")
 
@@ -3734,12 +3809,12 @@ def test_bedrock_openai_route_detection():
     Test that the OpenAI route is correctly detected.
     """
     from litellm.llms.bedrock.common_utils import BedrockModelInfo
-    
+
     test_cases = [
         ("openai/arn:aws:bedrock:us-east-1:123:imported-model/test", "openai"),
         ("bedrock/openai/arn:aws:bedrock:us-east-1:123:imported-model/test", "openai"),
     ]
-    
+
     for model, expected_route in test_cases:
         route = BedrockModelInfo.get_bedrock_route(model)
         assert route == expected_route, f"Failed for model: {model}, got route: {route}"
@@ -3751,15 +3826,30 @@ def test_bedrock_openai_explicit_route_check():
     Test the explicit OpenAI route checker helper method.
     """
     from litellm.llms.bedrock.common_utils import BedrockModelInfo
-    
+
     # Test with openai/ prefix
-    assert BedrockModelInfo._explicit_openai_route("openai/arn:aws:bedrock:us-east-1:123:imported-model/test") is True
-    assert BedrockModelInfo._explicit_openai_route("bedrock/openai/arn:aws:bedrock:us-east-1:123:imported-model/test") is True
-    
+    assert (
+        BedrockModelInfo._explicit_openai_route(
+            "openai/arn:aws:bedrock:us-east-1:123:imported-model/test"
+        )
+        is True
+    )
+    assert (
+        BedrockModelInfo._explicit_openai_route(
+            "bedrock/openai/arn:aws:bedrock:us-east-1:123:imported-model/test"
+        )
+        is True
+    )
+
     # Test without openai/ prefix
     assert BedrockModelInfo._explicit_openai_route("anthropic.claude-3-sonnet") is False
-    assert BedrockModelInfo._explicit_openai_route("arn:aws:bedrock:us-east-1:123:imported-model/test") is False
-    
+    assert (
+        BedrockModelInfo._explicit_openai_route(
+            "arn:aws:bedrock:us-east-1:123:imported-model/test"
+        )
+        is False
+    )
+
     print("✓ Explicit route check works correctly")
 
 
@@ -3767,16 +3857,18 @@ def test_bedrock_openai_config_initialization():
     """
     Test that AmazonBedrockOpenAIConfig can be properly initialized.
     """
-    from litellm.llms.bedrock.chat.invoke_transformations.amazon_openai_transformation import AmazonBedrockOpenAIConfig
-    
+    from litellm.llms.bedrock.chat.invoke_transformations.amazon_openai_transformation import (
+        AmazonBedrockOpenAIConfig,
+    )
+
     config = AmazonBedrockOpenAIConfig()
-    
+
     # Verify it has the necessary methods
-    assert hasattr(config, 'get_supported_openai_params')
-    assert hasattr(config, 'transform_request')
-    assert hasattr(config, 'transform_response')
-    assert hasattr(config, 'map_openai_params')
-    
+    assert hasattr(config, "get_supported_openai_params")
+    assert hasattr(config, "transform_request")
+    assert hasattr(config, "transform_response")
+    assert hasattr(config, "map_openai_params")
+
     print("✓ AmazonBedrockOpenAIConfig initializes correctly")
 
 
@@ -3785,9 +3877,9 @@ def test_bedrock_openai_multiple_message_types():
     Test that various message content types are handled correctly.
     """
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
-    
+
     client = HTTPHandler()
-    
+
     # Test with mixed content types
     messages = [
         {"role": "system", "content": "You are helpful"},
@@ -3796,11 +3888,14 @@ def test_bedrock_openai_multiple_message_types():
             "role": "user",
             "content": [
                 {"type": "text", "text": "Complex message with text"},
-                {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,iVBORw0KGg"}}
-            ]
-        }
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/jpeg;base64,iVBORw0KGg"},
+                },
+            ],
+        },
     ]
-    
+
     with patch.object(client, "post") as mock_post:
         try:
             response = completion(
@@ -3811,18 +3906,18 @@ def test_bedrock_openai_multiple_message_types():
             )
         except Exception as e:
             pass
-        
+
         # Verify the request was made
         if mock_post.called:
             request_body = json.loads(mock_post.call_args.kwargs["data"])
-            
+
             # Verify messages are preserved
             assert "messages" in request_body
             assert len(request_body["messages"]) == 3
-            
+
             # Verify mixed content is handled
             assert isinstance(request_body["messages"][2]["content"], list)
-            
+
             print("✓ Multiple message types handled correctly")
 
 
@@ -3835,18 +3930,18 @@ def test_bedrock_openai_error_handling():
     from litellm.llms.bedrock.common_utils import BedrockError
     from unittest.mock import Mock
     import json
-    
+
     bedrock_llm = BedrockLLM()
-    
+
     # Mock error response
     mock_response = Mock()
     mock_response.json.side_effect = Exception("Invalid JSON")
     mock_response.text = "Invalid response"
     mock_response.status_code = 422
-    
+
     model_response = ModelResponse()
     mock_logging = Mock()
-    
+
     with pytest.raises(BedrockError) as exc_info:
         bedrock_llm.process_response(
             model="openai/arn:aws:bedrock:us-east-1:123:imported-model/test",
@@ -3859,8 +3954,8 @@ def test_bedrock_openai_error_handling():
             data={},
             messages=[],
             print_verbose=lambda x: None,
-            encoding=None
+            encoding=None,
         )
-    
+
     assert exc_info.value.status_code == 422
     print("✓ Error handling works correctly")


### PR DESCRIPTION
Resolves issue #17910 where Amazon Nova models (like amazon.nova-pro-v1:0) were incorrectly identified as Amazon Titan models, causing requests to use textGenerationConfig instead of inferenceConfig.

The fix moves the "nova" check before the initial provider check on the split model name. This ensures that models containing "nova" (like amazon.nova-pro-v1:0 or amazon.nova-2-lite-v1:0) are correctly identified as Nova models, rather than matching "amazon" first.

## Relevant issues

Fixes #17910

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

  > **CI status guideline:**
  >
  > - 50-55 passing tests: main is stable with minor issues.
  > - 45-49 passing tests: acceptable but needs attention
  > - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

  - [ ] **Branch creation CI run**
         Link:

  - [ ] **CI run for the last commit**
         Link:

  - [ ] **Merge / cherry-pick CI run**
         Links:

  ## Type

  🐛 Bug Fix

  ## Changes

  - Added early check for "nova" in model name before split-based provider detection in:
    - `litellm/llms/bedrock/base_aws_llm.py`
    - `litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py`
  - Added comprehensive test cases in `tests/llm_translation/test_bedrock_completion.py`:
    - `test_bedrock_nova_provider_detection` - Tests various Nova model formats including cross-region prefixes, invoke/ prefix, and case variations
    - Extended `test_bedrock_invoke_provider` with additional Nova model assertions