### PR TITLE
fix(responses-api): use list format with input_text for tool results

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -167,28 +167,27 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     )
             elif role == "tool":
                 # Convert tool message to function call output format
-                # The Responses API expects 'output' to be a string, not a list
+                # The Responses API expects 'output' to be a list with input_text/input_image types
+                # Using list format for consistency across text and multimodal content
+                tool_output: List[Dict[str, Any]]
                 if content is None:
-                    output_str = ""
+                    tool_output = []
                 elif isinstance(content, str):
-                    output_str = content
+                    # Convert string to list with input_text
+                    tool_output = [{"type": "input_text", "text": content}]
                 elif isinstance(content, list):
-                    # If content is a list, extract text parts and join them
-                    text_parts = []
-                    for item in content:
-                        if isinstance(item, str):
-                            text_parts.append(item)
-                        elif isinstance(item, dict) and item.get("type") == "text":
-                            text_parts.append(item.get("text", ""))
-                    output_str = " ".join(text_parts) if text_parts else str(content)
+                    # Transform list content to Responses API format
+                    tool_output = self._convert_content_to_responses_format(
+                        content, "user"  # Use "user" role to get input_* types
+                    )
                 else:
-                    # Fallback: convert unexpected types to string
-                    output_str = str(content)
+                    # Fallback: convert unexpected types to input_text
+                    tool_output = [{"type": "input_text", "text": str(content)}]
                 input_items.append(
                     {
                         "type": "function_call_output",
                         "call_id": tool_call_id,
-                        "output": output_str,
+                        "output": tool_output,
                     }
                 )
             elif role == "assistant" and tool_calls and isinstance(tool_calls, list):


### PR DESCRIPTION
## Relevant issues

Fixes the regression introduced in #18226

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Fixes the regression introduced in #18226 where tool results were using conflicting formats
- Uses consistent list format with `input_text`/`input_image` types for all tool results
- Resolves test conflicts between `test_convert_chat_completion_messages_to_responses_api_tool_result_with_text` and `test_tool_message_output_is_string_not_list`

### Details
- Tool results now always use list format: `[{"type": "input_text", "text": "..."}]`
- Images in tool results correctly use: `[{"type": "input_image", "image_url": "..."}]`
- Updated test to reflect the correct expected format

## Test plan
- [x] All 17 unit tests pass
- [x] Tested with real OpenAI API call (text tool result via `openai/responses/gpt-4o-mini`)
- [x] Tested with real OpenAI API call (image tool result via `openai/responses/gpt-4o-mini`)