### PR TITLE
ensure datadog llm obs ignores dd base url override

### DIFF
--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -56,11 +56,6 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
                 f"https://api.{self.DD_SITE}/api/intake/llm-obs/v1/trace/spans"
             )
 
-            # testing base url
-            dd_base_url = os.getenv("DD_BASE_URL")
-            if dd_base_url:
-                self.intake_url = f"{dd_base_url}/api/intake/llm-obs/v1/trace/spans"
-
             asyncio.create_task(self.periodic_flush())
             self.flush_lock = asyncio.Lock()
             self.log_queue: List[LLMObsPayload] = []

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -293,6 +293,19 @@ class TestDataDogLLMObsLogger:
         assert logger._get_datadog_span_kind("unknown_call_type") == "llm"
         assert logger._get_datadog_span_kind(None) == "llm"
 
+    def test_dd_base_url_does_not_override_intake_url(self, mock_env_vars):
+        """Even if DD_BASE_URL is set, intake_url should remain DD_SITE-based"""
+        with patch.dict(os.environ, {"DD_BASE_URL": "https://example.datadog"}):
+            with patch(
+                "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
+            ), patch("asyncio.create_task"):
+                logger = DataDogLLMObsLogger()
+
+        expected_url = (
+            f"https://api.{logger.DD_SITE}/api/intake/llm-obs/v1/trace/spans"
+        )
+        assert logger.intake_url == expected_url
+
     @pytest.mark.asyncio
     async def test_async_log_failure_event(self, mock_env_vars):
         """Test that async_log_failure_event correctly processes failure payloads according to DD LLM Obs API spec"""


### PR DESCRIPTION
## Relevant issues

LIT-1576

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/52324/workflows/e75be47a-a7eb-4eb3-91b0-313cb19450b6

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/52323/workflows/50a0ee01-f3c6-4b49-9e56-be0ab89e8d3b

- [x] **Merge / cherry-pick CI run**  
       Links: https://app.circleci.com/pipelines/github/BerriAI/litellm/52326/workflows/a8922b50-4484-4a30-b8c1-327d44d17e8f

## Type

🐛 Bug Fix
✅ Test

## Changes

Datadog’s agent doesn’t expose the LLM Observability intake path, so using DD_BASE_URL to point at the agent caused every batch flush to fail. This change bypasses the agent by ignoring DD_BASE_URL for LLM Obs and always sending spans directly to the Datadog cloud endpoint.
