### PR TITLE
fix(oci): handle OpenAI-style image_url object in multimodal messages

### DIFF
--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -1124,8 +1124,11 @@ def adapt_messages_to_generic_oci_standard_content_message(
 
         elif type == "image_url":
             image_url = content_item.get("image_url")
+            # Handle both OpenAI format (object with url) and string format
+            if isinstance(image_url, dict):
+                image_url = image_url.get("url")
             if not isinstance(image_url, str):
-                raise Exception("Prop `image_url` is not a string")
+                raise Exception("Prop `image_url` must be a string or an object with a `url` property")
             new_content.append(OCIImageContentPart(imageUrl=image_url))
 
     return OCIMessage(


### PR DESCRIPTION
## Relevant issues

Fixes #18270

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

The OCI adapter was rejecting OpenAI-style `image_url` objects in multimodal messages. When using the Vision API format:

```json
{
  "type": "image_url",
  "image_url": {
    "url": "https://example.com/image.png"
  }
}
```

The adapter raised: `Exception: Prop image_url is not a string`

### Fix

Modified `adapt_messages_to_generic_oci_standard_content_message()` in `litellm/llms/oci/chat/transformation.py` to handle both formats:

- **String**: `"image_url": "https://example.com/image.png"`
- **Object**: `"image_url": {"url": "https://example.com/image.png"}`

### Tests Added

Added 4 tests in `tests/litellm/llms/oci/chat/test_oci_chat_transformation.py`:
- `test_image_url_as_string` - existing string format works
- `test_image_url_as_openai_object` - OpenAI object format works
- `test_image_url_invalid_type_raises_error` - invalid types rejected
- `test_image_url_object_missing_url_raises_error` - object without `url` property rejected