### PR TITLE
[Fix] vertex credentials being logged

### DIFF
--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -18,6 +18,7 @@ class SensitiveDataMasker:
             "token",
             "auth",
             "credential",
+            "credentials",
             "access",
             "private",
             "certificate",

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1169,9 +1169,6 @@ class Router:
             if litellm.redact_user_api_key_info:
                 masker = SensitiveDataMasker(visible_prefix=2, visible_suffix=0)
                 _deployment_copy["litellm_params"] = masker.mask_dict(litellm_params)
-            elif "api_key" in litellm_params:
-                litellm_params["api_key"] = litellm_params["api_key"][:2] + "*" * 10
-
             return _deployment_copy
         except Exception as e:
             verbose_router_logger.debug(


### PR DESCRIPTION
## Relevant issues
Vertex credentials were being logged even when  `redact_user_api_key_info: true.` 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:



## Type
🐛 Bug Fix

## Changes
Added "credentials" to SensitiveDataMasker so it recognises vertex_credentials field to redact when redact_user_api_key_info: true.  Also removed the api_key redaction when "redact_user_api_key_info: true" is not specified in the config for consistency as it logs every other key/secret without it.

