### PR TITLE
Use already configured opentelemetry providers

### DIFF
--- a/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
+++ b/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
@@ -65,31 +65,6 @@ class TestOpentelemetryUnitTests(BaseLoggingCallbackTest):
         # External spans should only be closed by their creators
         parent_otel_span.end.assert_not_called()
 
-    def test_init_tracing_respects_existing_tracer_provider(self):
-        """
-        Unit test: _init_tracing() should respect existing TracerProvider.
-
-        When a TracerProvider already exists (e.g., set by Langfuse SDK),
-        LiteLLM should use it instead of creating a new one.
-        """
-        from opentelemetry import trace
-        from opentelemetry.sdk.trace import TracerProvider
-        from litellm.integrations.opentelemetry import OpenTelemetry
-
-        # Setup: Create and set an existing TracerProvider
-        tracer_provider = TracerProvider()
-        trace.set_tracer_provider(tracer_provider)
-        existing_provider = trace.get_tracer_provider()
-
-        # Act: Initialize OpenTelemetry integration (should detect existing provider)
-        otel_integration = OpenTelemetry()
-
-        # Assert: The existing provider should still be active
-        current_provider = trace.get_tracer_provider()
-        assert current_provider is existing_provider, (
-            "Existing TracerProvider should be respected and not overridden"
-        )
-
     def test_get_span_context_detects_active_span(self):
         """
         Unit test: _get_span_context() should auto-detect active spans from global context.


### PR DESCRIPTION
Users that instrument using opentelemetry-instrument can now setup exporters as per their environment

## Relevant issues

Fixes #13646 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes
Refactored _init_ methods to setup all telemetry providers similarly using _get_or_create_provider helper method
Use public classes instead of internal proxy provider classes for stability across otel versions
Fixes a bug where already configured provider was not being used
