### PR TITLE
fix(gemini): filter functionCall parts from reasoning_content

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1147,6 +1147,10 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         reasoning_content_str: Optional[str] = None
 
         for part in parts:
+            # Skip parts that contain functionCall - these should not contribute to content/reasoning
+            # Function calls have their own dedicated handling and should not leak into text content
+            if "functionCall" in part:
+                continue
             _content_str = ""
             if "text" in part:
                 text_content = part["text"]
@@ -1198,6 +1202,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         """
         thinking_blocks: List[ChatCompletionThinkingBlock] = []
         for part in parts:
+            # Skip parts that contain functionCall - these are tool calls, not thinking content
+            if "functionCall" in part:
+                continue
             if part.get("thought") is True:
                 thinking_text = part.get("text", "")
                 block: ChatCompletionThinkingBlock = {


### PR DESCRIPTION
## Summary

When Gemini models return response parts with both `thought: true` and `functionCall`, the empty text strings or JSON artifacts were leaking into the `reasoning_content` stream. This causes clients to receive malformed reasoning content like:
- `{"text": ""}` at the end of responses
- `{"functionCall": {"name": "...", "args": {...}}}` during tool calls

## Changes

This PR adds a check to skip parts containing `functionCall` in two methods:

1. **`get_assistant_content_message()`** - prevents empty strings from leaking into content/reasoning_content
2. **`_extract_thinking_blocks_from_parts()`** - prevents artifacts in thinking blocks

Function calls already have their own dedicated handling via `_transform_parts()` and should not contribute to text content or reasoning.

## Testing

Tested with Gemini 3 Pro Preview with thinking enabled + tool calls. After this fix:
- Normal thinking content streams correctly
- Tool calls work as expected
- No JSON artifacts appear in reasoning_content

## Related

This bug was discovered when using Gemini models with thinking enabled and tools. The `thought: true` parts that also contained `functionCall` were being processed as text content instead of being filtered out.