### PR TITLE
fix: enable JSON-only provider routing + add xiaomi_mimo provider

### DIFF
--- a/docs/my-website/docs/providers/xiaomi_mimo.md
+++ b/docs/my-website/docs/providers/xiaomi_mimo.md
@@ -1,0 +1,137 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Xiaomi MiMo
+https://platform.xiaomimimo.com/#/docs
+
+:::tip
+
+**We support ALL Xiaomi MiMo models, just set `model=xiaomi_mimo/<any-model-on-xiaomi-mimo>` as a prefix when sending litellm requests**
+
+:::
+
+## API Key
+```python
+# env variable
+os.environ['XIAOMI_MIMO_API_KEY']
+```
+
+## Sample Usage
+```python
+from litellm import completion
+import os
+
+os.environ['XIAOMI_MIMO_API_KEY'] = ""
+response = completion(
+    model="xiaomi_mimo/mimo-v2-flash",
+    messages=[
+        {
+            "role": "user",
+            "content": "What's the weather like in Boston today in Fahrenheit?",
+        }
+    ],
+    max_tokens=1024,
+    temperature=0.3,
+    top_p=0.95,
+)
+print(response)
+```
+
+## Sample Usage - Streaming
+```python
+from litellm import completion
+import os
+
+os.environ['XIAOMI_MIMO_API_KEY'] = ""
+response = completion(
+    model="xiaomi_mimo/mimo-v2-flash",
+    messages=[
+        {
+            "role": "user",
+            "content": "What's the weather like in Boston today in Fahrenheit?",
+        }
+    ],
+    stream=True,
+    max_tokens=1024,
+    temperature=0.3,
+    top_p=0.95,
+)
+
+for chunk in response:
+    print(chunk)
+```
+
+
+## Usage with LiteLLM Proxy Server
+
+Here's how to call a Xiaomi MiMo model with the LiteLLM Proxy Server
+
+1. Modify the config.yaml 
+
+  ```yaml
+  model_list:
+    - model_name: my-model
+      litellm_params:
+        model: xiaomi_mimo/<your-model-name>  # add xiaomi_mimo/ prefix to route as Xiaomi MiMo provider
+        api_key: api-key                      # api key to send your model
+  ```
+
+
+2. Start the proxy 
+
+  ```bash
+  $ litellm --config /path/to/config.yaml
+  ```
+
+3. Send Request to LiteLLM Proxy Server
+
+  <Tabs>
+
+  <TabItem value="openai" label="OpenAI Python v1.0.0+">
+
+  ```python
+  import openai
+  client = openai.OpenAI(
+      api_key="sk-1234",             # pass litellm proxy key, if you're using virtual keys
+      base_url="http://0.0.0.0:4000" # litellm-proxy-base url
+  )
+
+  response = client.chat.completions.create(
+      model="my-model",
+      messages = [
+          {
+              "role": "user",
+              "content": "what llm are you"
+          }
+      ],
+  )
+
+  print(response)
+  ```
+  </TabItem>
+
+  <TabItem value="curl" label="curl">
+
+  ```shell
+  curl --location 'http://0.0.0.0:4000/chat/completions' \
+      --header 'Authorization: Bearer sk-1234' \
+      --header 'Content-Type: application/json' \
+      --data '{
+      "model": "my-model",
+      "messages": [
+          {
+          "role": "user",
+          "content": "what llm are you"
+          }
+      ],
+  }'
+  ```
+  </TabItem>
+
+  </Tabs>
+
+## Supported Models
+
+| Model Name | Usage |
+|------------|-------|
+| mimo-v2-flash | `completion(model="xiaomi_mimo/mimo-v2-flash", messages)` |

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -289,7 +289,7 @@ const sidebars = {
           label: "All Endpoints (Swagger)",
           href: "https://litellm-api.up.railway.app/",
         },
-  "proxy/enterprise",
+        "proxy/enterprise",
         {
           type: "category",
           label: "Authentication",
@@ -470,10 +470,10 @@ const sidebars = {
             "proxy/managed_finetuning",
           ]
         },
-          "generateContent",
-          "apply_guardrail",
-          "bedrock_invoke",
-          "interactions",
+        "generateContent",
+        "apply_guardrail",
+        "bedrock_invoke",
+        "interactions",
         {
           type: "category",
           label: "/images",
@@ -783,6 +783,7 @@ const sidebars = {
           ]
         },
         "providers/xai",
+        "providers/xiaomi_mimo",
         "providers/xinference",
         "providers/zai",
       ],

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -555,9 +555,13 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             provider_config: Optional[BaseConfig] = None
 
             if custom_llm_provider is not None and model is not None:
-                provider_config = ProviderConfigManager.get_provider_chat_config(
-                    model=model, provider=LlmProviders(custom_llm_provider)
-                )
+                try:
+                    provider_config = ProviderConfigManager.get_provider_chat_config(
+                        model=model, provider=LlmProviders(custom_llm_provider)
+                    )
+                except ValueError:
+                    # JSON-configured providers may not be in LlmProviders enum
+                    provider_config = None
 
             if provider_config is None:
                 provider_config = OpenAIConfig()

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -18,5 +18,12 @@
   "veniceai": {
     "base_url": "https://api.venice.ai/api/v1",
     "api_key_env": "VENICE_AI_API_KEY"
+  },
+  "xiaomi_mimo": {
+    "base_url": "https://api.xiaomimimo.com/v1",
+    "api_key_env": "XIAOMI_MIMO_API_KEY",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
   }
 }

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -68,6 +68,7 @@ from litellm.constants import (
     DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT,
 )
 from litellm.exceptions import LiteLLMUnknownProvider
+from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.litellm_core_utils.audio_utils.utils import (
@@ -2263,6 +2264,7 @@ def completion(  # type: ignore # noqa: PLR0915
             or custom_llm_provider == "wandb"
             or custom_llm_provider == "clarifai"
             or custom_llm_provider in litellm.openai_compatible_providers
+            or JSONProviderRegistry.exists(custom_llm_provider)  # JSON-configured providers
             or "ft:gpt-3.5-turbo" in model  # finetune gpt-3.5-turbo
         ):  # allow user to make an openai call with a custom base
             # note: if a user sets a custom base - we should ensure this works


### PR DESCRIPTION
## Relevant issues

Fixes the JSON-only provider routing issue discussed in https://github.com/BerriAI/litellm/pull/18284

This PR enables providers configured in `providers.json` to work without requiring additional entries in `LlmProviders` enum, `LITELLM_CHAT_PROVIDERS`, or `openai_compatible_providers` lists.

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem

JSON-configured providers in `providers.json` did not work without additional entries in:
- `LlmProviders` enum in `types/utils.py`
- `LITELLM_CHAT_PROVIDERS` in `constants.py`
- `openai_compatible_providers` in `constants.py`

This contradicted the [documentation](https://docs.litellm.ai/docs/contributing/adding_openai_compatible_providers) which states that adding a provider should only require editing `providers.json`.

### Solution

Added `JSONProviderRegistry.exists()` checks in three locations:

1. **`litellm/litellm_core_utils/get_llm_provider_logic.py`** - Check JSON providers before `provider_list` check
2. **`litellm/main.py`** - Add JSON provider check for completion routing
3. **`litellm/llms/openai/openai.py`** - Handle JSON providers not in `LlmProviders` enum with try-except

### Test Results

All existing providers continue to work:
```
groq: OK
cerebras: OK
openai: OK
together_ai: OK
veniceai (JSON): OK
xiaomi_mimo (JSON): OK
```

### Files Changed

| File | Change |
|------|--------|
| `litellm/litellm_core_utils/get_llm_provider_logic.py` | Added JSONProviderRegistry import and check |
| `litellm/main.py` | Added JSONProviderRegistry import and routing check |
| `litellm/llms/openai/openai.py` | Added try-except for LlmProviders enum conversion |
| `litellm/llms/openai_like/providers.json` | Added xiaomi_mimo as proof-of-concept |

<img width="596" height="222" alt="image" src="https://github.com/user-attachments/assets/deae332a-32be-4cdd-a4a0-1a123002aa4f" />
