### PR TITLE
feat(ui): add comprehensive dark mode support to dashboard

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -68,7 +68,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
 
   return (
     <ConfigProvider theme={getAntdTheme(isDarkMode)}>
-      <div className="flex flex-col min-h-screen bg-white dark:bg-[#141414]">
+      <div className="flex flex-col min-h-screen bg-white dark:bg-[#0e0e0e]">
         <Navbar
           isPublicPage={false}
           sidebarCollapsed={sidebarCollapsed}
@@ -88,7 +88,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
           <div className="mt-2">
             <SidebarProvider setPage={handleSetPage} defaultSelectedKey={page} sidebarCollapsed={sidebarCollapsed} />
           </div>
-          <main className="flex-1 bg-gray-50 dark:bg-[#1a1a1a] text-gray-900 dark:text-gray-100">{children}</main>
+          <main className="flex-1 bg-gray-50 dark:bg-[#151515] text-gray-900 dark:text-gray-100">{children}</main>
         </div>
       </div>
     </ConfigProvider>

--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React, { Suspense, useEffect, useState } from "react";
+import { ConfigProvider } from "antd";
 import Navbar from "@/components/navbar";
-import { ThemeProvider } from "@/contexts/ThemeContext";
+import { ThemeProvider, useTheme } from "@/contexts/ThemeContext";
+import { getAntdTheme } from "@/config/antdTheme";
 import SidebarProvider from "@/app/(dashboard)/components/SidebarProvider";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -38,6 +40,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { accessToken, userRole, userId, userEmail, premiumUser } = useAuthorized();
+  const { isDarkMode, toggleDarkMode } = useTheme();
   const [sidebarCollapsed, setSidebarCollapsed] = React.useState(false);
   const [page, setPage] = useState(() => {
     return searchParams.get("page") || "api-keys";
@@ -64,8 +67,8 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
   const toggleSidebar = () => setSidebarCollapsed((v) => !v);
 
   return (
-    <ThemeProvider accessToken={""}>
-      <div className="flex flex-col min-h-screen">
+    <ConfigProvider theme={getAntdTheme(isDarkMode)}>
+      <div className="flex flex-col min-h-screen bg-white dark:bg-[#141414]">
         <Navbar
           isPublicPage={false}
           sidebarCollapsed={sidebarCollapsed}
@@ -75,31 +78,29 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
           userRole={userRole}
           premiumUser={premiumUser}
           proxySettings={undefined}
-          setProxySettings={() => { }}
+          setProxySettings={() => {}}
           accessToken={accessToken}
-          isDarkMode={false}
-          toggleDarkMode={() => { }}
+          isDarkMode={isDarkMode}
+          toggleDarkMode={toggleDarkMode}
         />
         <DebugWarningBanner accessToken={accessToken} />
         <div className="flex flex-1 overflow-auto">
           <div className="mt-2">
-            <SidebarProvider
-              setPage={handleSetPage}
-              defaultSelectedKey={page}
-              sidebarCollapsed={sidebarCollapsed}
-            />
+            <SidebarProvider setPage={handleSetPage} defaultSelectedKey={page} sidebarCollapsed={sidebarCollapsed} />
           </div>
-          <main className="flex-1">{children}</main>
+          <main className="flex-1 bg-gray-50 dark:bg-[#1a1a1a] text-gray-900 dark:text-gray-100">{children}</main>
         </div>
       </div>
-    </ThemeProvider>
+    </ConfigProvider>
   );
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Loading...</div>}>
-      <LayoutContent>{children}</LayoutContent>
+      <ThemeProvider accessToken={""}>
+        <LayoutContent>{children}</LayoutContent>
+      </ThemeProvider>
     </Suspense>
   );
 }

--- a/ui/litellm-dashboard/src/app/globals.css
+++ b/ui/litellm-dashboard/src/app/globals.css
@@ -2,20 +2,49 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ============================================
+   CSS Variables - Dark Mode Colors
+   ============================================ */
 :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 255, 255, 255;
   --background-end-rgb: 255, 255, 255;
   --neutral-border: #dcddeb;
+
+  /* Dark mode color tokens (for reference and non-component usage) */
+  /* Using a more subtle gradient with less contrast between levels */
+  --dark-bg-base: #141414; /* Main background - slightly lighter for less stark contrast */
+  --dark-bg-elevated: #1a1a1a; /* Cards, panels - subtle elevation */
+  --dark-bg-surface: #1e1e1e; /* Interior content areas */
+  --dark-bg-hover: #252525; /* Hover states */
+  --dark-border: #2a2a2a; /* Subtle borders */
+  --dark-border-hover: #3a3a3a; /* Hover borders */
+  --dark-text-primary: #e5e7eb;
+  --dark-text-secondary: #a1a1aa;
+  --dark-text-muted: #71717a;
+  --dark-accent-blue: #3b82f6;
 }
 
-/* @media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-} */
+.dark {
+  --foreground-rgb: 229, 231, 235;
+  --background-start-rgb: 20, 20, 20; /* Matches --dark-bg-base #141414 */
+  --background-end-rgb: 20, 20, 20;
+  --neutral-border: #2a2a2a; /* Matches --dark-border */
+
+  /* Tremor CSS variable overrides for dark mode */
+  --tremor-background-muted: #141414;
+  --tremor-background-subtle: #1a1a1a;
+  --tremor-background-default: #141414;
+  --tremor-background-emphasis: #252525;
+  --tremor-border-default: #2a2a2a;
+  --tremor-ring-default: #2a2a2a;
+  --tremor-content-default: #e5e7eb;
+  --tremor-content-emphasis: #e5e7eb;
+  --tremor-content-strong: #e5e7eb;
+  --tremor-content-moderate: #a1a1aa;
+  --tremor-content-subtle: #71717a;
+  --tremor-content-inverted: #141414;
+}
 
 body {
   color: rgb(var(--foreground-rgb));
@@ -28,12 +57,1776 @@ body {
   }
 }
 
+/* ============================================
+   Layout Utilities
+   ============================================ */
 .table-wrapper {
   overflow-x: scroll;
-  /* max-width: 80%; */
   margin: 0px 24px;
 }
 
 .custom-border {
   border: 1px solid var(--neutral-border);
+}
+
+/* ============================================
+   Ant Design Dropdown - Custom Behavior
+   (These are behavioral overrides, not theme colors)
+   ============================================ */
+.ant-dropdown-menu-item {
+  padding: 0 !important;
+}
+
+.ant-dropdown-menu-item > div {
+  transition: all 0.2s ease;
+}
+
+/* Don't apply hover to user info section */
+.ant-dropdown-menu-item[data-menu-id$="user-info"]:hover {
+  background-color: transparent !important;
+  cursor: default;
+}
+
+.ant-dropdown-menu-item[data-menu-id$="user-info"] > div {
+  cursor: default;
+}
+
+.ant-dropdown-menu {
+  padding: 4px !important;
+  min-width: 280px !important;
+}
+
+.ant-dropdown-menu-item-divider {
+  margin: 4px 0;
+}
+
+/* ============================================
+   Tremor Components - Dark Mode
+   (Tremor is not controlled by Ant Design ConfigProvider)
+   ============================================ */
+.dark [class*="tremor-Card"],
+.dark .tremor-Card-root {
+  background-color: var(--dark-bg-base) !important;
+  border-color: transparent !important;
+  --tw-ring-color: transparent !important;
+  --tw-ring-opacity: 0 !important;
+  box-shadow: none !important;
+}
+
+.dark [class*="tremor-TextInput"],
+.dark .tremor-TextInput-root {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark [class*="tremor-Title"],
+.dark .tremor-Title {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark [class*="tremor-Text"],
+.dark .tremor-Text {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark [class*="tremor-Metric"],
+.dark .tremor-Metric {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark [class*="tremor-Table"],
+.dark .tremor-Table-root {
+  background-color: transparent !important;
+}
+
+.dark .tremor-Table-root table,
+.dark .tremor-Table-table {
+  background-color: transparent !important;
+}
+
+.dark [class*="tremor-TableHead"],
+.dark .tremor-TableHead-root {
+  background-color: transparent !important;
+}
+
+.dark [class*="tremor-TableHeaderCell"] {
+  color: var(--dark-text-secondary) !important;
+  border-color: var(--dark-border) !important;
+  background-color: transparent !important;
+}
+
+.dark [class*="tremor-TableBody"],
+.dark .tremor-TableBody-root {
+  background-color: transparent !important;
+}
+
+.dark [class*="tremor-TableRow"],
+.dark .tremor-TableRow-row {
+  background-color: transparent !important;
+}
+
+.dark [class*="tremor-TableCell"] {
+  color: var(--dark-text-primary) !important;
+  border-color: var(--dark-border) !important;
+  background-color: transparent !important;
+}
+
+.dark [class*="tremor-TableRow"]:hover {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark [class*="tremor-Select"],
+.dark .tremor-Select-root {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark [class*="tremor-Button"][class*="secondary"] {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+/* Tremor buttons with blue backgrounds (used in tables for IDs) */
+.dark [class*="tremor-Button"].bg-blue-50 {
+  background-color: rgba(59, 130, 246, 0.15) !important;
+}
+
+.dark [class*="tremor-Button"].bg-blue-50:hover,
+.dark [class*="tremor-Button"].hover\:bg-blue-100:hover {
+  background-color: rgba(59, 130, 246, 0.25) !important;
+}
+
+/* ============================================
+   Provider Logo - Dark Mode Utility
+   ============================================ */
+.provider-logo {
+  /* Light mode: no background needed */
+}
+
+.dark .provider-logo {
+  background-color: var(--dark-bg-hover);
+  border-radius: 4px;
+  padding: 2px;
+}
+
+/* ============================================
+   Code Blocks
+   ============================================ */
+.dark pre,
+.dark code {
+  background-color: var(--dark-bg-elevated) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+/* ============================================
+   Scrollbar Styling
+   ============================================ */
+.dark ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.dark ::-webkit-scrollbar-track {
+  background: var(--dark-bg-elevated);
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: var(--dark-border-hover);
+  border-radius: 4px;
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: #4a4a4a;
+}
+
+/* ============================================
+   Ant Design Components - Supplementary Overrides
+   (Only for components/states not fully covered by ConfigProvider)
+   ============================================ */
+
+/* Dropdown dark mode - ConfigProvider doesn't fully control dropdowns rendered in portals */
+.dark .ant-dropdown-menu {
+  background-color: #141414 !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-dropdown-menu-item {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-dropdown-menu-item:hover {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+/* Select dropdown (rendered in portal) */
+.dark .ant-select-dropdown {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-select-item {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-select-item-option-active,
+.dark .ant-select-item-option-selected {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+/* Tooltip (rendered in portal) */
+.dark .ant-tooltip-inner {
+  background-color: var(--dark-bg-hover) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+/* Popover (rendered in portal) */
+.dark .ant-popover-inner {
+  background-color: var(--dark-bg-elevated) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-popover-title {
+  color: var(--dark-text-primary) !important;
+  border-color: var(--dark-border) !important;
+}
+
+/* Modal (rendered in portal) */
+.dark .ant-modal-content {
+  background-color: var(--dark-bg-elevated) !important;
+}
+
+.dark .ant-modal-header {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-modal-title {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-modal-close {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-modal-close:hover {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-modal-body {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-modal-footer {
+  border-color: var(--dark-border) !important;
+}
+
+/* Alert styling */
+.dark .ant-alert {
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-alert-info {
+  background-color: rgba(59, 130, 246, 0.1) !important;
+  border-color: var(--dark-accent-blue) !important;
+}
+
+.dark .ant-alert-message {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-alert-description {
+  color: var(--dark-text-secondary) !important;
+}
+
+/* Empty state description */
+.dark .ant-empty-description {
+  color: var(--dark-text-secondary) !important;
+}
+
+/* ============================================
+   Ant Design Menu - Sidebar
+   ============================================ */
+.dark .ant-menu {
+  background-color: var(--dark-bg-base) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-menu-item {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-menu-item:hover {
+  background-color: var(--dark-bg-elevated) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-menu-item-selected {
+  background-color: var(--dark-bg-elevated) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-menu-item-selected::after {
+  border-color: var(--dark-accent-blue) !important;
+}
+
+.dark .ant-menu-submenu-title {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-menu-submenu-title:hover {
+  background-color: var(--dark-bg-elevated) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-menu-submenu-arrow {
+  color: var(--dark-text-muted) !important;
+}
+
+.dark .ant-menu-submenu-arrow::before,
+.dark .ant-menu-submenu-arrow::after {
+  background: var(--dark-text-muted) !important;
+}
+
+.dark .ant-menu-sub {
+  background-color: var(--dark-bg-base) !important;
+}
+
+.dark .ant-menu-inline .ant-menu-item,
+.dark .ant-menu-inline .ant-menu-submenu-title {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-menu-inline .ant-menu-item:hover,
+.dark .ant-menu-inline .ant-menu-submenu-title:hover {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-menu-inline .ant-menu-item-selected {
+  color: var(--dark-text-primary) !important;
+  background-color: var(--dark-bg-elevated) !important;
+}
+
+/* ============================================
+   Ant Design Layout
+   ============================================ */
+.dark .ant-layout-sider {
+  background-color: var(--dark-bg-base) !important;
+}
+
+.dark .ant-layout-sider-light {
+  background-color: var(--dark-bg-base) !important;
+}
+
+.dark .ant-layout-sider-children {
+  background-color: var(--dark-bg-base) !important;
+}
+
+.dark .ant-layout {
+  background-color: var(--dark-bg-base) !important;
+}
+
+/* ============================================
+   Ant Design Card
+   ============================================ */
+.dark .ant-card {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-card-head {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-card-head-title {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-card-body {
+  color: var(--dark-text-primary) !important;
+}
+
+/* ============================================
+   Ant Design Table
+   ============================================ */
+.dark .ant-table {
+  background-color: var(--dark-bg-elevated) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-table-thead > tr > th {
+  background-color: var(--dark-bg-base) !important;
+  color: var(--dark-text-secondary) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-table-tbody > tr > td {
+  background-color: var(--dark-bg-elevated) !important;
+  color: var(--dark-text-primary) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-table-tbody > tr:hover > td {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark .ant-table-row:hover {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark .ant-table-placeholder {
+  background-color: var(--dark-bg-elevated) !important;
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-table-container {
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-table-cell {
+  border-color: var(--dark-border) !important;
+}
+
+/* ============================================
+   Ant Design Typography
+   (Headings and text rendered by Typography component)
+   ============================================ */
+.dark .ant-typography {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark h1.ant-typography,
+.dark h2.ant-typography,
+.dark h3.ant-typography,
+.dark h4.ant-typography,
+.dark h5.ant-typography,
+.dark .ant-typography h1,
+.dark .ant-typography h2,
+.dark .ant-typography h3,
+.dark .ant-typography h4,
+.dark .ant-typography h5 {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-typography.ant-typography-secondary {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-typography a {
+  color: #60a5fa !important;
+}
+
+.dark .ant-typography a:hover {
+  color: #93c5fd !important;
+}
+
+/* ============================================
+   Ant Design Form/Input
+   ============================================ */
+.dark .ant-input {
+  background-color: var(--dark-bg-base) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-input:hover,
+.dark .ant-input:focus {
+  border-color: var(--dark-border-hover) !important;
+}
+
+.dark .ant-input::placeholder {
+  color: var(--dark-text-muted) !important;
+}
+
+.dark .ant-input-affix-wrapper {
+  background-color: var(--dark-bg-base) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-input-affix-wrapper > .ant-input {
+  background-color: transparent !important;
+}
+
+.dark .ant-input-group-addon {
+  background-color: var(--dark-bg-hover) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-input-number {
+  background-color: var(--dark-bg-base) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-input-number-input {
+  background-color: transparent !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-input-number-handler-wrap {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark .ant-input-number-handler {
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-input-textarea {
+  background-color: var(--dark-bg-base) !important;
+}
+
+.dark .ant-input-textarea > textarea {
+  background-color: var(--dark-bg-base) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-select-selector {
+  background-color: var(--dark-bg-base) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-select:not(.ant-select-disabled):hover .ant-select-selector {
+  border-color: var(--dark-border-hover) !important;
+}
+
+.dark .ant-select-selection-placeholder {
+  color: var(--dark-text-muted) !important;
+}
+
+.dark .ant-select-selection-item {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-select-arrow {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-select-clear {
+  background-color: var(--dark-bg-base) !important;
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-select-multiple .ant-select-selection-item {
+  background-color: var(--dark-bg-hover) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-picker {
+  background-color: var(--dark-bg-base) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-picker-input > input {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-picker-suffix {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-picker-clear {
+  background-color: var(--dark-bg-base) !important;
+  color: var(--dark-text-secondary) !important;
+}
+
+/* ============================================
+   Ant Design Button
+   ============================================ */
+.dark .ant-btn-default {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-btn-default:hover {
+  background-color: var(--dark-bg-hover) !important;
+  border-color: var(--dark-border-hover) !important;
+  color: #ffffff !important;
+}
+
+/* ============================================
+   Ant Design Tabs
+   ============================================ */
+.dark .ant-tabs-tab {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-tabs-tab:hover {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-tabs-ink-bar {
+  background-color: var(--dark-accent-blue) !important;
+}
+
+.dark .ant-tabs-nav::before {
+  border-color: var(--dark-border) !important;
+}
+
+/* ============================================
+   Ant Design Form
+   ============================================ */
+.dark .ant-form-item-label > label {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-form-item-explain-error {
+  color: #ef4444 !important;
+}
+
+/* ============================================
+   Ant Design Pagination
+   ============================================ */
+.dark .ant-pagination-item {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-pagination-item a {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-pagination-item-active {
+  border-color: var(--dark-accent-blue) !important;
+}
+
+.dark .ant-pagination-prev .ant-pagination-item-link,
+.dark .ant-pagination-next .ant-pagination-item-link {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+/* ============================================
+   Ant Design Spin
+   ============================================ */
+.dark .ant-spin-text {
+  color: var(--dark-text-primary) !important;
+}
+
+/* ============================================
+   Ant Design Icons - Global Color Override
+   (Icons inherit currentColor but some contexts don't set color)
+   ============================================ */
+.dark .anticon {
+  color: var(--dark-text-secondary);
+}
+
+.dark .anticon svg {
+  fill: currentColor;
+}
+
+/* Ensure icons in specific contexts get proper colors */
+.dark .ant-empty .anticon {
+  color: var(--dark-text-muted) !important;
+}
+
+.dark .ant-upload .anticon {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-upload-drag-icon .anticon {
+  color: var(--dark-text-secondary) !important;
+}
+
+/* ============================================
+   Ant Design Tag
+   ============================================ */
+.dark .ant-tag {
+  background-color: var(--dark-bg-hover) !important;
+  border-color: var(--dark-border-hover) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+/* ============================================
+   Ant Design Divider
+   ============================================ */
+.dark .ant-divider {
+  border-color: var(--dark-border) !important;
+}
+
+/* ============================================
+   Ant Design Collapse/Accordion
+   ============================================ */
+.dark .ant-collapse {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark .ant-collapse-header {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-collapse-content {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+/* ============================================
+   Ant Design Checkbox
+   ============================================ */
+.dark .ant-checkbox-inner {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border-hover) !important;
+}
+
+.dark .ant-checkbox-wrapper {
+  color: var(--dark-text-primary) !important;
+}
+
+/* ============================================
+   Ant Design Radio
+   ============================================ */
+.dark .ant-radio-inner {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border-hover) !important;
+}
+
+.dark .ant-radio-wrapper {
+  color: var(--dark-text-primary) !important;
+}
+
+/* ============================================
+   Ant Design Switch
+   ============================================ */
+.dark .ant-switch {
+  background-color: var(--dark-border-hover) !important;
+}
+
+/* ============================================
+   Ant Design Breadcrumb
+   ============================================ */
+.dark .ant-breadcrumb-link {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .ant-breadcrumb-link:hover {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .ant-breadcrumb-separator {
+  color: var(--dark-text-muted) !important;
+}
+
+/* ============================================
+   Tremor Components - Extended Dark Mode
+   (Comprehensive overrides for all Tremor components)
+   ============================================ */
+
+/* Tremor Tabs */
+.dark [class*="tremor-Tab-root"],
+.dark [class*="tremor-TabList"],
+.dark .tremor-TabList-root {
+  border-color: var(--dark-border) !important;
+}
+
+.dark [class*="tremor-Tab-root"] {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark [class*="tremor-Tab-root"]:hover {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark [class*="tremor-Tab-root"][data-headlessui-state*="selected"],
+.dark [class*="tremor-Tab-root"][aria-selected="true"] {
+  color: var(--dark-text-primary) !important;
+  border-color: var(--dark-accent-blue) !important;
+}
+
+.dark [class*="tremor-TabPanel"],
+.dark .tremor-TabPanel-root {
+  background-color: transparent !important;
+}
+
+/* Tremor Grid/Col */
+.dark [class*="tremor-Grid"],
+.dark .tremor-Grid-root {
+  background-color: transparent !important;
+}
+
+.dark [class*="tremor-Col"],
+.dark .tremor-Col-root {
+  background-color: transparent !important;
+}
+
+/* Tremor Badge */
+.dark [class*="tremor-Badge"],
+.dark .tremor-Badge-root {
+  background-color: var(--dark-bg-hover) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+/* Tremor Accordion */
+.dark [class*="tremor-Accordion"],
+.dark .tremor-Accordion-root {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark [class*="tremor-AccordionHeader"],
+.dark .tremor-AccordionHeader-root {
+  background-color: var(--dark-bg-elevated) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark [class*="tremor-AccordionBody"],
+.dark .tremor-AccordionBody-root {
+  background-color: var(--dark-bg-elevated) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+/* Tremor Callout */
+.dark [class*="tremor-Callout"],
+.dark .tremor-Callout-root {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+/* Tremor Icon */
+.dark [class*="tremor-Icon"],
+.dark .tremor-Icon-root {
+  color: var(--dark-text-secondary) !important;
+}
+
+/* Tremor NumberInput */
+.dark [class*="tremor-NumberInput"],
+.dark .tremor-NumberInput-root {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+/* Tremor Switch */
+.dark [class*="tremor-Switch"],
+.dark .tremor-Switch-root {
+  background-color: var(--dark-border-hover) !important;
+}
+
+/* Tremor List */
+.dark [class*="tremor-List"],
+.dark .tremor-List-root {
+  background-color: transparent !important;
+}
+
+.dark [class*="tremor-ListItem"],
+.dark .tremor-ListItem-root {
+  color: var(--dark-text-primary) !important;
+}
+
+/* Tremor MultiSelect */
+.dark [class*="tremor-MultiSelect"],
+.dark .tremor-MultiSelect-root {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+/* Tremor DateRangePicker */
+.dark [class*="tremor-DateRangePicker"],
+.dark .tremor-DateRangePicker-root {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+/* Tremor SearchSelect */
+.dark [class*="tremor-SearchSelect"],
+.dark .tremor-SearchSelect-root {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+/* Tremor AreaChart / BarChart / LineChart */
+.dark [class*="tremor-AreaChart"],
+.dark [class*="tremor-BarChart"],
+.dark [class*="tremor-LineChart"] {
+  background-color: transparent !important;
+}
+
+/* Tremor Legend */
+.dark [class*="tremor-Legend"],
+.dark .tremor-Legend-root {
+  color: var(--dark-text-secondary) !important;
+}
+
+/* Tremor Dropdown Menu (Headless UI) */
+.dark [class*="tremor-Dropdown"],
+.dark .tremor-DropdownMenu-root {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark [class*="tremor-DropdownItem"] {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark [class*="tremor-DropdownItem"]:hover {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+/* Tremor SelectItem */
+.dark [class*="tremor-SelectItem"] {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark [class*="tremor-SelectItem"]:hover,
+.dark [class*="tremor-SelectItem"][data-headlessui-state*="active"] {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+/* Tremor Dialog/Modal */
+.dark [class*="tremor-Dialog"],
+.dark .tremor-Dialog-root {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+/* Tremor Tracker */
+.dark [class*="tremor-Tracker"],
+.dark .tremor-Tracker-root {
+  background-color: transparent !important;
+}
+
+/* Headless UI Listbox (used by Tremor Select internally) */
+.dark [data-headlessui-state] {
+  color: var(--dark-text-primary);
+}
+
+/* Headless UI Popover panel */
+.dark [class*="tremor"][role="listbox"] {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+/* Tremor divider */
+.dark [class*="tremor-Divider"] {
+  background-color: var(--dark-border) !important;
+}
+
+/* Tremor DonutChart center text */
+.dark [class*="tremor-DonutChart"] text {
+  fill: var(--dark-text-primary) !important;
+}
+
+/* Tremor ProgressBar */
+.dark [class*="tremor-ProgressBar"] {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+/* ============================================
+   Tremor/Headless UI Popovers and Dropdowns
+   (These render in portals outside the main app)
+   ============================================ */
+
+/* Generic dark mode for any floating panel */
+.dark [data-headlessui-portal] [role="listbox"],
+.dark [data-headlessui-portal] [role="menu"],
+.dark [data-headlessui-portal] [role="dialog"] {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+/* Options in dropdowns */
+.dark [data-headlessui-portal] [role="option"] {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark [data-headlessui-portal] [role="option"]:hover,
+.dark [data-headlessui-portal] [role="option"][data-headlessui-state*="active"] {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+/* Calendar/Date picker popover */
+.dark [data-headlessui-portal] .react-datepicker,
+.dark .react-datepicker {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+  color: var(--dark-text-primary) !important;
+}
+
+.dark [data-headlessui-portal] .react-datepicker__header,
+.dark .react-datepicker__header {
+  background-color: var(--dark-bg-base) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark [data-headlessui-portal] .react-datepicker__day,
+.dark .react-datepicker__day {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark [data-headlessui-portal] .react-datepicker__day:hover,
+.dark .react-datepicker__day:hover {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark [data-headlessui-portal] .react-datepicker__day--selected,
+.dark .react-datepicker__day--selected {
+  background-color: var(--dark-accent-blue) !important;
+}
+
+.dark [data-headlessui-portal] .react-datepicker__current-month,
+.dark .react-datepicker__current-month,
+.dark [data-headlessui-portal] .react-datepicker__day-name,
+.dark .react-datepicker__day-name {
+  color: var(--dark-text-primary) !important;
+}
+
+/* ============================================
+   Recharts (used by Tremor charts internally)
+   ============================================ */
+.dark .recharts-cartesian-axis-tick-value {
+  fill: var(--dark-text-secondary) !important;
+}
+
+.dark .recharts-legend-item-text {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .recharts-tooltip-wrapper .recharts-default-tooltip {
+  background-color: var(--dark-bg-elevated) !important;
+  border-color: var(--dark-border) !important;
+}
+
+.dark .recharts-tooltip-item {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .recharts-tooltip-label {
+  color: var(--dark-text-primary) !important;
+}
+
+/* ============================================
+   Generic Tailwind bg-white/bg-gray overrides
+   (For components using hardcoded Tailwind classes)
+   ============================================ */
+
+/* Override bg-white in dark mode - use base for consistency */
+.dark .bg-white {
+  background-color: var(--dark-bg-base) !important;
+}
+
+/* Override bg-gray-50 in dark mode */
+.dark .bg-gray-50 {
+  background-color: var(--dark-bg-base) !important;
+}
+
+/* Override bg-gray-100 in dark mode */
+.dark .bg-gray-100 {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+/* Override text-gray colors in dark mode for better contrast */
+.dark .text-gray-900 {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .text-gray-800 {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .text-gray-700 {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .text-gray-600 {
+  color: var(--dark-text-secondary) !important;
+}
+
+.dark .text-gray-500 {
+  color: var(--dark-text-muted) !important;
+}
+
+.dark .text-gray-400 {
+  color: var(--dark-text-muted) !important;
+}
+
+/* Override border-gray colors in dark mode */
+.dark .border-gray-200 {
+  border-color: var(--dark-border) !important;
+}
+
+.dark .border-gray-300 {
+  border-color: var(--dark-border-hover) !important;
+}
+
+/* Override hover states */
+.dark .hover\:bg-gray-50:hover {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark .hover\:bg-gray-100:hover {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark .hover\:bg-white:hover {
+  background-color: var(--dark-bg-elevated) !important;
+}
+
+/* Override shadow in dark mode */
+.dark .shadow,
+.dark .shadow-sm,
+.dark .shadow-md,
+.dark .shadow-lg,
+.dark .shadow-xl {
+  --tw-shadow-color: rgba(0, 0, 0, 0.5);
+}
+
+/* Override rounded-lg with white background */
+.dark .rounded-lg.bg-white,
+.dark .rounded-lg.shadow {
+  background-color: var(--dark-bg-elevated) !important;
+}
+
+/* Neutralize default-gray directional borders; scoped so semantic colored borders (e.g. border-b border-blue-500) keep their color */
+.dark .border-b.border-gray-100,
+.dark .border-b.border-gray-200,
+.dark .border-b.border-gray-300,
+.dark .border-t.border-gray-100,
+.dark .border-t.border-gray-200,
+.dark .border-t.border-gray-300 {
+  border-color: var(--dark-border) !important;
+}
+
+/* Ring overrides for focused elements */
+.dark .ring-gray-200,
+.dark .ring-gray-300 {
+  --tw-ring-color: var(--dark-border) !important;
+}
+
+/* Ensure p, div, span inherit dark text colors when using text-gray-* */
+.dark p.text-gray-600,
+.dark div.text-gray-600,
+.dark span.text-gray-600 {
+  color: var(--dark-text-secondary) !important;
+}
+
+/* Override white/80 opacity patterns */
+.dark .bg-white\/80 {
+  background-color: rgba(18, 18, 18, 0.8) !important;
+}
+
+/* Override outline colors */
+.dark .outline {
+  outline-color: var(--dark-border) !important;
+}
+
+/* ============================================
+   Blue Highlight Overrides (bg-blue-50/100)
+   (Used extensively for ID buttons, selection states, etc.)
+   ============================================ */
+
+/* Blue backgrounds */
+.dark .bg-blue-50 {
+  background-color: rgba(59, 130, 246, 0.1) !important;
+}
+
+.dark .bg-blue-100 {
+  background-color: rgba(59, 130, 246, 0.2) !important;
+}
+
+/* Blue hover states */
+.dark .hover\:bg-blue-50:hover {
+  background-color: rgba(59, 130, 246, 0.15) !important;
+}
+
+.dark .hover\:bg-blue-100:hover {
+  background-color: rgba(59, 130, 246, 0.25) !important;
+}
+
+/* Blue text colors */
+.dark .text-blue-600 {
+  color: #60a5fa !important;
+}
+
+.dark .text-blue-700 {
+  color: #60a5fa !important;
+}
+
+.dark .text-blue-800 {
+  color: #93c5fd !important;
+}
+
+/* Blue border colors */
+.dark .border-blue-100 {
+  border-color: rgba(59, 130, 246, 0.3) !important;
+}
+
+.dark .border-blue-200 {
+  border-color: rgba(59, 130, 246, 0.4) !important;
+}
+
+/* ============================================
+   Green Highlight Overrides
+   (Used for success states, active indicators)
+   ============================================ */
+
+.dark .bg-green-50 {
+  background-color: rgba(34, 197, 94, 0.1) !important;
+}
+
+.dark .bg-green-100 {
+  background-color: rgba(34, 197, 94, 0.2) !important;
+}
+
+.dark .hover\:bg-green-50:hover {
+  background-color: rgba(34, 197, 94, 0.15) !important;
+}
+
+.dark .hover\:bg-green-100:hover {
+  background-color: rgba(34, 197, 94, 0.25) !important;
+}
+
+.dark .text-green-600 {
+  color: #4ade80 !important;
+}
+
+.dark .text-green-700 {
+  color: #4ade80 !important;
+}
+
+.dark .text-green-800 {
+  color: #86efac !important;
+}
+
+.dark .border-green-100 {
+  border-color: rgba(34, 197, 94, 0.3) !important;
+}
+
+.dark .border-green-200 {
+  border-color: rgba(34, 197, 94, 0.4) !important;
+}
+
+/* ============================================
+   Red Highlight Overrides
+   (Used for error states, delete buttons)
+   ============================================ */
+
+.dark .bg-red-50 {
+  background-color: rgba(239, 68, 68, 0.1) !important;
+}
+
+.dark .bg-red-100 {
+  background-color: rgba(239, 68, 68, 0.2) !important;
+}
+
+.dark .hover\:bg-red-50:hover {
+  background-color: rgba(239, 68, 68, 0.15) !important;
+}
+
+.dark .hover\:bg-red-100:hover {
+  background-color: rgba(239, 68, 68, 0.25) !important;
+}
+
+.dark .text-red-600 {
+  color: #f87171 !important;
+}
+
+.dark .text-red-700 {
+  color: #f87171 !important;
+}
+
+.dark .text-red-800 {
+  color: #fca5a5 !important;
+}
+
+.dark .border-red-100 {
+  border-color: rgba(239, 68, 68, 0.3) !important;
+}
+
+.dark .border-red-200 {
+  border-color: rgba(239, 68, 68, 0.4) !important;
+}
+
+/* ============================================
+   Yellow/Amber Highlight Overrides
+   (Used for warning states)
+   ============================================ */
+
+.dark .bg-yellow-50 {
+  background-color: rgba(234, 179, 8, 0.1) !important;
+}
+
+.dark .bg-yellow-100 {
+  background-color: rgba(234, 179, 8, 0.2) !important;
+}
+
+.dark .bg-amber-50 {
+  background-color: rgba(245, 158, 11, 0.1) !important;
+}
+
+.dark .bg-amber-100 {
+  background-color: rgba(245, 158, 11, 0.2) !important;
+}
+
+.dark .hover\:bg-yellow-50:hover {
+  background-color: rgba(234, 179, 8, 0.15) !important;
+}
+
+.dark .hover\:bg-yellow-100:hover {
+  background-color: rgba(234, 179, 8, 0.25) !important;
+}
+
+.dark .text-yellow-600 {
+  color: #facc15 !important;
+}
+
+.dark .text-yellow-700 {
+  color: #facc15 !important;
+}
+
+.dark .text-yellow-800 {
+  color: #fde047 !important;
+}
+
+.dark .text-amber-600 {
+  color: #fbbf24 !important;
+}
+
+.dark .text-amber-700 {
+  color: #fbbf24 !important;
+}
+
+.dark .border-yellow-100 {
+  border-color: rgba(234, 179, 8, 0.3) !important;
+}
+
+.dark .border-yellow-200 {
+  border-color: rgba(234, 179, 8, 0.4) !important;
+}
+
+/* ============================================
+   Purple/Indigo Highlight Overrides
+   (Used for special states)
+   ============================================ */
+
+.dark .bg-purple-50 {
+  background-color: rgba(168, 85, 247, 0.1) !important;
+}
+
+.dark .bg-purple-100 {
+  background-color: rgba(168, 85, 247, 0.2) !important;
+}
+
+.dark .bg-indigo-50 {
+  background-color: rgba(99, 102, 241, 0.1) !important;
+}
+
+.dark .bg-indigo-100 {
+  background-color: rgba(99, 102, 241, 0.2) !important;
+}
+
+.dark .text-purple-600 {
+  color: #c084fc !important;
+}
+
+.dark .text-purple-700 {
+  color: #c084fc !important;
+}
+
+.dark .text-indigo-600 {
+  color: #818cf8 !important;
+}
+
+.dark .text-indigo-700 {
+  color: #818cf8 !important;
+}
+
+.dark .border-purple-100 {
+  border-color: rgba(168, 85, 247, 0.3) !important;
+}
+
+.dark .border-indigo-100 {
+  border-color: rgba(99, 102, 241, 0.3) !important;
+}
+
+/* ============================================
+   Orange Highlight Overrides
+   (Used for warning/attention states)
+   ============================================ */
+
+.dark .bg-orange-50 {
+  background-color: rgba(249, 115, 22, 0.1) !important;
+}
+
+.dark .bg-orange-100 {
+  background-color: rgba(249, 115, 22, 0.2) !important;
+}
+
+.dark .hover\:bg-orange-50:hover {
+  background-color: rgba(249, 115, 22, 0.15) !important;
+}
+
+.dark .hover\:bg-orange-100:hover {
+  background-color: rgba(249, 115, 22, 0.25) !important;
+}
+
+.dark .text-orange-600 {
+  color: #fb923c !important;
+}
+
+.dark .text-orange-700 {
+  color: #fb923c !important;
+}
+
+.dark .border-orange-100 {
+  border-color: rgba(249, 115, 22, 0.3) !important;
+}
+
+/* ============================================
+   Slate/Zinc Backgrounds
+   (Used for neutral backgrounds)
+   ============================================ */
+
+.dark .bg-slate-50 {
+  background-color: var(--dark-bg-base) !important;
+}
+
+.dark .bg-slate-100 {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark .bg-zinc-50 {
+  background-color: var(--dark-bg-base) !important;
+}
+
+.dark .bg-zinc-100 {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+/* ============================================
+   Form Element Overrides
+   (For various form backgrounds)
+   ============================================ */
+
+/* Input focus ring */
+.dark .focus\:ring-blue-500:focus {
+  --tw-ring-color: rgba(59, 130, 246, 0.5) !important;
+}
+
+.dark .focus\:ring-blue-300:focus {
+  --tw-ring-color: rgba(59, 130, 246, 0.3) !important;
+}
+
+/* Focus border states */
+.dark .focus\:border-blue-500:focus {
+  border-color: #3b82f6 !important;
+}
+
+.dark .focus\:border-blue-300:focus {
+  border-color: rgba(59, 130, 246, 0.5) !important;
+}
+
+/* Placeholder text */
+.dark .placeholder-gray-400::placeholder {
+  color: var(--dark-text-muted) !important;
+}
+
+.dark .placeholder-gray-500::placeholder {
+  color: var(--dark-text-muted) !important;
+}
+
+/* ============================================
+   Divide Borders
+   (For list dividers and table separators)
+   ============================================ */
+
+.dark .divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--dark-border) !important;
+}
+
+.dark .divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--dark-border) !important;
+}
+
+.dark .divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--dark-border-hover) !important;
+}
+
+/* ============================================
+   Disabled States
+   (For disabled buttons and inputs)
+   ============================================ */
+
+.dark .disabled\:bg-gray-100:disabled {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark .disabled\:text-gray-400:disabled {
+  color: var(--dark-text-muted) !important;
+}
+
+.dark .disabled\:opacity-50:disabled {
+  opacity: 0.5;
+}
+
+/* ============================================
+   Selection/Active States
+   (For selected items in lists)
+   ============================================ */
+
+.dark .active\:bg-gray-100:active {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark .active\:bg-blue-100:active {
+  background-color: rgba(59, 130, 246, 0.25) !important;
+}
+
+/* ============================================
+   Odd/Even Row Backgrounds
+   (For striped tables)
+   ============================================ */
+
+.dark .odd\:bg-white:nth-child(odd) {
+  background-color: var(--dark-bg-elevated) !important;
+}
+
+.dark .even\:bg-gray-50:nth-child(even) {
+  background-color: var(--dark-bg-base) !important;
+}
+
+/* ============================================
+   Group Hover States
+   (For parent-child hover interactions)
+   ============================================ */
+
+.dark .group:hover .group-hover\:bg-gray-50 {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark .group:hover .group-hover\:bg-gray-100 {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark .group:hover .group-hover\:text-gray-700 {
+  color: var(--dark-text-primary) !important;
+}
+
+.dark .group:hover .group-hover\:text-gray-900 {
+  color: var(--dark-text-primary) !important;
+}
+
+/* ============================================
+   Specific Component Patterns
+   (Common patterns found across the codebase)
+   ============================================ */
+
+/* Card headers with bg-gray-50 */
+.dark .bg-gray-50.rounded-t-lg {
+  background-color: var(--dark-bg-base) !important;
+}
+
+/* Footer sections */
+.dark .bg-gray-50.rounded-b-lg {
+  background-color: var(--dark-bg-base) !important;
+}
+
+/* Info boxes with bg-blue-50 */
+.dark .bg-blue-50.rounded-lg {
+  background-color: rgba(59, 130, 246, 0.1) !important;
+}
+
+.dark .bg-blue-50.rounded-md {
+  background-color: rgba(59, 130, 246, 0.1) !important;
+}
+
+/* Warning boxes with bg-yellow-50 */
+.dark .bg-yellow-50.rounded-lg {
+  background-color: rgba(234, 179, 8, 0.1) !important;
+}
+
+.dark .bg-yellow-50.rounded-md {
+  background-color: rgba(234, 179, 8, 0.1) !important;
+}
+
+/* Error boxes with bg-red-50 */
+.dark .bg-red-50.rounded-lg {
+  background-color: rgba(239, 68, 68, 0.1) !important;
+}
+
+.dark .bg-red-50.rounded-md {
+  background-color: rgba(239, 68, 68, 0.1) !important;
+}
+
+/* Success boxes with bg-green-50 */
+.dark .bg-green-50.rounded-lg {
+  background-color: rgba(34, 197, 94, 0.1) !important;
+}
+
+.dark .bg-green-50.rounded-md {
+  background-color: rgba(34, 197, 94, 0.1) !important;
+}
+
+/* ============================================
+   Input/Select Specific Overrides
+   (Form elements that may not be covered by Ant Design)
+   ============================================ */
+
+.dark input[type="text"],
+.dark input[type="email"],
+.dark input[type="password"],
+.dark input[type="number"],
+.dark input[type="search"],
+.dark input[type="url"],
+.dark input[type="tel"],
+.dark textarea {
+  background-color: var(--dark-bg-elevated);
+  border-color: var(--dark-border);
+  color: var(--dark-text-primary);
+}
+
+.dark input[type="text"]:focus,
+.dark input[type="email"]:focus,
+.dark input[type="password"]:focus,
+.dark input[type="number"]:focus,
+.dark input[type="search"]:focus,
+.dark input[type="url"]:focus,
+.dark input[type="tel"]:focus,
+.dark textarea:focus {
+  border-color: var(--dark-accent-blue);
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.dark input::placeholder,
+.dark textarea::placeholder {
+  color: var(--dark-text-muted);
+}
+
+.dark select {
+  background-color: var(--dark-bg-elevated);
+  border-color: var(--dark-border);
+  color: var(--dark-text-primary);
+}
+
+.dark select:focus {
+  border-color: var(--dark-accent-blue);
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+/* ============================================
+   Link Colors
+   (Ensure links are visible in dark mode)
+   ============================================ */
+
+.dark a.text-blue-600 {
+  color: #60a5fa !important;
+}
+
+.dark a.text-blue-600:hover {
+  color: #93c5fd !important;
+}
+
+.dark a.hover\:text-blue-800:hover {
+  color: #93c5fd !important;
+}
+
+/* ============================================
+   Icon Button Backgrounds
+   (Common pattern for icon-only buttons)
+   ============================================ */
+
+.dark button.bg-gray-100 {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark button.hover\:bg-gray-200:hover {
+  background-color: #27272a !important;
+}
+
+.dark button.bg-white {
+  background-color: var(--dark-bg-elevated) !important;
+}
+
+/* ============================================
+   Status Dot Colors
+   (Colored dots for status indicators)
+   ============================================ */
+
+.dark .bg-green-500 {
+  background-color: #22c55e !important;
+}
+
+.dark .bg-red-500 {
+  background-color: #ef4444 !important;
+}
+
+.dark .bg-yellow-500 {
+  background-color: #eab308 !important;
+}
+
+.dark .bg-blue-500 {
+  background-color: #3b82f6 !important;
+}
+
+.dark .bg-gray-500 {
+  background-color: #6b7280 !important;
+}
+
+/* ============================================
+   Prose/Content Overrides
+   (For rich text content areas)
+   ============================================ */
+
+.dark .prose {
+  color: var(--dark-text-primary);
+}
+
+.dark .prose h1,
+.dark .prose h2,
+.dark .prose h3,
+.dark .prose h4,
+.dark .prose h5,
+.dark .prose h6 {
+  color: var(--dark-text-primary);
+}
+
+.dark .prose p {
+  color: var(--dark-text-secondary);
+}
+
+.dark .prose a {
+  color: #60a5fa;
+}
+
+.dark .prose strong {
+  color: var(--dark-text-primary);
+}
+
+.dark .prose code {
+  background-color: var(--dark-bg-hover);
+  color: var(--dark-text-primary);
+}
+
+.dark .prose blockquote {
+  border-color: var(--dark-border);
+  color: var(--dark-text-secondary);
+}
+
+.dark .prose hr {
+  border-color: var(--dark-border);
+}
+
+.dark .prose ul > li::before {
+  background-color: var(--dark-text-muted);
+}
+
+.dark .prose ol > li::before {
+  color: var(--dark-text-muted);
 }

--- a/ui/litellm-dashboard/src/app/globals.css
+++ b/ui/litellm-dashboard/src/app/globals.css
@@ -13,12 +13,12 @@
 
   /* Dark mode color tokens (for reference and non-component usage) */
   /* Using a more subtle gradient with less contrast between levels */
-  --dark-bg-base: #141414; /* Main background - slightly lighter for less stark contrast */
-  --dark-bg-elevated: #1a1a1a; /* Cards, panels - subtle elevation */
-  --dark-bg-surface: #1e1e1e; /* Interior content areas */
-  --dark-bg-hover: #252525; /* Hover states */
-  --dark-border: #2a2a2a; /* Subtle borders */
-  --dark-border-hover: #3a3a3a; /* Hover borders */
+  --dark-bg-base: #0e0e0e; /* Main background */
+  --dark-bg-elevated: #151515; /* Cards, panels - subtle elevation */
+  --dark-bg-surface: #1a1a1a; /* Interior content areas */
+  --dark-bg-hover: #1f1f1f; /* Hover states */
+  --dark-border: #1e1e1e; /* Subtle borders - barely lifted from surfaces */
+  --dark-border-hover: #282828; /* Hover borders */
   --dark-text-primary: #e5e7eb;
   --dark-text-secondary: #a1a1aa;
   --dark-text-muted: #71717a;
@@ -27,23 +27,23 @@
 
 .dark {
   --foreground-rgb: 229, 231, 235;
-  --background-start-rgb: 20, 20, 20; /* Matches --dark-bg-base #141414 */
-  --background-end-rgb: 20, 20, 20;
-  --neutral-border: #2a2a2a; /* Matches --dark-border */
+  --background-start-rgb: 14, 14, 14; /* Matches --dark-bg-base #0e0e0e */
+  --background-end-rgb: 14, 14, 14;
+  --neutral-border: #1e1e1e; /* Matches --dark-border */
 
   /* Tremor CSS variable overrides for dark mode */
-  --tremor-background-muted: #141414;
-  --tremor-background-subtle: #1a1a1a;
-  --tremor-background-default: #141414;
-  --tremor-background-emphasis: #252525;
-  --tremor-border-default: #2a2a2a;
-  --tremor-ring-default: #2a2a2a;
+  --tremor-background-muted: #0e0e0e;
+  --tremor-background-subtle: #151515;
+  --tremor-background-default: #0e0e0e;
+  --tremor-background-emphasis: #1f1f1f;
+  --tremor-border-default: #1e1e1e;
+  --tremor-ring-default: #1e1e1e;
   --tremor-content-default: #e5e7eb;
   --tremor-content-emphasis: #e5e7eb;
   --tremor-content-strong: #e5e7eb;
   --tremor-content-moderate: #a1a1aa;
   --tremor-content-subtle: #71717a;
-  --tremor-content-inverted: #141414;
+  --tremor-content-inverted: #0e0e0e;
 }
 
 body {
@@ -54,6 +54,22 @@ body {
 @layer utilities {
   .text-balance {
     text-wrap: balance;
+  }
+}
+
+/* ============================================
+   Dark Mode - default border color
+   Tailwind preflight falls colorless `border` utilities back to a light gray
+   (#e5e7eb), which stands out against dark surfaces (e.g. the Top Virtual Keys
+   table box). Override the default in dark mode so plain `border` boxes blend
+   in. Lives in @layer base so any explicit border-color utility (border-blue-200,
+   the scoped .dark .border-gray-* rules below, etc.) still wins.
+   ============================================ */
+@layer base {
+  .dark *,
+  .dark ::before,
+  .dark ::after {
+    border-color: var(--dark-border);
   }
 }
 
@@ -248,7 +264,7 @@ body {
 
 /* Dropdown dark mode - ConfigProvider doesn't fully control dropdowns rendered in portals */
 .dark .ant-dropdown-menu {
-  background-color: #141414 !important;
+  background-color: var(--dark-bg-base) !important;
   border-color: var(--dark-border) !important;
 }
 
@@ -863,11 +879,18 @@ body {
   background-color: transparent !important;
 }
 
-/* Tremor Badge */
-.dark [class*="tremor-Badge"],
-.dark .tremor-Badge-root {
-  background-color: var(--dark-bg-hover) !important;
-  color: var(--dark-text-primary) !important;
+/* Tremor Badge - render as a subtle dark pill that keeps its colored text.
+   The previous `[class*="tremor-Badge"]` selector also matched the inner
+   `tremor-Badge-text` span, giving the text its own grey background box. Target
+   only the root, and explicitly clear the text span. `span.tremor-Badge-root`
+   outranks the `.dark .bg-*-500` status-dot overrides so colored badges (which
+   carry bg-green-500 etc.) stay a neutral pill instead of a solid color block,
+   while real status dots are untouched. */
+.dark span.tremor-Badge-root {
+  background-color: var(--dark-bg-elevated) !important;
+}
+.dark .tremor-Badge-text {
+  background-color: transparent !important;
 }
 
 /* Tremor Accordion */
@@ -911,11 +934,13 @@ body {
   color: var(--dark-text-primary) !important;
 }
 
-/* Tremor Switch */
-.dark [class*="tremor-Switch"],
-.dark .tremor-Switch-root {
-  background-color: var(--dark-border-hover) !important;
-}
+/* Tremor Switch
+   Tremor's switch already ships dark classes (dark:bg-dark-tremor-border for the
+   off track, dark:bg-dark-tremor-brand for the on track) and those tokens are
+   defined in tailwind.config, so it renders correctly on its own. The previous
+   `[class*="tremor-Switch"]` override matched the root wrapper and button too,
+   painting a box behind the whole toggle and flattening the on/off colors. Leave
+   it to Tremor's native dark styling. */
 
 /* Tremor List */
 .dark [class*="tremor-List"],
@@ -1127,6 +1152,17 @@ body {
 
 /* Override bg-gray-100 in dark mode */
 .dark .bg-gray-100 {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+/* Override bg-gray-200 / bg-gray-300 in dark mode - these stay light otherwise,
+   rendering as pale boxes behind text (e.g. the model-hub URL chip and disabled
+   buttons). Map them to subtle dark surfaces. */
+.dark .bg-gray-200 {
+  background-color: var(--dark-bg-hover) !important;
+}
+
+.dark .bg-gray-300 {
   background-color: var(--dark-bg-hover) !important;
 }
 

--- a/ui/litellm-dashboard/src/app/layout.tsx
+++ b/ui/litellm-dashboard/src/app/layout.tsx
@@ -13,13 +13,33 @@ export const metadata: Metadata = {
   icons: { icon: "./favicon.ico" },
 };
 
+// Runs before hydration to set the dark class from the stored preference, avoiding a flash of light mode
+const themeScript = `
+  (function() {
+    try {
+      var stored = localStorage.getItem('litellm-dark-mode');
+      var isDark = stored === null
+        ? window.matchMedia('(prefers-color-scheme: dark)').matches
+        : stored === 'true';
+      if (isDark) {
+        document.documentElement.classList.add('dark');
+      }
+    } catch (e) {}
+  })();
+`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Static, developer-controlled theme bootstrap; must run before paint to prevent a flash of light mode */}
+        {/* eslint-disable-next-line react/no-danger */}
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
       <body className={inter.className}>
         <ReactQueryProvider>
           <AntdGlobalProvider>{children}</AntdGlobalProvider>

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -43,16 +43,16 @@ import { MemoryView } from "@/components/MemoryView";
 import WorkflowRuns from "@/components/workflow_runs";
 import SpendLogsTable from "@/components/view_logs";
 import ViewUserDashboard from "@/components/view_users";
-import { ThemeProvider } from "@/contexts/ThemeContext";
+import { ThemeProvider, useTheme } from "@/contexts/ThemeContext";
 import { clearTokenCookies, getCookie } from "@/utils/cookieUtils";
 import { isJwtExpired } from "@/utils/jwtUtils";
 import { buildLoginUrlWithReturn, consumeReturnUrl, isValidReturnUrl, normalizeUrlForCompare, storeReturnUrl } from "@/utils/returnUrlUtils";
 import { formatUserRole, isAdminRole } from "@/utils/roles";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { jwtDecode } from "jwt-decode";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useMemo, useRef, useState } from "react";
-import { ConfigProvider, theme } from "antd";
+import { ConfigProvider } from "antd";
+import { getAntdTheme } from "@/config/antdTheme";
 
 function deleteCookie(name: string, path = "/") {
   // Best-effort client-side clear (works for non-HttpOnly cookies without Domain)
@@ -110,11 +110,7 @@ function CreateKeyPageContent() {
   const [showClaudeCodePrompt, setShowClaudeCodePrompt] = useState(false);
   const [showClaudeCodeModal, setShowClaudeCodeModal] = useState(false);
 
-  // Dark mode state
-  const [isDarkMode, setIsDarkMode] = useState(false);
-  const toggleDarkMode = () => {
-    setIsDarkMode(!isDarkMode);
-  };
+  const { isDarkMode, toggleDarkMode } = useTheme();
 
   const invitation_id = searchParams.get("invitation_id");
 
@@ -450,10 +446,7 @@ function CreateKeyPageContent() {
 
   return (
     <Suspense fallback={<LoadingScreen />}>
-      <ConfigProvider theme={{
-          algorithm: isDarkMode ? theme.darkAlgorithm : theme.defaultAlgorithm,
-        }}>
-          <ThemeProvider accessToken={accessToken}>
+      <ConfigProvider theme={getAntdTheme(isDarkMode)}>
             {invitation_id ? (
               <UserDashboard
                 userID={userID}
@@ -681,7 +674,6 @@ function CreateKeyPageContent() {
                 />
               </div>
             )}
-          </ThemeProvider>
         </ConfigProvider>
     </Suspense>
   );
@@ -690,7 +682,9 @@ function CreateKeyPageContent() {
 export default function CreateKeyPage() {
   return (
     <Suspense fallback={<LoadingScreen />}>
-      <CreateKeyPageContent />
+      <ThemeProvider accessToken={""}>
+        <CreateKeyPageContent />
+      </ThemeProvider>
     </Suspense>
   );
 }

--- a/ui/litellm-dashboard/src/components/navbar.test.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import React, { useState } from "react";
+import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen, waitFor } from "../../tests/test-utils";
 import Navbar from "./navbar";
@@ -304,10 +304,9 @@ describe("Navbar", () => {
     expect(window.location.href).toBe("");
   });
 
-  it("should not render dark mode toggle slider", () => {
+  it("renders the dark mode toggle slider", () => {
     renderWithProviders(<Navbar {...defaultProps} />);
 
-    // DO NOT RENDER THIS UNTIL ALL COMPONENTS ARE CONFIRMED TO SUPPORT DARK MODE STYLES. IT IS AN ISSUE IF THIS TEST FAILS.
-    expect(screen.queryByTestId("dark-mode-toggle")).not.toBeInTheDocument();
+    expect(screen.getByTestId("dark-mode-toggle")).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -87,7 +87,7 @@ const Navbar: React.FC<NavbarProps> = ({
   };
 
   return (
-    <nav className="bg-white border-b border-gray-200 sticky top-0 z-10">
+    <nav className="bg-white dark:bg-[#141414] border-b border-gray-200 dark:border-[#2a2a2a] sticky top-0 z-10">
       <div className="w-full">
         <div className="flex items-center h-14 px-4">
           <div className="flex items-center flex-shrink-0">
@@ -142,17 +142,13 @@ const Navbar: React.FC<NavbarProps> = ({
           <div className="flex items-center space-x-5 ml-auto">
             <WorkerDropdown onWorkerSwitch={handleWorkerSwitch} />
             <CommunityEngagementButtons />
-            {/* Dark mode is currently a work in progress. To test, you can change 'false' to 'true' below.
-            Do not set this to true by default until all components are confirmed to support dark mode styles. */}
-            {false && (
-              <Switch
-                data-testid="dark-mode-toggle"
-                checked={isDarkMode}
-                onChange={toggleDarkMode}
-                checkedChildren={<MoonOutlined />}
-                unCheckedChildren={<SunOutlined />}
-              />
-            )}
+            <Switch
+              data-testid="dark-mode-toggle"
+              checked={isDarkMode}
+              onChange={toggleDarkMode}
+              checkedChildren={<MoonOutlined />}
+              unCheckedChildren={<SunOutlined />}
+            />
             <Button type="text" href="https://docs.litellm.ai/docs/" target="_blank" rel="noopener noreferrer">
               Docs
             </Button>

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -87,7 +87,7 @@ const Navbar: React.FC<NavbarProps> = ({
   };
 
   return (
-    <nav className="bg-white dark:bg-[#141414] border-b border-gray-200 dark:border-[#2a2a2a] sticky top-0 z-10">
+    <nav className="bg-white dark:bg-[#0e0e0e] border-b border-gray-200 dark:border-[#1e1e1e] sticky top-0 z-10">
       <div className="w-full">
         <div className="flex items-center h-14 px-4">
           <div className="flex items-center flex-shrink-0">

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -1,4 +1,5 @@
 import { ThemeProvider } from "@/contexts/ThemeContext";
+import { useDarkMode } from "@/hooks/useDarkMode";
 import { ExternalLinkIcon, SearchIcon } from "@heroicons/react/outline";
 import { ColumnDef } from "@tanstack/react-table";
 import { Button, Card, Text, Title } from "@tremor/react";
@@ -115,6 +116,7 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
   const [selectedAgentSkills, setSelectedAgentSkills] = useState<string[]>([]);
   const [selectedMcpTransports, setSelectedMcpTransports] = useState<string[]>([]);
   const [serviceStatus, setServiceStatus] = useState<string>("I'm alive! ✓");
+  const { isDarkMode, toggleDarkMode } = useDarkMode();
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isAgentModalVisible, setIsAgentModalVisible] = useState(false);
   const [isMcpModalVisible, setIsMcpModalVisible] = useState(false);
@@ -991,8 +993,8 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
             proxySettings={proxySettings}
             accessToken={accessToken || null}
             isPublicPage={true}
-            isDarkMode={false}
-            toggleDarkMode={() => {}}
+            isDarkMode={isDarkMode}
+            toggleDarkMode={toggleDarkMode}
           />
         )}
 

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -1,9 +1,9 @@
-import { ThemeProvider } from "@/contexts/ThemeContext";
-import { useDarkMode } from "@/hooks/useDarkMode";
+import { ThemeProvider, useTheme } from "@/contexts/ThemeContext";
+import { getAntdTheme } from "@/config/antdTheme";
 import { ExternalLinkIcon, SearchIcon } from "@heroicons/react/outline";
 import { ColumnDef } from "@tanstack/react-table";
 import { Button, Card, Text, Title } from "@tremor/react";
-import { Modal, Select, Tabs, Tag, Tooltip } from "antd";
+import { ConfigProvider, Modal, Select, Tabs, Tag, Tooltip } from "antd";
 import { Copy, Info } from "lucide-react";
 import React, { useEffect, useMemo, useState } from "react";
 import { ModelDataTable } from "./model_dashboard/table";
@@ -96,7 +96,7 @@ interface PublicModelHubProps {
   isEmbedded?: boolean; // When true, hides navbar and adjusts layout for embedding in dashboard
 }
 
-const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded = false }) => {
+const PublicModelHubContent: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded = false }) => {
   const [modelHubData, setModelHubData] = useState<ModelGroupInfo[] | null>(null);
   const [agentHubData, setAgentHubData] = useState<AgentCard[] | null>(null);
   const [mcpHubData, setMcpHubData] = useState<MCPServerData[] | null>(null);
@@ -116,7 +116,7 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
   const [selectedAgentSkills, setSelectedAgentSkills] = useState<string[]>([]);
   const [selectedMcpTransports, setSelectedMcpTransports] = useState<string[]>([]);
   const [serviceStatus, setServiceStatus] = useState<string>("I'm alive! ✓");
-  const { isDarkMode, toggleDarkMode } = useDarkMode();
+  const { isDarkMode, toggleDarkMode } = useTheme();
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isAgentModalVisible, setIsAgentModalVisible] = useState(false);
   const [isMcpModalVisible, setIsMcpModalVisible] = useState(false);
@@ -980,8 +980,8 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
   ];
 
   return (
-    <ThemeProvider accessToken={accessToken}>
-      <div className={isEmbedded ? "w-full" : "min-h-screen bg-white"}>
+    <ConfigProvider theme={getAntdTheme(isDarkMode)}>
+      <div className={isEmbedded ? "w-full" : "min-h-screen bg-white dark:bg-[#0e0e0e]"}>
         {/* Navigation - only show when not embedded */}
         {!isEmbedded && (
           <Navbar
@@ -2027,8 +2027,14 @@ if __name__ == "__main__":
           )}
         </Modal>
       </div>
-    </ThemeProvider>
+    </ConfigProvider>
   );
 };
+
+const PublicModelHub: React.FC<PublicModelHubProps> = (props) => (
+  <ThemeProvider accessToken={props.accessToken}>
+    <PublicModelHubContent {...props} />
+  </ThemeProvider>
+);
 
 export default PublicModelHub;

--- a/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
+++ b/ui/litellm-dashboard/src/components/workflow_runs/index.tsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { Button, Collapse, Drawer, Empty, Spin, Table, Tooltip, Typography } from "antd";
+import { Button, Collapse, Drawer, Empty, Spin, Table, Tooltip } from "antd";
 import { ReloadOutlined } from "@ant-design/icons";
 import { proxyBaseUrl } from "@/components/networking";
-
-const { Text } = Typography;
+import { useTheme } from "@/contexts/ThemeContext";
 
 interface WorkflowRunsProps {
   accessToken: string | null;
@@ -49,6 +48,7 @@ interface WorkflowRunMessage {
 
 // ── design tokens ─────────────────────────────────────────────────────────────
 
+// Status dot colors read fine on both light and dark surfaces, so they are shared.
 const STATUS_DOT: Record<RunStatus, string> = {
   pending:   "#a1a1aa",
   running:   "#3b82f6",
@@ -57,15 +57,84 @@ const STATUS_DOT: Record<RunStatus, string> = {
   failed:    "#ef4444",
 };
 
-const EVENT_COLOR: Record<string, { bar: string; border: string; text: string }> = {
+// Semantic palette - switches with the active theme. Everything in this view is
+// inline-styled (so the global dark-mode CSS can't reach it); these tokens are
+// the single source of truth for the colors used below.
+interface Palette {
+  pageBg: string;
+  chipBg: string;
+  border: string;
+  borderSubtle: string;
+  borderStrong: string;
+  textStrong: string;
+  textBody: string;
+  textMuted: string;
+  textFaint: string;
+  barBg: string;
+  barBorder: string;
+  barText: string;
+  link: string;
+}
+
+function palette(dark: boolean): Palette {
+  return dark
+    ? {
+        pageBg: "transparent", // inherit the themed dashboard content area
+        chipBg: "#1f1f1f",
+        border: "#242424",
+        borderSubtle: "#1e1e1e",
+        borderStrong: "#282828",
+        textStrong: "#e5e7eb",
+        textBody: "#d4d4d8",
+        textMuted: "#a1a1aa",
+        textFaint: "#71717a",
+        barBg: "#1a1a1a",
+        barBorder: "#3f3f46",
+        barText: "#a1a1aa",
+        link: "#60a5fa",
+      }
+    : {
+        pageBg: "#fff",
+        chipBg: "#f4f4f5",
+        border: "#e4e4e7",
+        borderSubtle: "#f4f4f5",
+        borderStrong: "#d4d4d8",
+        textStrong: "#18181b",
+        textBody: "#27272a",
+        textMuted: "#52525b",
+        textFaint: "#a1a1aa",
+        barBg: "#f4f4f5",
+        barBorder: "#d4d4d8",
+        barText: "#71717a",
+        link: "#2563eb",
+      };
+}
+
+interface EventStyle {
+  bar: string;
+  border: string;
+  text: string;
+}
+
+const EVENT_COLOR_LIGHT: Record<string, EventStyle> = {
   "step.started":  { bar: "#f0fdf4", border: "#86efac", text: "#16a34a" },
   "step.failed":   { bar: "#fef2f2", border: "#fca5a5", text: "#dc2626" },
   "hook.waiting":  { bar: "#fffbeb", border: "#fcd34d", text: "#d97706" },
   "hook.received": { bar: "#eff6ff", border: "#93c5fd", text: "#2563eb" },
 };
 
-function eventStyle(type: string) {
-  return EVENT_COLOR[type] ?? { bar: "#f4f4f5", border: "#d4d4d8", text: "#52525b" };
+const EVENT_COLOR_DARK: Record<string, EventStyle> = {
+  "step.started":  { bar: "#16221a", border: "#2f6b3f", text: "#4ade80" },
+  "step.failed":   { bar: "#241818", border: "#7f3a3a", text: "#f87171" },
+  "hook.waiting":  { bar: "#241f12", border: "#7a5a1f", text: "#fbbf24" },
+  "hook.received": { bar: "#161d2b", border: "#2f4f7a", text: "#60a5fa" },
+};
+
+function eventStyle(type: string, dark: boolean): EventStyle {
+  if (dark) {
+    return EVENT_COLOR_DARK[type] ?? { bar: "#1a1a1a", border: "#3f3f46", text: "#a1a1aa" };
+  }
+  return EVENT_COLOR_LIGHT[type] ?? { bar: "#f4f4f5", border: "#d4d4d8", text: "#52525b" };
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -117,13 +186,13 @@ const StatusDot: React.FC<{ status: RunStatus; size?: number }> = ({ status, siz
 
 const TRUNCATE_AT = 120;
 
-const TruncatedValue: React.FC<{ value: string }> = ({ value }) => {
+const TruncatedValue: React.FC<{ value: string; c: Palette }> = ({ value, c }) => {
   const [expanded, setExpanded] = useState(false);
   if (value.length <= TRUNCATE_AT) {
-    return <span style={{ color: "#27272a", wordBreak: "break-all" }}>{value}</span>;
+    return <span style={{ color: c.textBody, wordBreak: "break-all" }}>{value}</span>;
   }
   return (
-    <span style={{ color: "#27272a", wordBreak: "break-all" }}>
+    <span style={{ color: c.textBody, wordBreak: "break-all" }}>
       {expanded ? value : value.slice(0, TRUNCATE_AT) + "…"}
       <button
         onClick={() => setExpanded((e) => !e)}
@@ -132,7 +201,7 @@ const TruncatedValue: React.FC<{ value: string }> = ({ value }) => {
           border: "none",
           padding: "0 4px",
           cursor: "pointer",
-          color: "#2563eb",
+          color: c.link,
           fontSize: 11,
           flexShrink: 0,
         }}
@@ -145,7 +214,7 @@ const TruncatedValue: React.FC<{ value: string }> = ({ value }) => {
 
 // ── metadata card ─────────────────────────────────────────────────────────────
 
-const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
+const MetadataCard: React.FC<{ run: WorkflowRun; c: Palette }> = ({ run, c }) => {
   const meta = run.metadata ?? {};
 
   const primaryFields: { key: string; label: string }[] = [
@@ -164,7 +233,7 @@ const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
     <div
       style={{
         borderRadius: 8,
-        border: "1px solid #e4e4e7",
+        border: `1px solid ${c.border}`,
         marginBottom: 16,
         overflow: "hidden",
       }}
@@ -173,22 +242,22 @@ const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
       <div
         style={{
           padding: "14px 20px",
-          borderBottom: "1px solid #f4f4f5",
+          borderBottom: `1px solid ${c.borderSubtle}`,
           display: "flex",
           alignItems: "center",
           gap: 10,
         }}
       >
         <StatusDot status={run.status} size={10} />
-        <span style={{ fontSize: 14, fontWeight: 600, color: "#18181b", flex: 1 }}>
+        <span style={{ fontSize: 14, fontWeight: 600, color: c.textStrong, flex: 1 }}>
           {runTitle(run)}
         </span>
         <span
           style={{
             fontFamily: "monospace",
             fontSize: 11,
-            color: "#a1a1aa",
-            background: "#f4f4f5",
+            color: c.textFaint,
+            background: c.chipBg,
             padding: "2px 8px",
             borderRadius: 4,
           }}
@@ -198,8 +267,8 @@ const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
         <span
           style={{
             fontSize: 11,
-            color: "#a1a1aa",
-            background: "#f4f4f5",
+            color: c.textFaint,
+            background: c.chipBg,
             padding: "2px 8px",
             borderRadius: 4,
           }}
@@ -219,20 +288,20 @@ const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
           fontSize: 12,
         }}
       >
-        <FieldPair label="status">
-          <span style={{ textTransform: "capitalize", color: "#27272a" }}>{run.status}</span>
+        <FieldPair label="status" c={c}>
+          <span style={{ textTransform: "capitalize", color: c.textBody }}>{run.status}</span>
         </FieldPair>
-        <FieldPair label="created">
-          <span style={{ color: "#27272a" }}>{timeAgo(run.created_at)}</span>
+        <FieldPair label="created" c={c}>
+          <span style={{ color: c.textBody }}>{timeAgo(run.created_at)}</span>
         </FieldPair>
 
         {meta.pr_url && (
-          <FieldPair label="pr">
+          <FieldPair label="pr" c={c}>
             <a
               href={String(meta.pr_url)}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: "#2563eb", textDecoration: "none", wordBreak: "break-all" }}
+              style={{ color: c.link, textDecoration: "none", wordBreak: "break-all" }}
             >
               {String(meta.pr_url)}
             </a>
@@ -244,8 +313,8 @@ const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
           if (v === null || v === undefined || v === "") return null;
           const str = typeof v === "object" ? JSON.stringify(v) : String(v);
           return (
-            <FieldPair key={key} label={label}>
-              <TruncatedValue value={str} />
+            <FieldPair key={key} label={label} c={c}>
+              <TruncatedValue value={str} c={c} />
             </FieldPair>
           );
         })}
@@ -253,8 +322,8 @@ const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
         {extraEntries.map(([k, v]) => {
           const str = typeof v === "object" ? JSON.stringify(v) : String(v);
           return (
-            <FieldPair key={k} label={k}>
-              <TruncatedValue value={str} />
+            <FieldPair key={k} label={k} c={c}>
+              <TruncatedValue value={str} c={c} />
             </FieldPair>
           );
         })}
@@ -263,12 +332,13 @@ const MetadataCard: React.FC<{ run: WorkflowRun }> = ({ run }) => {
   );
 };
 
-const FieldPair: React.FC<{ label: string; children: React.ReactNode }> = ({
+const FieldPair: React.FC<{ label: string; c: Palette; children: React.ReactNode }> = ({
   label,
+  c,
   children,
 }) => (
   <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
-    <span style={{ fontSize: 10, color: "#a1a1aa", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+    <span style={{ fontSize: 10, color: c.textFaint, textTransform: "uppercase", letterSpacing: "0.06em" }}>
       {label}
     </span>
     <span style={{ fontSize: 12 }}>{children}</span>
@@ -280,10 +350,12 @@ const FieldPair: React.FC<{ label: string; children: React.ReactNode }> = ({
 const GanttTimeline: React.FC<{
   run: WorkflowRun;
   events: WorkflowRunEvent[];
-}> = ({ run, events }) => {
+  c: Palette;
+  dark: boolean;
+}> = ({ run, events, c, dark }) => {
   if (events.length === 0) {
     return (
-      <div style={{ padding: "16px 0", color: "#a1a1aa", fontSize: 12, fontFamily: "monospace" }}>
+      <div style={{ padding: "16px 0", color: c.textFaint, fontSize: 12, fontFamily: "monospace" }}>
         No events recorded
       </div>
     );
@@ -309,7 +381,7 @@ const GanttTimeline: React.FC<{
                 left: `${pct}%`,
                 transform: pct === 100 ? "translateX(-100%)" : undefined,
                 fontSize: 10,
-                color: "#a1a1aa",
+                color: c.textFaint,
               }}
             >
               {pct === 0 ? "0" : totalDur}
@@ -320,21 +392,21 @@ const GanttTimeline: React.FC<{
 
       {/* outer run bar */}
       <div style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: "0 12px", marginBottom: 4 }}>
-        <div style={{ color: "#3f3f46", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", paddingTop: 2 }}>
+        <div style={{ color: c.textMuted, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", paddingTop: 2 }}>
           {runTitle(run)}
         </div>
         <div
           style={{
             height: 24,
-            background: "#f4f4f5",
-            border: "1px solid #d4d4d8",
+            background: c.barBg,
+            border: `1px solid ${c.borderStrong}`,
             borderRadius: 4,
             display: "flex",
             alignItems: "center",
             paddingLeft: 8,
           }}
         >
-          <span style={{ color: "#71717a", fontSize: 11 }}>{totalDur}</span>
+          <span style={{ color: c.textMuted, fontSize: 11 }}>{totalDur}</span>
         </div>
       </div>
 
@@ -350,7 +422,7 @@ const GanttTimeline: React.FC<{
               ? new Date(events[nextIdx].created_at).getTime()
               : lastTime + Math.max(totalSpan * 0.12, 500);
           const widthPct = Math.max(8, ((nextTime - evTime) / totalSpan) * 100);
-          const style = eventStyle(ev.event_type);
+          const style = eventStyle(ev.event_type, dark);
           const dur = fmtDuration(nextTime - evTime);
 
           return (
@@ -399,7 +471,7 @@ const GanttTimeline: React.FC<{
                     }}
                   >
                     <span style={{ color: style.text, whiteSpace: "nowrap", fontSize: 11 }}>{ev.event_type}</span>
-                    {dur && <span style={{ color: "#a1a1aa", whiteSpace: "nowrap", fontSize: 11 }}>{dur}</span>}
+                    {dur && <span style={{ color: c.textFaint, whiteSpace: "nowrap", fontSize: 11 }}>{dur}</span>}
                   </div>
                 </Tooltip>
               </div>
@@ -413,7 +485,7 @@ const GanttTimeline: React.FC<{
 
 // ── message row ───────────────────────────────────────────────────────────────
 
-const MessageRow: React.FC<{ msg: WorkflowRunMessage }> = ({ msg }) => {
+const MessageRow: React.FC<{ msg: WorkflowRunMessage; c: Palette }> = ({ msg, c }) => {
   const roleColor: Record<string, string> = {
     user:        "#2563eb",
     assistant:   "#16a34a",
@@ -429,7 +501,7 @@ const MessageRow: React.FC<{ msg: WorkflowRunMessage }> = ({ msg }) => {
         gridTemplateColumns: "80px 1fr",
         gap: "0 16px",
         padding: "10px 0",
-        borderBottom: "1px solid #f4f4f5",
+        borderBottom: `1px solid ${c.borderSubtle}`,
         fontFamily: "monospace",
         fontSize: 12,
         alignItems: "start",
@@ -439,7 +511,7 @@ const MessageRow: React.FC<{ msg: WorkflowRunMessage }> = ({ msg }) => {
       <div>
         <span
           style={{
-            color: "#27272a",
+            color: c.textBody,
             lineHeight: 1.6,
             whiteSpace: "pre-wrap",
             wordBreak: "break-word",
@@ -448,7 +520,7 @@ const MessageRow: React.FC<{ msg: WorkflowRunMessage }> = ({ msg }) => {
         >
           {msg.content}
         </span>
-        <span style={{ color: "#a1a1aa", fontSize: 11, marginTop: 2, display: "block" }}>
+        <span style={{ color: c.textFaint, fontSize: 11, marginTop: 2, display: "block" }}>
           {timeAgo(msg.created_at)}
         </span>
       </div>
@@ -459,6 +531,9 @@ const MessageRow: React.FC<{ msg: WorkflowRunMessage }> = ({ msg }) => {
 // ── main component ────────────────────────────────────────────────────────────
 
 const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
+  const { isDarkMode } = useTheme();
+  const c = palette(isDarkMode);
+
   const [runs, setRuns] = useState<WorkflowRun[]>([]);
   const [loadingRuns, setLoadingRuns] = useState(false);
   const [selectedRun, setSelectedRun] = useState<WorkflowRun | null>(null);
@@ -536,10 +611,10 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <StatusDot status={run.status} size={7} />
           <div>
-            <div style={{ fontSize: 13, color: "#18181b", fontWeight: 500, lineHeight: 1.4 }}>
+            <div style={{ fontSize: 13, color: c.textStrong, fontWeight: 500, lineHeight: 1.4 }}>
               {runTitle(run)}
             </div>
-            <div style={{ fontFamily: "monospace", fontSize: 11, color: "#a1a1aa" }}>
+            <div style={{ fontFamily: "monospace", fontSize: 11, color: c.textFaint }}>
               {shortId(run.run_id)}
             </div>
           </div>
@@ -551,7 +626,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
       dataIndex: "workflow_type",
       key: "workflow_type",
       render: (v: string) => (
-        <span style={{ fontFamily: "monospace", fontSize: 12, color: "#71717a" }}>{v}</span>
+        <span style={{ fontFamily: "monospace", fontSize: 12, color: c.textMuted }}>{v}</span>
       ),
     },
     {
@@ -563,7 +638,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
         return (
           <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
             <StatusDot status={status} size={7} />
-            <span style={{ fontSize: 12, color: "#52525b", textTransform: "capitalize" }}>
+            <span style={{ fontSize: 12, color: c.textMuted, textTransform: "capitalize" }}>
               {state ?? status}
             </span>
           </div>
@@ -575,7 +650,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
       dataIndex: "created_at",
       key: "created_at",
       render: (v: string) => (
-        <span style={{ fontSize: 12, color: "#a1a1aa" }}>{timeAgo(v)}</span>
+        <span style={{ fontSize: 12, color: c.textFaint }}>{timeAgo(v)}</span>
       ),
     },
   ];
@@ -586,7 +661,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
         padding: "24px 32px",
         fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
         minHeight: "calc(100vh - 64px)",
-        background: "#fff",
+        background: c.pageBg,
       }}
     >
       {/* page header */}
@@ -599,8 +674,8 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
         }}
       >
         <div>
-          <div style={{ fontSize: 18, fontWeight: 600, color: "#18181b" }}>Workflow Runs</div>
-          <div style={{ fontSize: 13, color: "#71717a", marginTop: 2 }}>
+          <div style={{ fontSize: 18, fontWeight: 600, color: c.textStrong }}>Workflow Runs</div>
+          <div style={{ fontSize: 13, color: c.textMuted, marginTop: 2 }}>
             Durable state tracking for agents and automated workflows
           </div>
         </div>
@@ -608,7 +683,6 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
           icon={<ReloadOutlined />}
           onClick={fetchRuns}
           loading={loadingRuns}
-          style={{ color: "#71717a", borderColor: "#e4e4e7" }}
         >
           Refresh
         </Button>
@@ -630,7 +704,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
           locale={{
             emptyText: (
               <Empty
-                description={<span style={{ color: "#a1a1aa", fontSize: 13 }}>No workflow runs yet</span>}
+                description={<span style={{ color: c.textFaint, fontSize: 13 }}>No workflow runs yet</span>}
                 image={Empty.PRESENTED_IMAGE_SIMPLE}
               />
             ),
@@ -673,7 +747,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
                   cursor: "pointer",
                   padding: "4px 0",
                   fontSize: 12,
-                  color: "#a1a1aa",
+                  color: c.textFaint,
                   display: "flex",
                   alignItems: "center",
                   gap: 4,
@@ -686,55 +760,54 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
                 icon={<ReloadOutlined />}
                 onClick={() => fetchRunDetail(selectedRun)}
                 loading={loadingDetail}
-                style={{ color: "#71717a", borderColor: "#e4e4e7" }}
               >
                 Refresh
               </Button>
             </div>
 
             {/* metadata card — top */}
-            <MetadataCard run={selectedRun} />
+            <MetadataCard run={selectedRun} c={c} />
 
             {/* collapsible sections */}
             <Collapse
               defaultActiveKey={["timeline"]}
               ghost={false}
-              style={{ border: "1px solid #e4e4e7", borderRadius: 8, overflow: "hidden" }}
+              style={{ border: `1px solid ${c.border}`, borderRadius: 8, overflow: "hidden" }}
               items={[
                 {
                   key: "timeline",
                   label: (
-                    <span style={{ fontSize: 12, fontWeight: 500, color: "#3f3f46" }}>
+                    <span style={{ fontSize: 12, fontWeight: 500, color: c.textMuted }}>
                       Timeline
-                      <span style={{ marginLeft: 6, fontSize: 11, color: "#a1a1aa", fontWeight: 400 }}>
+                      <span style={{ marginLeft: 6, fontSize: 11, color: c.textFaint, fontWeight: 400 }}>
                         {events.length} {events.length === 1 ? "event" : "events"}
                       </span>
                     </span>
                   ),
                   children: (
                     <div style={{ padding: "4px 4px 12px" }}>
-                      <GanttTimeline run={selectedRun} events={events} />
+                      <GanttTimeline run={selectedRun} events={events} c={c} dark={isDarkMode} />
                     </div>
                   ),
                 },
                 {
                   key: "messages",
                   label: (
-                    <span style={{ fontSize: 12, fontWeight: 500, color: "#3f3f46" }}>
+                    <span style={{ fontSize: 12, fontWeight: 500, color: c.textMuted }}>
                       Messages
-                      <span style={{ marginLeft: 6, fontSize: 11, color: "#a1a1aa", fontWeight: 400 }}>
+                      <span style={{ marginLeft: 6, fontSize: 11, color: c.textFaint, fontWeight: 400 }}>
                         {messages.length}
                       </span>
                     </span>
                   ),
                   children: messages.length === 0 ? (
-                    <div style={{ padding: "12px 4px", color: "#a1a1aa", fontSize: 12, fontFamily: "monospace" }}>
+                    <div style={{ padding: "12px 4px", color: c.textFaint, fontSize: 12, fontFamily: "monospace" }}>
                       No messages
                     </div>
                   ) : (
                     <div style={{ paddingBottom: 4 }}>
                       {messages.map((msg) => (
-                        <MessageRow key={msg.message_id} msg={msg} />
+                        <MessageRow key={msg.message_id} msg={msg} c={c} />
                       ))}
                     </div>
                   ),

--- a/ui/litellm-dashboard/src/config/antdTheme.ts
+++ b/ui/litellm-dashboard/src/config/antdTheme.ts
@@ -1,0 +1,103 @@
+import { theme, ThemeConfig } from "antd";
+
+export const darkModeColors = {
+  bgBase: "#141414",
+  bgElevated: "#1a1a1a",
+  bgSurface: "#1e1e1e",
+  bgHover: "#252525",
+
+  border: "#2a2a2a",
+  borderHover: "#3a3a3a",
+
+  textPrimary: "#e5e7eb",
+  textSecondary: "#a1a1aa",
+  textMuted: "#71717a",
+
+  accentBlue: "#3b82f6",
+  accentError: "#ef4444",
+} as const;
+
+export const getAntdTheme = (isDarkMode: boolean): ThemeConfig => ({
+  algorithm: isDarkMode ? theme.darkAlgorithm : theme.defaultAlgorithm,
+  token: isDarkMode
+    ? {
+        colorBgContainer: darkModeColors.bgElevated,
+        colorBgElevated: darkModeColors.bgElevated,
+        colorBorder: darkModeColors.border,
+        colorText: darkModeColors.textPrimary,
+        colorTextSecondary: darkModeColors.textSecondary,
+      }
+    : {},
+  components: isDarkMode
+    ? {
+        Menu: {
+          iconSize: 18,
+          fontSize: 14,
+          itemBg: darkModeColors.bgBase,
+          itemColor: darkModeColors.textSecondary,
+          itemHoverColor: darkModeColors.textPrimary,
+          itemHoverBg: darkModeColors.bgElevated,
+          itemSelectedColor: darkModeColors.textPrimary,
+          itemSelectedBg: darkModeColors.bgElevated,
+          subMenuItemBg: darkModeColors.bgBase,
+        },
+        Card: {
+          colorBgContainer: darkModeColors.bgElevated,
+          colorBorderSecondary: darkModeColors.border,
+        },
+        Table: {
+          colorBgContainer: darkModeColors.bgElevated,
+          headerBg: darkModeColors.bgBase,
+          rowHoverBg: darkModeColors.bgHover,
+          borderColor: darkModeColors.border,
+        },
+        Input: {
+          colorBgContainer: darkModeColors.bgBase,
+          colorBorder: darkModeColors.border,
+          hoverBorderColor: darkModeColors.borderHover,
+          activeBorderColor: darkModeColors.accentBlue,
+        },
+        InputNumber: {
+          colorBgContainer: darkModeColors.bgBase,
+          colorBorder: darkModeColors.border,
+          hoverBorderColor: darkModeColors.borderHover,
+          handleBg: darkModeColors.bgHover,
+        },
+        Select: {
+          colorBgContainer: darkModeColors.bgBase,
+          colorBorder: darkModeColors.border,
+          optionSelectedBg: darkModeColors.bgHover,
+          optionActiveBg: darkModeColors.bgHover,
+          selectorBg: darkModeColors.bgBase,
+        },
+        DatePicker: {
+          colorBgContainer: darkModeColors.bgBase,
+          colorBorder: darkModeColors.border,
+        },
+        Modal: {
+          contentBg: darkModeColors.bgElevated,
+          headerBg: darkModeColors.bgElevated,
+          footerBg: darkModeColors.bgElevated,
+        },
+        Dropdown: {
+          colorBgElevated: darkModeColors.bgElevated,
+          controlItemBgHover: darkModeColors.bgHover,
+        },
+        Button: {
+          defaultBg: darkModeColors.bgElevated,
+          defaultBorderColor: darkModeColors.border,
+        },
+        Tabs: {
+          inkBarColor: darkModeColors.accentBlue,
+        },
+        Form: {
+          labelColor: darkModeColors.textPrimary,
+        },
+      }
+    : {
+        Menu: {
+          iconSize: 18,
+          fontSize: 14,
+        },
+      },
+});

--- a/ui/litellm-dashboard/src/config/antdTheme.ts
+++ b/ui/litellm-dashboard/src/config/antdTheme.ts
@@ -1,13 +1,13 @@
 import { theme, ThemeConfig } from "antd";
 
 export const darkModeColors = {
-  bgBase: "#141414",
-  bgElevated: "#1a1a1a",
-  bgSurface: "#1e1e1e",
-  bgHover: "#252525",
+  bgBase: "#0e0e0e",
+  bgElevated: "#151515",
+  bgSurface: "#1a1a1a",
+  bgHover: "#1f1f1f",
 
-  border: "#2a2a2a",
-  borderHover: "#3a3a3a",
+  border: "#1e1e1e",
+  borderHover: "#282828",
 
   textPrimary: "#e5e7eb",
   textSecondary: "#a1a1aa",

--- a/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
@@ -1,11 +1,14 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from "react";
 import { getProxyBaseUrl } from "@/components/networking";
+import { useDarkMode } from "@/hooks/useDarkMode";
 
 interface ThemeContextType {
   logoUrl: string | null;
   setLogoUrl: (url: string | null) => void;
   faviconUrl: string | null;
   setFaviconUrl: (url: string | null) => void;
+  isDarkMode: boolean;
+  toggleDarkMode: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
@@ -26,6 +29,7 @@ interface ThemeProviderProps {
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessToken }) => {
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
   const [faviconUrl, setFaviconUrl] = useState<string | null>(null);
+  const { isDarkMode, toggleDarkMode } = useDarkMode();
 
   useEffect(() => {
     const loadThemeSettings = async () => {
@@ -71,7 +75,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessTo
   }, [faviconUrl]);
 
   return (
-    <ThemeContext.Provider value={{ logoUrl, setLogoUrl, faviconUrl, setFaviconUrl }}>
+    <ThemeContext.Provider value={{ logoUrl, setLogoUrl, faviconUrl, setFaviconUrl, isDarkMode, toggleDarkMode }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/ui/litellm-dashboard/src/hooks/useDarkMode.ts
+++ b/ui/litellm-dashboard/src/hooks/useDarkMode.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+export const DARK_MODE_STORAGE_KEY = "litellm-dark-mode";
+
+export const readStoredDarkMode = (): boolean => {
+  if (typeof window === "undefined") return false;
+  const stored = localStorage.getItem(DARK_MODE_STORAGE_KEY);
+  if (stored === null) return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  return stored === "true";
+};
+
+export const useDarkMode = (): { isDarkMode: boolean; toggleDarkMode: () => void } => {
+  const [isDarkMode, setIsDarkMode] = useState<boolean>(readStoredDarkMode);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", isDarkMode);
+  }, [isDarkMode]);
+
+  const toggleDarkMode = () => {
+    setIsDarkMode((prev) => {
+      const next = !prev;
+      if (typeof window !== "undefined") {
+        localStorage.setItem(DARK_MODE_STORAGE_KEY, String(next));
+      }
+      return next;
+    });
+  };
+
+  return { isDarkMode, toggleDarkMode };
+};

--- a/ui/litellm-dashboard/tests/CreateKeyPage.expiredToken.test.tsx
+++ b/ui/litellm-dashboard/tests/CreateKeyPage.expiredToken.test.tsx
@@ -140,6 +140,14 @@ vi.mock("@/contexts/ThemeContext", () => {
   const React = require("react");
   return {
     ThemeProvider: ({ children }: any) => React.createElement(React.Fragment, null, children),
+    useTheme: () => ({
+      logoUrl: null,
+      setLogoUrl: () => {},
+      faviconUrl: null,
+      setFaviconUrl: () => {},
+      isDarkMode: false,
+      toggleDarkMode: () => {},
+    }),
   };
 });
 vi.mock("@/lib/cva.config", () => ({


### PR DESCRIPTION
## Relevant issues

Closes #10177

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

This enables dark mode for the admin dashboard. The navbar already shipped a dark-mode toggle that was scaffolded but gated off behind `{false && ...}`, with a note to keep it disabled until the dashboard supported dark styles end to end; this wires that toggle up and makes it work.

A shared `useDarkMode` hook owns the boolean. It persists the choice to `localStorage`, falls back to the OS `prefers-color-scheme` on first load, and toggles the `dark` class on the document element. The App Router dashboard layout, the legacy root page, and the public model hub all consume the same hook, so the toggle behaves consistently no matter which surface renders the navbar. Previously the legacy page kept its own local dark-mode state that did not persist or set the `dark` class, so Tremor components stayed light; routing it through the hook fixes that.

Ant Design is themed centrally through `getAntdTheme` on a `ConfigProvider` (dark algorithm plus component tokens for Menu, Table, Input, Modal, and friends). Tremor has no `ConfigProvider`, so its dark styling lives in `globals.css` keyed off the `.dark` class. An inline pre-hydration script in the root layout sets the `dark` class before first paint to avoid a flash of light mode.

The work targets `litellm_oss_branch` per the contribution flow for external PRs. The branch carries only UI changes; no `uv.lock`, dependency, or Python files are touched.

## Screenshots / Proof of Fix

To verify locally, run the dashboard and flip the Sun/Moon toggle in the navbar (top right). The selected mode persists across reloads, a fresh session follows the OS setting, and there is no flash of light mode on load. Worth checking the models table, logs, and the playground.
