### PR TITLE
[Fix] Key Info Page Internal Viewer Button Visibility

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -1,8 +1,8 @@
-import { render, waitFor, screen } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import useTeams from "@/app/(dashboard)/hooks/useTeams";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { KeyResponse, Team } from "../key_team_helpers/key_list";
 import KeyInfoView from "./key_info_view";
-import useTeams from "@/app/(dashboard)/hooks/useTeams";
 
 vi.mock("@/app/(dashboard)/hooks/useTeams", () => ({
   default: vi.fn(),
@@ -245,6 +245,34 @@ describe("KeyInfoView", () => {
         accessToken={"test-token"}
         userID={"other-user-id"}
         userRole={"user"}
+        premiumUser={true}
+        teams={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Regenerate Key")).not.toBeInTheDocument();
+      expect(screen.queryByText("Delete Key")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should not allow Internal Viewer to modify key even if they own it", async () => {
+    vi.mocked(useTeams).mockReturnValue({
+      teams: [],
+      setTeams: vi.fn(),
+    });
+
+    const ownerUserId = "internal-viewer-user-id";
+    const keyData = { ...MOCK_KEY_DATA, user_id: ownerUserId };
+    render(
+      <KeyInfoView
+        keyData={keyData}
+        onClose={() => {}}
+        keyId={"test-key-id"}
+        onKeyDataUpdate={() => {}}
+        accessToken={"test-token"}
+        userID={ownerUserId}
+        userRole={"Internal Viewer"}
         premiumUser={true}
         teams={[]}
       />,

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -302,6 +302,7 @@ export default function KeyInfoView({
     });
     return `${dateStr} at ${timeStr}`;
   };
+  console.log("userRole", userRole);
 
   const canModifyKey =
     isProxyAdminRole(userRole || "") ||
@@ -310,7 +311,7 @@ export default function KeyInfoView({
         teamsData?.filter((team) => team.team_id === currentKeyData.team_id)[0],
         userID || "",
       )) ||
-    userID === currentKeyData.user_id;
+    (userID === currentKeyData.user_id && userRole !== "Internal Viewer");
 
   return (
     <div className="w-full h-screen p-4">


### PR DESCRIPTION
## Relevant issues
Internal viewers cannot modify their own keys, so we should not show the regenerate and delete button to them.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="1040" height="247" alt="image" src="https://github.com/user-attachments/assets/387d85ad-f3ca-49af-ab3b-8015a102f807" />
<img width="1032" height="291" alt="image" src="https://github.com/user-attachments/assets/b6a79f42-5405-4f2a-86e4-ce17626766d8" />
<img width="822" height="182" alt="image" src="https://github.com/user-attachments/assets/492e8b56-3019-4e6e-93e3-326e17b8abea" />
