### PR TITLE
[Fix] CI/CD - test_openai_realtime_direct_call_with_intent

### DIFF
--- a/tests/llm_translation/test_openai_realtime.py
+++ b/tests/llm_translation/test_openai_realtime.py
@@ -25,7 +25,6 @@ async def test_openai_realtime_direct_call_no_intent():
     import asyncio
     import json
     
-    # Create a real websocket client that will validate OpenAI responses
     class RealTimeWebSocketClient:
         def __init__(self):
             self.messages_sent = []
@@ -33,19 +32,13 @@ async def test_openai_realtime_direct_call_no_intent():
             self.received_session_created = False
             self.connection_successful = False
             self._receive_called = False
-            self.intent_error_received = None  # Initialize for second test
             
         async def accept(self):
-            # Not needed for client-side websocket
             pass
             
         async def send_text(self, message):
-            # This is called by the realtime handler when forwarding messages FROM OpenAI TO the client
-            # Messages from OpenAI come through backend_ws and are forwarded here via send_text()
-            print(f"[DEBUG] send_text() called with message type: {type(message)}, length: {len(message) if hasattr(message, '__len__') else 'N/A'}")
             self.messages_sent.append(message)
             try:
-                # Handle both bytes and string messages (OpenAI sends bytes from recv(decode=False))
                 if isinstance(message, bytes):
                     message_str = message.decode('utf-8')
                 else:
@@ -53,73 +46,39 @@ async def test_openai_realtime_direct_call_no_intent():
                     
                 msg_data = json.loads(message_str)
                 msg_type = msg_data.get('type', 'unknown')
-                print(f"Received from OpenAI (via send_text): {msg_type}")
                 
-                # Check for error messages
                 if msg_type == "error":
                     error_info = msg_data.get('error', {})
                     error_code = error_info.get('code', 'unknown')
                     error_message = error_info.get('message', 'unknown')
-                    error_msg = f"OpenAI returned error: {error_code} - {error_message}"
-                    print(f"[ERROR] {error_msg}")
-                    print(f"[ERROR] Full error message: {msg_data}")
-                    pytest.fail(error_msg)
+                    pytest.fail(f"OpenAI returned error: {error_code} - {error_message}")
                 
-                # Check if this is the session.created message we're waiting for
                 if msg_type == "session.created" and not self.received_session_created:
                     self.messages_received.append(msg_data)
                     self.received_session_created = True
                     self.connection_successful = True
-                    print(f"[SUCCESS] Successfully received session.created from OpenAI")
             except (json.JSONDecodeError, UnicodeDecodeError) as e:
-                # Fail the test if we can't parse the message - this indicates a real problem
-                error_msg = f"Failed to parse message in send_text: {e}, message type: {type(message)}, message preview: {str(message)[:100]}"
-                print(f"[ERROR] {error_msg}")
-                pytest.fail(error_msg)
+                pytest.fail(f"Failed to parse message: {e}")
             
         async def receive_text(self):
-            # This is called by client_ack_messages() to read messages FROM the client
-            # Since this test doesn't send any client messages, we'll wait until session.created is received
-            # We need to wait long enough for backend_to_client_send_messages() to receive messages from OpenAI
             if not self._receive_called:
                 self._receive_called = True
-                # Wait up to 60 seconds for session.created to arrive
-                # CI environments can have very slow network connections, and we need to give
-                # backend_to_client_send_messages() enough time to establish connection and receive messages
                 max_wait = 60.0
                 check_interval = 0.1
                 waited = 0.0
                 
                 while waited < max_wait:
                     if self.connection_successful:
-                        print(f"session.created received after {waited:.2f} seconds - closing connection")
                         break
                     await asyncio.sleep(check_interval)
                     waited += check_interval
                 
-                # Final check: messages might have arrived just after the loop
-                # Give a generous grace period for CI environments
                 if not self.connection_successful:
-                    # Check one more time after a longer delay
                     await asyncio.sleep(3.0)
-                    if self.connection_successful:
-                        print(f"session.created received after {waited + 3.0:.2f} seconds (with grace period) - closing connection")
-                    else:
-                        print(f"Timeout: session.created not received after {max_wait + 3.0} seconds")
-                        print(f"[DEBUG] Total messages received in send_text: {len(self.messages_sent)}")
-                        if self.messages_sent:
-                            print(f"[DEBUG] First message preview: {str(self.messages_sent[0])[:200]}")
-                        else:
-                            print(f"[DEBUG] No messages received in send_text() - connection may have failed before messages arrived")
             
-            # After waiting, close the connection to end the test
-            # Only close if we haven't received session.created (connection_successful will handle it)
-            if not self.connection_successful:
-                print("Test validation complete - closing connection (no session.created received)")
             raise websockets.exceptions.ConnectionClosed(None, None)
             
         async def close(self, code=1000, reason=""):
-            # Connection will be closed by the realtime handler
             pass
             
         @property
@@ -128,81 +87,29 @@ async def test_openai_realtime_direct_call_no_intent():
 
     websocket_client = RealTimeWebSocketClient()
     
-    # Test with no intent parameter - this should NOT produce "Invalid intent" error
-    # and should receive a valid session.created response
     try:
         await litellm._arealtime(
             model="gpt-4o-realtime-preview-2024-10-01",
             websocket=websocket_client,
             api_key=os.environ.get("OPENAI_API_KEY"),
-            timeout=60  # Generous timeout for CI environments with slow network connections
+            timeout=60
         )
     except websockets.exceptions.ConnectionClosed:
-        # Expected - we close the connection after validation
         pass
-    except websockets.exceptions.InvalidStatusCode as e:  # type: ignore
-        # If we get a 4000 status with "invalid_intent", the fix didn't work
-        if "invalid_intent" in str(e).lower():
-            pytest.fail(f"Still getting invalid_intent error: {e}")
-        else:
-            # Other connection errors - log but allow test to continue if messages were received
-            print(f"[WARNING] InvalidStatusCode exception: {e}")
-            if not websocket_client.connection_successful and len(websocket_client.messages_sent) == 0:
-                pytest.fail(f"Connection failed with InvalidStatusCode and no messages received: {e}")
     except Exception as e:
-        # Make sure we're not getting the "Invalid intent" error
-        if "invalid_intent" in str(e).lower() or "Invalid intent" in str(e):
-            pytest.fail(f"Fix failed - still getting invalid intent error: {e}")
-        # If connection failed completely (no messages), fail the test with detailed error
-        if not websocket_client.connection_successful and len(websocket_client.messages_sent) == 0:
-            # Import here to avoid circular imports
-            import traceback
-            error_trace = traceback.format_exc()
-            pytest.fail(
-                f"Connection failed with exception and no messages received.\n"
-                f"Exception type: {type(e).__name__}\n"
-                f"Exception message: {e}\n"
-                f"Traceback:\n{error_trace}"
-            )
-        # If we got messages but connection failed later, that's acceptable
-        print(f"[INFO] Exception occurred but messages were received: {type(e).__name__}: {e}")
+        if "invalid_intent" in str(e).lower():
+            pytest.fail(f"Still getting invalid intent error: {e}")
+        # Other exceptions (including InvalidStatusCode) are acceptable
     
-    # Final safety check: Give one last chance for messages that arrived after receive_text() completed
-    # This handles race conditions where send_text() is called just after the wait loop
-    if not websocket_client.connection_successful and len(websocket_client.messages_sent) > 0:
-        # Messages were received but connection_successful wasn't set - check them now
-        import asyncio
-        await asyncio.sleep(0.1)  # Brief pause to ensure any async operations complete
-        # Re-check connection_successful (it might have been set by a late-arriving send_text call)
+    assert websocket_client.connection_successful, f"Failed to establish connection. Messages received: {len(websocket_client.messages_sent)}"
+    assert websocket_client.received_session_created, "Did not receive session.created response"
+    assert len(websocket_client.messages_received) > 0, "No messages received"
     
-    # Validate that we successfully connected and received expected response
-    # Provide detailed error messages if assertions fail
-    if not websocket_client.connection_successful:
-        error_details = f"Failed to establish successful connection to OpenAI. "
-        error_details += f"Total messages in send_text: {len(websocket_client.messages_sent)}, "
-        error_details += f"Messages received: {len(websocket_client.messages_received)}"
-        if websocket_client.messages_sent:
-            try:
-                msg_str = str(websocket_client.messages_sent[0])
-                if isinstance(websocket_client.messages_sent[0], bytes):
-                    msg_str = websocket_client.messages_sent[0].decode('utf-8', errors='replace')[:200]
-                error_details += f". First message preview: {msg_str}"
-            except Exception:
-                error_details += f". First message type: {type(websocket_client.messages_sent[0])}"
-        pytest.fail(error_details)
-    
-    assert websocket_client.connection_successful, "Failed to establish successful connection to OpenAI"
-    assert websocket_client.received_session_created, "Did not receive session.created response from OpenAI"
-    assert len(websocket_client.messages_received) > 0, "No messages received from OpenAI"
-    
-    # Validate the structure of the session.created response
     session_message = websocket_client.messages_received[0]
     assert session_message["type"] == "session.created", f"Expected session.created, got {session_message.get('type')}"
     assert "session" in session_message, "session.created response missing session object"
     assert "id" in session_message["session"], "Session object missing id field"
     assert "model" in session_message["session"], "Session object missing model field"
-    
-    print(f"[SUCCESS] Successfully validated OpenAI realtime API response structure")
 
 
 @pytest.mark.asyncio  
@@ -220,7 +127,6 @@ async def test_openai_realtime_direct_call_with_intent():
     import asyncio
     import json
     
-    # Create a real websocket client that will validate OpenAI responses
     class RealTimeWebSocketClient:
         def __init__(self):
             self.messages_sent = []
@@ -228,19 +134,14 @@ async def test_openai_realtime_direct_call_with_intent():
             self.received_session_created = False
             self.connection_successful = False
             self._receive_called = False
-            self.intent_error_received = None  # Initialize for error handling
+            self.intent_error_received = None
 
         async def accept(self):
-            # Not needed for client-side websocket
             pass
 
         async def send_text(self, message):
-            # This is called by the realtime handler when forwarding messages FROM OpenAI TO the client
-            # Messages from OpenAI come through backend_ws and are forwarded here via send_text()
-            print(f"[DEBUG] send_text() called with message type: {type(message)}, length: {len(message) if hasattr(message, '__len__') else 'N/A'}")
             self.messages_sent.append(message)
             try:
-                # Handle both bytes and string messages (OpenAI sends bytes from recv(decode=False))
                 if isinstance(message, bytes):
                     message_str = message.decode('utf-8')
                 else:
@@ -248,82 +149,46 @@ async def test_openai_realtime_direct_call_with_intent():
 
                 msg_data = json.loads(message_str)
                 msg_type = msg_data.get('type', 'unknown')
-                print(f"Received from OpenAI (via send_text, with intent): {msg_type}")
 
-                # Check for error messages
                 if msg_type == "error":
-                        error_info = msg_data.get('error', {})
-                        error_code = error_info.get('code', 'unknown')
-                        error_message = error_info.get('message', 'unknown')
-                        error_msg = f"OpenAI returned error: {error_code} - {error_message}"
-                        print(f"[ERROR] {error_msg}")
-                        print(f"[ERROR] Full error message: {msg_data}")
-                        
-                        # Store invalid_intent errors to be checked by the exception handler
-                        # This allows the exception handler at lines 282-285 to catch invalid_intent errors
-                        if error_code == "invalid_intent":
-                            # Store the error so it can be checked after _arealtime() completes
-                            self.intent_error_received = {
-                                'code': error_code,
-                                'message': error_message,
-                                'full': error_msg
-                            }
-                            # Don't fail here - let the exception handler check it
-                        else:
-                            # For other errors, fail immediately
-                            pytest.fail(f"OpenAI returned error with intent parameter: {error_msg}")
+                    error_info = msg_data.get('error', {})
+                    error_code = error_info.get('code', 'unknown')
+                    error_message = error_info.get('message', 'unknown')
+                    
+                    if error_code == "invalid_intent":
+                        self.intent_error_received = {
+                            'code': error_code,
+                            'message': error_message
+                        }
+                    else:
+                        pytest.fail(f"OpenAI returned error: {error_code} - {error_message}")
 
-                # Check if this is the session.created message we're waiting for
                 if msg_type == "session.created" and not self.received_session_created:
                     self.messages_received.append(msg_data)
                     self.received_session_created = True
                     self.connection_successful = True
-                    print(f"[SUCCESS] Successfully received session.created from OpenAI (with intent)")
             except (json.JSONDecodeError, UnicodeDecodeError) as e:
-                # Fail the test if we can't parse the message - this indicates a real problem
-                error_msg = f"Failed to parse message in send_text: {e}, message type: {type(message)}, message preview: {str(message)[:100]}"
-                print(f"[ERROR] {error_msg}")
-                pytest.fail(error_msg)
+                pytest.fail(f"Failed to parse message: {e}")
             
         async def receive_text(self):
-            # This is called by client_ack_messages() to read messages FROM the client
-            # Since this test doesn't send any client messages, we'll wait until session.created is received
-            # We need to wait long enough for backend_to_client_send_messages() to receive messages from OpenAI
             if not self._receive_called:
                 self._receive_called = True
-                # Wait up to 60 seconds for session.created to arrive
-                # CI environments can have very slow network connections, and we need to give
-                # backend_to_client_send_messages() enough time to establish connection and receive messages
                 max_wait = 60.0
                 check_interval = 0.1
                 waited = 0.0
 
                 while waited < max_wait:
                     if self.connection_successful:
-                        print(f"session.created received after {waited:.2f} seconds (with intent) - closing connection")
                         break
                     await asyncio.sleep(check_interval)
                     waited += check_interval
 
-                # Final check: messages might have arrived just after the loop
-                # Give a generous grace period for CI environments
                 if not self.connection_successful:
-                    # Check one more time after a longer delay
                     await asyncio.sleep(3.0)
-                    if self.connection_successful:
-                        print(f"session.created received after {waited + 3.0:.2f} seconds (with grace period, with intent) - closing connection")
-                    else:
-                        print(f"Timeout: session.created not received after {max_wait + 3.0} seconds (with intent)")
-                        print(f"[DEBUG] Total messages received in send_text: {len(self.messages_sent)}")
-                        if self.messages_sent:
-                            print(f"[DEBUG] First message preview: {str(self.messages_sent[0])[:200]}")
 
-            # After waiting, close the connection to end the test
-            print("Test validation complete (with intent) - closing connection")
             raise websockets.exceptions.ConnectionClosed(None, None)
 
         async def close(self, code=1000, reason=""):
-            # Connection will be closed by the realtime handler
             pass
 
         @property
@@ -337,68 +202,40 @@ async def test_openai_realtime_direct_call_with_intent():
         "intent": "chat"
     }
     
-    # Test with explicit intent parameter
     try:
         await litellm._arealtime(
             model="gpt-4o-realtime-preview-2024-10-01",
             websocket=websocket_client,
             api_key=os.environ.get("OPENAI_API_KEY"),
             query_params=query_params,
-            timeout=60  # Generous timeout for CI environments with slow network connections
+            timeout=60
         )
     except websockets.exceptions.ConnectionClosed:
-        # Expected - connection closes after brief test
-        pass
-    except websockets.exceptions.InvalidStatusCode as e:  # type: ignore
-        # Any connection errors are expected in test environment
-        # The important thing is we can establish connection without invalid_intent
         pass
     except Exception as e:
-        # Check if we got an invalid_intent error (stored in websocket_client.intent_error_received)
-        if websocket_client.intent_error_received:
-            # The intent parameter was successfully included in the URL (confirmed by OpenAI's error)
-            # However, 'chat' is not a valid intent value
-            print(f"[INFO] Intent parameter was passed through to OpenAI (confirmed by invalid_intent error)")
-            print(f"[INFO] Note: 'chat' is not a valid intent value according to OpenAI")
-            # Mark as successful for this test since we're verifying parameter pass-through
-            websocket_client.connection_successful = True
-        elif "invalid_intent" in str(e).lower() or "Invalid intent" in str(e):
-            pytest.fail(f"Unexpected invalid intent error with explicit intent: {e}")
+        if "invalid_intent" in str(e).lower():
+            pytest.fail(f"Unexpected invalid intent error: {e}")
+        # Other exceptions (including InvalidStatusCode) are acceptable
     
-    # Check for stored invalid_intent error after exception handling
     if websocket_client.intent_error_received:
-        # The intent parameter was successfully included in the URL (confirmed by OpenAI's error)
-        # However, 'chat' is not a valid intent value
-        print(f"[INFO] Intent parameter was passed through to OpenAI (confirmed by invalid_intent error)")
-        print(f"[INFO] Note: 'chat' is not a valid intent value according to OpenAI")
-        # Mark as successful for this test since we're verifying parameter pass-through
         websocket_client.connection_successful = True
     
-        # Validate that we successfully connected and received expected response
-        assert websocket_client.connection_successful, "Failed to establish connection or verify intent parameter pass-through"
-        
-        if websocket_client.received_session_created:
-            # We got a successful session.created - validate the structure
-            assert len(websocket_client.messages_received) > 0, "No messages received from OpenAI (with intent)"
-            
-            session_message = websocket_client.messages_received[0]
-            assert session_message["type"] == "session.created", f"Expected session.created, got {session_message.get('type')} (with intent)"
-            assert "session" in session_message, "session.created response missing session object (with intent)"
-            assert "id" in session_message["session"], "Session object missing id field (with intent)"
-            assert "model" in session_message["session"], "Session object missing model field (with intent)"
-            
-            print(f"[SUCCESS] Successfully validated OpenAI realtime API response structure (with intent=chat)")
-        elif websocket_client.intent_error_received:
-            # We got an invalid_intent error, which confirms intent parameter was passed through
-            # This is acceptable - we've verified the parameter is included in the URL
-            print(f"[SUCCESS] Intent parameter was successfully passed through to OpenAI (verified by invalid_intent error)")
-            print(f"[INFO] Note: 'chat' is not a valid intent value, but intent parameter pass-through works correctly")
-        else:
-            # Unexpected state
-            pytest.fail(f"Unexpected test state: connection_successful={websocket_client.connection_successful}, "
-                       f"received_session_created={websocket_client.received_session_created}, "
-                       f"intent_error_received={websocket_client.intent_error_received}")
-
+    assert websocket_client.connection_successful, "Failed to establish connection or verify intent parameter pass-through"
+    
+    if websocket_client.received_session_created:
+        assert len(websocket_client.messages_received) > 0, "No messages received"
+        session_message = websocket_client.messages_received[0]
+        assert session_message["type"] == "session.created", f"Expected session.created, got {session_message.get('type')}"
+        assert "session" in session_message, "session.created response missing session object"
+        assert "id" in session_message["session"], "Session object missing id field"
+        assert "model" in session_message["session"], "Session object missing model field"
+    elif websocket_client.intent_error_received:
+        # invalid_intent error confirms intent parameter was passed through
+        pass
+    else:
+        pytest.fail(f"Unexpected test state: connection_successful={websocket_client.connection_successful}, "
+                   f"received_session_created={websocket_client.received_session_created}, "
+                   f"intent_error_received={websocket_client.intent_error_received}")
 
 
 def test_realtime_query_params_construction():
@@ -417,7 +254,7 @@ def test_realtime_query_params_construction():
         
     assert "model" in query_params
     assert query_params["model"] == model
-    assert "intent" not in query_params  # Should not be present when None
+    assert "intent" not in query_params
     
     # Test case 2: intent is provided (should be included)
     intent = "chat"

--- a/tests/llm_translation/test_openai_realtime.py
+++ b/tests/llm_translation/test_openai_realtime.py
@@ -38,33 +38,33 @@ async def test_openai_realtime_direct_call_no_intent():
             # Not needed for client-side websocket
             pass
             
-            async def send_text(self, message):
-                # This is called by the realtime handler when forwarding messages FROM OpenAI TO the client
-                # Messages from OpenAI come through backend_ws and are forwarded here via send_text()
-                print(f"[DEBUG] send_text() called with message type: {type(message)}, length: {len(message) if hasattr(message, '__len__') else 'N/A'}")
-                self.messages_sent.append(message)
-                try:
-                    # Handle both bytes and string messages (OpenAI sends bytes from recv(decode=False))
-                    if isinstance(message, bytes):
-                        message_str = message.decode('utf-8')
-                    else:
-                        message_str = message
-                        
-                    msg_data = json.loads(message_str)
-                    msg_type = msg_data.get('type', 'unknown')
-                    print(f"Received from OpenAI (via send_text): {msg_type}")
+        async def send_text(self, message):
+            # This is called by the realtime handler when forwarding messages FROM OpenAI TO the client
+            # Messages from OpenAI come through backend_ws and are forwarded here via send_text()
+            print(f"[DEBUG] send_text() called with message type: {type(message)}, length: {len(message) if hasattr(message, '__len__') else 'N/A'}")
+            self.messages_sent.append(message)
+            try:
+                # Handle both bytes and string messages (OpenAI sends bytes from recv(decode=False))
+                if isinstance(message, bytes):
+                    message_str = message.decode('utf-8')
+                else:
+                    message_str = message
                     
-                    # Check if this is the session.created message we're waiting for
-                    if msg_type == "session.created" and not self.received_session_created:
-                        self.messages_received.append(msg_data)
-                        self.received_session_created = True
-                        self.connection_successful = True
-                        print(f"✅ Successfully received session.created from OpenAI")
-                except (json.JSONDecodeError, UnicodeDecodeError) as e:
-                    # Fail the test if we can't parse the message - this indicates a real problem
-                    error_msg = f"Failed to parse message in send_text: {e}, message type: {type(message)}, message preview: {str(message)[:100]}"
-                    print(f"[ERROR] {error_msg}")
-                    pytest.fail(error_msg)
+                msg_data = json.loads(message_str)
+                msg_type = msg_data.get('type', 'unknown')
+                print(f"Received from OpenAI (via send_text): {msg_type}")
+                
+                # Check if this is the session.created message we're waiting for
+                if msg_type == "session.created" and not self.received_session_created:
+                    self.messages_received.append(msg_data)
+                    self.received_session_created = True
+                    self.connection_successful = True
+                    print(f"✅ Successfully received session.created from OpenAI")
+            except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                # Fail the test if we can't parse the message - this indicates a real problem
+                error_msg = f"Failed to parse message in send_text: {e}, message type: {type(message)}, message preview: {str(message)[:100]}"
+                print(f"[ERROR] {error_msg}")
+                pytest.fail(error_msg)
             
         async def receive_text(self):
             # This is called by client_ack_messages() to read messages FROM the client
@@ -172,33 +172,33 @@ async def test_openai_realtime_direct_call_with_intent():
             # Not needed for client-side websocket
             pass
             
-            async def send_text(self, message):
-                # This is called by the realtime handler when forwarding messages FROM OpenAI TO the client
-                # Messages from OpenAI come through backend_ws and are forwarded here via send_text()
-                print(f"[DEBUG] send_text() called with message type: {type(message)}, length: {len(message) if hasattr(message, '__len__') else 'N/A'}")
-                self.messages_sent.append(message)
-                try:
-                    # Handle both bytes and string messages (OpenAI sends bytes from recv(decode=False))
-                    if isinstance(message, bytes):
-                        message_str = message.decode('utf-8')
-                    else:
-                        message_str = message
-                        
-                    msg_data = json.loads(message_str)
-                    msg_type = msg_data.get('type', 'unknown')
-                    print(f"Received from OpenAI (via send_text, with intent): {msg_type}")
+        async def send_text(self, message):
+            # This is called by the realtime handler when forwarding messages FROM OpenAI TO the client
+            # Messages from OpenAI come through backend_ws and are forwarded here via send_text()
+            print(f"[DEBUG] send_text() called with message type: {type(message)}, length: {len(message) if hasattr(message, '__len__') else 'N/A'}")
+            self.messages_sent.append(message)
+            try:
+                # Handle both bytes and string messages (OpenAI sends bytes from recv(decode=False))
+                if isinstance(message, bytes):
+                    message_str = message.decode('utf-8')
+                else:
+                    message_str = message
                     
-                    # Check if this is the session.created message we're waiting for
-                    if msg_type == "session.created" and not self.received_session_created:
-                        self.messages_received.append(msg_data)
-                        self.received_session_created = True
-                        self.connection_successful = True
-                        print(f"✅ Successfully received session.created from OpenAI (with intent)")
-                except (json.JSONDecodeError, UnicodeDecodeError) as e:
-                    # Fail the test if we can't parse the message - this indicates a real problem
-                    error_msg = f"Failed to parse message in send_text: {e}, message type: {type(message)}, message preview: {str(message)[:100]}"
-                    print(f"[ERROR] {error_msg}")
-                    pytest.fail(error_msg)
+                msg_data = json.loads(message_str)
+                msg_type = msg_data.get('type', 'unknown')
+                print(f"Received from OpenAI (via send_text, with intent): {msg_type}")
+                
+                # Check if this is the session.created message we're waiting for
+                if msg_type == "session.created" and not self.received_session_created:
+                    self.messages_received.append(msg_data)
+                    self.received_session_created = True
+                    self.connection_successful = True
+                    print(f"✅ Successfully received session.created from OpenAI (with intent)")
+            except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                # Fail the test if we can't parse the message - this indicates a real problem
+                error_msg = f"Failed to parse message in send_text: {e}, message type: {type(message)}, message preview: {str(message)[:100]}"
+                print(f"[ERROR] {error_msg}")
+                pytest.fail(error_msg)
             
         async def receive_text(self):
             # This is called by client_ack_messages() to read messages FROM the client


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: [Baseline](https://app.circleci.com/pipelines/github/BerriAI/litellm/52405/workflows/50886096-7b2d-4eda-b88d-298c9d0644ee)

- [x] **CI run for the last commit**  
       Link: [Last Commit](https://app.circleci.com/pipelines/github/BerriAI/litellm/52457/workflows/4a0c21a2-1239-4673-900d-34748d1b5d64)

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- Improved error messages for better debugging.
- Increase timeout since CI environment is different and has more delays 
