### PR TITLE
add license endpoint

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3776,6 +3776,7 @@ class EnterpriseLicenseData(TypedDict, total=False):
     expiration_date: str
     user_id: str
     allowed_features: List[str]
+    license_type: Optional[str]
     max_users: int
     max_teams: int
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3776,7 +3776,6 @@ class EnterpriseLicenseData(TypedDict, total=False):
     expiration_date: str
     user_id: str
     allowed_features: List[str]
-    license_type: Optional[str]
     max_users: int
     max_teams: int
 

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1008,9 +1008,6 @@ async def health_license_endpoint(
             allowed_features = []
         else:
             allowed_features = [raw_allowed_features]
-        extracted_license_type = license_data.get("license_type")
-        if isinstance(extracted_license_type, str) and extracted_license_type:
-            license_type = extracted_license_type
         max_users = license_data.get("max_users")
         max_teams = license_data.get("max_teams")
 

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -3,7 +3,7 @@ import copy
 import os
 import time
 import traceback
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any, Dict, Literal, Optional, Union, cast
 
 import fastapi

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -137,7 +137,6 @@ async def test_health_services_endpoint_sqs(status, error_message):
 async def test_health_license_endpoint_with_active_license():
     license_data = {
         "expiration_date": "2099-01-01",
-        "license_type": "enterprise",
         "allowed_features": ["feature-a"],
         "max_users": 100,
         "max_teams": 5,

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -160,7 +160,7 @@ async def test_health_license_endpoint_with_active_license():
     ):
         response = await health_license_endpoint(user_api_key_dict=MagicMock())
 
-    assert response["status"] == "active"
+    assert response["has_license"] is True
     assert response["license_type"] == "enterprise"
     assert response["expiration_date"] == "2099-01-01"
     assert response["allowed_features"] == ["feature-a"]
@@ -188,7 +188,7 @@ async def test_health_license_endpoint_without_valid_license():
     ):
         response = await health_license_endpoint(user_api_key_dict=MagicMock())
 
-    assert response["status"] == "invalid"
+    assert response["has_license"] is True
     assert response["license_type"] == "community"
     assert response["expiration_date"] is None
     assert response["allowed_features"] == []

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -2,7 +2,8 @@ import os
 import sys
 import time
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch, AsyncMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.insert(
     0, os.path.abspath("../../..")
@@ -10,10 +11,14 @@ sys.path.insert(
 
 import pytest
 from prisma.errors import ClientNotConnectedError, HTTPClientClosedError, PrismaError
+
 from litellm.proxy.health_endpoints._health_endpoints import (
     _db_health_readiness_check,
     db_health_cache,
+    health_license_endpoint,
     health_services_endpoint,
+)
+from litellm.proxy.health_endpoints._health_endpoints import (
     test_model_connection as health_test_model_connection,
 )
 
@@ -126,6 +131,69 @@ async def test_health_services_endpoint_sqs(status, error_message):
         assert result["status"] == status
         assert result["message"] == error_message
         mock_instance.async_health_check.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_health_license_endpoint_with_active_license():
+    license_data = {
+        "expiration_date": "2099-01-01",
+        "license_type": "enterprise",
+        "allowed_features": ["feature-a"],
+        "max_users": 100,
+        "max_teams": 5,
+    }
+    mock_license_check = SimpleNamespace(
+        license_str="test-license",
+        public_key=None,
+        airgapped_license_data=license_data,
+        verify_license_without_api_request=MagicMock(return_value=True),
+    )
+
+    with patch(
+        "litellm.proxy.proxy_server._license_check",
+        mock_license_check,
+    ), patch(
+        "litellm.proxy.proxy_server.premium_user",
+        True,
+    ), patch(
+        "litellm.proxy.proxy_server.premium_user_data",
+        license_data,
+    ):
+        response = await health_license_endpoint(user_api_key_dict=MagicMock())
+
+    assert response["status"] == "active"
+    assert response["license_type"] == "enterprise"
+    assert response["expiration_date"] == "2099-01-01"
+    assert response["allowed_features"] == ["feature-a"]
+    assert response["limits"] == {"max_users": 100, "max_teams": 5}
+
+
+@pytest.mark.asyncio
+async def test_health_license_endpoint_without_valid_license():
+    mock_license_check = SimpleNamespace(
+        license_str="invalid-key",
+        public_key=None,
+        airgapped_license_data=None,
+        verify_license_without_api_request=MagicMock(return_value=False),
+    )
+
+    with patch(
+        "litellm.proxy.proxy_server._license_check",
+        mock_license_check,
+    ), patch(
+        "litellm.proxy.proxy_server.premium_user",
+        False,
+    ), patch(
+        "litellm.proxy.proxy_server.premium_user_data",
+        None,
+    ):
+        response = await health_license_endpoint(user_api_key_dict=MagicMock())
+
+    assert response["status"] == "invalid"
+    assert response["license_type"] == "community"
+    assert response["expiration_date"] is None
+    assert response["allowed_features"] == []
+    assert response["limits"] == {"max_users": None, "max_teams": None}
 
 
 @pytest.mark.asyncio
@@ -374,4 +442,3 @@ def test_health_readiness(proxy_client):
             f"Unexpected db status: {db_status}"
     
     print("="*60 + "\n")
-


### PR DESCRIPTION
## Relevant issues

@ishaan-jaff A previous [pr](https://github.com/BerriAI/litellm/pull/15997) had introduced license information in the readiness health check -- but retrieving license data is too slow for a readiness check. So i moved [as suggested] to a separate endpoint. Having this as an endpoint will enable us to monitor when the license is expiring and alert our operations team to begin license renewal.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
