### PR TITLE
Use tempfile for proxy UI/assets cache

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12,6 +12,7 @@ import time
 import traceback
 import warnings
 from datetime import datetime, timedelta
+import tempfile
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -946,7 +947,7 @@ try:
     # This prevents mutating the packaged UI directory (e.g. site-packages or the repo checkout)
     # and ensures extensionless routes like /ui/login work via <route>/index.html.
     is_non_root = os.getenv("LITELLM_NON_ROOT", "").lower() == "true"
-    runtime_ui_path = "/tmp/litellm_ui"
+    runtime_ui_path = os.path.join(tempfile.gettempdir(), "litellm_ui")
 
     if _dir_has_content(runtime_ui_path):
         if is_non_root:
@@ -8884,7 +8885,11 @@ def get_image():
     default_site_logo = os.path.join(current_dir, "logo.jpg")
 
     is_non_root = os.getenv("LITELLM_NON_ROOT", "").lower() == "true"
-    assets_dir = "/tmp/litellm_assets" if is_non_root else current_dir
+    assets_dir = (
+        os.path.join(tempfile.gettempdir(), "litellm_assets")
+        if is_non_root
+        else current_dir
+    )
 
     if is_non_root:
         os.makedirs(assets_dir, exist_ok=True)


### PR DESCRIPTION
Removes the usage of hardcoded temp dirs in `litellm/proxy/proxy_server.py` (`/tmp/litellm_ui` and `/tmp/litellm_assets`).
Addressing the security concern CWE‑377: using predictable, hardcoded temporary directories can enable symlink or race attacks, especially in shared or non-root environments, and is less portable across platforms.

The fix replaces those hardcoded paths with `tempfile.gettempdir()` so the temp location is OS‑appropriate and less error‑prone while preserving the same runtime behavior for non‑root setups.

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
🐛 Bug Fix

## Changes
