### PR TITLE
fix: lost tool_calls when streaming has both text and tool_calls

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -740,9 +740,7 @@ class LiteLLMAnthropicMessagesAdapter:
         from litellm.types.llms.anthropic import TextBlock, ToolUseBlock
 
         for choice in choices:
-            if choice.delta.content is not None and len(choice.delta.content) > 0:
-                return "text", TextBlock(type="text", text="")
-            elif (
+            if (
                 choice.delta.tool_calls is not None
                 and len(choice.delta.tool_calls) > 0
                 and choice.delta.tool_calls[0].function is not None
@@ -753,6 +751,8 @@ class LiteLLMAnthropicMessagesAdapter:
                     name=choice.delta.tool_calls[0].function.name or "",
                     input={},  # type: ignore[typeddict-item]
                 )
+            elif choice.delta.content is not None and len(choice.delta.content) > 0:
+                return "text", TextBlock(type="text", text="")
             elif isinstance(choice, StreamingChoices) and hasattr(
                 choice.delta, "thinking_blocks"
             ):
@@ -796,7 +796,7 @@ class LiteLLMAnthropicMessagesAdapter:
         for choice in choices:
             if choice.delta.content is not None and len(choice.delta.content) > 0:
                 text += choice.delta.content
-            elif choice.delta.tool_calls is not None:
+            if choice.delta.tool_calls is not None:
                 partial_json = ""
                 for tool in choice.delta.tool_calls:
                     if (


### PR DESCRIPTION
## Relevant issues

Fixes #18238

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### Problem

When a streaming choice contains both text content &  tool_calls, the tool_calls were ignored due to the use of `elif`. This caused the tool name to be lost.

### Solution

1. Changed `elif` to `if` in [_translate_streaming_openai_chunk_to_anthropic](cci:1://file:///d:/OSS/litellm/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py:779:4-840:84) so both text & tool_calls are processed when both exist.

2. Reordered checks in [_translate_streaming_openai_chunk_to_anthropic_content_block](cci:1://file:///d:/OSS/litellm/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py:732:4-777:54) so tool_calls are checked first. Tool names are critical and appear only once, so they should take priority.

### Testing

Added [test_streaming_chunk_with_both_text_and_tool_calls_issue_18238](cci:1://file:///d:/OSS/litellm/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py:1059:0-1109:77) to verify both text and tool_calls are processed correctly when both exist in the same streaming chunk.