### PR TITLE
feat: datadog log trace linking

### DIFF
--- a/litellm/types/integrations/datadog.py
+++ b/litellm/types/integrations/datadog.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from litellm.types.integrations.custom_logger import StandardCustomLoggerInitParams
 
@@ -14,13 +14,20 @@ class DataDogStatus(str, Enum):
     ERROR = "error"
 
 
-class DatadogPayload(TypedDict, total=False):
-    ddsource: str
-    ddtags: str
-    hostname: str
-    message: str
-    service: str
-    status: str
+DatadogPayload = TypedDict(
+    "DatadogPayload",
+    {
+        "ddsource": str,
+        "ddtags": str,
+        "hostname": str,
+        "message": str,
+        "service": str,
+        "status": str,
+        "dd.trace_id": NotRequired[str],
+        "dd.span_id": NotRequired[str],
+    },
+    total=False,
+)
 
 
 class DD_ERRORS(Enum):


### PR DESCRIPTION
## Relevant issues

LIT-1575

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/52476/workflows/d0891cd7-73d6-4373-990d-e3e7ef316809

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/52480/workflows/a55da074-fa98-467f-bc40-92544a97bfbd

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
✅ Test

## Changes

This PR adds log-trace correlation for Datadog by injecting `dd.trace_id` and `dd.span_id` into logs, so logs and traces are properly linked in the Datadog UI.

<img width="1521" height="640" alt="image" src="https://github.com/user-attachments/assets/77161c44-1266-41a7-97f0-8c05776b603e" />
