### PR TITLE
fix: vertex binary issue

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2818,9 +2818,7 @@ class BaseLLMHTTPHandler:
             transformed_request, bytes
         ):
             # Handle traditional file uploads
-            # Ensure transformed_request is a string for httpx compatibility
-            if isinstance(transformed_request, bytes):
-                transformed_request = transformed_request.decode("utf-8")
+            # httpx accepts both str and bytes for the data parameter
 
             # Use the HTTP method specified by the provider config
             http_method = provider_config.file_upload_http_method.upper()
@@ -2828,14 +2826,14 @@ class BaseLLMHTTPHandler:
                 upload_response = sync_httpx_client.put(
                     url=api_base,
                     headers=headers,
-                    data=transformed_request,
+                    content=transformed_request,
                     timeout=timeout,
                 )
             else:  # Default to POST
                 upload_response = sync_httpx_client.post(
                     url=api_base,
                     headers=headers,
-                    data=transformed_request,
+                    content=transformed_request,
                     timeout=timeout,
                 )
         else:
@@ -2929,9 +2927,7 @@ class BaseLLMHTTPHandler:
             transformed_request, bytes
         ):
             # Handle traditional file uploads
-            # Ensure transformed_request is a string for httpx compatibility
-            if isinstance(transformed_request, bytes):
-                transformed_request = transformed_request.decode("utf-8")
+            # httpx accepts both str and bytes for the content parameter
 
             # Use the HTTP method specified by the provider config
             http_method = provider_config.file_upload_http_method.upper()
@@ -2939,14 +2935,14 @@ class BaseLLMHTTPHandler:
                 upload_response = await async_httpx_client.put(
                     url=api_base,
                     headers=headers,
-                    data=transformed_request,
+                    content=transformed_request,
                     timeout=timeout,
                 )
             else:  # Default to POST
                 upload_response = await async_httpx_client.post(
                     url=api_base,
                     headers=headers,
-                    data=transformed_request,
+                    content=transformed_request,
                     timeout=timeout,
                 )
         else:

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2818,9 +2818,6 @@ class BaseLLMHTTPHandler:
             transformed_request, bytes
         ):
             # Handle traditional file uploads
-            # httpx accepts both str and bytes for the data parameter
-
-            # Use the HTTP method specified by the provider config
             http_method = provider_config.file_upload_http_method.upper()
             if http_method == "PUT":
                 upload_response = sync_httpx_client.put(
@@ -2927,9 +2924,6 @@ class BaseLLMHTTPHandler:
             transformed_request, bytes
         ):
             # Handle traditional file uploads
-            # httpx accepts both str and bytes for the content parameter
-
-            # Use the HTTP method specified by the provider config
             http_method = provider_config.file_upload_http_method.upper()
             if http_method == "PUT":
                 upload_response = await async_httpx_client.put(

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -224,8 +224,10 @@ async def test_async_create_file_handles_binary_data():
     """
     handler = BaseLLMHTTPHandler()
 
+    # Binary content with invalid UTF-8 bytes (would fail decode)
     binary_content = bytes([0xFF, 0xFE, 0x00, 0x01, 0x02, 0x03, 0x50, 0x44, 0x46])
 
+    # Mock the provider config
     mock_provider_config = Mock()
     mock_provider_config.custom_llm_provider = "vertex_ai"
     mock_provider_config.file_upload_http_method = "POST"
@@ -233,15 +235,18 @@ async def test_async_create_file_handles_binary_data():
         return_value={"id": "file-123", "object": "file"}
     )
 
+    # Mock the logging object
     mock_logging_obj = Mock()
     mock_logging_obj.pre_call = Mock()
 
+    # Mock the response
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.json.return_value = {"id": "file-123", "object": "file"}
     mock_response.headers = {}
     mock_response.text = '{"id": "file-123", "object": "file"}'
 
+    # Mock the async client
     mock_async_client = AsyncMock()
     mock_async_client.post = AsyncMock(return_value=mock_response)
 
@@ -260,6 +265,7 @@ async def test_async_create_file_handles_binary_data():
             timeout=30.0,
         )
 
+    # Verify binary content was passed directly without modification
     mock_async_client.post.assert_called_once()
     call_kwargs = mock_async_client.post.call_args.kwargs
 

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1,7 +1,8 @@
 import os
 import sys
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+import httpx
 import pytest
 
 sys.path.insert(
@@ -215,3 +216,125 @@ async def test_async_anthropic_messages_handler_header_priority():
         assert captured_headers["X-Forwarded-Only"] == "keep"
         assert captured_headers["X-Extra-Only"] == "also-keep"
         assert captured_headers["X-Provider-Only"] == "keep-this-too"
+
+
+@pytest.mark.asyncio
+async def test_async_create_file_handles_binary_data():
+    """
+    Test that async_create_file correctly handles binary file data without
+    attempting to decode it as UTF-8.
+    
+    This test ensures that binary files (PDFs, images, etc.) can be uploaded
+    without encountering UnicodeDecodeError.
+    
+    Regression test for: UnicodeDecodeError when uploading binary files to Vertex AI
+    """
+    handler = BaseLLMHTTPHandler()
+    
+    # Create binary data that would fail UTF-8 decoding
+    # 0xFF and 0xFE are not valid UTF-8 start bytes
+    binary_content = bytes([0xFF, 0xFE, 0x00, 0x01, 0x02, 0x03, 0x50, 0x44, 0x46])
+    
+    # Mock provider config
+    mock_provider_config = Mock()
+    mock_provider_config.custom_llm_provider = "vertex_ai"
+    mock_provider_config.file_upload_http_method = "POST"
+    mock_provider_config.transform_file_upload_response = Mock(
+        return_value={"id": "file-123", "object": "file"}
+    )
+    
+    # Mock logging object
+    mock_logging_obj = Mock()
+    mock_logging_obj.pre_call = Mock()
+    
+    # Mock async httpx client
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "file-123", "object": "file"}
+    mock_response.headers = {}
+    mock_response.text = '{"id": "file-123", "object": "file"}'
+    
+    mock_async_client = AsyncMock()
+    mock_async_client.post = AsyncMock(return_value=mock_response)
+    
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.get_async_httpx_client",
+        return_value=mock_async_client
+    ):
+        # This should NOT raise UnicodeDecodeError
+        await handler.async_create_file(
+            transformed_request=binary_content,
+            litellm_params={},
+            provider_config=mock_provider_config,
+            headers={"Content-Type": "application/octet-stream"},
+            api_base="https://api.example.com/upload",
+            logging_obj=mock_logging_obj,
+            client=None,
+            timeout=30.0,
+        )
+    
+    # Verify the binary content was passed directly to httpx without modification
+    mock_async_client.post.assert_called_once()
+    call_kwargs = mock_async_client.post.call_args.kwargs
+    
+    # The key assertion: content should be the original binary bytes, not decoded
+    assert call_kwargs["content"] == binary_content
+    assert isinstance(call_kwargs["content"], bytes)
+
+
+@pytest.mark.asyncio
+async def test_create_file_handles_binary_data_sync():
+    """
+    Test that create_file (sync version) correctly handles binary file data
+    without attempting to decode it as UTF-8.
+    """
+    handler = BaseLLMHTTPHandler()
+    
+    # Create binary data that would fail UTF-8 decoding
+    binary_content = bytes([0xFF, 0xFE, 0x00, 0x01, 0x02, 0x03])
+    
+    # Mock provider config
+    mock_provider_config = Mock()
+    mock_provider_config.custom_llm_provider = "vertex_ai"
+    mock_provider_config.file_upload_http_method = "POST"
+    mock_provider_config.transform_file_upload_response = Mock(
+        return_value={"id": "file-123", "object": "file"}
+    )
+    
+    # Mock logging object
+    mock_logging_obj = Mock()
+    mock_logging_obj.pre_call = Mock()
+    
+    # Mock sync httpx client
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "file-123", "object": "file"}
+    mock_response.headers = {}
+    mock_response.text = '{"id": "file-123", "object": "file"}'
+    
+    mock_sync_client = Mock()
+    mock_sync_client.post = Mock(return_value=mock_response)
+    
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.get_sync_httpx_client",
+        return_value=mock_sync_client
+    ):
+        # This should NOT raise UnicodeDecodeError
+        handler.create_file(
+            transformed_request=binary_content,
+            litellm_params={},
+            provider_config=mock_provider_config,
+            headers={"Content-Type": "application/octet-stream"},
+            api_base="https://api.example.com/upload",
+            logging_obj=mock_logging_obj,
+            client=None,
+            timeout=30.0,
+        )
+    
+    # Verify the binary content was passed directly to httpx without modification
+    mock_sync_client.post.assert_called_once()
+    call_kwargs = mock_sync_client.post.call_args.kwargs
+    
+    # The key assertion: content should be the original binary bytes, not decoded
+    assert call_kwargs["content"] == binary_content
+    assert isinstance(call_kwargs["content"], bytes)

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1,8 +1,7 @@
 import os
 import sys
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
-import httpx
 import pytest
 
 sys.path.insert(
@@ -282,59 +281,3 @@ async def test_async_create_file_handles_binary_data():
     assert isinstance(call_kwargs["content"], bytes)
 
 
-@pytest.mark.asyncio
-async def test_create_file_handles_binary_data_sync():
-    """
-    Test that create_file (sync version) correctly handles binary file data
-    without attempting to decode it as UTF-8.
-    """
-    handler = BaseLLMHTTPHandler()
-    
-    # Create binary data that would fail UTF-8 decoding
-    binary_content = bytes([0xFF, 0xFE, 0x00, 0x01, 0x02, 0x03])
-    
-    # Mock provider config
-    mock_provider_config = Mock()
-    mock_provider_config.custom_llm_provider = "vertex_ai"
-    mock_provider_config.file_upload_http_method = "POST"
-    mock_provider_config.transform_file_upload_response = Mock(
-        return_value={"id": "file-123", "object": "file"}
-    )
-    
-    # Mock logging object
-    mock_logging_obj = Mock()
-    mock_logging_obj.pre_call = Mock()
-    
-    # Mock sync httpx client
-    mock_response = Mock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {"id": "file-123", "object": "file"}
-    mock_response.headers = {}
-    mock_response.text = '{"id": "file-123", "object": "file"}'
-    
-    mock_sync_client = Mock()
-    mock_sync_client.post = Mock(return_value=mock_response)
-    
-    with patch(
-        "litellm.llms.custom_httpx.llm_http_handler.get_sync_httpx_client",
-        return_value=mock_sync_client
-    ):
-        # This should NOT raise UnicodeDecodeError
-        handler.create_file(
-            transformed_request=binary_content,
-            litellm_params={},
-            provider_config=mock_provider_config,
-            headers={"Content-Type": "application/octet-stream"},
-            api_base="https://api.example.com/upload",
-            logging_obj=mock_logging_obj,
-            client=None,
-            timeout=30.0,
-        )
-    
-    # Verify the binary content was passed directly to httpx without modification
-    mock_sync_client.post.assert_called_once()
-    call_kwargs = mock_sync_client.post.call_args.kwargs
-    
-    # The key assertion: content should be the original binary bytes, not decoded
-    assert call_kwargs["content"] == binary_content
-    assert isinstance(call_kwargs["content"], bytes)


### PR DESCRIPTION
## Relevant issues

Fixes binary file upload to Vertex AI (UnicodeDecodeError when uploading PDFs/images)

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Fixed `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff` when uploading binary files (PDFs, images) to Vertex AI via the `/files` endpoint.

**Root cause:** The file upload handler was calling `.decode("utf-8")` on binary file content before sending to httpx, which fails for non-UTF-8 binary data.

**Fix:** 
1. Removed the unnecessary `.decode("utf-8")` call - httpx accepts bytes directly
2. Changed `data=` to `content=` - the correct httpx parameter for raw body content
3. Applied fix to both sync (`create_file`) and async (`async_create_file`) code paths