### PR TITLE
docs(openai): fix gpt-5-mini reasoning_effort supported values

### DIFF
--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -495,7 +495,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 |-------|----------------------|------------------|
 | `gpt-5.1` | `none` | `none`, `low`, `medium`, `high` |
 | `gpt-5` | `medium` | `minimal`, `low`, `medium`, `high` |
-| `gpt-5-mini` | `medium` | `none`, `minimal`, `low`, `medium`, `high` |
+| `gpt-5-mini` | `medium` | `minimal`, `low`, `medium`, `high` |
 | `gpt-5-nano` | `none` | `none`, `low`, `medium`, `high` |
 | `gpt-5-codex` | `adaptive` | `low`, `medium`, `high` (no `minimal`) |
 | `gpt-5.1-codex` | `adaptive` | `low`, `medium`, `high` (no `minimal`) |


### PR DESCRIPTION
## Relevant issues

Closes #18337

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) - N/A for documentation-only changes
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) - N/A for documentation-only changes
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

Fixed the `reasoning_effort` supported values table for `gpt-5-mini` in the OpenAI provider documentation.

**What was fixed:**
- Removed `none` from the supported values for `gpt-5-mini`
- `gpt-5-mini` now correctly shows it supports: `minimal`, `low`, `medium`, `high`

This aligns with the actual OpenAI API behavior where `gpt-5-mini` does not accept `reasoning_effort="none"`.