### PR TITLE
[Feat] Enable async_post_call_failure_hook to transform error responses

### DIFF
--- a/docs/my-website/docs/proxy/call_hooks.md
+++ b/docs/my-website/docs/proxy/call_hooks.md
@@ -17,6 +17,7 @@ import Image from '@theme/IdealImage';
 | `async_pre_call_hook` | Modify incoming request before it's sent to model | Before the LLM API call is made |
 | `async_moderation_hook` | Run checks on input in parallel to LLM API call | In parallel with the LLM API call |
 | `async_post_call_success_hook` | Modify outgoing response (non-streaming) | After successful LLM API call, for non-streaming responses |
+| `async_post_call_failure_hook` | Transform error responses sent to clients | After failed LLM API call |
 | `async_post_call_streaming_hook` | Modify outgoing response (streaming) | After successful LLM API call, for streaming responses |
 
 See a complete example with our [parallel request rate limiter](https://github.com/BerriAI/litellm/blob/main/litellm/proxy/hooks/parallel_request_limiter.py)
@@ -60,7 +61,21 @@ class MyCustomHandler(CustomLogger): # https://docs.litellm.ai/docs/observabilit
         original_exception: Exception, 
         user_api_key_dict: UserAPIKeyAuth,
         traceback_str: Optional[str] = None,
-    ):
+    ) -> Optional[HTTPException]:
+        """
+        Transform error responses sent to clients.
+        
+        Return an HTTPException to replace the original error with a user-friendly message.
+        Return None to use the original exception.
+        
+        Example:
+            if isinstance(original_exception, litellm.ContextWindowExceededError):
+                return HTTPException(
+                    status_code=400,
+                    detail="Your prompt is too long. Please reduce the length and try again."
+                )
+            return None  # Use original exception
+        """
         pass
 
     async def async_post_call_success_hook(
@@ -339,3 +354,106 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
     "usage": {}
 }
 ```
+
+## Advanced - Transform Error Responses
+
+Transform technical API errors into user-friendly messages using `async_post_call_failure_hook`. This allows you to customize error messages sent to clients, similar to how `async_post_call_success_hook` can modify successful responses.
+
+### 1. Create Custom Handler
+
+```python
+from litellm.integrations.custom_logger import CustomLogger
+from fastapi import HTTPException
+from typing import Optional
+import litellm
+
+class MyErrorTransformer(CustomLogger):
+    def __init__(self):
+        pass
+
+    async def async_post_call_failure_hook(
+        self,
+        request_data: dict,
+        original_exception: Exception,
+        user_api_key_dict: UserAPIKeyAuth,
+        traceback_str: Optional[str] = None,
+    ) -> Optional[HTTPException]:
+        """
+        Transform technical errors into user-friendly messages.
+        
+        Return HTTPException to replace the original error.
+        Return None to use the original exception.
+        """
+        # Transform context window errors
+        if isinstance(original_exception, litellm.ContextWindowExceededError):
+            return HTTPException(
+                status_code=400,
+                detail="Your prompt is too long. Please reduce the length and try again."
+            )
+        
+        # Transform rate limit errors
+        if isinstance(original_exception, litellm.RateLimitError):
+            return HTTPException(
+                status_code=429,
+                detail="Rate limit exceeded. Please try again in a moment."
+            )
+        
+        # Transform authentication errors
+        if "authentication" in str(original_exception).lower():
+            return HTTPException(
+                status_code=401,
+                detail="Authentication failed. Please check your API key."
+            )
+        
+        # Return None to use original exception for other errors
+        return None
+
+proxy_handler_instance = MyErrorTransformer()
+```
+
+### 2. Update config.yaml
+
+```yaml
+model_list:
+  - model_name: gpt-3.5-turbo
+    litellm_params:
+      model: gpt-3.5-turbo
+
+litellm_settings:
+  callbacks: custom_callbacks.proxy_handler_instance
+```
+
+### 3. Test it!
+
+When an error occurs, clients will receive your transformed error message instead of the technical error:
+
+**Before (Technical Error):**
+```json
+{
+  "error": {
+    "message": "ContextWindowExceededError: Prompt exceeds context window",
+    "type": "invalid_request_error",
+    "code": 400
+  }
+}
+```
+
+**After (User-Friendly Error):**
+```json
+{
+  "error": {
+    "message": "Your prompt is too long. Please reduce the length and try again.",
+    "type": "invalid_request_error",
+    "code": 400
+  }
+}
+```
+
+### Comparison: Success vs Failure Hooks
+
+| Hook | Can Modify Response | Return Type | Use Case |
+|------|---------------------|-------------|----------|
+| `async_post_call_success_hook` | ✅ Yes - modifies successful responses | `Any` (modified response) | Transform successful LLM responses |
+| `async_post_call_failure_hook` | ✅ Yes - transforms error responses | `Optional[HTTPException]` | Transform error messages sent to clients |
+
+Both hooks are now awaited (not fire-and-forget), allowing you to modify what clients receive.

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -32,6 +32,8 @@ from litellm.types.utils import (
 )
 
 if TYPE_CHECKING:
+    from fastapi import HTTPException
+
     from litellm.caching.caching import DualCache
     from opentelemetry.trace import Span as _Span
 
@@ -348,7 +350,20 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         original_exception: Exception,
         user_api_key_dict: UserAPIKeyAuth,
         traceback_str: Optional[str] = None,
-    ):
+    ) -> Optional["HTTPException"]:
+        """
+        Called after an LLM API call fails. Can return or raise HTTPException to transform error responses.
+
+        Args:
+            - request_data: dict - The request data.
+            - original_exception: Exception - The original exception that occurred.
+            - user_api_key_dict: UserAPIKeyAuth - The user API key dictionary.
+            - traceback_str: Optional[str] - The traceback string.
+
+        Returns:
+            - Optional[HTTPException]: Return an HTTPException to transform the error response sent to the client.
+                                      Return None to use the original exception.
+        """
         pass
 
     async def async_post_call_success_hook(

--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -2,7 +2,6 @@
 Handles Authentication Errors
 """
 
-import asyncio
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from fastapi import HTTPException, Request, status

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -786,11 +786,15 @@ class ProxyBaseLLMRequestProcessing:
         verbose_proxy_logger.exception(
             f"litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occured - {str(e)}"
         )
-        await proxy_logging_obj.post_call_failure_hook(
+        # Allow callbacks to transform the error response
+        transformed_exception = await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict,
             original_exception=e,
             request_data=self.data,
         )
+        # Use transformed exception if callback returned one, otherwise use original
+        if transformed_exception is not None:
+            e = transformed_exception
         litellm_debug_info = getattr(e, "litellm_debug_info", "")
         verbose_proxy_logger.debug(
             "\033[1;31mAn error occurred: %s %s\n\n Debug this by setting `--debug`, e.g. `litellm --model gpt-3.5-turbo --debug`",
@@ -970,11 +974,15 @@ class ProxyBaseLLMRequestProcessing:
                     str(e)
                 )
             )
-            await proxy_logging_obj.post_call_failure_hook(
+            # Allow callbacks to transform the error response
+            transformed_exception = await proxy_logging_obj.post_call_failure_hook(
                 user_api_key_dict=user_api_key_dict,
                 original_exception=e,
                 request_data=request_data,
             )
+            # Use transformed exception if callback returned one, otherwise use original
+            if transformed_exception is not None:
+                e = transformed_exception
             verbose_proxy_logger.debug(
                 f"\033[1;31mAn error occurred: {e}\n\n Debug this by setting `--debug`, e.g. `litellm --model gpt-3.5-turbo --debug`"
             )

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -278,8 +278,8 @@ async def test_proxy_admin_expired_key_from_cache():
     mock_proxy_logging_obj.internal_usage_cache = MagicMock()
     mock_proxy_logging_obj.internal_usage_cache.dual_cache = AsyncMock()
     mock_proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
-    # Mock post_call_failure_hook as async function
-    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock()
+    # Mock post_call_failure_hook as async function returning None (no transformation)
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
     
     # Mock prisma_client
     mock_prisma_client = MagicMock()

--- a/tests/test_litellm/proxy/hooks/test_post_call_failure_hook_integration.py
+++ b/tests/test_litellm/proxy/hooks/test_post_call_failure_hook_integration.py
@@ -1,0 +1,146 @@
+"""
+Integration tests for async_post_call_failure_hook.
+
+Tests verify that the failure hook can transform error responses sent to clients,
+similar to how async_post_call_success_hook can transform successful responses.
+"""
+
+import os
+import sys
+import pytest
+from typing import Optional
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from fastapi import HTTPException
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+class ErrorTransformerLogger(CustomLogger):
+    """Logger that transforms errors into user-friendly messages"""
+    
+    def __init__(self):
+        self.called = False
+        self.transformed_exception = None
+    
+    async def async_post_call_failure_hook(
+        self,
+        request_data: dict,
+        original_exception: Exception,
+        user_api_key_dict: UserAPIKeyAuth,
+        traceback_str: Optional[str] = None,
+    ):
+        self.called = True
+        self.transformed_exception = HTTPException(
+            status_code=400,
+            detail="User-friendly error: Your request could not be processed."
+        )
+        return self.transformed_exception
+
+
+@pytest.mark.asyncio
+async def test_failure_hook_transforms_error_response():
+    """
+    Test that async_post_call_failure_hook can transform error responses.
+    This mirrors how async_post_call_success_hook can transform successful responses.
+    """
+    transformer = ErrorTransformerLogger()
+    
+    # Mock litellm.callbacks to include our transformer
+    with patch("litellm.callbacks", [transformer]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+        
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+        original_exception = Exception("Technical error message")
+        request_data = {"model": "test-model"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+        
+        # Call the hook
+        result = await proxy_logging.post_call_failure_hook(
+            request_data=request_data,
+            original_exception=original_exception,
+            user_api_key_dict=user_api_key_dict,
+        )
+        
+        # Verify hook was called
+        assert transformer.called is True
+        
+        # Verify transformed exception is returned
+        assert result is not None
+        assert isinstance(result, HTTPException)
+        assert result.detail == "User-friendly error: Your request could not be processed."
+
+
+@pytest.mark.asyncio
+async def test_failure_hook_returns_none_when_no_transformation():
+    """
+    Test that hook returning None uses original exception.
+    """
+    class NoOpLogger(CustomLogger):
+        def __init__(self):
+            self.called = False
+        
+        async def async_post_call_failure_hook(self, *args, **kwargs):
+            self.called = True
+            return None
+    
+    logger = NoOpLogger()
+    
+    with patch("litellm.callbacks", [logger]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+        
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+        original_exception = Exception("Original error")
+        request_data = {"model": "test"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="test")
+        
+        result = await proxy_logging.post_call_failure_hook(
+            request_data=request_data,
+            original_exception=original_exception,
+            user_api_key_dict=user_api_key_dict,
+        )
+        
+        # Should return None (original exception will be used)
+        assert result is None
+        assert logger.called is True
+
+
+@pytest.mark.asyncio
+async def test_failure_hook_handles_exceptions_gracefully():
+    """
+    Test that hook failures don't break the error flow.
+    """
+    class FailingLogger(CustomLogger):
+        def __init__(self):
+            self.called = False
+        
+        async def async_post_call_failure_hook(self, *args, **kwargs):
+            self.called = True
+            raise RuntimeError("Hook crashed!")
+    
+    logger = FailingLogger()
+    
+    with patch("litellm.callbacks", [logger]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+        
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+        original_exception = Exception("Original error")
+        request_data = {"model": "test"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="test")
+        
+        # Should not raise, should handle gracefully
+        result = await proxy_logging.post_call_failure_hook(
+            request_data=request_data,
+            original_exception=original_exception,
+            user_api_key_dict=user_api_key_dict,
+        )
+        
+        # Should return None (original exception will be used)
+        assert result is None
+        assert logger.called is True
+

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -1148,7 +1148,7 @@ class TestBedrockLLMProxyRoute:
             mock_user_api_key_dict.allowed_model_region = None
 
             mock_proxy_logging_obj = Mock()
-            mock_proxy_logging_obj.post_call_failure_hook = AsyncMock()
+            mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
 
             endpoint = "model/test-model/converse"
             model = "test-model"
@@ -1291,7 +1291,7 @@ class TestBedrockLLMProxyRoute:
             mock_user_api_key_dict = Mock()
             mock_user_api_key_dict.api_key = "test-key"
             mock_proxy_logging_obj = Mock()
-            mock_proxy_logging_obj.post_call_failure_hook = AsyncMock()
+            mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
 
             with patch(
                 "litellm.passthrough.main.llm_passthrough_route",


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: [Baseline](https://app.circleci.com/pipelines/github/BerriAI/litellm/52539/workflows/cd92d01f-6079-4131-b43f-0795c4960d34)

- [x] **CI run for the last commit**  
       Link: [Last Commit](https://app.circleci.com/pipelines/github/BerriAI/litellm/52545/workflows/edda3d32-8c17-4dd5-a7f1-9dee4e1484ad)

- [ ] **Merge / cherry-pick CI run**  
       Links: **None**

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Manual Tests

<img width="2574" height="1709" alt="Screenshot 2025-12-22 103932" src="https://github.com/user-attachments/assets/2ae506e9-072b-4e2d-9a66-845fb0dd9fe6" />

## Summary

Enables `async_post_call_failure_hook` to transform error responses sent to clients, similar to how `async_post_call_success_hook` can modify successful responses. Callbacks can now return or raise `HTTPException` to replace technical API errors with user-friendly messages.

## Changes

### Core Implementation

- **`litellm/proxy/utils.py`**: Updated `post_call_failure_hook` to:
  - Return `Optional[HTTPException]` instead of `None`
  - Change from `asyncio.create_task()` (fire-and-forget) to `await` for callback invocation
  - Capture and return HTTPExceptions from callbacks (returned or raised)
  - Return the first HTTPException found, otherwise `None`

- **`litellm/integrations/custom_logger.py`**: Updated `async_post_call_failure_hook`:
  - Changed return type annotation to `Optional[HTTPException]`
  - Added docstring explaining the new behavior
  - Added `HTTPException` to TYPE_CHECKING imports

### Call Sites Updates

- **`litellm/proxy/common_request_processing.py`**:
  - Updated `_handle_llm_api_exception` to capture and use transformed HTTPException
  - Updated `async_sse_data_generator` to handle transformed exceptions for streaming errors

- **`litellm/proxy/auth/auth_exception_handler.py`**:
  - Changed from `asyncio.create_task()` to `await` in `_handle_authentication_error`
  - Updated to capture and use transformed HTTPException
  - Removed unused `asyncio` import

### Testing

- **`tests/test_litellm/proxy/hooks/test_post_call_failure_hook_integration.py`** (new file):
  - Added 3 integration tests verifying:
    - Hook can transform errors (returns HTTPException)
    - Hook returning None uses original exception
    - Hook failures are handled gracefully

### Documentation

- **`docs/my-website/docs/proxy/call_hooks.md`**:
  - Added `async_post_call_failure_hook` to hook comparison table
  - Added example showing error transformation
  - Documented return type and behavior

## Behavior Change

**Before**: `async_post_call_failure_hook` ran as fire-and-forget; return values were ignored.

**After**: `async_post_call_failure_hook` is awaited; callbacks can return/raise `HTTPException` to transform error responses sent to clients.

## Backward Compatibility

**Fully backward compatible**: Existing hooks that return `None` or nothing continue to work unchanged. Only hooks that explicitly return/raise `HTTPException` will transform errors.

## Example Usage

```python
class MyErrorTransformer(CustomLogger):
    async def async_post_call_failure_hook(
        self,
        request_data: dict,
        original_exception: Exception,
        user_api_key_dict: UserAPIKeyAuth,
        traceback_str: Optional[str] = None,
    ) -> Optional[HTTPException]:
        if isinstance(original_exception, litellm.ContextWindowExceededError):
            return HTTPException(
                status_code=400,
                detail="Your prompt is too long. Please reduce the length and try again."
            )
        return None  # Use original exception
```

