### PR TITLE
[Fix] UI - Key Creation MCP Settings Submit Form Unintentionally

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.test.tsx
@@ -1,21 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderWithProviders } from "../../../tests/test-utils";
 import MCPToolPermissions from "./MCPToolPermissions";
 import * as networking from "../networking";
 
 vi.mock("../networking");
-
-const createQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        gcTime: 0,
-      },
-    },
-  });
 
 describe("MCPToolPermissions", () => {
   const mockAccessToken = "test-token";
@@ -53,16 +43,13 @@ describe("MCPToolPermissions", () => {
       error: false,
     });
 
-    const queryClient = createQueryClient();
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MCPToolPermissions
-          accessToken={mockAccessToken}
-          selectedServers={[mockServerId]}
-          toolPermissions={{}}
-          onChange={mockOnChange}
-        />
-      </QueryClientProvider>,
+    renderWithProviders(
+      <MCPToolPermissions
+        accessToken={mockAccessToken}
+        selectedServers={[mockServerId]}
+        toolPermissions={{}}
+        onChange={mockOnChange}
+      />,
     );
 
     // Wait for server and tools to load
@@ -86,5 +73,107 @@ describe("MCPToolPermissions", () => {
     // Verify API calls
     expect(networking.fetchMCPServers).toHaveBeenCalledWith(mockAccessToken);
     expect(networking.listMCPTools).toHaveBeenCalledWith(mockAccessToken, mockServerId);
+  });
+
+  it("should select all tools when Select All button is clicked", async () => {
+    const mockOnChange = vi.fn();
+    const mockTools = [
+      { name: "read_wiki_structure", description: "Get documentation topics" },
+      { name: "read_wiki_contents", description: "View documentation" },
+      { name: "ask_question", description: "Ask questions" },
+    ];
+
+    // Mock fetchMCPServers to return server details
+    vi.mocked(networking.fetchMCPServers).mockResolvedValue([
+      {
+        server_id: mockServerId,
+        server_name: mockServerName,
+        alias: mockServerName,
+      },
+    ]);
+
+    // Mock listMCPTools to return tools for the server
+    vi.mocked(networking.listMCPTools).mockResolvedValue({
+      tools: mockTools,
+      error: false,
+    });
+
+    renderWithProviders(
+      <MCPToolPermissions
+        accessToken={mockAccessToken}
+        selectedServers={[mockServerId]}
+        toolPermissions={{}}
+        onChange={mockOnChange}
+      />,
+    );
+
+    // Wait for server and tools to load
+    await waitFor(() => {
+      expect(screen.getByText(mockServerName)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("read_wiki_structure")).toBeInTheDocument();
+    });
+
+    // Click the Select All button
+    const selectAllButton = screen.getByRole("button", { name: "Select All" });
+    await userEvent.click(selectAllButton);
+
+    // Verify onChange was called with all tools selected
+    expect(mockOnChange).toHaveBeenCalledWith({
+      [mockServerId]: ["read_wiki_structure", "read_wiki_contents", "ask_question"],
+    });
+  });
+
+  it("should deselect all tools when Deselect All button is clicked", async () => {
+    const mockOnChange = vi.fn();
+    const mockTools = [
+      { name: "read_wiki_structure", description: "Get documentation topics" },
+      { name: "read_wiki_contents", description: "View documentation" },
+      { name: "ask_question", description: "Ask questions" },
+    ];
+
+    // Mock fetchMCPServers to return server details
+    vi.mocked(networking.fetchMCPServers).mockResolvedValue([
+      {
+        server_id: mockServerId,
+        server_name: mockServerName,
+        alias: mockServerName,
+      },
+    ]);
+
+    // Mock listMCPTools to return tools for the server
+    vi.mocked(networking.listMCPTools).mockResolvedValue({
+      tools: mockTools,
+      error: false,
+    });
+
+    renderWithProviders(
+      <MCPToolPermissions
+        accessToken={mockAccessToken}
+        selectedServers={[mockServerId]}
+        toolPermissions={{ [mockServerId]: ["read_wiki_structure", "read_wiki_contents"] }}
+        onChange={mockOnChange}
+      />,
+    );
+
+    // Wait for server and tools to load
+    await waitFor(() => {
+      expect(screen.getByText(mockServerName)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("read_wiki_structure")).toBeInTheDocument();
+    });
+
+    // Click the Deselect All button
+    const deselectAllButton = screen.getByRole("button", { name: "Deselect All" });
+    await userEvent.click(deselectAllButton);
+
+    // Verify onChange was called with no tools selected
+    expect(mockOnChange).toHaveBeenCalledWith({
+      [mockServerId]: [],
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.tsx
@@ -80,17 +80,19 @@ const MCPToolPermissions: React.FC<MCPToolPermissionsProps> = ({
 
   const handleSelectAll = (serverId: string) => {
     const tools = serverTools[serverId] || [];
-    onChange({
+    const newPermissions = {
       ...toolPermissions,
       [serverId]: tools.map((t) => t.name),
-    });
+    };
+    onChange(newPermissions);
   };
 
   const handleDeselectAll = (serverId: string) => {
-    onChange({
+    const newPermissions = {
       ...toolPermissions,
       [serverId]: [],
-    });
+    };
+    onChange(newPermissions);
   };
 
   if (selectedServers.length === 0) {
@@ -116,6 +118,7 @@ const MCPToolPermissions: React.FC<MCPToolPermissionsProps> = ({
               </div>
               <div className="flex items-center gap-3">
                 <button
+                  type="button"
                   className="text-sm text-blue-600 hover:text-blue-700 font-medium"
                   onClick={() => handleSelectAll(server.server_id)}
                   disabled={disabled || isLoading}
@@ -123,6 +126,7 @@ const MCPToolPermissions: React.FC<MCPToolPermissionsProps> = ({
                   Select All
                 </button>
                 <button
+                  type="button"
                   className="text-sm text-blue-600 hover:text-blue-700 font-medium"
                   onClick={() => handleDeselectAll(server.server_id)}
                   disabled={disabled || isLoading}
@@ -130,6 +134,7 @@ const MCPToolPermissions: React.FC<MCPToolPermissionsProps> = ({
                   Deselect All
                 </button>
                 <button
+                  type="button"
                   className="text-gray-400 hover:text-gray-600"
                   onClick={() => {
                     // Handle remove server if needed


### PR DESCRIPTION
## Relevant issues
The MCP Settings inside of the key creation modal submits the key creation form unintentionally. This was due to the buttons not being the proper type.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="957" height="147" alt="image" src="https://github.com/user-attachments/assets/e60a5c0d-5046-4751-96d7-27ec6e83dc77" />
