### PR TITLE
[Bug] add auth to unsecured routes in debug utils

### DIFF
--- a/litellm/proxy/common_utils/debug_utils.py
+++ b/litellm/proxy/common_utils/debug_utils.py
@@ -43,7 +43,9 @@ configure_gc_thresholds()
 
 
 @router.get("/debug/asyncio-tasks")
-async def get_active_tasks_stats():
+async def get_active_tasks_stats(
+    _: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
     """
     Returns:
       total_active_tasks: int
@@ -97,7 +99,9 @@ if os.environ.get("LITELLM_PROFILE", "false").lower() == "true":
     tracemalloc.start(10)
 
     @router.get("/memory-usage", include_in_schema=False)
-    async def memory_usage():
+    async def memory_usage(
+        _: UserAPIKeyAuth = Depends(user_api_key_auth),
+    ):
         # Take a snapshot of the current memory usage
         snapshot = tracemalloc.take_snapshot()
         top_stats = snapshot.statistics("lineno")
@@ -670,7 +674,9 @@ async def configure_gc_thresholds_endpoint(
 
 
 @router.get("/otel-spans", include_in_schema=False)
-async def get_otel_spans():
+async def get_otel_spans(
+    _: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
     from litellm.proxy.proxy_server import open_telemetry_logger
 
     if open_telemetry_logger is None:


### PR DESCRIPTION
## Relevant issues
Some routes in debug utils did not have the user_api_key_auth which made them unsecure.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix


## Changes
Injected user_api_key_auth dependecy to debug util routes.
