### PR TITLE
[Bug] Add json serilization to posthog integration

### DIFF
--- a/litellm/integrations/posthog.py
+++ b/litellm/integrations/posthog.py
@@ -22,6 +22,7 @@ from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
 )
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.types.integrations.posthog import (
     POSTHOG_MAX_BATCH_SIZE,
     PostHogEventPayload,
@@ -88,9 +89,12 @@ class PostHogLogger(CustomBatchLogger):
             payload = self._create_posthog_payload([event_payload], api_key)
             capture_url = f"{api_url.rstrip('/')}/batch/"
 
+            # Serialize payload using safe_dumps to handle non-JSON-serializable objects
+            json_payload = safe_dumps(payload)
+
             response = self.sync_client.post(
                 url=capture_url,
-                json=payload,
+                content=json_payload,
                 headers=headers,
             )
             response.raise_for_status()
@@ -338,9 +342,12 @@ class PostHogLogger(CustomBatchLogger):
                 payload = self._create_posthog_payload(events, api_key)
                 capture_url = f"{api_url.rstrip('/')}/batch/"
 
+                # Serialize payload using safe_dumps to handle non-JSON-serializable objects
+                json_payload = safe_dumps(payload)
+
                 response = await self.async_client.post(
                     url=capture_url,
-                    json=payload,
+                    content=json_payload,
                     headers=headers,
                 )
                 response.raise_for_status()
@@ -417,9 +424,12 @@ class PostHogLogger(CustomBatchLogger):
                 payload = self._create_posthog_payload(events, api_key)
                 capture_url = f"{api_url.rstrip('/')}/batch/"
 
+                # Serialize payload using safe_dumps to handle non-JSON-serializable objects
+                json_payload = safe_dumps(payload)
+
                 response = self.sync_client.post(
                     url=capture_url,
-                    json=payload,
+                    content=json_payload,
                     headers=headers,
                 )
                 response.raise_for_status()

--- a/tests/logging_callback_tests/test_posthog.py
+++ b/tests/logging_callback_tests/test_posthog.py
@@ -1,13 +1,13 @@
 import os
 import sys
-from typing import cast
-
-import pytest
 
 sys.path.insert(0, os.path.abspath("../.."))
 
+import pytest
+
 from litellm.integrations.posthog import PostHogLogger
 from litellm.types.utils import StandardLoggingPayload
+from typing import cast
 
 # Set env vars for tests
 os.environ["POSTHOG_API_KEY"] = "test_key"
@@ -93,6 +93,7 @@ async def test_posthog_embedding_event():
 
 @pytest.mark.asyncio
 async def test_trace_id_fallback_from_standard_logging_object():
+    """Test that trace_id is properly extracted from standard_logging_object"""
     posthog_logger = PostHogLogger()
     standard_payload = create_standard_logging_payload()
     standard_payload["trace_id"] = "test-trace-123"
@@ -102,13 +103,17 @@ async def test_trace_id_fallback_from_standard_logging_object():
     event_payload = posthog_logger.create_posthog_event_payload(kwargs)
 
     assert event_payload["properties"]["$ai_trace_id"] == "test-trace-123"
-    assert event_payload["properties"]["$ai_span_id"] == "test_id"
+    assert (
+        event_payload["properties"]["$ai_span_id"] == "test_id"
+    )  # from standard_payload["id"]
 
 
 @pytest.mark.asyncio
 async def test_trace_id_uuid_fallback():
+    """Test that UUID is generated when no trace_id is available"""
     posthog_logger = PostHogLogger()
     standard_payload = create_standard_logging_payload()
+    # Remove trace_id to test fallback
     del standard_payload["trace_id"]
     del standard_payload["id"]
 
@@ -116,16 +121,18 @@ async def test_trace_id_uuid_fallback():
 
     event_payload = posthog_logger.create_posthog_event_payload(kwargs)
 
-    assert len(event_payload["properties"]["$ai_trace_id"]) == 36
-    assert len(event_payload["properties"]["$ai_span_id"]) == 36
-    assert "-" in event_payload["properties"]["$ai_trace_id"]
+    # Should have generated UUIDs
+    assert len(event_payload["properties"]["$ai_trace_id"]) == 36  # UUID length
+    assert len(event_payload["properties"]["$ai_span_id"]) == 36  # UUID length
+    assert "-" in event_payload["properties"]["$ai_trace_id"]  # UUID format
 
 
 @pytest.mark.asyncio
 async def test_distinct_id_fallback_chain():
+    """Test the distinct_id fallback priority chain"""
     posthog_logger = PostHogLogger()
 
-    # 1. metadata.user_id
+    # Test 1: user_id from metadata (highest priority)
     standard_payload = create_standard_logging_payload()
     kwargs = {
         "standard_logging_object": standard_payload,
@@ -135,12 +142,12 @@ async def test_distinct_id_fallback_chain():
     distinct_id = posthog_logger._get_distinct_id(standard_payload, kwargs)
     assert distinct_id == "metadata-user-123"
 
-    # 2. trace_id
-    kwargs = {"standard_logging_object": standard_payload}
+    # Test 2: trace_id from standard_logging_object (second priority)
+    kwargs = {"standard_logging_object": standard_payload}  # no metadata
     distinct_id = posthog_logger._get_distinct_id(standard_payload, kwargs)
     assert distinct_id == "test_trace_id"
 
-    # 3. end_user
+    # Test 3: end_user from standard_logging_object (third priority)
     standard_payload_no_trace = create_standard_logging_payload()
     del standard_payload_no_trace["trace_id"]
     standard_payload_no_trace["end_user"] = "end-user-456"
@@ -148,32 +155,226 @@ async def test_distinct_id_fallback_chain():
     distinct_id = posthog_logger._get_distinct_id(standard_payload_no_trace, {})
     assert distinct_id == "end-user-456"
 
-    # 4. UUID fallback
+    # Test 4: UUID fallback (lowest priority)
     standard_payload_empty = create_standard_logging_payload()
     del standard_payload_empty["trace_id"]
     del standard_payload_empty["end_user"]
 
     distinct_id = posthog_logger._get_distinct_id(standard_payload_empty, {})
-    assert len(distinct_id) == 36
-    assert "-" in distinct_id
+    assert len(distinct_id) == 36  # UUID length
+    assert "-" in distinct_id  # UUID format
 
 
 @pytest.mark.asyncio
 async def test_missing_standard_logging_object():
+    """Test error handling when standard_logging_object is missing"""
     posthog_logger = PostHogLogger()
 
+    kwargs = {}  # Missing standard_logging_object
+
     with pytest.raises(ValueError, match="standard_logging_object not found in kwargs"):
-        posthog_logger.create_posthog_event_payload({})
+        posthog_logger.create_posthog_event_payload(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_custom_metadata_support():
+    """Test that custom metadata fields are added directly to properties"""
+    posthog_logger = PostHogLogger()
+    standard_payload = create_standard_logging_payload()
+
+    kwargs = {
+        "standard_logging_object": standard_payload,
+        "litellm_params": {
+            "metadata": {
+                "user_id": "user-123",
+                "project_name": "test_project",
+                "environment": "staging",
+                "custom_field": "custom_value",
+            }
+        },
+    }
+
+    event_payload = posthog_logger.create_posthog_event_payload(kwargs)
+
+    assert event_payload["properties"]["project_name"] == "test_project"
+    assert event_payload["properties"]["environment"] == "staging"
+    assert event_payload["properties"]["custom_field"] == "custom_value"
+
+    assert event_payload["distinct_id"] == "user-123"
+    assert "user_id" not in event_payload["properties"]
+
+
+@pytest.mark.asyncio
+async def test_custom_metadata_filters_internal_fields():
+    """Test that LiteLLM internal fields are filtered out from custom metadata"""
+    posthog_logger = PostHogLogger()
+    standard_payload = create_standard_logging_payload()
+
+    kwargs = {
+        "standard_logging_object": standard_payload,
+        "litellm_params": {
+            "metadata": {
+                "custom_field": "should_appear",
+                "endpoint": "/chat/completions",
+                "user_api_key_hash": "hash123",
+                "headers": {"content-type": "application/json"},
+                "model_info": {"id": "123"},
+            }
+        },
+    }
+
+    event_payload = posthog_logger.create_posthog_event_payload(kwargs)
+
+    assert event_payload["properties"]["custom_field"] == "should_appear"
+
+    assert "endpoint" not in event_payload["properties"]
+    assert "user_api_key_hash" not in event_payload["properties"]
+    assert "headers" not in event_payload["properties"]
+    assert "model_info" not in event_payload["properties"]
+
+
+@pytest.mark.asyncio
+async def test_custom_metadata_with_no_metadata():
+    """Test that logger handles cases with no metadata gracefully"""
+    posthog_logger = PostHogLogger()
+    standard_payload = create_standard_logging_payload()
+
+    kwargs = {"standard_logging_object": standard_payload}
+    event_payload = posthog_logger.create_posthog_event_payload(kwargs)
+
+    assert event_payload["event"] == "$ai_generation"
+    assert event_payload["properties"]["$ai_model"] == "gpt-3.5-turbo"
+
+    kwargs = {
+        "standard_logging_object": standard_payload,
+        "litellm_params": {"metadata": {}},
+    }
+    event_payload = posthog_logger.create_posthog_event_payload(kwargs)
+
+    assert event_payload["event"] == "$ai_generation"
+    assert event_payload["properties"]["$ai_model"] == "gpt-3.5-turbo"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_credentials():
+    """Test that per-request credentials override environment variables"""
+    from litellm.types.utils import StandardCallbackDynamicParams
+
+    posthog_logger = PostHogLogger()
+
+    kwargs = {}
+    api_key, api_url = posthog_logger._get_credentials_for_request(kwargs)
+    assert api_key == "test_key"
+    assert api_url == "https://app.posthog.com"
+
+    standard_callback_dynamic_params = StandardCallbackDynamicParams(
+        posthog_api_key="dynamic_key", posthog_api_url="https://custom.posthog.com"
+    )
+    kwargs = {"standard_callback_dynamic_params": standard_callback_dynamic_params}
+    api_key, api_url = posthog_logger._get_credentials_for_request(kwargs)
+    assert api_key == "dynamic_key"
+    assert api_url == "https://custom.posthog.com"
+
+    standard_callback_dynamic_params = StandardCallbackDynamicParams(
+        posthog_api_key="another_key"
+    )
+    kwargs = {"standard_callback_dynamic_params": standard_callback_dynamic_params}
+    api_key, api_url = posthog_logger._get_credentials_for_request(kwargs)
+    assert api_key == "another_key"
+    assert api_url == "https://app.posthog.com"
+
+    standard_callback_dynamic_params = StandardCallbackDynamicParams(
+        posthog_api_url="https://another.posthog.com"
+    )
+    kwargs = {"standard_callback_dynamic_params": standard_callback_dynamic_params}
+    api_key, api_url = posthog_logger._get_credentials_for_request(kwargs)
+    assert api_key == "test_key"
+    assert api_url == "https://another.posthog.com"
+
+
+def test_async_callback_atexit_handler_exists():
+    import atexit
+    from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+
+    assert hasattr(GLOBAL_LOGGING_WORKER, "_flush_on_exit")
+
+    posthog_logger = PostHogLogger()
+    assert hasattr(posthog_logger, "_flush_on_exit")
+
+    GLOBAL_LOGGING_WORKER._flush_on_exit()
+    posthog_logger._flush_on_exit()
+
+
+@pytest.mark.asyncio
+async def test_posthog_atexit_flushes_internal_queue():
+    from unittest.mock import Mock, patch
+
+    posthog_logger = PostHogLogger()
+
+    standard_payload = create_standard_logging_payload()
+    kwargs = {"standard_logging_object": standard_payload}
+    event_payload = posthog_logger.create_posthog_event_payload(kwargs)
+
+    posthog_logger.log_queue.append(
+        {
+            "event": event_payload,
+            "api_key": "test_key",
+            "api_url": "https://app.posthog.com",
+        }
+    )
+
+    assert len(posthog_logger.log_queue) == 1
+
+    with patch.object(posthog_logger.sync_client, "post") as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        posthog_logger._flush_on_exit()
+
+        assert mock_post.called
+        assert len(posthog_logger.log_queue) == 0
+
+        call_args = mock_post.call_args
+        assert "/batch/" in call_args.kwargs["url"]
+
+
+@pytest.mark.asyncio
+async def test_sync_callback_not_affected_by_atexit():
+    from unittest.mock import Mock, patch
+
+    callback_invoked_immediately = False
+
+    def mock_log_success(self, kwargs, response_obj, start_time, end_time):
+        nonlocal callback_invoked_immediately
+        callback_invoked_immediately = True
+
+    with patch.object(PostHogLogger, "log_success_event", mock_log_success):
+        with patch("httpx.Client.post") as mock_post:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = Mock()
+            mock_post.return_value = mock_response
+
+            posthog_logger = PostHogLogger()
+            standard_payload = create_standard_logging_payload()
+            kwargs = {"standard_logging_object": standard_payload}
+
+            posthog_logger.log_success_event(kwargs, None, 0.0, 0.0)
+
+            assert callback_invoked_immediately
 
 
 def test_json_serialization_with_non_serializable_objects():
     """
-    Sync-only test. No asyncio marker.
+    FIXED: sync test (no asyncio marker)
     """
     from unittest.mock import Mock, patch
     from datetime import datetime
 
     posthog_logger = PostHogLogger()
+
     standard_payload = create_standard_logging_payload()
 
     messages_with_non_serializable = [
@@ -208,6 +409,7 @@ def test_json_serialization_with_non_serializable_objects():
         posthog_logger.log_success_event(kwargs, None, 0.0, 0.0)
 
         assert mock_post.called
+
         json_payload = mock_post.call_args.kwargs["content"]
         assert isinstance(json_payload, str)
         assert len(json_payload) > 0
@@ -216,12 +418,15 @@ def test_json_serialization_with_non_serializable_objects():
 
 @pytest.mark.asyncio
 async def test_async_json_serialization_with_non_serializable_objects():
+    """
+    FIXED: use Mock response (not AsyncMock)
+    """
     from unittest.mock import Mock, patch
     from datetime import datetime
 
     posthog_logger = PostHogLogger()
-    standard_payload = create_standard_logging_payload()
 
+    standard_payload = create_standard_logging_payload()
     messages_with_datetime = [
         cast(
             dict,
@@ -255,6 +460,59 @@ async def test_async_json_serialization_with_non_serializable_objects():
         await posthog_logger.async_send_batch()
 
         assert mock_post.called
+
+        json_payload = mock_post.call_args.kwargs["content"]
+        assert isinstance(json_payload, str)
+        assert len(json_payload) > 0
+
+
+@pytest.mark.asyncio
+async def test_atexit_json_serialization_with_non_serializable_objects():
+    from unittest.mock import Mock, patch
+    from datetime import datetime
+
+    posthog_logger = PostHogLogger()
+
+    standard_payload = create_standard_logging_payload()
+    messages_with_complex_data = [
+        cast(
+            dict,
+            {
+                "role": "user",
+                "content": "Test atexit serialization",
+                "timestamp": datetime(2024, 3, 1, 15, 45, 0),
+                "complex_data": {
+                    "tuple_data": (1, 2, 3),
+                    "frozenset_data": frozenset([1, 2, 3]),
+                },
+            },
+        )
+    ]
+    standard_payload["messages"] = messages_with_complex_data  # type: ignore
+
+    kwargs = {"standard_logging_object": standard_payload}
+    event_payload = posthog_logger.create_posthog_event_payload(kwargs)
+
+    posthog_logger.log_queue.append(
+        {
+            "event": event_payload,
+            "api_key": "test_key",
+            "api_url": "https://app.posthog.com",
+        }
+    )
+
+    with patch.object(posthog_logger.sync_client, "post") as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = "OK"
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        posthog_logger._flush_on_exit()
+
+        assert mock_post.called
+        assert len(posthog_logger.log_queue) == 0
+
         json_payload = mock_post.call_args.kwargs["content"]
         assert isinstance(json_payload, str)
         assert len(json_payload) > 0

--- a/tests/logging_callback_tests/test_posthog.py
+++ b/tests/logging_callback_tests/test_posthog.py
@@ -417,7 +417,9 @@ async def test_sync_callback_not_affected_by_atexit():
             assert callback_invoked_immediately, "Sync callback should be invoked immediately"
 
 
-        mock_response = Mock()
+@pytest.mark.asyncio
+async def test_json_serialization_with_non_serializable_objects():
+    """
     Test that PostHog logger handles non-JSON-serializable objects correctly
     using safe_dumps for serialization.
     

--- a/tests/logging_callback_tests/test_posthog.py
+++ b/tests/logging_callback_tests/test_posthog.py
@@ -417,9 +417,7 @@ async def test_sync_callback_not_affected_by_atexit():
             assert callback_invoked_immediately, "Sync callback should be invoked immediately"
 
 
-@pytest.mark.asyncio
-async def test_json_serialization_with_non_serializable_objects():
-    """
+        mock_response = Mock()
     Test that PostHog logger handles non-JSON-serializable objects correctly
     using safe_dumps for serialization.
     


### PR DESCRIPTION
## Relevant issues
https://github.com/BerriAI/litellm/issues/18332

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
Replaced json=payload with content=safe_dumps(payload) — manually serialize using safe_dumps() to handle non-JSON-serializable objects (datetime, sets, circular refs, etc.).
Switched from json= to content= parameter — content= accepts a pre-serialized string, while json= would use httpx's default serializer and fail on non-serializable objects.
