### PR TITLE
[Feature] UI - Add Error Code Filtering on UI

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1771,7 +1771,7 @@ async def ui_view_spend_logs(  # noqa: PLR0915
         if error_code is not None:
             metadata_filters.append({
                 "path": ["error_information", "error_code"],
-                "equals": error_code,
+                "equals": f'"{error_code}"',
             })
 
         if metadata_filters:
@@ -1781,7 +1781,6 @@ async def ui_view_spend_logs(  # noqa: PLR0915
                 where_conditions["AND"] = where_conditions.get("AND", []) + [
                     {"metadata": filter_cond} for filter_cond in metadata_filters
                 ]
-
         if end_user is not None:
             where_conditions["end_user"] = end_user
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1895,9 +1895,12 @@ async def test_ui_view_spend_logs_with_error_code(client):
                 metadata_filter = where_conditions["metadata"]
                 if metadata_filter.get("path") == ["error_information", "error_code"]:
                     error_code = metadata_filter.get("equals")
-                    if error_code == "404":
+                    # Handle both string and integer error codes
+                    # The endpoint wraps error_code in quotes, so strip them for comparison
+                    error_code_value = str(error_code).strip('"')
+                    if error_code_value == "404":
                         return [mock_spend_logs[0]]
-                    elif error_code == "500":
+                    elif error_code_value == "500":
                         return [mock_spend_logs[1]]
             return mock_spend_logs
 
@@ -1907,9 +1910,12 @@ async def test_ui_view_spend_logs_with_error_code(client):
                 metadata_filter = where_conditions["metadata"]
                 if metadata_filter.get("path") == ["error_information", "error_code"]:
                     error_code = metadata_filter.get("equals")
-                    if error_code == "404":
+                    # Handle both string and integer error codes
+                    # The endpoint wraps error_code in quotes, so strip them for comparison
+                    error_code_value = str(error_code).strip('"')
+                    if error_code_value == "404":
                         return 1
-                    elif error_code == "500":
+                    elif error_code_value == "500":
                         return 1
             return len(mock_spend_logs)
 
@@ -1995,7 +2001,10 @@ async def test_ui_view_spend_logs_with_error_code_and_key_alias(client):
                         elif metadata_filter.get("path") == ["error_information", "error_code"]:
                             error_code_filter = metadata_filter.get("equals")
 
-                if key_alias_filter == "test-key-1" and error_code_filter == "500":
+                # Handle both string and integer error codes
+                # The endpoint wraps error_code in quotes, so strip them for comparison
+                error_code_value = str(error_code_filter).strip('"')
+                if key_alias_filter == "test-key-1" and error_code_value == "500":
                     return [mock_spend_logs[2]]  # Only log3 matches both conditions
             return mock_spend_logs
 
@@ -2012,7 +2021,10 @@ async def test_ui_view_spend_logs_with_error_code_and_key_alias(client):
                         elif metadata_filter.get("path") == ["error_information", "error_code"]:
                             error_code_filter = metadata_filter.get("equals")
 
-                if key_alias_filter == "test-key-1" and error_code_filter == "500":
+                # Handle both string and integer error codes
+                # The endpoint wraps error_code in quotes, so strip them for comparison
+                error_code_value = str(error_code_filter).strip('"')
+                if key_alias_filter == "test-key-1" and error_code_value == "500":
                     return 1
             return len(mock_spend_logs)
 

--- a/ui/litellm-dashboard/src/components/molecules/filter.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/filter.tsx
@@ -129,6 +129,7 @@ const FilterComponent: React.FC<FilterComponentProps> = ({
     "Key Alias",
     "User ID",
     "End User",
+    "Error Code",
     "Key Hash",
     "Model",
   ];

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2687,6 +2687,7 @@ export const uiSpendLogsCall = async (
   status_filter?: string,
   model?: string,
   keyAlias?: string,
+  error_code?: string,
 ) => {
   try {
     // Construct base URL
@@ -2706,6 +2707,7 @@ export const uiSpendLogsCall = async (
     if (status_filter) queryParams.append("status_filter", status_filter);
     if (model) queryParams.append("model", model);
     if (keyAlias) queryParams.append("key_alias", keyAlias);
+    if (error_code) queryParams.append("error_code", error_code);
     // Append query parameters to URL if any exist
     const queryString = queryParams.toString();
     if (queryString) {

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -366,6 +366,24 @@ export default function SpendLogsTable({
     setExpandedRequestId(requestId);
   };
 
+  // Function to extract unique error codes from logs
+  const extractErrorCodes = (logs: LogEntry[], searchText: string = "") => {
+    const errorCodes = new Set<string>();
+    logs.forEach((log) => {
+      const metadata = log.metadata || {};
+      if (metadata.status === "failure" && metadata.error_information) {
+        const errorCode = metadata.error_information.error_code;
+        if (errorCode && (!searchText || errorCode.toLowerCase().includes(searchText.toLowerCase()))) {
+          errorCodes.add(errorCode);
+        }
+      }
+    });
+    return Array.from(errorCodes).map((code) => ({
+      label: code,
+      value: code,
+    }));
+  };
+
   const logFilterOptions: FilterOption[] = [
     {
       name: "Team ID",
@@ -424,6 +442,14 @@ export default function SpendLogsTable({
         const users = data?.map((u: any) => u.user_id) || [];
         const filtered = users.filter((u: string) => u.toLowerCase().includes(searchText.toLowerCase()));
         return filtered.map((u: string) => ({ label: u, value: u }));
+      },
+    },
+    {
+      name: "Error Code",
+      label: "Error Code",
+      isSearchable: true,
+      searchFn: async (searchText: string) => {
+        return extractErrorCodes(logsData.data, searchText);
       },
     },
     {

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -17,6 +17,7 @@ export const FILTER_KEYS = {
   END_USER: "End User",
   STATUS: "Status",
   KEY_ALIAS: "Key Alias",
+  ERROR_CODE: "Error Code",
 } as const;
 
 export type FilterKey = keyof typeof FILTER_KEYS;
@@ -53,6 +54,7 @@ export function useLogFilterLogic({
       [FILTER_KEYS.END_USER]: "",
       [FILTER_KEYS.STATUS]: "",
       [FILTER_KEYS.KEY_ALIAS]: "",
+      [FILTER_KEYS.ERROR_CODE]: "",
     }),
     [],
   );
@@ -94,6 +96,7 @@ export function useLogFilterLogic({
           filters[FILTER_KEYS.STATUS] || undefined,
           filters[FILTER_KEYS.MODEL] || undefined,
           filters[FILTER_KEYS.KEY_ALIAS] || undefined,
+          filters[FILTER_KEYS.ERROR_CODE] || undefined,
         );
 
         if (currentTimestamp === lastSearchTimestamp.current && response.data) {
@@ -133,7 +136,8 @@ export function useLogFilterLogic({
         filters[FILTER_KEYS.KEY_HASH] ||
         filters[FILTER_KEYS.REQUEST_ID] ||
         filters[FILTER_KEYS.USER_ID] ||
-        filters[FILTER_KEYS.END_USER]
+        filters[FILTER_KEYS.END_USER] ||
+        filters[FILTER_KEYS.ERROR_CODE]
       ),
     [filters],
   );
@@ -180,6 +184,14 @@ export function useLogFilterLogic({
 
     if (filters[FILTER_KEYS.END_USER]) {
       filteredData = filteredData.filter((log) => log.end_user === filters[FILTER_KEYS.END_USER]);
+    }
+
+    if (filters[FILTER_KEYS.ERROR_CODE]) {
+      filteredData = filteredData.filter((log) => {
+        const metadata = log.metadata || {};
+        const errorInfo = metadata.error_information;
+        return errorInfo && errorInfo.error_code === filters[FILTER_KEYS.ERROR_CODE];
+      });
     }
 
     return {


### PR DESCRIPTION
## Relevant issues
This PR integrates with the error_code support the /spend/logs/ui endpoint has now, and adds a select to allow users to filter for specific error codes on the spend logs page. The select is prepopulated with error codes that occurred in the fetched group of spend logs
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="1442" height="645" alt="image" src="https://github.com/user-attachments/assets/d6c34e58-e98a-498e-9bef-3824eaeae7fa" />
<img width="830" height="212" alt="image" src="https://github.com/user-attachments/assets/83776271-f5a1-452c-87df-a39dbe245ca2" />
