### PR TITLE
Add custom providers import

### DIFF
--- a/docs/my-website/docs/contributing/adding_openai_compatible_providers.md
+++ b/docs/my-website/docs/contributing/adding_openai_compatible_providers.md
@@ -4,9 +4,18 @@ For simple OpenAI-compatible providers (like Hyperbolic, Nscale, etc.), you can 
 
 ## Quick Start
 
+### Option 1: Edit Local JSON File
 1. Edit `litellm/llms/openai_like/providers.json`
 2. Add your provider configuration
 3. Test with: `litellm.completion(model="your_provider/model-name", ...)`
+
+### Option 2: Load from Custom URL
+1. Create a custom JSON file with your provider configurations
+2. Host it at a URL (can be a local file server, cloud storage, or any HTTP endpoint)
+3. Set the environment variable: `LITELLM_CUSTOM_PROVIDERS_URL=https://example.com/my-providers.json`
+4. Start LiteLLM - it will automatically load and merge your custom providers
+
+This is useful when you want to define custom providers without modifying LiteLLM's source code or waiting for PR approval.
 
 ## Basic Configuration
 
@@ -82,6 +91,27 @@ That's it! The provider is now available.
 
 ## Usage
 
+### Using Custom Providers from URL
+
+```python
+import litellm
+import os
+
+# Set the URL to your custom providers JSON
+os.environ["LITELLM_CUSTOM_PROVIDERS_URL"] = "https://example.com/my-providers.json"
+
+# Set your API key
+os.environ["YOUR_PROVIDER_API_KEY"] = "your-key-here"
+
+# Use the provider
+response = litellm.completion(
+    model="your_provider/model-name",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+```
+
+### Using Built-in Providers
+
 ```python
 import litellm
 import os
@@ -95,6 +125,15 @@ response = litellm.completion(
     messages=[{"role": "user", "content": "Hello"}],
 )
 ```
+
+## Custom Provider URL Behavior
+
+When `LITELLM_CUSTOM_PROVIDERS_URL` is set:
+- LiteLLM loads local providers from `providers.json` first
+- Then fetches and merges providers from the specified URL
+- Custom providers from the URL can overwrite local providers with the same name
+- If the URL is unreachable or returns invalid JSON, LiteLLM logs a warning and continues with local providers only
+- The fetch happens once at startup (providers are cached)
 
 ## When to Use Python Instead
 

--- a/litellm/llms/openai_like/README.md
+++ b/litellm/llms/openai_like/README.md
@@ -142,16 +142,14 @@ The first JSON-configured provider:
 ```python
 import litellm
 import os
-import json
 
 # Define provider inline
-custom_providers = {
+os.environ["LITELLM_CUSTOM_PROVIDERS"] = """
     "my_provider": {
         "base_url": "https://api.myprovider.com/v1",
         "api_key_env": "MY_PROVIDER_KEY"
     }
-}
-os.environ["LITELLM_CUSTOM_PROVIDERS"] = json.dumps(custom_providers)
+"""
 
 # Use your custom provider
 response = litellm.completion(
@@ -235,12 +233,3 @@ The JSON system is integrated at:
 - `litellm/litellm_core_utils/get_llm_provider_logic.py` - Provider resolution
 - `litellm/utils.py` - ProviderConfigManager
 - `litellm/constants.py` - openai_compatible_providers list
-
-### Custom Provider Loading
-
-The custom provider loading features:
-- **JSON string**: Parses inline JSON from `LITELLM_CUSTOM_PROVIDERS` env var
-- **URL loading**: Uses `httpx.Client` with 10-second timeout for `LITELLM_CUSTOM_PROVIDERS_URL`
-- Graceful error handling (logs warnings, doesn't crash)
-- Merge behavior: custom providers can overwrite built-in ones
-- Single fetch/parse at startup (no repeated operations)

--- a/litellm/llms/openai_like/json_loader.py
+++ b/litellm/llms/openai_like/json_loader.py
@@ -48,6 +48,14 @@ class JSONProviderRegistry:
         try:
             verbose_logger.debug(f"Attempting to load custom providers from URL: {url}")
             
+            # Basic URL validation to prevent SSRF
+            # Allow http/https schemes only
+            if not url.startswith(("http://", "https://")):
+                verbose_logger.warning(
+                    f"Invalid URL scheme for custom providers: {url}. Only http:// and https:// are allowed."
+                )
+                return
+            
             # Use httpx to fetch the JSON from URL
             with httpx.Client(timeout=10.0) as client:
                 response = client.get(url)

--- a/tests/test_litellm/llms/openai_like/test_json_loader_url.py
+++ b/tests/test_litellm/llms/openai_like/test_json_loader_url.py
@@ -145,6 +145,22 @@ class TestJSONProviderURLLoader:
                 assert provider.base_url == "https://custom.publicai.com/v1"
                 assert provider.api_key_env == "CUSTOM_PUBLICAI_KEY"
 
+    def test_invalid_url_scheme(self):
+        """Test that non-http/https URL schemes are rejected"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+        
+        # Reset the registry
+        JSONProviderRegistry._loaded = False
+        JSONProviderRegistry._providers = {}
+
+        # Try with file:// scheme (should be rejected)
+        with patch.dict(os.environ, {"LITELLM_CUSTOM_PROVIDERS_URL": "file:///etc/passwd"}):
+            # Should not raise, just log warning
+            JSONProviderRegistry.load()
+            
+            # Should still be loaded
+            assert JSONProviderRegistry._loaded
+
     def test_merge_local_and_custom_providers(self):
         """Test that local and custom providers are merged"""
         # Mock custom provider (different from existing ones)
@@ -176,7 +192,3 @@ class TestJSONProviderURLLoader:
                 assert JSONProviderRegistry.exists("publicai")  # Local provider
                 assert JSONProviderRegistry.exists("my_custom_llm")  # Custom provider
 
-
-if __name__ == "__main__":
-    # Run tests
-    pytest.main([__file__, "-v"])

--- a/tests/test_litellm/llms/openai_like/test_json_loader_url.py
+++ b/tests/test_litellm/llms/openai_like/test_json_loader_url.py
@@ -1,0 +1,182 @@
+"""
+Tests for URL-based provider loading in JSON provider system.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+# Add workspace to path
+workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+sys.path.insert(0, workspace_path)
+
+
+class TestJSONProviderURLLoader:
+    """Test URL-based provider loading"""
+
+    def test_load_from_url_success(self):
+        """Test successfully loading providers from URL"""
+        # Mock custom provider data
+        custom_providers = {
+            "custom_provider": {
+                "base_url": "https://api.custom.com/v1",
+                "api_key_env": "CUSTOM_API_KEY",
+                "api_base_env": "CUSTOM_API_BASE",
+                "base_class": "openai_gpt",
+                "param_mappings": {
+                    "max_completion_tokens": "max_tokens"
+                }
+            }
+        }
+
+        # Mock httpx response
+        mock_response = MagicMock()
+        mock_response.json.return_value = custom_providers
+        mock_response.raise_for_status.return_value = None
+
+        # Reset the registry
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+        JSONProviderRegistry._loaded = False
+        JSONProviderRegistry._providers = {}
+
+        with patch('httpx.Client') as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+            
+            # Set environment variable
+            with patch.dict(os.environ, {"LITELLM_CUSTOM_PROVIDERS_URL": "https://example.com/providers.json"}):
+                JSONProviderRegistry.load()
+
+                # Verify provider was loaded
+                assert JSONProviderRegistry.exists("custom_provider")
+                provider = JSONProviderRegistry.get("custom_provider")
+                assert provider is not None
+                assert provider.base_url == "https://api.custom.com/v1"
+                assert provider.api_key_env == "CUSTOM_API_KEY"
+
+    def test_load_from_url_http_error(self):
+        """Test handling HTTP errors when loading from URL"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+        
+        # Reset the registry
+        JSONProviderRegistry._loaded = False
+        JSONProviderRegistry._providers = {}
+
+        # Mock HTTP error
+        with patch('httpx.Client') as mock_client:
+            mock_client.return_value.__enter__.return_value.get.side_effect = httpx.HTTPError("Connection failed")
+            
+            with patch.dict(os.environ, {"LITELLM_CUSTOM_PROVIDERS_URL": "https://example.com/providers.json"}):
+                # Should not raise, just log warning
+                JSONProviderRegistry.load()
+                
+                # Should still be loaded (but with no providers)
+                assert JSONProviderRegistry._loaded
+
+    def test_load_from_url_json_decode_error(self):
+        """Test handling JSON decode errors when loading from URL"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+        
+        # Reset the registry
+        JSONProviderRegistry._loaded = False
+        JSONProviderRegistry._providers = {}
+
+        # Mock response with invalid JSON
+        mock_response = MagicMock()
+        mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
+        mock_response.raise_for_status.return_value = None
+
+        with patch('httpx.Client') as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+            
+            with patch.dict(os.environ, {"LITELLM_CUSTOM_PROVIDERS_URL": "https://example.com/providers.json"}):
+                # Should not raise, just log warning
+                JSONProviderRegistry.load()
+                
+                # Should still be loaded
+                assert JSONProviderRegistry._loaded
+
+    def test_load_without_url_env_var(self):
+        """Test loading when no URL environment variable is set"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+        
+        # Reset the registry
+        JSONProviderRegistry._loaded = False
+        JSONProviderRegistry._providers = {}
+
+        with patch.dict(os.environ, {}, clear=True):
+            # Should load without errors
+            JSONProviderRegistry.load()
+            assert JSONProviderRegistry._loaded
+
+    def test_custom_provider_overwrites_local(self):
+        """Test that custom providers from URL can overwrite local providers"""
+        # Mock custom provider that overwrites publicai
+        custom_providers = {
+            "publicai": {
+                "base_url": "https://custom.publicai.com/v1",
+                "api_key_env": "CUSTOM_PUBLICAI_KEY",
+                "base_class": "openai_gpt"
+            }
+        }
+
+        # Mock httpx response
+        mock_response = MagicMock()
+        mock_response.json.return_value = custom_providers
+        mock_response.raise_for_status.return_value = None
+
+        # Reset the registry
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+        JSONProviderRegistry._loaded = False
+        JSONProviderRegistry._providers = {}
+
+        with patch('httpx.Client') as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+            
+            with patch.dict(os.environ, {"LITELLM_CUSTOM_PROVIDERS_URL": "https://example.com/providers.json"}):
+                JSONProviderRegistry.load()
+
+                # Verify custom provider overwrote the local one
+                provider = JSONProviderRegistry.get("publicai")
+                assert provider is not None
+                assert provider.base_url == "https://custom.publicai.com/v1"
+                assert provider.api_key_env == "CUSTOM_PUBLICAI_KEY"
+
+    def test_merge_local_and_custom_providers(self):
+        """Test that local and custom providers are merged"""
+        # Mock custom provider (different from existing ones)
+        custom_providers = {
+            "my_custom_llm": {
+                "base_url": "https://api.mycustom.com/v1",
+                "api_key_env": "MY_CUSTOM_API_KEY",
+                "base_class": "openai_gpt"
+            }
+        }
+
+        # Mock httpx response
+        mock_response = MagicMock()
+        mock_response.json.return_value = custom_providers
+        mock_response.raise_for_status.return_value = None
+
+        # Reset the registry
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+        JSONProviderRegistry._loaded = False
+        JSONProviderRegistry._providers = {}
+
+        with patch('httpx.Client') as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+            
+            with patch.dict(os.environ, {"LITELLM_CUSTOM_PROVIDERS_URL": "https://example.com/providers.json"}):
+                JSONProviderRegistry.load()
+
+                # Verify both local and custom providers exist
+                assert JSONProviderRegistry.exists("publicai")  # Local provider
+                assert JSONProviderRegistry.exists("my_custom_llm")  # Custom provider
+
+
+if __name__ == "__main__":
+    # Run tests
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
📖 Documentation

## Changes

Users can now define custom OpenAI-compatible providers without modifying source code or waiting for PR merges. Two methods are supported:

* Inline JSON via LITELLM_CUSTOM_PROVIDERS environment variable (no network calls)
* URL-based via LITELLM_CUSTOM_PROVIDERS_URL (hosted JSON file)

Implementation

* Core (litellm/llms/openai_like/json_loader.py)
* Merge behavior (local + inline + URL, overwriting)

Documentation
Updated:
* docs/my-website/docs/contributing/adding_openai_compatible_providers.md - usage guide for both methods
* litellm/llms/openai_like/README.md - implementation details
