### PR TITLE
Fix Bedrock Converse API returning both json_tool_call and real tools when tools and response_format are used

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1652,39 +1652,59 @@ class AmazonConverseConfig(BaseConfig):
                 self._transform_thinking_blocks(reasoningContentBlocks)
             )
         chat_completion_message["content"] = content_str
-        if (
-            json_mode is True
-            and tools is not None
-            and len(tools) == 1
-            and tools[0]["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
-        ):
-            verbose_logger.debug(
-                "Processing JSON tool call response for response_format"
-            )
-            json_mode_content_str: Optional[str] = tools[0]["function"].get("arguments")
-            if json_mode_content_str is not None:
-                import json
+        
+        # Filter out json_tool_call from tools if json_mode is enabled
+        # This handles the case where both real tools and response_format are used together
+        filtered_tools = tools
+        json_tool_call_found = False
+        if json_mode is True and tools is not None and len(tools) > 0:
+            # Check if json_tool_call is present
+            json_tool_call_index = None
+            for idx, tool in enumerate(tools):
+                if tool["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME:
+                    json_tool_call_index = idx
+                    json_tool_call_found = True
+                    break
+            
+            # If json_tool_call is the ONLY tool, convert it to content (existing behavior)
+            if len(tools) == 1 and json_tool_call_found:
+                verbose_logger.debug(
+                    "Processing JSON tool call response for response_format (single tool)"
+                )
+                json_mode_content_str: Optional[str] = tools[0]["function"].get("arguments")
+                if json_mode_content_str is not None:
+                    import json
 
-                # Bedrock returns the response wrapped in a "properties" object
-                # We need to extract the actual content from this wrapper
-                try:
-                    response_data = json.loads(json_mode_content_str)
+                    # Bedrock returns the response wrapped in a "properties" object
+                    # We need to extract the actual content from this wrapper
+                    try:
+                        response_data = json.loads(json_mode_content_str)
 
-                    # If Bedrock wrapped the response in "properties", extract the content
-                    if (
-                        isinstance(response_data, dict)
-                        and "properties" in response_data
-                        and len(response_data) == 1
-                    ):
-                        response_data = response_data["properties"]
-                        json_mode_content_str = json.dumps(response_data)
-                except json.JSONDecodeError:
-                    # If parsing fails, use the original response
-                    pass
+                        # If Bedrock wrapped the response in "properties", extract the content
+                        if (
+                            isinstance(response_data, dict)
+                            and "properties" in response_data
+                            and len(response_data) == 1
+                        ):
+                            response_data = response_data["properties"]
+                            json_mode_content_str = json.dumps(response_data)
+                    except json.JSONDecodeError:
+                        # If parsing fails, use the original response
+                        pass
 
-                chat_completion_message["content"] = json_mode_content_str
-        else:
-            chat_completion_message["tool_calls"] = tools
+                    chat_completion_message["content"] = json_mode_content_str
+                # Don't set tool_calls when json_tool_call is the only tool
+                filtered_tools = []
+            # If there are multiple tools and json_tool_call is present, filter it out
+            elif len(tools) > 1 and json_tool_call_found and json_tool_call_index is not None:
+                verbose_logger.debug(
+                    f"Filtering out {RESPONSE_FORMAT_TOOL_NAME} from tool calls (multiple tools present)"
+                )
+                filtered_tools = [tool for idx, tool in enumerate(tools) if idx != json_tool_call_index]
+        
+        # Only set tool_calls if there are tools remaining after filtering
+        if filtered_tools and len(filtered_tools) > 0:
+            chat_completion_message["tool_calls"] = filtered_tools
 
         ## CALCULATING USAGE - bedrock returns usage in the headers
         usage = self._transform_usage(completion_response["usage"])


### PR DESCRIPTION
## Summary

Fixed issue #18381 where Bedrock Converse API returns both `json_tool_call` (internal tool for structured output) and real tools when `tools` and `response_format` parameters are used together.

## Changes

- **Modified `_transform_response` method** in `litellm/llms/bedrock/chat/converse_transformation.py`:
  - Added logic to detect when both `json_tool_call` and real tools are present in the response
  - Filter out `json_tool_call` when multiple tools are returned and json_mode is enabled
  - Preserve existing behavior when `json_tool_call` is the only tool (convert to content)
  - Only return real tools to the user, hiding the internal `json_tool_call` implementation detail

- **Added comprehensive tests** in `tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py`:
  - `test_transform_response_with_structured_response_calling_tool`: Tests scenario where only real tool is called
  - `test_transform_response_with_both_json_tool_call_and_real_tool`: Tests the bug scenario where both tools are returned
  - Both tests verify that `json_tool_call` is properly filtered out from the response

## Relevant issues

Fixes #18381

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem

When using both `tools` and `response_format` parameters with Bedrock Converse API, LiteLLM internally adds a fake tool called `json_tool_call` to handle structured output. However, Bedrock sometimes returns both:
1. The `json_tool_call` (internal implementation detail)
2. The real tool that the user defined

This caused the response to contain the internal `json_tool_call` in the tool_calls array, which should be hidden from the user.

### Solution

Modified the `_transform_response` method to intelligently filter tool calls based on the scenario:

1. **Single tool (json_tool_call only)**: Convert to content (existing behavior)
2. **Multiple tools with json_tool_call present**: Filter out `json_tool_call` and only return real tools
3. **Multiple tools without json_tool_call**: Return all tools as-is (no change)

### Code Changes

**File**: `litellm/llms/bedrock/chat/converse_transformation.py`

Lines 1473-1525: Refactored tool filtering logic to handle three scenarios:
- Detect if `json_tool_call` is present in the response
- If it's the only tool, convert to content (existing behavior)
- If there are multiple tools, filter out `json_tool_call` and return only real tools
- Only set `tool_calls` if there are tools remaining after filtering

### Testing

Added two comprehensive test cases:

1. **`test_transform_response_with_structured_response_calling_tool`** (line 623):
   - Tests scenario where both tools are provided but only the real tool is called
   - Verifies that only the real tool appears in the response

2. **`test_transform_response_with_both_json_tool_call_and_real_tool`** (line 750):
   - Tests the exact bug scenario from issue #18381
   - Simulates Bedrock returning both `json_tool_call` and real tool
   - Verifies that `json_tool_call` is filtered out and only real tool is returned

All 58 tests in `test_converse_transformation.py` are passing.

### Edge Cases Handled

- ✅ Single `json_tool_call` only → Convert to content
- ✅ Multiple tools with `json_tool_call` → Filter out `json_tool_call`
- ✅ Multiple tools without `json_tool_call` → Return all tools
- ✅ No tools → No changes
- ✅ Empty tools list → No changes

### Backward Compatibility

This change is fully backward compatible:
- Existing behavior for single `json_tool_call` is preserved
- Only affects the new edge case where both tools are returned
- No API changes or breaking changes to existing functionality

