### PR TITLE
[Refactor] Consolidate lazy import handlers with registry pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ update_model_cost_map.py
 tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
 litellm/proxy/_experimental/out/guardrails/index.html
 scripts/test_vertex_ai_search.py
+LAZY_LOADING_IMPROVEMENTS.md

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1573,81 +1573,11 @@ if TYPE_CHECKING:
     # Note: AmazonConverseConfig and OpenAILikeChatConfig are imported above in TYPE_CHECKING block
 
 
-# Cached registry for lazy imports - built once on first access
-# Maps attribute names to their handler function
-_LAZY_IMPORT_REGISTRY: Optional[dict[str, Callable[[str], Any]]] = None
-
-
-def _get_lazy_import_registry() -> dict[str, Callable[[str], Any]]:
-    """
-    Build and cache the lazy import registry (only once).
-    
-    Returns a dictionary mapping attribute names to their handler functions.
-    This avoids importing all name tuples on every __getattr__ call.
-    """
-    global _LAZY_IMPORT_REGISTRY
-    if _LAZY_IMPORT_REGISTRY is None:
-        # Import name tuples and handler functions only once (first time __getattr__ is called)
-        from ._lazy_imports import (
-            COST_CALCULATOR_NAMES,
-            LITELLM_LOGGING_NAMES,
-            UTILS_NAMES,
-            TOKEN_COUNTER_NAMES,
-            LLM_CLIENT_CACHE_NAMES,
-            BEDROCK_TYPES_NAMES,
-            TYPES_UTILS_NAMES,
-            CACHING_NAMES,
-            HTTP_HANDLER_NAMES,
-            DOTPROMPT_NAMES,
-            LLM_CONFIG_NAMES,
-            TYPES_NAMES,
-            _lazy_import_cost_calculator,
-            _lazy_import_litellm_logging,
-            _lazy_import_utils,
-            _lazy_import_token_counter,
-            _lazy_import_llm_client_cache,
-            _lazy_import_bedrock_types,
-            _lazy_import_types_utils,
-            _lazy_import_caching,
-            _lazy_import_http_handlers,
-            _lazy_import_dotprompt,
-            _lazy_import_llm_configs,
-            _lazy_import_types,
-        )
-        
-        # Build unified registry mapping names directly to handler functions
-        _LAZY_IMPORT_REGISTRY = {}
-        for name in COST_CALCULATOR_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_cost_calculator
-        for name in LITELLM_LOGGING_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_litellm_logging
-        for name in UTILS_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_utils
-        for name in TOKEN_COUNTER_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_token_counter
-        for name in LLM_CLIENT_CACHE_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_llm_client_cache
-        for name in BEDROCK_TYPES_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_bedrock_types
-        for name in TYPES_UTILS_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_types_utils
-        for name in CACHING_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_caching
-        for name in HTTP_HANDLER_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_http_handlers
-        for name in DOTPROMPT_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_dotprompt
-        for name in LLM_CONFIG_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_llm_configs
-        for name in TYPES_NAMES:
-            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_types
-    
-    return _LAZY_IMPORT_REGISTRY
-
-
 def __getattr__(name: str) -> Any:
     """Lazy import handler with cached registry for improved performance."""
-    # Use cached registry instead of importing tuples every time
+    # Use cached registry from _lazy_imports instead of importing tuples every time
+    from ._lazy_imports import _get_lazy_import_registry
+    
     registry = _get_lazy_import_registry()
     
     # Check if name is in registry and call the cached handler function

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1587,11 +1587,13 @@ def __getattr__(name: str) -> Any:
 
     # Lazy load encoding from main.py to avoid heavy tiktoken import
     if name == "encoding":
-        from .main import encoding as _encoding
-        # Cache it in the module's __dict__ for subsequent accesses
-        import sys
-        sys.modules[__name__].__dict__["encoding"] = _encoding
-        return _encoding
+        from ._lazy_imports import _get_litellm_globals
+        _globals = _get_litellm_globals()
+        # Check if already cached
+        if "encoding" not in _globals:
+            from .main import encoding as _encoding
+            _globals["encoding"] = _encoding
+        return _globals["encoding"]
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1573,86 +1573,87 @@ if TYPE_CHECKING:
     # Note: AmazonConverseConfig and OpenAILikeChatConfig are imported above in TYPE_CHECKING block
 
 
+# Cached registry for lazy imports - built once on first access
+# Maps attribute names to their handler function
+_LAZY_IMPORT_REGISTRY: Optional[dict[str, Callable[[str], Any]]] = None
+
+
+def _get_lazy_import_registry() -> dict[str, Callable[[str], Any]]:
+    """
+    Build and cache the lazy import registry (only once).
+    
+    Returns a dictionary mapping attribute names to their handler functions.
+    This avoids importing all name tuples on every __getattr__ call.
+    """
+    global _LAZY_IMPORT_REGISTRY
+    if _LAZY_IMPORT_REGISTRY is None:
+        # Import name tuples and handler functions only once (first time __getattr__ is called)
+        from ._lazy_imports import (
+            COST_CALCULATOR_NAMES,
+            LITELLM_LOGGING_NAMES,
+            UTILS_NAMES,
+            TOKEN_COUNTER_NAMES,
+            LLM_CLIENT_CACHE_NAMES,
+            BEDROCK_TYPES_NAMES,
+            TYPES_UTILS_NAMES,
+            CACHING_NAMES,
+            HTTP_HANDLER_NAMES,
+            DOTPROMPT_NAMES,
+            LLM_CONFIG_NAMES,
+            TYPES_NAMES,
+            _lazy_import_cost_calculator,
+            _lazy_import_litellm_logging,
+            _lazy_import_utils,
+            _lazy_import_token_counter,
+            _lazy_import_llm_client_cache,
+            _lazy_import_bedrock_types,
+            _lazy_import_types_utils,
+            _lazy_import_caching,
+            _lazy_import_http_handlers,
+            _lazy_import_dotprompt,
+            _lazy_import_llm_configs,
+            _lazy_import_types,
+        )
+        
+        # Build unified registry mapping names directly to handler functions
+        _LAZY_IMPORT_REGISTRY = {}
+        for name in COST_CALCULATOR_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_cost_calculator
+        for name in LITELLM_LOGGING_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_litellm_logging
+        for name in UTILS_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_utils
+        for name in TOKEN_COUNTER_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_token_counter
+        for name in LLM_CLIENT_CACHE_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_llm_client_cache
+        for name in BEDROCK_TYPES_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_bedrock_types
+        for name in TYPES_UTILS_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_types_utils
+        for name in CACHING_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_caching
+        for name in HTTP_HANDLER_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_http_handlers
+        for name in DOTPROMPT_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_dotprompt
+        for name in LLM_CONFIG_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_llm_configs
+        for name in TYPES_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_types
+    
+    return _LAZY_IMPORT_REGISTRY
+
+
 def __getattr__(name: str) -> Any:
-    """Lazy import handler"""
-    from ._lazy_imports import (
-        COST_CALCULATOR_NAMES,
-        LITELLM_LOGGING_NAMES,
-        UTILS_NAMES,
-        TOKEN_COUNTER_NAMES,
-        LLM_CLIENT_CACHE_NAMES,
-        BEDROCK_TYPES_NAMES,
-        TYPES_UTILS_NAMES,
-        CACHING_NAMES,
-        HTTP_HANDLER_NAMES,
-        DOTPROMPT_NAMES,
-        LLM_CONFIG_NAMES,
-        TYPES_NAMES,
-    )
+    """Lazy import handler with cached registry for improved performance."""
+    # Use cached registry instead of importing tuples every time
+    registry = _get_lazy_import_registry()
     
-    # Lazy load cost_calculator functions
-    if name in COST_CALCULATOR_NAMES:
-        from ._lazy_imports import _lazy_import_cost_calculator
-        return _lazy_import_cost_calculator(name)
-
-    # Lazy load litellm_logging functions
-    if name in LITELLM_LOGGING_NAMES:
-        from ._lazy_imports import _lazy_import_litellm_logging
-        return _lazy_import_litellm_logging(name)
-
-    # Lazy load utils functions
-    if name in UTILS_NAMES:
-        from ._lazy_imports import _lazy_import_utils
-        return _lazy_import_utils(name)
-    
-    # Lazy load token counter utilities
-    if name in TOKEN_COUNTER_NAMES:
-        from ._lazy_imports import _lazy_import_token_counter
-        return _lazy_import_token_counter(name)
-    
-    # Lazy load Bedrock type aliases
-    if name in BEDROCK_TYPES_NAMES:
-        from ._lazy_imports import _lazy_import_bedrock_types
-        return _lazy_import_bedrock_types(name)
-    
-    # Lazy load common types.utils symbols
-    if name in TYPES_UTILS_NAMES:
-        from ._lazy_imports import _lazy_import_types_utils
-        return _lazy_import_types_utils(name)
-    
-    # Lazy load LLM client cache and its singleton
-    if name in LLM_CLIENT_CACHE_NAMES:
-        from ._lazy_imports import _lazy_import_llm_client_cache
-        return _lazy_import_llm_client_cache(name)
-    
-    # Lazy load caching classes
-    if name in CACHING_NAMES:
-        from ._lazy_imports import _lazy_import_caching
-        return _lazy_import_caching(name)
-    
-    # Lazy-load HTTP handler singletons used across the codebase
-    if name in HTTP_HANDLER_NAMES:
-        from ._lazy_imports import _lazy_import_http_handlers
-
-        return _lazy_import_http_handlers(name)
-
-    # Lazy load dotprompt integration globals
-    if name in DOTPROMPT_NAMES:
-        from ._lazy_imports import _lazy_import_dotprompt
-
-        return _lazy_import_dotprompt(name)
-
-    # Lazy load LLM config classes
-    if name in LLM_CONFIG_NAMES:
-        from ._lazy_imports import _lazy_import_llm_configs
-
-        return _lazy_import_llm_configs(name)
-
-    # Lazy load types
-    if name in TYPES_NAMES:
-        from ._lazy_imports import _lazy_import_types
-
-        return _lazy_import_types(name)
+    # Check if name is in registry and call the cached handler function
+    if name in registry:
+        handler_func = registry[name]
+        return handler_func(name)
 
     # Lazy load encoding from main.py to avoid heavy tiktoken import
     if name == "encoding":

--- a/litellm/_lazy_imports.py
+++ b/litellm/_lazy_imports.py
@@ -1,3 +1,4 @@
+import importlib
 import sys
 from typing import Any, Optional, cast, Callable
 
@@ -165,7 +166,6 @@ def _lazy_import_utils(name: str) -> Any:
     module_path, attr_name = _UTILS_IMPORT_MAP[name]
     
     # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    import importlib
     module = importlib.import_module(module_path, package="litellm")
     value = getattr(module, attr_name)
     
@@ -187,7 +187,6 @@ def _lazy_import_cost_calculator(name: str) -> Any:
     module_path, attr_name = _COST_CALCULATOR_IMPORT_MAP[name]
     
     # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    import importlib
     module = importlib.import_module(module_path, package="litellm")
     value = getattr(module, attr_name)
     
@@ -209,7 +208,6 @@ def _lazy_import_token_counter(name: str) -> Any:
     module_path, attr_name = _TOKEN_COUNTER_IMPORT_MAP[name]
     
     # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    import importlib
     module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
@@ -231,7 +229,6 @@ def _lazy_import_bedrock_types(name: str) -> Any:
     module_path, attr_name = _BEDROCK_TYPES_IMPORT_MAP[name]
     
     # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    import importlib
     module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
@@ -253,7 +250,6 @@ def _lazy_import_types_utils(name: str) -> Any:
     module_path, attr_name = _TYPES_UTILS_IMPORT_MAP[name]
     
     # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    import importlib
     module = importlib.import_module(module_path, package="litellm")
     value = getattr(module, attr_name)
     
@@ -275,7 +271,6 @@ def _lazy_import_caching(name: str) -> Any:
     module_path, attr_name = _CACHING_IMPORT_MAP[name]
     
     # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    import importlib
     module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
@@ -293,7 +288,6 @@ def _lazy_import_llm_client_cache(name: str) -> Any:
     
     # Import the class
     # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    import importlib
     module = importlib.import_module("litellm.caching.llm_caching_handler")
     LLMClientCache = getattr(module, "LLMClientCache")
     
@@ -325,7 +319,6 @@ def _lazy_import_litellm_logging(name: str) -> Any:
     module_path, attr_name = _LITELLM_LOGGING_IMPORT_MAP[name]
     
     # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    import importlib
     module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
@@ -379,7 +372,6 @@ def _lazy_import_dotprompt(name: str) -> Any:
     module_path, attr_name = _DOTPROMPT_IMPORT_MAP[name]
     
     # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    import importlib
     module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
@@ -401,7 +393,6 @@ def _lazy_import_types(name: str) -> Any:
     module_path, attr_name = _TYPES_IMPORT_MAP[name]
     
     # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    import importlib
     module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
@@ -423,7 +414,6 @@ def _lazy_import_llm_configs(name: str) -> Any:
     module_path, attr_name = _LLM_CONFIGS_IMPORT_MAP[name]
     
     # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    import importlib
     module = importlib.import_module(module_path, package="litellm")
     value = getattr(module, attr_name)
     

--- a/litellm/_lazy_imports.py
+++ b/litellm/_lazy_imports.py
@@ -1,6 +1,34 @@
 import sys
 from typing import Any, Optional, cast, Callable
 
+# Import all name tuples and import maps from the registry
+from ._lazy_imports_registry import (
+    # Name tuples
+    COST_CALCULATOR_NAMES,
+    LITELLM_LOGGING_NAMES,
+    UTILS_NAMES,
+    TOKEN_COUNTER_NAMES,
+    LLM_CLIENT_CACHE_NAMES,
+    BEDROCK_TYPES_NAMES,
+    TYPES_UTILS_NAMES,
+    CACHING_NAMES,
+    HTTP_HANDLER_NAMES,
+    DOTPROMPT_NAMES,
+    LLM_CONFIG_NAMES,
+    TYPES_NAMES,
+    # Import maps
+    _UTILS_IMPORT_MAP,
+    _COST_CALCULATOR_IMPORT_MAP,
+    _TYPES_UTILS_IMPORT_MAP,
+    _TOKEN_COUNTER_IMPORT_MAP,
+    _BEDROCK_TYPES_IMPORT_MAP,
+    _CACHING_IMPORT_MAP,
+    _LITELLM_LOGGING_IMPORT_MAP,
+    _DOTPROMPT_IMPORT_MAP,
+    _TYPES_IMPORT_MAP,
+    _LLM_CONFIGS_IMPORT_MAP,
+)
+
 
 def _get_litellm_globals() -> dict:
     """Helper to get the globals dictionary of the litellm module."""
@@ -75,137 +103,6 @@ def _get_token_counter_new() -> Any:
         _token_counter_new_func = _token_counter_imported
     return _token_counter_new_func
 
-# Cost calculator names that support lazy loading via _lazy_import_cost_calculator
-COST_CALCULATOR_NAMES = (
-    "completion_cost",
-    "cost_per_token",
-    "response_cost_calculator",
-)
-
-# Litellm logging names that support lazy loading via _lazy_import_litellm_logging
-LITELLM_LOGGING_NAMES = (
-    "Logging",
-    "modify_integration",
-)
-
-# Utils names that support lazy loading via _lazy_import_utils
-UTILS_NAMES = (
-    "exception_type", "get_optional_params", "get_response_string", "token_counter",
-    "create_pretrained_tokenizer", "create_tokenizer", "supports_function_calling",
-    "supports_web_search", "supports_url_context", "supports_response_schema",
-    "supports_parallel_function_calling", "supports_vision", "supports_audio_input",
-    "supports_audio_output", "supports_system_messages", "supports_reasoning",
-    "get_litellm_params", "acreate", "get_max_tokens", "get_model_info",
-    "register_prompt_template", "validate_environment", "check_valid_key",
-    "register_model", "encode", "decode", "_calculate_retry_after", "_should_retry",
-    "get_supported_openai_params", "get_api_base", "get_first_chars_messages",
-    "ModelResponse", "ModelResponseStream", "EmbeddingResponse", "ImageResponse",
-    "TranscriptionResponse", "TextCompletionResponse", "get_provider_fields",
-    "ModelResponseListIterator", "get_valid_models",
-)
-
-# Token counter names that support lazy loading via _lazy_import_token_counter
-TOKEN_COUNTER_NAMES = (
-    "get_modified_max_tokens",
-)
-
-# LLM client cache names that support lazy loading via _lazy_import_llm_client_cache
-LLM_CLIENT_CACHE_NAMES = (
-    "LLMClientCache",
-    "in_memory_llm_clients_cache",
-)
-
-# Bedrock type names that support lazy loading via _lazy_import_bedrock_types
-BEDROCK_TYPES_NAMES = (
-    "COHERE_EMBEDDING_INPUT_TYPES",
-)
-
-# Common types from litellm.types.utils that support lazy loading via
-# _lazy_import_types_utils
-TYPES_UTILS_NAMES = (
-    "ImageObject",
-    "BudgetConfig",
-    "all_litellm_params",
-    "_litellm_completion_params",
-    "CredentialItem",
-    "PriorityReservationDict",
-    "StandardKeyGenerationConfig",
-    "SearchProviders",
-    "GenericStreamingChunk",
-)
-
-# Caching / cache classes that support lazy loading via _lazy_import_caching
-CACHING_NAMES = (
-    "Cache",
-    "DualCache",
-    "RedisCache",
-    "InMemoryCache",
-)
-
-# HTTP handler names that support lazy loading via _lazy_import_http_handlers
-HTTP_HANDLER_NAMES = (
-    "module_level_aclient",
-    "module_level_client",
-)
-
-# Dotprompt integration names that support lazy loading via _lazy_import_dotprompt
-DOTPROMPT_NAMES = (
-    "global_prompt_manager",
-    "global_prompt_directory",
-    "set_global_prompt_directory",
-)
-
-# LLM config classes that support lazy loading via _lazy_import_llm_configs
-LLM_CONFIG_NAMES = (
-    "AmazonConverseConfig",
-    "OpenAILikeChatConfig",
-    "GaladrielChatConfig",
-    "GithubChatConfig",
-    "AzureAnthropicConfig",
-    "BytezChatConfig",
-    "CompactifAIChatConfig",
-    "EmpowerChatConfig",
-    "MinimaxChatConfig",
-    "AiohttpOpenAIChatConfig",
-    "HuggingFaceChatConfig",
-    "HuggingFaceEmbeddingConfig",
-    "OobaboogaConfig",
-    "MaritalkConfig",
-    "OpenrouterConfig",
-    "DataRobotConfig",
-    "AnthropicConfig",
-    "AnthropicTextConfig",
-    "GroqSTTConfig",
-    "TritonConfig",
-    "TritonGenerateConfig",
-    "TritonInferConfig",
-    "TritonEmbeddingConfig",
-    "HuggingFaceRerankConfig",
-    "DatabricksConfig",
-    "DatabricksEmbeddingConfig",
-    "PredibaseConfig",
-    "ReplicateConfig",
-    "SnowflakeConfig",
-    "CohereRerankConfig",
-    "CohereRerankV2Config",
-    "AzureAIRerankConfig",
-    "InfinityRerankConfig",
-    "JinaAIRerankConfig",
-    "DeepinfraRerankConfig",
-    "HostedVLLMRerankConfig",
-    "NvidiaNimRerankConfig",
-    "NvidiaNimRankingConfig",
-    "VertexAIRerankConfig",
-    "FireworksAIRerankConfig",
-    "VoyageRerankConfig",
-    "ClarifaiConfig",
-    "AI21ChatConfig",
-)
-
-# Types that support lazy loading via _lazy_import_types
-TYPES_NAMES = (
-    "GuardrailItem",
-)
 
 # Cached registry for lazy imports - built once on first access
 # Maps attribute names to their handler function
@@ -252,143 +149,6 @@ def _get_lazy_import_registry() -> dict[str, Callable[[str], Any]]:
     return _LAZY_IMPORT_REGISTRY
 
 
-# Import maps for registry pattern - reduces repetition
-_UTILS_IMPORT_MAP = {
-    "exception_type": (".utils", "exception_type"),
-    "get_optional_params": (".utils", "get_optional_params"),
-    "get_response_string": (".utils", "get_response_string"),
-    "token_counter": (".utils", "token_counter"),
-    "create_pretrained_tokenizer": (".utils", "create_pretrained_tokenizer"),
-    "create_tokenizer": (".utils", "create_tokenizer"),
-    "supports_function_calling": (".utils", "supports_function_calling"),
-    "supports_web_search": (".utils", "supports_web_search"),
-    "supports_url_context": (".utils", "supports_url_context"),
-    "supports_response_schema": (".utils", "supports_response_schema"),
-    "supports_parallel_function_calling": (".utils", "supports_parallel_function_calling"),
-    "supports_vision": (".utils", "supports_vision"),
-    "supports_audio_input": (".utils", "supports_audio_input"),
-    "supports_audio_output": (".utils", "supports_audio_output"),
-    "supports_system_messages": (".utils", "supports_system_messages"),
-    "supports_reasoning": (".utils", "supports_reasoning"),
-    "get_litellm_params": (".utils", "get_litellm_params"),
-    "acreate": (".utils", "acreate"),
-    "get_max_tokens": (".utils", "get_max_tokens"),
-    "get_model_info": (".utils", "get_model_info"),
-    "register_prompt_template": (".utils", "register_prompt_template"),
-    "validate_environment": (".utils", "validate_environment"),
-    "check_valid_key": (".utils", "check_valid_key"),
-    "register_model": (".utils", "register_model"),
-    "encode": (".utils", "encode"),
-    "decode": (".utils", "decode"),
-    "_calculate_retry_after": (".utils", "_calculate_retry_after"),
-    "_should_retry": (".utils", "_should_retry"),
-    "get_supported_openai_params": (".utils", "get_supported_openai_params"),
-    "get_api_base": (".utils", "get_api_base"),
-    "get_first_chars_messages": (".utils", "get_first_chars_messages"),
-    "ModelResponse": (".utils", "ModelResponse"),
-    "ModelResponseStream": (".utils", "ModelResponseStream"),
-    "EmbeddingResponse": (".utils", "EmbeddingResponse"),
-    "ImageResponse": (".utils", "ImageResponse"),
-    "TranscriptionResponse": (".utils", "TranscriptionResponse"),
-    "TextCompletionResponse": (".utils", "TextCompletionResponse"),
-    "get_provider_fields": (".utils", "get_provider_fields"),
-    "ModelResponseListIterator": (".utils", "ModelResponseListIterator"),
-    "get_valid_models": (".utils", "get_valid_models"),
-}
-
-_COST_CALCULATOR_IMPORT_MAP = {
-    "completion_cost": (".cost_calculator", "completion_cost"),
-    "cost_per_token": (".cost_calculator", "cost_per_token"),
-    "response_cost_calculator": (".cost_calculator", "response_cost_calculator"),
-}
-
-_TYPES_UTILS_IMPORT_MAP = {
-    "ImageObject": (".types.utils", "ImageObject"),
-    "BudgetConfig": (".types.utils", "BudgetConfig"),
-    "all_litellm_params": (".types.utils", "all_litellm_params"),
-    "_litellm_completion_params": (".types.utils", "all_litellm_params"),  # Alias
-    "CredentialItem": (".types.utils", "CredentialItem"),
-    "PriorityReservationDict": (".types.utils", "PriorityReservationDict"),
-    "StandardKeyGenerationConfig": (".types.utils", "StandardKeyGenerationConfig"),
-    "SearchProviders": (".types.utils", "SearchProviders"),
-    "GenericStreamingChunk": (".types.utils", "GenericStreamingChunk"),
-}
-
-_TOKEN_COUNTER_IMPORT_MAP = {
-    "get_modified_max_tokens": ("litellm.litellm_core_utils.token_counter", "get_modified_max_tokens"),
-}
-
-_BEDROCK_TYPES_IMPORT_MAP = {
-    "COHERE_EMBEDDING_INPUT_TYPES": ("litellm.types.llms.bedrock", "COHERE_EMBEDDING_INPUT_TYPES"),
-}
-
-_CACHING_IMPORT_MAP = {
-    "Cache": ("litellm.caching.caching", "Cache"),
-    "DualCache": ("litellm.caching.caching", "DualCache"),
-    "RedisCache": ("litellm.caching.caching", "RedisCache"),
-    "InMemoryCache": ("litellm.caching.caching", "InMemoryCache"),
-}
-
-_LITELLM_LOGGING_IMPORT_MAP = {
-    "Logging": ("litellm.litellm_core_utils.litellm_logging", "Logging"),
-    "modify_integration": ("litellm.litellm_core_utils.litellm_logging", "modify_integration"),
-}
-
-_DOTPROMPT_IMPORT_MAP = {
-    "global_prompt_manager": ("litellm.integrations.dotprompt", "global_prompt_manager"),
-    "global_prompt_directory": ("litellm.integrations.dotprompt", "global_prompt_directory"),
-    "set_global_prompt_directory": ("litellm.integrations.dotprompt", "set_global_prompt_directory"),
-}
-
-_TYPES_IMPORT_MAP = {
-    "GuardrailItem": ("litellm.types.guardrails", "GuardrailItem"),
-}
-
-_LLM_CONFIGS_IMPORT_MAP = {
-    "AmazonConverseConfig": (".llms.bedrock.chat.converse_transformation", "AmazonConverseConfig"),
-    "OpenAILikeChatConfig": (".llms.openai_like.chat.handler", "OpenAILikeChatConfig"),
-    "GaladrielChatConfig": (".llms.galadriel.chat.transformation", "GaladrielChatConfig"),
-    "GithubChatConfig": (".llms.github.chat.transformation", "GithubChatConfig"),
-    "AzureAnthropicConfig": (".llms.azure_ai.anthropic.transformation", "AzureAnthropicConfig"),
-    "BytezChatConfig": (".llms.bytez.chat.transformation", "BytezChatConfig"),
-    "CompactifAIChatConfig": (".llms.compactifai.chat.transformation", "CompactifAIChatConfig"),
-    "EmpowerChatConfig": (".llms.empower.chat.transformation", "EmpowerChatConfig"),
-    "MinimaxChatConfig": (".llms.minimax.chat.transformation", "MinimaxChatConfig"),
-    "AiohttpOpenAIChatConfig": (".llms.aiohttp_openai.chat.transformation", "AiohttpOpenAIChatConfig"),
-    "HuggingFaceChatConfig": (".llms.huggingface.chat.transformation", "HuggingFaceChatConfig"),
-    "HuggingFaceEmbeddingConfig": (".llms.huggingface.embedding.transformation", "HuggingFaceEmbeddingConfig"),
-    "OobaboogaConfig": (".llms.oobabooga.chat.transformation", "OobaboogaConfig"),
-    "MaritalkConfig": (".llms.maritalk", "MaritalkConfig"),
-    "OpenrouterConfig": (".llms.openrouter.chat.transformation", "OpenrouterConfig"),
-    "DataRobotConfig": (".llms.datarobot.chat.transformation", "DataRobotConfig"),
-    "AnthropicConfig": (".llms.anthropic.chat.transformation", "AnthropicConfig"),
-    "AnthropicTextConfig": (".llms.anthropic.completion.transformation", "AnthropicTextConfig"),
-    "GroqSTTConfig": (".llms.groq.stt.transformation", "GroqSTTConfig"),
-    "TritonConfig": (".llms.triton.completion.transformation", "TritonConfig"),
-    "TritonGenerateConfig": (".llms.triton.completion.transformation", "TritonGenerateConfig"),
-    "TritonInferConfig": (".llms.triton.completion.transformation", "TritonInferConfig"),
-    "TritonEmbeddingConfig": (".llms.triton.embedding.transformation", "TritonEmbeddingConfig"),
-    "HuggingFaceRerankConfig": (".llms.huggingface.rerank.transformation", "HuggingFaceRerankConfig"),
-    "DatabricksConfig": (".llms.databricks.chat.transformation", "DatabricksConfig"),
-    "DatabricksEmbeddingConfig": (".llms.databricks.embed.transformation", "DatabricksEmbeddingConfig"),
-    "PredibaseConfig": (".llms.predibase.chat.transformation", "PredibaseConfig"),
-    "ReplicateConfig": (".llms.replicate.chat.transformation", "ReplicateConfig"),
-    "SnowflakeConfig": (".llms.snowflake.chat.transformation", "SnowflakeConfig"),
-    "CohereRerankConfig": (".llms.cohere.rerank.transformation", "CohereRerankConfig"),
-    "CohereRerankV2Config": (".llms.cohere.rerank_v2.transformation", "CohereRerankV2Config"),
-    "AzureAIRerankConfig": (".llms.azure_ai.rerank.transformation", "AzureAIRerankConfig"),
-    "InfinityRerankConfig": (".llms.infinity.rerank.transformation", "InfinityRerankConfig"),
-    "JinaAIRerankConfig": (".llms.jina_ai.rerank.transformation", "JinaAIRerankConfig"),
-    "DeepinfraRerankConfig": (".llms.deepinfra.rerank.transformation", "DeepinfraRerankConfig"),
-    "HostedVLLMRerankConfig": (".llms.hosted_vllm.rerank.transformation", "HostedVLLMRerankConfig"),
-    "NvidiaNimRerankConfig": (".llms.nvidia_nim.rerank.transformation", "NvidiaNimRerankConfig"),
-    "NvidiaNimRankingConfig": (".llms.nvidia_nim.rerank.ranking_transformation", "NvidiaNimRankingConfig"),
-    "VertexAIRerankConfig": (".llms.vertex_ai.rerank.transformation", "VertexAIRerankConfig"),
-    "FireworksAIRerankConfig": (".llms.fireworks_ai.rerank.transformation", "FireworksAIRerankConfig"),
-    "VoyageRerankConfig": (".llms.voyage.rerank.transformation", "VoyageRerankConfig"),
-    "ClarifaiConfig": (".llms.clarifai.chat.transformation", "ClarifaiConfig"),
-    "AI21ChatConfig": (".llms.ai21.chat.transformation", "AI21ChatConfig"),
-}
 
 # Lazy import for utils module - imports only the requested item by name.
 def _lazy_import_utils(name: str) -> Any:

--- a/litellm/_lazy_imports.py
+++ b/litellm/_lazy_imports.py
@@ -199,6 +199,7 @@ LLM_CONFIG_NAMES = (
     "FireworksAIRerankConfig",
     "VoyageRerankConfig",
     "ClarifaiConfig",
+    "AI21ChatConfig",
 )
 
 # Types that support lazy loading via _lazy_import_types
@@ -386,6 +387,7 @@ _LLM_CONFIGS_IMPORT_MAP = {
     "FireworksAIRerankConfig": (".llms.fireworks_ai.rerank.transformation", "FireworksAIRerankConfig"),
     "VoyageRerankConfig": (".llms.voyage.rerank.transformation", "VoyageRerankConfig"),
     "ClarifaiConfig": (".llms.clarifai.chat.transformation", "ClarifaiConfig"),
+    "AI21ChatConfig": (".llms.ai21.chat.transformation", "AI21ChatConfig"),
 }
 
 # Lazy import for utils module - imports only the requested item by name.

--- a/litellm/_lazy_imports.py
+++ b/litellm/_lazy_imports.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Optional, cast
+from typing import Any, Optional, cast, Callable
 
 
 def _get_litellm_globals() -> dict:
@@ -205,6 +205,51 @@ LLM_CONFIG_NAMES = (
 TYPES_NAMES = (
     "GuardrailItem",
 )
+
+# Cached registry for lazy imports - built once on first access
+# Maps attribute names to their handler function
+_LAZY_IMPORT_REGISTRY: Optional[dict[str, Callable[[str], Any]]] = None
+
+
+def _get_lazy_import_registry() -> dict[str, Callable[[str], Any]]:
+    """
+    Build and cache the lazy import registry (only once).
+    
+    Returns a dictionary mapping attribute names to their handler functions.
+    This avoids importing all name tuples on every __getattr__ call.
+    """
+    global _LAZY_IMPORT_REGISTRY
+    if _LAZY_IMPORT_REGISTRY is None:
+        # Build unified registry mapping names directly to handler functions
+        # All name tuples and handler functions are already in this module
+        _LAZY_IMPORT_REGISTRY = {}
+        for name in COST_CALCULATOR_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_cost_calculator
+        for name in LITELLM_LOGGING_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_litellm_logging
+        for name in UTILS_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_utils
+        for name in TOKEN_COUNTER_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_token_counter
+        for name in LLM_CLIENT_CACHE_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_llm_client_cache
+        for name in BEDROCK_TYPES_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_bedrock_types
+        for name in TYPES_UTILS_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_types_utils
+        for name in CACHING_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_caching
+        for name in HTTP_HANDLER_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_http_handlers
+        for name in DOTPROMPT_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_dotprompt
+        for name in LLM_CONFIG_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_llm_configs
+        for name in TYPES_NAMES:
+            _LAZY_IMPORT_REGISTRY[name] = _lazy_import_types
+    
+    return _LAZY_IMPORT_REGISTRY
+
 
 # Lazy import for utils module - imports only the requested item by name.
 # Note: PLR0915 (too many statements) is suppressed because the many if statements

--- a/litellm/_lazy_imports.py
+++ b/litellm/_lazy_imports.py
@@ -313,6 +313,81 @@ _TYPES_UTILS_IMPORT_MAP = {
     "GenericStreamingChunk": (".types.utils", "GenericStreamingChunk"),
 }
 
+_TOKEN_COUNTER_IMPORT_MAP = {
+    "get_modified_max_tokens": ("litellm.litellm_core_utils.token_counter", "get_modified_max_tokens"),
+}
+
+_BEDROCK_TYPES_IMPORT_MAP = {
+    "COHERE_EMBEDDING_INPUT_TYPES": ("litellm.types.llms.bedrock", "COHERE_EMBEDDING_INPUT_TYPES"),
+}
+
+_CACHING_IMPORT_MAP = {
+    "Cache": ("litellm.caching.caching", "Cache"),
+    "DualCache": ("litellm.caching.caching", "DualCache"),
+    "RedisCache": ("litellm.caching.caching", "RedisCache"),
+    "InMemoryCache": ("litellm.caching.caching", "InMemoryCache"),
+}
+
+_LITELLM_LOGGING_IMPORT_MAP = {
+    "Logging": ("litellm.litellm_core_utils.litellm_logging", "Logging"),
+    "modify_integration": ("litellm.litellm_core_utils.litellm_logging", "modify_integration"),
+}
+
+_DOTPROMPT_IMPORT_MAP = {
+    "global_prompt_manager": ("litellm.integrations.dotprompt", "global_prompt_manager"),
+    "global_prompt_directory": ("litellm.integrations.dotprompt", "global_prompt_directory"),
+    "set_global_prompt_directory": ("litellm.integrations.dotprompt", "set_global_prompt_directory"),
+}
+
+_TYPES_IMPORT_MAP = {
+    "GuardrailItem": ("litellm.types.guardrails", "GuardrailItem"),
+}
+
+_LLM_CONFIGS_IMPORT_MAP = {
+    "AmazonConverseConfig": (".llms.bedrock.chat.converse_transformation", "AmazonConverseConfig"),
+    "OpenAILikeChatConfig": (".llms.openai_like.chat.handler", "OpenAILikeChatConfig"),
+    "GaladrielChatConfig": (".llms.galadriel.chat.transformation", "GaladrielChatConfig"),
+    "GithubChatConfig": (".llms.github.chat.transformation", "GithubChatConfig"),
+    "AzureAnthropicConfig": (".llms.azure_ai.anthropic.transformation", "AzureAnthropicConfig"),
+    "BytezChatConfig": (".llms.bytez.chat.transformation", "BytezChatConfig"),
+    "CompactifAIChatConfig": (".llms.compactifai.chat.transformation", "CompactifAIChatConfig"),
+    "EmpowerChatConfig": (".llms.empower.chat.transformation", "EmpowerChatConfig"),
+    "MinimaxChatConfig": (".llms.minimax.chat.transformation", "MinimaxChatConfig"),
+    "AiohttpOpenAIChatConfig": (".llms.aiohttp_openai.chat.transformation", "AiohttpOpenAIChatConfig"),
+    "HuggingFaceChatConfig": (".llms.huggingface.chat.transformation", "HuggingFaceChatConfig"),
+    "HuggingFaceEmbeddingConfig": (".llms.huggingface.embedding.transformation", "HuggingFaceEmbeddingConfig"),
+    "OobaboogaConfig": (".llms.oobabooga.chat.transformation", "OobaboogaConfig"),
+    "MaritalkConfig": (".llms.maritalk", "MaritalkConfig"),
+    "OpenrouterConfig": (".llms.openrouter.chat.transformation", "OpenrouterConfig"),
+    "DataRobotConfig": (".llms.datarobot.chat.transformation", "DataRobotConfig"),
+    "AnthropicConfig": (".llms.anthropic.chat.transformation", "AnthropicConfig"),
+    "AnthropicTextConfig": (".llms.anthropic.completion.transformation", "AnthropicTextConfig"),
+    "GroqSTTConfig": (".llms.groq.stt.transformation", "GroqSTTConfig"),
+    "TritonConfig": (".llms.triton.completion.transformation", "TritonConfig"),
+    "TritonGenerateConfig": (".llms.triton.completion.transformation", "TritonGenerateConfig"),
+    "TritonInferConfig": (".llms.triton.completion.transformation", "TritonInferConfig"),
+    "TritonEmbeddingConfig": (".llms.triton.embedding.transformation", "TritonEmbeddingConfig"),
+    "HuggingFaceRerankConfig": (".llms.huggingface.rerank.transformation", "HuggingFaceRerankConfig"),
+    "DatabricksConfig": (".llms.databricks.chat.transformation", "DatabricksConfig"),
+    "DatabricksEmbeddingConfig": (".llms.databricks.embed.transformation", "DatabricksEmbeddingConfig"),
+    "PredibaseConfig": (".llms.predibase.chat.transformation", "PredibaseConfig"),
+    "ReplicateConfig": (".llms.replicate.chat.transformation", "ReplicateConfig"),
+    "SnowflakeConfig": (".llms.snowflake.chat.transformation", "SnowflakeConfig"),
+    "CohereRerankConfig": (".llms.cohere.rerank.transformation", "CohereRerankConfig"),
+    "CohereRerankV2Config": (".llms.cohere.rerank_v2.transformation", "CohereRerankV2Config"),
+    "AzureAIRerankConfig": (".llms.azure_ai.rerank.transformation", "AzureAIRerankConfig"),
+    "InfinityRerankConfig": (".llms.infinity.rerank.transformation", "InfinityRerankConfig"),
+    "JinaAIRerankConfig": (".llms.jina_ai.rerank.transformation", "JinaAIRerankConfig"),
+    "DeepinfraRerankConfig": (".llms.deepinfra.rerank.transformation", "DeepinfraRerankConfig"),
+    "HostedVLLMRerankConfig": (".llms.hosted_vllm.rerank.transformation", "HostedVLLMRerankConfig"),
+    "NvidiaNimRerankConfig": (".llms.nvidia_nim.rerank.transformation", "NvidiaNimRerankConfig"),
+    "NvidiaNimRankingConfig": (".llms.nvidia_nim.rerank.ranking_transformation", "NvidiaNimRankingConfig"),
+    "VertexAIRerankConfig": (".llms.vertex_ai.rerank.transformation", "VertexAIRerankConfig"),
+    "FireworksAIRerankConfig": (".llms.fireworks_ai.rerank.transformation", "FireworksAIRerankConfig"),
+    "VoyageRerankConfig": (".llms.voyage.rerank.transformation", "VoyageRerankConfig"),
+    "ClarifaiConfig": (".llms.clarifai.chat.transformation", "ClarifaiConfig"),
+}
+
 # Lazy import for utils module - imports only the requested item by name.
 def _lazy_import_utils(name: str) -> Any:
     """Lazy import for utils module - imports only the requested item by name."""
@@ -368,32 +443,54 @@ def _lazy_import_cost_calculator(name: str) -> Any:
 
 def _lazy_import_token_counter(name: str) -> Any:
     """Lazy import for token_counter utilities."""
+    if name not in _TOKEN_COUNTER_IMPORT_MAP:
+        raise AttributeError(f"Token counter lazy import: unknown attribute {name!r}")
+    
     _globals = _get_litellm_globals()
-
-    if name == "get_modified_max_tokens":
-        from litellm.litellm_core_utils.token_counter import (
-            get_modified_max_tokens as _get_modified_max_tokens,
-        )
-
-        _globals["get_modified_max_tokens"] = _get_modified_max_tokens
-        return _get_modified_max_tokens
-
-    raise AttributeError(f"Token counter lazy import: unknown attribute {name!r}")
+    
+    # Check if already cached
+    if name in _globals:
+        return _globals[name]
+    
+    module_path, attr_name = _TOKEN_COUNTER_IMPORT_MAP[name]
+    
+    # Cache module reference to avoid repeated importlib calls
+    _module_cache_key = f"_cached_module_{module_path}"
+    if _module_cache_key not in _globals:
+        import importlib
+        _globals[_module_cache_key] = importlib.import_module(module_path)
+    
+    module = _globals[_module_cache_key]
+    value = getattr(module, attr_name)
+    
+    _globals[name] = value
+    return value
 
 
 def _lazy_import_bedrock_types(name: str) -> Any:
     """Lazy import for Bedrock type aliases."""
+    if name not in _BEDROCK_TYPES_IMPORT_MAP:
+        raise AttributeError(f"Bedrock types lazy import: unknown attribute {name!r}")
+    
     _globals = _get_litellm_globals()
-
-    if name == "COHERE_EMBEDDING_INPUT_TYPES":
-        from litellm.types.llms.bedrock import (
-            COHERE_EMBEDDING_INPUT_TYPES as _COHERE_EMBEDDING_INPUT_TYPES,
-        )
-
-        _globals["COHERE_EMBEDDING_INPUT_TYPES"] = _COHERE_EMBEDDING_INPUT_TYPES
-        return _COHERE_EMBEDDING_INPUT_TYPES
-
-    raise AttributeError(f"Bedrock types lazy import: unknown attribute {name!r}")
+    
+    # Check if already cached
+    if name in _globals:
+        return _globals[name]
+    
+    module_path, attr_name = _BEDROCK_TYPES_IMPORT_MAP[name]
+    
+    # Cache module reference to avoid repeated importlib calls
+    _module_cache_key = f"_cached_module_{module_path}"
+    if _module_cache_key not in _globals:
+        import importlib
+        _globals[_module_cache_key] = importlib.import_module(module_path)
+    
+    module = _globals[_module_cache_key]
+    value = getattr(module, attr_name)
+    
+    _globals[name] = value
+    return value
 
 
 def _lazy_import_types_utils(name: str) -> Any:
@@ -424,77 +521,86 @@ def _lazy_import_types_utils(name: str) -> Any:
 
 def _lazy_import_caching(name: str) -> Any:
     """Lazy import for caching module classes."""
+    if name not in _CACHING_IMPORT_MAP:
+        raise AttributeError(f"Caching lazy import: unknown attribute {name!r}")
+    
     _globals = _get_litellm_globals()
-
-    if name == "Cache":
-        from litellm.caching.caching import Cache as _Cache
-
-        _globals["Cache"] = _Cache
-        return _Cache
-
-    if name == "DualCache":
-        from litellm.caching.caching import DualCache as _DualCache
-
-        _globals["DualCache"] = _DualCache
-        return _DualCache
-
-    if name == "RedisCache":
-        from litellm.caching.caching import RedisCache as _RedisCache
-
-        _globals["RedisCache"] = _RedisCache
-        return _RedisCache
-
-    if name == "InMemoryCache":
-        from litellm.caching.caching import InMemoryCache as _InMemoryCache
-
-        _globals["InMemoryCache"] = _InMemoryCache
-        return _InMemoryCache
-
-    raise AttributeError(f"Caching lazy import: unknown attribute {name!r}")
+    
+    # Check if already cached
+    if name in _globals:
+        return _globals[name]
+    
+    module_path, attr_name = _CACHING_IMPORT_MAP[name]
+    
+    # Cache module reference to avoid repeated importlib calls
+    _module_cache_key = f"_cached_module_{module_path}"
+    if _module_cache_key not in _globals:
+        import importlib
+        _globals[_module_cache_key] = importlib.import_module(module_path)
+    
+    module = _globals[_module_cache_key]
+    value = getattr(module, attr_name)
+    
+    _globals[name] = value
+    return value
 
 
 def _lazy_import_llm_client_cache(name: str) -> Any:
     """Lazy import for LLM client cache class and singleton."""
     _globals = _get_litellm_globals()
-
+    
+    # Check if already cached
+    if name in _globals:
+        return _globals[name]
+    
+    # Import the class
+    module_path = "litellm.caching.llm_caching_handler"
+    _module_cache_key = f"_cached_module_{module_path}"
+    if _module_cache_key not in _globals:
+        import importlib
+        _globals[_module_cache_key] = importlib.import_module(module_path)
+    
+    module = _globals[_module_cache_key]
+    LLMClientCache = getattr(module, "LLMClientCache")
+    
     if name == "LLMClientCache":
-        from litellm.caching.llm_caching_handler import (
-            LLMClientCache as _LLMClientCache,
-        )
-
-        _globals["LLMClientCache"] = _LLMClientCache
-        return _LLMClientCache
-
+        _globals["LLMClientCache"] = LLMClientCache
+        return LLMClientCache
+    
     if name == "in_memory_llm_clients_cache":
-        from litellm.caching.llm_caching_handler import (
-            LLMClientCache as _LLMClientCache,
-        )
-
-        instance = _LLMClientCache()
+        instance = LLMClientCache()
         # Only populate the requested singleton name to keep lazy-import
         # semantics consistent with other helpers (no extra symbols).
         _globals["in_memory_llm_clients_cache"] = instance
         return instance
-
+    
     raise AttributeError(f"LLM client cache lazy import: unknown attribute {name!r}")
 
 
 def _lazy_import_litellm_logging(name: str) -> Any:
     """Lazy import for litellm_logging module."""
+    if name not in _LITELLM_LOGGING_IMPORT_MAP:
+        raise AttributeError(f"Litellm logging lazy import: unknown attribute {name!r}")
+    
     _globals = _get_litellm_globals()
-    if name == "Logging":
-        from litellm.litellm_core_utils.litellm_logging import Logging as _Logging
-        _globals["Logging"] = _Logging
-        return _Logging
     
-    if name == "modify_integration":
-        from litellm.litellm_core_utils.litellm_logging import (
-            modify_integration as _modify_integration,
-        )
-        _globals["modify_integration"] = _modify_integration
-        return _modify_integration
+    # Check if already cached
+    if name in _globals:
+        return _globals[name]
     
-    raise AttributeError(f"Litellm logging lazy import: unknown attribute {name!r}")
+    module_path, attr_name = _LITELLM_LOGGING_IMPORT_MAP[name]
+    
+    # Cache module reference to avoid repeated importlib calls
+    _module_cache_key = f"_cached_module_{module_path}"
+    if _module_cache_key not in _globals:
+        import importlib
+        _globals[_module_cache_key] = importlib.import_module(module_path)
+    
+    module = _globals[_module_cache_key]
+    value = getattr(module, attr_name)
+    
+    _globals[name] = value
+    return value
 
 
 def _lazy_import_http_handlers(name: str) -> Any:
@@ -531,376 +637,77 @@ def _lazy_import_http_handlers(name: str) -> Any:
 
 def _lazy_import_dotprompt(name: str) -> Any:
     """Lazy import for dotprompt integration globals."""
+    if name not in _DOTPROMPT_IMPORT_MAP:
+        raise AttributeError(f"Dotprompt lazy import: unknown attribute {name!r}")
+    
     _globals = _get_litellm_globals()
-
-    if name == "global_prompt_manager":
-        from litellm.integrations.dotprompt import (
-            global_prompt_manager as _global_prompt_manager,
-        )
-
-        _globals["global_prompt_manager"] = _global_prompt_manager
-        return _global_prompt_manager
-
-    if name == "global_prompt_directory":
-        from litellm.integrations.dotprompt import (
-            global_prompt_directory as _global_prompt_directory,
-        )
-
-        _globals["global_prompt_directory"] = _global_prompt_directory
-        return _global_prompt_directory
-
-    if name == "set_global_prompt_directory":
-        from litellm.integrations.dotprompt import (
-            set_global_prompt_directory as _set_global_prompt_directory,
-        )
-
-        _globals["set_global_prompt_directory"] = _set_global_prompt_directory
-        return _set_global_prompt_directory
-
-    raise AttributeError(f"Dotprompt lazy import: unknown attribute {name!r}")
+    
+    # Check if already cached
+    if name in _globals:
+        return _globals[name]
+    
+    module_path, attr_name = _DOTPROMPT_IMPORT_MAP[name]
+    
+    # Cache module reference to avoid repeated importlib calls
+    _module_cache_key = f"_cached_module_{module_path}"
+    if _module_cache_key not in _globals:
+        import importlib
+        _globals[_module_cache_key] = importlib.import_module(module_path)
+    
+    module = _globals[_module_cache_key]
+    value = getattr(module, attr_name)
+    
+    _globals[name] = value
+    return value
 
 
 def _lazy_import_types(name: str) -> Any:
     """Lazy import for type classes."""
+    if name not in _TYPES_IMPORT_MAP:
+        raise AttributeError(f"Types lazy import: unknown attribute {name!r}")
+    
     _globals = _get_litellm_globals()
+    
+    # Check if already cached
+    if name in _globals:
+        return _globals[name]
+    
+    module_path, attr_name = _TYPES_IMPORT_MAP[name]
+    
+    # Cache module reference to avoid repeated importlib calls
+    _module_cache_key = f"_cached_module_{module_path}"
+    if _module_cache_key not in _globals:
+        import importlib
+        _globals[_module_cache_key] = importlib.import_module(module_path)
+    
+    module = _globals[_module_cache_key]
+    value = getattr(module, attr_name)
+    
+    _globals[name] = value
+    return value
 
-    if name == "GuardrailItem":
-        from litellm.types.guardrails import GuardrailItem as _GuardrailItem
 
-        _globals["GuardrailItem"] = _GuardrailItem
-        return _GuardrailItem
-
-    raise AttributeError(f"Types lazy import: unknown attribute {name!r}")
-
-
-def _lazy_import_llm_configs(name: str) -> Any:  # noqa: PLR0915
+def _lazy_import_llm_configs(name: str) -> Any:
     """Lazy import for LLM config classes."""
+    if name not in _LLM_CONFIGS_IMPORT_MAP:
+        raise AttributeError(f"LLM config lazy import: unknown attribute {name!r}")
+    
     _globals = _get_litellm_globals()
-
-    if name == "AmazonConverseConfig":
-        from .llms.bedrock.chat.converse_transformation import (
-            AmazonConverseConfig as _AmazonConverseConfig,
-        )
-
-        _globals["AmazonConverseConfig"] = _AmazonConverseConfig
-        return _AmazonConverseConfig
-
-    if name == "OpenAILikeChatConfig":
-        from .llms.openai_like.chat.handler import (
-            OpenAILikeChatConfig as _OpenAILikeChatConfig,
-        )
-
-        _globals["OpenAILikeChatConfig"] = _OpenAILikeChatConfig
-        return _OpenAILikeChatConfig
-
-    if name == "GaladrielChatConfig":
-        from .llms.galadriel.chat.transformation import (
-            GaladrielChatConfig as _GaladrielChatConfig,
-        )
-
-        _globals["GaladrielChatConfig"] = _GaladrielChatConfig
-        return _GaladrielChatConfig
-
-    if name == "GithubChatConfig":
-        from .llms.github.chat.transformation import (
-            GithubChatConfig as _GithubChatConfig,
-        )
-
-        _globals["GithubChatConfig"] = _GithubChatConfig
-        return _GithubChatConfig
-
-    if name == "AzureAnthropicConfig":
-        from .llms.azure_ai.anthropic.transformation import (
-            AzureAnthropicConfig as _AzureAnthropicConfig,
-        )
-
-        _globals["AzureAnthropicConfig"] = _AzureAnthropicConfig
-        return _AzureAnthropicConfig
-
-    if name == "BytezChatConfig":
-        from .llms.bytez.chat.transformation import BytezChatConfig as _BytezChatConfig
-
-        _globals["BytezChatConfig"] = _BytezChatConfig
-        return _BytezChatConfig
-
-    if name == "CompactifAIChatConfig":
-        from .llms.compactifai.chat.transformation import (
-            CompactifAIChatConfig as _CompactifAIChatConfig,
-        )
-
-        _globals["CompactifAIChatConfig"] = _CompactifAIChatConfig
-        return _CompactifAIChatConfig
-
-    if name == "EmpowerChatConfig":
-        from .llms.empower.chat.transformation import (
-            EmpowerChatConfig as _EmpowerChatConfig,
-        )
-
-        _globals["EmpowerChatConfig"] = _EmpowerChatConfig
-        return _EmpowerChatConfig
-
-    if name == "MinimaxChatConfig":
-        from .llms.minimax.chat.transformation import (
-            MinimaxChatConfig as _MinimaxChatConfig,
-        )
-
-        _globals["MinimaxChatConfig"] = _MinimaxChatConfig
-        return _MinimaxChatConfig
-
-    if name == "AiohttpOpenAIChatConfig":
-        from .llms.aiohttp_openai.chat.transformation import (
-            AiohttpOpenAIChatConfig as _AiohttpOpenAIChatConfig,
-        )
-
-        _globals["AiohttpOpenAIChatConfig"] = _AiohttpOpenAIChatConfig
-        return _AiohttpOpenAIChatConfig
-
-    if name == "HuggingFaceChatConfig":
-        from .llms.huggingface.chat.transformation import (
-            HuggingFaceChatConfig as _HuggingFaceChatConfig,
-        )
-
-        _globals["HuggingFaceChatConfig"] = _HuggingFaceChatConfig
-        return _HuggingFaceChatConfig
-
-    if name == "HuggingFaceEmbeddingConfig":
-        from .llms.huggingface.embedding.transformation import (
-            HuggingFaceEmbeddingConfig as _HuggingFaceEmbeddingConfig,
-        )
-
-        _globals["HuggingFaceEmbeddingConfig"] = _HuggingFaceEmbeddingConfig
-        return _HuggingFaceEmbeddingConfig
-
-    if name == "OobaboogaConfig":
-        from .llms.oobabooga.chat.transformation import (
-            OobaboogaConfig as _OobaboogaConfig,
-        )
-
-        _globals["OobaboogaConfig"] = _OobaboogaConfig
-        return _OobaboogaConfig
-
-    if name == "MaritalkConfig":
-        from .llms.maritalk import MaritalkConfig as _MaritalkConfig
-
-        _globals["MaritalkConfig"] = _MaritalkConfig
-        return _MaritalkConfig
-
-    if name == "OpenrouterConfig":
-        from .llms.openrouter.chat.transformation import (
-            OpenrouterConfig as _OpenrouterConfig,
-        )
-
-        _globals["OpenrouterConfig"] = _OpenrouterConfig
-        return _OpenrouterConfig
-
-    if name == "DataRobotConfig":
-        from .llms.datarobot.chat.transformation import (
-            DataRobotConfig as _DataRobotConfig,
-        )
-
-        _globals["DataRobotConfig"] = _DataRobotConfig
-        return _DataRobotConfig
-
-    if name == "AnthropicConfig":
-        from .llms.anthropic.chat.transformation import (
-            AnthropicConfig as _AnthropicConfig,
-        )
-
-        _globals["AnthropicConfig"] = _AnthropicConfig
-        return _AnthropicConfig
-
-    if name == "AnthropicTextConfig":
-        from .llms.anthropic.completion.transformation import (
-            AnthropicTextConfig as _AnthropicTextConfig,
-        )
-
-        _globals["AnthropicTextConfig"] = _AnthropicTextConfig
-        return _AnthropicTextConfig
-
-    if name == "GroqSTTConfig":
-        from .llms.groq.stt.transformation import GroqSTTConfig as _GroqSTTConfig
-
-        _globals["GroqSTTConfig"] = _GroqSTTConfig
-        return _GroqSTTConfig
-
-    if name == "TritonConfig":
-        from .llms.triton.completion.transformation import TritonConfig as _TritonConfig
-
-        _globals["TritonConfig"] = _TritonConfig
-        return _TritonConfig
-
-    if name == "TritonGenerateConfig":
-        from .llms.triton.completion.transformation import (
-            TritonGenerateConfig as _TritonGenerateConfig,
-        )
-
-        _globals["TritonGenerateConfig"] = _TritonGenerateConfig
-        return _TritonGenerateConfig
-
-    if name == "TritonInferConfig":
-        from .llms.triton.completion.transformation import (
-            TritonInferConfig as _TritonInferConfig,
-        )
-
-        _globals["TritonInferConfig"] = _TritonInferConfig
-        return _TritonInferConfig
-
-    if name == "TritonEmbeddingConfig":
-        from .llms.triton.embedding.transformation import (
-            TritonEmbeddingConfig as _TritonEmbeddingConfig,
-        )
-
-        _globals["TritonEmbeddingConfig"] = _TritonEmbeddingConfig
-        return _TritonEmbeddingConfig
-
-    if name == "HuggingFaceRerankConfig":
-        from .llms.huggingface.rerank.transformation import (
-            HuggingFaceRerankConfig as _HuggingFaceRerankConfig,
-        )
-
-        _globals["HuggingFaceRerankConfig"] = _HuggingFaceRerankConfig
-        return _HuggingFaceRerankConfig
-
-    if name == "DatabricksConfig":
-        from .llms.databricks.chat.transformation import (
-            DatabricksConfig as _DatabricksConfig,
-        )
-
-        _globals["DatabricksConfig"] = _DatabricksConfig
-        return _DatabricksConfig
-
-    if name == "DatabricksEmbeddingConfig":
-        from .llms.databricks.embed.transformation import (
-            DatabricksEmbeddingConfig as _DatabricksEmbeddingConfig,
-        )
-
-        _globals["DatabricksEmbeddingConfig"] = _DatabricksEmbeddingConfig
-        return _DatabricksEmbeddingConfig
-
-    if name == "PredibaseConfig":
-        from .llms.predibase.chat.transformation import (
-            PredibaseConfig as _PredibaseConfig,
-        )
-
-        _globals["PredibaseConfig"] = _PredibaseConfig
-        return _PredibaseConfig
-
-    if name == "ReplicateConfig":
-        from .llms.replicate.chat.transformation import (
-            ReplicateConfig as _ReplicateConfig,
-        )
-
-        _globals["ReplicateConfig"] = _ReplicateConfig
-        return _ReplicateConfig
-
-    if name == "SnowflakeConfig":
-        from .llms.snowflake.chat.transformation import (
-            SnowflakeConfig as _SnowflakeConfig,
-        )
-
-        _globals["SnowflakeConfig"] = _SnowflakeConfig
-        return _SnowflakeConfig
-
-    if name == "CohereRerankConfig":
-        from .llms.cohere.rerank.transformation import (
-            CohereRerankConfig as _CohereRerankConfig,
-        )
-
-        _globals["CohereRerankConfig"] = _CohereRerankConfig
-        return _CohereRerankConfig
-
-    if name == "CohereRerankV2Config":
-        from .llms.cohere.rerank_v2.transformation import (
-            CohereRerankV2Config as _CohereRerankV2Config,
-        )
-
-        _globals["CohereRerankV2Config"] = _CohereRerankV2Config
-        return _CohereRerankV2Config
-
-    if name == "AzureAIRerankConfig":
-        from .llms.azure_ai.rerank.transformation import (
-            AzureAIRerankConfig as _AzureAIRerankConfig,
-        )
-
-        _globals["AzureAIRerankConfig"] = _AzureAIRerankConfig
-        return _AzureAIRerankConfig
-
-    if name == "InfinityRerankConfig":
-        from .llms.infinity.rerank.transformation import (
-            InfinityRerankConfig as _InfinityRerankConfig,
-        )
-
-        _globals["InfinityRerankConfig"] = _InfinityRerankConfig
-        return _InfinityRerankConfig
-
-    if name == "JinaAIRerankConfig":
-        from .llms.jina_ai.rerank.transformation import (
-            JinaAIRerankConfig as _JinaAIRerankConfig,
-        )
-
-        _globals["JinaAIRerankConfig"] = _JinaAIRerankConfig
-        return _JinaAIRerankConfig
-
-    if name == "DeepinfraRerankConfig":
-        from .llms.deepinfra.rerank.transformation import (
-            DeepinfraRerankConfig as _DeepinfraRerankConfig,
-        )
-
-        _globals["DeepinfraRerankConfig"] = _DeepinfraRerankConfig
-        return _DeepinfraRerankConfig
-
-    if name == "HostedVLLMRerankConfig":
-        from .llms.hosted_vllm.rerank.transformation import (
-            HostedVLLMRerankConfig as _HostedVLLMRerankConfig,
-        )
-
-        _globals["HostedVLLMRerankConfig"] = _HostedVLLMRerankConfig
-        return _HostedVLLMRerankConfig
-
-    if name == "NvidiaNimRerankConfig":
-        from .llms.nvidia_nim.rerank.transformation import (
-            NvidiaNimRerankConfig as _NvidiaNimRerankConfig,
-        )
-
-        _globals["NvidiaNimRerankConfig"] = _NvidiaNimRerankConfig
-        return _NvidiaNimRerankConfig
-
-    if name == "NvidiaNimRankingConfig":
-        from .llms.nvidia_nim.rerank.ranking_transformation import (
-            NvidiaNimRankingConfig as _NvidiaNimRankingConfig,
-        )
-
-        _globals["NvidiaNimRankingConfig"] = _NvidiaNimRankingConfig
-        return _NvidiaNimRankingConfig
-
-    if name == "VertexAIRerankConfig":
-        from .llms.vertex_ai.rerank.transformation import (
-            VertexAIRerankConfig as _VertexAIRerankConfig,
-        )
-
-        _globals["VertexAIRerankConfig"] = _VertexAIRerankConfig
-        return _VertexAIRerankConfig
-
-    if name == "FireworksAIRerankConfig":
-        from .llms.fireworks_ai.rerank.transformation import (
-            FireworksAIRerankConfig as _FireworksAIRerankConfig,
-        )
-
-        _globals["FireworksAIRerankConfig"] = _FireworksAIRerankConfig
-        return _FireworksAIRerankConfig
-
-    if name == "VoyageRerankConfig":
-        from .llms.voyage.rerank.transformation import (
-            VoyageRerankConfig as _VoyageRerankConfig,
-        )
-
-        _globals["VoyageRerankConfig"] = _VoyageRerankConfig
-        return _VoyageRerankConfig
-
-    if name == "ClarifaiConfig":
-        from .llms.clarifai.chat.transformation import ClarifaiConfig as _ClarifaiConfig
-
-        _globals["ClarifaiConfig"] = _ClarifaiConfig
-        return _ClarifaiConfig
-
-    raise AttributeError(f"LLM config lazy import: unknown attribute {name!r}")
+    
+    # Check if already cached
+    if name in _globals:
+        return _globals[name]
+    
+    module_path, attr_name = _LLM_CONFIGS_IMPORT_MAP[name]
+    
+    # Cache module reference to avoid repeated importlib calls
+    _module_cache_key = f"_cached_module_{module_path}"
+    if _module_cache_key not in _globals:
+        import importlib
+        _globals[_module_cache_key] = importlib.import_module(module_path, package="litellm")
+    
+    module = _globals[_module_cache_key]
+    value = getattr(module, attr_name)
+    
+    _globals[name] = value
+    return value

--- a/litellm/_lazy_imports.py
+++ b/litellm/_lazy_imports.py
@@ -150,132 +150,67 @@ def _get_lazy_import_registry() -> dict[str, Callable[[str], Any]]:
     return _LAZY_IMPORT_REGISTRY
 
 
+def _generic_lazy_import(name: str, import_map: dict[str, tuple[str, str]], category: str) -> Any:
+    """
+    Generic lazy import handler that works with any import map.
+    
+    Args:
+        name: Attribute name to import
+        import_map: Dictionary mapping attribute names to (module_path, attr_name) tuples
+        category: Category name for error messages (e.g., "Utils", "Cost calculator")
+    """
+    if name not in import_map:
+        raise AttributeError(f"{category} lazy import: unknown attribute {name!r}")
+    
+    _globals = _get_litellm_globals()
+    
+    # Check if already cached
+    if name in _globals:
+        return _globals[name]
+    
+    module_path, attr_name = import_map[name]
+    
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    # Use package="litellm" for relative imports (starting with "."), otherwise use absolute import
+    if module_path.startswith("."):
+        module = importlib.import_module(module_path, package="litellm")
+    else:
+        module = importlib.import_module(module_path)
+    
+    value = getattr(module, attr_name)
+    _globals[name] = value
+    return value
+
 
 # Lazy import for utils module - imports only the requested item by name.
 def _lazy_import_utils(name: str) -> Any:
     """Lazy import for utils module - imports only the requested item by name."""
-    if name not in _UTILS_IMPORT_MAP:
-        raise AttributeError(f"Utils lazy import: unknown attribute {name!r}")
-    
-    _globals = _get_litellm_globals()
-    
-    # Check if already cached
-    if name in _globals:
-        return _globals[name]
-    
-    module_path, attr_name = _UTILS_IMPORT_MAP[name]
-    
-    # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    module = importlib.import_module(module_path, package="litellm")
-    value = getattr(module, attr_name)
-    
-    _globals[name] = value
-    return value
+    return _generic_lazy_import(name, _UTILS_IMPORT_MAP, "Utils")
 
 
 def _lazy_import_cost_calculator(name: str) -> Any:
     """Lazy import for cost_calculator functions."""
-    if name not in _COST_CALCULATOR_IMPORT_MAP:
-        raise AttributeError(f"Cost calculator lazy import: unknown attribute {name!r}")
-    
-    _globals = _get_litellm_globals()
-    
-    # Check if already cached
-    if name in _globals:
-        return _globals[name]
-    
-    module_path, attr_name = _COST_CALCULATOR_IMPORT_MAP[name]
-    
-    # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    module = importlib.import_module(module_path, package="litellm")
-    value = getattr(module, attr_name)
-    
-    _globals[name] = value
-    return value
+    return _generic_lazy_import(name, _COST_CALCULATOR_IMPORT_MAP, "Cost calculator")
 
 
 def _lazy_import_token_counter(name: str) -> Any:
     """Lazy import for token_counter utilities."""
-    if name not in _TOKEN_COUNTER_IMPORT_MAP:
-        raise AttributeError(f"Token counter lazy import: unknown attribute {name!r}")
-    
-    _globals = _get_litellm_globals()
-    
-    # Check if already cached
-    if name in _globals:
-        return _globals[name]
-    
-    module_path, attr_name = _TOKEN_COUNTER_IMPORT_MAP[name]
-    
-    # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    module = importlib.import_module(module_path)
-    value = getattr(module, attr_name)
-    
-    _globals[name] = value
-    return value
+    return _generic_lazy_import(name, _TOKEN_COUNTER_IMPORT_MAP, "Token counter")
 
 
 def _lazy_import_bedrock_types(name: str) -> Any:
     """Lazy import for Bedrock type aliases."""
-    if name not in _BEDROCK_TYPES_IMPORT_MAP:
-        raise AttributeError(f"Bedrock types lazy import: unknown attribute {name!r}")
-    
-    _globals = _get_litellm_globals()
-    
-    # Check if already cached
-    if name in _globals:
-        return _globals[name]
-    
-    module_path, attr_name = _BEDROCK_TYPES_IMPORT_MAP[name]
-    
-    # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    module = importlib.import_module(module_path)
-    value = getattr(module, attr_name)
-    
-    _globals[name] = value
-    return value
+    return _generic_lazy_import(name, _BEDROCK_TYPES_IMPORT_MAP, "Bedrock types")
 
 
 def _lazy_import_types_utils(name: str) -> Any:
     """Lazy import for common types and constants from litellm.types.utils."""
-    if name not in _TYPES_UTILS_IMPORT_MAP:
-        raise AttributeError(f"Types utils lazy import: unknown attribute {name!r}")
-    
-    _globals = _get_litellm_globals()
-    
-    # Check if already cached
-    if name in _globals:
-        return _globals[name]
-    
-    module_path, attr_name = _TYPES_UTILS_IMPORT_MAP[name]
-    
-    # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    module = importlib.import_module(module_path, package="litellm")
-    value = getattr(module, attr_name)
-    
-    _globals[name] = value
-    return value
+    return _generic_lazy_import(name, _TYPES_UTILS_IMPORT_MAP, "Types utils")
 
 
 def _lazy_import_caching(name: str) -> Any:
     """Lazy import for caching module classes."""
-    if name not in _CACHING_IMPORT_MAP:
-        raise AttributeError(f"Caching lazy import: unknown attribute {name!r}")
-    
-    _globals = _get_litellm_globals()
-    
-    # Check if already cached
-    if name in _globals:
-        return _globals[name]
-    
-    module_path, attr_name = _CACHING_IMPORT_MAP[name]
-    
-    # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    module = importlib.import_module(module_path)
-    value = getattr(module, attr_name)
-    
-    _globals[name] = value
-    return value
+    return _generic_lazy_import(name, _CACHING_IMPORT_MAP, "Caching")
 
 
 def _lazy_import_llm_client_cache(name: str) -> Any:
@@ -307,23 +242,7 @@ def _lazy_import_llm_client_cache(name: str) -> Any:
 
 def _lazy_import_litellm_logging(name: str) -> Any:
     """Lazy import for litellm_logging module."""
-    if name not in _LITELLM_LOGGING_IMPORT_MAP:
-        raise AttributeError(f"Litellm logging lazy import: unknown attribute {name!r}")
-    
-    _globals = _get_litellm_globals()
-    
-    # Check if already cached
-    if name in _globals:
-        return _globals[name]
-    
-    module_path, attr_name = _LITELLM_LOGGING_IMPORT_MAP[name]
-    
-    # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    module = importlib.import_module(module_path)
-    value = getattr(module, attr_name)
-    
-    _globals[name] = value
-    return value
+    return _generic_lazy_import(name, _LITELLM_LOGGING_IMPORT_MAP, "Litellm logging")
 
 
 def _lazy_import_http_handlers(name: str) -> Any:
@@ -360,62 +279,14 @@ def _lazy_import_http_handlers(name: str) -> Any:
 
 def _lazy_import_dotprompt(name: str) -> Any:
     """Lazy import for dotprompt integration globals."""
-    if name not in _DOTPROMPT_IMPORT_MAP:
-        raise AttributeError(f"Dotprompt lazy import: unknown attribute {name!r}")
-    
-    _globals = _get_litellm_globals()
-    
-    # Check if already cached
-    if name in _globals:
-        return _globals[name]
-    
-    module_path, attr_name = _DOTPROMPT_IMPORT_MAP[name]
-    
-    # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    module = importlib.import_module(module_path)
-    value = getattr(module, attr_name)
-    
-    _globals[name] = value
-    return value
+    return _generic_lazy_import(name, _DOTPROMPT_IMPORT_MAP, "Dotprompt")
 
 
 def _lazy_import_types(name: str) -> Any:
     """Lazy import for type classes."""
-    if name not in _TYPES_IMPORT_MAP:
-        raise AttributeError(f"Types lazy import: unknown attribute {name!r}")
-    
-    _globals = _get_litellm_globals()
-    
-    # Check if already cached
-    if name in _globals:
-        return _globals[name]
-    
-    module_path, attr_name = _TYPES_IMPORT_MAP[name]
-    
-    # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    module = importlib.import_module(module_path)
-    value = getattr(module, attr_name)
-    
-    _globals[name] = value
-    return value
+    return _generic_lazy_import(name, _TYPES_IMPORT_MAP, "Types")
 
 
 def _lazy_import_llm_configs(name: str) -> Any:
     """Lazy import for LLM config classes."""
-    if name not in _LLM_CONFIGS_IMPORT_MAP:
-        raise AttributeError(f"LLM config lazy import: unknown attribute {name!r}")
-    
-    _globals = _get_litellm_globals()
-    
-    # Check if already cached
-    if name in _globals:
-        return _globals[name]
-    
-    module_path, attr_name = _LLM_CONFIGS_IMPORT_MAP[name]
-    
-    # importlib.import_module() already caches in sys.modules, so no need for extra caching
-    module = importlib.import_module(module_path, package="litellm")
-    value = getattr(module, attr_name)
-    
-    _globals[name] = value
-    return value
+    return _generic_lazy_import(name, _LLM_CONFIGS_IMPORT_MAP, "LLM config")

--- a/litellm/_lazy_imports.py
+++ b/litellm/_lazy_imports.py
@@ -164,13 +164,9 @@ def _lazy_import_utils(name: str) -> Any:
     
     module_path, attr_name = _UTILS_IMPORT_MAP[name]
     
-    # Cache module reference to avoid repeated importlib calls
-    _module_cache_key = f"_cached_module_{module_path}"
-    if _module_cache_key not in _globals:
-        import importlib
-        _globals[_module_cache_key] = importlib.import_module(module_path, package="litellm")
-    
-    module = _globals[_module_cache_key]
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    import importlib
+    module = importlib.import_module(module_path, package="litellm")
     value = getattr(module, attr_name)
     
     _globals[name] = value
@@ -190,13 +186,9 @@ def _lazy_import_cost_calculator(name: str) -> Any:
     
     module_path, attr_name = _COST_CALCULATOR_IMPORT_MAP[name]
     
-    # Cache module reference to avoid repeated importlib calls
-    _module_cache_key = f"_cached_module_{module_path}"
-    if _module_cache_key not in _globals:
-        import importlib
-        _globals[_module_cache_key] = importlib.import_module(module_path, package="litellm")
-    
-    module = _globals[_module_cache_key]
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    import importlib
+    module = importlib.import_module(module_path, package="litellm")
     value = getattr(module, attr_name)
     
     _globals[name] = value
@@ -216,13 +208,9 @@ def _lazy_import_token_counter(name: str) -> Any:
     
     module_path, attr_name = _TOKEN_COUNTER_IMPORT_MAP[name]
     
-    # Cache module reference to avoid repeated importlib calls
-    _module_cache_key = f"_cached_module_{module_path}"
-    if _module_cache_key not in _globals:
-        import importlib
-        _globals[_module_cache_key] = importlib.import_module(module_path)
-    
-    module = _globals[_module_cache_key]
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    import importlib
+    module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
     _globals[name] = value
@@ -242,13 +230,9 @@ def _lazy_import_bedrock_types(name: str) -> Any:
     
     module_path, attr_name = _BEDROCK_TYPES_IMPORT_MAP[name]
     
-    # Cache module reference to avoid repeated importlib calls
-    _module_cache_key = f"_cached_module_{module_path}"
-    if _module_cache_key not in _globals:
-        import importlib
-        _globals[_module_cache_key] = importlib.import_module(module_path)
-    
-    module = _globals[_module_cache_key]
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    import importlib
+    module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
     _globals[name] = value
@@ -268,13 +252,9 @@ def _lazy_import_types_utils(name: str) -> Any:
     
     module_path, attr_name = _TYPES_UTILS_IMPORT_MAP[name]
     
-    # Cache module reference to avoid repeated importlib calls
-    _module_cache_key = f"_cached_module_{module_path}"
-    if _module_cache_key not in _globals:
-        import importlib
-        _globals[_module_cache_key] = importlib.import_module(module_path, package="litellm")
-    
-    module = _globals[_module_cache_key]
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    import importlib
+    module = importlib.import_module(module_path, package="litellm")
     value = getattr(module, attr_name)
     
     _globals[name] = value
@@ -294,13 +274,9 @@ def _lazy_import_caching(name: str) -> Any:
     
     module_path, attr_name = _CACHING_IMPORT_MAP[name]
     
-    # Cache module reference to avoid repeated importlib calls
-    _module_cache_key = f"_cached_module_{module_path}"
-    if _module_cache_key not in _globals:
-        import importlib
-        _globals[_module_cache_key] = importlib.import_module(module_path)
-    
-    module = _globals[_module_cache_key]
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    import importlib
+    module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
     _globals[name] = value
@@ -316,13 +292,9 @@ def _lazy_import_llm_client_cache(name: str) -> Any:
         return _globals[name]
     
     # Import the class
-    module_path = "litellm.caching.llm_caching_handler"
-    _module_cache_key = f"_cached_module_{module_path}"
-    if _module_cache_key not in _globals:
-        import importlib
-        _globals[_module_cache_key] = importlib.import_module(module_path)
-    
-    module = _globals[_module_cache_key]
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    import importlib
+    module = importlib.import_module("litellm.caching.llm_caching_handler")
     LLMClientCache = getattr(module, "LLMClientCache")
     
     if name == "LLMClientCache":
@@ -352,13 +324,9 @@ def _lazy_import_litellm_logging(name: str) -> Any:
     
     module_path, attr_name = _LITELLM_LOGGING_IMPORT_MAP[name]
     
-    # Cache module reference to avoid repeated importlib calls
-    _module_cache_key = f"_cached_module_{module_path}"
-    if _module_cache_key not in _globals:
-        import importlib
-        _globals[_module_cache_key] = importlib.import_module(module_path)
-    
-    module = _globals[_module_cache_key]
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    import importlib
+    module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
     _globals[name] = value
@@ -410,13 +378,9 @@ def _lazy_import_dotprompt(name: str) -> Any:
     
     module_path, attr_name = _DOTPROMPT_IMPORT_MAP[name]
     
-    # Cache module reference to avoid repeated importlib calls
-    _module_cache_key = f"_cached_module_{module_path}"
-    if _module_cache_key not in _globals:
-        import importlib
-        _globals[_module_cache_key] = importlib.import_module(module_path)
-    
-    module = _globals[_module_cache_key]
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    import importlib
+    module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
     _globals[name] = value
@@ -436,13 +400,9 @@ def _lazy_import_types(name: str) -> Any:
     
     module_path, attr_name = _TYPES_IMPORT_MAP[name]
     
-    # Cache module reference to avoid repeated importlib calls
-    _module_cache_key = f"_cached_module_{module_path}"
-    if _module_cache_key not in _globals:
-        import importlib
-        _globals[_module_cache_key] = importlib.import_module(module_path)
-    
-    module = _globals[_module_cache_key]
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    import importlib
+    module = importlib.import_module(module_path)
     value = getattr(module, attr_name)
     
     _globals[name] = value
@@ -462,13 +422,9 @@ def _lazy_import_llm_configs(name: str) -> Any:
     
     module_path, attr_name = _LLM_CONFIGS_IMPORT_MAP[name]
     
-    # Cache module reference to avoid repeated importlib calls
-    _module_cache_key = f"_cached_module_{module_path}"
-    if _module_cache_key not in _globals:
-        import importlib
-        _globals[_module_cache_key] = importlib.import_module(module_path, package="litellm")
-    
-    module = _globals[_module_cache_key]
+    # importlib.import_module() already caches in sys.modules, so no need for extra caching
+    import importlib
+    module = importlib.import_module(module_path, package="litellm")
     value = getattr(module, attr_name)
     
     _globals[name] = value

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -1,0 +1,305 @@
+"""
+Registry data for lazy imports.
+
+This module contains all the name tuples and import maps used by the lazy import system.
+Separated from the handler functions for better organization.
+"""
+
+# Cost calculator names that support lazy loading via _lazy_import_cost_calculator
+COST_CALCULATOR_NAMES = (
+    "completion_cost",
+    "cost_per_token",
+    "response_cost_calculator",
+)
+
+# Litellm logging names that support lazy loading via _lazy_import_litellm_logging
+LITELLM_LOGGING_NAMES = (
+    "Logging",
+    "modify_integration",
+)
+
+# Utils names that support lazy loading via _lazy_import_utils
+UTILS_NAMES = (
+    "exception_type", "get_optional_params", "get_response_string", "token_counter",
+    "create_pretrained_tokenizer", "create_tokenizer", "supports_function_calling",
+    "supports_web_search", "supports_url_context", "supports_response_schema",
+    "supports_parallel_function_calling", "supports_vision", "supports_audio_input",
+    "supports_audio_output", "supports_system_messages", "supports_reasoning",
+    "get_litellm_params", "acreate", "get_max_tokens", "get_model_info",
+    "register_prompt_template", "validate_environment", "check_valid_key",
+    "register_model", "encode", "decode", "_calculate_retry_after", "_should_retry",
+    "get_supported_openai_params", "get_api_base", "get_first_chars_messages",
+    "ModelResponse", "ModelResponseStream", "EmbeddingResponse", "ImageResponse",
+    "TranscriptionResponse", "TextCompletionResponse", "get_provider_fields",
+    "ModelResponseListIterator", "get_valid_models",
+)
+
+# Token counter names that support lazy loading via _lazy_import_token_counter
+TOKEN_COUNTER_NAMES = (
+    "get_modified_max_tokens",
+)
+
+# LLM client cache names that support lazy loading via _lazy_import_llm_client_cache
+LLM_CLIENT_CACHE_NAMES = (
+    "LLMClientCache",
+    "in_memory_llm_clients_cache",
+)
+
+# Bedrock type names that support lazy loading via _lazy_import_bedrock_types
+BEDROCK_TYPES_NAMES = (
+    "COHERE_EMBEDDING_INPUT_TYPES",
+)
+
+# Common types from litellm.types.utils that support lazy loading via
+# _lazy_import_types_utils
+TYPES_UTILS_NAMES = (
+    "ImageObject",
+    "BudgetConfig",
+    "all_litellm_params",
+    "_litellm_completion_params",
+    "CredentialItem",
+    "PriorityReservationDict",
+    "StandardKeyGenerationConfig",
+    "SearchProviders",
+    "GenericStreamingChunk",
+)
+
+# Caching / cache classes that support lazy loading via _lazy_import_caching
+CACHING_NAMES = (
+    "Cache",
+    "DualCache",
+    "RedisCache",
+    "InMemoryCache",
+)
+
+# HTTP handler names that support lazy loading via _lazy_import_http_handlers
+HTTP_HANDLER_NAMES = (
+    "module_level_aclient",
+    "module_level_client",
+)
+
+# Dotprompt integration names that support lazy loading via _lazy_import_dotprompt
+DOTPROMPT_NAMES = (
+    "global_prompt_manager",
+    "global_prompt_directory",
+    "set_global_prompt_directory",
+)
+
+# LLM config classes that support lazy loading via _lazy_import_llm_configs
+LLM_CONFIG_NAMES = (
+    "AmazonConverseConfig",
+    "OpenAILikeChatConfig",
+    "GaladrielChatConfig",
+    "GithubChatConfig",
+    "AzureAnthropicConfig",
+    "BytezChatConfig",
+    "CompactifAIChatConfig",
+    "EmpowerChatConfig",
+    "MinimaxChatConfig",
+    "AiohttpOpenAIChatConfig",
+    "HuggingFaceChatConfig",
+    "HuggingFaceEmbeddingConfig",
+    "OobaboogaConfig",
+    "MaritalkConfig",
+    "OpenrouterConfig",
+    "DataRobotConfig",
+    "AnthropicConfig",
+    "AnthropicTextConfig",
+    "GroqSTTConfig",
+    "TritonConfig",
+    "TritonGenerateConfig",
+    "TritonInferConfig",
+    "TritonEmbeddingConfig",
+    "HuggingFaceRerankConfig",
+    "DatabricksConfig",
+    "DatabricksEmbeddingConfig",
+    "PredibaseConfig",
+    "ReplicateConfig",
+    "SnowflakeConfig",
+    "CohereRerankConfig",
+    "CohereRerankV2Config",
+    "AzureAIRerankConfig",
+    "InfinityRerankConfig",
+    "JinaAIRerankConfig",
+    "DeepinfraRerankConfig",
+    "HostedVLLMRerankConfig",
+    "NvidiaNimRerankConfig",
+    "NvidiaNimRankingConfig",
+    "VertexAIRerankConfig",
+    "FireworksAIRerankConfig",
+    "VoyageRerankConfig",
+    "ClarifaiConfig",
+    "AI21ChatConfig",
+)
+
+# Types that support lazy loading via _lazy_import_types
+TYPES_NAMES = (
+    "GuardrailItem",
+)
+
+# Import maps for registry pattern - reduces repetition
+_UTILS_IMPORT_MAP = {
+    "exception_type": (".utils", "exception_type"),
+    "get_optional_params": (".utils", "get_optional_params"),
+    "get_response_string": (".utils", "get_response_string"),
+    "token_counter": (".utils", "token_counter"),
+    "create_pretrained_tokenizer": (".utils", "create_pretrained_tokenizer"),
+    "create_tokenizer": (".utils", "create_tokenizer"),
+    "supports_function_calling": (".utils", "supports_function_calling"),
+    "supports_web_search": (".utils", "supports_web_search"),
+    "supports_url_context": (".utils", "supports_url_context"),
+    "supports_response_schema": (".utils", "supports_response_schema"),
+    "supports_parallel_function_calling": (".utils", "supports_parallel_function_calling"),
+    "supports_vision": (".utils", "supports_vision"),
+    "supports_audio_input": (".utils", "supports_audio_input"),
+    "supports_audio_output": (".utils", "supports_audio_output"),
+    "supports_system_messages": (".utils", "supports_system_messages"),
+    "supports_reasoning": (".utils", "supports_reasoning"),
+    "get_litellm_params": (".utils", "get_litellm_params"),
+    "acreate": (".utils", "acreate"),
+    "get_max_tokens": (".utils", "get_max_tokens"),
+    "get_model_info": (".utils", "get_model_info"),
+    "register_prompt_template": (".utils", "register_prompt_template"),
+    "validate_environment": (".utils", "validate_environment"),
+    "check_valid_key": (".utils", "check_valid_key"),
+    "register_model": (".utils", "register_model"),
+    "encode": (".utils", "encode"),
+    "decode": (".utils", "decode"),
+    "_calculate_retry_after": (".utils", "_calculate_retry_after"),
+    "_should_retry": (".utils", "_should_retry"),
+    "get_supported_openai_params": (".utils", "get_supported_openai_params"),
+    "get_api_base": (".utils", "get_api_base"),
+    "get_first_chars_messages": (".utils", "get_first_chars_messages"),
+    "ModelResponse": (".utils", "ModelResponse"),
+    "ModelResponseStream": (".utils", "ModelResponseStream"),
+    "EmbeddingResponse": (".utils", "EmbeddingResponse"),
+    "ImageResponse": (".utils", "ImageResponse"),
+    "TranscriptionResponse": (".utils", "TranscriptionResponse"),
+    "TextCompletionResponse": (".utils", "TextCompletionResponse"),
+    "get_provider_fields": (".utils", "get_provider_fields"),
+    "ModelResponseListIterator": (".utils", "ModelResponseListIterator"),
+    "get_valid_models": (".utils", "get_valid_models"),
+}
+
+_COST_CALCULATOR_IMPORT_MAP = {
+    "completion_cost": (".cost_calculator", "completion_cost"),
+    "cost_per_token": (".cost_calculator", "cost_per_token"),
+    "response_cost_calculator": (".cost_calculator", "response_cost_calculator"),
+}
+
+_TYPES_UTILS_IMPORT_MAP = {
+    "ImageObject": (".types.utils", "ImageObject"),
+    "BudgetConfig": (".types.utils", "BudgetConfig"),
+    "all_litellm_params": (".types.utils", "all_litellm_params"),
+    "_litellm_completion_params": (".types.utils", "all_litellm_params"),  # Alias
+    "CredentialItem": (".types.utils", "CredentialItem"),
+    "PriorityReservationDict": (".types.utils", "PriorityReservationDict"),
+    "StandardKeyGenerationConfig": (".types.utils", "StandardKeyGenerationConfig"),
+    "SearchProviders": (".types.utils", "SearchProviders"),
+    "GenericStreamingChunk": (".types.utils", "GenericStreamingChunk"),
+}
+
+_TOKEN_COUNTER_IMPORT_MAP = {
+    "get_modified_max_tokens": ("litellm.litellm_core_utils.token_counter", "get_modified_max_tokens"),
+}
+
+_BEDROCK_TYPES_IMPORT_MAP = {
+    "COHERE_EMBEDDING_INPUT_TYPES": ("litellm.types.llms.bedrock", "COHERE_EMBEDDING_INPUT_TYPES"),
+}
+
+_CACHING_IMPORT_MAP = {
+    "Cache": ("litellm.caching.caching", "Cache"),
+    "DualCache": ("litellm.caching.caching", "DualCache"),
+    "RedisCache": ("litellm.caching.caching", "RedisCache"),
+    "InMemoryCache": ("litellm.caching.caching", "InMemoryCache"),
+}
+
+_LITELLM_LOGGING_IMPORT_MAP = {
+    "Logging": ("litellm.litellm_core_utils.litellm_logging", "Logging"),
+    "modify_integration": ("litellm.litellm_core_utils.litellm_logging", "modify_integration"),
+}
+
+_DOTPROMPT_IMPORT_MAP = {
+    "global_prompt_manager": ("litellm.integrations.dotprompt", "global_prompt_manager"),
+    "global_prompt_directory": ("litellm.integrations.dotprompt", "global_prompt_directory"),
+    "set_global_prompt_directory": ("litellm.integrations.dotprompt", "set_global_prompt_directory"),
+}
+
+_TYPES_IMPORT_MAP = {
+    "GuardrailItem": ("litellm.types.guardrails", "GuardrailItem"),
+}
+
+_LLM_CONFIGS_IMPORT_MAP = {
+    "AmazonConverseConfig": (".llms.bedrock.chat.converse_transformation", "AmazonConverseConfig"),
+    "OpenAILikeChatConfig": (".llms.openai_like.chat.handler", "OpenAILikeChatConfig"),
+    "GaladrielChatConfig": (".llms.galadriel.chat.transformation", "GaladrielChatConfig"),
+    "GithubChatConfig": (".llms.github.chat.transformation", "GithubChatConfig"),
+    "AzureAnthropicConfig": (".llms.azure_ai.anthropic.transformation", "AzureAnthropicConfig"),
+    "BytezChatConfig": (".llms.bytez.chat.transformation", "BytezChatConfig"),
+    "CompactifAIChatConfig": (".llms.compactifai.chat.transformation", "CompactifAIChatConfig"),
+    "EmpowerChatConfig": (".llms.empower.chat.transformation", "EmpowerChatConfig"),
+    "MinimaxChatConfig": (".llms.minimax.chat.transformation", "MinimaxChatConfig"),
+    "AiohttpOpenAIChatConfig": (".llms.aiohttp_openai.chat.transformation", "AiohttpOpenAIChatConfig"),
+    "HuggingFaceChatConfig": (".llms.huggingface.chat.transformation", "HuggingFaceChatConfig"),
+    "HuggingFaceEmbeddingConfig": (".llms.huggingface.embedding.transformation", "HuggingFaceEmbeddingConfig"),
+    "OobaboogaConfig": (".llms.oobabooga.chat.transformation", "OobaboogaConfig"),
+    "MaritalkConfig": (".llms.maritalk", "MaritalkConfig"),
+    "OpenrouterConfig": (".llms.openrouter.chat.transformation", "OpenrouterConfig"),
+    "DataRobotConfig": (".llms.datarobot.chat.transformation", "DataRobotConfig"),
+    "AnthropicConfig": (".llms.anthropic.chat.transformation", "AnthropicConfig"),
+    "AnthropicTextConfig": (".llms.anthropic.completion.transformation", "AnthropicTextConfig"),
+    "GroqSTTConfig": (".llms.groq.stt.transformation", "GroqSTTConfig"),
+    "TritonConfig": (".llms.triton.completion.transformation", "TritonConfig"),
+    "TritonGenerateConfig": (".llms.triton.completion.transformation", "TritonGenerateConfig"),
+    "TritonInferConfig": (".llms.triton.completion.transformation", "TritonInferConfig"),
+    "TritonEmbeddingConfig": (".llms.triton.embedding.transformation", "TritonEmbeddingConfig"),
+    "HuggingFaceRerankConfig": (".llms.huggingface.rerank.transformation", "HuggingFaceRerankConfig"),
+    "DatabricksConfig": (".llms.databricks.chat.transformation", "DatabricksConfig"),
+    "DatabricksEmbeddingConfig": (".llms.databricks.embed.transformation", "DatabricksEmbeddingConfig"),
+    "PredibaseConfig": (".llms.predibase.chat.transformation", "PredibaseConfig"),
+    "ReplicateConfig": (".llms.replicate.chat.transformation", "ReplicateConfig"),
+    "SnowflakeConfig": (".llms.snowflake.chat.transformation", "SnowflakeConfig"),
+    "CohereRerankConfig": (".llms.cohere.rerank.transformation", "CohereRerankConfig"),
+    "CohereRerankV2Config": (".llms.cohere.rerank_v2.transformation", "CohereRerankV2Config"),
+    "AzureAIRerankConfig": (".llms.azure_ai.rerank.transformation", "AzureAIRerankConfig"),
+    "InfinityRerankConfig": (".llms.infinity.rerank.transformation", "InfinityRerankConfig"),
+    "JinaAIRerankConfig": (".llms.jina_ai.rerank.transformation", "JinaAIRerankConfig"),
+    "DeepinfraRerankConfig": (".llms.deepinfra.rerank.transformation", "DeepinfraRerankConfig"),
+    "HostedVLLMRerankConfig": (".llms.hosted_vllm.rerank.transformation", "HostedVLLMRerankConfig"),
+    "NvidiaNimRerankConfig": (".llms.nvidia_nim.rerank.transformation", "NvidiaNimRerankConfig"),
+    "NvidiaNimRankingConfig": (".llms.nvidia_nim.rerank.ranking_transformation", "NvidiaNimRankingConfig"),
+    "VertexAIRerankConfig": (".llms.vertex_ai.rerank.transformation", "VertexAIRerankConfig"),
+    "FireworksAIRerankConfig": (".llms.fireworks_ai.rerank.transformation", "FireworksAIRerankConfig"),
+    "VoyageRerankConfig": (".llms.voyage.rerank.transformation", "VoyageRerankConfig"),
+    "ClarifaiConfig": (".llms.clarifai.chat.transformation", "ClarifaiConfig"),
+    "AI21ChatConfig": (".llms.ai21.chat.transformation", "AI21ChatConfig"),
+}
+
+# Export all name tuples and import maps for use in _lazy_imports.py
+__all__ = [
+    # Name tuples
+    "COST_CALCULATOR_NAMES",
+    "LITELLM_LOGGING_NAMES",
+    "UTILS_NAMES",
+    "TOKEN_COUNTER_NAMES",
+    "LLM_CLIENT_CACHE_NAMES",
+    "BEDROCK_TYPES_NAMES",
+    "TYPES_UTILS_NAMES",
+    "CACHING_NAMES",
+    "HTTP_HANDLER_NAMES",
+    "DOTPROMPT_NAMES",
+    "LLM_CONFIG_NAMES",
+    "TYPES_NAMES",
+    # Import maps
+    "_UTILS_IMPORT_MAP",
+    "_COST_CALCULATOR_IMPORT_MAP",
+    "_TYPES_UTILS_IMPORT_MAP",
+    "_TOKEN_COUNTER_IMPORT_MAP",
+    "_BEDROCK_TYPES_IMPORT_MAP",
+    "_CACHING_IMPORT_MAP",
+    "_LITELLM_LOGGING_IMPORT_MAP",
+    "_DOTPROMPT_IMPORT_MAP",
+    "_TYPES_IMPORT_MAP",
+    "_LLM_CONFIGS_IMPORT_MAP",
+]
+


### PR DESCRIPTION

## Relevant issues

<!-- e.g. "Fixes #000" -->
N/A - Internal refactoring to improve code maintainability

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: [Baseline](https://app.circleci.com/pipelines/github/BerriAI/litellm/52684/workflows/39ae58d7-7c47-4b11-bdac-dbcac2102c8d)

- [x] **CI run for the last commit**  
       Link: [Last Commit](https://app.circleci.com/pipelines/github/BerriAI/litellm/52693/workflows/f4f832e7-800d-4201-acbc-a73310f55776)

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring

## Changes

### Overview
This PR refactors the lazy loading mechanism in `litellm/__init__.py` to improve maintainability, reduce code duplication, and make the system easier to extend.

### Key Improvements

1. **Cached Registry Pattern** (`8b5db52873`, `32d4b90003`)
   - Registry is built once on first `__getattr__` call instead of importing all name tuples on every call
   - Maps attribute names directly to handler functions for O(1) lookup
   - Performance improvement: ~2.82x average speedup

2. **Separated Data from Logic** (`ee9fc4edb2`)
   - Created `litellm/_lazy_imports_registry.py` to hold all import maps and name tuples
   - Better separation of concerns (data vs. implementation)
   - Easier to maintain and update registry entries

3. **Consolidated Repetitive Code** (`d09c1b519c`, `248fff78ad`, `193906c3f6`)
   - Created `_generic_lazy_import()` function that handles the common import pattern
   - Reduced 10 handler functions from ~200 lines to ~30 lines (85% reduction)
   - Each handler is now just 1 line calling the generic function
   - Automatically handles relative vs. absolute imports

4. **Code Quality Improvements**
   - Removed redundant module cache key (`d35c42efea`) - Python's `sys.modules` already caches
   - Moved `importlib` to module-level import (`6ec4a667f2`) - follows Python best practices
   - Standardized encoding lazy import pattern (`40a1e401df`)
   - Added comprehensive comments explaining the system (`cac0d92197`)

### Files Changed

- `litellm/__init__.py` - Updated `__getattr__` to use cached registry
- `litellm/_lazy_imports.py` - Refactored handlers, added generic function, improved comments
- `litellm/_lazy_imports_registry.py` - **New file** containing all import maps and name tuples

### Code Reduction

- **Net reduction**: ~500+ lines removed across multiple commits
- **Maintainability**: Adding new lazy imports now requires just 1 line + registry entry
- **Consistency**: All imports follow the same pattern

### Special Cases Preserved

- `_lazy_import_llm_client_cache` - Handles singleton instance creation (custom logic)
- `_lazy_import_http_handlers` - Needs factory functions with timeout/params (custom logic)

### Test Results

**Unit Tests**

<img width="2578" height="358" alt="Screenshot 2025-12-23 102033" src="https://github.com/user-attachments/assets/65912900-0d03-48d4-b307-ecd30f497bc9" />

- Failures seem unrelated

**Lazy Load Tests**

<img width="2601" height="1383" alt="Screenshot 2025-12-23 100456" src="https://github.com/user-attachments/assets/0d4833c6-93e3-4eef-bd7b-252afda59cb6" />
