### PR TITLE
[Refactor]: Lazy load additional components (types, callbacks, utilities)

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1075,9 +1075,6 @@ from .llms.vertex_ai.vertex_embeddings.transformation import (
 
 vertexAITextEmbeddingConfig = VertexAITextEmbeddingConfig()
 
-from .llms.bedrock.chat.invoke_handler import (
-    bedrock_tool_name_mappings,
-)
 
 from .llms.bedrock.embed.amazon_titan_v2_transformation import (
     AmazonTitanV2Config,
@@ -1506,6 +1503,10 @@ if TYPE_CHECKING:
     module_level_aclient: AsyncHTTPHandler
     module_level_client: HTTPHandler
 
+    # Bedrock tool name mappings instance (lazy-loaded)
+    from litellm.caching.caching import InMemoryCache
+    bedrock_tool_name_mappings: InMemoryCache
+
     # Note: AmazonConverseConfig and OpenAILikeChatConfig are imported above in TYPE_CHECKING block
 
 
@@ -1530,6 +1531,16 @@ def __getattr__(name: str) -> Any:
             from .main import encoding as _encoding
             _globals["encoding"] = _encoding
         return _globals["encoding"]
+    
+    # Lazy load bedrock_tool_name_mappings instance
+    if name == "bedrock_tool_name_mappings":
+        from ._lazy_imports import _get_litellm_globals
+        _globals = _get_litellm_globals()
+        # Check if already cached
+        if "bedrock_tool_name_mappings" not in _globals:
+            from .llms.bedrock.chat.invoke_handler import bedrock_tool_name_mappings as _bedrock_tool_name_mappings
+            _globals["bedrock_tool_name_mappings"] = _bedrock_tool_name_mappings
+        return _globals["bedrock_tool_name_mappings"]
     
     # Lazy load openaiOSeriesConfig instance
     if name == "openaiOSeriesConfig":

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1515,6 +1515,10 @@ if TYPE_CHECKING:
 
     # Custom logger class (lazy-loaded)
     from litellm.integrations.custom_logger import CustomLogger
+    
+    # Logging callback manager class and instance (lazy-loaded)
+    from litellm.litellm_core_utils.logging_callback_manager import LoggingCallbackManager
+    logging_callback_manager: LoggingCallbackManager
 
     # Note: AmazonConverseConfig and OpenAILikeChatConfig are imported above in TYPE_CHECKING block
 

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -74,7 +74,6 @@ from litellm.constants import (
     DEFAULT_SOFT_BUDGET,
     DEFAULT_ALLOWED_FAILS,
 )
-from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.logging_callback_manager import LoggingCallbackManager
 import httpx
 import dotenv
@@ -91,7 +90,7 @@ if set_verbose:
     _turn_on_debug()
 ####################################################
 ### Callbacks /Logging / Success / Failure Handlers #####
-CALLBACK_TYPES = Union[str, Callable, CustomLogger]
+CALLBACK_TYPES = Union[str, Callable, "CustomLogger"]  # CustomLogger is lazy-loaded
 input_callback: List[CALLBACK_TYPES] = []
 success_callback: List[CALLBACK_TYPES] = []
 failure_callback: List[CALLBACK_TYPES] = []
@@ -148,7 +147,7 @@ _known_custom_logger_compatible_callbacks: List = list(
     get_args(_custom_logger_compatible_callbacks_literal)
 )
 callbacks: List[
-    Union[Callable, _custom_logger_compatible_callbacks_literal, CustomLogger]
+    Union[Callable, _custom_logger_compatible_callbacks_literal, "CustomLogger"]  # CustomLogger is lazy-loaded
 ] = []
 callback_settings: Dict[str, Dict[str, Any]] = {}
 initialized_langfuse_clients: int = 0
@@ -165,13 +164,13 @@ generic_api_use_v1: Optional[bool] = (
     False  # if you want to use v1 generic api logged payload
 )
 argilla_transformation_object: Optional[Dict[str, Any]] = None
-_async_input_callback: List[Union[str, Callable, CustomLogger]] = (
+_async_input_callback: List[Union[str, Callable, "CustomLogger"]] = (  # CustomLogger is lazy-loaded
     []
 )  # internal variable - async custom callbacks are routed here.
-_async_success_callback: List[Union[str, Callable, CustomLogger]] = (
+_async_success_callback: List[Union[str, Callable, "CustomLogger"]] = (  # CustomLogger is lazy-loaded
     []
 )  # internal variable - async custom callbacks are routed here.
-_async_failure_callback: List[Union[str, Callable, CustomLogger]] = (
+_async_failure_callback: List[Union[str, Callable, "CustomLogger"]] = (  # CustomLogger is lazy-loaded
     []
 )  # internal variable - async custom callbacks are routed here.
 pre_call_rules: List[Callable] = []
@@ -1517,6 +1516,9 @@ if TYPE_CHECKING:
         KeyManagementSystem,
         KeyManagementSettings,  # Not lazy-loaded - needed for _key_management_settings initialization
     )
+
+    # Custom logger class (lazy-loaded)
+    from litellm.integrations.custom_logger import CustomLogger
 
     # Note: AmazonConverseConfig and OpenAILikeChatConfig are imported above in TYPE_CHECKING block
 

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -78,10 +78,6 @@ from litellm.types.secret_managers.main import (
     KeyManagementSystem,
     KeyManagementSettings,
 )
-from litellm.types.proxy.management_endpoints.ui_sso import (
-    DefaultTeamSSOParams,
-    LiteLLM_UpperboundKeyGenerateParams,
-)
 from litellm.types.utils import LlmProviders
 from litellm.types.utils import PriorityReservationSettings
 from litellm.integrations.custom_logger import CustomLogger
@@ -1462,6 +1458,10 @@ if TYPE_CHECKING:
         StandardKeyGenerationConfig,
     )
     from litellm.types.guardrails import GuardrailItem
+    from litellm.types.proxy.management_endpoints.ui_sso import (
+        DefaultTeamSSOParams,
+        LiteLLM_UpperboundKeyGenerateParams,
+    )
 
     # Cost calculator functions
     cost_per_token: Callable[..., Tuple[float, float]]

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1519,6 +1519,10 @@ if TYPE_CHECKING:
     # Logging callback manager class and instance (lazy-loaded)
     from litellm.litellm_core_utils.logging_callback_manager import LoggingCallbackManager
     logging_callback_manager: LoggingCallbackManager
+    
+    # provider_list is lazy-loaded
+    from litellm.types.utils import LlmProviders
+    provider_list: List[Union[LlmProviders, str]]
 
     # Note: AmazonConverseConfig and OpenAILikeChatConfig are imported above in TYPE_CHECKING block
 

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1084,9 +1084,6 @@ from .llms.topaz.common_utils import TopazModelInfo
 # OpenAIOSeriesConfig is lazy loaded - openaiOSeriesConfig will be created on first access
 # OpenAIGPTConfig, OpenAIGPT5Config, etc. are lazy loaded - instances will be created on first access
 from .llms.xai.common_utils import XAIModelInfo
-from .llms.azure.azure import (
-    AzureOpenAIError,
-)
 # PublicAI now uses JSON-based configuration (see litellm/llms/openai_like/providers.json)
 # All remaining configs are now lazy loaded - see _lazy_imports_registry.py
 
@@ -1507,6 +1504,9 @@ if TYPE_CHECKING:
     from litellm.caching.caching import InMemoryCache
     bedrock_tool_name_mappings: InMemoryCache
 
+    # Azure exception class (lazy-loaded)
+    from litellm.llms.azure.common_utils import AzureOpenAIError
+
     # Note: AmazonConverseConfig and OpenAILikeChatConfig are imported above in TYPE_CHECKING block
 
 
@@ -1541,6 +1541,16 @@ def __getattr__(name: str) -> Any:
             from .llms.bedrock.chat.invoke_handler import bedrock_tool_name_mappings as _bedrock_tool_name_mappings
             _globals["bedrock_tool_name_mappings"] = _bedrock_tool_name_mappings
         return _globals["bedrock_tool_name_mappings"]
+    
+    # Lazy load AzureOpenAIError exception class
+    if name == "AzureOpenAIError":
+        from ._lazy_imports import _get_litellm_globals
+        _globals = _get_litellm_globals()
+        # Check if already cached
+        if "AzureOpenAIError" not in _globals:
+            from .llms.azure.common_utils import AzureOpenAIError as _AzureOpenAIError
+            _globals["AzureOpenAIError"] = _AzureOpenAIError
+        return _globals["AzureOpenAIError"]
     
     # Lazy load openaiOSeriesConfig instance
     if name == "openaiOSeriesConfig":

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1041,7 +1041,7 @@ openai_image_generation_models = ["dall-e-2", "dall-e-3"]
 ####### VIDEO GENERATION MODELS ###################
 openai_video_generation_models = ["sora-2"]
 
-from .timeout import timeout
+# timeout is lazy-loaded via __getattr__
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 from litellm.litellm_core_utils.core_helpers import remove_index_from_tool_calls
 

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -278,6 +278,8 @@ TYPES_NAMES = (
     "DefaultTeamSSOParams",
     "LiteLLM_UpperboundKeyGenerateParams",
     "KeyManagementSystem",
+    # Note: LlmProviders is NOT lazy-loaded because it's imported during import time
+    # in multiple places including openai.py (via main import)
     # Note: KeyManagementSettings is NOT lazy-loaded because _key_management_settings
     # is accessed during import time in secret_managers/main.py
 )

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -277,6 +277,9 @@ TYPES_NAMES = (
     "GuardrailItem",
     "DefaultTeamSSOParams",
     "LiteLLM_UpperboundKeyGenerateParams",
+    "KeyManagementSystem",
+    # Note: KeyManagementSettings is NOT lazy-loaded because _key_management_settings
+    # is accessed during import time in secret_managers/main.py
 )
 
 # Import maps for registry pattern - reduces repetition
@@ -371,6 +374,7 @@ _TYPES_IMPORT_MAP = {
     "GuardrailItem": ("litellm.types.guardrails", "GuardrailItem"),
     "DefaultTeamSSOParams": ("litellm.types.proxy.management_endpoints.ui_sso", "DefaultTeamSSOParams"),
     "LiteLLM_UpperboundKeyGenerateParams": ("litellm.types.proxy.management_endpoints.ui_sso", "LiteLLM_UpperboundKeyGenerateParams"),
+    "KeyManagementSystem": ("litellm.types.secret_managers.main", "KeyManagementSystem"),
 }
 
 _LLM_CONFIGS_IMPORT_MAP = {

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -280,6 +280,7 @@ TYPES_NAMES = (
     "KeyManagementSystem",
     "PriorityReservationSettings",
     "CustomLogger",
+    "LoggingCallbackManager",
     # Note: LlmProviders is NOT lazy-loaded because it's imported during import time
     # in multiple places including openai.py (via main import)
     # Note: KeyManagementSettings is NOT lazy-loaded because _key_management_settings
@@ -381,6 +382,7 @@ _TYPES_IMPORT_MAP = {
     "KeyManagementSystem": ("litellm.types.secret_managers.main", "KeyManagementSystem"),
     "PriorityReservationSettings": ("litellm.types.utils", "PriorityReservationSettings"),
     "CustomLogger": ("litellm.integrations.custom_logger", "CustomLogger"),
+    "LoggingCallbackManager": ("litellm.litellm_core_utils.logging_callback_manager", "LoggingCallbackManager"),
 }
 
 _LLM_CONFIGS_IMPORT_MAP = {

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -31,7 +31,7 @@ UTILS_NAMES = (
     "get_supported_openai_params", "get_api_base", "get_first_chars_messages",
     "ModelResponse", "ModelResponseStream", "EmbeddingResponse", "ImageResponse",
     "TranscriptionResponse", "TextCompletionResponse", "get_provider_fields",
-    "ModelResponseListIterator", "get_valid_models",
+    "ModelResponseListIterator", "get_valid_models", "timeout",
 )
 
 # Token counter names that support lazy loading via _lazy_import_token_counter
@@ -329,6 +329,7 @@ _UTILS_IMPORT_MAP = {
     "get_provider_fields": (".utils", "get_provider_fields"),
     "ModelResponseListIterator": (".utils", "ModelResponseListIterator"),
     "get_valid_models": (".utils", "get_valid_models"),
+    "timeout": (".timeout", "timeout"),
 }
 
 _COST_CALCULATOR_IMPORT_MAP = {

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -278,6 +278,7 @@ TYPES_NAMES = (
     "DefaultTeamSSOParams",
     "LiteLLM_UpperboundKeyGenerateParams",
     "KeyManagementSystem",
+    "PriorityReservationSettings",
     # Note: LlmProviders is NOT lazy-loaded because it's imported during import time
     # in multiple places including openai.py (via main import)
     # Note: KeyManagementSettings is NOT lazy-loaded because _key_management_settings
@@ -377,6 +378,7 @@ _TYPES_IMPORT_MAP = {
     "DefaultTeamSSOParams": ("litellm.types.proxy.management_endpoints.ui_sso", "DefaultTeamSSOParams"),
     "LiteLLM_UpperboundKeyGenerateParams": ("litellm.types.proxy.management_endpoints.ui_sso", "LiteLLM_UpperboundKeyGenerateParams"),
     "KeyManagementSystem": ("litellm.types.secret_managers.main", "KeyManagementSystem"),
+    "PriorityReservationSettings": ("litellm.types.utils", "PriorityReservationSettings"),
 }
 
 _LLM_CONFIGS_IMPORT_MAP = {

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -279,6 +279,7 @@ TYPES_NAMES = (
     "LiteLLM_UpperboundKeyGenerateParams",
     "KeyManagementSystem",
     "PriorityReservationSettings",
+    "CustomLogger",
     # Note: LlmProviders is NOT lazy-loaded because it's imported during import time
     # in multiple places including openai.py (via main import)
     # Note: KeyManagementSettings is NOT lazy-loaded because _key_management_settings
@@ -379,6 +380,7 @@ _TYPES_IMPORT_MAP = {
     "LiteLLM_UpperboundKeyGenerateParams": ("litellm.types.proxy.management_endpoints.ui_sso", "LiteLLM_UpperboundKeyGenerateParams"),
     "KeyManagementSystem": ("litellm.types.secret_managers.main", "KeyManagementSystem"),
     "PriorityReservationSettings": ("litellm.types.utils", "PriorityReservationSettings"),
+    "CustomLogger": ("litellm.integrations.custom_logger", "CustomLogger"),
 }
 
 _LLM_CONFIGS_IMPORT_MAP = {

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -275,6 +275,8 @@ LLM_CONFIG_NAMES = (
 # Types that support lazy loading via _lazy_import_types
 TYPES_NAMES = (
     "GuardrailItem",
+    "DefaultTeamSSOParams",
+    "LiteLLM_UpperboundKeyGenerateParams",
 )
 
 # Import maps for registry pattern - reduces repetition
@@ -367,6 +369,8 @@ _DOTPROMPT_IMPORT_MAP = {
 
 _TYPES_IMPORT_MAP = {
     "GuardrailItem": ("litellm.types.guardrails", "GuardrailItem"),
+    "DefaultTeamSSOParams": ("litellm.types.proxy.management_endpoints.ui_sso", "DefaultTeamSSOParams"),
+    "LiteLLM_UpperboundKeyGenerateParams": ("litellm.types.proxy.management_endpoints.ui_sso", "LiteLLM_UpperboundKeyGenerateParams"),
 }
 
 _LLM_CONFIGS_IMPORT_MAP = {

--- a/litellm/litellm_core_utils/default_encoding.py
+++ b/litellm/litellm_core_utils/default_encoding.py
@@ -19,5 +19,22 @@ os.environ["TIKTOKEN_CACHE_DIR"] = os.getenv(
     "CUSTOM_TIKTOKEN_CACHE_DIR", filename
 )  # use local copy of tiktoken b/c of - https://github.com/BerriAI/litellm/issues/1071
 import tiktoken
+import time
+import random
 
-encoding = tiktoken.get_encoding("cl100k_base")
+# Retry logic to handle race conditions when multiple processes try to create
+# the tiktoken cache file simultaneously (common in parallel test execution on Windows)
+_max_retries = 5
+_retry_delay = 0.1  # Start with 100ms
+
+for attempt in range(_max_retries):
+    try:
+        encoding = tiktoken.get_encoding("cl100k_base")
+        break
+    except (FileExistsError, OSError) as e:
+        if attempt == _max_retries - 1:
+            # Last attempt, re-raise the exception
+            raise
+        # Exponential backoff with jitter to reduce collision probability
+        delay = _retry_delay * (2 ** attempt) + random.uniform(0, 0.1)
+        time.sleep(delay)


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: [Baseline](https://app.circleci.com/pipelines/github/BerriAI/litellm/52711/workflows/71b16b5b-4290-46a1-85cc-c2bb476f0454)

- [x] **CI run for the last commit**  
       Link: [Last Commit](https://app.circleci.com/pipelines/github/BerriAI/litellm/52718/workflows/f71cef3b-8b1b-402d-9364-84a8b3d47660)

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

This PR extends the lazy loading migration by converting additional components from eager imports to lazy loading, further reducing initial import time and memory footprint.

### Lazy-Loaded Components

1. **Type Classes & Instances:**
   - `PriorityReservationSettings` and `priority_reservation_settings` instance
   - `DefaultTeamSSOParams` and `LiteLLM_UpperboundKeyGenerateParams`
   - `KeyManagementSystem` (kept `KeyManagementSettings` eagerly imported due to import-time access)
   - `CustomLogger` class
   - `LoggingCallbackManager` class and `logging_callback_manager` instance
   - `AzureOpenAIError` exception class
   - `bedrock_tool_name_mappings` instance

2. **Utility Functions:**
   - `timeout` decorator
   - `provider_list` (moved `LlmProviders` import earlier due to import-time access)

3. **Initialization Functions:**
   - `register_async_client_cleanup()` - now called lazily on first access

### Bug Fixes

- **Fixed tiktoken cache race condition**: Added retry logic with exponential backoff in `litellm/litellm_core_utils/default_encoding.py` to handle `FileExistsError` when multiple processes create the cache file simultaneously (common in parallel test execution on Windows)

### Type Safety

- Added type stubs in `TYPE_CHECKING` block for all lazy-loaded components to resolve mypy errors:
  - `logging_callback_manager: LoggingCallbackManager`
  - `provider_list: List[Union[LlmProviders, str]]`
  - Resolved 34 mypy `attr-defined` errors across 12 files

## Test Results

<img width="2632" height="525" alt="Screenshot 2025-12-23 133220" src="https://github.com/user-attachments/assets/78679c96-940d-447e-a76f-1e3c5608040f" />

<img width="2532" height="1525" alt="Screenshot 2025-12-23 133400" src="https://github.com/user-attachments/assets/e79ec70f-80ca-4ea2-84fe-db33b6bbbda6" />

