### PR TITLE
[Fix] Disable Admin UI Flag

### DIFF
--- a/litellm/proxy/discovery_endpoints/ui_discovery_endpoints.py
+++ b/litellm/proxy/discovery_endpoints/ui_discovery_endpoints.py
@@ -18,9 +18,11 @@ async def get_ui_config():
     from litellm.proxy.auth.auth_utils import _has_user_setup_sso
 
     auto_redirect_ui_login_to_sso = os.getenv("AUTO_REDIRECT_UI_LOGIN_TO_SSO", "true").lower() == "true"
+    admin_ui_disabled = os.getenv("DISABLE_ADMIN_UI", "false").lower() == "true"
 
     return UiDiscoveryEndpoints(
         server_root_path=get_server_root_path(),
         proxy_base_url=get_proxy_base_url(),
         auto_redirect_to_sso=_has_user_setup_sso() and auto_redirect_ui_login_to_sso,
+        admin_ui_disabled=admin_ui_disabled,
     )

--- a/litellm/types/proxy/discovery_endpoints/ui_discovery_endpoints.py
+++ b/litellm/types/proxy/discovery_endpoints/ui_discovery_endpoints.py
@@ -7,3 +7,4 @@ class UiDiscoveryEndpoints(BaseModel):
     server_root_path: str
     proxy_base_url: Optional[str]
     auto_redirect_to_sso: bool
+    admin_ui_disabled: bool

--- a/tests/test_litellm/proxy/discovery_endpoints/test_ui_discovery_endpoints.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_ui_discovery_endpoints.py
@@ -21,7 +21,7 @@ def test_ui_discovery_endpoints_with_defaults():
     with patch("litellm.proxy.utils.get_server_root_path", return_value="/"), \
          patch("litellm.proxy.utils.get_proxy_base_url", return_value=None), \
          patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=False), \
-         patch.dict(os.environ, {}, clear=False):
+         patch.dict(os.environ, {"DISABLE_ADMIN_UI": "false"}, clear=False):
         
         response = client.get("/.well-known/litellm-ui-config")
         
@@ -41,7 +41,7 @@ def test_ui_discovery_endpoints_with_custom_server_root_path():
     with patch("litellm.proxy.utils.get_server_root_path", return_value="/litellm"), \
          patch("litellm.proxy.utils.get_proxy_base_url", return_value=None), \
          patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=False), \
-         patch.dict(os.environ, {}, clear=False):
+         patch.dict(os.environ, {"DISABLE_ADMIN_UI": "false"}, clear=False):
         
         response = client.get("/.well-known/litellm-ui-config")
         
@@ -60,7 +60,7 @@ def test_ui_discovery_endpoints_with_proxy_base_url_when_set():
     with patch("litellm.proxy.utils.get_server_root_path", return_value="/"), \
          patch("litellm.proxy.utils.get_proxy_base_url", return_value="https://proxy.example.com"), \
          patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=False), \
-         patch.dict(os.environ, {}, clear=False):
+         patch.dict(os.environ, {"DISABLE_ADMIN_UI": "false"}, clear=False):
         
         response = client.get("/litellm/.well-known/litellm-ui-config")
         
@@ -79,7 +79,7 @@ def test_ui_discovery_endpoints_with_sso_configured_and_auto_redirect_enabled():
     with patch("litellm.proxy.utils.get_server_root_path", return_value="/litellm"), \
          patch("litellm.proxy.utils.get_proxy_base_url", return_value="https://proxy.example.com"), \
          patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=True), \
-         patch.dict(os.environ, {"AUTO_REDIRECT_UI_LOGIN_TO_SSO": "true"}, clear=False):
+         patch.dict(os.environ, {"AUTO_REDIRECT_UI_LOGIN_TO_SSO": "true", "DISABLE_ADMIN_UI": "false"}, clear=False):
         
         response = client.get("/.well-known/litellm-ui-config")
         
@@ -98,7 +98,7 @@ def test_ui_discovery_endpoints_with_sso_configured_but_auto_redirect_disabled()
     with patch("litellm.proxy.utils.get_server_root_path", return_value="/litellm"), \
          patch("litellm.proxy.utils.get_proxy_base_url", return_value="https://proxy.example.com"), \
          patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=True), \
-         patch.dict(os.environ, {"AUTO_REDIRECT_UI_LOGIN_TO_SSO": "false"}, clear=False):
+         patch.dict(os.environ, {"AUTO_REDIRECT_UI_LOGIN_TO_SSO": "false", "DISABLE_ADMIN_UI": "false"}, clear=False):
         
         response = client.get("/.well-known/litellm-ui-config")
         
@@ -117,7 +117,7 @@ def test_ui_discovery_endpoints_with_sso_not_configured_but_auto_redirect_enable
     with patch("litellm.proxy.utils.get_server_root_path", return_value="/"), \
          patch("litellm.proxy.utils.get_proxy_base_url", return_value=None), \
          patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=False), \
-         patch.dict(os.environ, {"AUTO_REDIRECT_UI_LOGIN_TO_SSO": "true"}, clear=False):
+         patch.dict(os.environ, {"AUTO_REDIRECT_UI_LOGIN_TO_SSO": "true", "DISABLE_ADMIN_UI": "false"}, clear=False):
         
         response = client.get("/.well-known/litellm-ui-config")
         
@@ -136,7 +136,7 @@ def test_ui_discovery_endpoints_both_routes_return_same_data():
     with patch("litellm.proxy.utils.get_server_root_path", return_value="/litellm"), \
          patch("litellm.proxy.utils.get_proxy_base_url", return_value="https://proxy.example.com"), \
          patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=True), \
-         patch.dict(os.environ, {"AUTO_REDIRECT_UI_LOGIN_TO_SSO": "true"}, clear=False):
+         patch.dict(os.environ, {"AUTO_REDIRECT_UI_LOGIN_TO_SSO": "true", "DISABLE_ADMIN_UI": "false"}, clear=False):
         
         response1 = client.get("/.well-known/litellm-ui-config")
         response2 = client.get("/litellm/.well-known/litellm-ui-config")

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
@@ -1,12 +1,15 @@
 /* @vitest-environment jsdom */
-import { renderHook } from "@testing-library/react";
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import useAuthorized from "./useAuthorized";
 
-const { replaceMock, clearTokenCookiesMock, getProxyBaseUrlMock } = vi.hoisted(() => ({
+const { replaceMock, clearTokenCookiesMock, getProxyBaseUrlMock, getUiConfigMock } = vi.hoisted(() => ({
   replaceMock: vi.fn(),
   clearTokenCookiesMock: vi.fn(),
   getProxyBaseUrlMock: vi.fn(() => "http://proxy.example"),
+  getUiConfigMock: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -15,9 +18,14 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
-vi.mock("@/components/networking", () => ({
-  getProxyBaseUrl: getProxyBaseUrlMock,
-}));
+vi.mock("@/components/networking", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/networking")>();
+  return {
+    ...actual,
+    getProxyBaseUrl: getProxyBaseUrlMock,
+    getUiConfig: getUiConfigMock,
+  };
+});
 
 vi.mock("@/utils/cookieUtils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/utils/cookieUtils")>();
@@ -26,6 +34,21 @@ vi.mock("@/utils/cookieUtils", async (importOriginal) => {
     clearTokenCookies: clearTokenCookiesMock,
   };
 });
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = createQueryClient();
+  return React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
 
 const createJwt = (payload: Record<string, unknown>) => {
   const base64Url = btoa(JSON.stringify(payload)).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
@@ -41,10 +64,18 @@ describe("useAuthorized", () => {
     replaceMock.mockReset();
     clearTokenCookiesMock.mockReset();
     getProxyBaseUrlMock.mockClear();
+    getUiConfigMock.mockReset();
     clearCookie();
   });
 
-  it("should decode the token and expose user details", () => {
+  it("should decode the token and expose user details", async () => {
+    getUiConfigMock.mockResolvedValue({
+      server_root_path: "/",
+      proxy_base_url: null,
+      auto_redirect_to_sso: false,
+      admin_ui_disabled: false,
+    });
+
     const token = createJwt({
       key: "api-key-123",
       user_id: "user-1",
@@ -56,9 +87,12 @@ describe("useAuthorized", () => {
     });
     document.cookie = `token=${token}; path=/;`;
 
-    const { result } = renderHook(() => useAuthorized());
+    const { result } = renderHook(() => useAuthorized(), { wrapper });
 
-    expect(result.current.token).toBe(token);
+    await waitFor(() => {
+      expect(result.current.token).toBe(token);
+    });
+
     expect(result.current.accessToken).toBe("api-key-123");
     expect(result.current.userId).toBe("user-1");
     expect(result.current.userEmail).toBe("user@example.com");
@@ -69,14 +103,54 @@ describe("useAuthorized", () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  it("should clear cookies and redirect on an invalid token", () => {
+  it("should clear cookies and redirect on an invalid token", async () => {
+    getUiConfigMock.mockResolvedValue({
+      server_root_path: "/",
+      proxy_base_url: null,
+      auto_redirect_to_sso: false,
+      admin_ui_disabled: false,
+    });
+
     document.cookie = "token=invalid-token; path=/;";
 
-    const { result } = renderHook(() => useAuthorized());
+    const { result } = renderHook(() => useAuthorized(), { wrapper });
 
-    expect(clearTokenCookiesMock).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(clearTokenCookiesMock).toHaveBeenCalled();
+    });
+
     expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login");
     expect(result.current.accessToken).toBeNull();
     expect(result.current.userRole).toBe("Undefined Role");
+  });
+
+  it("should redirect even with valid token if admin_ui_disabled is true", async () => {
+    getUiConfigMock.mockResolvedValue({
+      server_root_path: "/",
+      proxy_base_url: null,
+      auto_redirect_to_sso: false,
+      admin_ui_disabled: true,
+    });
+
+    const token = createJwt({
+      key: "api-key-123",
+      user_id: "user-1",
+      user_email: "user@example.com",
+      user_role: "app_admin",
+      premium_user: true,
+      disabled_non_admin_personal_key_creation: false,
+      login_method: "username_password",
+    });
+    document.cookie = `token=${token}; path=/;`;
+
+    const { result } = renderHook(() => useAuthorized(), { wrapper });
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login");
+    });
+
+    expect(result.current.accessToken).toBe("api-key-123");
+    expect(result.current.userId).toBe("user-1");
+    expect(result.current.userEmail).toBe("user@example.com");
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
-import { useRouter } from "next/navigation";
-import { jwtDecode } from "jwt-decode";
-import { clearTokenCookies, getCookie } from "@/utils/cookieUtils";
 import { getProxyBaseUrl } from "@/components/networking";
+import { clearTokenCookies, getCookie } from "@/utils/cookieUtils";
+import { jwtDecode } from "jwt-decode";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo } from "react";
+import { useUIConfig } from "./uiConfig/useUIConfig";
 
 function formatUserRole(userRole: string) {
   if (!userRole) {
@@ -37,15 +38,19 @@ function formatUserRole(userRole: string) {
 
 const useAuthorized = () => {
   const router = useRouter();
+  const { data: uiConfig, isLoading: isUIConfigLoading } = useUIConfig();
 
   const token = typeof document !== "undefined" ? getCookie("token") : null;
 
   // Redirect after mount if missing/invalid token
   useEffect(() => {
-    if (!token) {
+    if (isUIConfigLoading) {
+      return;
+    }
+    if (!token || uiConfig?.admin_ui_disabled) {
       router.replace(`${getProxyBaseUrl()}/ui/login`);
     }
-  }, [token, router]);
+  }, [token, router, isUIConfigLoading, uiConfig]);
 
   // Decode safely
   const decoded = useMemo(() => {

--- a/ui/litellm-dashboard/src/app/login/LoginPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.test.tsx
@@ -169,4 +169,27 @@ describe("LoginPage", () => {
 
     expect(mockPush).not.toHaveBeenCalled();
   });
+
+  it("should show alert when admin_ui_disabled is true", async () => {
+    (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { admin_ui_disabled: true, server_root_path: "/", proxy_base_url: null },
+      isLoading: false,
+    });
+    (getCookie as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <LoginPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByText("Admin UI Disabled")).toBeInTheDocument();
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
 });

--- a/ui/litellm-dashboard/src/app/login/LoginPage.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.tsx
@@ -25,6 +25,12 @@ function LoginPageContent() {
       return;
     }
 
+    // Check if admin UI is disabled
+    if (uiConfig && uiConfig.admin_ui_disabled) {
+      setIsLoading(false);
+      return;
+    }
+
     const rawToken = getCookie("token");
     if (rawToken && !isJwtExpired(rawToken)) {
       router.replace(`${getProxyBaseUrl()}/ui`);
@@ -57,6 +63,38 @@ function LoginPageContent() {
 
   if (isConfigLoading || isLoading) {
     return <LoadingScreen />;
+  }
+
+  // Show disabled message if admin UI is disabled
+  if (uiConfig && uiConfig.admin_ui_disabled) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <Card className="w-full max-w-lg shadow-md">
+          <Space direction="vertical" size="middle" className="w-full">
+            <div className="text-center">
+              <Title level={2}>🚅 LiteLLM</Title>
+            </div>
+
+            <Alert
+              message="Admin UI Disabled"
+              description={
+                <>
+                  <Paragraph className="text-sm">
+                    The Admin UI has been disabled by the administrator. To re-enable it, please update the following
+                    environment variable:
+                  </Paragraph>
+                  <Paragraph className="text-sm">
+                    <code className="bg-gray-100 px-1 py-0.5 rounded text-xs">DISABLE_ADMIN_UI=False</code>
+                  </Paragraph>
+                </>
+              }
+              type="warning"
+              showIcon
+            />
+          </Space>
+        </Card>
+      </div>
+    );
   }
 
   return (

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -230,6 +230,7 @@ export interface LiteLLMWellKnownUiConfig {
   server_root_path: string;
   proxy_base_url: string | null;
   auto_redirect_to_sso: boolean;
+  admin_ui_disabled: boolean;
 }
 
 export interface CredentialsResponse {


### PR DESCRIPTION
## Relevant issues
LiteLLM supports an environment variable called DISABLE_ADMIN_UI, but this flag was not properly implemented. This PR implements the Disable Admin UI Flag with the following behavior when the flag is set to True:
1. UI Login is disabled with an error message (See screenshot)
2. Active UI Sessions are also redirected to the login page where it shows the error message

Testing:
1 and 2 above, works properly
3. Tested with flag set to False, ensured login and UI worked as expected
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="849" height="166" alt="image" src="https://github.com/user-attachments/assets/57d1a9a6-554d-4df9-a3ec-78a3df741661" />
<img width="657" height="437" alt="image" src="https://github.com/user-attachments/assets/d8de519a-c77d-4225-85ce-4c22b5188e89" />
<img width="839" height="70" alt="image" src="https://github.com/user-attachments/assets/dc1b932d-1dfd-48a9-a9c1-ab2262c97751" />
