### PR TITLE
[Fix] Allow Organization Admins to See Organization Tab

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/components/SidebarProvider.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/components/SidebarProvider.tsx
@@ -1,4 +1,3 @@
-import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import Sidebar from "@/components/leftnav";
 
 interface SidebarProviderProps {
@@ -8,17 +7,7 @@ interface SidebarProviderProps {
 }
 
 const SidebarProvider = ({ setPage, defaultSelectedKey, sidebarCollapsed }: SidebarProviderProps) => {
-  const { accessToken, userRole } = useAuthorized();
-
-  return (
-    <Sidebar
-      accessToken={accessToken}
-      setPage={setPage}
-      userRole={userRole}
-      defaultSelectedKey={defaultSelectedKey}
-      collapsed={sidebarCollapsed}
-    />
-  );
+  return <Sidebar setPage={setPage} defaultSelectedKey={defaultSelectedKey} collapsed={sidebarCollapsed} />;
 };
 
 export default SidebarProvider;

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/organizations/useOrganizations.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/organizations/useOrganizations.ts
@@ -1,0 +1,13 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { createQueryKeys } from "../common/queryKeysFactory";
+import { organizationListCall, Organization } from "@/components/networking";
+
+const organizationKeys = createQueryKeys("organizations");
+
+export const useOrganizations = (accessToken: string | null): UseQueryResult<Organization[]> => {
+  return useQuery<Organization[]>({
+    queryKey: organizationKeys.list({}),
+    queryFn: async () => await organizationListCall(accessToken!),
+    enabled: Boolean(accessToken),
+  });
+};

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -1,3 +1,5 @@
+import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import {
   ApiOutlined,
   AppstoreOutlined,
@@ -21,17 +23,17 @@ import {
   ToolOutlined,
   UserOutlined,
 } from "@ant-design/icons";
-import { Badge, ConfigProvider, Layout, Menu } from "antd";
 import type { MenuProps } from "antd";
+import { Badge, ConfigProvider, Layout, Menu } from "antd";
+import { useMemo } from "react";
 import { all_admin_roles, internalUserRoles, isAdminRole, rolesWithWriteAccess } from "../utils/roles";
+import type { Organization } from "./networking";
 import UsageIndicator from "./usage_indicator";
 const { Sider } = Layout;
 
 // Define the props type
 interface SidebarProps {
-  accessToken: string | null;
   setPage: (page: string) => void;
-  userRole: string;
   defaultSelectedKey: string;
   collapsed?: boolean;
 }
@@ -53,7 +55,18 @@ interface MenuGroup {
   roles?: string[];
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ accessToken, setPage, userRole, defaultSelectedKey, collapsed = false }) => {
+const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapsed = false }) => {
+  const { userId, accessToken, userRole } = useAuthorized();
+  const { data: organizations } = useOrganizations(accessToken);
+
+  // Check if user is an org_admin
+  const isOrgAdmin = useMemo(() => {
+    if (!userId || !organizations) return false;
+    return organizations.some((org: Organization) =>
+      org.members?.some((member) => member.user_id === userId && member.user_role === "org_admin"),
+    );
+  }, [userId, organizations]);
+
   // Navigate to page helper
   const navigateToPage = (page: string) => {
     const newSearchParams = new URLSearchParams(window.location.search);
@@ -146,7 +159,7 @@ const Sidebar: React.FC<SidebarProps> = ({ accessToken, setPage, userRole, defau
             <span className="flex items-center gap-4">
               Usage <Badge color="blue" count="New" />
             </span>
-        ),
+          ),
         },
         {
           key: "logs",
@@ -302,7 +315,13 @@ const Sidebar: React.FC<SidebarProps> = ({ accessToken, setPage, userRole, defau
   // Filter items based on user role
   const filterItemsByRole = (items: MenuItem[]): MenuItem[] => {
     return items
-      .filter((item) => !item.roles || item.roles.includes(userRole))
+      .filter((item) => {
+        // Special handling for organizations menu item - allow org_admins
+        if (item.key === "organizations") {
+          return !item.roles || item.roles.includes(userRole) || isOrgAdmin;
+        }
+        return !item.roles || item.roles.includes(userRole);
+      })
       .map((item) => ({
         ...item,
         children: item.children ? filterItemsByRole(item.children) : undefined,


### PR DESCRIPTION
## Relevant issues
Org admins are classified internally as internal_user, which the UI previously classified as cannot see the Organization Tab. This PR implements changes such that org admins can see the organization tab. Partially solves https://github.com/BerriAI/litellm/issues/18131

The backend currently does not support an org admin seeing the org info page, will implement in another PR
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="1706" height="580" alt="image" src="https://github.com/user-attachments/assets/87dda7b8-c094-4336-a35e-cb440ee57dae" />
<img width="833" height="188" alt="image" src="https://github.com/user-attachments/assets/0dc41768-d737-4476-909f-f72b93b1eba7" />
