### PR TITLE
fix(braintrust): pass span_attributes in async logging and skip tags on non-root spans

### DIFF
--- a/litellm/integrations/braintrust_logging.py
+++ b/litellm/integrations/braintrust_logging.py
@@ -225,10 +225,13 @@ class BraintrustLogger(CustomLogger):
                 "id": litellm_call_id,
                 "input": prompt["messages"],
                 "metadata": standard_logging_object,
-                "tags": tags,
                 "span_attributes": {"name": span_name, "type": "llm"},
             }
-            
+
+            # Braintrust cannot specify 'tags' for non-root spans 
+            if dynamic_metadata.get("root_span_id") is None:
+                request_data["tags"] = tags
+
             # Only add those that are not None (or falsy)
             for key, value in span_attributes.items():
                 if value:
@@ -351,6 +354,20 @@ class BraintrustLogger(CustomLogger):
             # Allow metadata override for span name
             span_name = dynamic_metadata.get("span_name", "Chat Completion")
 
+            # Span parents is a special case
+            span_parents = dynamic_metadata.get("span_parents")
+
+            # Convert comma-separated string to list if present
+            if span_parents:
+                span_parents = [s.strip() for s in span_parents.split(",") if s.strip()]
+
+            # Add optional span attributes only if present
+            span_attributes = {
+                "span_id": dynamic_metadata.get("span_id"),
+                "root_span_id": dynamic_metadata.get("root_span_id"),
+                "span_parents": span_parents,
+            }
+
             request_data = {
                 "id": litellm_call_id,
                 "input": prompt["messages"],
@@ -362,32 +379,16 @@ class BraintrustLogger(CustomLogger):
             # Braintrust cannot specify 'tags' for non-root spans 
             if dynamic_metadata.get("root_span_id") is None:
                 request_data["tags"] = tags
-            # Span parents is a special case
-            span_parents = dynamic_metadata.get("span_parents")
-
-            # Convert comma-separated string to list if present
-            if span_parents:
-                span_parents = [s.strip() for s in span_parents.split(",") if s.strip()]
-
-            span_attributes = {
-                "span_id": dynamic_metadata.get("span_id"),
-                "root_span_id": dynamic_metadata.get("root_span_id"),
-                "span_parents": span_parents,
-            }
 
             # Only add those that are not None (or falsy)
             for key, value in span_attributes.items():
                 if value:
                     request_data[key] = value
 
-
             if choices is not None:
                 request_data["output"] = [choice.dict() for choice in choices]
             else:
                 request_data["output"] = output
-
-            if metrics is not None:
-                request_data["metrics"] = metrics
 
             if metrics is not None:
                 request_data["metrics"] = metrics


### PR DESCRIPTION
This PR fixes two issues in the Braintrust logger:

1. **`async_log_success_event` did not pass `span_attributes`**
   The sync version (`log_success_event`) did pass custom `span_attributes`, but the async version did not.
   This caused span metadata to be lost when using async logging.

2. **`tags` should not be sent for non-root spans**
   Braintrust returns an error when `tags` are set on non-root spans:
   `Braintrust cannot specify 'tags' for non-root spans`.

   This PR only includes `tags` when `root_span_id` is not present.

Docs: https://docs.litellm.ai/docs/observability/braintrust

---

### Changes

* Pass custom `span_attributes` in `async_log_success_event`.
* Only send `tags` for root spans.
