### PR TITLE
[Fix] Allow Organization Admins to View Their Organization Info

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1467,7 +1467,7 @@ async def get_users(
     ),
 ):
     """
-    Get a paginated list of users with filtering and sorting options
+    Get a paginated list of users with filtering and sorting options.
 
     Parameters:
         role: Optional[str]

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1467,7 +1467,7 @@ async def get_users(
     ),
 ):
     """
-    Get a paginated list of users with filtering and sorting options.
+    Get a paginated list of users with filtering and sorting options
 
     Parameters:
         role: Optional[str]

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -24,6 +24,7 @@ from litellm.proxy.common_utils.http_parsing_utils import (
     get_form_data,
     get_request_body,
     get_tags_from_request_body,
+    populate_request_with_path_params,
 )
 
 
@@ -630,3 +631,69 @@ def test_get_tags_from_request_body_with_null_metadata():
 
     assert result == []
     assert isinstance(result, list)
+
+
+def test_populate_request_with_path_params_adds_query_params():
+    """
+    Test that populate_request_with_path_params correctly adds query parameters
+    like organization_id to the request data.
+    """
+    # Create a mock request with query parameters
+    mock_request = MagicMock()
+    # Mock query_params as a dict-like object that can be converted to dict
+    mock_request.query_params = {
+        "organization_id": "org-123",
+        "user_id": "user-456"
+    }
+    mock_request.path_params = {}
+    # Mock url.path to avoid errors in _add_vector_store_id_from_path
+    mock_request.url.path = "/v1/chat/completions"
+
+    # Initial request data without query params
+    request_data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}]
+    }
+
+    # Call the function
+    result = populate_request_with_path_params(request_data, mock_request)
+
+    # Verify query params were added
+    assert result["organization_id"] == "org-123"
+    assert result["user_id"] == "user-456"
+    # Verify original data is preserved
+    assert result["model"] == "gpt-4"
+    assert result["messages"] == [{"role": "user", "content": "Hello"}]
+
+
+def test_populate_request_with_path_params_does_not_overwrite_existing_values():
+    """
+    Test that populate_request_with_path_params does not overwrite existing values
+    in request_data when query params contain the same keys.
+    """
+    # Create a mock request with query parameters
+    mock_request = MagicMock()
+    # Mock query_params as a dict-like object that can be converted to dict
+    mock_request.query_params = {
+        "organization_id": "org-query-param",
+        "model": "gpt-3.5-turbo"
+    }
+    mock_request.path_params = {}
+    # Mock url.path to avoid errors in _add_vector_store_id_from_path
+    mock_request.url.path = "/v1/chat/completions"
+
+    # Initial request data with existing values
+    request_data = {
+        "model": "gpt-4",  # This should NOT be overwritten
+        "organization_id": "org-existing",  # This should NOT be overwritten
+        "messages": [{"role": "user", "content": "Hello"}]
+    }
+
+    # Call the function
+    result = populate_request_with_path_params(request_data, mock_request)
+
+    # Verify existing values were NOT overwritten
+    assert result["model"] == "gpt-4"  # Should keep original, not "gpt-3.5-turbo"
+    assert result["organization_id"] == "org-existing"  # Should keep original, not "org-query-param"
+    # Verify other data is preserved
+    assert result["messages"] == [{"role": "user", "content": "Hello"}]


### PR DESCRIPTION
## Relevant issues
Previously org admins were receiving a 401 when they are trying to view their org's info in the UI. This is because for non-proxy admins the request goes though additional parsing, and the common function did not take into account query params. This PR adds support in the common function for query params, while keeping backwards compatibility by not overwriting existing values.

Testing:
1. Proxy Admin Can still view all organization's info
2. Org admins can view their organization's info
3. Users outside of the organization cannot view the organization's info
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/52756

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/52757

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
