### PR TITLE
[Fix] UI - Model Page Sorting Sorts Entire Set

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
@@ -661,7 +661,6 @@ const ModelsAndEndpointsView: React.FC<ModelDashboardProps> = ({
                   setSelectedModelId={setSelectedModelId}
                   setSelectedTeamId={setSelectedTeamId}
                   setEditModel={setEditModel}
-                  modelData={modelData}
                 />
                 {!shouldHideAddModelTab && (
                   <TabPanel className="h-full">

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
@@ -1,8 +1,26 @@
 import * as useAuthorizedModule from "@/app/(dashboard)/hooks/useAuthorized";
-import * as useTeamsModule from "@/app/(dashboard)/hooks/useTeams";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AllModelsTab from "./AllModelsTab";
+
+// Mock the useModelsInfo hook
+const mockUseModelsInfo = vi.fn(() => ({ data: { data: [] } })) as any;
+
+vi.mock("../../hooks/models/useModels", () => ({
+  useModelsInfo: () => mockUseModelsInfo(),
+}));
+
+// Mock the useTeams hook (react-query implementation)
+const mockUseTeams = vi.fn(() => ({
+  data: [],
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+})) as any;
+
+vi.mock("../../hooks/teams/useTeams", () => ({
+  useTeams: () => mockUseTeams(),
+}));
 
 describe("AllModelsTab", () => {
   const mockSetSelectedModelGroup = vi.fn();
@@ -18,9 +36,6 @@ describe("AllModelsTab", () => {
     setSelectedModelId: mockSetSelectedModelId,
     setSelectedTeamId: mockSetSelectedTeamId,
     setEditModel: mockSetEditModel,
-    modelData: {
-      data: [],
-    },
   };
 
   const mockUseAuthorized = {
@@ -40,9 +55,13 @@ describe("AllModelsTab", () => {
   });
 
   it("should render with empty data", () => {
-    vi.spyOn(useTeamsModule, "default").mockReturnValue({
-      teams: [],
-      setTeams: vi.fn(),
+    mockUseModelsInfo.mockReturnValueOnce({ data: { data: [] } });
+
+    mockUseTeams.mockReturnValueOnce({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
     });
 
     render(<AllModelsTab {...defaultProps} />);
@@ -66,9 +85,11 @@ describe("AllModelsTab", () => {
       },
     ];
 
-    vi.spyOn(useTeamsModule, "default").mockReturnValue({
-      teams: mockTeams,
-      setTeams: vi.fn(),
+    mockUseTeams.mockReturnValueOnce({
+      data: mockTeams,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
     });
 
     const modelData = {
@@ -92,7 +113,9 @@ describe("AllModelsTab", () => {
       ],
     };
 
-    render(<AllModelsTab {...defaultProps} modelData={modelData} />);
+    mockUseModelsInfo.mockReturnValue({ data: modelData });
+
+    render(<AllModelsTab {...defaultProps} />);
 
     await waitFor(() => {
       expect(screen.getByText("Showing 0 results")).toBeInTheDocument();
@@ -116,9 +139,11 @@ describe("AllModelsTab", () => {
       },
     ];
 
-    vi.spyOn(useTeamsModule, "default").mockReturnValue({
-      teams: mockTeams,
-      setTeams: vi.fn(),
+    mockUseTeams.mockReturnValue({
+      data: mockTeams,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
     });
 
     const modelData = {
@@ -142,7 +167,9 @@ describe("AllModelsTab", () => {
       ],
     };
 
-    render(<AllModelsTab {...defaultProps} modelData={modelData} />);
+    mockUseModelsInfo.mockReturnValue({ data: modelData });
+
+    render(<AllModelsTab {...defaultProps} />);
 
     await waitFor(() => {
       expect(screen.getByText("Showing 0 results")).toBeInTheDocument();
@@ -150,9 +177,11 @@ describe("AllModelsTab", () => {
   });
 
   it("should filter models by direct_access for personal team", async () => {
-    vi.spyOn(useTeamsModule, "default").mockReturnValue({
-      teams: [],
-      setTeams: vi.fn(),
+    mockUseTeams.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
     });
 
     const modelData = {
@@ -178,7 +207,9 @@ describe("AllModelsTab", () => {
       ],
     };
 
-    render(<AllModelsTab {...defaultProps} modelData={modelData} />);
+    mockUseModelsInfo.mockReturnValue({ data: modelData });
+
+    render(<AllModelsTab {...defaultProps} />);
 
     await waitFor(() => {
       expect(screen.getByText("Showing 1 - 1 of 1 results")).toBeInTheDocument();
@@ -186,9 +217,11 @@ describe("AllModelsTab", () => {
   });
 
   it("should show config model status for models defined in configs", async () => {
-    vi.spyOn(useTeamsModule, "default").mockReturnValue({
-      teams: [],
-      setTeams: vi.fn(),
+    mockUseTeams.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
     });
 
     const modelData = {
@@ -226,7 +259,9 @@ describe("AllModelsTab", () => {
       ],
     };
 
-    render(<AllModelsTab {...defaultProps} modelData={modelData} />);
+    mockUseModelsInfo.mockReturnValue({ data: modelData });
+
+    render(<AllModelsTab {...defaultProps} />);
 
     await waitFor(() => {
       expect(screen.getByText("Config Model")).toBeInTheDocument();
@@ -235,19 +270,21 @@ describe("AllModelsTab", () => {
   });
 
   it("should show 'Defined in config' for models defined in configs", async () => {
-    vi.spyOn(useTeamsModule, "default").mockReturnValue({
-      teams: [],
-      setTeams: vi.fn(),
+    mockUseTeams.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
     });
 
     const modelData = {
       data: [
         {
-          model_name: "gpt-4-config-model",
-          litellm_model_name: "gpt-4-config-model",
+          model_name: "gpt-4-config",
+          litellm_model_name: "gpt-4-config",
           provider: "openai",
           model_info: {
-            id: "model-config-defined",
+            id: "model-config-1",
             db_model: false,
             direct_access: true,
             access_via_team_ids: [],
@@ -260,8 +297,12 @@ describe("AllModelsTab", () => {
       ],
     };
 
-    render(<AllModelsTab {...defaultProps} modelData={modelData} />);
+    mockUseModelsInfo.mockReturnValue({ data: modelData });
 
-    expect(screen.getByText("Defined in config")).toBeInTheDocument();
+    render(<AllModelsTab {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Defined in config")).toBeInTheDocument();
+    });
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
@@ -1,13 +1,14 @@
+import { useTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import useTeams from "@/app/(dashboard)/hooks/useTeams";
 import { Team } from "@/components/key_team_helpers/key_list";
 import { ModelDataTable } from "@/components/model_dashboard/table";
 import { columns } from "@/components/molecules/models/columns";
 import { getDisplayModelName } from "@/components/view_model/model_name_display";
 import { InfoCircleOutlined } from "@ant-design/icons";
-import { PaginationState, Table as TableInstance } from "@tanstack/react-table";
+import { PaginationState } from "@tanstack/react-table";
 import { Grid, Select, SelectItem, TabPanel, Text } from "@tremor/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useModelsInfo } from "../../hooks/models/useModels";
 
 type ModelViewMode = "all" | "current_team";
 
@@ -19,7 +20,6 @@ interface AllModelsTabProps {
   setSelectedModelId: (id: string) => void;
   setSelectedTeamId: (id: string) => void;
   setEditModel: (edit: boolean) => void;
-  modelData: any;
 }
 
 const AllModelsTab = ({
@@ -30,10 +30,10 @@ const AllModelsTab = ({
   setSelectedModelId,
   setSelectedTeamId,
   setEditModel,
-  modelData,
 }: AllModelsTabProps) => {
+  const { data: modelData } = useModelsInfo();
   const { userId, userRole, premiumUser } = useAuthorized();
-  const { teams } = useTeams();
+  const { data: teams } = useTeams();
 
   const [modelNameSearch, setModelNameSearch] = useState<string>("");
   const [modelViewMode, setModelViewMode] = useState<ModelViewMode>("current_team");
@@ -45,7 +45,6 @@ const AllModelsTab = ({
     pageIndex: 0,
     pageSize: 50,
   });
-  const tableRef = useRef<TableInstance<any>>(null);
 
   const filteredData = useMemo(() => {
     if (!modelData || !modelData.data || modelData.data.length === 0) {
@@ -87,12 +86,6 @@ const AllModelsTab = ({
       return searchMatch && modelNameMatch && accessGroupMatch && teamAccessMatch;
     });
   }, [modelData, modelNameSearch, selectedModelGroup, selectedModelAccessGroupFilter, currentTeam, modelViewMode]);
-
-  const paginatedData = useMemo(() => {
-    const startIndex = pagination.pageIndex * pagination.pageSize;
-    const endIndex = startIndex + pagination.pageSize;
-    return filteredData.slice(startIndex, endIndex);
-  }, [filteredData, pagination.pageIndex, pagination.pageSize]);
 
   useEffect(() => {
     setPagination((prev: PaginationState) => ({ ...prev, pageIndex: 0 }));
@@ -370,9 +363,11 @@ const AllModelsTab = ({
                 expandedRows,
                 setExpandedRows,
               )}
-              data={paginatedData}
+              data={filteredData}
               isLoading={false}
-              table={tableRef}
+              pagination={pagination}
+              onPaginationChange={setPagination}
+              enablePagination={true}
             />
           </div>
         </div>

--- a/ui/litellm-dashboard/src/components/model_dashboard/HealthCheckComponent.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard/HealthCheckComponent.tsx
@@ -596,7 +596,6 @@ const HealthCheckComponent: React.FC<HealthCheckComponentProps> = ({
             };
           })}
           isLoading={false}
-          table={healthTableRef}
         />
       </div>
 

--- a/ui/litellm-dashboard/src/components/model_dashboard/table.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard/table.tsx
@@ -3,10 +3,13 @@ import {
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
+  getPaginationRowModel,
   SortingState,
   useReactTable,
   ColumnResizeMode,
   VisibilityState,
+  PaginationState,
+  OnChangeFn,
 } from "@tanstack/react-table";
 import React from "react";
 import { Table, TableHead, TableHeaderCell, TableBody, TableRow, TableCell } from "@tremor/react";
@@ -23,16 +26,20 @@ interface ModelDataTableProps<TData, TValue> {
   data: TData[];
   columns: ColumnDef<TData, TValue>[];
   isLoading?: boolean;
-  table: any; // Add table prop to access column visibility controls
   defaultSorting?: SortingState;
+  pagination?: PaginationState;
+  onPaginationChange?: OnChangeFn<PaginationState>;
+  enablePagination?: boolean;
 }
 
 export function ModelDataTable<TData, TValue>({
   data = [],
   columns,
   isLoading = false,
-  table,
   defaultSorting = [],
+  pagination,
+  onPaginationChange,
+  enablePagination = false,
 }: ModelDataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>(defaultSorting);
   const [columnResizeMode] = React.useState<ColumnResizeMode>("onChange");
@@ -46,13 +53,16 @@ export function ModelDataTable<TData, TValue>({
       sorting,
       columnSizing,
       columnVisibility,
+      ...(enablePagination && pagination ? { pagination } : {}),
     },
     columnResizeMode,
     onSortingChange: setSorting,
     onColumnSizingChange: setColumnSizing,
     onColumnVisibilityChange: setColumnVisibility,
+    ...(enablePagination && onPaginationChange ? { onPaginationChange } : {}),
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    ...(enablePagination ? { getPaginationRowModel: getPaginationRowModel() } : {}),
     enableSorting: true,
     enableColumnResizing: true,
     defaultColumn: {
@@ -60,13 +70,6 @@ export function ModelDataTable<TData, TValue>({
       maxSize: 500,
     },
   });
-
-  // Expose table instance to parent
-  React.useEffect(() => {
-    if (table) {
-      table.current = tableInstance;
-    }
-  }, [tableInstance, table]);
 
   const getHeaderText = (header: any): string => {
     if (typeof header === "string") {

--- a/ui/litellm-dashboard/src/components/model_hub_table.tsx
+++ b/ui/litellm-dashboard/src/components/model_hub_table.tsx
@@ -1,10 +1,9 @@
 import { CopyOutlined } from "@ant-design/icons";
-import { Table as TableInstance } from "@tanstack/react-table";
 import { Badge, Button, Card, Tab, TabGroup, TabList, TabPanel, TabPanels, Text, Title } from "@tremor/react";
 import { Modal } from "antd";
 import { Copy } from "lucide-react";
 import { useRouter } from "next/navigation";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { isAdminRole } from "../utils/roles";
 import { agentHubColumns, AgentHubData } from "./agent_hub_table_columns";
@@ -76,9 +75,6 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
   const [isMcpModalVisible, setIsMcpModalVisible] = useState(false);
   const [isMakeMcpPublicModalVisible, setIsMakeMcpPublicModalVisible] = useState(false);
   const router = useRouter();
-  const tableRef = useRef<TableInstance<any>>(null);
-  const agentTableRef = useRef<TableInstance<any>>(null);
-  const mcpTableRef = useRef<TableInstance<any>>(null);
 
   useEffect(() => {
     const fetchData = async (accessToken: string) => {
@@ -404,7 +400,6 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
                     columns={modelHubColumns(showModal, copyToClipboard, publicPage)}
                     data={filteredData}
                     isLoading={loading}
-                    table={tableRef}
                     defaultSorting={[{ id: "model_group", desc: false }]}
                   />
                 </Card>
@@ -431,7 +426,6 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
                     columns={agentHubColumns(showAgentModal, copyToClipboard, publicPage)}
                     data={agentHubData || []}
                     isLoading={agentLoading}
-                    table={agentTableRef}
                     defaultSorting={[{ id: "name", desc: false }]}
                   />
                 </Card>
@@ -458,7 +452,6 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
                     columns={mcpHubColumns(showMcpModal, copyToClipboard, publicPage)}
                     data={mcpHubData || []}
                     isLoading={mcpLoading}
-                    table={mcpTableRef}
                     defaultSorting={[{ id: "server_name", desc: false }]}
                   />
                 </Card>

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -1,25 +1,24 @@
-import React, { useEffect, useState, useRef, useMemo } from "react";
-import {
-  modelHubPublicModelsCall,
-  getPublicModelHubInfo,
-  agentHubPublicModelsCall,
-  mcpHubPublicServersCall,
-  getUiConfig,
-} from "./networking";
-import { ModelDataTable } from "./model_dashboard/table";
-import { ColumnDef } from "@tanstack/react-table";
-import { Card, Text, Title, Button } from "@tremor/react";
-import { Tag, Tooltip, Modal, Select, Tabs } from "antd";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 import { ExternalLinkIcon, SearchIcon } from "@heroicons/react/outline";
+import { ColumnDef } from "@tanstack/react-table";
+import { Button, Card, Text, Title } from "@tremor/react";
+import { Modal, Select, Tabs, Tag, Tooltip } from "antd";
 import { Copy, Info } from "lucide-react";
-import { Table as TableInstance } from "@tanstack/react-table";
+import React, { useEffect, useMemo, useState } from "react";
+import { ModelDataTable } from "./model_dashboard/table";
+import NotificationsManager from "./molecules/notifications_manager";
+import Navbar from "./navbar";
+import {
+  agentHubPublicModelsCall,
+  getPublicModelHubInfo,
+  getUiConfig,
+  mcpHubPublicServersCall,
+  modelHubPublicModelsCall,
+} from "./networking";
 import { generateCodeSnippet } from "./playground/chat_ui/CodeSnippets";
 import { getEndpointType } from "./playground/chat_ui/mode_endpoint_mapping";
 import { MessageType } from "./playground/chat_ui/types";
 import { getProviderLogoAndName } from "./provider_info_helpers";
-import Navbar from "./navbar";
-import { ThemeProvider } from "@/contexts/ThemeContext";
-import NotificationsManager from "./molecules/notifications_manager";
 
 const { TabPane } = Tabs;
 
@@ -118,9 +117,6 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
   const [selectedMcpServer, setSelectedMcpServer] = useState<null | MCPServerData>(null);
   const [proxySettings, setProxySettings] = useState<any>({});
   const [activeTab, setActiveTab] = useState<string>("models");
-  const tableRef = useRef<TableInstance<any>>(null);
-  const agentTableRef = useRef<TableInstance<any>>(null);
-  const mcpTableRef = useRef<TableInstance<any>>(null);
 
   useEffect(() => {
     const initializeAndFetch = async () => {
@@ -1121,7 +1117,6 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
                   columns={publicModelHubColumns()}
                   data={filteredData}
                   isLoading={loading}
-                  table={tableRef}
                   defaultSorting={[{ id: "model_group", desc: false }]}
                 />
 
@@ -1184,7 +1179,6 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
                     columns={publicAgentHubColumns()}
                     data={filteredAgentData}
                     isLoading={agentLoading}
-                    table={agentTableRef}
                     defaultSorting={[{ id: "name", desc: false }]}
                   />
 
@@ -1248,7 +1242,6 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
                     columns={publicMCPHubColumns()}
                     data={filteredMcpData}
                     isLoading={mcpLoading}
-                    table={mcpTableRef}
                     defaultSorting={[{ id: "server_name", desc: false }]}
                   />
 

--- a/ui/litellm-dashboard/src/components/templates/model_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/templates/model_dashboard.tsx
@@ -1,65 +1,74 @@
-import React, { useState, useEffect, useRef, useMemo } from "react";
 import {
   Card,
-  Title,
+  Col,
+  Grid,
   Subtitle,
   Table,
-  TableHead,
-  TableRow,
-  TableHeaderCell,
-  TableCell,
   TableBody,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
   Text,
-  Grid,
-  Col,
+  Title,
 } from "@tremor/react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { CredentialItem, credentialListCall, CredentialsResponse } from "../networking";
 
 import { handleAddModelSubmit } from "../add_model/handle_add_model_submit";
 
 import CredentialsPanel from "@/components/model_add/credentials";
-import { getDisplayModelName } from "../view_model/model_name_display";
-import { TabPanel, TabPanels, TabGroup, TabList, Tab, Icon } from "@tremor/react";
-import { Select, SelectItem, DateRangePickerValue } from "@tremor/react";
-import UsageDatePicker from "../shared/usage_date_picker";
+import { InfoCircleOutlined } from "@ant-design/icons";
+import { FilterIcon, RefreshIcon } from "@heroicons/react/outline";
 import {
-  modelInfoCall,
-  modelCostMap,
-  healthCheckCall,
-  modelMetricsCall,
-  streamingModelMetricsCall,
-  modelExceptionsCall,
-  modelMetricsSlowResponsesCall,
-  getCallbacksCall,
-  setCallbacksCall,
-  modelSettingsCall,
+  AreaChart,
+  BarChart,
+  Button,
+  DateRangePickerValue,
+  Icon,
+  Select,
+  SelectItem,
+  Tab,
+  TabGroup,
+  TabList,
+  TabPanel,
+  TabPanels,
+} from "@tremor/react";
+import type { UploadProps } from "antd";
+import { Form, InputNumber, Popover, Typography } from "antd";
+import AddModelTab from "../add_model/add_model_tab";
+import { Team } from "../key_team_helpers/key_list";
+import ModelInfoView from "../model_info_view";
+import TimeToFirstToken from "../model_metrics/time_to_first_token";
+import {
   adminGlobalActivityExceptions,
   adminGlobalActivityExceptionsPerDeployment,
   allEndUsersCall,
+  getCallbacksCall,
+  healthCheckCall,
+  modelCostMap,
+  modelExceptionsCall,
+  modelInfoCall,
+  modelMetricsCall,
+  modelMetricsSlowResponsesCall,
+  modelSettingsCall,
+  setCallbacksCall,
+  streamingModelMetricsCall,
 } from "../networking";
-import { BarChart, AreaChart } from "@tremor/react";
-import { Popover, Form, InputNumber } from "antd";
-import { Button } from "@tremor/react";
-import { Typography } from "antd";
-import { RefreshIcon, FilterIcon } from "@heroicons/react/outline";
-import { InfoCircleOutlined } from "@ant-design/icons";
-import type { UploadProps } from "antd";
-import TimeToFirstToken from "../model_metrics/time_to_first_token";
-import { Team } from "../key_team_helpers/key_list";
+import { getPlaceholder, getProviderModels, provider_map, Providers } from "../provider_info_helpers";
+import UsageDatePicker from "../shared/usage_date_picker";
 import TeamInfoView from "../team/team_info";
-import { Providers, provider_map, getPlaceholder, getProviderModels } from "../provider_info_helpers";
-import ModelInfoView from "../model_info_view";
-import AddModelTab from "../add_model/add_model_tab";
+import { getDisplayModelName } from "../view_model/model_name_display";
 
-import { ModelDataTable } from "../model_dashboard/table";
-import { columns } from "../molecules/models/columns";
-import PriceDataReload from "../price_data_reload";
-import HealthCheckComponent from "../model_dashboard/HealthCheckComponent";
-import PassThroughSettings from "../pass_through_settings";
-import ModelGroupAliasSettings from "../model_group_alias_settings";
 import { all_admin_roles } from "@/utils/roles";
-import { Table as TableInstance, PaginationState } from "@tanstack/react-table";
+import { PaginationState } from "@tanstack/react-table";
+import HealthCheckComponent from "../model_dashboard/HealthCheckComponent";
+import { ModelDataTable } from "../model_dashboard/table";
+import ModelGroupAliasSettings from "../model_group_alias_settings";
+import { columns } from "../molecules/models/columns";
 import NotificationsManager from "../molecules/notifications_manager";
+import PassThroughSettings from "../pass_through_settings";
+import PriceDataReload from "../price_data_reload";
 
 interface ModelDashboardProps {
   accessToken: string | null;
@@ -196,7 +205,6 @@ const OldModelDashboard: React.FC<ModelDashboardProps> = ({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const tableRef = useRef<TableInstance<any>>(null);
 
   // Pagination state
   const [pagination, setPagination] = useState<PaginationState>({
@@ -1325,7 +1333,6 @@ const OldModelDashboard: React.FC<ModelDashboardProps> = ({
                           )}
                           data={paginatedData}
                           isLoading={false}
-                          table={tableRef}
                         />
                       </div>
                     </div>


### PR DESCRIPTION
## Relevant issues
Previously the model table does not sort the entire set of the data, only what is shown on the page. This was bad UX. This PR implements sorting on the entire set of data instead of just what is shown on the page.

Under the hood I made these changes:
1. Model info now comes from useModels (react-query)
2. Team data now comes from useTeams (react-query)
3. No more manual pagination, pagination is handled by tanstack's react table
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="1009" height="250" alt="image" src="https://github.com/user-attachments/assets/f5402a9e-820c-4158-b23a-352ade6f5d4e" />
<img width="1417" height="213" alt="image" src="https://github.com/user-attachments/assets/f4d353ba-5298-4893-9167-4a259810e001" />
