### PR TITLE
feat: add anthropic system prompt to langfuse logging

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -228,12 +228,15 @@ class LangFuseLogger:
 
             functions = optional_params.pop("functions", None)
             tools = optional_params.pop("tools", None)
+            system = optional_params.pop("system", None)
             # Remove secret_fields to prevent leaking sensitive data (e.g., authorization headers)
             optional_params.pop("secret_fields", None)
             if functions is not None:
                 prompt["functions"] = functions
             if tools is not None:
                 prompt["tools"] = tools
+            if system is not None:
+                prompt["system"] = system
 
             # langfuse only accepts str, int, bool, float for logging
             for param, value in optional_params.items():


### PR DESCRIPTION
🆕 New Feature

## Changes
this is an example of anthropic request:

```
{
  "model": ...,
  "tools": ...,
  "stream": true,
  "system": ...,
  "messages": ...,
  "max_tokens": 32000
}
```

For now the langfuse module only logged "messages", "functions" and "tools", we hope it can also log the "system" prompt.
