### PR TITLE
fix(sap): pass through extra params from allowed_openai_params

### DIFF
--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -203,9 +203,13 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         headers: dict,
     ) -> dict:
         supported_params = self.get_supported_openai_params(model)
+        # Include extra params that passed validation (e.g., thinking_config for Gemini models via allowed_openai_params)
+        extra_params = [k for k in optional_params if k not in supported_params and k not in {"tools", "model_version"}]
+        supported_params = supported_params + extra_params
         model_params = {
             k: v for k, v in optional_params.items() if k in supported_params
         }
+
         model_version = optional_params.pop("model_version", "latest")
         template = []
         for message in messages:


### PR DESCRIPTION
## Problem

When using `allowed_openai_params` with the SAP provider, extra parameters 
(like Gemini's `thinking_config`) are filtered out in `transform_request`.
```python
response = litellm.completion(
    model="sap/gemini-2.5-flash",
    messages=[...],
    thinking_config={"thinking_budget": 0},
    allowed_openai_params=["thinking_config"],  # Ignored!
)
```

## Solution

Extend `supported_params` with any extra params that passed `get_optional_params()` 
validation (via `allowed_openai_params`).

This is a generic fix - any new provider-specific params can be passed through 
without code changes.

## Changes

- `litellm/llms/sap/chat/transformation.py`: 2 lines added in `transform_request`

Fixes #18412 