### PR TITLE
Fix typo in dashboard title from 'Faild' to 'Failed'

### DIFF
--- a/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_1/grafana_dashboard.json
+++ b/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_1/grafana_dashboard.json
@@ -384,7 +384,7 @@
             "refId": "A"
           }
         ],
-        "title": "Faild Requests",
+        "title": "Failed Requests",
         "type": "stat"
       },
       {


### PR DESCRIPTION
## Relevant issues

N/A – minor typo fix, no existing issue.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement**  
  _Not applicable — change is a static Grafana dashboard JSON typo and does not affect runtime logic._
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)  
  _Not applicable — no code changes._
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: N/A

- [ ] **CI run for the last commit**  
       Link: N/A

- [ ] **Merge / cherry-pick CI run**  
       Links: N/A

## Type

🐛 **Bug Fix**

## Changes

- Fixed a typo in the Grafana dashboard title:
  - Changed **"Faild" → "Failed"**
- File affected:
  - `cookbook/litellm_proxy_server/grafana_dashboard/dashboard_1/grafana_dashboard.json`
  - Line 387
- No functional or behavioral changes; purely a UI text correction.
