### PR TITLE
feat: calculate `total_tokens` manually if it is missing and can be calculated from input and output tokens

### DIFF
--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -443,11 +443,18 @@ class ResponseAPILoggingUtils:
                 completion_tokens=0,
                 total_tokens=0,
             )
-        response_api_usage: ResponseAPIUsage = (
-            ResponseAPIUsage(**usage_input)
-            if isinstance(usage_input, dict)
-            else usage_input
-        )
+        response_api_usage: ResponseAPIUsage
+        if isinstance(usage_input, dict):
+            total_tokens = usage_input.get("total_tokens")
+            if total_tokens is None:
+                input_tokens = usage_input.get("input_tokens")
+                output_tokens = usage_input.get("output_tokens")
+                if input_tokens is not None and output_tokens is not None:
+                    total_tokens = input_tokens + output_tokens
+                    usage_input["total_tokens"] = total_tokens
+            response_api_usage = ResponseAPIUsage(**usage_input)
+        else:
+            response_api_usage = usage_input
         prompt_tokens: int = response_api_usage.input_tokens or 0
         completion_tokens: int = response_api_usage.output_tokens or 0
         prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -203,3 +203,22 @@ class TestResponseAPILoggingUtils:
         assert result.prompt_tokens == 0
         assert result.completion_tokens == 20
         assert result.total_tokens == 20
+
+    def test_transform_response_api_usage_calculates_total_from_input_and_output_tokens_if_available(self):
+        """Test transformation calculates total_tokens when it's None and input / output tokens are present"""
+        # Setup
+        usage = {
+            "input_tokens": 15,
+            "output_tokens": 25,
+            "total_tokens": None,
+        }
+
+        # Execute
+        result = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+            usage
+        )
+
+        # Assert
+        assert result.prompt_tokens == 15
+        assert result.completion_tokens == 25
+        assert result.total_tokens == 40  # 15 + 25


### PR DESCRIPTION
## Implements Feature #18468 

Improves logging experience that I ran into while trying to use LiteLLM to serve non-Anthropic models from [deepinfra](https://deepinfra.com/) to Claude Code.

Certain responses from [deepinfra](https://deepinfra.com/) were being logged as failures in the "Observability > Logs" section of the LiteLLM admin interface because `total_tokens` was `None` when passed into the constructor for `ResponseAPIUsage`.  I noticed that in the cases I logged, `input_tokens` and `output_tokens` were both present.

This PR addresses the issue by calculating `total_tokens` as the sum of `input_tokens` and `output_tokens` _if_ they are both present when `total_tokens` is not.  I'm not sure if this is semantically correct.  

Other potential workarounds:

- hard-code `total_tokens` as 0 instead of `None`
- make the `total_tokens` member of `ResponseAPIUsage` an `Optional[int]` instead of `int`
- figure out if `total_tokens` should be calculated using other information available at the time `ResponseAPIUsage` is instantiated.
- contact [deepinfra](https://deepinfra.com/) to see if their response format could be updated

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
