### PR TITLE
fix(gemini): support snake_case for google_search tool parameters

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -479,19 +479,26 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 or tool_name == VertexToolName.CODE_EXECUTION.value
             ):  # code_execution maintained for backwards compatibility
                 code_execution = self.get_tool_value(tool, "codeExecution")
-            elif tool_name and tool_name == VertexToolName.GOOGLE_SEARCH.value:
+            elif tool_name and (
+                tool_name == VertexToolName.GOOGLE_SEARCH.value
+                or tool_name == "google_search"
+            ):
                 googleSearch = self.get_tool_value(
-                    tool, VertexToolName.GOOGLE_SEARCH.value
+                    tool, tool_name
                 )
-            elif (
-                tool_name and tool_name == VertexToolName.GOOGLE_SEARCH_RETRIEVAL.value
+            elif tool_name and (
+                tool_name == VertexToolName.GOOGLE_SEARCH_RETRIEVAL.value
+                or tool_name == "google_search_retrieval"
             ):
                 googleSearchRetrieval = self.get_tool_value(
-                    tool, VertexToolName.GOOGLE_SEARCH_RETRIEVAL.value
+                    tool, tool_name
                 )
-            elif tool_name and tool_name == VertexToolName.ENTERPRISE_WEB_SEARCH.value:
+            elif tool_name and (
+                tool_name == VertexToolName.ENTERPRISE_WEB_SEARCH.value
+                or tool_name == "enterprise_web_search"
+            ):
                 enterpriseWebSearch = self.get_tool_value(
-                    tool, VertexToolName.ENTERPRISE_WEB_SEARCH.value
+                    tool, tool_name
                 )
             elif tool_name and (
                 tool_name == VertexToolName.URL_CONTEXT.value

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -483,23 +483,17 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 tool_name == VertexToolName.GOOGLE_SEARCH.value
                 or tool_name == "google_search"
             ):
-                googleSearch = self.get_tool_value(
-                    tool, tool_name
-                )
+                googleSearch = self.get_tool_value(tool, tool_name)
             elif tool_name and (
                 tool_name == VertexToolName.GOOGLE_SEARCH_RETRIEVAL.value
                 or tool_name == "google_search_retrieval"
             ):
-                googleSearchRetrieval = self.get_tool_value(
-                    tool, tool_name
-                )
+                googleSearchRetrieval = self.get_tool_value(tool, tool_name)
             elif tool_name and (
                 tool_name == VertexToolName.ENTERPRISE_WEB_SEARCH.value
                 or tool_name == "enterprise_web_search"
             ):
-                enterpriseWebSearch = self.get_tool_value(
-                    tool, tool_name
-                )
+                enterpriseWebSearch = self.get_tool_value(tool, tool_name)
             elif tool_name and (
                 tool_name == VertexToolName.URL_CONTEXT.value
                 or tool_name == "urlContext"

--- a/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
+++ b/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
@@ -7,6 +7,7 @@ sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 from litellm.llms.vertex_ai.gemini import transformation
+from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexGeminiConfig
 from litellm.types.llms import openai
 from litellm.types import completion
 from litellm.types.llms.vertex_ai import RequestBody
@@ -226,3 +227,64 @@ async def test__transform_request_body_image_config_with_image_size():
     assert "imageConfig" in rb["generationConfig"]
     assert rb["generationConfig"]["imageConfig"]["aspectRatio"] == "16:9"
     assert rb["generationConfig"]["imageConfig"]["imageSize"] == "4K"
+
+
+def test_map_function_google_search_snake_case():
+    """
+    Test that google_search tool (snake_case) is properly mapped to googleSearch.
+    Fixes issue where tools=[{"google_search": {}}] was being stripped.
+    """
+    config = VertexGeminiConfig()
+    optional_params = {}
+
+    # Test snake_case google_search
+    tools = [{"google_search": {}}]
+    result = config._map_function(tools, optional_params)
+
+    assert len(result) == 1
+    assert "googleSearch" in result[0]
+    assert result[0]["googleSearch"] == {}
+
+
+def test_map_function_google_search_camel_case():
+    """
+    Test that googleSearch tool (camelCase) still works.
+    """
+    config = VertexGeminiConfig()
+    optional_params = {}
+
+    # Test camelCase googleSearch
+    tools = [{"googleSearch": {}}]
+    result = config._map_function(tools, optional_params)
+
+    assert len(result) == 1
+    assert "googleSearch" in result[0]
+    assert result[0]["googleSearch"] == {}
+
+
+def test_map_function_google_search_retrieval_snake_case():
+    """
+    Test that google_search_retrieval tool (snake_case) is properly mapped.
+    """
+    config = VertexGeminiConfig()
+    optional_params = {}
+
+    tools = [{"google_search_retrieval": {"dynamic_retrieval_config": {"mode": "MODE_DYNAMIC"}}}]
+    result = config._map_function(tools, optional_params)
+
+    assert len(result) == 1
+    assert "googleSearchRetrieval" in result[0]
+
+
+def test_map_function_enterprise_web_search_snake_case():
+    """
+    Test that enterprise_web_search tool (snake_case) is properly mapped.
+    """
+    config = VertexGeminiConfig()
+    optional_params = {}
+
+    tools = [{"enterprise_web_search": {}}]
+    result = config._map_function(tools, optional_params)
+
+    assert len(result) == 1
+    assert "enterpriseWebSearch" in result[0]


### PR DESCRIPTION
## Relevant issues

Fixes #18171

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Summary
Adds snake_case support for Gemini/Vertex AI tool parameters to align with:
- OpenAI API naming conventions (snake_case for function names)
- PEP 8 Python style guide (snake_case for functions/variables)
- Google's official Gemini API documentation
- Existing LiteLLM patterns (e.g., `google_maps`, `url_context`)

When users follow Google's Gemini API documentation and use `{"google_search": {}}`, the tool parameter is ignored, causing a 400 error. This violates LiteLLM's core principle: **"Call all LLM APIs using the OpenAI format"**.

### Solution
Accept both `snake_case` and `camelCase` variants for tool names:
- `google_search` → `googleSearch`
- `google_search_retrieval` → `googleSearchRetrieval`
- `enterprise_web_search` → `enterpriseWebSearch`

**Maintains backward compatibility** - existing `googleSearch` calls continue to work.

### Files Modified
- `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`
  - Updated tool name matching to accept both snake_case and camelCase
  - Follows same pattern as `google_maps` (line 502-504)
  
- `tests/litellm/llms/vertex_ai/gemini/test_transformation.py`
  - Added 4 comprehensive tests covering all tool variants

Users following official Google documentation should not receive errors. LiteLLM's job is to translate Python-style input → provider-native format, not force users to learn provider-specific naming conventions.

### Documentation References
- **Google's Official Docs:**
  - [Gemini API - Google Search Tool](https://ai.google.dev/gemini-api/docs/google-search) - uses `google_search`
  - [Vertex AI Python SDK Example](https://cloud.google.com/vertex-ai/generative-ai/docs/samples/googlegenaisdk-tools-google-search-with-txt) - uses `Tool(google_search=GoogleSearch())`

- **Python Standards:**
  - [PEP 8 - Function and Variable Names](https://peps.python.org/pep-0008/#function-and-variable-names) - _"Function names should be lowercase, with words separated by underscores as necessary to improve readability."_

- **LiteLLM Design Principle:**
  - [README](https://github.com/BerriAI/litellm#readme) - _"Call all LLM APIs using the OpenAI (or native) format"_ & _"Translate inputs to provider's completion endpoints"_


---

**Note:** This PR reopens the discussion from #18189. The implementation includes the same fixes with additional formatting improvements.
