### PR TITLE
fix: use error_message variable in raise_rate_limit_error

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -132,7 +132,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             error_message = error_message + " " + additional_details
         raise HTTPException(
             status_code=429,
-            detail=f"Max parallel request limit reached {additional_details}",
+            detail=error_message,
             headers={"retry-after": str(self.time_to_next_minute())},
         )
 

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
@@ -1,0 +1,61 @@
+"""
+Unit Tests for the max parallel request limiter for the proxy
+"""
+
+import pytest
+from fastapi import HTTPException
+from unittest.mock import MagicMock
+
+from litellm.proxy.hooks.parallel_request_limiter import (
+    _PROXY_MaxParallelRequestsHandler,
+)
+
+
+@pytest.fixture
+def parallel_request_handler():
+    """Create a parallel request handler with mocked internal_usage_cache."""
+    mock_cache = MagicMock()
+    return _PROXY_MaxParallelRequestsHandler(internal_usage_cache=mock_cache)
+
+
+class TestRaiseRateLimitError:
+    """Tests for the raise_rate_limit_error method."""
+
+    def test_error_message_without_additional_details(self, parallel_request_handler):
+        """
+        Test that when additional_details is None, the error message does not contain 'None'.
+
+        This is a regression test for a bug where the error message would include
+        the literal string 'None' when additional_details was not provided.
+        """
+        with pytest.raises(HTTPException) as exc_info:
+            parallel_request_handler.raise_rate_limit_error(additional_details=None)
+
+        assert exc_info.value.status_code == 429
+        assert "None" not in exc_info.value.detail
+        assert exc_info.value.detail == "Max parallel request limit reached"
+
+    def test_error_message_with_additional_details(self, parallel_request_handler):
+        """
+        Test that when additional_details is provided, it is included in the error message.
+        """
+        additional_info = "for api_key: sk-1234"
+
+        with pytest.raises(HTTPException) as exc_info:
+            parallel_request_handler.raise_rate_limit_error(additional_details=additional_info)
+
+        assert exc_info.value.status_code == 429
+        assert additional_info in exc_info.value.detail
+        assert exc_info.value.detail == f"Max parallel request limit reached {additional_info}"
+
+    def test_error_includes_retry_after_header(self, parallel_request_handler):
+        """
+        Test that the HTTPException includes a retry-after header.
+        """
+        with pytest.raises(HTTPException) as exc_info:
+            parallel_request_handler.raise_rate_limit_error()
+
+        assert "retry-after" in exc_info.value.headers
+        # retry-after should be a string representing seconds
+        assert exc_info.value.headers["retry-after"].isdigit() or \
+               float(exc_info.value.headers["retry-after"]) >= 0


### PR DESCRIPTION
## Summary

Fixed a bug in `raise_rate_limit_error` where the `error_message` variable was constructed but not used, causing the literal string "None" to appear in error messages.

**Before:**
```
Max parallel request limit reached None
```

**After:**
```
Max parallel request limit reached
```

## Relevant issues

Fixes #18460

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### Code Change (1 line)
`litellm/proxy/hooks/parallel_request_limiter.py:135`

```diff
- detail=f"Max parallel request limit reached {additional_details}",
+ detail=error_message,
```

### Tests Added
`tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py`

- `test_error_message_without_additional_details` - Verifies "None" is not in the message
- `test_error_message_with_additional_details` - Verifies details are included when provided
- `test_error_includes_retry_after_header` - Verifies retry-after header exists