### PR TITLE
Fix BudgetManager created_at default time evaluation

### DIFF
--- a/litellm/budget_manager.py
+++ b/litellm/budget_manager.py
@@ -78,8 +78,10 @@ class BudgetManager:
         total_budget: float,
         user: str,
         duration: Optional[Literal["daily", "weekly", "monthly", "yearly"]] = None,
-        created_at: float = time.time(),
+        created_at: Optional[float] = None,
     ):
+        if created_at is None:
+            created_at = time.time()
         self.user_dict[user] = {"total_budget": total_budget}
         if duration is None:
             return self.user_dict[user]

--- a/tests/test_litellm/test_budget_manager.py
+++ b/tests/test_litellm/test_budget_manager.py
@@ -1,0 +1,17 @@
+﻿from litellm import BudgetManager
+import litellm.budget_manager as budget_manager_module
+
+
+def test_create_budget_uses_current_time(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    manager = BudgetManager(project_name="test", client_type="local")
+    monkeypatch.setattr(manager, "_save_data_thread", lambda: None)
+    times = iter([1000.0, 1001.0])
+    monkeypatch.setattr(budget_manager_module.time, "time", lambda: next(times))
+
+    budget1 = manager.create_budget(100.0, "user1", duration="daily")
+    budget2 = manager.create_budget(100.0, "user2", duration="daily")
+
+    assert budget1["created_at"] == 1000.0
+    assert budget2["created_at"] == 1001.0
+    assert budget2["created_at"] > budget1["created_at"]

--- a/tests/test_litellm/test_budget_manager.py
+++ b/tests/test_litellm/test_budget_manager.py
@@ -1,4 +1,4 @@
-﻿from litellm import BudgetManager
+from litellm import BudgetManager
 import litellm.budget_manager as budget_manager_module
 
 
@@ -14,4 +14,3 @@ def test_create_budget_uses_current_time(monkeypatch, tmp_path):
 
     assert budget1["created_at"] == 1000.0
     assert budget2["created_at"] == 1001.0
-    assert budget2["created_at"] > budget1["created_at"]


### PR DESCRIPTION
## Summary

Fixed a bug in `BudgetManager.create_budget()` where `time.time()` was used as a default argument value. This caused all budget creations to use the same timestamp (module load time) instead of the actual call time.

**Before:**
```python
created_at: float = time.time()  # Evaluated once at module load
```

**After:**
```python
created_at: Optional[float] = None
...
if created_at is None:
    created_at = time.time()  # Evaluated at each call
```

## Relevant issues

Fixes #18459

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### Code Change (2 lines)
`litellm/budget_manager.py:81-84`

```diff
- created_at: float = time.time(),
+ created_at: Optional[float] = None,
...
+ if created_at is None:
+     created_at = time.time()
```

### Tests Added
`tests/test_litellm/test_budget_manager.py`

- `test_create_budget_uses_current_time` - Verifies each call gets a fresh timestamp using mocked `time.time()`