### PR TITLE
fix unreachable text-completion-codestral branch in get_llm_provider

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -1,4 +1,5 @@
 from typing import Optional, Tuple
+from urllib.parse import urlparse
 
 import httpx
 
@@ -8,6 +9,10 @@ from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.secret_managers.main import get_secret, get_secret_str
 
 from ..types.router import LiteLLM_Params
+
+CODESTRAL_HOST = "codestral.mistral.ai"
+CODESTRAL_CHAT_COMPLETIONS_PATH = "/v1/chat/completions"
+CODESTRAL_FIM_COMPLETIONS_PATH = "/v1/fim/completions"
 
 
 def _is_non_openai_azure_model(model: str) -> bool:
@@ -33,6 +38,35 @@ def _is_azure_claude_model(model: str) -> bool:
         return "claude" in model_lower or model_lower.startswith("claude")
     except Exception:
         return False
+
+
+def _parse_api_base_host_path(api_base: str) -> Tuple[Optional[str], str]:
+    normalized_api_base = api_base
+    if "://" not in normalized_api_base:
+        normalized_api_base = f"https://{normalized_api_base}"
+    try:
+        parsed = urlparse(normalized_api_base)
+    except Exception:
+        return None, ""
+    host = parsed.hostname.lower() if parsed.hostname else None
+    path = parsed.path or ""
+    return host, path
+
+
+def _get_codestral_provider_from_api_base(api_base: str) -> Optional[str]:
+    """
+    Codestral splits chat vs FIM by endpoint path; use api_base host/path to route.
+    """
+    host, path = _parse_api_base_host_path(api_base)
+    if host != CODESTRAL_HOST:
+        return None
+
+    normalized_path = path.rstrip("/").lower()
+    if normalized_path in ("", "/v1", CODESTRAL_CHAT_COMPLETIONS_PATH):
+        return "codestral"
+    if normalized_path == CODESTRAL_FIM_COMPLETIONS_PATH:
+        return "text-completion-codestral"
+    return None
 
 
 def handle_cohere_chat_model_custom_llm_provider(
@@ -196,7 +230,25 @@ def get_llm_provider(  # noqa: PLR0915
                 )
             return model, custom_llm_provider, dynamic_api_key, api_base
         # check if api base is a known openai compatible endpoint
-        if api_base:
+        if api_base and isinstance(api_base, str):
+            codestral_provider = _get_codestral_provider_from_api_base(api_base)
+            if codestral_provider:
+                # Codestral splits chat vs FIM across endpoints; infer provider from api_base path.
+                custom_llm_provider = codestral_provider
+                dynamic_api_key = get_secret_str("CODESTRAL_API_KEY")
+                if api_base is not None and not isinstance(api_base, str):
+                    raise Exception(
+                        "api base needs to be a string. api_base={}".format(api_base)
+                    )
+                if dynamic_api_key is not None and not isinstance(
+                    dynamic_api_key, str
+                ):
+                    raise Exception(
+                        "dynamic_api_key needs to be a string. dynamic_api_key={}".format(
+                            dynamic_api_key
+                        )
+                    )
+                return model, custom_llm_provider, dynamic_api_key, api_base
             for endpoint in litellm.openai_compatible_endpoints:
                 if endpoint in api_base:
                     if endpoint == "api.perplexity.ai":
@@ -229,12 +281,6 @@ def get_llm_provider(  # noqa: PLR0915
                     elif endpoint == "https://api.ai21.com/studio/v1":
                         custom_llm_provider = "ai21_chat"
                         dynamic_api_key = get_secret_str("AI21_API_KEY")
-                    elif endpoint == "https://codestral.mistral.ai/v1":
-                        custom_llm_provider = "codestral"
-                        dynamic_api_key = get_secret_str("CODESTRAL_API_KEY")
-                    elif endpoint == "https://codestral.mistral.ai/v1":
-                        custom_llm_provider = "text-completion-codestral"
-                        dynamic_api_key = get_secret_str("CODESTRAL_API_KEY")
                     elif endpoint == "app.empower.dev/api/v1":
                         custom_llm_provider = "empower"
                         dynamic_api_key = get_secret_str("EMPOWER_API_KEY")

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -236,10 +236,6 @@ def get_llm_provider(  # noqa: PLR0915
                 # Codestral splits chat vs FIM across endpoints; infer provider from api_base path.
                 custom_llm_provider = codestral_provider
                 dynamic_api_key = get_secret_str("CODESTRAL_API_KEY")
-                if api_base is not None and not isinstance(api_base, str):
-                    raise Exception(
-                        "api base needs to be a string. api_base={}".format(api_base)
-                    )
                 if dynamic_api_key is not None and not isinstance(
                     dynamic_api_key, str
                 ):

--- a/tests/test_litellm/litellm_core_utils/test_codestral_provider_routing.py
+++ b/tests/test_litellm/litellm_core_utils/test_codestral_provider_routing.py
@@ -1,0 +1,48 @@
+import pytest
+
+from litellm.litellm_core_utils.get_llm_provider_logic import (
+    _get_codestral_provider_from_api_base,
+    get_llm_provider,
+)
+
+
+def test_codestral_chat_endpoint_routes_to_codestral_provider():
+    _, provider, _, _ = get_llm_provider(
+        model="codestral-latest",
+        api_base="https://codestral.mistral.ai/v1/chat/completions",
+    )
+    assert provider == "codestral"
+
+
+def test_codestral_fim_endpoint_routes_to_text_completion_provider():
+    _, provider, _, _ = get_llm_provider(
+        model="codestral-latest",
+        api_base="https://codestral.mistral.ai/v1/fim/completions",
+    )
+    assert provider == "text-completion-codestral"
+
+
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "https://codestral.mistral.ai",
+        "https://codestral.mistral.ai/v1",
+        "https://codestral.mistral.ai/v1/chat/completions/",
+        "https://CODESTRAL.MISTRAL.AI/v1",
+    ],
+)
+def test_codestral_chat_provider_routing_with_host_variants(api_base):
+    _, provider, _, _ = get_llm_provider(
+        model="codestral-latest",
+        api_base=api_base,
+    )
+    assert provider == "codestral"
+
+
+def test_codestral_helper_ignores_similar_domain():
+    assert (
+        _get_codestral_provider_from_api_base(
+            "https://codestral.mistral.ai.evil.com/v1/fim/completions"
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary

**Before:** Two identical `elif endpoint == "https://codestral.mistral.ai/v1"` conditions existed, making `text-completion-codestral` provider unreachable. Also, the condition never matched because `openai_compatible_endpoints` entries don't have `https://` prefix.

**After:** 
- Added `_get_codestral_provider_from_api_base()` helper that uses `urlparse` for proper URL parsing
- Routes FIM requests (`/v1/fim/completions`) to `text-completion-codestral`, chat requests to `codestral`
- Handles URL variants (with/without scheme, trailing slash, case-insensitive host)
- Rejects similar domains (e.g., `codestral.mistral.ai.evil.com`)

## Relevant issues

Fixes #18464

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### Code (`litellm/litellm_core_utils/get_llm_provider_logic.py`)

Added helper functions:

```python
def _parse_api_base_host_path(api_base: str) -> Tuple[Optional[str], str]:
    """Parse api_base URL into (host, path) tuple."""
    ...

def _get_codestral_provider_from_api_base(api_base: str) -> Optional[str]:
    """
    Codestral splits chat vs FIM by endpoint path; use api_base host/path to route.
    """
    host, path = _parse_api_base_host_path(api_base)
    if host != CODESTRAL_HOST:
        return None
    normalized_path = path.rstrip("/").lower()
    if normalized_path in ("", "/v1", CODESTRAL_CHAT_COMPLETIONS_PATH):
        return "codestral"
    if normalized_path == CODESTRAL_FIM_COMPLETIONS_PATH:
        return "text-completion-codestral"
    return None
```

Removed duplicate unreachable branches and moved Codestral routing before `openai_compatible_endpoints` loop.

### Test (`tests/test_litellm/litellm_core_utils/test_codestral_provider_routing.py`)

- `test_codestral_chat_endpoint_routes_to_codestral_provider`
- `test_codestral_fim_endpoint_routes_to_text_completion_provider`
- `test_codestral_chat_provider_routing_with_host_variants` (parametrized: scheme, trailing slash, case)
- `test_codestral_helper_ignores_similar_domain` (security: rejects `codestral.mistral.ai.evil.com`)