### PR TITLE
Add `output_text` property to `ResponsesAPIResponse`

### DIFF
--- a/tests/test_litellm/types/llms/test_types_llms_openai.py
+++ b/tests/test_litellm/types/llms/test_types_llms_openai.py
@@ -35,3 +35,67 @@ def test_output_item_added_event():
     assert event.sequence_number == 4
     assert event.output_index == 1
     assert event.item is None
+
+
+def test_responses_api_response_output_text_from_output_text_block():
+    from litellm.types.llms.openai import ResponsesAPIResponse
+
+    response = ResponsesAPIResponse(
+        id="resp_1",
+        created_at=0,
+        output=[
+            {"type": "message", "content": [{"type": "output_text", "text": "Hello"}]}
+        ],
+    )
+
+    assert response.output_text == "Hello"
+
+
+def test_responses_api_response_output_text_from_text_value_dict_output():
+    from litellm.types.llms.openai import ResponsesAPIResponse
+
+    output = {"type": "message", "content": {"type": "text", "value": "Hi"}}
+    response = ResponsesAPIResponse.model_construct(
+        id="resp_2", created_at=0, output=output
+    )
+
+    assert response.output_text == "Hi"
+
+
+def test_responses_api_response_output_text_ignores_non_message_and_blank():
+    from litellm.types.llms.openai import ResponsesAPIResponse
+    from litellm.types.responses.main import (
+        GenericResponseOutputItem,
+        OutputFunctionToolCall,
+        OutputText,
+    )
+
+    tool_call_item = OutputFunctionToolCall(
+        type="function_call",
+        status="completed",
+        arguments="{}",
+        call_id="call_1",
+        name="test_func",
+        id="fc_1",
+    )
+    message_item = GenericResponseOutputItem(
+        type="message",
+        id="item_1",
+        status="completed",
+        role="assistant",
+        content=[
+            OutputText(type="text", text="A", annotations=None),
+            OutputText(type="output_text", text=" ", annotations=None),
+            OutputText(type="text", text="B", annotations=None),
+        ],
+    )
+    response = ResponsesAPIResponse(
+        id="resp_3",
+        created_at=0,
+        output=[
+            tool_call_item,
+            message_item,
+        ],
+    )
+
+    assert response.output_text == "A B"


### PR DESCRIPTION
## Relevant issues

Fixes #18470

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

New Feature

## Changes

- Add `ResponsesAPIResponse.output_text` derived from response output message content.
- Add unit tests covering output_text extraction variants.