### PR TITLE
feat(zai): Add GLM-4.7 model with reasoning support

### DIFF
--- a/docs/my-website/docs/providers/zai.md
+++ b/docs/my-website/docs/providers/zai.md
@@ -19,7 +19,7 @@ import os
 
 os.environ['ZAI_API_KEY'] = ""
 response = completion(
-    model="zai/glm-4.6",
+    model="zai/glm-4.7",
     messages=[
        {"role": "user", "content": "hello from litellm"}
    ],
@@ -34,7 +34,7 @@ import os
 
 os.environ['ZAI_API_KEY'] = ""
 response = completion(
-    model="zai/glm-4.6",
+    model="zai/glm-4.7",
     messages=[
        {"role": "user", "content": "hello from litellm"}
    ],
@@ -51,7 +51,8 @@ We support ALL Z.AI GLM models, just set `zai/` as a prefix when sending complet
 
 | Model Name | Function Call | Notes |
 |------------|---------------|-------|
-| glm-4.6 | `completion(model="zai/glm-4.6", messages)` | Latest flagship model, 200K context |
+| glm-4.7 | `completion(model="zai/glm-4.7", messages)` | **Latest flagship**, 200K context, **Reasoning** |
+| glm-4.6 | `completion(model="zai/glm-4.6", messages)` | 200K context |
 | glm-4.5 | `completion(model="zai/glm-4.5", messages)` | 128K context |
 | glm-4.5v | `completion(model="zai/glm-4.5v", messages)` | Vision model |
 | glm-4.5-x | `completion(model="zai/glm-4.5-x", messages)` | Premium tier |
@@ -62,16 +63,17 @@ We support ALL Z.AI GLM models, just set `zai/` as a prefix when sending complet
 
 ## Model Pricing
 
-| Model | Input ($/1M tokens) | Output ($/1M tokens) | Context Window |
-|-------|---------------------|----------------------|----------------|
-| glm-4.6 | $0.60 | $2.20 | 200K |
-| glm-4.5 | $0.60 | $2.20 | 128K |
-| glm-4.5v | $0.60 | $1.80 | 128K |
-| glm-4.5-x | $2.20 | $8.90 | 128K |
-| glm-4.5-air | $0.20 | $1.10 | 128K |
-| glm-4.5-airx | $1.10 | $4.50 | 128K |
-| glm-4-32b-0414-128k | $0.10 | $0.10 | 128K |
-| glm-4.5-flash | **FREE** | **FREE** | 128K |
+| Model | Input ($/1M tokens) | Output ($/1M tokens) | Cached Input ($/1M tokens) | Context Window |
+|-------|---------------------|----------------------|---------------------------|----------------|
+| glm-4.7 | $0.60 | $2.20 | $0.11 | 200K |
+| glm-4.6 | $0.60 | $2.20 | - | 200K |
+| glm-4.5 | $0.60 | $2.20 | - | 128K |
+| glm-4.5v | $0.60 | $1.80 | - | 128K |
+| glm-4.5-x | $2.20 | $8.90 | - | 128K |
+| glm-4.5-air | $0.20 | $1.10 | - | 128K |
+| glm-4.5-airx | $1.10 | $4.50 | - | 128K |
+| glm-4-32b-0414-128k | $0.10 | $0.10 | - | 128K |
+| glm-4.5-flash | **FREE** | **FREE** | - | 128K |
 
 ## Using with LiteLLM Proxy
 
@@ -84,7 +86,7 @@ import os
 
 os.environ['ZAI_API_KEY'] = ""
 response = completion(
-    model="zai/glm-4.6",
+    model="zai/glm-4.7",
     messages=[{"role": "user", "content": "Hello, how are you?"}],
 )
 
@@ -98,9 +100,9 @@ print(response.choices[0].message.content)
 
 ```yaml
 model_list:
-  - model_name: glm-4.6
+  - model_name: glm-4.7
     litellm_params:
-        model: zai/glm-4.6
+        model: zai/glm-4.7
         api_key: os.environ/ZAI_API_KEY
   - model_name: glm-4.5-flash  # Free tier
     litellm_params:
@@ -121,7 +123,7 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Bearer sk-1234' \
 -d '{
-    "model": "glm-4.6",
+    "model": "glm-4.7",
     "messages": [
       {
         "role": "user",

--- a/litellm/llms/zai/chat/transformation.py
+++ b/litellm/llms/zai/chat/transformation.py
@@ -20,7 +20,7 @@ class ZAIChatConfig(OpenAIGPTConfig):
         return api_base, dynamic_api_key
 
     def get_supported_openai_params(self, model: str) -> list:
-        return [
+        base_params = [
             "max_tokens",
             "stream",
             "stream_options",
@@ -31,3 +31,12 @@ class ZAIChatConfig(OpenAIGPTConfig):
             "tool_choice",
         ]
 
+        import litellm
+
+        try:
+            if litellm.supports_reasoning(model=model, custom_llm_provider=self.custom_llm_provider):
+                base_params.append("thinking")
+        except Exception:
+            pass
+
+        return base_params

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -29241,6 +29241,20 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "zai/glm-4.7": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 1.1e-07,
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-4.6": {
         "input_cost_per_token": 6e-07,
         "output_cost_per_token": 2.2e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -29275,6 +29275,20 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "zai/glm-4.7": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 1.1e-07,
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-4.6": {
         "input_cost_per_token": 6e-07,
         "output_cost_per_token": 2.2e-06,


### PR DESCRIPTION
## Summary

Add support for Z.AI GLM-4.7, latest flagship model with enhanced reasoning capabilities.

## Changes

### Model Configuration
- Added `zai/glm-4.7` to `model_prices_and_context_window.json`
- Added `zai/glm-4.7` to `litellm/model_prices_and_context_window_backup.json`
- Input: \$0.60/1M tokens
- Output: \$2.20/1M tokens
- Cache: \$0.11/1M read tokens (limited-time free creation)
- Context: 200K input, 128K output
- Supports: reasoning, function calling, tool choice, prompt caching

### Code Changes
- **`litellm/llms/zai/chat/transformation.py`**:
  - Updated `get_supported_openai_params()` to support `thinking` parameter
  - Added conditional logic: only add `thinking` if `supports_reasoning` is true
  - Uses `litellm.supports_reasoning()` to check model capability

### Documentation Updates
- **`docs/my-website/docs/providers/zai.md`**:
  - GLM-4.7 added as "Latest flagship" model (first in supported models list)
  - Updated "Model Pricing" table with "Cached Input" column
  - GLM-4.7 shows cached input price (\$0.11/M), others show "-"
  - All code examples updated to use GLM-4.7

### Tests
- **`tests/test_litellm/llms/zai/test_zai_provider.py`**:
  - Added `zai/glm-4.7` to model list test
  - Added `test_glm47_supports_reasoning()` - verifies supports_reasoning flag
  - Added `test_glm47_cost_calculation()` - verifies pricing calculation
  - All tests passing (9/9)

## Model Specifications

**Z.AI GLM-4.7**
- Latest flagship model with enhanced reasoning
- Context: 200K input, 128K output
- Pricing: Same as GLM-4.6 (\$0.60/M input, \$2.20/M output)
- Prompt Caching: \$0.11/M read tokens (limited-time free creation)
- Supports: Reasoning (thinking parameter), Function Calling, Tool Choice, Prompt Caching

## Testing

All tests pass:
- [x] test_glm47_supports_reasoning
- [x] test_glm47_cost_calculation
- [x] test_zai_models_in_model_cost
- [x] test_get_llm_provider_zai
- [x] test_zai_in_provider_lists
- [x] test_zai_glm46_cost_calculation
- [x] test_zai_flash_model_is_free
- [x] test_zai_completion_call (async with mock)
- [x] test_zai_sync_completion (sync with mock)

## References

- Z.AI GLM-4.7 Documentation: https://docs.z.ai/guides/llm/glm-4.7
- Z.AI Pricing: https://docs.z.ai/guides/overview/pricing
- LiteLLM Z.AI Provider Docs: https://docs.litellm.ai/docs/providers/zai