### PR TITLE
google genai adapter inline data support

### DIFF
--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -8,8 +8,10 @@ from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionAssistantMessage,
     ChatCompletionAssistantToolCall,
+    ChatCompletionImageObject,
     ChatCompletionRequest,
     ChatCompletionSystemMessage,
+    ChatCompletionTextObject,
     ChatCompletionToolCallFunctionChunk,
     ChatCompletionToolChoiceValues,
     ChatCompletionToolMessage,
@@ -385,13 +387,36 @@ class GoogleGenAIAdapter:
 
             if role == "user":
                 # Handle user messages with potential function responses
-                combined_text = ""
+                content_parts: List[
+                    Union[ChatCompletionTextObject, ChatCompletionImageObject]
+                ] = []
                 tool_messages: List[ChatCompletionToolMessage] = []
 
                 for part in parts:
                     if isinstance(part, dict):
                         if "text" in part:
-                            combined_text += part["text"]
+                            content_parts.append(
+                                cast(
+                                    ChatCompletionTextObject,
+                                    {"type": "text", "text": part["text"]},
+                                )
+                            )
+                        elif "inline_data" in part:
+                            # Handle Base64 image data
+                            inline_data = part["inline_data"]
+                            mime_type = inline_data.get("mime_type", "image/jpeg")
+                            data = inline_data.get("data", "")
+                            content_parts.append(
+                                cast(
+                                    ChatCompletionImageObject,
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {
+                                            "url": f"data:{mime_type};base64,{data}"
+                                        },
+                                    },
+                                )
+                            )
                         elif "functionResponse" in part:
                             # Transform function response to tool message
                             func_response = part["functionResponse"]
@@ -402,13 +427,33 @@ class GoogleGenAIAdapter:
                             )
                             tool_messages.append(tool_message)
                     elif isinstance(part, str):
-                        combined_text += part
+                        content_parts.append(
+                            cast(
+                                ChatCompletionTextObject, {"type": "text", "text": part}
+                            )
+                        )
 
-                # Add user message if there's text content
-                if combined_text:
-                    messages.append(
-                        ChatCompletionUserMessage(role="user", content=combined_text)
-                    )
+                # Add user message if there's content
+                if content_parts:
+                    # If only one text part, use simple string format for backward compatibility
+                    if (
+                        len(content_parts) == 1
+                        and isinstance(content_parts[0], dict)
+                        and content_parts[0].get("type") == "text"
+                    ):
+                        text_part = cast(ChatCompletionTextObject, content_parts[0])
+                        messages.append(
+                            ChatCompletionUserMessage(
+                                role="user", content=text_part["text"]
+                            )
+                        )
+                    else:
+                        # Use multimodal format (array of content parts)
+                        messages.append(
+                            ChatCompletionUserMessage(
+                                role="user", content=content_parts
+                            )
+                        )
 
                 # Add tool messages
                 messages.extend(tool_messages)
@@ -467,7 +512,6 @@ class GoogleGenAIAdapter:
         Returns:
             Dict in Google GenAI generate_content response format
         """
-
 
         # Extract the main response content
         choice = response.choices[0] if response.choices else None

--- a/tests/test_litellm/google_genai/test_google_genai_adapter.py
+++ b/tests/test_litellm/google_genai/test_google_genai_adapter.py
@@ -1197,6 +1197,131 @@ async def test_agenerate_content_x_goog_api_key_header():
             
             # Verify other expected headers
             assert headers.get("Content-Type") == "application/json", f"Expected Content-Type application/json, got {headers.get('Content-Type')}"
-            
+
             print(f"✓ Test passed: x-goog-api-key header correctly set to {api_key_value}")
             print(f"✓ All headers: {list(headers.keys())}")
+
+
+def test_inline_data_base64_image_transformation():
+    """Test transformation of Gemini inline_data (Base64 images) to OpenAI format"""
+    from litellm.google_genai.adapters.transformation import GoogleGenAIAdapter
+
+    adapter = GoogleGenAIAdapter()
+
+    # Test input with Base64 image
+    model = "gpt-4-vision-preview"
+    contents = {
+        "role": "user",
+        "parts": [
+            {"text": "What's in this image?"},
+            {
+                "inline_data": {
+                    "mime_type": "image/jpeg",
+                    "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                }
+            }
+        ]
+    }
+
+    # Transform to completion format
+    completion_request = adapter.translate_generate_content_to_completion(
+        model=model,
+        contents=contents
+    )
+
+    # Verify the transformation
+    assert completion_request["model"] == model
+    assert len(completion_request["messages"]) == 1
+    assert completion_request["messages"][0]["role"] == "user"
+
+    # Verify content is an array (multimodal format)
+    content = completion_request["messages"][0]["content"]
+    assert isinstance(content, list), "Content should be a list for multimodal messages"
+    assert len(content) == 2, "Should have 2 content parts (text + image)"
+
+    # Verify text part
+    text_part = content[0]
+    assert text_part["type"] == "text"
+    assert text_part["text"] == "What's in this image?"
+
+    # Verify image part
+    image_part = content[1]
+    assert image_part["type"] == "image_url"
+    assert "image_url" in image_part
+    assert "url" in image_part["image_url"]
+    assert image_part["image_url"]["url"].startswith("data:image/jpeg;base64,")
+    assert "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" in image_part["image_url"]["url"]
+
+
+def test_inline_data_image_only_transformation():
+    """Test transformation of Gemini inline_data with only image (no text)"""
+    from litellm.google_genai.adapters.transformation import GoogleGenAIAdapter
+
+    adapter = GoogleGenAIAdapter()
+
+    # Test input with only Base64 image (no text)
+    model = "gpt-4-vision-preview"
+    contents = {
+        "role": "user",
+        "parts": [
+            {
+                "inline_data": {
+                    "mime_type": "image/png",
+                    "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                }
+            }
+        ]
+    }
+
+    # Transform to completion format
+    completion_request = adapter.translate_generate_content_to_completion(
+        model=model,
+        contents=contents
+    )
+
+    # Verify the transformation
+    assert completion_request["model"] == model
+    assert len(completion_request["messages"]) == 1
+    assert completion_request["messages"][0]["role"] == "user"
+
+    # Verify content is an array (multimodal format)
+    content = completion_request["messages"][0]["content"]
+    assert isinstance(content, list), "Content should be a list for multimodal messages"
+    assert len(content) == 1, "Should have 1 content part (image only)"
+
+    # Verify image part
+    image_part = content[0]
+    assert image_part["type"] == "image_url"
+    assert "image_url" in image_part
+    assert "url" in image_part["image_url"]
+    assert image_part["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_inline_data_backward_compatibility_text_only():
+    """Test that pure text messages still use simple string format (backward compatibility)"""
+    from litellm.google_genai.adapters.transformation import GoogleGenAIAdapter
+
+    adapter = GoogleGenAIAdapter()
+
+    # Test input with only text (no images)
+    model = "gpt-3.5-turbo"
+    contents = {
+        "role": "user",
+        "parts": [{"text": "Hello, how are you?"}]
+    }
+
+    # Transform to completion format
+    completion_request = adapter.translate_generate_content_to_completion(
+        model=model,
+        contents=contents
+    )
+
+    # Verify the transformation
+    assert completion_request["model"] == model
+    assert len(completion_request["messages"]) == 1
+    assert completion_request["messages"][0]["role"] == "user"
+
+    # Verify content is a simple string (not an array) for backward compatibility
+    content = completion_request["messages"][0]["content"]
+    assert isinstance(content, str), "Content should be a string for text-only messages (backward compatibility)"
+    assert content == "Hello, how are you?"


### PR DESCRIPTION
  ## Relevant issues

  <!-- If there's a related issue, reference it here. Otherwise, you can describe the problem this PR solves -->
  Fixes support for inline image data (base64 encoded images) in Google GenAI/Gemini responses

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## CI (LiteLLM team)

  > **CI status guideline:**
  >
  > - 50-55passing tests: main is stable with minor issues.
  > - 45-49 passing tests: acceptable but needs attention
  > - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

  - [ ] **Branch creation CI run**Link:

  - [ ] **CI run for the last commit**
         Link:

  - [ ] **Merge / cherry-pick CI run**
         Links:

  ## Type

  🐛 Bug Fix /🆕 New Feature

  ## Changes

  ### Summary
  Added support for `inline_data` (base64 encoded images) in the Google GenAI adapter, enabling proper handling of multimodal responses from Gemini models that include embedded image data.

  ### Problem
  Previously, the Google GenAI adapter only handled text content by concatenating all text parts into a single string. When Gemini responses included `inline_data` fields (base64 encoded images), they were ignored, causing image data to be lost in the conversion to OpenAI format.

  ### Solution
  - Modified `litellm/google_genai/adapters/transformation.py` to properly handle multimodal content
  - Changed from concatenating text to building a list of content parts (`content_parts`)
  - Added handling for `inline_data` field, converting it to OpenAI's `image_url` format with data URI scheme (`data:{mime_type};base64,{data}`)
  - Maintained backward compatibility by using simple string format when there's only one text part
  - Added comprehensive tests in `tests/litellm/google_genai/test_google_genai_adapter.py` (127 lines)

  ### Technical Details
  The adapter now:
  1. Parses `inline_data` from Google GenAI responses
  2. Extracts `mime_type` and base64 `data`
  3. Converts to OpenAI-compatible format: `{"type": "image_url", "image_url": {"url": "data:{mime_type};base64,{data}"}}`
  4. Supports mixed content (text + images) in user messages

  ### Files Changed
  - `litellm/google_genai/adapters/__init__.py` - Minor updates
  - `litellm/google_genai/adapters/transformation.py` - Core implementation (+53 lines)
  - `tests/litellm/google_genai/test_google_genai_adapter.py` - Test coverage (+127 lines)
