### PR TITLE
  fix: update_price_and_context_window workflow from running in forks

### DIFF
--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   auto_update_price_and_context_window:
+    if: github.repository == 'BerriAI/litellm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Relevant issues

N/A - Infrastructure improvement

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - **N/A**: This is a GitHub Actions workflow change that doesn't require unit tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - **N/A**: No code changes to test
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
  - Single-line change to prevent workflow execution in forks

## Type

🚄 Infrastructure

## Changes

Adds a repository check to the `auto_update_price_and_context_window` workflow to prevent it from running in forks.

- Added `if: github.repository == 'BerriAI/litellm'` condition to the workflow job
- Scheduled workflows run in forks by default, causing unnecessary executions and failures
- In forks: workflow will be skipped (no notifications, no resource usage)
- In BerriAI/litellm: workflow continues to run normally every Sunday at midnight

<img width="300"  alt="Screenshot 2025-12-28 at 11 23 48" src="https://github.com/user-attachments/assets/3afa3e68-e43c-4de7-af46-b87397281d8f" />
