### PR TITLE
Fix: Clean up callback environment variables on delete

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -9705,6 +9705,20 @@ async def delete_callback(
                 },
             )
 
+        # Get environment variables for this callback
+        from litellm.integrations.custom_logger import CustomLogger
+
+        callback_env_vars = CustomLogger.get_callback_env_vars(callback_name)
+
+        # Remove callback's environment variables (both uppercase and lowercase)
+        if callback_env_vars and "environment_variables" in config:
+            env_vars = config["environment_variables"]
+            for var_name in callback_env_vars:
+                # Remove both uppercase and lowercase versions to handle duplicates
+                env_vars.pop(var_name, None)
+                env_vars.pop(var_name.lower(), None)
+            config["environment_variables"] = env_vars
+
         # Remove callback from success_callback list
         success_callbacks.remove(callback_name)
         config.setdefault("litellm_settings", {})[


### PR DESCRIPTION
## Relevant issues

Fixes #15776

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### The Bug

When adding a callback via UI, credentials get saved:

```json
{
  "environment_variables": {
    "LANGFUSE_PUBLIC_KEY": "encrypted_value_1",
    "LANGFUSE_SECRET_KEY": "encrypted_value_2", 
    "LANGFUSE_HOST": "encrypted_value_3"
  }
}
```

When deleting the callback via UI, credentials don't get deleted:

```json
{
  "environment_variables": {
    "LANGFUSE_PUBLIC_KEY": "encrypted_value_1",
    "langfuse_public_key": "encrypted_value_1",
    "LANGFUSE_SECRET_KEY": "encrypted_value_2",
    "langfuse_secret_key": "encrypted_value_2",
    "LANGFUSE_HOST": "encrypted_value_3",
    "langfuse_host": "encrypted_value_3"
  }
}
```

On proxy startup, the code tries to decrypt all environment variables, including these orphaned credentials. If the `LITELLM_MASTER_KEY` changed, decryption fails with "Ciphertext failed verification" errors.

### The Fix

When deleting a callback, now removes its environment variables:

```python
callback_env_vars = CustomLogger.get_callback_env_vars(callback_name)
for var_name in callback_env_vars:
    env_vars.pop(var_name, None)
    env_vars.pop(var_name.lower(), None)
```

After delete:

```json
{
  "environment_variables": {}
}
```

Now the proxy doesn't try to decrypt orphaned credentials on startup.

### For Users

After upgrading to version that includes this fix:

1. Delete your callback from the UI
2. Re-add the callback with your credentials

This will clean up the orphaned credentials from your database.

### Testing

Manually tested:
- Add Langfuse callback via UI → credentials saved in DB
- Delete Langfuse callback via UI → credentials removed from DB
- Verified no orphaned credentials remain
- Verified uppercase/lowercase duplicates are both removed

Modified: `litellm/proxy/proxy_server.py` lines 9708-9720