### PR TITLE
fix: use DeepSeek production API endpoint (/v1) instead of /beta

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -666,7 +666,7 @@ def _get_openai_compatible_provider_info(  # noqa: PLR0915
         api_base = (
             api_base
             or get_secret("DEEPSEEK_API_BASE")
-            or "https://api.deepseek.com/beta"
+            or "https://api.deepseek.com/v1"
         )  # type: ignore
 
         dynamic_api_key = api_key or get_secret_str("DEEPSEEK_API_KEY")

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -99,7 +99,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         api_base = (
             api_base
             or get_secret_str("DEEPSEEK_API_BASE")
-            or "https://api.deepseek.com/beta"
+            or "https://api.deepseek.com/v1"
         )  # type: ignore
         dynamic_api_key = api_key or get_secret_str("DEEPSEEK_API_KEY")
         return api_base, dynamic_api_key
@@ -117,7 +117,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         If api_base is not provided, use the default DeepSeek /chat/completions endpoint.
         """
         if not api_base:
-            api_base = "https://api.deepseek.com/beta"
+            api_base = "https://api.deepseek.com/v1"
 
         if not api_base.endswith("/chat/completions"):
             api_base = f"{api_base}/chat/completions"

--- a/tests/llm_translation/test_deepseek_completion.py
+++ b/tests/llm_translation/test_deepseek_completion.py
@@ -97,7 +97,7 @@ async def test_deepseek_provider_async_completion(stream):
 
     # Check request body
     request_body = json.loads(call_args.kwargs["data"])
-    assert call_args.kwargs["url"] == "https://api.deepseek.com/beta/chat/completions"
+    assert call_args.kwargs["url"] == "https://api.deepseek.com/v1/chat/completions"
     assert (
         request_body["model"] == "deepseek-reasoner"
     )  # Model name should be stripped of provider prefix


### PR DESCRIPTION
## Summary

Changes the default DeepSeek API base URL from `https://api.deepseek.com/beta` to `https://api.deepseek.com/v1` as recommended by [DeepSeek's official API documentation](https://api-docs.deepseek.com/).

## Motivation

As reported in #15986:
- The `/beta` endpoint is poorly documented
- It may not serve the latest models
- It may lack features (such as reasoner mode)
- DeepSeek's official documentation explicitly recommends using `/v1` for OpenAI compatibility

## Changes

| File | Change |
|------|--------|
| `litellm/llms/deepseek/chat/transformation.py` | Updated default API base from `/beta` to `/v1` (2 occurrences) |
| `litellm/litellm_core_utils/get_llm_provider_logic.py` | Updated default API base from `/beta` to `/v1` |
| `tests/llm_translation/test_deepseek_completion.py` | Updated test expectation to match new URL |

## Test Plan

- [x] Updated existing test to expect `/v1` endpoint
- [x] Syntax validation passed

## Notes

The comment in `get_llm_provider_logic.py` already mentioned `/v1` as the correct endpoint, but the code was using `/beta`. This PR makes the code consistent with its own documentation.

Fixes #15986

🤖 Generated with [Claude Code](https://claude.com/claude-code)