### PR TITLE
fix: correct deepseek-v3p2 pricing for Fireworks AI

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10885,13 +10885,13 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-v3p2": {
-        "input_cost_per_token": 1.2e-06,
+        "input_cost_per_token": 5.6e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
         "max_tokens": 163840,
         "mode": "chat",
-        "output_cost_per_token": 1.2e-06,
+        "output_cost_per_token": 1.68e-06,
         "source": "https://fireworks.ai/models/fireworks/deepseek-v3p2",
         "supports_function_calling": true,
         "supports_reasoning": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10943,13 +10943,13 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-v3p2": {
-        "input_cost_per_token": 1.2e-06,
+        "input_cost_per_token": 5.6e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
         "max_tokens": 163840,
         "mode": "chat",
-        "output_cost_per_token": 1.2e-06,
+        "output_cost_per_token": 1.68e-06,
         "source": "https://fireworks.ai/models/fireworks/deepseek-v3p2",
         "supports_function_calling": true,
         "supports_reasoning": true,


### PR DESCRIPTION
## Summary
- Updated pricing for `fireworks_ai/accounts/fireworks/models/deepseek-v3p2` to match actual Fireworks AI pricing

## Changes
- `input_cost_per_token`: `1.2e-06` → `5.6e-07` ($0.56/1M tokens)
- `output_cost_per_token`: `1.2e-06` → `1.68e-06` ($1.68/1M tokens)

## Source
Pricing verified from [Fireworks AI DeepSeek v3.2 model page](https://fireworks.ai/models/fireworks/deepseek-v3p2):
- Input tokens: $0.56 per 1M tokens
- Output tokens: $1.68 per 1M tokens

Fixes #17998