### PR TITLE
fix: strip <think> tag from content when reasoning_content is separate

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -135,6 +135,7 @@ from litellm.litellm_core_utils.llm_response_utils.response_metadata import (
 )
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     _parse_content_for_reasoning,
+    _strip_leading_thinking_tags_from_content,
 )
 from litellm.litellm_core_utils.redact_messages import (
     LiteLLMLoggingObject,


### PR DESCRIPTION
## Summary
- Fixes issue where DeepSeek v3.1 responses via Together AI contain an erroneous `<think>` tag in the `content` field
- Together AI returns `reasoning_content` as a separate field but leaves the opening `<think>` tag in `content`
- Added `_strip_leading_thinking_tags_from_content()` helper to clean thinking tags from content
- Updated `_extract_reasoning_content()` to use this helper when `reasoning_content` or `reasoning` fields are present

Fixes #16451

## Test plan
- [x] Added unit tests for `_strip_leading_thinking_tags_from_content()` covering all tag variants
- [x] Added integration test simulating Together AI response format
- [x] Added test for `reasoning` field format
- [x] Verified existing `test_parse_content_for_reasoning` tests still pass

## Changes
| File | Changes |
|------|---------|
| `litellm/litellm_core_utils/prompt_templates/common_utils.py` | Added `_strip_leading_thinking_tags_from_content()` helper and updated `_extract_reasoning_content()` |
| `litellm/utils.py` | Exported new helper function |
| `tests/litellm_utils_tests/test_utils.py` | Added comprehensive tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)