### PR TITLE
fix: pass all usage fields in streaming response for DeepSeek prompt_tokens_details

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -152,14 +152,12 @@ async def convert_to_streaming_response_async(response_object: Optional[dict] = 
     model_response_object.choices = choice_list
 
     if "usage" in response_object and response_object["usage"] is not None:
+        # Pass all usage fields to preserve provider-specific fields like
+        # prompt_cache_hit_tokens, prompt_cache_miss_tokens (DeepSeek)
         setattr(
             model_response_object,
             "usage",
-            Usage(
-                completion_tokens=response_object["usage"].get("completion_tokens", 0),
-                prompt_tokens=response_object["usage"].get("prompt_tokens", 0),
-                total_tokens=response_object["usage"].get("total_tokens", 0),
-            ),
+            Usage(**response_object["usage"]),
         )
 
     if "id" in response_object:
@@ -207,10 +205,9 @@ def convert_to_streaming_response(response_object: Optional[dict] = None):
     model_response_object.choices = choice_list
 
     if "usage" in response_object and response_object["usage"] is not None:
-        setattr(model_response_object, "usage", Usage())
-        model_response_object.usage.completion_tokens = response_object["usage"].get("completion_tokens", 0)  # type: ignore
-        model_response_object.usage.prompt_tokens = response_object["usage"].get("prompt_tokens", 0)  # type: ignore
-        model_response_object.usage.total_tokens = response_object["usage"].get("total_tokens", 0)  # type: ignore
+        # Pass all usage fields to preserve provider-specific fields like
+        # prompt_cache_hit_tokens, prompt_cache_miss_tokens (DeepSeek)
+        setattr(model_response_object, "usage", Usage(**response_object["usage"]))
 
     if "id" in response_object:
         model_response_object.id = response_object["id"]


### PR DESCRIPTION
## Summary
- Fixes issue where `prompt_tokens_details` was `null` for DeepSeek responses
- The streaming response conversion functions were only passing 3 basic usage fields, causing DeepSeek's `prompt_cache_hit_tokens` and `prompt_cache_miss_tokens` to be lost
- Updated both `convert_to_streaming_response` and `convert_to_streaming_response_async` to pass all usage fields via `Usage(**response_object["usage"])`

Fixes #16009

## Root Cause
The streaming response conversion was creating Usage objects like this:
```python
# Before (broken)
Usage(
    completion_tokens=response_object["usage"].get("completion_tokens", 0),
    prompt_tokens=response_object["usage"].get("prompt_tokens", 0),
    total_tokens=response_object["usage"].get("total_tokens", 0),
)
```

This dropped DeepSeek's `prompt_cache_hit_tokens` and `prompt_cache_miss_tokens` fields, preventing the Usage constructor's DeepSeek mapping logic from running.

## Fix
```python
# After (fixed)
Usage(**response_object["usage"])
```

Now all usage fields are passed to the constructor, allowing the DeepSeek mapping to:
- Set `prompt_tokens_details.cached_tokens` from `prompt_cache_hit_tokens`
- Preserve `prompt_cache_miss_tokens` as an attribute
- Set `_cache_read_input_tokens` for cost calculation

## Test plan
- [x] Added `test_convert_to_model_response_object_with_deepseek_cache_tokens()` - verifies non-streaming path
- [x] Added `test_convert_to_streaming_response_with_deepseek_cache_tokens()` - verifies streaming path
- [x] Both tests verify `prompt_tokens_details.cached_tokens` is populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)