### PR TITLE
fix: route codestral endpoints to correct providers

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -229,10 +229,10 @@ def get_llm_provider(  # noqa: PLR0915
                     elif endpoint == "https://api.ai21.com/studio/v1":
                         custom_llm_provider = "ai21_chat"
                         dynamic_api_key = get_secret_str("AI21_API_KEY")
-                    elif endpoint == "https://codestral.mistral.ai/v1":
+                    elif endpoint == "codestral.mistral.ai/v1/chat/completions":
                         custom_llm_provider = "codestral"
                         dynamic_api_key = get_secret_str("CODESTRAL_API_KEY")
-                    elif endpoint == "https://codestral.mistral.ai/v1":
+                    elif endpoint == "codestral.mistral.ai/v1/fim/completions":
                         custom_llm_provider = "text-completion-codestral"
                         dynamic_api_key = get_secret_str("CODESTRAL_API_KEY")
                     elif endpoint == "app.empower.dev/api/v1":

--- a/tests/local_testing/test_get_llm_provider.py
+++ b/tests/local_testing/test_get_llm_provider.py
@@ -417,3 +417,31 @@ def test_get_llm_provider_use_proxy_arg_true_with_direct_args():
     assert provider == "litellm_proxy"
     assert key == arg_api_key  # Should use the argument key
     assert base == arg_api_base # Should use the argument base
+
+
+def test_get_llm_provider_codestral_chat_endpoint():
+    """
+    Tests that codestral.mistral.ai/v1/chat/completions endpoint is correctly
+    routed to the 'codestral' provider.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/18464
+    """
+    model, custom_llm_provider, dynamic_api_key, api_base = litellm.get_llm_provider(
+        model="some-model",
+        api_base="https://codestral.mistral.ai/v1/chat/completions",
+    )
+    assert custom_llm_provider == "codestral"
+
+
+def test_get_llm_provider_codestral_fim_endpoint():
+    """
+    Tests that codestral.mistral.ai/v1/fim/completions endpoint is correctly
+    routed to the 'text-completion-codestral' provider for FIM (Fill-In-Middle).
+
+    Regression test for https://github.com/BerriAI/litellm/issues/18464
+    """
+    model, custom_llm_provider, dynamic_api_key, api_base = litellm.get_llm_provider(
+        model="some-model",
+        api_base="https://codestral.mistral.ai/v1/fim/completions",
+    )
+    assert custom_llm_provider == "text-completion-codestral"


### PR DESCRIPTION
## Summary

Fixes #18464

The endpoint detection for Codestral had two issues:

1. **Duplicate conditions**: Both `elif` conditions checked for the same endpoint string `"https://codestral.mistral.ai/v1"`, making the second branch (`text-completion-codestral`) unreachable.

2. **Wrong endpoint format**: The endpoint string didn't match the actual endpoints in `openai_compatible_endpoints`:
   - List contains: `codestral.mistral.ai/v1/chat/completions` and `codestral.mistral.ai/v1/fim/completions` (no `https://` prefix, with full path)
   - Code checked for: `https://codestral.mistral.ai/v1` (which never matches)

**Fix**: Check the correct endpoint strings:
- `codestral.mistral.ai/v1/chat/completions` → `codestral` provider
- `codestral.mistral.ai/v1/fim/completions` → `text-completion-codestral` provider

## Test plan

- [x] Added `test_get_llm_provider_codestral_chat_endpoint` - verifies chat endpoint routes to `codestral`
- [x] Added `test_get_llm_provider_codestral_fim_endpoint` - verifies FIM endpoint routes to `text-completion-codestral`
- [x] Tests pass: `pytest tests/local_testing/test_get_llm_provider.py::test_get_llm_provider_codestral_chat_endpoint tests/local_testing/test_get_llm_provider.py::test_get_llm_provider_codestral_fim_endpoint -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)