### PR TITLE
fix: use current time in create_budget instead of module load time

### DIFF
--- a/litellm/budget_manager.py
+++ b/litellm/budget_manager.py
@@ -78,8 +78,10 @@ class BudgetManager:
         total_budget: float,
         user: str,
         duration: Optional[Literal["daily", "weekly", "monthly", "yearly"]] = None,
-        created_at: float = time.time(),
+        created_at: Optional[float] = None,
     ):
+        if created_at is None:
+            created_at = time.time()
         self.user_dict[user] = {"total_budget": total_budget}
         if duration is None:
             return self.user_dict[user]


### PR DESCRIPTION
## Summary

Fixes #18459

`BudgetManager.create_budget()` was using `time.time()` as a default argument value, which is evaluated once at module load time, not at each function call. This is a [classic Python antipattern](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments).

**Before:**
```python
def create_budget(
    self,
    total_budget: float,
    user: str,
    duration: Optional[Literal["daily", "weekly", "monthly", "yearly"]] = None,
    created_at: float = time.time(),  # <- Bug: evaluated at module load time
):
```

All budgets created in the same process had identical `created_at` timestamps.

**After:**
```python
def create_budget(
    self,
    total_budget: float,
    user: str,
    duration: Optional[Literal["daily", "weekly", "monthly", "yearly"]] = None,
    created_at: Optional[float] = None,
):
    if created_at is None:
        created_at = time.time()
```

Each budget now gets a fresh timestamp at creation time.

## Test plan

- [x] Added `test_create_budget_uses_current_time` - verifies timestamps are different for budgets created at different times
- [x] Added `test_create_budget_allows_custom_created_at` - verifies custom timestamps still work
- [x] Tests pass: `pytest tests/local_testing/test_budget_manager.py -v`
- [x] Linting passes: `ruff check litellm/budget_manager.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)