### PR TITLE
feat(types): add output_text property to ResponsesAPIResponse

### DIFF
--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1197,6 +1197,39 @@ class ResponsesAPIResponse(BaseLiteLLMOpenAIResponseObject):
     # Define private attributes using PrivateAttr
     _hidden_params: dict = PrivateAttr(default_factory=dict)
 
+    @property
+    def output_text(self) -> str:
+        """
+        Convenience property that aggregates all `output_text` items from the `output` list.
+
+        If no `output_text` content blocks exist, then an empty string is returned.
+
+        This matches the OpenAI SDK's Response.output_text behavior.
+        """
+        texts: List[str] = []
+        for output_item in self.output:
+            # Handle both dict and object access patterns
+            if isinstance(output_item, dict):
+                item_type = output_item.get("type")
+                content = output_item.get("content", [])
+            else:
+                item_type = getattr(output_item, "type", None)
+                content = getattr(output_item, "content", [])
+
+            if item_type == "message":
+                for content_item in content:
+                    if isinstance(content_item, dict):
+                        content_type = content_item.get("type")
+                        text = content_item.get("text", "")
+                    else:
+                        content_type = getattr(content_item, "type", None)
+                        text = getattr(content_item, "text", "") or ""
+
+                    if content_type == "output_text":
+                        texts.append(text)
+
+        return "".join(texts)
+
 
 class ResponsesAPIStreamEvents(str, Enum):
     """

--- a/tests/test_litellm/types/llms/test_types_llms_openai.py
+++ b/tests/test_litellm/types/llms/test_types_llms_openai.py
@@ -35,3 +35,137 @@ def test_output_item_added_event():
     assert event.sequence_number == 4
     assert event.output_index == 1
     assert event.item is None
+
+
+class TestResponsesAPIResponseOutputText:
+    """Tests for the output_text property on ResponsesAPIResponse"""
+
+    def test_output_text_with_single_message(self):
+        """Test output_text with a single message containing text output"""
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        response = ResponsesAPIResponse(
+            id="resp_123",
+            created_at=1234567890,
+            output=[
+                {
+                    "type": "message",
+                    "id": "msg_123",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Hello, world!",
+                        }
+                    ],
+                }
+            ],
+        )
+
+        assert response.output_text == "Hello, world!"
+
+    def test_output_text_with_multiple_messages(self):
+        """Test output_text with multiple messages aggregates all text"""
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        response = ResponsesAPIResponse(
+            id="resp_123",
+            created_at=1234567890,
+            output=[
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "First part. ",
+                        }
+                    ],
+                },
+                {
+                    "type": "message",
+                    "id": "msg_2",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Second part.",
+                        }
+                    ],
+                },
+            ],
+        )
+
+        assert response.output_text == "First part. Second part."
+
+    def test_output_text_with_no_text_content(self):
+        """Test output_text returns empty string when no output_text content exists"""
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        response = ResponsesAPIResponse(
+            id="resp_123",
+            created_at=1234567890,
+            output=[
+                {
+                    "type": "function_call",
+                    "id": "call_123",
+                    "status": "completed",
+                    "name": "get_weather",
+                    "arguments": "{}",
+                }
+            ],
+        )
+
+        assert response.output_text == ""
+
+    def test_output_text_with_mixed_content(self):
+        """Test output_text only aggregates output_text type content"""
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        response = ResponsesAPIResponse(
+            id="resp_123",
+            created_at=1234567890,
+            output=[
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "The weather is sunny. ",
+                        },
+                        {
+                            "type": "refusal",
+                            "refusal": "I cannot do that.",
+                        },
+                    ],
+                },
+                {
+                    "type": "function_call",
+                    "id": "call_123",
+                    "status": "completed",
+                    "name": "get_weather",
+                    "arguments": "{}",
+                },
+            ],
+        )
+
+        assert response.output_text == "The weather is sunny. "
+
+    def test_output_text_with_empty_output(self):
+        """Test output_text returns empty string with empty output list"""
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        response = ResponsesAPIResponse(
+            id="resp_123",
+            created_at=1234567890,
+            output=[],
+        )
+
+        assert response.output_text == ""


### PR DESCRIPTION
## Summary
- Add `output_text` convenience property to `ResponsesAPIResponse` that aggregates all `output_text` items from the output list
- Matches the OpenAI SDK's `Response.output_text` behavior for SDK compatibility
- Returns empty string if no `output_text` content blocks exist

## Usage
```python
response = litellm.responses.create(
    model="gpt-4o",
    input="Hello, how are you?",
)
print(response.output_text)  # Now works like OpenAI SDK
```

Fixes #18470

## Test plan
- [x] Added unit tests for single message output
- [x] Added unit tests for multiple messages aggregation
- [x] Added unit tests for mixed content types (function calls, refusals)
- [x] Added unit tests for empty output list
- [x] Tests handle both dict and Pydantic model access patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)