### PR TITLE
Fix formatting in proxy configs documentation

### DIFF
--- a/docs/my-website/docs/proxy/configs.md
+++ b/docs/my-website/docs/proxy/configs.md
@@ -116,7 +116,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
           "role": "user",
           "content": "what llm are you"
         }
-      ],
+      ]
     }
 '
 ```


### PR DESCRIPTION
This pull request makes a minor formatting change to the example curl command in the documentation. No functional changes were made. 

Got an error message:

```
{"error":{"message":"Invalid JSON payload: trailing comma is not allowed: line 8 column 8 (char141)","type":"invalid_request_error","param":"request_body","code":"400"}}%
```
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
📖 Documentation

## Changes
