### PR TITLE
fix authentication errors at messages API via azure_ai

### DIFF
--- a/litellm/llms/azure_ai/anthropic/messages_transformation.py
+++ b/litellm/llms/azure_ai/anthropic/messages_transformation.py
@@ -48,7 +48,12 @@ class AzureAnthropicMessagesConfig(AnthropicMessagesConfig):
         headers = BaseAzureLLM._base_validate_azure_environment(
             headers=headers, litellm_params=litellm_params_obj
         )
-        
+
+        # Azure Anthropic uses x-api-key header (not api-key)
+        # Convert api-key to x-api-key if present
+        if "api-key" in headers and "x-api-key" not in headers:
+            headers["x-api-key"] = headers.pop("api-key")
+
         # Set anthropic-version header
         if "anthropic-version" not in headers:
             headers["anthropic-version"] = "2023-06-01"

--- a/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_messages_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_messages_transformation.py
@@ -55,11 +55,12 @@ class TestAzureAnthropicMessagesConfig:
             assert isinstance(call_args[1]["litellm_params"], GenericLiteLLMParams)
             assert call_args[1]["litellm_params"].api_key == "test-api-key"
             assert "anthropic-version" in result
-            # api-key header is preserved as-is (no conversion to x-api-key)
-            assert "api-key" in result
+            assert "x-api-key" in result
+            assert result["x-api-key"] == "test-api-key"
+            assert "api-key" not in result
 
-    def test_validate_anthropic_messages_environment_preserves_api_key_header(self):
-        """Test that api-key header is preserved as-is (Azure handles the header internally)"""
+    def test_validate_anthropic_messages_environment_converts_api_key_to_x_api_key(self):
+        """Test that api-key header is converted to x-api-key"""
         config = AzureAnthropicMessagesConfig()
         headers = {}
         model = "claude-sonnet-4-5"
@@ -79,9 +80,10 @@ class TestAzureAnthropicMessagesConfig:
                 litellm_params=litellm_params,
             )
 
-            # Verify api-key header is preserved as-is
-            assert "api-key" in result
-            assert result["api-key"] == "test-api-key"
+            # Verify api-key was converted to x-api-key
+            assert "x-api-key" in result
+            assert result["x-api-key"] == "test-api-key"
+            assert "api-key" not in result
 
     def test_validate_anthropic_messages_environment_sets_headers(self):
         """Test that required headers are set"""
@@ -108,8 +110,7 @@ class TestAzureAnthropicMessagesConfig:
             assert result["anthropic-version"] == "2023-06-01"
             assert "content-type" in result
             assert result["content-type"] == "application/json"
-            # api-key header is preserved as-is
-            assert "api-key" in result
+            assert "x-api-key" in result
 
     def test_get_complete_url_with_base_url(self):
         """Test get_complete_url with base URL"""


### PR DESCRIPTION
Use x-api-key instead of api-key.
This has been removed by commit 61e737e361d1b2649e9fd491580529ea894dd0d4 for unknown reason.
For chat and responses API the changes in the mentioned commit works.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
