### PR TITLE
[Refactor] UI - Keys Table

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/TopKeyView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/TopKeyView.tsx
@@ -268,16 +268,7 @@ const TopKeyView: React.FC<TopKeyViewProps> = ({ topKeys, teams, showTags = fals
 
               {/* Content */}
               <div className="p-6 h-full">
-                <KeyInfoView
-                  keyId={selectedKey}
-                  onClose={handleClose}
-                  keyData={keyData}
-                  accessToken={accessToken}
-                  userID={userID}
-                  userRole={userRole}
-                  teams={teams}
-                  premiumUser={premiumUser}
-                />
+                <KeyInfoView keyId={selectedKey} onClose={handleClose} keyData={keyData} teams={teams} />
               </div>
             </div>
           </div>

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -1,13 +1,13 @@
 import { screen, waitFor } from "@testing-library/react";
 import { vi, it, expect } from "vitest";
-import { renderWithProviders } from "../../tests/test-utils";
-import { AllKeysTable } from "./all_keys_table";
-import { KeyResponse, Team } from "./key_team_helpers/key_list";
-import { Organization } from "./networking";
+import { renderWithProviders } from "../../../tests/test-utils";
+import { VirtualKeysTable } from "./VirtualKeysTable";
+import { KeyResponse, Team } from "../key_team_helpers/key_list";
+import { Organization } from "../networking";
 
 // Mock network calls
 vi.mock("./networking", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./networking")>();
+  const actual = await importOriginal<typeof import("../networking")>();
   return {
     ...actual,
     userListCall: vi.fn().mockResolvedValue({
@@ -131,7 +131,7 @@ const mockOrganization: Organization = {
   members: [],
 };
 
-it("should render AllKeysTable component", () => {
+it("should render VirtualKeysTable component", () => {
   const mockProps = {
     keys: [mockKey],
     setKeys: vi.fn(),
@@ -156,7 +156,7 @@ it("should render AllKeysTable component", () => {
     premiumUser: false,
   };
 
-  renderWithProviders(<AllKeysTable {...mockProps} />);
+  renderWithProviders(<VirtualKeysTable {...mockProps} />);
 
   expect(screen.getByText("Test Key Alias")).toBeInTheDocument();
 });
@@ -186,7 +186,7 @@ it("should display key information correctly", async () => {
     premiumUser: false,
   };
 
-  renderWithProviders(<AllKeysTable {...mockProps} />);
+  renderWithProviders(<VirtualKeysTable {...mockProps} />);
 
   await waitFor(() => {
     expect(screen.getByText("Test Key Alias")).toBeInTheDocument();
@@ -220,7 +220,7 @@ it("should display user email correctly", async () => {
     premiumUser: false,
   };
 
-  renderWithProviders(<AllKeysTable {...mockProps} />);
+  renderWithProviders(<VirtualKeysTable {...mockProps} />);
 
   await waitFor(() => {
     expect(screen.getByText("user@example.com")).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchAllKeyAliases, fetchAllOrganizations, fetchAllTeams } from "./filter_helpers";
 import { debounce } from "lodash";
 import { defaultPageSize } from "../constants";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 export interface FilterState {
   "Team ID": string;
@@ -21,12 +22,10 @@ export function useFilterLogic({
   keys,
   teams,
   organizations,
-  accessToken,
 }: {
   keys: KeyResponse[];
   teams: Team[] | null;
   organizations: Organization[] | null;
-  accessToken: string | null;
 }) {
   const defaultFilters: FilterState = {
     "Team ID": "",
@@ -36,6 +35,7 @@ export function useFilterLogic({
     "Sort By": "created_at",
     "Sort Order": "desc",
   };
+  const { accessToken } = useAuthorized();
   const [filters, setFilters] = useState<FilterState>(defaultFilters);
   const [allTeams, setAllTeams] = useState<Team[]>(teams || []);
   const [allOrganizations, setAllOrganizations] = useState<Organization[]>(organizations || []);

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -401,7 +401,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
       console.log("key create Response:", response);
 
       // Add the data to the state in the parent component
-      // Also directly update the keys list in AllKeysTable without an API call
+      // Also directly update the keys list in VirtualKeysTable without an API call
       addKey(response);
 
       setApiKey(response["key"]);

--- a/ui/litellm-dashboard/src/components/organisms/regenerate_key_modal.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/regenerate_key_modal.tsx
@@ -1,31 +1,22 @@
-import React, { useEffect, useState } from "react";
-import { Button, Text, TextInput, Title, Grid, Col } from "@tremor/react";
-import { Modal, Form, InputNumber } from "antd";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { Button, Col, Grid, Text, TextInput, Title } from "@tremor/react";
+import { Form, InputNumber, Modal } from "antd";
 import { add } from "date-fns";
-import { regenerateKeyCall } from "../networking";
-import { KeyResponse } from "../key_team_helpers/key_list";
+import { useEffect, useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
+import { KeyResponse } from "../key_team_helpers/key_list";
 import NotificationManager from "../molecules/notifications_manager";
+import { regenerateKeyCall } from "../networking";
 
 interface RegenerateKeyModalProps {
   selectedToken: KeyResponse | null;
   visible: boolean;
   onClose: () => void;
-  accessToken: string | null;
-  premiumUser: boolean;
-  setAccessToken?: (token: string) => void;
   onKeyUpdate?: (updatedKeyData: Partial<KeyResponse>) => void;
 }
 
-export function RegenerateKeyModal({
-  selectedToken,
-  visible,
-  onClose,
-  accessToken,
-  premiumUser,
-  setAccessToken,
-  onKeyUpdate,
-}: RegenerateKeyModalProps) {
+export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdate }: RegenerateKeyModalProps) {
+  const { accessToken } = useAuthorized();
   const [form] = Form.useForm();
   const [regeneratedKey, setRegeneratedKey] = useState<string | null>(null);
   const [regenerateFormData, setRegenerateFormData] = useState<any>(null);
@@ -131,14 +122,6 @@ export function RegenerateKeyModal({
       };
 
       console.log("Updated key data with new token:", updatedKeyData); // Debug log
-
-      // If user regenerated their own auth key, update both local and global access tokens
-      if (isOwnKey) {
-        setCurrentAccessToken(response.key); // Update local token immediately
-        if (setAccessToken) {
-          setAccessToken(response.key); // Update global token
-        }
-      }
 
       // Update the parent component with new key data
       if (onKeyUpdate) {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -1,10 +1,15 @@
 import useTeams from "@/app/(dashboard)/hooks/useTeams";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { KeyResponse, Team } from "../key_team_helpers/key_list";
 import KeyInfoView from "./key_info_view";
 
 vi.mock("@/app/(dashboard)/hooks/useTeams", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: vi.fn(),
 }));
 
@@ -85,17 +90,27 @@ describe("KeyInfoView", () => {
     key_rotation_at: undefined,
   };
 
+  // Base mock for useAuthorized hook
+  const baseUseAuthorizedMock = {
+    accessToken: "test-token",
+    userId: "test-user",
+    userRole: "admin",
+    premiumUser: true,
+    token: "test-token",
+    userEmail: null,
+    disabledPersonalKeyCreation: null,
+    showSSOBanner: false,
+  };
+
   it("should render tags", async () => {
+    vi.mocked(useAuthorized).mockReturnValue(baseUseAuthorizedMock);
+
     const { getByText } = render(
       <KeyInfoView
         keyData={MOCK_KEY_DATA}
         onClose={() => {}}
         keyId={"test-key-id"}
         onKeyDataUpdate={() => {}}
-        accessToken={"test-token"}
-        userID={"test-user"}
-        userRole={"admin"}
-        premiumUser={true}
         teams={[]}
       />,
     );
@@ -105,16 +120,14 @@ describe("KeyInfoView", () => {
   });
 
   it("should not render tags in metadata textarea", async () => {
+    vi.mocked(useAuthorized).mockReturnValue(baseUseAuthorizedMock);
+
     const { container, getByText } = render(
       <KeyInfoView
         keyData={MOCK_KEY_DATA}
         onClose={() => {}}
         keyId={"test-key-id"}
         onKeyDataUpdate={() => {}}
-        accessToken={"test-token"}
-        userID={"test-user"}
-        userRole={"admin"}
-        premiumUser={true}
         teams={[]}
       />,
     );
@@ -132,19 +145,15 @@ describe("KeyInfoView", () => {
       setTeams: vi.fn(),
     });
 
+    vi.mocked(useAuthorized).mockReturnValue({
+      ...baseUseAuthorizedMock,
+      userId: "proxy-admin-user",
+      userRole: "proxy_admin",
+    });
+
     const keyData = { ...MOCK_KEY_DATA, user_id: "other-user-id" };
     render(
-      <KeyInfoView
-        keyData={keyData}
-        onClose={() => {}}
-        keyId={"test-key-id"}
-        onKeyDataUpdate={() => {}}
-        accessToken={"test-token"}
-        userID={"proxy-admin-user"}
-        userRole={"proxy_admin"}
-        premiumUser={true}
-        teams={[]}
-      />,
+      <KeyInfoView keyData={keyData} onClose={() => {}} keyId={"test-key-id"} onKeyDataUpdate={() => {}} teams={[]} />,
     );
 
     await waitFor(() => {
@@ -180,19 +189,15 @@ describe("KeyInfoView", () => {
       setTeams: vi.fn(),
     });
 
+    vi.mocked(useAuthorized).mockReturnValue({
+      ...baseUseAuthorizedMock,
+      userId: teamAdminUserId,
+      userRole: "user",
+    });
+
     const keyData = { ...MOCK_KEY_DATA, team_id: teamId, user_id: "other-user-id" };
     render(
-      <KeyInfoView
-        keyData={keyData}
-        onClose={() => {}}
-        keyId={"test-key-id"}
-        onKeyDataUpdate={() => {}}
-        accessToken={"test-token"}
-        userID={teamAdminUserId}
-        userRole={"user"}
-        premiumUser={true}
-        teams={[]}
-      />,
+      <KeyInfoView keyData={keyData} onClose={() => {}} keyId={"test-key-id"} onKeyDataUpdate={() => {}} teams={[]} />,
     );
 
     await waitFor(() => {
@@ -207,20 +212,16 @@ describe("KeyInfoView", () => {
       setTeams: vi.fn(),
     });
 
+    vi.mocked(useAuthorized).mockReturnValue({
+      ...baseUseAuthorizedMock,
+      userId: "owner-user-id",
+      userRole: "user",
+    });
+
     const ownerUserId = "owner-user-id";
     const keyData = { ...MOCK_KEY_DATA, user_id: ownerUserId };
     render(
-      <KeyInfoView
-        keyData={keyData}
-        onClose={() => {}}
-        keyId={"test-key-id"}
-        onKeyDataUpdate={() => {}}
-        accessToken={"test-token"}
-        userID={ownerUserId}
-        userRole={"user"}
-        premiumUser={true}
-        teams={[]}
-      />,
+      <KeyInfoView keyData={keyData} onClose={() => {}} keyId={"test-key-id"} onKeyDataUpdate={() => {}} teams={[]} />,
     );
 
     await waitFor(() => {
@@ -235,19 +236,15 @@ describe("KeyInfoView", () => {
       setTeams: vi.fn(),
     });
 
+    vi.mocked(useAuthorized).mockReturnValue({
+      ...baseUseAuthorizedMock,
+      userId: "other-user-id",
+      userRole: "user",
+    });
+
     const keyData = { ...MOCK_KEY_DATA, user_id: "owner-user-id" };
     render(
-      <KeyInfoView
-        keyData={keyData}
-        onClose={() => {}}
-        keyId={"test-key-id"}
-        onKeyDataUpdate={() => {}}
-        accessToken={"test-token"}
-        userID={"other-user-id"}
-        userRole={"user"}
-        premiumUser={true}
-        teams={[]}
-      />,
+      <KeyInfoView keyData={keyData} onClose={() => {}} keyId={"test-key-id"} onKeyDataUpdate={() => {}} teams={[]} />,
     );
 
     await waitFor(() => {
@@ -262,20 +259,16 @@ describe("KeyInfoView", () => {
       setTeams: vi.fn(),
     });
 
+    vi.mocked(useAuthorized).mockReturnValue({
+      ...baseUseAuthorizedMock,
+      userId: "internal-viewer-user-id",
+      userRole: "Internal Viewer",
+    });
+
     const ownerUserId = "internal-viewer-user-id";
     const keyData = { ...MOCK_KEY_DATA, user_id: ownerUserId };
     render(
-      <KeyInfoView
-        keyData={keyData}
-        onClose={() => {}}
-        keyId={"test-key-id"}
-        onKeyDataUpdate={() => {}}
-        accessToken={"test-token"}
-        userID={ownerUserId}
-        userRole={"Internal Viewer"}
-        premiumUser={true}
-        teams={[]}
-      />,
+      <KeyInfoView keyData={keyData} onClose={() => {}} keyId={"test-key-id"} onKeyDataUpdate={() => {}} teams={[]} />,
     );
 
     await waitFor(() => {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -19,6 +19,7 @@ import ObjectPermissionsView from "../object_permissions_view";
 import { RegenerateKeyModal } from "../organisms/regenerate_key_modal";
 import { parseErrorMessage } from "../shared/errorUtils";
 import { KeyEditView } from "./key_edit_view";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 interface KeyInfoViewProps {
   keyId: string;
@@ -26,12 +27,7 @@ interface KeyInfoViewProps {
   keyData: KeyResponse | undefined;
   onKeyDataUpdate?: (data: Partial<KeyResponse>) => void;
   onDelete?: () => void;
-  accessToken: string | null;
-  userID: string | null;
-  userRole: string | null;
   teams: any[] | null;
-  premiumUser: boolean;
-  setAccessToken?: (token: string) => void;
   backButtonText?: string;
 }
 
@@ -43,19 +39,14 @@ interface KeyInfoViewProps {
  * ─────────────────────────────────────────────────────────────────────────
  */
 export default function KeyInfoView({
-  keyId,
   onClose,
   keyData,
-  accessToken,
-  userID,
-  userRole,
   teams,
   onKeyDataUpdate,
   onDelete,
-  premiumUser,
-  setAccessToken,
   backButtonText = "Back to Keys",
 }: KeyInfoViewProps) {
+  const { accessToken, userId: userID, userRole, premiumUser } = useAuthorized();
   const { teams: teamsData } = useTeams();
   const [isEditing, setIsEditing] = useState(false);
   const [form] = Form.useForm();
@@ -400,9 +391,6 @@ export default function KeyInfoView({
         selectedToken={currentKeyData}
         visible={isRegenerateModalOpen}
         onClose={() => setIsRegenerateModalOpen(false)}
-        accessToken={accessToken}
-        premiumUser={premiumUser}
-        setAccessToken={setAccessToken}
         onKeyUpdate={handleRegenerateKeyUpdate}
       />
 

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -526,12 +526,8 @@ export default function SpendLogsTable({
               <KeyInfoView
                 keyId={selectedKeyIdInfoView}
                 keyData={selectedKeyInfo}
-                accessToken={accessToken}
-                userID={userID}
-                userRole={userRole}
                 teams={allTeams}
                 onClose={() => setSelectedKeyIdInfoView(null)}
-                premiumUser={premiumUser}
                 backButtonText="Back to Logs"
               />
             ) : selectedSessionId ? (
@@ -968,10 +964,7 @@ export function RequestViewer({ row }: { row: Row<LogEntry> }) {
       </div>
 
       {/* Cost Breakdown - Show if cost breakdown data is available */}
-      <CostBreakdownViewer
-        costBreakdown={row.original.metadata?.cost_breakdown}
-        totalSpend={row.original.spend || 0}
-      />
+      <CostBreakdownViewer costBreakdown={row.original.metadata?.cost_breakdown} totalSpend={row.original.spend || 0} />
 
       {/* Configuration Info Message - Show when data is missing */}
       <ConfigInfoMessage show={missingData} />


### PR DESCRIPTION
## Relevant issues
The PR refactors the keys table to alleviate some technical debt that has accumulated over time. This PR changes the following:
1. accessToken, userId, userRole is now obtained from the reusable useAuthorized hook instead of props
2. Regenerate Key will not set the access token anymore. To my knowledge this key is never shown on the UI, and the access token is always given by useAuthorized, so it does not make sense to set it
3. Removed unused states and useEffects

No difference in behavior expected
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring
✅ Test

## Changes
<img width="833" height="172" alt="image" src="https://github.com/user-attachments/assets/a3f4d675-7848-460b-8cef-574d95c10882" />
