### PR TITLE
[Feature] UI - Key Table Loading Skeleton

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -236,3 +236,31 @@ it("should display user email correctly", async () => {
     expect(screen.getByText("user@example.com")).toBeInTheDocument();
   });
 });
+
+it("should show skeleton loaders when isLoading is true", () => {
+  // Mock loading state
+  mockUseKeys.mockReturnValue({
+    data: null,
+    isPending: true,
+    refetch: vi.fn(),
+  } as any);
+
+  const mockProps = {
+    teams: [mockTeam],
+    organizations: [mockOrganization],
+    onSortChange: vi.fn(),
+    currentSort: {
+      sortBy: "created_at",
+      sortOrder: "desc" as const,
+    },
+  };
+
+  renderWithProviders(<VirtualKeysTable {...mockProps} />);
+
+  // Check that loading message is shown
+  expect(screen.getByText("🚅 Loading keys...")).toBeInTheDocument();
+
+  // Check that actual key data is not shown
+  expect(screen.queryByText("Test Key Alias")).not.toBeInTheDocument();
+  expect(screen.queryByText("Test Team")).not.toBeInTheDocument();
+});

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -24,7 +24,7 @@ import {
   TableRow,
   Text,
 } from "@tremor/react";
-import { Tooltip } from "antd";
+import { Skeleton, Tooltip } from "antd";
 import React, { useEffect, useState } from "react";
 import { getModelDisplayName } from "../key_team_helpers/fetch_available_models_team_key";
 import { useFilterLogic } from "../key_team_helpers/filter_logic";
@@ -520,6 +520,10 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
     }
   }, [currentSort]);
 
+  const { pageIndex, pageSize } = table.getState().pagination;
+  const start = pageIndex * pageSize + 1;
+  const end = Math.min((pageIndex + 1) * pageSize, totalCount);
+  const rangeLabel = `${start} - ${end}`;
   return (
     <div className="w-full h-full overflow-hidden">
       {selectedKey ? (
@@ -541,38 +545,46 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
           </div>
 
           <div className="flex items-center justify-between w-full mb-4">
-            <span className="inline-flex text-sm text-gray-700">
-              Showing{" "}
-              {isLoading
-                ? "..."
-                : `${table.getState().pagination.pageIndex * table.getState().pagination.pageSize + 1} - ${Math.min(
-                    (table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize,
-                    totalCount,
-                  )}`}{" "}
-              of {isLoading ? "..." : totalCount} results
-            </span>
+            {isLoading ? (
+              <Skeleton.Input active style={{ width: 200, height: 20 }} />
+            ) : (
+              <span className="inline-flex text-sm text-gray-700">
+                Showing {rangeLabel} of {totalCount} results
+              </span>
+            )}
 
             <div className="inline-flex items-center gap-2">
-              <span className="text-sm text-gray-700">
-                Page {isLoading ? "..." : table.getState().pagination.pageIndex + 1} of{" "}
-                {isLoading ? "..." : table.getPageCount()}
-              </span>
+              {isLoading ? (
+                <Skeleton.Input active size="small" style={{ width: 50, height: 20 }} />
+              ) : (
+                <span className="text-sm text-gray-700">
+                  Page {pageIndex + 1} of {table.getPageCount()}
+                </span>
+              )}
 
-              <button
-                onClick={() => table.previousPage()}
-                disabled={isLoading || !table.getCanPreviousPage()}
-                className="px-3 py-1 text-sm border rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                Previous
-              </button>
+              {isLoading ? (
+                <Skeleton.Button active size="small" style={{ width: 84, height: 30 }} />
+              ) : (
+                <button
+                  onClick={() => table.previousPage()}
+                  disabled={isLoading || !table.getCanPreviousPage()}
+                  className="px-3 py-1 text-sm border rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Previous
+                </button>
+              )}
 
-              <button
-                onClick={() => table.nextPage()}
-                disabled={isLoading || !table.getCanNextPage()}
-                className="px-3 py-1 text-sm border rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                Next
-              </button>
+              {isLoading ? (
+                <Skeleton.Button active size="small" style={{ width: 58, height: 30 }} />
+              ) : (
+                <button
+                  onClick={() => table.nextPage()}
+                  disabled={isLoading || !table.getCanNextPage()}
+                  className="px-3 py-1 text-sm border rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Next
+                </button>
+              )}
             </div>
           </div>
           <div className="h-[75vh] overflow-auto">

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -1,4 +1,5 @@
 "use client";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Accordion, AccordionBody, AccordionHeader, Button, Col, Grid, Text, TextInput, Title } from "@tremor/react";
@@ -39,14 +40,10 @@ import VectorStoreSelector from "../vector_store_management/VectorStoreSelector"
 const { Option } = Select;
 
 interface CreateKeyProps {
-  userID: string;
   team: Team | null;
-  userRole: string | null;
-  accessToken: string;
   data: any[] | null;
   teams: Team[] | null;
   addKey: (data: any) => void;
-  premiumUser?: boolean;
 }
 
 interface User {
@@ -137,16 +134,8 @@ export const fetchUserModels = async (
  * Please contribute to the new refactor.
  * ─────────────────────────────────────────────────────────────────────────
  */
-const CreateKey: React.FC<CreateKeyProps> = ({
-  userID,
-  team,
-  teams,
-  userRole,
-  accessToken,
-  data,
-  addKey,
-  premiumUser = false,
-}) => {
+const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
+  const { accessToken, userId: userID, userRole, premiumUser } = useAuthorized();
   const [form] = Form.useForm();
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [apiKey, setApiKey] = useState(null);
@@ -170,7 +159,6 @@ const CreateKey: React.FC<CreateKeyProps> = ({
   const [modelAliases, setModelAliases] = useState<{ [key: string]: string }>({});
   const [autoRotationEnabled, setAutoRotationEnabled] = useState<boolean>(false);
   const [rotationInterval, setRotationInterval] = useState<string>("30d");
-
   const handleOk = () => {
     setIsModalVisible(false);
     form.resetFields();
@@ -490,14 +478,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
           + Create New Key
         </Button>
       )}
-      <Modal
-        // title="Create Key"
-        visible={isModalVisible}
-        width={1000}
-        footer={null}
-        onOk={handleOk}
-        onCancel={handleCancel}
-      >
+      <Modal open={isModalVisible} width={1000} footer={null} onOk={handleOk} onCancel={handleCancel}>
         <Form form={form} onFinish={handleCreate} labelCol={{ span: 8 }} wrapperCol={{ span: 16 }} labelAlign="left">
           {/* Section 1: Key Ownership */}
           <div className="mb-8">

--- a/ui/litellm-dashboard/src/components/user_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/user_dashboard.tsx
@@ -92,13 +92,7 @@ const UserDashboard: React.FC<UserDashboardProps> = ({
   const [teamSpend, setTeamSpend] = useState<number | null>(null);
   const [userModels, setUserModels] = useState<string[]>([]);
   const [proxySettings, setProxySettings] = useState<ProxySettings | null>(null);
-  const defaultTeam: TeamInterface = {
-    models: [],
-    team_alias: "Default Team",
-    team_id: null,
-  };
   const [selectedTeam, setSelectedTeam] = useState<any | null>(null);
-  const [selectedKeyAlias, setSelectedKeyAlias] = useState<string | null>(null);
   // check if window is not undefined
   if (typeof window !== "undefined") {
     window.addEventListener("beforeunload", function () {
@@ -352,14 +346,10 @@ const UserDashboard: React.FC<UserDashboardProps> = ({
         <Col numColSpan={1} className="flex flex-col gap-2">
           <CreateKey
             key={selectedTeam ? selectedTeam.team_id : null}
-            userID={userID}
             team={selectedTeam as Team | null}
             teams={teams as Team[]}
-            userRole={userRole}
-            accessToken={accessToken}
             data={keys}
             addKey={addKey}
-            premiumUser={premiumUser}
           />
           <VirtualKeysTable teams={teams} organizations={organizations} />
         </Col>


### PR DESCRIPTION
## Relevant issues
This PR adds loading skeletons for labels and buttons while the keys table is fetching data. This brings the Keys table more in line with the ideal design of the UI. This change should not affect the behavior of this table
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="773" height="173" alt="image" src="https://github.com/user-attachments/assets/0700565a-9d47-4110-b07e-5e241433a1fc" />
<img width="1415" height="306" alt="image" src="https://github.com/user-attachments/assets/708cc9a7-adf4-4a80-bbf4-3f99cd605322" />
