### PR TITLE
fix: add deprecation_date for discontinued Google models

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11632,6 +11632,7 @@
         "supports_tool_choice": true
     },
     "gemini-1.5-flash": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 2e-06,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
         "input_cost_per_character": 1.875e-08,
@@ -11736,6 +11737,7 @@
         "supports_vision": true
     },
     "gemini-1.5-flash-exp-0827": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 2e-06,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
         "input_cost_per_character": 1.875e-08,
@@ -11770,6 +11772,7 @@
         "supports_vision": true
     },
     "gemini-1.5-flash-preview-0514": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 2e-06,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
         "input_cost_per_character": 1.875e-08,
@@ -11803,6 +11806,7 @@
         "supports_vision": true
     },
     "gemini-1.5-pro": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -11890,6 +11894,7 @@
         "supports_vision": true
     },
     "gemini-1.5-pro-preview-0215": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -11917,6 +11922,7 @@
         "supports_tool_choice": true
     },
     "gemini-1.5-pro-preview-0409": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -11943,6 +11949,7 @@
         "supports_tool_choice": true
     },
     "gemini-1.5-pro-preview-0514": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -12214,6 +12221,7 @@
         "tpm": 250000
     },
     "gemini-2.0-flash-preview-image-generation": {
+        "deprecation_date": "2025-11-14",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
@@ -12252,6 +12260,7 @@
         "supports_web_search": true
     },
     "gemini-2.0-flash-thinking-exp": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -12300,6 +12309,7 @@
         "supports_web_search": true
     },
     "gemini-2.0-flash-thinking-exp-01-21": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -12486,6 +12496,7 @@
         "tpm": 8000000
     },
     "gemini-2.5-flash-image-preview": {
+        "deprecation_date": "2026-01-15",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -12796,6 +12807,7 @@
         "tpm": 8000000
     },
     "gemini-2.5-flash-lite-preview-06-17": {
+        "deprecation_date": "2025-11-18",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
@@ -12885,6 +12897,7 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-preview-05-20": {
+        "deprecation_date": "2025-11-18",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -13156,6 +13169,7 @@
         "supports_web_search": true
     },
     "gemini-2.5-pro-preview-03-25": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
@@ -13201,6 +13215,7 @@
         "supports_web_search": true
     },
     "gemini-2.5-pro-preview-05-06": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
@@ -13416,6 +13431,7 @@
         "tpm": 10000000
     },
     "gemini/gemini-1.5-flash": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 7.5e-08,
         "input_cost_per_token_above_128k_tokens": 1.5e-07,
         "litellm_provider": "gemini",
@@ -13499,6 +13515,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-8b": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13525,6 +13542,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-8b-exp-0827": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13550,6 +13568,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-8b-exp-0924": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13576,6 +13595,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-exp-0827": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13601,6 +13621,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-latest": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 7.5e-08,
         "input_cost_per_token_above_128k_tokens": 1.5e-07,
         "litellm_provider": "gemini",
@@ -13627,6 +13648,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 3.5e-06,
         "input_cost_per_token_above_128k_tokens": 7e-06,
         "litellm_provider": "gemini",
@@ -13688,6 +13710,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro-exp-0801": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 3.5e-06,
         "input_cost_per_token_above_128k_tokens": 7e-06,
         "litellm_provider": "gemini",
@@ -13707,6 +13730,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro-exp-0827": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13726,6 +13750,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro-latest": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 3.5e-06,
         "input_cost_per_token_above_128k_tokens": 7e-06,
         "litellm_provider": "gemini",
@@ -13908,6 +13933,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-2.0-flash-lite-preview-02-05": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 1.875e-08,
         "input_cost_per_audio_token": 7.5e-08,
         "input_cost_per_token": 7.5e-08,
@@ -13945,6 +13971,7 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.0-flash-live-001": {
+        "deprecation_date": "2025-12-09",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 2.1e-06,
         "input_cost_per_image": 2.1e-06,
@@ -13993,6 +14020,7 @@
         "tpm": 250000
     },
     "gemini/gemini-2.0-flash-preview-image-generation": {
+        "deprecation_date": "2025-11-14",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
@@ -14032,6 +14060,7 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.0-flash-thinking-exp": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -14081,6 +14110,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-2.0-flash-thinking-exp-01-21": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -14269,6 +14299,7 @@
         "tpm": 8000000
     },
     "gemini/gemini-2.5-flash-image-preview": {
+        "deprecation_date": "2026-01-15",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -14589,6 +14620,7 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-lite-preview-06-17": {
+        "deprecation_date": "2025-11-18",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
@@ -14680,6 +14712,7 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-preview-05-20": {
+        "deprecation_date": "2025-11-18",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -15026,6 +15059,7 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-pro-preview-03-25": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1.25e-06,
@@ -15066,6 +15100,7 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.5-pro-preview-05-06": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1.25e-06,
@@ -15341,6 +15376,7 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "gemini/imagen-3.0-generate-002": {
+        "deprecation_date": "2025-11-10",
         "litellm_provider": "gemini",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
@@ -15407,6 +15443,7 @@
         ]
     },
     "gemini/veo-3.0-fast-generate-preview": {
+        "deprecation_date": "2025-11-12",
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -15421,6 +15458,7 @@
         ]
     },
     "gemini/veo-3.0-generate-preview": {
+        "deprecation_date": "2025-11-12",
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -24776,6 +24814,7 @@
         "source": "https://docs.mistral.ai/capabilities/code_generation/"
     },
     "text-embedding-004": {
+        "deprecation_date": "2026-01-14",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -27546,6 +27585,7 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "vertex_ai/imagen-3.0-generate-002": {
+        "deprecation_date": "2025-11-10",
         "litellm_provider": "vertex_ai-image-models",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
@@ -28056,6 +28096,7 @@
         ]
     },
     "vertex_ai/veo-3.0-fast-generate-preview": {
+        "deprecation_date": "2025-11-12",
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -28070,6 +28111,7 @@
         ]
     },
     "vertex_ai/veo-3.0-generate-preview": {
+        "deprecation_date": "2025-11-12",
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,


### PR DESCRIPTION
  Add deprecation_date for Google models per official documentation:
  - https://ai.google.dev/gemini-api/docs/changelog (past shutdowns)
  - https://ai.google.dev/gemini-api/docs/deprecations (upcoming)

  Models updated:
  - 2025-09-29: gemini-1.5-flash, gemini-1.5-pro, gemini-1.5-flash-8b variants
  - 2025-11-10: imagen-3.0-generate-002
  - 2025-11-12: veo-3.0 preview models
  - 2025-11-14: gemini-2.0-flash image generation
  - 2025-11-18: gemini-2.5-flash preview models
  - 2025-12-02: gemini-2.0-flash-thinking-exp, pro previews, lite-preview
  - 2025-12-09: gemini-2.0-flash-live-001
  - 2026-01-14: text-embedding-004
  - 2026-01-15: gemini-2.5-flash-image-preview
 
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

## Changes
