### PR TITLE
fix: prevent LiteLLM from closing external OTEL spans

### DIFF
--- a/docs/my-website/docs/observability/opentelemetry_integration.md
+++ b/docs/my-website/docs/observability/opentelemetry_integration.md
@@ -12,7 +12,9 @@ OpenTelemetry is a CNCF standard for observability. It connects to any observabi
 
 From v1.81.0, the request/response will be set as attributes on the parent "Received Proxy Server Request" span by default. This allows you to see the request/response in the parent span in your observability tool.
 
-To use the older behavior with nested "litellm_request" spans, set the following environment variable:
+**Note:** When making multiple LLM calls within an external OTEL span context, the last call's attributes will overwrite previous calls' attributes on the parent span.
+
+To use the older behavior with nested "litellm_request" spans (which creates separate spans for each call), set the following environment variable:
 
 ```shell
 USE_OTEL_LITELLM_REQUEST_SPAN=true

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -233,14 +233,16 @@ class OpenTelemetry(CustomLogger):
                 trace.set_tracer_provider(tracer_provider)
         else:
             # Tracer provider explicitly provided (e.g., for testing)
+            # Do NOT call set_tracer_provider - the caller is responsible for managing global state
+            # If they want it to be global, they've already set it before passing it to us
             verbose_logger.debug(
                 "OpenTelemetry: Using provided TracerProvider: %s",
                 type(tracer_provider).__name__,
             )
-            trace.set_tracer_provider(tracer_provider)
 
-        # grab our tracer
-        self.tracer = trace.get_tracer(LITELLM_TRACER_NAME)
+        # Grab our tracer from the TracerProvider (not from global context)
+        # This ensures we use the provided TracerProvider (e.g., for testing)
+        self.tracer = tracer_provider.get_tracer(LITELLM_TRACER_NAME)
         self.span_kind = SpanKind
 
     def _init_metrics(self, meter_provider):
@@ -514,6 +516,7 @@ class OpenTelemetry(CustomLogger):
         response: LLMResponseTypes,
     ):
         from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
+        from opentelemetry.trace import Status, StatusCode
 
         litellm_logging_obj = data.get("litellm_logging_obj")
 
@@ -527,6 +530,12 @@ class OpenTelemetry(CustomLogger):
 
             # 3. Guardrail span
             self._create_guardrail_span(kwargs=kwargs, context=ctx)
+
+            # End the proxy request span (created by Proxy in create_litellm_proxy_request_started_span)
+            if parent_span is not None:
+                parent_span.set_status(Status(StatusCode.OK))
+                parent_span.end(end_time=self._to_ns(datetime.now()))
+
         return response
 
     #########################################################
@@ -557,9 +566,9 @@ class OpenTelemetry(CustomLogger):
 
     def _get_dynamic_otel_headers_from_kwargs(self, kwargs) -> Optional[dict]:
         """Extract dynamic headers from kwargs if available."""
-        standard_callback_dynamic_params: Optional[StandardCallbackDynamicParams] = (
-            kwargs.get("standard_callback_dynamic_params")
-        )
+        standard_callback_dynamic_params: Optional[
+            StandardCallbackDynamicParams
+        ] = kwargs.get("standard_callback_dynamic_params")
 
         if not standard_callback_dynamic_params:
             return None
@@ -607,18 +616,33 @@ class OpenTelemetry(CustomLogger):
         )
         ctx, parent_span = self._get_span_context(kwargs)
 
-        if get_secret_bool("USE_OTEL_LITELLM_REQUEST_SPAN"):
-            primary_span_parent = None
-        else:
-            primary_span_parent = parent_span
-
-        # 1. Primary span
-        span = self._start_primary_span(
-            kwargs, response_obj, start_time, end_time, ctx, primary_span_parent
+        # Decide whether to create a primary span
+        # Always create if no parent span exists (backward compatibility)
+        # OR if USE_OTEL_LITELLM_REQUEST_SPAN is explicitly enabled
+        should_create_primary_span = parent_span is None or get_secret_bool(
+            "USE_OTEL_LITELLM_REQUEST_SPAN"
         )
 
-        # 2. Raw‐request sub-span (if enabled)
-        self._maybe_log_raw_request(kwargs, response_obj, start_time, end_time, span)
+        if should_create_primary_span:
+            # Create a new litellm_request span
+            span = self._start_primary_span(
+                kwargs, response_obj, start_time, end_time, ctx
+            )
+            # Raw-request sub-span (if enabled) - child of litellm_request span
+            self._maybe_log_raw_request(
+                kwargs, response_obj, start_time, end_time, span
+            )
+        else:
+            # Do not create primary span (keep hierarchy shallow when parent exists)
+            from opentelemetry.trace import Status, StatusCode
+
+            span = None
+            parent_span.set_status(Status(StatusCode.OK))
+            self.set_attributes(parent_span, kwargs, response_obj)
+            # Raw-request as direct child of parent_span
+            self._maybe_log_raw_request(
+                kwargs, response_obj, start_time, end_time, parent_span
+            )
 
         # 3. Guardrail span
         self._create_guardrail_span(kwargs=kwargs, context=ctx)
@@ -628,12 +652,13 @@ class OpenTelemetry(CustomLogger):
 
         # 5. Semantic logs.
         if self.config.enable_events:
-            self._emit_semantic_logs(kwargs, response_obj, span)
+            log_span = span if span is not None else parent_span
+            if log_span is not None:
+                self._emit_semantic_logs(kwargs, response_obj, log_span)
 
-        # 6. End parent span (only if it wasn't reused as the primary span)
-        # If parent_span was reused as the primary span, it was already ended in _start_primary_span
-        if parent_span is not None and parent_span is not span:
-            parent_span.end(end_time=self._to_ns(datetime.now()))
+        # 6. Do NOT end parent span - it should be managed by its creator
+        # External spans (from Langfuse, user code, HTTP headers, global context) must not be closed by LiteLLM
+        # Proxy-created spans are closed in async_post_call_failure_hook (line 508)
 
     def _start_primary_span(
         self,
@@ -642,16 +667,19 @@ class OpenTelemetry(CustomLogger):
         start_time,
         end_time,
         context,
-        parent_span: Optional[Span] = None,
     ):
         from opentelemetry.trace import Status, StatusCode
 
         otel_tracer: Tracer = self.get_tracer_to_use_for_request(kwargs)
-        span = parent_span or otel_tracer.start_span(
+
+        # Always create a new span
+        # The parent relationship is preserved through the context parameter
+        span = otel_tracer.start_span(
             name=self._get_span_name(kwargs),
             start_time=self._to_ns(start_time),
             context=context,
         )
+
         span.set_status(Status(StatusCode.OK))
         self.set_attributes(span, kwargs, response_obj)
         span.end(end_time=self._to_ns(end_time))
@@ -764,10 +792,10 @@ class OpenTelemetry(CustomLogger):
             return float(val)
         # isinstance(val, str) - parse datetime string (with or without microseconds)
         try:
-            return datetime.strptime(val, '%Y-%m-%d %H:%M:%S.%f').timestamp()
+            return datetime.strptime(val, "%Y-%m-%d %H:%M:%S.%f").timestamp()
         except ValueError:
             try:
-                return datetime.strptime(val, '%Y-%m-%d %H:%M:%S').timestamp()
+                return datetime.strptime(val, "%Y-%m-%d %H:%M:%S").timestamp()
             except ValueError:
                 return None
 
@@ -775,23 +803,23 @@ class OpenTelemetry(CustomLogger):
         """Record Time to First Token (TTFT) metric for streaming requests."""
         optional_params = kwargs.get("optional_params", {})
         is_streaming = optional_params.get("stream", False)
-        
+
         if not (self._time_to_first_token_histogram and is_streaming):
             return
-        
+
         # Use api_call_start_time for precision (matches Prometheus implementation)
         # This excludes LiteLLM overhead and measures pure LLM API latency
         api_call_start_time = kwargs.get("api_call_start_time", None)
         completion_start_time = kwargs.get("completion_start_time", None)
-        
+
         if api_call_start_time is not None and completion_start_time is not None:
             # Convert to timestamps if needed (handles datetime, float, and string)
             api_call_start_ts = self._to_timestamp(api_call_start_time)
             completion_start_ts = self._to_timestamp(completion_start_time)
-            
+
             if api_call_start_ts is None or completion_start_ts is None:
                 return  # Skip recording if conversion failed
-            
+
             time_to_first_token_seconds = completion_start_ts - api_call_start_ts
             self._time_to_first_token_histogram.record(
                 time_to_first_token_seconds, attributes=common_attrs
@@ -806,38 +834,40 @@ class OpenTelemetry(CustomLogger):
         common_attrs: dict,
     ):
         """Record Time Per Output Token (TPOT) metric.
-        
+
         Calculated as: generation_time / completion_tokens
         - For streaming: uses end_time - completion_start_time (time to generate all tokens after first)
         - For non-streaming: uses end_time - api_call_start_time (total generation time)
         """
         if not self._time_per_output_token_histogram:
             return
-        
+
         # Get completion tokens from response_obj
         completion_tokens = None
         if response_obj and (usage := response_obj.get("usage")):
             completion_tokens = usage.get("completion_tokens")
-        
+
         if completion_tokens is None or completion_tokens <= 0:
             return
-        
+
         # Calculate generation time
         completion_start_time = kwargs.get("completion_start_time", None)
         api_call_start_time = kwargs.get("api_call_start_time", None)
-        
+
         # Convert end_time to timestamp (handles datetime, float, and string)
         end_time_ts = self._to_timestamp(end_time)
         if end_time_ts is None:
             # Fallback to duration_s if conversion failed
             generation_time_seconds = duration_s
             if generation_time_seconds > 0:
-                time_per_output_token_seconds = generation_time_seconds / completion_tokens
+                time_per_output_token_seconds = (
+                    generation_time_seconds / completion_tokens
+                )
                 self._time_per_output_token_histogram.record(
                     time_per_output_token_seconds, attributes=common_attrs
                 )
             return
-        
+
         if completion_start_time is not None:
             # Streaming: use completion_start_time (when first token arrived)
             # This measures time to generate all tokens after the first one
@@ -858,7 +888,7 @@ class OpenTelemetry(CustomLogger):
         else:
             # Fallback: use duration_s (already calculated as (end_time - start_time).total_seconds())
             generation_time_seconds = duration_s
-        
+
         if generation_time_seconds > 0:
             time_per_output_token_seconds = generation_time_seconds / completion_tokens
             self._time_per_output_token_histogram.record(
@@ -872,37 +902,37 @@ class OpenTelemetry(CustomLogger):
         common_attrs: dict,
     ):
         """Record Total Generation Time (response duration) metric.
-        
+
         Measures pure LLM API generation time: end_time - api_call_start_time
         This excludes LiteLLM overhead and measures only the LLM provider's response time.
         Works for both streaming and non-streaming requests.
-        
+
         Mirrors Prometheus's litellm_llm_api_latency_metric.
         Uses kwargs.get("end_time") with fallback to parameter for consistency with Prometheus.
         """
         if not self._response_duration_histogram:
             return
-        
+
         api_call_start_time = kwargs.get("api_call_start_time", None)
         if api_call_start_time is None:
             return
-        
+
         # Use end_time from kwargs if available (matches Prometheus), otherwise use parameter
         # For streaming: end_time is when the stream completes (final chunk received)
         # For non-streaming: end_time is when the response is received
         _end_time = kwargs.get("end_time") or end_time
         if _end_time is None:
             _end_time = datetime.now()
-        
+
         # Convert to timestamps if needed (handles datetime, float, and string)
         api_call_start_ts = self._to_timestamp(api_call_start_time)
         end_time_ts = self._to_timestamp(_end_time)
-        
+
         if api_call_start_ts is None or end_time_ts is None:
             return  # Skip recording if conversion failed
-        
+
         response_duration_seconds = end_time_ts - api_call_start_ts
-        
+
         if response_duration_seconds > 0:
             self._response_duration_histogram.record(
                 response_duration_seconds, attributes=common_attrs
@@ -1065,26 +1095,41 @@ class OpenTelemetry(CustomLogger):
         )
         _parent_context, parent_otel_span = self._get_span_context(kwargs)
 
-        # Span 1: Requst sent to litellm SDK
-        otel_tracer: Tracer = self.get_tracer_to_use_for_request(kwargs)
-        span = otel_tracer.start_span(
-            name=self._get_span_name(kwargs),
-            start_time=self._to_ns(start_time),
-            context=_parent_context,
+        # Decide whether to create a primary span
+        # Always create if no parent span exists (backward compatibility)
+        # OR if USE_OTEL_LITELLM_REQUEST_SPAN is explicitly enabled
+        should_create_primary_span = parent_otel_span is None or get_secret_bool(
+            "USE_OTEL_LITELLM_REQUEST_SPAN"
         )
-        span.set_status(Status(StatusCode.ERROR))
-        self.set_attributes(span, kwargs, response_obj)
 
-        # Record exception information using OTEL standard method
-        self._record_exception_on_span(span=span, kwargs=kwargs)
+        if should_create_primary_span:
+            # Span 1: Request sent to litellm SDK
+            otel_tracer: Tracer = self.get_tracer_to_use_for_request(kwargs)
+            span = otel_tracer.start_span(
+                name=self._get_span_name(kwargs),
+                start_time=self._to_ns(start_time),
+                context=_parent_context,
+            )
+            span.set_status(Status(StatusCode.ERROR))
+            self.set_attributes(span, kwargs, response_obj)
 
-        span.end(end_time=self._to_ns(end_time))
+            # Record exception information using OTEL standard method
+            self._record_exception_on_span(span=span, kwargs=kwargs)
+
+            span.end(end_time=self._to_ns(end_time))
+        else:
+            # When parent span exists and USE_OTEL_LITELLM_REQUEST_SPAN=false,
+            # record error on parent span (keeps hierarchy shallow)
+            parent_otel_span.set_status(Status(StatusCode.ERROR))
+            self.set_attributes(parent_otel_span, kwargs, response_obj)
+            self._record_exception_on_span(span=parent_otel_span, kwargs=kwargs)
 
         # Create span for guardrail information
         self._create_guardrail_span(kwargs=kwargs, context=_parent_context)
 
-        if parent_otel_span is not None:
-            parent_otel_span.end(end_time=self._to_ns(datetime.now()))
+        # Do NOT end parent span - it should be managed by its creator
+        # External spans (from Langfuse, user code, HTTP headers, global context) must not be closed by LiteLLM
+        # Proxy-created spans are closed in async_post_call_failure_hook (line 508)
 
     def _record_exception_on_span(self, span: Span, kwargs: dict):
         """
@@ -1263,7 +1308,9 @@ class OpenTelemetry(CustomLogger):
                 )
                 return
             elif self.callback_name == "weave_otel":
-                from litellm.integrations.weave.weave_otel import set_weave_otel_attributes
+                from litellm.integrations.weave.weave_otel import (
+                    set_weave_otel_attributes,
+                )
 
                 set_weave_otel_attributes(span, kwargs, response_obj)
                 return
@@ -1994,7 +2041,7 @@ class OpenTelemetry(CustomLogger):
         """
         Create a span for the received proxy server request.
         """
-        
+
         return self.tracer.start_span(
             name="Received Proxy Server Request",
             start_time=self._to_ns(start_time),


### PR DESCRIPTION
## Relevant issues

Fixes #16779
https://github.com/langfuse/langfuse/issues/10532

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/52935/workflows/6532851b-858c-4413-b21c-6fa19cc3c47f

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/52934/workflows/9ad75734-27d0-4171-9a6c-adf609df9284

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
📖 Documentation
✅ Test

## Changes

Fixed a critical bug where LiteLLM incorrectly closed external OpenTelemetry spans, preventing multiple LLM calls within the same parent span context.