### PR TITLE
[Fix] CI/CD - litellm_utils_testing

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -554,6 +554,7 @@ amazon_nova_models: Set = set()
 stability_models: Set = set()
 github_copilot_models: Set = set()
 minimax_models: Set = set()
+aws_polly_models: Set = set()
 
 
 def is_bedrock_pricing_only_model(key: str) -> bool:
@@ -804,6 +805,8 @@ def add_known_models():
             github_copilot_models.add(key)
         elif value.get("litellm_provider") == "minimax":
             minimax_models.add(key)
+        elif value.get("litellm_provider") == "aws_polly":
+            aws_polly_models.add(key)
 
 
 add_known_models()
@@ -1009,6 +1012,7 @@ models_by_provider: dict = {
     "stability": stability_models,
     "github_copilot": github_copilot_models,
     "minimax": minimax_models,
+    "aws_polly": aws_polly_models,
 }
 
 # mapping for those models which have larger equivalents

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -553,6 +553,7 @@ docker_model_runner_models: Set = set()
 amazon_nova_models: Set = set()
 stability_models: Set = set()
 github_copilot_models: Set = set()
+minimax_models: Set = set()
 
 
 def is_bedrock_pricing_only_model(key: str) -> bool:
@@ -801,6 +802,8 @@ def add_known_models():
             stability_models.add(key)
         elif value.get("litellm_provider") == "github_copilot":
             github_copilot_models.add(key)
+        elif value.get("litellm_provider") == "minimax":
+            minimax_models.add(key)
 
 
 add_known_models()
@@ -1005,6 +1008,7 @@ models_by_provider: dict = {
     "amazon_nova": amazon_nova_models,
     "stability": stability_models,
     "github_copilot": github_copilot_models,
+    "minimax": minimax_models,
 }
 
 # mapping for those models which have larger equivalents

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18117,6 +18117,18 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
+    "groq/gemma-7b-it": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 8e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
     "groq/meta-llama/llama-guard-4-12b": {
         "input_cost_per_token": 2e-07,
         "litellm_provider": "groq",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18175,6 +18175,18 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
+    "groq/gemma-7b-it": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 8e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
     "groq/meta-llama/llama-guard-4-12b": {
         "input_cost_per_token": 2e-07,
         "litellm_provider": "groq",


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: [Baseline](https://app.circleci.com/pipelines/github/BerriAI/litellm/52971/workflows/51df542f-a490-4a25-b97d-df48794b37a9)

- [x] **CI run for the last commit**  
       Link: [Last Commit](https://app.circleci.com/pipelines/github/BerriAI/litellm/52975/workflows/8fca0146-7ea5-4ec8-8807-2c9cff512225)

- [ ] **Merge / cherry-pick CI run**  
       Links: **None**

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- **Added `minimax` provider support to `models_by_provider`**
  - Added `minimax_models` set definition in `litellm/__init__.py`
  - Added handling in `add_known_models()` to populate `minimax_models` from the model cost map
  - Added `"minimax": minimax_models` entry to the `models_by_provider` dictionary
  - Fixes `test_models_by_provider` assertion error where `'minimax'` was missing

- **Added `aws_polly` provider support to `models_by_provider`**
  - Added `aws_polly_models` set definition in `litellm/__init__.py`
  - Added handling in `add_known_models()` to populate `aws_polly_models` from the model cost map
  - Added `"aws_polly": aws_polly_models` entry to the `models_by_provider` dictionary
  - Fixes `test_models_by_provider` assertion error where `'aws_polly'` was missing

- **Added `groq/gemma-7b-it` model to model cost maps**
  - Added model entry to `model_prices_and_context_window.json` with pricing and capabilities
  - Added model entry to `litellm/model_prices_and_context_window_backup.json` (used when `LITELLM_LOCAL_MODEL_COST_MAP=True`)
  - Configured with:
    - Input cost: `5e-08` per token
    - Output cost: `8e-08` per token
    - Max tokens: 8192
    - `supports_function_calling: true`
    - `supports_tool_choice: true`
  - Fixes `test_supports_function_calling` failure for `groq/gemma-7b-it`
