### PR TITLE
Feat/add watsonx fields

### DIFF
--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -2865,8 +2865,8 @@
         "key": "api_base",
         "label": "API Base",
         "placeholder": null,
-        "tooltip": null,
-        "required": true,
+        "tooltip": "Base URL of your WatsonX instance",
+        "required": false,
         "field_type": "text",
         "options": null,
         "default_value": null
@@ -2875,8 +2875,28 @@
         "key": "api_key",
         "label": "API Key",
         "placeholder": null,
-        "tooltip": null,
-        "required": true,
+        "tooltip": "IBM Cloud API key. Required if not using Token or Zen API Key",
+        "required": false,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "token",
+        "label": "IAM Token",
+        "placeholder": null,
+        "tooltip": "Pre-generated IAM bearer token. Use instead of API Key if you manage tokens externally",
+        "required": false,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "zen_api_key",
+        "label": "Zen API Key",
+        "placeholder": null,
+        "tooltip": "Zen API Key for Cloud Pak for Data deployments. Use instead of API Key for on-premises",
+        "required": false,
         "field_type": "password",
         "options": null,
         "default_value": null
@@ -2885,8 +2905,8 @@
         "key": "project_id",
         "label": "Project ID",
         "placeholder": null,
-        "tooltip": "Your Watsonx.ai Project ID",
-        "required": true,
+        "tooltip": "Optional: Your Watsonx.ai Project ID",
+        "required": false,
         "field_type": "text",
         "options": null,
         "default_value": null

--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -2866,7 +2866,7 @@
         "label": "API Base",
         "placeholder": null,
         "tooltip": null,
-        "required": false,
+        "required": true,
         "field_type": "text",
         "options": null,
         "default_value": null
@@ -2876,13 +2876,29 @@
         "label": "API Key",
         "placeholder": null,
         "tooltip": null,
-        "required": false,
+        "required": true,
         "field_type": "password",
         "options": null,
         "default_value": null
+      },
+      {
+        "key": "project_id",
+        "label": "Project ID",
+        "placeholder": null,
+        "tooltip": "Your Watsonx.ai Project ID",
+        "required": true,
+        "field_type": "text"
+      },
+      {
+        "key": "space_id",
+        "label": "Deployment Space ID",
+        "placeholder": null,
+        "tooltip": "Optional: Watsonx.ai Deployment Space ID",
+        "required": false,
+        "field_type": "text"
       }
     ],
-    "default_model_placeholder": "gpt-3.5-turbo"
+    "default_model_placeholder": "watsonx/ibm/granite-3-3-8b-instruct"
   },
   {
     "provider": "WATSONX_TEXT",

--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -2887,7 +2887,9 @@
         "placeholder": null,
         "tooltip": "Your Watsonx.ai Project ID",
         "required": true,
-        "field_type": "text"
+        "field_type": "text",
+        "options": null,
+        "default_value": null
       },
       {
         "key": "space_id",
@@ -2895,7 +2897,9 @@
         "placeholder": null,
         "tooltip": "Optional: Watsonx.ai Deployment Space ID",
         "required": false,
-        "field_type": "text"
+        "field_type": "text",
+        "options": null,
+        "default_value": null
       }
     ],
     "default_model_placeholder": "watsonx/ibm/granite-3-3-8b-instruct"

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -78,3 +78,20 @@ def test_get_litellm_model_cost_map_returns_cost_map():
     # Check for common cost fields that should be present
     assert "input_cost_per_token" in sample_model_data or "output_cost_per_token" in sample_model_data
 
+
+def test_watsonx_provider_fields():
+    """Test that Watsonx provider has project_id and space_id fields."""
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/public/providers/fields")
+    providers = response.json()
+
+    watsonx = next((p for p in providers if p["provider"] == "WATSONX"), None)
+    assert watsonx is not None
+
+    field_keys = [f["key"] for f in watsonx["credential_fields"]]
+    assert "project_id" in field_keys
+    assert "space_id" in field_keys
+

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -80,7 +80,7 @@ def test_get_litellm_model_cost_map_returns_cost_map():
 
 
 def test_watsonx_provider_fields():
-    """Test that Watsonx provider has project_id and space_id fields."""
+    """Test that Watsonx provider has all required credential fields including multiple auth options."""
     app = FastAPI()
     app.include_router(router)
     client = TestClient(app)
@@ -92,6 +92,12 @@ def test_watsonx_provider_fields():
     assert watsonx is not None
 
     field_keys = [f["key"] for f in watsonx["credential_fields"]]
+    # Core fields
+    assert "api_base" in field_keys
     assert "project_id" in field_keys
     assert "space_id" in field_keys
+    # Multiple auth methods supported
+    assert "api_key" in field_keys
+    assert "token" in field_keys
+    assert "zen_api_key" in field_keys
 

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -1,4 +1,3 @@
-
 export enum Providers {
   A2A_Agent = "A2A Agent",
   AIML = "AI/ML API",
@@ -43,6 +42,7 @@ export enum Providers {
   Voyage = "Voyage AI",
   xAI = "xAI",
   SAP = "SAP Generative AI Hub",
+  Watsonx = "Watsonx",
 }
 
 export const provider_map: Record<string, string> = {
@@ -88,7 +88,8 @@ export const provider_map: Record<string, string> = {
   DeepInfra: "deepinfra",
   Hosted_Vllm: "hosted_vllm",
   Infinity: "infinity",
-    SAP: "sap",
+  SAP: "sap",
+  Watsonx: "watsonx",
 };
 
 const asset_logos_folder = "../ui/assets/logos/";
@@ -136,7 +137,7 @@ export const providerLogoMap: Record<string, string> = {
   [Providers.JinaAI]: `${asset_logos_folder}jina.png`,
   [Providers.VolcEngine]: `${asset_logos_folder}volcengine.png`,
   [Providers.DeepInfra]: `${asset_logos_folder}deepinfra.png`,
-    [Providers.SAP]: `${asset_logos_folder}sap.png`,
+  [Providers.SAP]: `${asset_logos_folder}sap.png`,
 };
 
 export const getProviderLogoAndName = (providerValue: string): { logo: string; displayName: string } => {
@@ -200,6 +201,8 @@ export const getPlaceholder = (selectedProvider: string): string => {
     return "fal_ai/fal-ai/flux-pro/v1.1-ultra";
   } else if (selectedProvider == Providers.RunwayML) {
     return "runwayml/gen4_turbo";
+  } else if (selectedProvider === Providers.Watsonx) {
+    return "watsonx/ibm/granite-3-3-8b-instruct";
   } else {
     return "gpt-3.5-turbo";
   }


### PR DESCRIPTION
## Relevant issues
Implements requested feature from #18364. Watsonx provider was already available in the dropdown menu, only missing fields were needed. Decided to add a correct placeholder. 

Closes #18364

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
📖 Documentation

## Changes
- Add required field for project_id and optional field for space_id
- Make api_base and api_key required fields, as outlined in the issue
- Add test for new watsonx provider fields
- Add watsonx to the providers enum and add valid placeholder, which was displayed in the issue
- Small formatting change in `ui/litellm-dashboard/src/components/provider_info_helpers.tsx`
