### PR TITLE
[Fix] UI - Change Budget page to Have Tabs

### DIFF
--- a/ui/litellm-dashboard/src/components/budgets/budget_panel.tsx
+++ b/ui/litellm-dashboard/src/components/budgets/budget_panel.tsx
@@ -27,6 +27,7 @@ import NotificationsManager from "../molecules/notifications_manager";
 import { budgetDeleteCall, getBudgetList } from "../networking";
 import BudgetModal from "./budget_modal";
 import EditBudgetModal from "./edit_budget_modal";
+import { CREATE_END_USER_CURL_COMMAND, CHAT_COMPLETIONS_CURL_COMMAND, OPENAI_SDK_PYTHON_CODE } from "./constants";
 
 interface BudgetSettingsPageProps {
   accessToken: string | null;
@@ -110,139 +111,111 @@ const BudgetPanel: React.FC<BudgetSettingsPageProps> = ({ accessToken }) => {
       <Button size="sm" variant="primary" className="mb-2" onClick={() => setIsCreateModelVisible(true)}>
         + Create Budget
       </Button>
-      <BudgetModal
-        accessToken={accessToken}
-        isModalVisible={isCreateModelVisible}
-        setIsModalVisible={setIsCreateModelVisible}
-        setBudgetList={setBudgetList}
-      />
-      {selectedBudget && (
-        <EditBudgetModal
-          accessToken={accessToken}
-          isModalVisible={isEditModalVisible}
-          setIsModalVisible={setIsEditModalVisible}
-          setBudgetList={setBudgetList}
-          existingBudget={selectedBudget}
-          handleUpdateCall={handleUpdateCall}
-        />
-      )}
-      <Card>
-        <Text>Create a budget to assign to customers.</Text>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableHeaderCell>Budget ID</TableHeaderCell>
-              <TableHeaderCell>Max Budget</TableHeaderCell>
-              <TableHeaderCell>TPM</TableHeaderCell>
-              <TableHeaderCell>RPM</TableHeaderCell>
-            </TableRow>
-          </TableHead>
+      <TabGroup>
+        <TabList>
+          <Tab>Budgets</Tab>
+          <Tab>Examples</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <div className="mt-6">
+              <BudgetModal
+                accessToken={accessToken}
+                isModalVisible={isCreateModelVisible}
+                setIsModalVisible={setIsCreateModelVisible}
+                setBudgetList={setBudgetList}
+              />
+              {selectedBudget && (
+                <EditBudgetModal
+                  accessToken={accessToken}
+                  isModalVisible={isEditModalVisible}
+                  setIsModalVisible={setIsEditModalVisible}
+                  setBudgetList={setBudgetList}
+                  existingBudget={selectedBudget}
+                  handleUpdateCall={handleUpdateCall}
+                />
+              )}
+              <Card>
+                <Text>Create a budget to assign to customers.</Text>
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableHeaderCell>Budget ID</TableHeaderCell>
+                      <TableHeaderCell>Max Budget</TableHeaderCell>
+                      <TableHeaderCell>TPM</TableHeaderCell>
+                      <TableHeaderCell>RPM</TableHeaderCell>
+                    </TableRow>
+                  </TableHead>
 
-          <TableBody>
-            {budgetList
-              .slice() // Creates a shallow copy to avoid mutating the original array
-              .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()) // Sort by updated_at in descending order
-              .map((value: budgetItem, index: number) => (
-                <TableRow key={index}>
-                  <TableCell>{value.budget_id}</TableCell>
-                  <TableCell>{value.max_budget ? value.max_budget : "n/a"}</TableCell>
-                  <TableCell>{value.tpm_limit ? value.tpm_limit : "n/a"}</TableCell>
-                  <TableCell>{value.rpm_limit ? value.rpm_limit : "n/a"}</TableCell>
-                  <TableIconActionButton
-                    variant="Edit"
-                    tooltipText="Edit budget"
-                    onClick={() => handleEditCall(value)}
-                  />
-                  <TableIconActionButton
-                    variant="Delete"
-                    tooltipText="Delete budget"
-                    onClick={() => handleDeleteClick(value)}
-                  />
-                </TableRow>
-              ))}
-          </TableBody>
-        </Table>
-      </Card>
-      <DeleteResourceModal
-        isOpen={isDeleteModalVisible}
-        title="Delete Budget?"
-        message="Are you sure you want to delete this budget? This action cannot be undone."
-        resourceInformationTitle="Budget Information"
-        resourceInformation={[
-          { label: "Budget ID", value: selectedBudget?.budget_id, code: true },
-          { label: "Max Budget", value: selectedBudget?.max_budget },
-          { label: "TPM", value: selectedBudget?.tpm_limit },
-          { label: "RPM", value: selectedBudget?.rpm_limit },
-        ]}
-        onCancel={handleDeleteCancel}
-        onOk={handleDeleteConfirm}
-        confirmLoading={isDeleting}
-      />
-      <div className="mt-5">
-        <Text className="text-base">How to use budget id</Text>
-        <TabGroup>
-          <TabList>
-            <Tab>Assign Budget to Customer</Tab>
-            <Tab>Test it (Curl)</Tab>
-
-            <Tab>Test it (OpenAI SDK)</Tab>
-          </TabList>
-          <TabPanels>
-            <TabPanel>
-              <SyntaxHighlighter language="bash">
-                {`
-curl -X POST --location '<your_proxy_base_url>/end_user/new' \
-
--H 'Authorization: Bearer <your-master-key>' \
-
--H 'Content-Type: application/json' \
-
--d '{"user_id": "my-customer-id', "budget_id": "<BUDGET_ID>"}' # 👈 KEY CHANGE
-
-            `}
-              </SyntaxHighlighter>
-            </TabPanel>
-            <TabPanel>
-              <SyntaxHighlighter language="bash">
-                {`
-curl -X POST --location '<your_proxy_base_url>/chat/completions' \
-
--H 'Authorization: Bearer <your-master-key>' \
-
--H 'Content-Type: application/json' \
-
--d '{
-  "model": "gpt-3.5-turbo', 
-  "messages":[{"role": "user", "content": "Hey, how's it going?"}],
-  "user": "my-customer-id"
-}' # 👈 KEY CHANGE
-
-            `}
-              </SyntaxHighlighter>
-            </TabPanel>
-            <TabPanel>
-              <SyntaxHighlighter language="python">
-                {`from openai import OpenAI
-client = OpenAI(
-  base_url="<your_proxy_base_url>",
-  api_key="<your_proxy_key>"
-)
-
-completion = client.chat.completions.create(
-  model="gpt-3.5-turbo",
-  messages=[
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": "Hello!"}
-  ],
-  user="my-customer-id"
-)
-
-print(completion.choices[0].message)`}
-              </SyntaxHighlighter>
-            </TabPanel>
-          </TabPanels>
-        </TabGroup>
-      </div>
+                  <TableBody>
+                    {budgetList
+                      .slice() // Creates a shallow copy to avoid mutating the original array
+                      .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()) // Sort by updated_at in descending order
+                      .map((value: budgetItem, index: number) => (
+                        <TableRow key={index}>
+                          <TableCell>{value.budget_id}</TableCell>
+                          <TableCell>{value.max_budget ? value.max_budget : "n/a"}</TableCell>
+                          <TableCell>{value.tpm_limit ? value.tpm_limit : "n/a"}</TableCell>
+                          <TableCell>{value.rpm_limit ? value.rpm_limit : "n/a"}</TableCell>
+                          <TableIconActionButton
+                            variant="Edit"
+                            tooltipText="Edit budget"
+                            onClick={() => handleEditCall(value)}
+                            dataTestId="edit-budget-button"
+                          />
+                          <TableIconActionButton
+                            variant="Delete"
+                            tooltipText="Delete budget"
+                            onClick={() => handleDeleteClick(value)}
+                            dataTestId="delete-budget-button"
+                          />
+                        </TableRow>
+                      ))}
+                  </TableBody>
+                </Table>
+              </Card>
+              <DeleteResourceModal
+                isOpen={isDeleteModalVisible}
+                title="Delete Budget?"
+                message="Are you sure you want to delete this budget? This action cannot be undone."
+                resourceInformationTitle="Budget Information"
+                resourceInformation={[
+                  { label: "Budget ID", value: selectedBudget?.budget_id, code: true },
+                  { label: "Max Budget", value: selectedBudget?.max_budget },
+                  { label: "TPM", value: selectedBudget?.tpm_limit },
+                  { label: "RPM", value: selectedBudget?.rpm_limit },
+                ]}
+                onCancel={handleDeleteCancel}
+                onOk={handleDeleteConfirm}
+                confirmLoading={isDeleting}
+              />
+            </div>
+          </TabPanel>
+          <TabPanel>
+            <div className="mt-6">
+              <Text className="text-base">How to use budget id</Text>
+              <TabGroup>
+                <TabList>
+                  <Tab>Assign Budget to Customer</Tab>
+                  <Tab>Test it (Curl)</Tab>
+                  <Tab>Test it (OpenAI SDK)</Tab>
+                </TabList>
+                <TabPanels>
+                  <TabPanel>
+                    <SyntaxHighlighter language="bash">{CREATE_END_USER_CURL_COMMAND}</SyntaxHighlighter>
+                  </TabPanel>
+                  <TabPanel>
+                    <SyntaxHighlighter language="bash">{CHAT_COMPLETIONS_CURL_COMMAND}</SyntaxHighlighter>
+                  </TabPanel>
+                  <TabPanel>
+                    <SyntaxHighlighter language="python">{OPENAI_SDK_PYTHON_CODE}</SyntaxHighlighter>
+                  </TabPanel>
+                </TabPanels>
+              </TabGroup>
+            </div>
+          </TabPanel>
+        </TabPanels>
+      </TabGroup>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/components/budgets/constants.ts
+++ b/ui/litellm-dashboard/src/components/budgets/constants.ts
@@ -1,0 +1,42 @@
+export const CREATE_END_USER_CURL_COMMAND = `
+curl -X POST --location '<your_proxy_base_url>/end_user/new' \\
+
+-H 'Authorization: Bearer <your-master-key>' \\
+
+-H 'Content-Type: application/json' \\
+
+-d '{"user_id": "my-customer-id', "budget_id": "<BUDGET_ID>"}' # 👈 KEY CHANGE
+
+`;
+
+export const CHAT_COMPLETIONS_CURL_COMMAND = `
+curl -X POST --location '<your_proxy_base_url>/chat/completions' \\
+
+-H 'Authorization: Bearer <your-master-key>' \\
+
+-H 'Content-Type: application/json' \\
+
+-d '{
+  "model": "gpt-3.5-turbo',
+  "messages":[{"role": "user", "content": "Hey, how's it going?"}],
+  "user": "my-customer-id"
+}' # 👈 KEY CHANGE
+
+`;
+
+export const OPENAI_SDK_PYTHON_CODE = `from openai import OpenAI
+client = OpenAI(
+  base_url="<your_proxy_base_url>",
+  api_key="<your_proxy_key>"
+)
+
+completion = client.chat.completions.create(
+  model="gpt-3.5-turbo",
+  messages=[
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello!"}
+  ],
+  user="my-customer-id"
+)
+
+print(completion.choices[0].message)`;


### PR DESCRIPTION
## Relevant issues
The budget page has 2 components that are stacked on top of each other, and this deviates from the usual tab pattern that we have in the UI. This PR changes the budget page to be organized in tabs, updates existing tests, as well as increasing the test coverage for this component.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="1002" height="240" alt="image" src="https://github.com/user-attachments/assets/4e4f58bf-5fe9-48c2-b876-262148abc9f8" />
<img width="1483" height="321" alt="image" src="https://github.com/user-attachments/assets/c6c34804-b3c6-48a3-8230-7b79543f0f40" />
