### PR TITLE
Feature: Add `log_format` option to GenericAPILogger

### DIFF
--- a/docs/my-website/docs/observability/generic_api.md
+++ b/docs/my-website/docs/observability/generic_api.md
@@ -47,6 +47,7 @@ callback_settings:
 | `endpoint` | string | Yes | HTTP endpoint to send logs to |
 | `headers` | dict | No | Custom headers for the request |
 | `event_types` | list | No | Filter events: `llm_api_success`, `llm_api_failure`. Defaults to all events. |
+| `log_format` | string | No | Output format: `json_array` (default), `ndjson`, or `single`. Controls how logs are batched and sent. |
 
 ## Pre-configured Callbacks
 
@@ -106,5 +107,63 @@ callback_settings:
     batch_size: 100        # default: 100
     flush_interval: 60     # seconds, default: 60
 ```
+
+## Log Format Options
+
+Control how logs are formatted and sent to your endpoint.
+
+### JSON Array (Default)
+
+```yaml
+callback_settings:
+  my_api:
+    callback_type: generic_api
+    endpoint: https://your-endpoint.com
+    log_format: json_array  # default if not specified
+```
+
+Sends all logs in a batch as a single JSON array `[{log1}, {log2}, ...]`. This is the default behavior and maintains backward compatibility.
+
+**When to use**: Most HTTP endpoints expecting batched JSON data.
+
+### NDJSON (Newline-Delimited JSON)
+
+```yaml
+callback_settings:
+  my_api:
+    callback_type: generic_api
+    endpoint: https://your-endpoint.com
+    log_format: ndjson
+```
+
+Sends logs as newline-delimited JSON (one record per line):
+```
+{log1}
+{log2}
+{log3}
+```
+
+**When to use**: Log aggregation services like Sumo Logic, Splunk, or Datadog that support field extraction on individual records.
+
+**Benefits**:
+- Each log is ingested as a separate message
+- Field Extraction Rules work at ingest time
+- Better parsing and querying performance
+
+### Single
+
+```yaml
+callback_settings:
+  my_api:
+    callback_type: generic_api
+    endpoint: https://your-endpoint.com
+    log_format: single
+```
+
+Sends each log as an individual HTTP request in parallel when the batch is flushed.
+
+**When to use**: Endpoints that expect individual records, or when you need maximum compatibility.
+
+**Note**: This mode sends N HTTP requests per batch (more overhead). Consider using `ndjson` instead if your endpoint supports it.
 
 

--- a/docs/my-website/docs/observability/sumologic_integration.md
+++ b/docs/my-website/docs/observability/sumologic_integration.md
@@ -148,6 +148,51 @@ Example payload:
 
 ## Advanced Configuration
 
+### Log Format
+
+The Sumo Logic integration uses **NDJSON (newline-delimited JSON)** format by default. This format is optimal for Sumo Logic's parsing capabilities and allows Field Extraction Rules to work at ingest time.
+
+#### NDJSON Format
+
+Each log entry is sent as a separate line in the HTTP request:
+```
+{"id":"chatcmpl-1","model":"gpt-3.5-turbo","response_cost":0.0001,...}
+{"id":"chatcmpl-2","model":"gpt-4","response_cost":0.0003,...}
+{"id":"chatcmpl-3","model":"gpt-3.5-turbo","response_cost":0.0001,...}
+```
+
+#### Benefits for Field Extraction Rules (FERs)
+
+With NDJSON format, you can create Field Extraction Rules directly:
+
+```
+_sourceCategory=litellm/logs
+| json field=_raw "model", "response_cost", "user" as model, cost, user
+```
+
+**Before NDJSON** (with JSON array format):
+- Required `parse regex ... multi` workaround
+- FERs couldn't parse at ingest time
+- Query-time parsing impacted dashboard performance
+
+**After NDJSON**:
+- ✅ FERs parse fields at ingest time
+- ✅ No query-time workarounds needed
+- ✅ Better dashboard performance
+- ✅ Simpler query syntax
+
+#### Changing the Log Format (Advanced)
+
+If you need to change the log format (not recommended for Sumo Logic):
+
+```yaml
+callback_settings:
+  sumologic:
+    callback_type: generic_api
+    callback_name: sumologic
+    log_format: json_array  # Override to use JSON array instead
+```
+
 ### Batching Settings
 
 Control how LiteLLM batches logs before sending to Sumo Logic:

--- a/litellm/integrations/generic_api/generic_api_compatible_callbacks.json
+++ b/litellm/integrations/generic_api/generic_api_compatible_callbacks.json
@@ -22,6 +22,7 @@
         "headers": {
             "Content-Type": "application/json"
         },
-        "environment_variables": ["SUMOLOGIC_WEBHOOK_URL"]
+        "environment_variables": ["SUMOLOGIC_WEBHOOK_URL"],
+        "log_format": "ndjson"
     }
 }

--- a/litellm/litellm_core_utils/logging_callback_manager.py
+++ b/litellm/litellm_core_utils/logging_callback_manager.py
@@ -166,6 +166,7 @@ class LoggingCallbackManager:
             endpoint = callback_config.get("endpoint")
             headers = callback_config.get("headers")
             event_types = callback_config.get("event_types")
+            log_format = callback_config.get("log_format")
 
             if endpoint is None or headers is None:
                 verbose_logger.warning(
@@ -180,6 +181,7 @@ class LoggingCallbackManager:
                 and cached_logger.endpoint == endpoint
                 and cached_logger.headers == headers
                 and cached_logger.event_types == event_types
+                and cached_logger.log_format == log_format
             ):
                 return cached_logger
 
@@ -187,6 +189,7 @@ class LoggingCallbackManager:
                 endpoint=endpoint,
                 headers=headers,
                 event_types=event_types,
+                log_format=log_format,
             )
             _generic_api_logger_cache[callback] = new_logger
             return new_logger

--- a/tests/logging_callback_tests/test_generic_api_callback.py
+++ b/tests/logging_callback_tests/test_generic_api_callback.py
@@ -207,3 +207,253 @@ async def test_generic_api_callback_multiple_logs():
         assert (
             payload_item["response"]["choices"][0]["message"]["content"] == "hi"
         ), "Response should be hi"
+
+
+@pytest.mark.asyncio
+async def test_generic_api_callback_ndjson_format():
+    """
+    Test the GenericAPILogger callback with ndjson log format.
+    Validates that logs are sent as newline-delimited JSON.
+    """
+    # Create a mock for the async_httpx_client's post method
+    mock_post = AsyncMock()
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.text = "OK"
+
+    # Set up an endpoint for testing
+    test_endpoint = "https://example.com/api/logs"
+    test_headers = {"Authorization": "Bearer test_token"}
+    os.environ["GENERIC_LOGGER_ENDPOINT"] = test_endpoint
+
+    # Initialize the GenericAPILogger with ndjson format
+    generic_logger = GenericAPILogger(
+        endpoint=test_endpoint,
+        headers=test_headers,
+        flush_interval=1,
+        log_format="ndjson"  # Set NDJSON format
+    )
+    generic_logger.async_httpx_client.post = mock_post
+    litellm.callbacks = [generic_logger]
+
+    # Make multiple completion calls to generate multiple logs
+    for i in range(3):
+        response = await litellm.acompletion(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": f"Hello, world! {i}"}],
+            mock_response="hi",
+            user="test_user",
+        )
+
+    # Wait for async flush
+    await asyncio.sleep(3)
+
+    # Assert httpx post was called
+    mock_post.assert_called_once()
+
+    # Get the actual request body from the mock
+    actual_url = mock_post.call_args[1]["url"]
+    assert actual_url == test_endpoint, f"Expected URL {test_endpoint}, got {actual_url}"
+
+    # Get the data sent
+    ndjson_data = mock_post.call_args[1]["data"]
+    print("##########\n")
+    print("ndjson_data:", ndjson_data)
+    print("##########\n")
+
+    # Validate it's NDJSON format (newline-delimited)
+    assert isinstance(ndjson_data, str), "Data should be a string for NDJSON"
+
+    # Split by newlines and parse each line
+    lines = ndjson_data.strip().split("\n")
+    assert len(lines) == 3, f"Expected 3 lines of NDJSON, got {len(lines)}"
+
+    # Validate each line is valid JSON
+    for i, line in enumerate(lines):
+        payload_item = json.loads(line)
+        payload_item = StandardLoggingPayload(**payload_item)
+
+        # Basic assertions
+        assert payload_item["response_cost"] > 0, "Response cost should be greater than 0"
+        assert payload_item["model"] == "gpt-4o", "Model should be gpt-4o"
+        assert payload_item["model_parameters"]["user"] == "test_user", "User should be test_user"
+
+
+@pytest.mark.asyncio
+async def test_generic_api_callback_single_format():
+    """
+    Test the GenericAPILogger callback with single log format.
+    Validates that each log is sent as an individual request in parallel.
+    """
+    # Create a mock for the async_httpx_client's post method
+    mock_post = AsyncMock()
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.text = "OK"
+
+    # Set up an endpoint for testing
+    test_endpoint = "https://example.com/api/logs"
+    test_headers = {"Authorization": "Bearer test_token"}
+    os.environ["GENERIC_LOGGER_ENDPOINT"] = test_endpoint
+
+    # Initialize the GenericAPILogger with single format
+    generic_logger = GenericAPILogger(
+        endpoint=test_endpoint,
+        headers=test_headers,
+        flush_interval=1,  # Quick flush to trigger batch send
+        log_format="single"  # Set single format
+    )
+    generic_logger.async_httpx_client.post = mock_post
+    litellm.callbacks = [generic_logger]
+
+    # Make 3 completion calls
+    for i in range(3):
+        response = await litellm.acompletion(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": f"Hello, world! {i}"}],
+            mock_response="hi",
+            user="test_user",
+        )
+
+    # Wait for async flush
+    await asyncio.sleep(3)
+
+    # Assert httpx post was called 3 times (once per log in batch)
+    assert mock_post.call_count == 3, f"Expected 3 calls, got {mock_post.call_count}"
+
+    # Validate each call sent a single log object (not an array)
+    for call_idx in range(3):
+        call_args = mock_post.call_args_list[call_idx]
+        json_data = call_args[1]["data"]
+
+        print(f"########## Call {call_idx} ##########")
+        print("json_data:", json_data)
+
+        # Parse and validate - should be a single object, not an array
+        actual_request = json.loads(json_data)
+        assert isinstance(actual_request, dict), f"Call {call_idx}: Expected dict, got {type(actual_request)}"
+
+        # Validate it's a valid StandardLoggingPayload
+        payload_item = StandardLoggingPayload(**actual_request)
+        assert payload_item["response_cost"] > 0, "Response cost should be greater than 0"
+        assert payload_item["model"] == "gpt-4o", "Model should be gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_generic_api_callback_json_array_format_explicit():
+    """
+    Test the GenericAPILogger callback with explicit json_array format.
+    Validates backward compatibility when explicitly set to json_array.
+    """
+    # Create a mock for the async_httpx_client's post method
+    mock_post = AsyncMock()
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.text = "OK"
+
+    # Set up an endpoint for testing
+    test_endpoint = "https://example.com/api/logs"
+    test_headers = {"Authorization": "Bearer test_token"}
+    os.environ["GENERIC_LOGGER_ENDPOINT"] = test_endpoint
+
+    # Initialize the GenericAPILogger with explicit json_array format
+    generic_logger = GenericAPILogger(
+        endpoint=test_endpoint,
+        headers=test_headers,
+        flush_interval=1,
+        log_format="json_array"  # Explicitly set json_array
+    )
+    generic_logger.async_httpx_client.post = mock_post
+    litellm.callbacks = [generic_logger]
+
+    # Make multiple completion calls
+    for i in range(5):
+        response = await litellm.acompletion(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": f"Hello, world! {i}"}],
+            mock_response="hi",
+            user="test_user",
+        )
+
+    # Wait for async flush
+    await asyncio.sleep(3)
+
+    # Assert httpx post was called once (batched)
+    mock_post.assert_called_once()
+
+    # Get the data and validate it's a JSON array
+    json_data = mock_post.call_args[1]["data"]
+    actual_request = json.loads(json_data)
+
+    assert isinstance(actual_request, list), "Request body should be a list (JSON array)"
+    assert len(actual_request) == 5, f"Expected 5 items, got {len(actual_request)}"
+
+    # Validate each item
+    for payload_item in actual_request:
+        payload_item = StandardLoggingPayload(**payload_item)
+        assert payload_item["response_cost"] > 0, "Response cost should be greater than 0"
+        assert payload_item["model"] == "gpt-4o", "Model should be gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_generic_api_callback_sumologic_uses_ndjson():
+    """
+    Test that the sumologic callback uses ndjson format by default
+    when loaded from generic_api_compatible_callbacks.json
+    """
+    # Create a mock for the async_httpx_client's post method
+    mock_post = AsyncMock()
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.text = "OK"
+
+    # Set environment variable for sumologic
+    os.environ["SUMOLOGIC_WEBHOOK_URL"] = "https://collectors.sumologic.com/receiver/v1/http/test123"
+
+    # Initialize using callback_name (loads from JSON config)
+    generic_logger = GenericAPILogger(
+        callback_name="sumologic",
+        flush_interval=1
+    )
+    generic_logger.async_httpx_client.post = mock_post
+    litellm.callbacks = [generic_logger]
+
+    # Verify the logger has ndjson format
+    assert generic_logger.log_format == "ndjson", "Sumologic should use ndjson format"
+
+    # Make completion calls
+    for i in range(2):
+        await litellm.acompletion(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": f"Test {i}"}],
+            mock_response="response",
+            user="test_user",
+        )
+
+    # Wait for async flush
+    await asyncio.sleep(3)
+
+    # Assert httpx post was called
+    mock_post.assert_called_once()
+
+    # Verify NDJSON format
+    ndjson_data = mock_post.call_args[1]["data"]
+    assert isinstance(ndjson_data, str), "Data should be a string for NDJSON"
+
+    lines = ndjson_data.strip().split("\n")
+    assert len(lines) == 2, f"Expected 2 lines of NDJSON, got {len(lines)}"
+
+    # Each line should be valid JSON
+    for line in lines:
+        json.loads(line)  # Will raise if invalid JSON
+
+
+@pytest.mark.asyncio
+async def test_generic_api_callback_invalid_log_format():
+    """
+    Test that invalid log_format values raise a ValueError
+    """
+    test_endpoint = "https://example.com/api/logs"
+    os.environ["GENERIC_LOGGER_ENDPOINT"] = test_endpoint
+
+    with pytest.raises(ValueError, match="Invalid log_format"):
+        GenericAPILogger(
+            endpoint=test_endpoint,
+            log_format="invalid_format"  # type: ignore  # Intentionally invalid for testing
+        )


### PR DESCRIPTION
## Feature: Add `log_format` option to GenericAPILogger

### Problem
When sending logs to services like Sumo Logic, logs are sent as JSON arrays `[{log1}, {log2}]`. 
This makes it difficult to parse individual log records without using query-time workarounds 
like `parse regex ... multi`, which is not supported in Field Extraction Rules (FERs).

### Solution
Add a `log_format` parameter to `GenericAPILogger` with three options:
- `json_array` (default): Current behavior, backward compatible
- `ndjson`: Newline-delimited JSON, one record per line
- `single`: Send each log as individual HTTP request



### Usage
```yaml
callback_settings:
  my_callback:
    callback_type: generic_api
    endpoint: https://example.com
    log_format: ndjson
```

### Benefits for Sumo Logic Users
- Each log record is ingested as a separate message
- FERs can parse fields at ingest time
- No need for `parse regex ... multi` workaround
- Better dashboard performance

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes
- `litellm/integrations/generic_api/generic_api_callback.py`: Add `log_format` support
- `litellm/integrations/generic_api/generic_api_compatible_callbacks.json`: Add `log_format: "ndjson"` for sumologic