### PR TITLE
refactor: lazy-load heavy audio library and loggers

### DIFF
--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -290,6 +290,7 @@ TYPES_NAMES = (
 # LLM provider logic names that support lazy loading via _lazy_import_llm_provider_logic
 LLM_PROVIDER_LOGIC_NAMES = (
     "get_llm_provider",
+    "remove_index_from_tool_calls",
 )
 
 # Import maps for registry pattern - reduces repetition
@@ -393,6 +394,7 @@ _TYPES_IMPORT_MAP = {
 
 _LLM_PROVIDER_LOGIC_IMPORT_MAP = {
     "get_llm_provider": ("litellm.litellm_core_utils.get_llm_provider_logic", "get_llm_provider"),
+    "remove_index_from_tool_calls": ("litellm.litellm_core_utils.core_helpers", "remove_index_from_tool_calls"),
 }
 
 _LLM_CONFIGS_IMPORT_MAP = {


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: [Baseline](https://app.circleci.com/pipelines/github/BerriAI/litellm/53075/workflows/0b3a5550-4d8e-469b-8b9d-27d75766fa98)

- [x] **CI run for the last commit**  
       Link: [Last Commit](https://app.circleci.com/pipelines/github/BerriAI/litellm/53077/workflows/7f4b80c6-6ba6-4aec-8ef0-da39b8a49bf6)

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- Lazy load remove_index_from_tool_calls via __getattr__
- Lazy load _service_logger module via __getattr__ in __init__.py
- Lazy load audio_utils.utils with module-level caching in utils.py
- Remove direct imports that trigger heavy module loading

These changes reduce import-time memory usage by deferring imports until they are actually needed, while maintaining performance through caching for subsequent accesses.