### PR TITLE
refactor: lazy load get_llm_provider and remove_index_from_tool_calls

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1507,6 +1507,7 @@ if TYPE_CHECKING:
     get_first_chars_messages: Callable[..., str]
     get_provider_fields: Callable[..., List]
     get_valid_models: Callable[..., list]
+    get_llm_provider: Callable[..., Tuple[str, str, Optional[str], Optional[str]]]
     remove_index_from_tool_calls: Callable[..., None]
 
     # Response types - truly lazy loaded only (not in main.py or elsewhere)

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1507,7 +1507,6 @@ if TYPE_CHECKING:
     get_first_chars_messages: Callable[..., str]
     get_provider_fields: Callable[..., List]
     get_valid_models: Callable[..., list]
-    get_llm_provider: Callable[..., Tuple[str, str, Optional[str], Optional[str]]]
     remove_index_from_tool_calls: Callable[..., None]
 
     # Response types - truly lazy loaded only (not in main.py or elsewhere)

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -32,6 +32,7 @@ UTILS_NAMES = (
     "ModelResponse", "ModelResponseStream", "EmbeddingResponse", "ImageResponse",
     "TranscriptionResponse", "TextCompletionResponse", "get_provider_fields",
     "ModelResponseListIterator", "get_valid_models", "timeout",
+    "get_llm_provider", "remove_index_from_tool_calls",
 )
 
 # Token counter names that support lazy loading via _lazy_import_token_counter
@@ -336,6 +337,8 @@ _UTILS_IMPORT_MAP = {
     "ModelResponseListIterator": (".utils", "ModelResponseListIterator"),
     "get_valid_models": (".utils", "get_valid_models"),
     "timeout": (".timeout", "timeout"),
+    "get_llm_provider": ("litellm.litellm_core_utils.get_llm_provider_logic", "get_llm_provider"),
+    "remove_index_from_tool_calls": ("litellm.litellm_core_utils.core_helpers", "remove_index_from_tool_calls"),
 }
 
 _COST_CALCULATOR_IMPORT_MAP = {


### PR DESCRIPTION
## Relevant issues

High memory usage and high latency when importing Litellm.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: [Baseline](https://app.circleci.com/pipelines/github/BerriAI/litellm/53129/workflows/ebe1604d-aeb8-4c38-ae98-a0b606f7c934)

- [x] **CI run for the last commit**  
       Link: [Last Commit](https://app.circleci.com/pipelines/github/BerriAI/litellm/53130/workflows/93e7276d-5928-475a-881c-31a330311203)

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- `remove_index_from_tool_calls` was missing from the imports registry.
- Added `get_llm_provider` to the lazy loading registry.