### PR TITLE
refactor(utils): implement lazy loading for provider configs, model info classes, streaming handlers, and redact utilities

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -99,10 +99,7 @@ from litellm.litellm_core_utils.llm_response_utils.get_headers import (
     get_response_headers,
 )
 from litellm.litellm_core_utils.rules import Rules
-from litellm.llms.bedrock.common_utils import BedrockModelInfo
-from litellm.llms.cohere.common_utils import CohereModelInfo
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
-from litellm.llms.mistral.ocr.transformation import MistralOCRConfig
 from litellm.router_utils.get_retry_from_policy import (
     get_num_retries_from_retry_policy,
     reset_retry_policy,
@@ -340,6 +337,10 @@ if TYPE_CHECKING:
     from litellm.llms.base_llm.ocr.transformation import BaseOCRConfig
     from litellm.llms.base_llm.search.transformation import BaseSearchConfig
     from litellm.llms.base_llm.text_to_speech.transformation import BaseTextToSpeechConfig
+    from litellm.llms.bedrock.common_utils import BedrockModelInfo
+    from litellm.llms.cohere.common_utils import CohereModelInfo
+    from litellm.llms.mistral.ocr.transformation import MistralOCRConfig
+    from litellm.llms.mistral.ocr.transformation import MistralOCRConfig
 
 from litellm.llms.base_llm.batches.transformation import BaseBatchesConfig
 from litellm.llms.base_llm.chat.transformation import BaseConfig
@@ -4023,6 +4024,7 @@ def get_optional_params(  # noqa: PLR0915
             ),
         )
     elif custom_llm_provider == "bedrock":
+        BedrockModelInfo = getattr(sys.modules[__name__], 'BedrockModelInfo')
         bedrock_route = BedrockModelInfo.get_bedrock_route(model)
         bedrock_base_model = BedrockModelInfo.get_base_model(model)
         if bedrock_route == "converse" or bedrock_route == "converse_like":
@@ -7440,6 +7442,7 @@ class ProviderConfigManager:
             litellm.LlmProviders.COHERE_CHAT == provider
             or litellm.LlmProviders.COHERE == provider
         ):
+            CohereModelInfo = getattr(sys.modules[__name__], 'CohereModelInfo')
             route = CohereModelInfo.get_cohere_route(model)
             if route == "v2":
                 return litellm.CohereV2ChatConfig()
@@ -8290,6 +8293,7 @@ class ProviderConfigManager:
 
             return get_vertex_ai_ocr_config(model=model)
         
+        MistralOCRConfig = getattr(sys.modules[__name__], 'MistralOCRConfig')
         PROVIDER_TO_CONFIG_MAP = {
             litellm.LlmProviders.MISTRAL: MistralOCRConfig,
         }
@@ -8954,5 +8958,35 @@ def __getattr__(name: str) -> Any:  # noqa: PLR0915
             )
             _globals["BaseTextToSpeechConfig"] = _BaseTextToSpeechConfig
         return _globals["BaseTextToSpeechConfig"]
+    
+    # Lazy load BedrockModelInfo to avoid loading at module import time
+    if name == "BedrockModelInfo":
+        # Check if already cached
+        if "BedrockModelInfo" not in _globals:
+            from litellm.llms.bedrock.common_utils import (
+                BedrockModelInfo as _BedrockModelInfo,
+            )
+            _globals["BedrockModelInfo"] = _BedrockModelInfo
+        return _globals["BedrockModelInfo"]
+    
+    # Lazy load CohereModelInfo to avoid loading at module import time
+    if name == "CohereModelInfo":
+        # Check if already cached
+        if "CohereModelInfo" not in _globals:
+            from litellm.llms.cohere.common_utils import (
+                CohereModelInfo as _CohereModelInfo,
+            )
+            _globals["CohereModelInfo"] = _CohereModelInfo
+        return _globals["CohereModelInfo"]
+    
+    # Lazy load MistralOCRConfig to avoid loading at module import time
+    if name == "MistralOCRConfig":
+        # Check if already cached
+        if "MistralOCRConfig" not in _globals:
+            from litellm.llms.mistral.ocr.transformation import (
+                MistralOCRConfig as _MistralOCRConfig,
+            )
+            _globals["MistralOCRConfig"] = _MistralOCRConfig
+        return _globals["MistralOCRConfig"]
     
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -99,9 +99,6 @@ from litellm.litellm_core_utils.llm_response_utils.get_headers import (
     get_response_headers,
 )
 from litellm.litellm_core_utils.rules import Rules
-from litellm.llms.base_llm.ocr.transformation import BaseOCRConfig
-from litellm.llms.base_llm.search.transformation import BaseSearchConfig
-from litellm.llms.base_llm.text_to_speech.transformation import BaseTextToSpeechConfig
 from litellm.llms.bedrock.common_utils import BedrockModelInfo
 from litellm.llms.cohere.common_utils import CohereModelInfo
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
@@ -340,6 +337,9 @@ if TYPE_CHECKING:
     from litellm.llms.base_llm.google_genai.transformation import (
         BaseGoogleGenAIGenerateContentConfig,
     )
+    from litellm.llms.base_llm.ocr.transformation import BaseOCRConfig
+    from litellm.llms.base_llm.search.transformation import BaseSearchConfig
+    from litellm.llms.base_llm.text_to_speech.transformation import BaseTextToSpeechConfig
 
 from litellm.llms.base_llm.batches.transformation import BaseBatchesConfig
 from litellm.llms.base_llm.chat.transformation import BaseConfig
@@ -8924,5 +8924,35 @@ def __getattr__(name: str) -> Any:  # noqa: PLR0915
             )
             _globals["BaseGoogleGenAIGenerateContentConfig"] = _BaseGoogleGenAIGenerateContentConfig
         return _globals["BaseGoogleGenAIGenerateContentConfig"]
+    
+    # Lazy load BaseOCRConfig to avoid loading at module import time
+    if name == "BaseOCRConfig":
+        # Check if already cached
+        if "BaseOCRConfig" not in _globals:
+            from litellm.llms.base_llm.ocr.transformation import (
+                BaseOCRConfig as _BaseOCRConfig,
+            )
+            _globals["BaseOCRConfig"] = _BaseOCRConfig
+        return _globals["BaseOCRConfig"]
+    
+    # Lazy load BaseSearchConfig to avoid loading at module import time
+    if name == "BaseSearchConfig":
+        # Check if already cached
+        if "BaseSearchConfig" not in _globals:
+            from litellm.llms.base_llm.search.transformation import (
+                BaseSearchConfig as _BaseSearchConfig,
+            )
+            _globals["BaseSearchConfig"] = _BaseSearchConfig
+        return _globals["BaseSearchConfig"]
+    
+    # Lazy load BaseTextToSpeechConfig to avoid loading at module import time
+    if name == "BaseTextToSpeechConfig":
+        # Check if already cached
+        if "BaseTextToSpeechConfig" not in _globals:
+            from litellm.llms.base_llm.text_to_speech.transformation import (
+                BaseTextToSpeechConfig as _BaseTextToSpeechConfig,
+            )
+            _globals["BaseTextToSpeechConfig"] = _BaseTextToSpeechConfig
+        return _globals["BaseTextToSpeechConfig"]
     
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -99,9 +99,6 @@ from litellm.litellm_core_utils.llm_response_utils.get_headers import (
     get_response_headers,
 )
 from litellm.litellm_core_utils.rules import Rules
-from litellm.llms.base_llm.google_genai.transformation import (
-    BaseGoogleGenAIGenerateContentConfig,
-)
 from litellm.llms.base_llm.ocr.transformation import BaseOCRConfig
 from litellm.llms.base_llm.search.transformation import BaseSearchConfig
 from litellm.llms.base_llm.text_to_speech.transformation import BaseTextToSpeechConfig
@@ -340,6 +337,9 @@ if TYPE_CHECKING:
         redact_message_input_output_from_logging,
     )
     from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+    from litellm.llms.base_llm.google_genai.transformation import (
+        BaseGoogleGenAIGenerateContentConfig,
+    )
 
 from litellm.llms.base_llm.batches.transformation import BaseBatchesConfig
 from litellm.llms.base_llm.chat.transformation import BaseConfig
@@ -8914,5 +8914,15 @@ def __getattr__(name: str) -> Any:  # noqa: PLR0915
             )
             _globals["CustomStreamWrapper"] = _CustomStreamWrapper
         return _globals["CustomStreamWrapper"]
+    
+    # Lazy load BaseGoogleGenAIGenerateContentConfig to avoid loading at module import time
+    if name == "BaseGoogleGenAIGenerateContentConfig":
+        # Check if already cached
+        if "BaseGoogleGenAIGenerateContentConfig" not in _globals:
+            from litellm.llms.base_llm.google_genai.transformation import (
+                BaseGoogleGenAIGenerateContentConfig as _BaseGoogleGenAIGenerateContentConfig,
+            )
+            _globals["BaseGoogleGenAIGenerateContentConfig"] = _BaseGoogleGenAIGenerateContentConfig
+        return _globals["BaseGoogleGenAIGenerateContentConfig"]
     
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -340,7 +340,6 @@ if TYPE_CHECKING:
     from litellm.llms.bedrock.common_utils import BedrockModelInfo
     from litellm.llms.cohere.common_utils import CohereModelInfo
     from litellm.llms.mistral.ocr.transformation import MistralOCRConfig
-    from litellm.llms.mistral.ocr.transformation import MistralOCRConfig
 
 from litellm.llms.base_llm.batches.transformation import BaseBatchesConfig
 from litellm.llms.base_llm.chat.transformation import BaseConfig

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -99,7 +99,6 @@ from litellm.litellm_core_utils.llm_response_utils.get_headers import (
     get_response_headers,
 )
 from litellm.litellm_core_utils.rules import Rules
-from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from litellm.llms.base_llm.google_genai.transformation import (
     BaseGoogleGenAIGenerateContentConfig,
 )
@@ -340,6 +339,7 @@ if TYPE_CHECKING:
         LiteLLMLoggingObject,
         redact_message_input_output_from_logging,
     )
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 
 from litellm.llms.base_llm.batches.transformation import BaseBatchesConfig
 from litellm.llms.base_llm.chat.transformation import BaseConfig
@@ -8904,5 +8904,15 @@ def __getattr__(name: str) -> Any:  # noqa: PLR0915
             )
             _globals["redact_message_input_output_from_logging"] = _redact_message_input_output_from_logging
         return _globals["redact_message_input_output_from_logging"]
+    
+    # Lazy load CustomStreamWrapper to avoid loading at module import time
+    if name == "CustomStreamWrapper":
+        # Check if already cached
+        if "CustomStreamWrapper" not in _globals:
+            from litellm.litellm_core_utils.streaming_handler import (
+                CustomStreamWrapper as _CustomStreamWrapper,
+            )
+            _globals["CustomStreamWrapper"] = _CustomStreamWrapper
+        return _globals["CustomStreamWrapper"]
     
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -98,10 +98,6 @@ from litellm.litellm_core_utils.llm_response_utils.get_formatted_prompt import (
 from litellm.litellm_core_utils.llm_response_utils.get_headers import (
     get_response_headers,
 )
-from litellm.litellm_core_utils.redact_messages import (
-    LiteLLMLoggingObject,
-    redact_message_input_output_from_logging,
-)
 from litellm.litellm_core_utils.rules import Rules
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from litellm.llms.base_llm.google_genai.transformation import (
@@ -339,6 +335,10 @@ if TYPE_CHECKING:
     )
     from litellm.litellm_core_utils.prompt_templates.common_utils import (
         _parse_content_for_reasoning,
+    )
+    from litellm.litellm_core_utils.redact_messages import (
+        LiteLLMLoggingObject,
+        redact_message_input_output_from_logging,
     )
 
 from litellm.llms.base_llm.batches.transformation import BaseBatchesConfig
@@ -8885,5 +8885,24 @@ def __getattr__(name: str) -> Any:  # noqa: PLR0915
             )
             _globals["_parse_content_for_reasoning"] = __parse_content_for_reasoning
         return _globals["_parse_content_for_reasoning"]
+    
+    # Lazy load redact_messages to avoid loading at module import time
+    if name == "LiteLLMLoggingObject":
+        # Check if already cached
+        if "LiteLLMLoggingObject" not in _globals:
+            from litellm.litellm_core_utils.redact_messages import (
+                LiteLLMLoggingObject as _LiteLLMLoggingObject,
+            )
+            _globals["LiteLLMLoggingObject"] = _LiteLLMLoggingObject
+        return _globals["LiteLLMLoggingObject"]
+    
+    if name == "redact_message_input_output_from_logging":
+        # Check if already cached
+        if "redact_message_input_output_from_logging" not in _globals:
+            from litellm.litellm_core_utils.redact_messages import (
+                redact_message_input_output_from_logging as _redact_message_input_output_from_logging,
+            )
+            _globals["redact_message_input_output_from_logging"] = _redact_message_input_output_from_logging
+        return _globals["redact_message_input_output_from_logging"]
     
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53141/workflows/18db2ad3-28d4-4577-bb0d-71898c19432c

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53144/workflows/283e2a43-8673-4e8d-b81d-0d4edaca9b51

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring

## Changes

This PR implements lazy loading for multiple heavy imports in `litellm/utils.py` to reduce initial import time and memory footprint. All changes follow the existing lazy loading pattern established in `litellm/_lazy_imports.py` and `litellm/__init__.py`.

### Summary of Changes

Moved the following imports from top-level to lazy loading via `__getattr__`:

1. **redact_messages module** (commit 2943a2d652):
   - `LiteLLMLoggingObject`
   - `redact_message_input_output_from_logging`

2. **streaming_handler module** (commit b52feaa965):
   - `CustomStreamWrapper`

3. **google_genai.transformation module** (commit c32f358f8b):
   - `BaseGoogleGenAIGenerateContentConfig`

4. **base_llm transformation modules** (commit 54463e3cae):
   - `BaseOCRConfig`
   - `BaseSearchConfig`
   - `BaseTextToSpeechConfig`

5. **Provider-specific model info classes** (commit 5d0e66a88b):
   - `BedrockModelInfo`
   - `CohereModelInfo`
   - `MistralOCRConfig`