### PR TITLE
Add libsndfile to database Docker image for audio processing

### DIFF
--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -48,7 +48,7 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 USER root
 
 # Install runtime dependencies
-RUN apk add --no-cache bash openssl tzdata nodejs npm python3 py3-pip
+RUN apk add --no-cache bash openssl tzdata nodejs npm python3 py3-pip libsndfile
 
 WORKDIR /app
 # Copy the current directory contents into the container at /app


### PR DESCRIPTION
## Relevant issues

Fixes #18598

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) *(N/A - Infrastructure change)*
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🚄 Infrastructure

## Changes

### Summary
The `litellm-database` Docker image was missing the `libsndfile` system library, which is required by the `soundfile` Python package (included in `requirements.txt`) for audio file processing. This caused the following error when using audio transcription endpoints:

```
APIConnectionError: OpenAIException - cannot load library 'libsndfile.so': 
libsndfile.so: cannot open shared object file: No such file or directory
```

### Solution
Added `libsndfile` to the runtime dependencies in `docker/Dockerfile.database:51`, making it consistent with `docker/Dockerfile.alpine` which already includes this library.

### Files Changed
- `docker/Dockerfile.database` - Added `libsndfile` to the `apk add` command on line 51

### Testing
This change can be validated by:
1. Building the `litellm-database` Docker image
2. Running audio transcription endpoints (e.g., `gpt-4o-transcribe-diarize`)
3. Verifying that `soundfile` can be imported without errors