### PR TITLE
[Infra] UI - E2E Tests: Add Model - See Models from Selected Provider

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/constants.ts
+++ b/ui/litellm-dashboard/e2e_tests/constants.ts
@@ -1,0 +1,1 @@
+export const ADMIN_STORAGE_PATH = "admin.storageState.json";

--- a/ui/litellm-dashboard/e2e_tests/tests/modelsPage/addModel.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/modelsPage/addModel.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+import { ADMIN_STORAGE_PATH } from "../../constants";
+
+test.describe("Add Model", () => {
+  test.use({ storageState: ADMIN_STORAGE_PATH });
+
+  test("Able to see all models for a specific provider in the model dropdown", async ({ page }) => {
+    await page.goto("http://localhost:4000/ui");
+
+    await page.getByText("Models + Endpoints").click();
+    await page.getByRole("tab", { name: "Add Model" }).click();
+
+    const providerInputDropdown = page.getByRole("combobox", { name: /Provider/i });
+    await providerInputDropdown.fill("Anthropic");
+    await page.waitForTimeout(1000);
+    await providerInputDropdown.press("Enter");
+    await page.waitForTimeout(1000);
+
+    const providerModelsDropdown = page.locator(".ant-select-selection-overflow").first();
+    await providerModelsDropdown.click();
+    await expect(page.getByTitle("claude-haiku-4-5", { exact: true })).toBeVisible();
+  });
+});

--- a/ui/litellm-dashboard/e2e_tests/tests/navigation/sidebar.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/navigation/sidebar.spec.ts
@@ -1,5 +1,6 @@
 import test, { expect } from "@playwright/test";
 import { Role } from "../../fixtures/roles";
+import { ADMIN_STORAGE_PATH } from "../../constants";
 
 const sidebarButtons = {
   [Role.ProxyAdmin]: [
@@ -16,7 +17,7 @@ const sidebarButtons = {
   ],
 };
 
-const roles = [{ role: Role.ProxyAdmin, storage: "admin.storageState.json" }];
+const roles = [{ role: Role.ProxyAdmin, storage: ADMIN_STORAGE_PATH }];
 
 for (const { role, storage } of roles) {
   test.describe(`${role} sidebar`, () => {


### PR DESCRIPTION
## Relevant issues
This PR adds the E2E test for seeing specific models after selecting the provider inside the add model flow. This is the first of many e2e tests, that aims to cover the manual testing steps.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure
✅ Test

## Changes
<img width="1153" height="277" alt="image" src="https://github.com/user-attachments/assets/213593c4-e86d-481a-92ea-75c72a38a751" />
