### PR TITLE
[Feature] UI - Virtual Keys Table Loading State Between Pages

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -68,12 +68,13 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
   });
   const [tablePagination, setTablePagination] = React.useState<PaginationState>({
     pageIndex: 0,
-    pageSize: 100,
+    pageSize: 50,
   });
 
   const {
     data: keys,
     isPending: isLoading,
+    isFetching,
     refetch,
   } = useKeys(tablePagination.pageIndex + 1, tablePagination.pageSize);
   const totalCount = keys?.total_count || 0;
@@ -545,8 +546,8 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
           </div>
 
           <div className="flex items-center justify-between w-full mb-4">
-            {isLoading ? (
-              <Skeleton.Input active style={{ width: 200, height: 20 }} />
+            {isLoading || isFetching ? (
+              <Skeleton.Node active style={{ width: 200, height: 20 }} />
             ) : (
               <span className="inline-flex text-sm text-gray-700">
                 Showing {rangeLabel} of {totalCount} results
@@ -554,32 +555,32 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
             )}
 
             <div className="inline-flex items-center gap-2">
-              {isLoading ? (
-                <Skeleton.Input active size="small" style={{ width: 50, height: 20 }} />
+              {isLoading || isFetching ? (
+                <Skeleton.Node active style={{ width: 74, height: 20 }} />
               ) : (
                 <span className="text-sm text-gray-700">
                   Page {pageIndex + 1} of {table.getPageCount()}
                 </span>
               )}
 
-              {isLoading ? (
+              {isLoading || isFetching ? (
                 <Skeleton.Button active size="small" style={{ width: 84, height: 30 }} />
               ) : (
                 <button
                   onClick={() => table.previousPage()}
-                  disabled={isLoading || !table.getCanPreviousPage()}
+                  disabled={isLoading || isFetching || !table.getCanPreviousPage()}
                   className="px-3 py-1 text-sm border rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Previous
                 </button>
               )}
 
-              {isLoading ? (
+              {isLoading || isFetching ? (
                 <Skeleton.Button active size="small" style={{ width: 58, height: 30 }} />
               ) : (
                 <button
                   onClick={() => table.nextPage()}
-                  disabled={isLoading || !table.getCanNextPage()}
+                  disabled={isLoading || isFetching || !table.getCanNextPage()}
                   className="px-3 py-1 text-sm border rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Next
@@ -664,7 +665,7 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
                     ))}
                   </TableHead>
                   <TableBody>
-                    {isLoading ? (
+                    {isLoading || isFetching ? (
                       <TableRow>
                         <TableCell colSpan={columns.length} className="h-8 text-center">
                           <div className="text-center text-gray-500">


### PR DESCRIPTION
## Relevant issues
The Virtual Keys fetches a paginated query from /key/list. Previously when the user clicks the next button, the table updates the page number immediately, but the keys being shown is still the previous page. This creates a period of time where the table's information is misleading. To solve this, I implemented a loading state when the query is fetching to avoid any confusion. This loading state is the same as the loading state when the user first lands on the virtual keys page.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="685" height="316" alt="image" src="https://github.com/user-attachments/assets/e4a9758a-4140-430d-b75c-950daabd5d55" />
<img width="1189" height="213" alt="image" src="https://github.com/user-attachments/assets/59863860-8644-470b-8a51-a65a78d13c86" />
