### PR TITLE
[Feat] Add support for LangSmith organization-scoped API keys with tenant ID

### DIFF
--- a/litellm/integrations/callback_configs.json
+++ b/litellm/integrations/callback_configs.json
@@ -187,6 +187,12 @@
         "ui_name": "Sampling Rate",
         "description": "Sampling rate for logging (0.0 to 1.0, default: 1.0)",
         "required": false
+      },
+      "langsmith_tenant_id": {
+        "type": "text",
+        "ui_name": "Tenant ID",
+        "description": "LangSmith tenant ID for organization-scoped API keys (required when using org-scoped keys)",
+        "required": false
       }
     },
     "description": "Langsmith Logging Integration"

--- a/litellm/types/integrations/langsmith.py
+++ b/litellm/types/integrations/langsmith.py
@@ -31,6 +31,7 @@ class LangsmithCredentialsObject(TypedDict):
     LANGSMITH_API_KEY: Optional[str]
     LANGSMITH_PROJECT: Optional[str]
     LANGSMITH_BASE_URL: str
+    LANGSMITH_TENANT_ID: Optional[str]
 
 
 class LangsmithQueueObject(TypedDict):
@@ -52,6 +53,7 @@ class CredentialsKey(NamedTuple):
     api_key: str
     project: str
     base_url: str
+    tenant_id: Optional[str]
 
 
 @dataclass

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2677,6 +2677,7 @@ class StandardCallbackDynamicParams(TypedDict, total=False):
     langsmith_project: Optional[str]
     langsmith_base_url: Optional[str]
     langsmith_sampling_rate: Optional[float]
+    langsmith_tenant_id: Optional[str]
 
     # Humanloop dynamic params
     humanloop_api_key: Optional[str]

--- a/tests/logging_callback_tests/test_langsmith_unit_test.py
+++ b/tests/logging_callback_tests/test_langsmith_unit_test.py
@@ -47,6 +47,19 @@ async def test_get_credentials_from_env():
     credentials = logger.get_credentials_from_env()
     assert credentials["LANGSMITH_BASE_URL"] == "https://api.smith.langchain.com"
 
+    # Test with tenant_id
+    credentials = logger.get_credentials_from_env(
+        langsmith_tenant_id="test-tenant-id"
+    )
+    assert credentials["LANGSMITH_TENANT_ID"] == "test-tenant-id"
+
+    # Test tenant_id from environment variable
+    import os
+    os.environ["LANGSMITH_TENANT_ID"] = "env-tenant-id"
+    credentials = logger.get_credentials_from_env()
+    assert credentials["LANGSMITH_TENANT_ID"] == "env-tenant-id"
+    del os.environ["LANGSMITH_TENANT_ID"]
+
 
 @pytest.mark.asyncio
 async def test_group_batches_by_credentials():
@@ -60,6 +73,7 @@ async def test_group_batches_by_credentials():
             "LANGSMITH_API_KEY": "key1",
             "LANGSMITH_PROJECT": "proj1",
             "LANGSMITH_BASE_URL": "url1",
+            "LANGSMITH_TENANT_ID": None,
         },
     )
 
@@ -69,6 +83,7 @@ async def test_group_batches_by_credentials():
             "LANGSMITH_API_KEY": "key1",
             "LANGSMITH_PROJECT": "proj1",
             "LANGSMITH_BASE_URL": "url1",
+            "LANGSMITH_TENANT_ID": None,
         },
     )
 
@@ -95,6 +110,7 @@ async def test_group_batches_by_credentials_multiple_credentials():
             "LANGSMITH_API_KEY": "key1",
             "LANGSMITH_PROJECT": "proj1",
             "LANGSMITH_BASE_URL": "url1",
+            "LANGSMITH_TENANT_ID": None,
         },
     )
 
@@ -104,6 +120,7 @@ async def test_group_batches_by_credentials_multiple_credentials():
             "LANGSMITH_API_KEY": "key2",  # Different API key
             "LANGSMITH_PROJECT": "proj1",
             "LANGSMITH_BASE_URL": "url1",
+            "LANGSMITH_TENANT_ID": None,
         },
     )
 
@@ -113,6 +130,7 @@ async def test_group_batches_by_credentials_multiple_credentials():
             "LANGSMITH_API_KEY": "key1",
             "LANGSMITH_PROJECT": "proj2",  # Different project
             "LANGSMITH_BASE_URL": "url1",
+            "LANGSMITH_TENANT_ID": None,
         },
     )
 
@@ -125,6 +143,57 @@ async def test_group_batches_by_credentials_multiple_credentials():
     for key, batch_group in grouped.items():
         assert isinstance(key, CredentialsKey)
         assert len(batch_group.queue_objects) == 1  # Each group should have one object
+
+
+@pytest.mark.asyncio
+async def test_group_batches_by_credentials_with_tenant_id():
+
+    # Test that different tenant_ids create separate groups
+    logger = LangsmithLogger(langsmith_api_key="test-key")
+
+    queue_obj1 = LangsmithQueueObject(
+        data={"test": "data1"},
+        credentials={
+            "LANGSMITH_API_KEY": "key1",
+            "LANGSMITH_PROJECT": "proj1",
+            "LANGSMITH_BASE_URL": "url1",
+            "LANGSMITH_TENANT_ID": "tenant1",
+        },
+    )
+
+    queue_obj2 = LangsmithQueueObject(
+        data={"test": "data2"},
+        credentials={
+            "LANGSMITH_API_KEY": "key1",
+            "LANGSMITH_PROJECT": "proj1",
+            "LANGSMITH_BASE_URL": "url1",
+            "LANGSMITH_TENANT_ID": "tenant2",  # Different tenant_id
+        },
+    )
+
+    queue_obj3 = LangsmithQueueObject(
+        data={"test": "data3"},
+        credentials={
+            "LANGSMITH_API_KEY": "key1",
+            "LANGSMITH_PROJECT": "proj1",
+            "LANGSMITH_BASE_URL": "url1",
+            "LANGSMITH_TENANT_ID": "tenant1",  # Same as queue_obj1
+        },
+    )
+
+    logger.log_queue = [queue_obj1, queue_obj2, queue_obj3]
+
+    grouped = logger._group_batches_by_credentials()
+
+    # Should have two groups: one for tenant1 (queue_obj1 and queue_obj3), one for tenant2 (queue_obj2)
+    assert len(grouped) == 2
+    for key, batch_group in grouped.items():
+        assert isinstance(key, CredentialsKey)
+        assert key.tenant_id in ["tenant1", "tenant2"]
+        if key.tenant_id == "tenant1":
+            assert len(batch_group.queue_objects) == 2
+        else:
+            assert len(batch_group.queue_objects) == 1
 
 
 # Test make_dot_order
@@ -201,10 +270,43 @@ async def test_async_send_batch():
     call_args = logger.async_httpx_client.post.call_args
     assert "runs/batch" in call_args[1]["url"]
     assert "x-api-key" in call_args[1]["headers"]
+    # tenant_id should not be in headers if not provided
+    assert "x-tenant-id" not in call_args[1]["headers"]
 
 
 @pytest.mark.asyncio
-async def test_langsmith_key_based_logging(mocker):
+async def test_async_send_batch_with_tenant_id():
+    logger = LangsmithLogger(
+        langsmith_api_key="test-key",
+        langsmith_tenant_id="test-tenant-id"
+    )
+
+    # Mock the httpx client
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    logger.async_httpx_client = AsyncMock()
+    logger.async_httpx_client.post.return_value = mock_response
+
+    # Add test data to queue
+    logger.log_queue = [
+        LangsmithQueueObject(
+            data={"test": "data"}, credentials=logger.default_credentials
+        )
+    ]
+
+    await logger.async_send_batch()
+
+    # Verify the API call includes tenant_id header
+    logger.async_httpx_client.post.assert_called_once()
+    call_args = logger.async_httpx_client.post.call_args
+    assert "runs/batch" in call_args[1]["url"]
+    assert "x-api-key" in call_args[1]["headers"]
+    assert "x-tenant-id" in call_args[1]["headers"]
+    assert call_args[1]["headers"]["x-tenant-id"] == "test-tenant-id"
+
+
+@pytest.mark.asyncio
+async def test_langsmith_key_based_logging():
     """
     In key based logging langsmith_api_key and langsmith_project are passed directly to litellm.acompletion
     """
@@ -219,10 +321,11 @@ async def test_langsmith_key_based_logging(mocker):
         mock_response.text = ""
         mock_async_httpx_handler.post = AsyncMock(return_value=mock_response)
         
-        mock_get_client = mocker.patch(
+        mock_get_client = patch(
             "litellm.integrations.langsmith.get_async_httpx_client",
             return_value=mock_async_httpx_handler
         )
+        mock_get_client.start()
         
         litellm.set_verbose = True
         litellm.DEFAULT_FLUSH_INTERVAL_SECONDS = 1
@@ -253,6 +356,8 @@ async def test_langsmith_key_based_logging(mocker):
 
         # Check headers contain the correct API key
         assert call_args[1]["headers"]["x-api-key"] == "fake_key_project2"
+        # tenant_id should not be in headers if not provided
+        assert "x-tenant-id" not in call_args[1]["headers"]
 
         # Verify the request body contains the expected data
         request_body = call_args[1]["json"]
@@ -344,6 +449,8 @@ async def test_langsmith_key_based_logging(mocker):
             actual_body["post"][0]["session_name"]
             == expected_body["post"][0]["session_name"]
         )
+        
+        mock_get_client.stop()
 
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")


### PR DESCRIPTION
## Relevant issues
Adds support for organization-scoped LangSmith API keys. When using org-scoped keys, LangSmith requires the x-tenant-id header alongside x-api-key. Previously, LiteLLM only sent x-api-key, so org-scoped keys failed.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
🧹 Refactoring
✅ Test

## Changes
Added LANGSMITH_TENANT_ID environment variable support
Added langsmith_tenant_id parameter to LangsmithLogger initialization
Added langsmith_tenant_id to StandardCallbackDynamicParams for per-request tenant ID
Updated LangsmithCredentialsObject and CredentialsKey to include tenant ID
Modified _log_batch_on_langsmith() and get_run_by_id() to include x-tenant-id header when tenant ID is provided
Updated credential grouping to separate batches by tenant ID
Added tests for tenant ID functionality
Updated callback configs JSON with tenant ID field documentation
Backward Compatible: Existing code without tenant ID continues to work unchanged. The x-tenant-id header is only included when LANGSMITH_TENANT_ID is set or langsmith_tenant_id is provided.
