### PR TITLE
fix(router): Validate routing_strategy at startup to fail fast with helpful error

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -713,6 +713,23 @@ class Router:
         self, routing_strategy: Union[RoutingStrategy, str], routing_strategy_args: dict
     ):
         verbose_router_logger.info(f"Routing strategy: {routing_strategy}")
+
+        # Validate routing_strategy value to fail fast with helpful error
+        # See: https://github.com/BerriAI/litellm/issues/11330
+        # Derive valid strategies from RoutingStrategy enum + "simple-shuffle" (default, not in enum)
+        valid_strategy_strings = ["simple-shuffle"] + [s.value for s in RoutingStrategy]
+
+        if routing_strategy is not None:
+            is_valid_string = isinstance(routing_strategy, str) and routing_strategy in valid_strategy_strings
+            is_valid_enum = isinstance(routing_strategy, RoutingStrategy)
+            if not is_valid_string and not is_valid_enum:
+                raise ValueError(
+                    f"Invalid routing_strategy: '{routing_strategy}'. "
+                    f"Valid options: {valid_strategy_strings}. "
+                    f"Check 'router_settings.routing_strategy' in your config.yaml "
+                    f"or the 'routing_strategy' parameter if using the Router SDK directly."
+                )
+
         if (
             routing_strategy == RoutingStrategy.LEAST_BUSY.value
             or routing_strategy == RoutingStrategy.LEAST_BUSY

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -79,6 +79,73 @@ def test_routing_strategy_init(model_list):
         )
 
 
+def test_routing_strategy_init_invalid_strategy(model_list):
+    """Test that invalid routing_strategy raises ValueError with helpful message.
+
+    See: https://github.com/BerriAI/litellm/issues/11330
+    Invalid strategies like 'simple' (without '-shuffle') should fail fast
+    with a clear error, not silently cause 'No deployments available' errors.
+    """
+    router = Router(model_list=model_list)
+
+    # Test common mistake: "simple" instead of "simple-shuffle"
+    with pytest.raises(ValueError) as exc_info:
+        router.routing_strategy_init(
+            routing_strategy="simple",
+            routing_strategy_args={}
+        )
+
+    # Verify error message is helpful
+    error_msg = str(exc_info.value)
+    assert "Invalid routing_strategy" in error_msg
+    assert "simple" in error_msg
+    assert "simple-shuffle" in error_msg  # Suggests the correct option
+    # Verify error message tells user WHERE to fix it
+    assert "config.yaml" in error_msg
+    assert "router_settings.routing_strategy" in error_msg
+    assert "Router SDK" in error_msg
+
+    # Test completely invalid strategy
+    with pytest.raises(ValueError) as exc_info:
+        router.routing_strategy_init(
+            routing_strategy="not-a-real-strategy",
+            routing_strategy_args={}
+        )
+    assert "Invalid routing_strategy" in str(exc_info.value)
+
+
+def test_routing_strategy_init_valid_string_strategies(model_list):
+    """Test that all valid string routing strategies work without error.
+
+    Valid strategies are derived from RoutingStrategy enum values plus 'simple-shuffle'.
+    """
+    from litellm.types.router import RoutingStrategy
+
+    router = Router(model_list=model_list)
+
+    # All strategies from enum + simple-shuffle (default, not in enum)
+    valid_strategies = ["simple-shuffle"] + [s.value for s in RoutingStrategy]
+
+    for strategy in valid_strategies:
+        # Should not raise
+        router.routing_strategy_init(
+            routing_strategy=strategy, routing_strategy_args={}
+        )
+
+
+def test_routing_strategy_init_valid_enum_strategies(model_list):
+    """Test that RoutingStrategy enum values work without error."""
+    from litellm.types.router import RoutingStrategy
+
+    router = Router(model_list=model_list)
+
+    for strategy in RoutingStrategy:
+        # Should not raise when passing enum directly
+        router.routing_strategy_init(
+            routing_strategy=strategy, routing_strategy_args={}
+        )
+
+
 def test_print_deployment(model_list):
     """Test if the api key is masked correctly"""
 


### PR DESCRIPTION
## Summary

Invalid `routing_strategy` values (e.g., `"simple"` instead of `"simple-shuffle"`) previously failed silently, causing confusing "No deployments available" errors downstream. Users had to spend hours or days debugging, as reported in #11330.

This PR adds upfront validation in `routing_strategy_init()` to:
- Check if the provided strategy matches valid string values or `RoutingStrategy` enum
- Raise a clear `ValueError` listing valid options if invalid
- **Tell users WHERE to fix the issue** (config.yaml location or SDK parameter)
- Fail fast at startup instead of at request time

## Changes

**`litellm/router.py`:**
- Added validation at the start of `routing_strategy_init()` 
- Derives valid strategies from `RoutingStrategy` enum + `"simple-shuffle"` (the default)
- Raises `ValueError` with helpful message showing valid options AND where to fix it

**`tests/router_unit_tests/test_router_helper_utils.py`:**
- Added test for invalid strategy raising `ValueError`
- Added test verifying error message includes location hints
- Added test for all valid string strategies  
- Added test for all valid `RoutingStrategy` enum values

## Example Error Message

Before (confusing error at request time):
```
No deployments available for selected model
```

After (clear error at startup with actionable guidance):
```
ValueError: Invalid routing_strategy: 'simple'. Valid options: ['simple-shuffle', 'least-busy', 'latency-based-routing', 'cost-based-routing', 'usage-based-routing-v2', 'usage-based-routing', 'provider-budget-routing']. Check 'router_settings.routing_strategy' in your config.yaml or the 'routing_strategy' parameter if using the Router SDK directly.
```

## Testing

- [x] Tests pass locally
- [x] Tests cover invalid strategies, all valid strings, and all enum values
- [x] Error message includes the invalid value, valid options, AND where to fix it

Fixes behavior reported in #11330