### PR TITLE
feat(mcp): parallelize tool fetching from multiple MCP servers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -709,7 +709,8 @@ if MCP_AVAILABLE:
 
         extra_headers: Optional[Dict[str, str]] = None
         if server.auth_type == MCPAuth.oauth2:
-            extra_headers = oauth2_headers
+            # Copy to avoid mutating the original dict (important for parallel fetching)
+            extra_headers = oauth2_headers.copy() if oauth2_headers else None
 
         if server.extra_headers and raw_headers:
             if extra_headers is None:


### PR DESCRIPTION
## Summary
- Replaces sequential tool fetching with `asyncio.gather()` to reduce client timeouts when using multiple MCP servers
- Changes both code paths: MCP protocol (`list_tools()`) and REST API (`_get_tools_from_mcp_servers()`)

## Motivation
When using multiple MCP servers, clients timeout waiting for tools because of sequential fetching.

**Real-world example with 7 MCP servers:**
| Server | Response Time |
|--------|--------------|
| zai_web_search | 1.17s |
| zai_web_reader | 1.13s |
| zai_zread | 0.78s |
| context7 | 0.50s |
| exa | 0.38s |
| jina | 0.06s |
| sourcegraph (stdio) | ~0.5s |

**Sequential total: ~4.5+ seconds** (exceeds typical 5-second client timeouts)
**Parallel total: ~1.2 seconds** (max of all servers)

## Test plan
- [x] All 66 existing MCP tests pass (`test_mcp_server_manager.py` and `test_mcp_server.py`)
- [x] Syntax validation passes
- [x] No changes to external API behavior

Fixes #18626