### PR TITLE
refactor: remove redundant Bedrock guardrail block handling

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -1304,11 +1304,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     request_data=request_data,
                 )
 
-                if bedrock_response.get("action") == "BLOCKED":
-                    raise Exception(
-                        f"Content blocked by Bedrock guardrail: {bedrock_response.get('reason', 'Unknown reason')}"
-                    )
-
                 # Apply any masking that was applied by the guardrail
 
                 output_list = bedrock_response.get("output")


### PR DESCRIPTION
## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53200/workflows/664729ff-1245-4ce5-9ceb-a99b750b14ab

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53201/workflows/8e36694a-7f3d-48d4-9ebb-7cdb1611dedb

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring

## Changes

remove the ad-hoc BLOCKED check inside `make_bedrock_api_request` because guardrail blocking is already enforced by `_should_raise_guardrail_blocked_exception` and the hook logic