### PR TITLE
fix: auth header for custom api base in generate Content request

### DIFF
--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -153,7 +153,9 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
         gemini_api_key = api_key or self._get_google_ai_studio_api_key(
             dict(litellm_params or {})
         )
-        if gemini_api_key is not None:
+        if isinstance(gemini_api_key, dict):
+            default_headers.update(gemini_api_key)
+        elif gemini_api_key is not None:
             default_headers[self.XGOOGLE_API_KEY] = gemini_api_key
         if headers is not None:
             default_headers.update(headers)


### PR DESCRIPTION
## Relevant issues

Fixes #15587
Fixes #18604
fixed the bug where Gemini requests with custom api_base were failing with the error: Header value must be str or bytes..


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
- Added a if statment to detect if auth header is a dict and add it accordingly


## Testing
<img width="805" height="245" alt="image" src="https://github.com/user-attachments/assets/eb7801b7-f1bd-4504-8e66-d82753d1ec32" />