### PR TITLE
fix: Add custom llm provider to get_llm_provider when sent via UI

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -110,7 +110,6 @@ from litellm.types.utils import (
     RawRequestTypedDict,
     StreamingChoices,
 )
-
 from litellm.utils import (
     Choices,
     CustomStreamWrapper,
@@ -6656,7 +6655,16 @@ async def ahealth_check(
         if model in litellm.model_cost and mode is None:
             mode = litellm.model_cost[model].get("mode")
 
-        model, custom_llm_provider, _, _ = get_llm_provider(model=model)
+        custom_llm_provider_from_params = model_params.get("custom_llm_provider", None)
+        api_base_from_params = model_params.get("api_base", None)
+        api_key_from_params = model_params.get("api_key", None)
+        
+        model, custom_llm_provider, _, _ = get_llm_provider(
+            model=model,
+            custom_llm_provider=custom_llm_provider_from_params,
+            api_base=api_base_from_params,
+            api_key=api_key_from_params,
+        )
         if model in litellm.model_cost and mode is None:
             mode = litellm.model_cost[model].get("mode")
 

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -637,3 +637,40 @@ async def test_image_generation_health_check_prompt(monkeypatch):
 
     assert len(health_check_calls) == 1
     assert health_check_calls[0]["prompt"] == override_prompt
+
+
+@pytest.mark.asyncio
+async def test_health_check_with_custom_llm_provider():
+    """
+    Test that ahealth_check correctly uses custom_llm_provider from model_params.
+    
+    This test verifies the fix for the issue where the UI's "Test connect" button
+    failed with "LLM Provider NOT provided" error for OpenAI-compatible self-hosted
+    providers, even when a provider was selected in the dropdown.
+    
+    The fix ensures that when custom_llm_provider is passed in model_params,
+    it's properly forwarded to get_llm_provider() to identify the correct provider.
+    """
+    from unittest.mock import MagicMock
+    
+    # Mock the completion call to avoid making real API calls
+    mock_response = MagicMock()
+    mock_response._hidden_params = {"headers": {"x-ratelimit-remaining-tokens": "1000"}}
+    
+    with patch("litellm.acompletion", return_value=mock_response):
+        # Test with a custom model name that wouldn't be recognized without custom_llm_provider
+        response = await litellm.ahealth_check(
+            model_params={
+                "model": "deepseek-r1-distill-qwen-1.5B-q4",
+                "custom_llm_provider": "openai",
+                "api_base": "https://example.com/v1",
+                "api_key": "fake-key",
+            },
+            mode="chat",
+        )
+        
+        print(f"response: {response}")
+        
+        # Should succeed without "LLM Provider NOT provided" error
+        assert "error" not in response
+        assert isinstance(response, dict)

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -669,8 +669,6 @@ async def test_health_check_with_custom_llm_provider():
             mode="chat",
         )
         
-        print(f"response: {response}")
-        
         # Should succeed without "LLM Provider NOT provided" error
         assert "error" not in response
         assert isinstance(response, dict)


### PR DESCRIPTION
## Relevant issues

Fixes #16736
Fixes #18632

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix


## Changes
- Sends the the custom_llm_provider sent from the UI to get_llm_provider

## Testing
<img width="1268" height="785" alt="image" src="https://github.com/user-attachments/assets/056764d3-c391-4e0a-94d8-78c4a082d01d" />

<img width="814" height="128" alt="image" src="https://github.com/user-attachments/assets/71a1e894-e820-4492-bb25-285feb5da082" />
