### PR TITLE
[UI] Add view for estimating costs across requests

### DIFF
--- a/docs/my-website/docs/proxy/pricing_calculator.md
+++ b/docs/my-website/docs/proxy/pricing_calculator.md
@@ -1,0 +1,135 @@
+# Pricing Calculator (Cost Estimation)
+
+Estimate LLM costs based on expected token usage and request volume. This tool helps developers and platform teams forecast spending before deploying models to production.
+
+## When to Use This Feature
+
+Use the Pricing Calculator to:
+- **Budget planning** - Estimate monthly costs before committing to a model
+- **Model comparison** - Compare costs across different models for your use case
+- **Capacity planning** - Understand cost implications of scaling request volume
+- **Cost optimization** - Identify the most cost-effective model for your token requirements
+
+## Using the Pricing Calculator
+
+This walkthrough shows how to estimate LLM costs using the Pricing Calculator in the LiteLLM UI.
+
+### Step 1: Navigate to Settings
+
+From the LiteLLM dashboard, click on **Settings** in the left sidebar.
+
+![Click Settings](https://colony-recorder.s3.amazonaws.com/files/2026-01-05/183c437e-bda9-48b4-ab8f-95f023ba1146/ascreenshot_a1013487f545484194a9a4929eef4c49_text_export.jpeg)
+
+### Step 2: Open Cost Tracking
+
+Click on **Cost Tracking** to access the cost configuration options.
+
+![Click Cost Tracking](https://colony-recorder.s3.amazonaws.com/files/2026-01-05/05c92350-cbae-42ed-935b-e96a26003de8/ascreenshot_cc85f175a6664fc5be8dfdcc1759b442_text_export.jpeg)
+
+### Step 3: Open Pricing Calculator
+
+Click on **Pricing Calculator** to expand the calculator panel. This section allows you to estimate LLM costs based on expected token usage and request volume.
+
+![Click Pricing Calculator](https://colony-recorder.s3.amazonaws.com/files/2026-01-05/31ab5547-fa7d-4abd-b41a-7b4bbc0401f7/ascreenshot_f7f8b098ceba4b5199e5cbc60dddfd0a_text_export.jpeg)
+
+### Step 4: Select a Model
+
+Click the **Model** dropdown to select the model you want to estimate costs for.
+
+![Click Model field](https://colony-recorder.s3.amazonaws.com/files/2026-01-05/a6c236ce-3154-42a8-9701-120e3f7a017b/ascreenshot_635c61b832594e809f8ab79b5b3f32e1_text_export.jpeg)
+
+Choose a model from the list. The models shown are the ones configured on your LiteLLM proxy.
+
+![Select model](https://colony-recorder.s3.amazonaws.com/files/2026-01-05/96c4ebc4-1b88-4dea-b3b2-ea32fde36d9e/ascreenshot_7c2920f05a984ebbb530a8a85e669537_text_export.jpeg)
+
+### Step 5: Configure Token Counts
+
+Enter the expected **Input Tokens (per request)** - this is the average number of tokens in your prompts.
+
+![Click Input Tokens field](https://colony-recorder.s3.amazonaws.com/files/2026-01-05/d0b5ad8a-56e4-4f73-ac66-e1d728c81dc5/ascreenshot_42502082d6204a3891e0a2c3e89a1e38_text_export.jpeg)
+
+Enter the expected **Output Tokens (per request)** - this is the average number of tokens in model responses.
+
+![Click Output Tokens field](https://colony-recorder.s3.amazonaws.com/files/2026-01-05/d7481177-c63c-47f5-9316-1e87695f67f9/ascreenshot_8718cac4c0d14a82ab9f2b71795250c2_text_export.jpeg)
+
+### Step 6: Set Request Volume
+
+Enter your expected request volume. You can specify **Requests per Day** and/or **Requests per Month**.
+
+![Click Requests per Month field](https://colony-recorder.s3.amazonaws.com/files/2026-01-05/42270e11-93f1-41dc-b9c7-3bb6971ced31/ascreenshot_79f2ea9937b34e48ab1ff832ce7f7cb7_text_export.jpeg)
+
+For example, enter `10000000` for 10 million requests per month.
+
+![Enter request volume](https://colony-recorder.s3.amazonaws.com/files/2026-01-05/5e6c4338-ff87-44dd-9059-7577217fa3c8/ascreenshot_15c36610dc914536ac9446470eb39f05_text_export.jpeg)
+
+### Step 7: View Cost Estimates
+
+The calculator automatically updates as you change values. View the cost breakdown including:
+
+- **Per-Request Cost** - Total cost, input cost, output cost, and margin/fee per request
+- **Daily Costs** - Aggregated costs if you specified requests per day
+- **Monthly Costs** - Aggregated costs if you specified requests per month
+
+![View cost estimates](https://colony-recorder.s3.amazonaws.com/files/2026-01-05/4436cd11-df58-47cb-9742-c0d08865a61c/ascreenshot_f961298a4231464ea841bc4d184f731e_text_export.jpeg)
+
+## Cost Breakdown Details
+
+The Pricing Calculator shows:
+
+| Field | Description |
+|-------|-------------|
+| **Total Cost** | Complete cost including any configured margins |
+| **Input Cost** | Cost for input/prompt tokens |
+| **Output Cost** | Cost for output/completion tokens |
+| **Margin/Fee** | Any configured [provider margins](/docs/proxy/provider_margins) |
+| **Token Pricing** | Per-token rates (shown as $/1M tokens) |
+
+## API Endpoint
+
+You can also estimate costs programmatically using the `/cost/estimate` endpoint:
+
+```bash
+curl -X POST "http://localhost:4000/cost/estimate" \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4",
+    "input_tokens": 1000,
+    "output_tokens": 500,
+    "num_requests_per_day": 1000,
+    "num_requests_per_month": 30000
+  }'
+```
+
+**Response:**
+```json
+{
+  "model": "gpt-4",
+  "input_tokens": 1000,
+  "output_tokens": 500,
+  "num_requests_per_day": 1000,
+  "num_requests_per_month": 30000,
+  "cost_per_request": 0.045,
+  "input_cost_per_request": 0.03,
+  "output_cost_per_request": 0.015,
+  "margin_cost_per_request": 0.0,
+  "daily_cost": 45.0,
+  "daily_input_cost": 30.0,
+  "daily_output_cost": 15.0,
+  "daily_margin_cost": 0.0,
+  "monthly_cost": 1350.0,
+  "monthly_input_cost": 900.0,
+  "monthly_output_cost": 450.0,
+  "monthly_margin_cost": 0.0,
+  "input_cost_per_token": 3e-05,
+  "output_cost_per_token": 6e-05,
+  "provider": "openai"
+}
+```
+
+## Related Features
+
+- [Provider Margins](/docs/proxy/provider_margins) - Add fees or margins to LLM costs
+- [Provider Discounts](/docs/proxy/provider_discounts) - Apply discounts to provider costs
+- [Cost Tracking](/docs/proxy/cost_tracking) - Track and monitor LLM spend
+

--- a/docs/my-website/docs/proxy/pricing_calculator.md
+++ b/docs/my-website/docs/proxy/pricing_calculator.md
@@ -72,6 +72,13 @@ The calculator automatically updates as you change values. View the cost breakdo
 
 ![View cost estimates](https://colony-recorder.s3.amazonaws.com/files/2026-01-05/4436cd11-df58-47cb-9742-c0d08865a61c/ascreenshot_f961298a4231464ea841bc4d184f731e_text_export.jpeg)
 
+### Step 8: Export the Report
+
+Click the **Export** button to download your cost estimate. You can export as:
+
+- **PDF** - Opens a print dialog to save as PDF (great for sharing with stakeholders)
+- **CSV** - Downloads a spreadsheet-compatible file for further analysis
+
 ## Cost Breakdown Details
 
 The Pricing Calculator shows:

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -390,6 +390,7 @@ const sidebars = {
           items: [
             "proxy/cost_tracking",
             "proxy/custom_pricing",
+            "proxy/pricing_calculator",
             "proxy/provider_margins",
             "proxy/provider_discounts",
             "proxy/sync_models_github",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -11640,6 +11640,7 @@
         "supports_tool_choice": true
     },
     "gemini-1.5-flash": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 2e-06,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
         "input_cost_per_character": 1.875e-08,
@@ -11744,6 +11745,7 @@
         "supports_vision": true
     },
     "gemini-1.5-flash-exp-0827": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 2e-06,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
         "input_cost_per_character": 1.875e-08,
@@ -11778,6 +11780,7 @@
         "supports_vision": true
     },
     "gemini-1.5-flash-preview-0514": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 2e-06,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
         "input_cost_per_character": 1.875e-08,
@@ -11811,6 +11814,7 @@
         "supports_vision": true
     },
     "gemini-1.5-pro": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -11898,6 +11902,7 @@
         "supports_vision": true
     },
     "gemini-1.5-pro-preview-0215": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -11925,6 +11930,7 @@
         "supports_tool_choice": true
     },
     "gemini-1.5-pro-preview-0409": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -11951,6 +11957,7 @@
         "supports_tool_choice": true
     },
     "gemini-1.5-pro-preview-0514": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -12222,6 +12229,7 @@
         "tpm": 250000
     },
     "gemini-2.0-flash-preview-image-generation": {
+        "deprecation_date": "2025-11-14",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
@@ -12260,6 +12268,7 @@
         "supports_web_search": true
     },
     "gemini-2.0-flash-thinking-exp": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -12308,6 +12317,7 @@
         "supports_web_search": true
     },
     "gemini-2.0-flash-thinking-exp-01-21": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -12494,6 +12504,7 @@
         "tpm": 8000000
     },
     "gemini-2.5-flash-image-preview": {
+        "deprecation_date": "2026-01-15",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -12804,6 +12815,7 @@
         "tpm": 8000000
     },
     "gemini-2.5-flash-lite-preview-06-17": {
+        "deprecation_date": "2025-11-18",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
@@ -12893,6 +12905,7 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-preview-05-20": {
+        "deprecation_date": "2025-11-18",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -13164,6 +13177,7 @@
         "supports_web_search": true
     },
     "gemini-2.5-pro-preview-03-25": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
@@ -13209,6 +13223,7 @@
         "supports_web_search": true
     },
     "gemini-2.5-pro-preview-05-06": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
@@ -13424,6 +13439,7 @@
         "tpm": 10000000
     },
     "gemini/gemini-1.5-flash": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 7.5e-08,
         "input_cost_per_token_above_128k_tokens": 1.5e-07,
         "litellm_provider": "gemini",
@@ -13507,6 +13523,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-8b": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13533,6 +13550,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-8b-exp-0827": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13558,6 +13576,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-8b-exp-0924": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13584,6 +13603,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-exp-0827": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13609,6 +13629,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-latest": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 7.5e-08,
         "input_cost_per_token_above_128k_tokens": 1.5e-07,
         "litellm_provider": "gemini",
@@ -13635,6 +13656,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 3.5e-06,
         "input_cost_per_token_above_128k_tokens": 7e-06,
         "litellm_provider": "gemini",
@@ -13696,6 +13718,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro-exp-0801": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 3.5e-06,
         "input_cost_per_token_above_128k_tokens": 7e-06,
         "litellm_provider": "gemini",
@@ -13715,6 +13738,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro-exp-0827": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13734,6 +13758,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro-latest": {
+        "deprecation_date": "2025-09-29",
         "input_cost_per_token": 3.5e-06,
         "input_cost_per_token_above_128k_tokens": 7e-06,
         "litellm_provider": "gemini",
@@ -13916,6 +13941,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-2.0-flash-lite-preview-02-05": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 1.875e-08,
         "input_cost_per_audio_token": 7.5e-08,
         "input_cost_per_token": 7.5e-08,
@@ -13953,6 +13979,7 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.0-flash-live-001": {
+        "deprecation_date": "2025-12-09",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 2.1e-06,
         "input_cost_per_image": 2.1e-06,
@@ -14001,6 +14028,7 @@
         "tpm": 250000
     },
     "gemini/gemini-2.0-flash-preview-image-generation": {
+        "deprecation_date": "2025-11-14",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
@@ -14040,6 +14068,7 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.0-flash-thinking-exp": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -14089,6 +14118,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-2.0-flash-thinking-exp-01-21": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -14277,6 +14307,7 @@
         "tpm": 8000000
     },
     "gemini/gemini-2.5-flash-image-preview": {
+        "deprecation_date": "2026-01-15",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -14597,6 +14628,7 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-lite-preview-06-17": {
+        "deprecation_date": "2025-11-18",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
@@ -14688,6 +14720,7 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-preview-05-20": {
+        "deprecation_date": "2025-11-18",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -15034,6 +15067,7 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-pro-preview-03-25": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1.25e-06,
@@ -15074,6 +15108,7 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.5-pro-preview-05-06": {
+        "deprecation_date": "2025-12-02",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1.25e-06,
@@ -15349,6 +15384,7 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "gemini/imagen-3.0-generate-002": {
+        "deprecation_date": "2025-11-10",
         "litellm_provider": "gemini",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
@@ -15415,6 +15451,7 @@
         ]
     },
     "gemini/veo-3.0-fast-generate-preview": {
+        "deprecation_date": "2025-11-12",
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -15429,6 +15466,7 @@
         ]
     },
     "gemini/veo-3.0-generate-preview": {
+        "deprecation_date": "2025-11-12",
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -25126,6 +25164,7 @@
         "source": "https://docs.mistral.ai/capabilities/code_generation/"
     },
     "text-embedding-004": {
+        "deprecation_date": "2026-01-14",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -27896,6 +27935,7 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "vertex_ai/imagen-3.0-generate-002": {
+        "deprecation_date": "2025-11-10",
         "litellm_provider": "vertex_ai-image-models",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
@@ -28406,6 +28446,7 @@
         ]
     },
     "vertex_ai/veo-3.0-fast-generate-preview": {
+        "deprecation_date": "2025-11-12",
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -28420,6 +28461,7 @@
         ]
     },
     "vertex_ai/veo-3.0-generate-preview": {
+        "deprecation_date": "2025-11-12",
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3834,7 +3834,12 @@ class CostEstimateRequest(LiteLLMPydanticObjectBase):
     model: str = Field(description="Model name (from /model_group/info)")
     input_tokens: int = Field(description="Expected input tokens per request", ge=0)
     output_tokens: int = Field(description="Expected output tokens per request", ge=0)
-    num_requests: int = Field(default=1, description="Number of requests", ge=1)
+    num_requests_per_day: Optional[int] = Field(
+        default=None, description="Number of requests per day", ge=0
+    )
+    num_requests_per_month: Optional[int] = Field(
+        default=None, description="Number of requests per month", ge=0
+    )
 
 
 class CostEstimateResponse(LiteLLMPydanticObjectBase):
@@ -3843,17 +3848,23 @@ class CostEstimateResponse(LiteLLMPydanticObjectBase):
     model: str
     input_tokens: int
     output_tokens: int
-    num_requests: int
+    num_requests_per_day: Optional[int] = None
+    num_requests_per_month: Optional[int] = None
     # Per-request costs
     cost_per_request: float = Field(description="Total cost per request (includes margin)")
     input_cost_per_request: float = Field(description="Input token cost per request (before margin)")
     output_cost_per_request: float = Field(description="Output token cost per request (before margin)")
     margin_cost_per_request: float = Field(default=0.0, description="Margin/fee added per request")
-    # Total costs (per-request * num_requests)
-    total_cost: float = Field(description="Total cost for all requests (includes margin)")
-    total_input_cost: float = Field(description="Total input token cost (before margin)")
-    total_output_cost: float = Field(description="Total output token cost (before margin)")
-    total_margin_cost: float = Field(default=0.0, description="Total margin/fee for all requests")
+    # Daily costs (if num_requests_per_day provided)
+    daily_cost: Optional[float] = Field(default=None, description="Total daily cost (includes margin)")
+    daily_input_cost: Optional[float] = Field(default=None, description="Daily input token cost")
+    daily_output_cost: Optional[float] = Field(default=None, description="Daily output token cost")
+    daily_margin_cost: Optional[float] = Field(default=None, description="Daily margin/fee")
+    # Monthly costs (if num_requests_per_month provided)
+    monthly_cost: Optional[float] = Field(default=None, description="Total monthly cost (includes margin)")
+    monthly_input_cost: Optional[float] = Field(default=None, description="Monthly input token cost")
+    monthly_output_cost: Optional[float] = Field(default=None, description="Monthly output token cost")
+    monthly_margin_cost: Optional[float] = Field(default=None, description="Monthly margin/fee")
     # Pricing info
     input_cost_per_token: Optional[float] = None
     output_cost_per_token: Optional[float] = None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3825,3 +3825,35 @@ class LiteLLM_ManagedVectorStoresTable(LiteLLMPydanticObjectBase):
 
 class ResponseLiteLLM_ManagedVectorStore(TypedDict, total=False):
     vector_store: LiteLLM_ManagedVectorStoresTable
+
+
+class CostEstimateRequest(LiteLLMPydanticObjectBase):
+    """Request body for /cost/estimate endpoint."""
+
+    model: str = Field(description="Model name (from /model_group/info)")
+    input_tokens: int = Field(description="Expected input tokens per request", ge=0)
+    output_tokens: int = Field(description="Expected output tokens per request", ge=0)
+    num_requests: int = Field(default=1, description="Number of requests", ge=1)
+
+
+class CostEstimateResponse(LiteLLMPydanticObjectBase):
+    """Response body for /cost/estimate endpoint."""
+
+    model: str
+    input_tokens: int
+    output_tokens: int
+    num_requests: int
+    # Per-request costs
+    cost_per_request: float = Field(description="Total cost per request (includes margin)")
+    input_cost_per_request: float = Field(description="Input token cost per request (before margin)")
+    output_cost_per_request: float = Field(description="Output token cost per request (before margin)")
+    margin_cost_per_request: float = Field(default=0.0, description="Margin/fee added per request")
+    # Total costs (per-request * num_requests)
+    total_cost: float = Field(description="Total cost for all requests (includes margin)")
+    total_input_cost: float = Field(description="Total input token cost (before margin)")
+    total_output_cost: float = Field(description="Total output token cost (before margin)")
+    total_margin_cost: float = Field(default=0.0, description="Total margin/fee for all requests")
+    # Pricing info
+    input_cost_per_token: Optional[float] = None
+    output_cost_per_token: Optional[float] = None
+    provider: Optional[str] = None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -522,6 +522,7 @@ class LiteLLMRoutes(enum.Enum):
         "/spend/tags",
         "/spend/calculate",
         "/spend/logs",
+        "/cost/estimate",
     ]
 
     global_spend_tracking_routes = [

--- a/litellm/proxy/management_endpoints/cost_tracking_settings.py
+++ b/litellm/proxy/management_endpoints/cost_tracking_settings.py
@@ -10,7 +10,7 @@ PATCH /config/cost_margin_config - Update cost margin configuration
 POST /cost/estimate - Estimate cost for a given model and token counts
 """
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, Union
 
 from fastapi import APIRouter, Depends, HTTPException
 

--- a/tests/litellm/proxy/management_endpoints/test_cost_estimate_endpoint.py
+++ b/tests/litellm/proxy/management_endpoints/test_cost_estimate_endpoint.py
@@ -14,18 +14,10 @@ class TestCostEstimateEndpoint:
     """Tests for the cost estimation endpoint."""
 
     @pytest.mark.asyncio
-    async def test_estimate_cost_with_margin(self):
+    async def test_estimate_cost_uses_completion_cost(self):
         """
-        Test that cost estimation returns correct breakdown including margin.
+        Test that cost estimation uses completion_cost and returns breakdown.
         """
-        mock_model_group_info = MagicMock()
-        mock_model_group_info.providers = ["openai"]
-        mock_model_group_info.input_cost_per_token = 0.00003
-        mock_model_group_info.output_cost_per_token = 0.00006
-
-        mock_router = MagicMock()
-        mock_router.get_model_group_info.return_value = mock_model_group_info
-
         request = CostEstimateRequest(
             model="gpt-4",
             input_tokens=1000,
@@ -33,40 +25,45 @@ class TestCostEstimateEndpoint:
             num_requests=10,
         )
 
-        # Base cost = 0.00003 * 1000 + 0.00006 * 500 = 0.03 + 0.03 = 0.06
-        # With 10% margin = 0.06 + 0.006 = 0.066
-        with patch("litellm.cost_calculator._apply_cost_margin") as mock_apply_margin:
-            mock_apply_margin.return_value = (0.066, 0.10, 0.0, 0.006)
+        with patch(
+            "litellm.proxy.management_endpoints.cost_tracking_settings.completion_cost"
+        ) as mock_completion_cost:
+            mock_completion_cost.return_value = 0.066
 
-            with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+            with patch("litellm.get_model_info") as mock_get_model_info:
+                mock_get_model_info.return_value = {
+                    "input_cost_per_token": 0.00003,
+                    "output_cost_per_token": 0.00006,
+                    "litellm_provider": "openai",
+                }
+
                 response = await estimate_cost(
                     request=request,
                     user_api_key_dict=MagicMock(),
                 )
 
         assert response.model == "gpt-4"
-        assert response.input_cost_per_request == pytest.approx(0.03)
-        assert response.output_cost_per_request == pytest.approx(0.03)
-        assert response.margin_cost_per_request == pytest.approx(0.006)
-        assert response.cost_per_request == pytest.approx(0.066)
+        assert response.cost_per_request == 0.066
         assert response.total_cost == pytest.approx(0.66)
-        assert response.total_margin_cost == pytest.approx(0.06)
+        # Verify completion_cost was called
+        mock_completion_cost.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_estimate_cost_model_not_found(self):
         """
-        Test that 404 is raised when model is not found.
+        Test that 404 is raised when model cost calculation fails.
         """
-        mock_router = MagicMock()
-        mock_router.get_model_group_info.return_value = None
-
         request = CostEstimateRequest(
             model="nonexistent-model",
             input_tokens=1000,
             output_tokens=500,
         )
 
-        with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+        with patch(
+            "litellm.proxy.management_endpoints.cost_tracking_settings.completion_cost"
+        ) as mock_completion_cost:
+            mock_completion_cost.side_effect = Exception("Model not found in cost map")
+
             from fastapi import HTTPException
 
             with pytest.raises(HTTPException) as exc_info:

--- a/tests/litellm/proxy/management_endpoints/test_cost_estimate_endpoint.py
+++ b/tests/litellm/proxy/management_endpoints/test_cost_estimate_endpoint.py
@@ -1,0 +1,78 @@
+"""
+Tests for the /cost/estimate endpoint in cost_tracking_settings.py
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from litellm.proxy._types import CostEstimateRequest, CostEstimateResponse
+from litellm.proxy.management_endpoints.cost_tracking_settings import estimate_cost
+
+
+class TestCostEstimateEndpoint:
+    """Tests for the cost estimation endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_with_margin(self):
+        """
+        Test that cost estimation returns correct breakdown including margin.
+        """
+        mock_model_group_info = MagicMock()
+        mock_model_group_info.providers = ["openai"]
+        mock_model_group_info.input_cost_per_token = 0.00003
+        mock_model_group_info.output_cost_per_token = 0.00006
+
+        mock_router = MagicMock()
+        mock_router.get_model_group_info.return_value = mock_model_group_info
+
+        request = CostEstimateRequest(
+            model="gpt-4",
+            input_tokens=1000,
+            output_tokens=500,
+            num_requests=10,
+        )
+
+        # Base cost = 0.00003 * 1000 + 0.00006 * 500 = 0.03 + 0.03 = 0.06
+        # With 10% margin = 0.06 + 0.006 = 0.066
+        with patch("litellm.cost_calculator._apply_cost_margin") as mock_apply_margin:
+            mock_apply_margin.return_value = (0.066, 0.10, 0.0, 0.006)
+
+            with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+                response = await estimate_cost(
+                    request=request,
+                    user_api_key_dict=MagicMock(),
+                )
+
+        assert response.model == "gpt-4"
+        assert response.input_cost_per_request == pytest.approx(0.03)
+        assert response.output_cost_per_request == pytest.approx(0.03)
+        assert response.margin_cost_per_request == pytest.approx(0.006)
+        assert response.cost_per_request == pytest.approx(0.066)
+        assert response.total_cost == pytest.approx(0.66)
+        assert response.total_margin_cost == pytest.approx(0.06)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_model_not_found(self):
+        """
+        Test that 404 is raised when model is not found.
+        """
+        mock_router = MagicMock()
+        mock_router.get_model_group_info.return_value = None
+
+        request = CostEstimateRequest(
+            model="nonexistent-model",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+
+        with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+            from fastapi import HTTPException
+
+            with pytest.raises(HTTPException) as exc_info:
+                await estimate_cost(
+                    request=request,
+                    user_api_key_dict=MagicMock(),
+                )
+
+            assert exc_info.value.status_code == 404

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/cost_tracking_settings.tsx
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/cost_tracking_settings.tsx
@@ -38,7 +38,7 @@ const CostTrackingSettings: React.FC<CostTrackingSettingsProps> = ({
   const [marginForm] = Form.useForm();
   const [modal, contextHolder] = Modal.useModal();
   
-  const isProxyAdmin = userRole === "proxy_admin";
+  const isProxyAdmin = userRole === "proxy_admin" || userRole === "Admin";
 
   // Use custom hooks for discount and margin config
   const {

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/cost_tracking_settings.tsx
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/cost_tracking_settings.tsx
@@ -6,11 +6,13 @@ import ProviderDiscountTable from "./provider_discount_table";
 import AddProviderForm from "./add_provider_form";
 import ProviderMarginTable from "./provider_margin_table";
 import AddMarginForm from "./add_margin_form";
+import PricingCalculator from "./pricing_calculator/index";
 import { ExclamationCircleOutlined } from "@ant-design/icons";
 import { DocsMenu } from "../HelpLink";
 import HowItWorks from "./how_it_works";
 import { useDiscountConfig } from "./use_discount_config";
 import { useMarginConfig } from "./use_margin_config";
+import { fetchAvailableModels, ModelGroup } from "../playground/llm_calls/fetch_models";
 
 const DOCS_LINKS = [
   { label: "Custom pricing for models", href: "https://docs.litellm.ai/docs/proxy/custom_pricing" },
@@ -31,9 +33,12 @@ const CostTrackingSettings: React.FC<CostTrackingSettingsProps> = ({
   const [marginType, setMarginType] = useState<"percentage" | "fixed">("percentage");
   const [percentageValue, setPercentageValue] = useState<string>("");
   const [fixedAmountValue, setFixedAmountValue] = useState<string>("");
+  const [models, setModels] = useState<string[]>([]);
   const [form] = Form.useForm();
   const [marginForm] = Form.useForm();
   const [modal, contextHolder] = Modal.useModal();
+  
+  const isProxyAdmin = userRole === "proxy_admin";
 
   // Use custom hooks for discount and margin config
   const {
@@ -57,6 +62,17 @@ const CostTrackingSettings: React.FC<CostTrackingSettingsProps> = ({
       Promise.all([fetchDiscountConfig(), fetchMarginConfig()]).finally(() => {
         setIsFetching(false);
       });
+      
+      // Fetch models for pricing calculator (available to all roles)
+      const loadModels = async () => {
+        try {
+          const modelGroups = await fetchAvailableModels(accessToken);
+          setModels(modelGroups.map((m: ModelGroup) => m.model_group));
+        } catch (error) {
+          console.error("Error fetching models:", error);
+        }
+      };
+      loadModels();
     }
   }, [accessToken, fetchDiscountConfig, fetchMarginConfig]);
 
@@ -152,129 +168,153 @@ const CostTrackingSettings: React.FC<CostTrackingSettingsProps> = ({
 
       {/* Main Content Card with Accordions */}
       <div className="bg-white rounded-lg shadow w-full max-w-full space-y-4">
-        {/* Accordion 1: Provider Discounts */}
-        <Accordion>
-          <AccordionHeader className="px-6 py-4">
-            <div className="flex flex-col items-start w-full">
-              <Text className="text-lg font-semibold text-gray-900">Provider Discounts</Text>
-              <Text className="text-sm text-gray-500 mt-1">
-                Apply percentage-based discounts to reduce costs for specific providers
-              </Text>
-            </div>
-          </AccordionHeader>
-          <AccordionBody className="px-0">
-            <TabGroup>
-              <TabList className="px-6 pt-4">
-                <Tab>Discounts</Tab>
-                <Tab>Test It</Tab>
-              </TabList>
-              <TabPanels>
-                <TabPanel>
-                  <div className="p-6">
-                    <div className="flex justify-end mb-4">
-                      <Button
-                        onClick={() => setIsModalVisible(true)}
-                      >
-                        + Add Provider Discount
-                      </Button>
-                    </div>
-                    {isFetching ? (
-                      <div className="py-12 text-center">
-                        <Text className="text-gray-500">Loading configuration...</Text>
-                      </div>
-                    ) : Object.keys(discountConfig).length > 0 ? (
-                      <ProviderDiscountTable
-                        discountConfig={discountConfig}
-                        onDiscountChange={handleDiscountChange}
-                        onRemoveProvider={handleRemoveProvider}
-                      />
-                    ) : (
-                      <div className="py-16 px-6 text-center">
-                        <svg
-                          className="mx-auto h-12 w-12 text-gray-400 mb-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
+        {/* Accordion 1: Provider Discounts - Only for proxy admins */}
+        {isProxyAdmin && (
+          <Accordion>
+            <AccordionHeader className="px-6 py-4">
+              <div className="flex flex-col items-start w-full">
+                <Text className="text-lg font-semibold text-gray-900">Provider Discounts</Text>
+                <Text className="text-sm text-gray-500 mt-1">
+                  Apply percentage-based discounts to reduce costs for specific providers
+                </Text>
+              </div>
+            </AccordionHeader>
+            <AccordionBody className="px-0">
+              <TabGroup>
+                <TabList className="px-6 pt-4">
+                  <Tab>Discounts</Tab>
+                  <Tab>Test It</Tab>
+                </TabList>
+                <TabPanels>
+                  <TabPanel>
+                    <div className="p-6">
+                      <div className="flex justify-end mb-4">
+                        <Button
+                          onClick={() => setIsModalVisible(true)}
                         >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={1.5}
-                            d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                          />
-                        </svg>
-                        <Text className="text-gray-700 font-medium mb-2">
-                          No provider discounts configured
-                        </Text>
-                        <Text className="text-gray-500 text-sm">
-                          Click &quot;Add Provider Discount&quot; to get started
-                        </Text>
+                          + Add Provider Discount
+                        </Button>
                       </div>
-                    )}
-                  </div>
-                </TabPanel>
-                <TabPanel>
-                  <div className="px-6 pb-4">
-                    <HowItWorks />
-                  </div>
-                </TabPanel>
-              </TabPanels>
-            </TabGroup>
-          </AccordionBody>
-        </Accordion>
+                      {isFetching ? (
+                        <div className="py-12 text-center">
+                          <Text className="text-gray-500">Loading configuration...</Text>
+                        </div>
+                      ) : Object.keys(discountConfig).length > 0 ? (
+                        <ProviderDiscountTable
+                          discountConfig={discountConfig}
+                          onDiscountChange={handleDiscountChange}
+                          onRemoveProvider={handleRemoveProvider}
+                        />
+                      ) : (
+                        <div className="py-16 px-6 text-center">
+                          <svg
+                            className="mx-auto h-12 w-12 text-gray-400 mb-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={1.5}
+                              d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                            />
+                          </svg>
+                          <Text className="text-gray-700 font-medium mb-2">
+                            No provider discounts configured
+                          </Text>
+                          <Text className="text-gray-500 text-sm">
+                            Click &quot;Add Provider Discount&quot; to get started
+                          </Text>
+                        </div>
+                      )}
+                    </div>
+                  </TabPanel>
+                  <TabPanel>
+                    <div className="px-6 pb-4">
+                      <HowItWorks />
+                    </div>
+                  </TabPanel>
+                </TabPanels>
+              </TabGroup>
+            </AccordionBody>
+          </Accordion>
+        )}
 
-        {/* Accordion 2: Fee/Price Margin */}
-        <Accordion>
+        {/* Accordion 2: Fee/Price Margin - Only for proxy admins */}
+        {isProxyAdmin && (
+          <Accordion>
+            <AccordionHeader className="px-6 py-4">
+              <div className="flex flex-col items-start w-full">
+                <Text className="text-lg font-semibold text-gray-900">Fee/Price Margin</Text>
+                <Text className="text-sm text-gray-500 mt-1">
+                  Add fees or margins to LLM costs for internal billing and cost recovery
+                </Text>
+              </div>
+            </AccordionHeader>
+            <AccordionBody className="px-0">
+              <div className="p-6">
+                <div className="flex justify-end mb-4">
+                  <Button
+                    onClick={() => setIsMarginModalVisible(true)}
+                  >
+                    + Add Provider Margin
+                  </Button>
+                </div>
+                {isFetching ? (
+                  <div className="py-12 text-center">
+                    <Text className="text-gray-500">Loading configuration...</Text>
+                  </div>
+                ) : Object.keys(marginConfig).length > 0 ? (
+                  <ProviderMarginTable
+                    marginConfig={marginConfig}
+                    onMarginChange={handleMarginChange}
+                    onRemoveProvider={handleRemoveMargin}
+                  />
+                ) : (
+                  <div className="py-16 px-6 text-center">
+                    <svg
+                      className="mx-auto h-12 w-12 text-gray-400 mb-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
+                    </svg>
+                    <Text className="text-gray-700 font-medium mb-2">
+                      No provider margins configured
+                    </Text>
+                    <Text className="text-gray-500 text-sm">
+                      Click &quot;Add Provider Margin&quot; to get started
+                    </Text>
+                  </div>
+                )}
+              </div>
+            </AccordionBody>
+          </Accordion>
+        )}
+
+        {/* Accordion 3: Pricing Calculator - Available to all roles */}
+        <Accordion defaultOpen={true}>
           <AccordionHeader className="px-6 py-4">
             <div className="flex flex-col items-start w-full">
-              <Text className="text-lg font-semibold text-gray-900">Fee/Price Margin</Text>
+              <Text className="text-lg font-semibold text-gray-900">Pricing Calculator</Text>
               <Text className="text-sm text-gray-500 mt-1">
-                Add fees or margins to LLM costs for internal billing and cost recovery
+                Estimate LLM costs based on expected token usage and request volume
               </Text>
             </div>
           </AccordionHeader>
           <AccordionBody className="px-0">
             <div className="p-6">
-              <div className="flex justify-end mb-4">
-                <Button
-                  onClick={() => setIsMarginModalVisible(true)}
-                >
-                  + Add Provider Margin
-                </Button>
-              </div>
-              {isFetching ? (
-                <div className="py-12 text-center">
-                  <Text className="text-gray-500">Loading configuration...</Text>
-                </div>
-              ) : Object.keys(marginConfig).length > 0 ? (
-                <ProviderMarginTable
-                  marginConfig={marginConfig}
-                  onMarginChange={handleMarginChange}
-                  onRemoveProvider={handleRemoveMargin}
-                />
-              ) : (
-                <div className="py-16 px-6 text-center">
-                  <svg
-                    className="mx-auto h-12 w-12 text-gray-400 mb-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.5}
-                      d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
-                  <Text className="text-gray-700 font-medium mb-2">
-                    No provider margins configured
-                  </Text>
-                  <Text className="text-gray-500 text-sm">
-                    Click &quot;Add Provider Margin&quot; to get started
-                  </Text>
-                </div>
-              )}
+              <PricingCalculator
+                accessToken={accessToken}
+                models={models}
+              />
             </div>
           </AccordionBody>
         </Accordion>

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/cost_results.tsx
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/cost_results.tsx
@@ -1,0 +1,197 @@
+import React from "react";
+import { Text } from "@tremor/react";
+import { Card, Statistic, Row, Col, Divider, Spin } from "antd";
+import { DollarOutlined, LoadingOutlined } from "@ant-design/icons";
+import { CostEstimateResponse } from "../types";
+
+interface CostResultsProps {
+  result: CostEstimateResponse | null;
+  loading: boolean;
+}
+
+const formatCurrency = (value: number | null | undefined): string => {
+  if (value === null || value === undefined) return "-";
+  if (value < 0.01) return `$${value.toFixed(6)}`;
+  return `$${value.toFixed(4)}`;
+};
+
+const formatLargeCurrency = (value: number | null | undefined): string => {
+  if (value === null || value === undefined) return "-";
+  return `$${value.toFixed(2)}`;
+};
+
+const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
+  if (!result && !loading) {
+    return (
+      <div className="py-8 text-center border border-dashed border-gray-300 rounded-lg">
+        <Text className="text-gray-500">
+          Select a model to see cost estimates
+        </Text>
+      </div>
+    );
+  }
+
+  if (loading && !result) {
+    return (
+      <div className="py-8 text-center">
+        <Spin indicator={<LoadingOutlined spin />} />
+        <Text className="text-gray-500 block mt-2">Calculating costs...</Text>
+      </div>
+    );
+  }
+
+  if (!result) return null;
+
+  return (
+    <div className="space-y-4">
+      <Divider />
+
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <Text className="text-lg font-semibold text-gray-900">Cost Estimate</Text>
+          <Text className="text-sm text-gray-500 block mt-1">
+            Model: {result.model} {result.provider && `(${result.provider})`}
+          </Text>
+        </div>
+        {loading && <Spin indicator={<LoadingOutlined spin />} size="small" />}
+      </div>
+
+      <Card size="small" title="Per-Request Cost Breakdown">
+        <Row gutter={16}>
+          <Col span={6}>
+            <Statistic
+              title="Total Cost"
+              value={formatCurrency(result.cost_per_request)}
+              valueStyle={{ color: "#1890ff", fontSize: "18px" }}
+              prefix={<DollarOutlined />}
+            />
+          </Col>
+          <Col span={6}>
+            <Statistic
+              title="Input Cost"
+              value={formatCurrency(result.input_cost_per_request)}
+              valueStyle={{ fontSize: "16px" }}
+            />
+          </Col>
+          <Col span={6}>
+            <Statistic
+              title="Output Cost"
+              value={formatCurrency(result.output_cost_per_request)}
+              valueStyle={{ fontSize: "16px" }}
+            />
+          </Col>
+          <Col span={6}>
+            <Statistic
+              title="Margin/Fee"
+              value={formatCurrency(result.margin_cost_per_request)}
+              valueStyle={{
+                fontSize: "16px",
+                color: result.margin_cost_per_request > 0 ? "#faad14" : undefined,
+              }}
+            />
+          </Col>
+        </Row>
+      </Card>
+
+      {result.daily_cost !== null && (
+        <Card
+          size="small"
+          title={`Daily Costs (${result.num_requests_per_day?.toLocaleString()} requests/day)`}
+        >
+          <Row gutter={16}>
+            <Col span={6}>
+              <Statistic
+                title="Total Daily"
+                value={formatLargeCurrency(result.daily_cost)}
+                valueStyle={{ color: "#52c41a", fontSize: "18px" }}
+                prefix={<DollarOutlined />}
+              />
+            </Col>
+            <Col span={6}>
+              <Statistic
+                title="Input Cost"
+                value={formatLargeCurrency(result.daily_input_cost)}
+                valueStyle={{ fontSize: "16px" }}
+              />
+            </Col>
+            <Col span={6}>
+              <Statistic
+                title="Output Cost"
+                value={formatLargeCurrency(result.daily_output_cost)}
+                valueStyle={{ fontSize: "16px" }}
+              />
+            </Col>
+            <Col span={6}>
+              <Statistic
+                title="Margin/Fee"
+                value={formatLargeCurrency(result.daily_margin_cost)}
+                valueStyle={{
+                  fontSize: "16px",
+                  color: (result.daily_margin_cost ?? 0) > 0 ? "#faad14" : undefined,
+                }}
+              />
+            </Col>
+          </Row>
+        </Card>
+      )}
+
+      {result.monthly_cost !== null && (
+        <Card
+          size="small"
+          title={`Monthly Costs (${result.num_requests_per_month?.toLocaleString()} requests/month)`}
+        >
+          <Row gutter={16}>
+            <Col span={6}>
+              <Statistic
+                title="Total Monthly"
+                value={formatLargeCurrency(result.monthly_cost)}
+                valueStyle={{ color: "#722ed1", fontSize: "18px" }}
+                prefix={<DollarOutlined />}
+              />
+            </Col>
+            <Col span={6}>
+              <Statistic
+                title="Input Cost"
+                value={formatLargeCurrency(result.monthly_input_cost)}
+                valueStyle={{ fontSize: "16px" }}
+              />
+            </Col>
+            <Col span={6}>
+              <Statistic
+                title="Output Cost"
+                value={formatLargeCurrency(result.monthly_output_cost)}
+                valueStyle={{ fontSize: "16px" }}
+              />
+            </Col>
+            <Col span={6}>
+              <Statistic
+                title="Margin/Fee"
+                value={formatLargeCurrency(result.monthly_margin_cost)}
+                valueStyle={{
+                  fontSize: "16px",
+                  color: (result.monthly_margin_cost ?? 0) > 0 ? "#faad14" : undefined,
+                }}
+              />
+            </Col>
+          </Row>
+        </Card>
+      )}
+
+      {(result.input_cost_per_token || result.output_cost_per_token) && (
+        <div className="text-sm text-gray-500 mt-4">
+          <Text className="font-medium">Token Pricing: </Text>
+          {result.input_cost_per_token && (
+            <span>Input: ${(result.input_cost_per_token * 1000000).toFixed(2)}/1M tokens</span>
+          )}
+          {result.input_cost_per_token && result.output_cost_per_token && " | "}
+          {result.output_cost_per_token && (
+            <span>Output: ${(result.output_cost_per_token * 1000000).toFixed(2)}/1M tokens</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CostResults;
+

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/cost_results.tsx
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/cost_results.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useRef, useEffect } from "react";
-import { Text, Button } from "@tremor/react";
+import React from "react";
+import { Text } from "@tremor/react";
 import { Card, Statistic, Row, Col, Divider, Spin } from "antd";
-import { DollarOutlined, LoadingOutlined, DownloadOutlined, FilePdfOutlined, FileExcelOutlined } from "@ant-design/icons";
+import { DollarOutlined, LoadingOutlined } from "@ant-design/icons";
 import { CostEstimateResponse } from "../types";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
-import { exportToPDF, exportToCSV } from "./export_utils";
+import ExportDropdown from "./export_dropdown";
 
 interface CostResultsProps {
   result: CostEstimateResponse | null;
@@ -22,65 +22,6 @@ const formatCost = (value: number | null | undefined): string => {
 const formatRequests = (value: number | null | undefined): string => {
   if (value === null || value === undefined) return "-";
   return formatNumberWithCommas(value, 0, true);
-};
-
-const ExportDropdown: React.FC<{ result: CostEstimateResponse }> = ({ result }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isOpen]);
-
-  return (
-    <div className="relative inline-block" ref={menuRef}>
-      <Button
-        size="xs"
-        variant="secondary"
-        icon={DownloadOutlined}
-        onClick={() => setIsOpen(!isOpen)}
-      >
-        Export
-      </Button>
-
-      {isOpen && (
-        <div className="absolute right-0 mt-1 w-44 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50">
-          <button
-            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-            onClick={() => {
-              exportToPDF(result);
-              setIsOpen(false);
-            }}
-          >
-            <FilePdfOutlined className="mr-3 text-red-500" />
-            Export as PDF
-          </button>
-          <button
-            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-            onClick={() => {
-              exportToCSV(result);
-              setIsOpen(false);
-            }}
-          >
-            <FileExcelOutlined className="mr-3 text-green-600" />
-            Export as CSV
-          </button>
-        </div>
-      )}
-    </div>
-  );
 };
 
 const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/cost_results.tsx
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/cost_results.tsx
@@ -3,21 +3,24 @@ import { Text } from "@tremor/react";
 import { Card, Statistic, Row, Col, Divider, Spin } from "antd";
 import { DollarOutlined, LoadingOutlined } from "@ant-design/icons";
 import { CostEstimateResponse } from "../types";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 interface CostResultsProps {
   result: CostEstimateResponse | null;
   loading: boolean;
 }
 
-const formatCurrency = (value: number | null | undefined): string => {
+const formatCost = (value: number | null | undefined): string => {
   if (value === null || value === undefined) return "-";
-  if (value < 0.01) return `$${value.toFixed(6)}`;
-  return `$${value.toFixed(4)}`;
+  if (value === 0) return "$0";
+  if (value < 0.0001) return `$${value.toExponential(2)}`;
+  if (value < 1) return `$${value.toFixed(4)}`;
+  return `$${formatNumberWithCommas(value, 2, true)}`;
 };
 
-const formatLargeCurrency = (value: number | null | undefined): string => {
+const formatRequests = (value: number | null | undefined): string => {
   if (value === null || value === undefined) return "-";
-  return `$${value.toFixed(2)}`;
+  return formatNumberWithCommas(value, 0, true);
 };
 
 const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
@@ -61,7 +64,7 @@ const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
           <Col span={6}>
             <Statistic
               title="Total Cost"
-              value={formatCurrency(result.cost_per_request)}
+              value={formatCost(result.cost_per_request)}
               valueStyle={{ color: "#1890ff", fontSize: "18px" }}
               prefix={<DollarOutlined />}
             />
@@ -69,21 +72,21 @@ const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
           <Col span={6}>
             <Statistic
               title="Input Cost"
-              value={formatCurrency(result.input_cost_per_request)}
+              value={formatCost(result.input_cost_per_request)}
               valueStyle={{ fontSize: "16px" }}
             />
           </Col>
           <Col span={6}>
             <Statistic
               title="Output Cost"
-              value={formatCurrency(result.output_cost_per_request)}
+              value={formatCost(result.output_cost_per_request)}
               valueStyle={{ fontSize: "16px" }}
             />
           </Col>
           <Col span={6}>
             <Statistic
               title="Margin/Fee"
-              value={formatCurrency(result.margin_cost_per_request)}
+              value={formatCost(result.margin_cost_per_request)}
               valueStyle={{
                 fontSize: "16px",
                 color: result.margin_cost_per_request > 0 ? "#faad14" : undefined,
@@ -96,13 +99,13 @@ const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
       {result.daily_cost !== null && (
         <Card
           size="small"
-          title={`Daily Costs (${result.num_requests_per_day?.toLocaleString()} requests/day)`}
+          title={`Daily Costs (${formatRequests(result.num_requests_per_day)} requests/day)`}
         >
           <Row gutter={16}>
             <Col span={6}>
               <Statistic
                 title="Total Daily"
-                value={formatLargeCurrency(result.daily_cost)}
+                value={formatCost(result.daily_cost)}
                 valueStyle={{ color: "#52c41a", fontSize: "18px" }}
                 prefix={<DollarOutlined />}
               />
@@ -110,21 +113,21 @@ const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
             <Col span={6}>
               <Statistic
                 title="Input Cost"
-                value={formatLargeCurrency(result.daily_input_cost)}
+                value={formatCost(result.daily_input_cost)}
                 valueStyle={{ fontSize: "16px" }}
               />
             </Col>
             <Col span={6}>
               <Statistic
                 title="Output Cost"
-                value={formatLargeCurrency(result.daily_output_cost)}
+                value={formatCost(result.daily_output_cost)}
                 valueStyle={{ fontSize: "16px" }}
               />
             </Col>
             <Col span={6}>
               <Statistic
                 title="Margin/Fee"
-                value={formatLargeCurrency(result.daily_margin_cost)}
+                value={formatCost(result.daily_margin_cost)}
                 valueStyle={{
                   fontSize: "16px",
                   color: (result.daily_margin_cost ?? 0) > 0 ? "#faad14" : undefined,
@@ -138,13 +141,13 @@ const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
       {result.monthly_cost !== null && (
         <Card
           size="small"
-          title={`Monthly Costs (${result.num_requests_per_month?.toLocaleString()} requests/month)`}
+          title={`Monthly Costs (${formatRequests(result.num_requests_per_month)} requests/month)`}
         >
           <Row gutter={16}>
             <Col span={6}>
               <Statistic
                 title="Total Monthly"
-                value={formatLargeCurrency(result.monthly_cost)}
+                value={formatCost(result.monthly_cost)}
                 valueStyle={{ color: "#722ed1", fontSize: "18px" }}
                 prefix={<DollarOutlined />}
               />
@@ -152,21 +155,21 @@ const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
             <Col span={6}>
               <Statistic
                 title="Input Cost"
-                value={formatLargeCurrency(result.monthly_input_cost)}
+                value={formatCost(result.monthly_input_cost)}
                 valueStyle={{ fontSize: "16px" }}
               />
             </Col>
             <Col span={6}>
               <Statistic
                 title="Output Cost"
-                value={formatLargeCurrency(result.monthly_output_cost)}
+                value={formatCost(result.monthly_output_cost)}
                 valueStyle={{ fontSize: "16px" }}
               />
             </Col>
             <Col span={6}>
               <Statistic
                 title="Margin/Fee"
-                value={formatLargeCurrency(result.monthly_margin_cost)}
+                value={formatCost(result.monthly_margin_cost)}
                 valueStyle={{
                   fontSize: "16px",
                   color: (result.monthly_margin_cost ?? 0) > 0 ? "#faad14" : undefined,
@@ -181,11 +184,11 @@ const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
         <div className="text-sm text-gray-500 mt-4">
           <Text className="font-medium">Token Pricing: </Text>
           {result.input_cost_per_token && (
-            <span>Input: ${(result.input_cost_per_token * 1000000).toFixed(2)}/1M tokens</span>
+            <span>Input: ${formatNumberWithCommas(result.input_cost_per_token * 1_000_000, 2)}/1M tokens</span>
           )}
           {result.input_cost_per_token && result.output_cost_per_token && " | "}
           {result.output_cost_per_token && (
-            <span>Output: ${(result.output_cost_per_token * 1000000).toFixed(2)}/1M tokens</span>
+            <span>Output: ${formatNumberWithCommas(result.output_cost_per_token * 1_000_000, 2)}/1M tokens</span>
           )}
         </div>
       )}
@@ -194,4 +197,3 @@ const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
 };
 
 export default CostResults;
-

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/cost_results.tsx
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/cost_results.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { Text } from "@tremor/react";
+import React, { useState, useRef, useEffect } from "react";
+import { Text, Button } from "@tremor/react";
 import { Card, Statistic, Row, Col, Divider, Spin } from "antd";
-import { DollarOutlined, LoadingOutlined } from "@ant-design/icons";
+import { DollarOutlined, LoadingOutlined, DownloadOutlined, FilePdfOutlined, FileExcelOutlined } from "@ant-design/icons";
 import { CostEstimateResponse } from "../types";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { exportToPDF, exportToCSV } from "./export_utils";
 
 interface CostResultsProps {
   result: CostEstimateResponse | null;
@@ -21,6 +22,65 @@ const formatCost = (value: number | null | undefined): string => {
 const formatRequests = (value: number | null | undefined): string => {
   if (value === null || value === undefined) return "-";
   return formatNumberWithCommas(value, 0, true);
+};
+
+const ExportDropdown: React.FC<{ result: CostEstimateResponse }> = ({ result }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
+
+  return (
+    <div className="relative inline-block" ref={menuRef}>
+      <Button
+        size="xs"
+        variant="secondary"
+        icon={DownloadOutlined}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        Export
+      </Button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-1 w-44 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50">
+          <button
+            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+            onClick={() => {
+              exportToPDF(result);
+              setIsOpen(false);
+            }}
+          >
+            <FilePdfOutlined className="mr-3 text-red-500" />
+            Export as PDF
+          </button>
+          <button
+            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+            onClick={() => {
+              exportToCSV(result);
+              setIsOpen(false);
+            }}
+          >
+            <FileExcelOutlined className="mr-3 text-green-600" />
+            Export as CSV
+          </button>
+        </div>
+      )}
+    </div>
+  );
 };
 
 const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
@@ -56,7 +116,10 @@ const CostResults: React.FC<CostResultsProps> = ({ result, loading }) => {
             Model: {result.model} {result.provider && `(${result.provider})`}
           </Text>
         </div>
-        {loading && <Spin indicator={<LoadingOutlined spin />} size="small" />}
+        <div className="flex items-center gap-2">
+          {loading && <Spin indicator={<LoadingOutlined spin />} size="small" />}
+          <ExportDropdown result={result} />
+        </div>
       </div>
 
       <Card size="small" title="Per-Request Cost Breakdown">

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/export_dropdown.tsx
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/export_dropdown.tsx
@@ -1,0 +1,71 @@
+import React, { useState, useRef, useEffect } from "react";
+import { Button } from "@tremor/react";
+import { DownloadOutlined, FilePdfOutlined, FileExcelOutlined } from "@ant-design/icons";
+import { CostEstimateResponse } from "../types";
+import { exportToPDF, exportToCSV } from "./export_utils";
+
+interface ExportDropdownProps {
+  result: CostEstimateResponse;
+}
+
+const ExportDropdown: React.FC<ExportDropdownProps> = ({ result }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
+
+  return (
+    <div className="relative inline-block" ref={menuRef}>
+      <Button
+        size="xs"
+        variant="secondary"
+        icon={DownloadOutlined}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        Export
+      </Button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-1 w-44 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50">
+          <button
+            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+            onClick={() => {
+              exportToPDF(result);
+              setIsOpen(false);
+            }}
+          >
+            <FilePdfOutlined className="mr-3 text-red-500" />
+            Export as PDF
+          </button>
+          <button
+            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+            onClick={() => {
+              exportToCSV(result);
+              setIsOpen(false);
+            }}
+          >
+            <FileExcelOutlined className="mr-3 text-green-600" />
+            Export as CSV
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ExportDropdown;
+

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/export_utils.ts
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/export_utils.ts
@@ -1,0 +1,276 @@
+import { CostEstimateResponse } from "../types";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
+
+const formatCostForExport = (value: number | null | undefined): string => {
+  if (value === null || value === undefined) return "-";
+  if (value === 0) return "$0.00";
+  if (value < 0.01) return `$${value.toFixed(6)}`;
+  if (value < 1) return `$${value.toFixed(4)}`;
+  return `$${formatNumberWithCommas(value, 2)}`;
+};
+
+const formatRequestsForExport = (value: number | null | undefined): string => {
+  if (value === null || value === undefined) return "-";
+  return formatNumberWithCommas(value, 0);
+};
+
+export const exportToPDF = (result: CostEstimateResponse): void => {
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) {
+    alert("Please allow popups to export PDF");
+    return;
+  }
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Cost Estimate Report - ${result.model}</title>
+      <style>
+        body {
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+          padding: 40px;
+          max-width: 800px;
+          margin: 0 auto;
+          color: #333;
+        }
+        h1 {
+          color: #1a1a1a;
+          border-bottom: 2px solid #1890ff;
+          padding-bottom: 10px;
+          margin-bottom: 30px;
+        }
+        h2 {
+          color: #444;
+          margin-top: 30px;
+          margin-bottom: 15px;
+        }
+        .meta {
+          background: #f5f5f5;
+          padding: 15px;
+          border-radius: 8px;
+          margin-bottom: 30px;
+        }
+        .meta p {
+          margin: 5px 0;
+        }
+        table {
+          width: 100%;
+          border-collapse: collapse;
+          margin-bottom: 20px;
+        }
+        th, td {
+          padding: 12px;
+          text-align: left;
+          border-bottom: 1px solid #ddd;
+        }
+        th {
+          background: #f8f9fa;
+          font-weight: 600;
+        }
+        .cost-value {
+          font-family: monospace;
+          font-size: 14px;
+        }
+        .total-row {
+          font-weight: bold;
+          background: #e6f7ff;
+        }
+        .footer {
+          margin-top: 40px;
+          padding-top: 20px;
+          border-top: 1px solid #ddd;
+          font-size: 12px;
+          color: #666;
+        }
+        @media print {
+          body { padding: 20px; }
+        }
+      </style>
+    </head>
+    <body>
+      <h1>LLM Cost Estimate Report</h1>
+      
+      <div class="meta">
+        <p><strong>Model:</strong> ${result.model}</p>
+        ${result.provider ? `<p><strong>Provider:</strong> ${result.provider}</p>` : ""}
+        <p><strong>Input Tokens per Request:</strong> ${formatRequestsForExport(result.input_tokens)}</p>
+        <p><strong>Output Tokens per Request:</strong> ${formatRequestsForExport(result.output_tokens)}</p>
+        ${result.num_requests_per_day ? `<p><strong>Requests per Day:</strong> ${formatRequestsForExport(result.num_requests_per_day)}</p>` : ""}
+        ${result.num_requests_per_month ? `<p><strong>Requests per Month:</strong> ${formatRequestsForExport(result.num_requests_per_month)}</p>` : ""}
+      </div>
+
+      <h2>Per-Request Cost Breakdown</h2>
+      <table>
+        <tr>
+          <th>Cost Type</th>
+          <th>Amount</th>
+        </tr>
+        <tr>
+          <td>Input Cost</td>
+          <td class="cost-value">${formatCostForExport(result.input_cost_per_request)}</td>
+        </tr>
+        <tr>
+          <td>Output Cost</td>
+          <td class="cost-value">${formatCostForExport(result.output_cost_per_request)}</td>
+        </tr>
+        <tr>
+          <td>Margin/Fee</td>
+          <td class="cost-value">${formatCostForExport(result.margin_cost_per_request)}</td>
+        </tr>
+        <tr class="total-row">
+          <td>Total per Request</td>
+          <td class="cost-value">${formatCostForExport(result.cost_per_request)}</td>
+        </tr>
+      </table>
+
+      ${result.daily_cost !== null ? `
+      <h2>Daily Cost Estimate (${formatRequestsForExport(result.num_requests_per_day)} requests/day)</h2>
+      <table>
+        <tr>
+          <th>Cost Type</th>
+          <th>Amount</th>
+        </tr>
+        <tr>
+          <td>Input Cost</td>
+          <td class="cost-value">${formatCostForExport(result.daily_input_cost)}</td>
+        </tr>
+        <tr>
+          <td>Output Cost</td>
+          <td class="cost-value">${formatCostForExport(result.daily_output_cost)}</td>
+        </tr>
+        <tr>
+          <td>Margin/Fee</td>
+          <td class="cost-value">${formatCostForExport(result.daily_margin_cost)}</td>
+        </tr>
+        <tr class="total-row">
+          <td>Total Daily</td>
+          <td class="cost-value">${formatCostForExport(result.daily_cost)}</td>
+        </tr>
+      </table>
+      ` : ""}
+
+      ${result.monthly_cost !== null ? `
+      <h2>Monthly Cost Estimate (${formatRequestsForExport(result.num_requests_per_month)} requests/month)</h2>
+      <table>
+        <tr>
+          <th>Cost Type</th>
+          <th>Amount</th>
+        </tr>
+        <tr>
+          <td>Input Cost</td>
+          <td class="cost-value">${formatCostForExport(result.monthly_input_cost)}</td>
+        </tr>
+        <tr>
+          <td>Output Cost</td>
+          <td class="cost-value">${formatCostForExport(result.monthly_output_cost)}</td>
+        </tr>
+        <tr>
+          <td>Margin/Fee</td>
+          <td class="cost-value">${formatCostForExport(result.monthly_margin_cost)}</td>
+        </tr>
+        <tr class="total-row">
+          <td>Total Monthly</td>
+          <td class="cost-value">${formatCostForExport(result.monthly_cost)}</td>
+        </tr>
+      </table>
+      ` : ""}
+
+      ${result.input_cost_per_token || result.output_cost_per_token ? `
+      <h2>Token Pricing</h2>
+      <table>
+        <tr>
+          <th>Token Type</th>
+          <th>Price per 1M Tokens</th>
+        </tr>
+        ${result.input_cost_per_token ? `
+        <tr>
+          <td>Input Tokens</td>
+          <td class="cost-value">$${(result.input_cost_per_token * 1000000).toFixed(2)}</td>
+        </tr>
+        ` : ""}
+        ${result.output_cost_per_token ? `
+        <tr>
+          <td>Output Tokens</td>
+          <td class="cost-value">$${(result.output_cost_per_token * 1000000).toFixed(2)}</td>
+        </tr>
+        ` : ""}
+      </table>
+      ` : ""}
+
+      <div class="footer">
+        <p>Generated by LiteLLM Pricing Calculator on ${new Date().toLocaleString()}</p>
+      </div>
+    </body>
+    </html>
+  `;
+
+  printWindow.document.write(html);
+  printWindow.document.close();
+  printWindow.onload = () => {
+    printWindow.print();
+  };
+};
+
+export const exportToCSV = (result: CostEstimateResponse): void => {
+  const rows = [
+    ["LLM Cost Estimate Report"],
+    [""],
+    ["Configuration"],
+    ["Model", result.model],
+    ["Provider", result.provider || "-"],
+    ["Input Tokens per Request", result.input_tokens.toString()],
+    ["Output Tokens per Request", result.output_tokens.toString()],
+    ["Requests per Day", result.num_requests_per_day?.toString() || "-"],
+    ["Requests per Month", result.num_requests_per_month?.toString() || "-"],
+    [""],
+    ["Per-Request Costs"],
+    ["Input Cost", result.input_cost_per_request.toString()],
+    ["Output Cost", result.output_cost_per_request.toString()],
+    ["Margin/Fee", result.margin_cost_per_request.toString()],
+    ["Total per Request", result.cost_per_request.toString()],
+  ];
+
+  if (result.daily_cost !== null) {
+    rows.push(
+      [""],
+      ["Daily Costs"],
+      ["Daily Input Cost", result.daily_input_cost?.toString() || "-"],
+      ["Daily Output Cost", result.daily_output_cost?.toString() || "-"],
+      ["Daily Margin/Fee", result.daily_margin_cost?.toString() || "-"],
+      ["Total Daily", result.daily_cost.toString()]
+    );
+  }
+
+  if (result.monthly_cost !== null) {
+    rows.push(
+      [""],
+      ["Monthly Costs"],
+      ["Monthly Input Cost", result.monthly_input_cost?.toString() || "-"],
+      ["Monthly Output Cost", result.monthly_output_cost?.toString() || "-"],
+      ["Monthly Margin/Fee", result.monthly_margin_cost?.toString() || "-"],
+      ["Total Monthly", result.monthly_cost.toString()]
+    );
+  }
+
+  if (result.input_cost_per_token || result.output_cost_per_token) {
+    rows.push(
+      [""],
+      ["Token Pricing (per 1M tokens)"],
+      ["Input Token Price", result.input_cost_per_token ? `$${(result.input_cost_per_token * 1000000).toFixed(2)}` : "-"],
+      ["Output Token Price", result.output_cost_per_token ? `$${(result.output_cost_per_token * 1000000).toFixed(2)}` : "-"]
+    );
+  }
+
+  const csv = rows.map(row => row.join(",")).join("\n");
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `cost_estimate_${result.model.replace(/\//g, "_")}_${new Date().toISOString().split("T")[0]}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  window.URL.revokeObjectURL(url);
+};
+

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/index.tsx
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/index.tsx
@@ -1,0 +1,31 @@
+import React, { useCallback } from "react";
+import PricingForm from "./pricing_form";
+import CostResults from "./cost_results";
+import { useCostEstimate } from "./use_cost_estimate";
+import { PricingCalculatorProps, PricingFormValues } from "./types";
+
+const PricingCalculator: React.FC<PricingCalculatorProps> = ({
+  accessToken,
+  models,
+}) => {
+  const { loading, result, debouncedFetch } = useCostEstimate(accessToken);
+
+  const handleValuesChange = useCallback(
+    (_changedValues: Partial<PricingFormValues>, allValues: PricingFormValues) => {
+      if (allValues.model) {
+        debouncedFetch(allValues);
+      }
+    },
+    [debouncedFetch]
+  );
+
+  return (
+    <div className="space-y-6">
+      <PricingForm models={models} onValuesChange={handleValuesChange} />
+      <CostResults result={result} loading={loading} />
+    </div>
+  );
+};
+
+export default PricingCalculator;
+

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/pricing_form.tsx
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/pricing_form.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { Form, InputNumber, Select, Row, Col } from "antd";
+import { PricingFormValues } from "./types";
+
+interface PricingFormProps {
+  models: string[];
+  onValuesChange: (changedValues: Partial<PricingFormValues>, allValues: PricingFormValues) => void;
+}
+
+const PricingForm: React.FC<PricingFormProps> = ({ models, onValuesChange }) => {
+  return (
+    <Form
+      layout="vertical"
+      onValuesChange={onValuesChange}
+      initialValues={{
+        input_tokens: 1000,
+        output_tokens: 500,
+      }}
+    >
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item
+            name="model"
+            label="Model"
+            rules={[{ required: true, message: "Please select a model" }]}
+          >
+            <Select
+              showSearch
+              placeholder="Select a model"
+              optionFilterProp="label"
+              filterOption={(input, option) =>
+                String(option?.label ?? "").toLowerCase().includes(input.toLowerCase())
+              }
+              options={models.map((model) => ({
+                value: model,
+                label: model,
+              }))}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={6}>
+          <Form.Item
+            name="input_tokens"
+            label="Input Tokens (per request)"
+            rules={[{ required: true, message: "Required" }]}
+          >
+            <InputNumber
+              min={0}
+              style={{ width: "100%" }}
+              formatter={(value) => `${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={6}>
+          <Form.Item
+            name="output_tokens"
+            label="Output Tokens (per request)"
+            rules={[{ required: true, message: "Required" }]}
+          >
+            <InputNumber
+              min={0}
+              style={{ width: "100%" }}
+              formatter={(value) => `${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
+            />
+          </Form.Item>
+        </Col>
+      </Row>
+
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item
+            name="num_requests_per_day"
+            label="Requests per Day"
+            tooltip="Optional: Enter expected daily request volume"
+          >
+            <InputNumber
+              min={0}
+              style={{ width: "100%" }}
+              placeholder="e.g., 1000"
+              formatter={(value) => `${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            name="num_requests_per_month"
+            label="Requests per Month"
+            tooltip="Optional: Enter expected monthly request volume"
+          >
+            <InputNumber
+              min={0}
+              style={{ width: "100%" }}
+              placeholder="e.g., 30000"
+              formatter={(value) => `${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ",")}
+            />
+          </Form.Item>
+        </Col>
+      </Row>
+    </Form>
+  );
+};
+
+export default PricingForm;
+

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/types.ts
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/types.ts
@@ -1,0 +1,13 @@
+export interface PricingCalculatorProps {
+  accessToken: string | null;
+  models: string[];
+}
+
+export interface PricingFormValues {
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  num_requests_per_day?: number;
+  num_requests_per_month?: number;
+}
+

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/use_cost_estimate.ts
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/pricing_calculator/use_cost_estimate.ts
@@ -1,0 +1,87 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import { getProxyBaseUrl } from "@/components/networking";
+import NotificationsManager from "../../molecules/notifications_manager";
+import { CostEstimateRequest, CostEstimateResponse } from "../types";
+import { PricingFormValues } from "./types";
+
+const DEBOUNCE_MS = 500;
+
+export function useCostEstimate(accessToken: string | null) {
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<CostEstimateResponse | null>(null);
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  const fetchEstimate = useCallback(
+    async (values: PricingFormValues) => {
+      if (!accessToken || !values.model) {
+        setResult(null);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const proxyBaseUrl = getProxyBaseUrl();
+        const url = proxyBaseUrl
+          ? `${proxyBaseUrl}/cost/estimate`
+          : "/cost/estimate";
+
+        const requestBody: CostEstimateRequest = {
+          model: values.model,
+          input_tokens: values.input_tokens || 0,
+          output_tokens: values.output_tokens || 0,
+          num_requests_per_day: values.num_requests_per_day || null,
+          num_requests_per_month: values.num_requests_per_month || null,
+        };
+
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(requestBody),
+        });
+
+        if (response.ok) {
+          const data: CostEstimateResponse = await response.json();
+          setResult(data);
+        } else {
+          const errorData = await response.json();
+          const errorMessage =
+            errorData.detail?.error || errorData.detail || "Failed to estimate cost";
+          NotificationsManager.fromBackend(errorMessage);
+          setResult(null);
+        }
+      } catch (error) {
+        console.error("Error estimating cost:", error);
+        setResult(null);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [accessToken]
+  );
+
+  const debouncedFetch = useCallback(
+    (values: PricingFormValues) => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+      debounceRef.current = setTimeout(() => {
+        fetchEstimate(values);
+      }, DEBOUNCE_MS);
+    },
+    [fetchEstimate]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
+  return { loading, result, debouncedFetch };
+}
+

--- a/ui/litellm-dashboard/src/components/CostTrackingSettings/types.ts
+++ b/ui/litellm-dashboard/src/components/CostTrackingSettings/types.ts
@@ -20,3 +20,34 @@ export interface CostMarginResponse {
   values: MarginConfig;
 }
 
+export interface CostEstimateRequest {
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  num_requests_per_day?: number | null;
+  num_requests_per_month?: number | null;
+}
+
+export interface CostEstimateResponse {
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  num_requests_per_day: number | null;
+  num_requests_per_month: number | null;
+  cost_per_request: number;
+  input_cost_per_request: number;
+  output_cost_per_request: number;
+  margin_cost_per_request: number;
+  daily_cost: number | null;
+  daily_input_cost: number | null;
+  daily_output_cost: number | null;
+  daily_margin_cost: number | null;
+  monthly_cost: number | null;
+  monthly_input_cost: number | null;
+  monthly_output_cost: number | null;
+  monthly_margin_cost: number | null;
+  input_cost_per_token: number | null;
+  output_cost_per_token: number | null;
+  provider: string | null;
+}
+


### PR DESCRIPTION
## [UI] Add view for estimating costs across requests

<img width="1527" height="608" alt="Screenshot 2026-01-05 at 7 19 19 PM" src="https://github.com/user-attachments/assets/faa04298-dbaa-4e34-8a88-a592d5ce7106" />


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
