### PR TITLE
fix: check Black formatting in CI instead of auto-formatting

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -34,10 +34,10 @@ jobs:
         poetry install --with dev
         poetry run pip install openai==1.100.1
 
-    - name: Run Black formatting
+    - name: Check Black formatting
       run: |
         cd litellm
-        poetry run black .
+        poetry run black --check .
         cd ..
 
     - name: Debug - Check file state


### PR DESCRIPTION
## Relevant issues

Fixes #16283

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - Note: This is a CI workflow change - the test is that the workflow itself will now fail if Black formatting is not applied. No unit test needed for workflow changes.
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🚄 Infrastructure

## Changes

### Summary
- Changed CI workflow to use `black --check` instead of `black .`
- This makes the CI fail if code is not formatted, rather than auto-formatting and discarding changes
- Aligns with README.md promise that "all checks must pass before your PR can be merged"
- Follows [Black best practices for CI/CD pipelines](https://curiousity.ca/2024/best-practices-black/)

### Context
Currently the CI runs `black .` which auto-formats the code but the changes get discarded (not committed) in `.github/workflows/test-linting.yml:37-41`. This wastes GitHub Actions compute and doesn't actually enforce formatting standards.

### Technical Changes
- Updated `.github/workflows/test-linting.yml` to use `black --check` instead of `black .`
- Renamed step from "Run Black formatting" to "Check Black formatting" for clarity

### Test Plan
- [x] CI workflow updated to use `--check` flag
- [x] Contributors can use `make format` to format their code before committing
- [x] `make format-check` matches what CI runs