### PR TITLE
Add authentication_mode config for explicit auth control

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -64,6 +64,27 @@ else:
     Span = Any
 
 
+class AuthenticationMode(str, enum.Enum):
+    """
+    Controls how the proxy handles authentication.
+
+    - "off": No authentication required. All requests are allowed without any API key.
+             Use only on trusted internal networks or for local development.
+    - "secure": Full authentication. Requires master_key to be set. Validates all
+                API keys against master_key or database.
+
+    If not set explicitly:
+    - When master_key is set: defaults to "secure"
+    - When master_key is not set: defaults to "off" (with a warning logged at startup)
+    """
+
+    OFF = "off"
+    SECURE = "secure"
+
+    def __str__(self):
+        return str(self.value)
+
+
 class SupportedDBObjectType(str, enum.Enum):
     """
     Supported database object types for fine-grained DB storage control.
@@ -597,9 +618,7 @@ class LiteLLMRoutes(enum.Enum):
         + key_management_routes
     )
 
-    internal_user_view_only_routes = (
-        spend_tracking_routes + global_spend_tracking_routes
-    )
+    internal_user_view_only_routes = spend_tracking_routes + global_spend_tracking_routes
 
     self_managed_routes = [
         "/team/member_add",
@@ -639,12 +658,7 @@ class LiteLLMRoutes(enum.Enum):
     ] + info_routes
 
     # All routes accesible by an Org Admin
-    org_admin_allowed_routes = (
-        org_admin_only_routes
-        + management_routes
-        + self_managed_routes
-        + admin_viewer_routes
-    )
+    org_admin_allowed_routes = org_admin_only_routes + management_routes + self_managed_routes + admin_viewer_routes
 
 
 class LiteLLMPromptInjectionParams(LiteLLMPydanticObjectBase):
@@ -665,23 +679,11 @@ class LiteLLMPromptInjectionParams(LiteLLMPydanticObjectBase):
         llm_api_check = values.get("llm_api_check")
         if llm_api_check is True:
             if "llm_api_name" not in values or not values["llm_api_name"]:
-                raise ValueError(
-                    "If llm_api_check is set to True, llm_api_name must be provided"
-                )
-            if (
-                "llm_api_system_prompt" not in values
-                or not values["llm_api_system_prompt"]
-            ):
-                raise ValueError(
-                    "If llm_api_check is set to True, llm_api_system_prompt must be provided"
-                )
-            if (
-                "llm_api_fail_call_string" not in values
-                or not values["llm_api_fail_call_string"]
-            ):
-                raise ValueError(
-                    "If llm_api_check is set to True, llm_api_fail_call_string must be provided"
-                )
+                raise ValueError("If llm_api_check is set to True, llm_api_name must be provided")
+            if "llm_api_system_prompt" not in values or not values["llm_api_system_prompt"]:
+                raise ValueError("If llm_api_check is set to True, llm_api_system_prompt must be provided")
+            if "llm_api_fail_call_string" not in values or not values["llm_api_fail_call_string"]:
+                raise ValueError("If llm_api_check is set to True, llm_api_fail_call_string must be provided")
         return values
 
 
@@ -794,9 +796,7 @@ class ModelParams(LiteLLMPydanticObjectBase):
     @classmethod
     def set_model_info(cls, values):
         if values.get("model_info") is None:
-            values.update(
-                {"model_info": ModelInfo(id=None, mode="chat", base_model=None)}
-            )
+            values.update({"model_info": ModelInfo(id=None, mode="chat", base_model=None)})
         return values
 
 
@@ -830,9 +830,7 @@ class GenerateRequestBase(LiteLLMPydanticObjectBase):
     allowed_cache_controls: Optional[list] = []
     config: Optional[dict] = {}
     permissions: Optional[dict] = {}
-    model_max_budget: Optional[
-        dict
-    ] = {}  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
+    model_max_budget: Optional[dict] = {}  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
 
     model_config = ConfigDict(protected_namespaces=())
     model_rpm_limit: Optional[dict] = None
@@ -857,12 +855,12 @@ class KeyRequestBase(GenerateRequestBase):
     allowed_routes: Optional[list] = []
     allowed_passthrough_routes: Optional[list] = None
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
-    rpm_limit_type: Optional[
-        Literal["guaranteed_throughput", "best_effort_throughput", "dynamic"]
-    ] = None  # raise an error if 'guaranteed_throughput' is set and we're overallocating rpm
-    tpm_limit_type: Optional[
-        Literal["guaranteed_throughput", "best_effort_throughput", "dynamic"]
-    ] = None  # raise an error if 'guaranteed_throughput' is set and we're overallocating tpm
+    rpm_limit_type: Optional[Literal["guaranteed_throughput", "best_effort_throughput", "dynamic"]] = (
+        None  # raise an error if 'guaranteed_throughput' is set and we're overallocating rpm
+    )
+    tpm_limit_type: Optional[Literal["guaranteed_throughput", "best_effort_throughput", "dynamic"]] = (
+        None  # raise an error if 'guaranteed_throughput' is set and we're overallocating tpm
+    )
 
 
 class LiteLLMKeyType(str, enum.Enum):
@@ -883,9 +881,7 @@ class GenerateKeyRequest(KeyRequestBase):
         default=LiteLLMKeyType.DEFAULT,
         description="Type of key that determines default allowed routes.",
     )
-    auto_rotate: Optional[bool] = Field(
-        default=False, description="Whether this key should be automatically rotated"
-    )
+    auto_rotate: Optional[bool] = Field(default=False, description="Whether this key should be automatically rotated")
     rotation_interval: Optional[str] = Field(
         default=None,
         description="How often to rotate this key (e.g., '30d', '90d'). Required if auto_rotate=True",
@@ -946,9 +942,7 @@ class UpdateKeyRequest(KeyRequestBase):
     def validate_temp_budget(self) -> "UpdateKeyRequest":
         if self.temp_budget_increase is not None or self.temp_budget_expiry is not None:
             if self.temp_budget_increase is None or self.temp_budget_expiry is None:
-                raise ValueError(
-                    "temp_budget_increase and temp_budget_expiry must be set together"
-                )
+                raise ValueError("temp_budget_increase and temp_budget_expiry must be set together")
         return self
 
 
@@ -970,9 +964,7 @@ class KeyRequest(LiteLLMPydanticObjectBase):
     @classmethod
     def validate_at_least_one(cls, values):
         if not values.get("keys") and not values.get("key_aliases"):
-            raise ValueError(
-                "At least one of 'keys' or 'key_aliases' must be provided."
-            )
+            raise ValueError("At least one of 'keys' or 'key_aliases' must be provided.")
         return values
 
 
@@ -1071,9 +1063,7 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
                 auth_value = credentials.get("auth_value")  # type: ignore[attr-defined]
 
             if not auth_value:
-                raise ValueError(
-                    "auth_value is required when auth_type is api_key, bearer_token, or basic"
-                )
+                raise ValueError("auth_value is required when auth_type is api_key, bearer_token, or basic")
 
         return values
 
@@ -1235,9 +1225,7 @@ class NewUserRequest(GenerateRequestBase):
         ]
     ] = None
     teams: Optional[Union[List[str], List[NewUserRequestTeam]]] = None
-    auto_create_key: bool = (
-        True  # flag used for returning a key as part of the /user/new response
-    )
+    auto_create_key: bool = True  # flag used for returning a key as part of the /user/new response
     send_invite_email: Optional[bool] = None
     sso_user_id: Optional[str] = None
     organizations: Optional[List[str]] = None
@@ -1261,9 +1249,7 @@ class NewUserResponse(GenerateKeyResponse):
     updated_at: Optional[datetime] = None
 
 
-class UpdateUserRequestNoUserIDorEmail(
-    GenerateRequestBase
-):  # shared with BulkUpdateUserRequest
+class UpdateUserRequestNoUserIDorEmail(GenerateRequestBase):  # shared with BulkUpdateUserRequest
     password: Optional[str] = None
     spend: Optional[float] = None
     metadata: Optional[dict] = None
@@ -1313,12 +1299,8 @@ class BudgetNewRequest(LiteLLMPydanticObjectBase):
     max_parallel_requests: Optional[int] = Field(
         default=None, description="Max concurrent requests allowed for this budget id."
     )
-    tpm_limit: Optional[int] = Field(
-        default=None, description="Max tokens per minute, allowed for this budget id."
-    )
-    rpm_limit: Optional[int] = Field(
-        default=None, description="Max requests per minute, allowed for this budget id."
-    )
+    tpm_limit: Optional[int] = Field(default=None, description="Max tokens per minute, allowed for this budget id.")
+    rpm_limit: Optional[int] = Field(default=None, description="Max requests per minute, allowed for this budget id.")
     budget_duration: Optional[str] = Field(
         default=None,
         description="Max duration budget should be set for (e.g. '1hr', '1d', '28d')",
@@ -1362,12 +1344,10 @@ class NewCustomerRequest(BudgetNewRequest):
     blocked: bool = False  # allow/disallow requests for this end-user
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
     spend: Optional[float] = None
-    allowed_model_region: Optional[
-        AllowedModelRegion
-    ] = None  # require all user requests to use models in this specific region
-    default_model: Optional[
-        str
-    ] = None  # if no equivalent model in allowed region - default all requests to this model
+    allowed_model_region: Optional[AllowedModelRegion] = (
+        None  # require all user requests to use models in this specific region
+    )
+    default_model: Optional[str] = None  # if no equivalent model in allowed region - default all requests to this model
 
     @model_validator(mode="before")
     @classmethod
@@ -1389,12 +1369,10 @@ class UpdateCustomerRequest(LiteLLMPydanticObjectBase):
     blocked: bool = False  # allow/disallow requests for this end-user
     max_budget: Optional[float] = None
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
-    allowed_model_region: Optional[
-        AllowedModelRegion
-    ] = None  # require all user requests to use models in this specific region
-    default_model: Optional[
-        str
-    ] = None  # if no equivalent model in allowed region - default all requests to this model
+    allowed_model_region: Optional[AllowedModelRegion] = (
+        None  # require all user requests to use models in this specific region
+    )
+    default_model: Optional[str] = None  # if no equivalent model in allowed region - default all requests to this model
 
 
 class DeleteCustomerRequest(LiteLLMPydanticObjectBase):
@@ -1471,23 +1449,17 @@ class NewTeamRequest(TeamBase):
     allowed_passthrough_routes: Optional[list] = None
     secret_manager_settings: Optional[dict] = None
     model_rpm_limit: Optional[Dict[str, int]] = None
-    rpm_limit_type: Optional[
-        Literal["guaranteed_throughput", "best_effort_throughput"]
-    ] = None  # raise an error if 'guaranteed_throughput' is set and we're overallocating rpm
-    tpm_limit_type: Optional[
-        Literal["guaranteed_throughput", "best_effort_throughput"]
-    ] = None  # raise an error if 'guaranteed_throughput' is set and we're overallocating tpm
+    rpm_limit_type: Optional[Literal["guaranteed_throughput", "best_effort_throughput"]] = (
+        None  # raise an error if 'guaranteed_throughput' is set and we're overallocating rpm
+    )
+    tpm_limit_type: Optional[Literal["guaranteed_throughput", "best_effort_throughput"]] = (
+        None  # raise an error if 'guaranteed_throughput' is set and we're overallocating tpm
+    )
 
     model_tpm_limit: Optional[Dict[str, int]] = None
-    team_member_budget: Optional[
-        float
-    ] = None  # allow user to set a budget for all team members
-    team_member_rpm_limit: Optional[
-        int
-    ] = None  # allow user to set RPM limit for all team members
-    team_member_tpm_limit: Optional[
-        int
-    ] = None  # allow user to set TPM limit for all team members
+    team_member_budget: Optional[float] = None  # allow user to set a budget for all team members
+    team_member_rpm_limit: Optional[int] = None  # allow user to set RPM limit for all team members
+    team_member_tpm_limit: Optional[int] = None  # allow user to set TPM limit for all team members
     team_member_key_duration: Optional[str] = None  # e.g. "1d", "1w", "1m"
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
 
@@ -1573,9 +1545,7 @@ class BlockKeyRequest(LiteLLMPydanticObjectBase):
 
 class AddTeamCallback(LiteLLMPydanticObjectBase):
     callback_name: str
-    callback_type: Optional[
-        Literal["success", "failure", "success_and_failure"]
-    ] = "success_and_failure"
+    callback_type: Optional[Literal["success", "failure", "success_and_failure"]] = "success_and_failure"
     callback_vars: Dict[str, str]
 
     @model_validator(mode="before")
@@ -1585,9 +1555,7 @@ class AddTeamCallback(LiteLLMPydanticObjectBase):
         valid_keys = set(StandardCallbackDynamicParams.__annotations__.keys())
         for key, value in callback_vars.items():
             if key not in valid_keys:
-                raise ValueError(
-                    f"Invalid callback variable: {key}. Must be one of {valid_keys}"
-                )
+                raise ValueError(f"Invalid callback variable: {key}. Must be one of {valid_keys}")
             if not isinstance(value, str):
                 callback_vars[key] = str(value)
         return values
@@ -1627,9 +1595,7 @@ class TeamCallbackMetadata(LiteLLMPydanticObjectBase):
         if callback_vars is not None:
             for key in callback_vars:
                 if key not in valid_keys:
-                    raise ValueError(
-                        f"Invalid callback variable: {key}. Must be one of {valid_keys}"
-                    )
+                    raise ValueError(f"Invalid callback variable: {key}. Must be one of {valid_keys}")
         return values
 
 
@@ -1688,10 +1654,7 @@ class LiteLLM_TeamTable(TeamBase):
         if isinstance(values, BaseModel):
             values = values.model_dump()
 
-        if (
-            isinstance(values.get("members_with_roles"), dict)
-            and not values["members_with_roles"]
-        ):
+        if isinstance(values.get("members_with_roles"), dict) and not values["members_with_roles"]:
             values["members_with_roles"] = []
 
         for field in dict_fields:
@@ -1827,9 +1790,7 @@ class PassThroughGenericEndpoint(LiteLLMPydanticObjectBase):
         description="Optional unique identifier for the pass-through endpoint. If not provided, endpoints will be identified by path for backwards compatibility.",
     )
     path: str = Field(description="The route to be added to the LiteLLM Proxy Server.")
-    target: str = Field(
-        description="The URL to which requests for this path should be forwarded."
-    )
+    target: str = Field(description="The URL to which requests for this path should be forwarded.")
     headers: dict = Field(
         default={},
         description="Key-value pairs of headers to be forwarded with the request. You can set any key value pair here and it will be forwarded to your target endpoint",
@@ -1887,9 +1848,7 @@ class ConfigList(LiteLLMPydanticObjectBase):
     stored_in_db: Optional[bool]
     field_default_value: Any
     premium_field: bool = False
-    nested_fields: Optional[
-        List[FieldDetail]
-    ] = None  # For nested dictionary or Pydantic fields
+    nested_fields: Optional[List[FieldDetail]] = None  # For nested dictionary or Pydantic fields
 
 
 class UserHeaderMapping(LiteLLMPydanticObjectBase):
@@ -1913,20 +1872,21 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     Documents all the fields supported by `general_settings` in config.yaml
     """
 
-    completion_model: Optional[str] = Field(
-        None, description="proxy level default model for all chat completion calls"
-    )
+    completion_model: Optional[str] = Field(None, description="proxy level default model for all chat completion calls")
     key_management_system: Optional[KeyManagementSystem] = Field(
         None, description="key manager to load keys from / decrypt keys with"
     )
-    use_google_kms: Optional[bool] = Field(
-        None, description="decrypt keys with google kms"
-    )
-    use_azure_key_vault: Optional[bool] = Field(
-        None, description="load keys from azure key vault"
-    )
-    master_key: Optional[str] = Field(
-        None, description="require a key for all calls to proxy"
+    use_google_kms: Optional[bool] = Field(None, description="decrypt keys with google kms")
+    use_azure_key_vault: Optional[bool] = Field(None, description="load keys from azure key vault")
+    master_key: Optional[str] = Field(None, description="require a key for all calls to proxy")
+    authentication_mode: Optional[AuthenticationMode] = Field(
+        None,
+        description=(
+            "Controls authentication behavior. "
+            "'off': no auth required (for trusted networks/local dev). "
+            "'secure': validates API keys against master_key or database. "
+            "Defaults to 'secure' if master_key is set, 'off' otherwise (with warning)."
+        ),
     )
     database_url: Optional[str] = Field(
         None,
@@ -1939,9 +1899,7 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     database_connection_timeout: Optional[float] = Field(
         60, description="default timeout for a connection to the database"
     )
-    database_type: Optional[Literal["dynamo_db"]] = Field(
-        None, description="to use dynamodb instead of postgres db"
-    )
+    database_type: Optional[Literal["dynamo_db"]] = Field(None, description="to use dynamodb instead of postgres db")
     database_args: Optional[DynamoDBArgs] = Field(
         None,
         description="custom args for instantiating dynamodb client - e.g. billing provision",
@@ -1973,12 +1931,8 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="for `/models` endpoint, infers available model based on environment keys (e.g. OPENAI_API_KEY)",
     )
-    background_health_checks: Optional[bool] = Field(
-        None, description="run health checks in background"
-    )
-    health_check_interval: int = Field(
-        300, description="background health check interval in seconds"
-    )
+    background_health_checks: Optional[bool] = Field(None, description="run health checks in background")
+    health_check_interval: int = Field(300, description="background health check interval in seconds")
     alerting: Optional[List] = Field(
         None,
         description="List of alerting integrations. Today, just slack - `alerting: ['slack']`",
@@ -1998,12 +1952,8 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="sends alerts if requests hang for 5min+",
     )
-    ui_access_mode: Optional[Literal["admin_only", "all"]] = Field(
-        "all", description="Control access to the Proxy UI"
-    )
-    allowed_routes: Optional[List] = Field(
-        None, description="Proxy API Endpoints you want users to be able to access"
-    )
+    ui_access_mode: Optional[Literal["admin_only", "all"]] = Field("all", description="Control access to the Proxy UI")
+    allowed_routes: Optional[List] = Field(None, description="Proxy API Endpoints you want users to be able to access")
     reject_clientside_metadata_tags: Optional[bool] = Field(
         None,
         description="When set to True, rejects requests that contain client-side 'metadata.tags' to prevent users from influencing budgets by sending different tags. Tags can only be inherited from the API key metadata.",
@@ -2151,9 +2101,7 @@ class LiteLLM_VerificationTokenView(LiteLLM_VerificationToken):
         super().__init__(**kwargs)
 
 
-class UserAPIKeyAuth(
-    LiteLLM_VerificationTokenView
-):  # the expected response object for user api key auth
+class UserAPIKeyAuth(LiteLLM_VerificationTokenView):  # the expected response object for user api key auth
     """
     Return the row in the db
     """
@@ -2176,13 +2124,9 @@ class UserAPIKeyAuth(
     @classmethod
     def check_api_key(cls, values):
         if values.get("api_key") is not None:
-            values.update(
-                {"token": cls._safe_hash_litellm_api_key(values.get("api_key"))}
-            )
+            values.update({"token": cls._safe_hash_litellm_api_key(values.get("api_key"))})
             if isinstance(values.get("api_key"), str):
-                values.update(
-                    {"api_key": cls._safe_hash_litellm_api_key(values.get("api_key"))}
-                )
+                values.update({"api_key": cls._safe_hash_litellm_api_key(values.get("api_key"))})
         return values
 
     @classmethod
@@ -2275,9 +2219,7 @@ class LiteLLM_OrganizationMembershipTable(LiteLLMPydanticObjectBase):
     budget_id: Optional[str] = None
     created_at: datetime
     updated_at: datetime
-    user: Optional[
-        Any
-    ] = None  # You might want to replace 'Any' with a more specific type if available
+    user: Optional[Any] = None  # You might want to replace 'Any' with a more specific type if available
     litellm_budget_table: Optional[LiteLLM_BudgetTable] = None
 
     model_config = ConfigDict(protected_namespaces=())
@@ -2727,18 +2669,14 @@ class SpendLogsMetadata(TypedDict):
     Specific metadata k,v pairs logged to spendlogs for easier cost tracking
     """
 
-    additional_usage_values: Optional[
-        dict
-    ]  # covers provider-specific usage information - e.g. prompt caching
+    additional_usage_values: Optional[dict]  # covers provider-specific usage information - e.g. prompt caching
     user_api_key: Optional[str]
     user_api_key_alias: Optional[str]
     user_api_key_team_id: Optional[str]
     user_api_key_org_id: Optional[str]
     user_api_key_user_id: Optional[str]
     user_api_key_team_alias: Optional[str]
-    spend_logs_metadata: Optional[
-        dict
-    ]  # special param to log k,v pairs to spendlogs for a call
+    spend_logs_metadata: Optional[dict]  # special param to log k,v pairs to spendlogs for a call
     requester_ip_address: Optional[str]
     applied_guardrails: Optional[List[str]]
     mcp_tool_call_metadata: Optional[StandardLoggingMCPToolCall]
@@ -2750,13 +2688,9 @@ class SpendLogsMetadata(TypedDict):
     error_information: Optional[StandardLoggingPayloadErrorInformation]
     usage_object: Optional[dict]
     model_map_information: Optional[StandardLoggingModelInformation]
-    cold_storage_object_key: Optional[
-        str
-    ]  # S3/GCS object key for cold storage retrieval
+    cold_storage_object_key: Optional[str]  # S3/GCS object key for cold storage retrieval
     litellm_overhead_time_ms: Optional[float]  # LiteLLM overhead time in milliseconds
-    cost_breakdown: Optional[
-        CostBreakdown
-    ]  # Detailed cost breakdown (input_cost, output_cost, margin, discount, etc.)
+    cost_breakdown: Optional[CostBreakdown]  # Detailed cost breakdown (input_cost, output_cost, margin, discount, etc.)
 
 
 class SpendLogsPayload(TypedDict):
@@ -2880,10 +2814,7 @@ class ProxyException(Exception):
         # rules for proxyExceptions
         # Litellm router.py returns "No healthy deployment available" when there are no deployments available
         # Should map to 429 errors https://github.com/BerriAI/litellm/issues/2487
-        if (
-            "No healthy deployment available" in self.message
-            or "No deployments available" in self.message
-        ):
+        if "No healthy deployment available" in self.message or "No deployments available" in self.message:
             self.code = "429"
         elif RouterErrors.no_deployments_with_tag_routing.value in self.message:
             self.code = "401"
@@ -2902,19 +2833,13 @@ class ProxyException(Exception):
 
 
 class CommonProxyErrors(str, enum.Enum):
-    db_not_connected_error = (
-        "DB not connected. See https://docs.litellm.ai/docs/proxy/virtual_keys"
-    )
+    db_not_connected_error = "DB not connected. See https://docs.litellm.ai/docs/proxy/virtual_keys"
     no_llm_router = "No models configured on proxy"
     not_allowed_access = "Admin-only endpoint. Not allowed to access this."
     not_premium_user = "You must be a LiteLLM Enterprise user to use this feature. If you have a license please set `LITELLM_LICENSE` in your env. Get a 7 day trial key here: https://www.litellm.ai/enterprise#trial. \nPricing: https://www.litellm.ai/#pricing"
-    max_parallel_request_limit_reached = (
-        "Crossed TPM / RPM / Max Parallel Request Limit"
-    )
+    max_parallel_request_limit_reached = "Crossed TPM / RPM / Max Parallel Request Limit"
     missing_enterprise_package = "Missing litellm-enterprise package. Please install it to use this feature. Run `pip install litellm-enterprise`"
-    missing_enterprise_package_docker = (
-        "This uses the enterprise folder - only available on the Docker image."
-    )
+    missing_enterprise_package_docker = "This uses the enterprise folder - only available on the Docker image."
 
 
 class SpendCalculateRequest(LiteLLMPydanticObjectBase):
@@ -3108,10 +3033,7 @@ class MemberAddRequest(LiteLLMPydanticObjectBase):
         member_data = data.get("member")
         if isinstance(member_data, list):
             # If member is a list of dictionaries, convert each dictionary to a Member object
-            members = [
-                Member(**item) if isinstance(item, dict) else item
-                for item in member_data
-            ]
+            members = [Member(**item) if isinstance(item, dict) else item for item in member_data]
             # Replace member_data with the list of Member objects
             data["member"] = members
         elif isinstance(member_data, dict):
@@ -3205,12 +3127,8 @@ class TeamMemberDeleteRequest(MemberDeleteRequest):
 class TeamMemberUpdateRequest(TeamMemberDeleteRequest):
     max_budget_in_team: Optional[float] = None
     role: Optional[Literal["admin", "user"]] = None
-    tpm_limit: Optional[int] = Field(
-        default=None, description="Tokens per minute limit for this team member"
-    )
-    rpm_limit: Optional[int] = Field(
-        default=None, description="Requests per minute limit for this team member"
-    )
+    tpm_limit: Optional[int] = Field(default=None, description="Tokens per minute limit for this team member")
+    rpm_limit: Optional[int] = Field(default=None, description="Requests per minute limit for this team member")
 
 
 class TeamMemberUpdateResponse(MemberUpdateResponse):
@@ -3237,9 +3155,7 @@ class TeamModelDeleteRequest(BaseModel):
 # Organization Member Requests
 class OrganizationMemberAddRequest(OrgMemberAddRequest):
     organization_id: str
-    max_budget_in_organization: Optional[
-        float
-    ] = None  # Users max budget within the organization
+    max_budget_in_organization: Optional[float] = None  # Users max budget within the organization
 
 
 class OrganizationMemberDeleteRequest(MemberDeleteRequest):
@@ -3258,13 +3174,9 @@ class OrganizationMemberUpdateRequest(OrganizationMemberDeleteRequest):
     role: Optional[LitellmUserRoles] = None
 
     @field_validator("role")
-    def validate_role(
-        cls, value: Optional[LitellmUserRoles]
-    ) -> Optional[LitellmUserRoles]:
+    def validate_role(cls, value: Optional[LitellmUserRoles]) -> Optional[LitellmUserRoles]:
         if value is not None and value not in ROLES_WITHIN_ORG:
-            raise ValueError(
-                f"Invalid role. Must be one of: {[role.value for role in ROLES_WITHIN_ORG]}"
-            )
+            raise ValueError(f"Invalid role. Must be one of: {[role.value for role in ROLES_WITHIN_ORG]}")
         return value
 
 
@@ -3359,43 +3271,37 @@ class JWKUrlResponse(TypedDict, total=False):
 
 
 class UserManagementEndpointParamDocStringEnums(str, enum.Enum):
-    user_id_doc_str = (
-        "Optional[str] - Specify a user id. If not set, a unique id will be generated."
-    )
-    user_alias_doc_str = (
-        "Optional[str] - A descriptive name for you to know who this user id refers to."
-    )
+    user_id_doc_str = "Optional[str] - Specify a user id. If not set, a unique id will be generated."
+    user_alias_doc_str = "Optional[str] - A descriptive name for you to know who this user id refers to."
     teams_doc_str = "Optional[list] - specify a list of team id's a user belongs to."
     user_email_doc_str = "Optional[str] - Specify a user email."
-    send_invite_email_doc_str = (
-        "Optional[bool] - Specify if an invite email should be sent."
-    )
+    send_invite_email_doc_str = "Optional[bool] - Specify if an invite email should be sent."
     user_role_doc_str = """Optional[str] - Specify a user role - "proxy_admin", "proxy_admin_viewer", "internal_user", "internal_user_viewer", "team", "customer". Info about each role here: `https://github.com/BerriAI/litellm/litellm/proxy/_types.py#L20`"""
     max_budget_doc_str = """Optional[float] - Specify max budget for a given user."""
     budget_duration_doc_str = """Optional[str] - Budget is reset at the end of specified duration. If not set, budget is never reset. You can set duration as seconds ("30s"), minutes ("30m"), hours ("30h"), days ("30d"), months ("1mo")."""
-    models_doc_str = """Optional[list] - Model_name's a user is allowed to call. (if empty, key is allowed to call all models)"""
-    tpm_limit_doc_str = (
-        """Optional[int] - Specify tpm limit for a given user (Tokens per minute)"""
+    models_doc_str = (
+        """Optional[list] - Model_name's a user is allowed to call. (if empty, key is allowed to call all models)"""
     )
-    rpm_limit_doc_str = (
-        """Optional[int] - Specify rpm limit for a given user (Requests per minute)"""
-    )
+    tpm_limit_doc_str = """Optional[int] - Specify tpm limit for a given user (Tokens per minute)"""
+    rpm_limit_doc_str = """Optional[int] - Specify rpm limit for a given user (Requests per minute)"""
     auto_create_key_doc_str = """bool - Default=True. Flag used for returning a key as part of the /user/new response"""
     aliases_doc_str = """Optional[dict] - Model aliases for the user - [Docs](https://litellm.vercel.app/docs/proxy/virtual_keys#model-aliases)"""
     config_doc_str = """Optional[dict] - [DEPRECATED PARAM] User-specific config."""
     allowed_cache_controls_doc_str = """Optional[list] - List of allowed cache control values. Example - ["no-cache", "no-store"]. See all values - https://docs.litellm.ai/docs/proxy/caching#turn-on--off-caching-per-request-"""
-    blocked_doc_str = (
-        """Optional[bool] - [Not Implemented Yet] Whether the user is blocked."""
-    )
+    blocked_doc_str = """Optional[bool] - [Not Implemented Yet] Whether the user is blocked."""
     guardrails_doc_str = """Optional[List[str]] - [Not Implemented Yet] List of active guardrails for the user"""
-    permissions_doc_str = """Optional[dict] - [Not Implemented Yet] User-specific permissions, eg. turning off pii masking."""
+    permissions_doc_str = (
+        """Optional[dict] - [Not Implemented Yet] User-specific permissions, eg. turning off pii masking."""
+    )
     metadata_doc_str = """Optional[dict] - Metadata for user, store information for user. Example metadata = {"team": "core-infra", "app": "app2", "email": "ishaan@berri.ai" }"""
     max_parallel_requests_doc_str = """Optional[int] - Rate limit a user based on the number of parallel requests. Raises 429 error, if user's parallel requests > x."""
     soft_budget_doc_str = """Optional[float] - Get alerts when user crosses given budget, doesn't block requests."""
     model_max_budget_doc_str = """Optional[dict] - Model-specific max budget for user. [Docs](https://docs.litellm.ai/docs/proxy/users#add-model-specific-budgets-to-keys)"""
     model_rpm_limit_doc_str = """Optional[float] - Model-specific rpm limit for user. [Docs](https://docs.litellm.ai/docs/proxy/users#add-model-specific-limits-to-keys)"""
     model_tpm_limit_doc_str = """Optional[float] - Model-specific tpm limit for user. [Docs](https://docs.litellm.ai/docs/proxy/users#add-model-specific-limits-to-keys)"""
-    spend_doc_str = """Optional[float] - Amount spent by user. Default is 0. Will be updated by proxy whenever user is used."""
+    spend_doc_str = (
+        """Optional[float] - Amount spent by user. Default is 0. Will be updated by proxy whenever user is used."""
+    )
     team_id_doc_str = """Optional[str] - [DEPRECATED PARAM] The team id of the user. Default is None."""
     duration_doc_str = """Optional[str] - Duration for the key auto-created on `/user/new`. Default is None."""
 
@@ -3590,18 +3496,14 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
     user_allowed_email_domain: Optional[str] = None
     user_roles_jwt_field: Optional[str] = None
     user_allowed_roles: Optional[List[str]] = None
-    user_id_upsert: bool = Field(
-        default=False, description="If user doesn't exist, upsert them into the db."
-    )
+    user_id_upsert: bool = Field(default=False, description="If user doesn't exist, upsert them into the db.")
     end_user_id_jwt_field: Optional[str] = None
     public_key_ttl: float = 600
     public_allowed_routes: List[str] = ["public_routes"]
     enforce_rbac: bool = False
     roles_jwt_field: Optional[str] = None  # v2 on role mappings
     role_mappings: Optional[List[RoleMapping]] = None
-    object_id_jwt_field: Optional[
-        str
-    ] = None  # can be either user / team, inferred from the role mapping
+    object_id_jwt_field: Optional[str] = None  # can be either user / team, inferred from the role mapping
     scope_mappings: Optional[List[ScopeMapping]] = None
     enforce_scope_based_access: bool = False
     enforce_team_based_model_access: bool = False
@@ -3652,9 +3554,7 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
         if (user_roles_jwt_field is not None and user_allowed_roles is None) or (
             user_roles_jwt_field is None and user_allowed_roles is not None
         ):
-            raise ValueError(
-                "user_allowed_roles must be provided if user_roles_jwt_field is set."
-            )
+            raise ValueError("user_allowed_roles must be provided if user_roles_jwt_field is set.")
 
         if object_id_jwt_field is not None and role_mappings is None:
             raise ValueError(
@@ -3662,9 +3562,7 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
             )
 
         if scope_mappings is not None and not enforce_scope_based_access:
-            raise ValueError(
-                "scope_mappings must be set if enforce_scope_based_access is true."
-            )
+            raise ValueError("scope_mappings must be set if enforce_scope_based_access is true.")
 
         super().__init__(**kwargs)
 
@@ -3710,9 +3608,7 @@ class DefaultInternalUserParams(LiteLLMPydanticObjectBase):
         default=None,
         description="Default budget duration for new users (e.g. 'daily', 'weekly', 'monthly')",
     )
-    models: Optional[List[str]] = Field(
-        default=None, description="Default list of models that new users can access"
-    )
+    models: Optional[List[str]] = Field(default=None, description="Default list of models that new users can access")
 
     teams: Optional[Union[List[str], List[NewUserRequestTeam]]] = Field(
         default=None,
@@ -3834,12 +3730,8 @@ class CostEstimateRequest(LiteLLMPydanticObjectBase):
     model: str = Field(description="Model name (from /model_group/info)")
     input_tokens: int = Field(description="Expected input tokens per request", ge=0)
     output_tokens: int = Field(description="Expected output tokens per request", ge=0)
-    num_requests_per_day: Optional[int] = Field(
-        default=None, description="Number of requests per day", ge=0
-    )
-    num_requests_per_month: Optional[int] = Field(
-        default=None, description="Number of requests per month", ge=0
-    )
+    num_requests_per_day: Optional[int] = Field(default=None, description="Number of requests per day", ge=0)
+    num_requests_per_month: Optional[int] = Field(default=None, description="Number of requests per month", ge=0)
 
 
 class CostEstimateResponse(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -28,8 +28,8 @@ from litellm.proxy.auth.auth_checks import (
     _delete_cache_key_object,
     _get_user_role,
     _is_user_proxy_admin,
-    _virtual_key_max_budget_check,
     _virtual_key_max_budget_alert_check,
+    _virtual_key_max_budget_check,
     _virtual_key_soft_budget_check,
     can_key_call_model,
     common_checks,
@@ -106,6 +106,30 @@ azure_apim_header = APIKeyHeader(
 )
 
 
+def get_effective_authentication_mode(
+    general_settings: dict,
+    master_key: Optional[str],
+) -> AuthenticationMode:
+    """
+    Resolve the effective authentication mode based on config and master_key.
+
+    Priority:
+    1. Explicit authentication_mode in general_settings
+    2. If master_key is set: SECURE
+    3. If master_key is not set: OFF
+    """
+    explicit_mode = general_settings.get("authentication_mode")
+    if explicit_mode is not None:
+        if isinstance(explicit_mode, AuthenticationMode):
+            return explicit_mode
+        return AuthenticationMode(explicit_mode)
+
+    # Default based on master_key presence
+    if master_key is not None:
+        return AuthenticationMode.SECURE
+    return AuthenticationMode.OFF
+
+
 def _get_bearer_token_or_received_api_key(api_key: str) -> str:
     if api_key.startswith("Bearer "):  # ensure Bearer token passed in
         api_key = api_key.replace("Bearer ", "")  # extract the token
@@ -138,7 +162,7 @@ def _apply_budget_limits_to_end_user_params(
 ) -> None:
     """
     Helper function to apply budget limits to end user parameters.
-    
+
     Args:
         end_user_params: Dictionary to update with budget parameters
         budget_info: Budget table object containing limits
@@ -146,16 +170,14 @@ def _apply_budget_limits_to_end_user_params(
     """
     if budget_info.tpm_limit is not None:
         end_user_params["end_user_tpm_limit"] = budget_info.tpm_limit
-    
+
     if budget_info.rpm_limit is not None:
         end_user_params["end_user_rpm_limit"] = budget_info.rpm_limit
-    
+
     if budget_info.max_budget is not None:
         end_user_params["end_user_max_budget"] = budget_info.max_budget
-    
-    verbose_proxy_logger.debug(
-        f"Applied budget limits to end user {end_user_id}"
-    )
+
+    verbose_proxy_logger.debug(f"Applied budget limits to end user {end_user_id}")
 
 
 async def user_api_key_auth_websocket(websocket: WebSocket):
@@ -170,12 +192,10 @@ async def user_api_key_auth_websocket(websocket: WebSocket):
 
     model = query_params.get("model")
 
-    
     async def return_body():
         return _realtime_request_body(model)
-    
-    request.body = return_body  # type: ignore
 
+    request.body = return_body  # type: ignore
 
     authorization = websocket.headers.get("authorization")
     # If no Authorization header, try the api-key header
@@ -188,9 +208,7 @@ async def user_api_key_auth_websocket(websocket: WebSocket):
         # Extract the API key from the Bearer token
         if not authorization.startswith("Bearer "):
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
-            raise HTTPException(
-                status_code=403, detail="Invalid Authorization header format"
-            )
+            raise HTTPException(status_code=403, detail="Invalid Authorization header format")
 
         api_key = authorization[len("Bearer ") :].strip()
 
@@ -204,9 +222,7 @@ async def user_api_key_auth_websocket(websocket: WebSocket):
         raise HTTPException(status_code=403, detail=str(e))
 
 
-def update_valid_token_with_end_user_params(
-    valid_token: UserAPIKeyAuth, end_user_params: dict
-) -> UserAPIKeyAuth:
+def update_valid_token_with_end_user_params(valid_token: UserAPIKeyAuth, end_user_params: dict) -> UserAPIKeyAuth:
     valid_token.end_user_id = end_user_params.get("end_user_id")
     valid_token.end_user_tpm_limit = end_user_params.get("end_user_tpm_limit")
     valid_token.end_user_rpm_limit = end_user_params.get("end_user_rpm_limit")
@@ -224,14 +240,10 @@ async def get_global_proxy_spend(
     global_proxy_spend = None
     if litellm.max_budget > 0:  # user set proxy max budget
         # check cache
-        global_proxy_spend = await user_api_key_cache.async_get_cache(
-            key="{}:spend".format(litellm_proxy_admin_name)
-        )
+        global_proxy_spend = await user_api_key_cache.async_get_cache(key="{}:spend".format(litellm_proxy_admin_name))
         if global_proxy_spend is None and prisma_client is not None:
             # get from db
-            sql_query = (
-                """SELECT SUM(spend) as total_spend FROM "MonthlyGlobalSpend";"""
-            )
+            sql_query = """SELECT SUM(spend) as total_spend FROM "MonthlyGlobalSpend";"""
 
             response = await prisma_client.db.query_raw(query=sql_query)
 
@@ -347,10 +359,7 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
                     return UserAPIKeyAuth()
                 ## IF AUTH ENABLED
                 ### IF CUSTOM PARSER REQUIRED
-                if (
-                    endpoint.get("custom_auth_parser") is not None
-                    and endpoint.get("custom_auth_parser") == "langfuse"
-                ):
+                if endpoint.get("custom_auth_parser") is not None and endpoint.get("custom_auth_parser") == "langfuse":
                     """
                     - langfuse returns {'Authorization': 'Basic YW55dGhpbmc6YW55dGhpbmc'}
                     - check the langfuse public key if it contains the litellm api key
@@ -366,8 +375,7 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
                     if headers is not None:
                         header_key = headers.get("litellm_user_api_key", "")
                         if (
-                            isinstance(request.headers, dict)
-                            and request.headers.get(key=header_key) is not None  # type: ignore
+                            isinstance(request.headers, dict) and request.headers.get(key=header_key) is not None  # type: ignore
                         ):
                             api_key = request.headers.get(key=header_key)  # type: ignore
     return api_key
@@ -412,9 +420,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             request=request,
             route=route,
         )
-        pass_through_endpoints: Optional[List[dict]] = general_settings.get(
-            "pass_through_endpoints", None
-        )
+        pass_through_endpoints: Optional[List[dict]] = general_settings.get("pass_through_endpoints", None)
         ## CHECK IF X-LITELM-API-KEY IS PASSED IN - supercedes Authorization header
         api_key, passed_in_key = get_api_key(
             custom_litellm_key_header=custom_litellm_key_header,
@@ -436,18 +442,14 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             )
 
         if open_telemetry_logger is not None:
-            parent_otel_span = (
-                open_telemetry_logger.create_litellm_proxy_request_started_span(
-                    start_time=start_time,
-                    headers=dict(request.headers),
-                )
+            parent_otel_span = open_telemetry_logger.create_litellm_proxy_request_started_span(
+                start_time=start_time,
+                headers=dict(request.headers),
             )
 
         ### USER-DEFINED AUTH FUNCTION ###
         if enterprise_custom_auth is not None:
-            response = await enterprise_custom_auth(
-                request=request, api_key=api_key, user_custom_auth=user_custom_auth
-            )
+            response = await enterprise_custom_auth(request=request, api_key=api_key, user_custom_auth=user_custom_auth)
             if response is not None and isinstance(response, UserAPIKeyAuth):
                 return UserAPIKeyAuth.model_validate(response)
             elif response is not None and isinstance(response, str):
@@ -502,9 +504,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             from litellm.proxy.proxy_server import premium_user
 
             if premium_user is not True:
-                raise ValueError(
-                    f"JWT Auth is an enterprise only feature. {CommonProxyErrors.not_premium_user.value}"
-                )
+                raise ValueError(f"JWT Auth is an enterprise only feature. {CommonProxyErrors.not_premium_user.value}")
             is_jwt = jwt_handler.is_jwt(token=api_key)
             verbose_proxy_logger.debug("is_jwt: %s", is_jwt)
             if is_jwt:
@@ -530,9 +530,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 end_user_object = result["end_user_object"]
                 org_id = result["org_id"]
                 token = result["token"]
-                team_membership: Optional[LiteLLM_TeamMembership] = result.get(
-                    "team_membership", None
-                )
+                team_membership: Optional[LiteLLM_TeamMembership] = result.get("team_membership", None)
 
                 global_proxy_spend = await get_global_proxy_spend(
                     litellm_proxy_admin_name=litellm_proxy_admin_name,
@@ -551,15 +549,9 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 valid_token = UserAPIKeyAuth(
                     api_key=None,
                     team_id=team_id,
-                    team_alias=(
-                        team_object.team_alias if team_object is not None else None
-                    ),
-                    team_tpm_limit=(
-                        team_object.tpm_limit if team_object is not None else None
-                    ),
-                    team_rpm_limit=(
-                        team_object.rpm_limit if team_object is not None else None
-                    ),
+                    team_alias=(team_object.team_alias if team_object is not None else None),
+                    team_tpm_limit=(team_object.tpm_limit if team_object is not None else None),
+                    team_rpm_limit=(team_object.rpm_limit if team_object is not None else None),
                     team_models=team_object.models if team_object is not None else [],
                     user_role=(
                         LitellmUserRoles(user_object.user_role)
@@ -570,21 +562,13 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     org_id=org_id,
                     parent_otel_span=parent_otel_span,
                     end_user_id=end_user_id,
-                    user_tpm_limit=(
-                        user_object.tpm_limit if user_object is not None else None
-                    ),
-                    user_rpm_limit=(
-                        user_object.rpm_limit if user_object is not None else None
-                    ),
+                    user_tpm_limit=(user_object.tpm_limit if user_object is not None else None),
+                    user_rpm_limit=(user_object.rpm_limit if user_object is not None else None),
                     team_member_rpm_limit=(
-                        team_membership.safe_get_team_member_rpm_limit()
-                        if team_membership is not None
-                        else None
+                        team_membership.safe_get_team_member_rpm_limit() if team_membership is not None else None
                     ),
                     team_member_tpm_limit=(
-                        team_membership.safe_get_team_member_tpm_limit()
-                        if team_membership is not None
-                        else None
+                        team_membership.safe_get_team_member_tpm_limit() if team_membership is not None else None
                     ),
                     team_metadata=team_object.metadata if team_object is not None else None,
                 )
@@ -619,25 +603,24 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 api_key = response
             elif isinstance(response, UserAPIKeyAuth):
                 return response
-        if master_key is None:
-            if isinstance(api_key, str):
-                return UserAPIKeyAuth(
-                    api_key=api_key,
-                    user_role=LitellmUserRoles.PROXY_ADMIN,
-                    parent_otel_span=parent_otel_span,
-                )
-            else:
-                return UserAPIKeyAuth(
-                    user_role=LitellmUserRoles.PROXY_ADMIN,
-                    parent_otel_span=parent_otel_span,
-                )
-        elif api_key is None:  # only require api key if master key is set
-            raise Exception("No api key passed in.")
-        elif api_key == "":
-            # missing 'Bearer ' prefix
-            raise Exception(
-                "Malformed API Key passed in. Ensure Key has `Bearer ` prefix."
+        # Resolve authentication mode
+        auth_mode = get_effective_authentication_mode(general_settings, master_key)
+
+        if auth_mode == AuthenticationMode.OFF:
+            # No authentication required - grant admin access
+            return UserAPIKeyAuth(
+                api_key=api_key if isinstance(api_key, str) else None,
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                parent_otel_span=parent_otel_span,
             )
+
+        # auth_mode == AuthenticationMode.SECURE
+        # Require and validate API keys
+        if api_key is None:
+            raise Exception("No api key passed in.")
+        if api_key == "":
+            # missing 'Bearer ' prefix
+            raise Exception("Malformed API Key passed in. Ensure Key has `Bearer ` prefix.")
 
         if route == "/user/auth":
             if general_settings.get("allow_user_auth", False) is True:
@@ -652,9 +635,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         _end_user_object = None
         end_user_params = {}
 
-        end_user_id = get_end_user_id_from_request_body(
-            request_data, _safe_get_request_headers(request)
-        )
+        end_user_id = get_end_user_id_from_request_body(request_data, _safe_get_request_headers(request))
         if end_user_id:
             try:
                 end_user_params["end_user_id"] = end_user_id
@@ -669,9 +650,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     route=route,
                 )
                 if _end_user_object is not None:
-                    end_user_params["allowed_model_region"] = (
-                        _end_user_object.allowed_model_region
-                    )
+                    end_user_params["allowed_model_region"] = _end_user_object.allowed_model_region
                     if _end_user_object.litellm_budget_table is not None:
                         _apply_budget_limits_to_end_user_params(
                             end_user_params=end_user_params,
@@ -698,9 +677,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             except Exception as e:
                 if isinstance(e, litellm.BudgetExceededError):
                     raise e
-                verbose_proxy_logger.debug(
-                    "Unable to find user in db. Error - {}".format(str(e))
-                )
+                verbose_proxy_logger.debug("Unable to find user in db. Error - {}".format(str(e)))
                 pass
 
         ### CHECK IF ADMIN ###
@@ -723,9 +700,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
         ## Check UI Hash Key
         if valid_token is None and get_secret_bool("EXPERIMENTAL_UI_LOGIN"):
-            valid_token = ExperimentalUIJWTToken.get_key_object_from_ui_hash_key(
-                api_key
-            )
+            valid_token = ExperimentalUIJWTToken.get_key_object_from_ui_hash_key(api_key)
 
         if (
             valid_token is not None
@@ -738,10 +713,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     expiry_time = valid_token.expires
                 else:
                     expiry_time = datetime.fromisoformat(valid_token.expires)
-                if (
-                    expiry_time.tzinfo is None
-                    or expiry_time.tzinfo.utcoffset(expiry_time) is None
-                ):
+                if expiry_time.tzinfo is None or expiry_time.tzinfo.utcoffset(expiry_time) is None:
                     expiry_time = expiry_time.replace(tzinfo=timezone.utc)
                 if expiry_time < current_time:
                     await _delete_cache_key_object(
@@ -762,11 +734,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
             return valid_token
 
-        if (
-            valid_token is not None
-            and isinstance(valid_token, UserAPIKeyAuth)
-            and valid_token.team_id is not None
-        ):
+        if valid_token is not None and isinstance(valid_token, UserAPIKeyAuth) and valid_token.team_id is not None:
             ## UPDATE TEAM VALUES BASED ON CACHED TEAM OBJECT - allows `/team/update` values to work for cached token
             try:
                 team_obj: LiteLLM_TeamTableCachedObj = await get_team_object(
@@ -790,9 +758,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                         if field_name in valid_token.__fields__:
                             setattr(valid_token, field_name, v)
             except Exception as e:
-                verbose_logger.debug(
-                    e
-                )  # moving from .warning to .debug as it spams logs when team missing from cache.
+                verbose_logger.debug(e)  # moving from .warning to .debug as it spams logs when team missing from cache.
 
         try:
             is_master_key_valid = secrets.compare_digest(api_key, master_key)  # type: ignore
@@ -805,11 +771,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         except Exception:
             raise HTTPException(
                 status_code=500,
-                detail={
-                    "Master key must be a valid string. Current type={}".format(
-                        type(master_key)
-                    )
-                },
+                detail={"Master key must be a valid string. Current type={}".format(type(master_key))},
             )
 
         if is_master_key_valid:
@@ -843,9 +805,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         ## IF it's not a master key
         ## Route should not be in master_key_only_routes
         if route in LiteLLMRoutes.master_key_only_routes.value:  # type: ignore
-            raise Exception(
-                f"Tried to access route={route}, which is only for MASTER KEY"
-            )
+            raise Exception(f"Tried to access route={route}, which is only for MASTER KEY")
 
         ## Check DB
 
@@ -863,13 +823,9 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         _user_role = None
 
         if valid_token is None:
-            if isinstance(
-                api_key, str
-            ):  # if generated token, make sure it starts with sk-.
-                assert api_key.startswith(
-                    "sk-"
-                ), "LiteLLM Virtual Key expected. Received={}, expected to start with 'sk-'.".format(
-                    api_key
+            if isinstance(api_key, str):  # if generated token, make sure it starts with sk-.
+                assert api_key.startswith("sk-"), (
+                    "LiteLLM Virtual Key expected. Received={}, expected to start with 'sk-'.".format(api_key)
                 )  # prevent token hashes from being used
             else:
                 verbose_logger.warning(
@@ -900,9 +856,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             valid_token.end_user_id = end_user_params.get("end_user_id")
             valid_token.end_user_tpm_limit = end_user_params.get("end_user_tpm_limit")
             valid_token.end_user_rpm_limit = end_user_params.get("end_user_rpm_limit")
-            valid_token.allowed_model_region = end_user_params.get(
-                "allowed_model_region"
-            )
+            valid_token.allowed_model_region = end_user_params.get("allowed_model_region")
             # update key budget with temp budget increase
             valid_token = _update_key_budget_with_temp_budget_increase(
                 valid_token
@@ -926,21 +880,14 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
             ## base case ## key is disabled
             if valid_token.blocked is True:
-                raise Exception(
-                    "Key is blocked. Update via `/key/unblock` if you're admin."
-                )
+                raise Exception("Key is blocked. Update via `/key/unblock` if you're admin.")
             config = valid_token.config
 
             if config != {}:
                 model_list = config.get("model_list", [])
                 new_model_list = model_list
-                verbose_proxy_logger.debug(
-                    f"\n new llm router model list {new_model_list}"
-                )
-            elif (
-                isinstance(valid_token.models, list)
-                and "all-team-models" in valid_token.models
-            ):
+                verbose_proxy_logger.debug(f"\n new llm router model list {new_model_list}")
+            elif isinstance(valid_token.models, list) and "all-team-models" in valid_token.models:
                 # Do not do any validation at this step
                 # the validation will occur when checking the team has access to this model
                 pass
@@ -994,13 +941,10 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
             # Check 3. Check if user is in their team budget
             if valid_token.team_member_spend is not None:
-
                 if prisma_client is not None:
                     _cache_key = f"{valid_token.team_id}_{valid_token.user_id}"
 
-                    team_member_info = await user_api_key_cache.async_get_cache(
-                        key=_cache_key
-                    )
+                    team_member_info = await user_api_key_cache.async_get_cache(key=_cache_key)
                     if team_member_info is None:
                         # read from DB
                         _user_id = valid_token.user_id
@@ -1020,13 +964,8 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                                 ttl=5,
                             )
 
-                    if (
-                        team_member_info is not None
-                        and team_member_info.litellm_budget_table is not None
-                    ):
-                        team_member_budget = (
-                            team_member_info.litellm_budget_table.max_budget
-                        )
+                    if team_member_info is not None and team_member_info.litellm_budget_table is not None:
+                        team_member_budget = team_member_info.litellm_budget_table.max_budget
                         if team_member_budget is not None and team_member_budget > 0:
                             if valid_token.team_member_spend > team_member_budget:
                                 raise litellm.BudgetExceededError(
@@ -1041,10 +980,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     expiry_time = valid_token.expires
                 else:
                     expiry_time = datetime.fromisoformat(valid_token.expires)
-                if (
-                    expiry_time.tzinfo is None
-                    or expiry_time.tzinfo.utcoffset(expiry_time) is None
-                ):
+                if expiry_time.tzinfo is None or expiry_time.tzinfo.utcoffset(expiry_time) is None:
                     expiry_time = expiry_time.replace(tzinfo=timezone.utc)
                 verbose_proxy_logger.debug(
                     f"Checking if token expired, expiry time {expiry_time} and current time {current_time}"
@@ -1119,9 +1055,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             )  # save team table in cache - used for tpm/rpm limiting - tpm_rpm_limiter.py
 
             global_proxy_spend = None
-            if (
-                litellm.max_budget > 0 and prisma_client is not None
-            ):  # user set proxy max budget
+            if litellm.max_budget > 0 and prisma_client is not None:  # user set proxy max budget
                 # check cache
                 global_proxy_spend = await user_api_key_cache.async_get_cache(
                     key="{}:spend".format(litellm_proxy_admin_name)
@@ -1216,32 +1150,22 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         )
 
 
-
-
 @tracer.wrap()
 async def user_api_key_auth(
     request: Request,
     api_key: str = fastapi.Security(api_key_header),
     azure_api_key_header: str = fastapi.Security(azure_api_key_header),
-    anthropic_api_key_header: Optional[str] = fastapi.Security(
-        anthropic_api_key_header
-    ),
-    google_ai_studio_api_key_header: Optional[str] = fastapi.Security(
-        google_ai_studio_api_key_header
-    ),
+    anthropic_api_key_header: Optional[str] = fastapi.Security(anthropic_api_key_header),
+    google_ai_studio_api_key_header: Optional[str] = fastapi.Security(google_ai_studio_api_key_header),
     azure_apim_header: Optional[str] = fastapi.Security(azure_apim_header),
-    custom_litellm_key_header: Optional[str] = fastapi.Security(
-        custom_litellm_key_header
-    ),
+    custom_litellm_key_header: Optional[str] = fastapi.Security(custom_litellm_key_header),
 ) -> UserAPIKeyAuth:
     """
     Parent function to authenticate user api key / jwt token.
     """
 
     request_data = await _read_request_body(request=request)
-    request_data = populate_request_with_path_params(
-        request_data=request_data, request=request
-    )
+    request_data = populate_request_with_path_params(request_data=request_data, request=request)
     route: str = get_request_route(request=request)
 
     ## CHECK IF ROUTE IS ALLOWED
@@ -1260,9 +1184,7 @@ async def user_api_key_auth(
     ## ENSURE DISABLE ROUTE WORKS ACROSS ALL USER AUTH FLOWS ##
     RouteChecks.should_call_route(route=route, valid_token=user_api_key_auth_obj)
 
-    end_user_id = get_end_user_id_from_request_body(
-        request_data, _safe_get_request_headers(request)
-    )
+    end_user_id = get_end_user_id_from_request_body(request_data, _safe_get_request_headers(request))
     if end_user_id is not None:
         user_api_key_auth_obj.end_user_id = end_user_id
 
@@ -1293,9 +1215,7 @@ async def _return_user_api_key_auth_obj(
         )
     )
 
-    retrieved_user_role = (
-        user_role or _get_user_role(user_obj=user_obj) or LitellmUserRoles.INTERNAL_USER
-    )
+    retrieved_user_role = user_role or _get_user_role(user_obj=user_obj) or LitellmUserRoles.INTERNAL_USER
 
     user_api_key_kwargs = {
         "api_key": api_key,
@@ -1318,9 +1238,7 @@ async def _return_user_api_key_auth_obj(
         return UserAPIKeyAuth(**user_api_key_kwargs)
 
 
-def get_api_key_from_custom_header(
-    request: Request, custom_litellm_key_header_name: str
-) -> str:
+def get_api_key_from_custom_header(request: Request, custom_litellm_key_header_name: str) -> str:
     """
     Get API key from custom header
 
@@ -1357,10 +1275,7 @@ def get_api_key_from_custom_header(
 
 def _get_temp_budget_increase(valid_token: UserAPIKeyAuth):
     valid_token_metadata = valid_token.metadata
-    if (
-        "temp_budget_increase" in valid_token_metadata
-        and "temp_budget_expiry" in valid_token_metadata
-    ):
+    if "temp_budget_increase" in valid_token_metadata and "temp_budget_expiry" in valid_token_metadata:
         expiry = datetime.fromisoformat(valid_token_metadata["temp_budget_expiry"])
         if expiry > datetime.now():
             return valid_token_metadata["temp_budget_increase"]

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -62,7 +62,7 @@ def test_get_api_key_with_custom_litellm_key_header(
 def test_team_metadata_with_tags_flows_through_jwt_auth():
     """
     Test that team_metadata (specifically tags) flows through JWT authentication.
-    
+
     This is a regression test for the issue where JWT auth was not populating
     team_metadata, causing team-level tags to be missing in litellm_pre_call_utils.py
     """
@@ -77,7 +77,7 @@ def test_team_metadata_with_tags_flows_through_jwt_auth():
         rpm_limit=100,
         models=["gpt-4", "gpt-3.5-turbo"],
     )
-    
+
     # Simulate constructing UserAPIKeyAuth like we do in JWT auth
     # This is the pattern from user_api_key_auth.py lines 552-587
     user_api_key_auth = UserAPIKeyAuth(
@@ -90,14 +90,14 @@ def test_team_metadata_with_tags_flows_through_jwt_auth():
         user_role="internal_user",
         user_id="test-user",
     )
-    
+
     # Verify team_metadata is set
     assert user_api_key_auth.team_metadata is not None, "team_metadata should be populated"
     assert user_api_key_auth.team_metadata == team_object.metadata, (
         f"team_metadata not correctly mapped. "
         f"Expected: {team_object.metadata}, Got: {user_api_key_auth.team_metadata}"
     )
-    
+
     # Specifically verify tags are present
     assert "tags" in user_api_key_auth.team_metadata, "tags should be in team_metadata"
     assert user_api_key_auth.team_metadata["tags"] == ["production", "high-priority"], (
@@ -108,7 +108,7 @@ def test_team_metadata_with_tags_flows_through_jwt_auth():
 
 def test_route_checks_is_llm_api_route():
     """Test RouteChecks.is_llm_api_route() correctly identifies LLM API routes including passthrough endpoints"""
-    
+
     # Test OpenAI routes
     openai_routes = [
         "/v1/chat/completions",
@@ -132,7 +132,7 @@ def test_route_checks_is_llm_api_route():
         "/v1/realtime",
         "/realtime",
     ]
-    
+
     for route in openai_routes:
         assert RouteChecks.is_llm_api_route(route=route), f"Route {route} should be identified as LLM API route"
 
@@ -141,7 +141,7 @@ def test_route_checks_is_llm_api_route():
         "/v1/messages",
         "/v1/messages/count_tokens",
     ]
-    
+
     for route in anthropic_routes:
         assert RouteChecks.is_llm_api_route(route=route), f"Route {route} should be identified as LLM API route"
 
@@ -161,7 +161,7 @@ def test_route_checks_is_llm_api_route():
         "/vllm/v1/chat/completions",
         "/mistral/v1/chat/completions",
     ]
-    
+
     for route in passthrough_routes:
         assert RouteChecks.is_llm_api_route(route=route), f"Route {route} should be identified as LLM API route"
 
@@ -171,7 +171,7 @@ def test_route_checks_is_llm_api_route():
         "/mcp/",
         "/mcp/test",
     ]
-    
+
     for route in mcp_routes:
         assert RouteChecks.is_llm_api_route(route=route), f"Route {route} should be identified as LLM API route"
 
@@ -186,7 +186,7 @@ def test_route_checks_is_llm_api_route():
         "/v1/batches/batch_123",
         "/batches/batch_123",
     ]
-    
+
     for route in placeholder_routes:
         assert RouteChecks.is_llm_api_route(route=route), f"Route {route} should be identified as LLM API route"
 
@@ -197,7 +197,7 @@ def test_route_checks_is_llm_api_route():
         "/engines/gpt-4/chat/completions",
         "/engines/gpt-3.5-turbo/completions",
     ]
-    
+
     for route in azure_routes:
         assert RouteChecks.is_llm_api_route(route=route), f"Route {route} should be identified as LLM API route"
 
@@ -216,7 +216,7 @@ def test_route_checks_is_llm_api_route():
         "/debug",
         "/test",
     ]
-    
+
     for route in non_llm_routes:
         assert not RouteChecks.is_llm_api_route(route=route), f"Route {route} should NOT be identified as LLM API route"
 
@@ -228,7 +228,7 @@ def test_route_checks_is_llm_api_route():
         {},
         "",
     ]
-    
+
     for invalid_input in invalid_inputs:
         assert not RouteChecks.is_llm_api_route(route=invalid_input), f"Invalid input {invalid_input} should return False"
 
@@ -239,14 +239,14 @@ async def test_proxy_admin_expired_key_from_cache():
     Test that PROXY_ADMIN keys retrieved from cache are checked for expiration
     before being returned. This prevents expired keys from bypassing expiration checks
     when retrieved from cache (which normally happens at lines 1014-1036).
-    
+
     Regression test for issue where PROXY_ADMIN keys from cache skipped expiration check.
     """
     from datetime import datetime, timedelta, timezone
-    
+
     from fastapi import Request
     from starlette.datastructures import URL
-    
+
     from litellm.proxy._types import (
         LitellmUserRoles,
         ProxyErrorTypes,
@@ -255,24 +255,24 @@ async def test_proxy_admin_expired_key_from_cache():
     )
     from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
     from litellm.proxy.proxy_server import hash_token
-    
+
     # Create an expired PROXY_ADMIN key
     api_key = "sk-test-proxy-admin-key"
     hashed_key = hash_token(api_key)
     expired_time = datetime.now(timezone.utc) - timedelta(hours=1)  # Expired 1 hour ago
-    
+
     expired_token = UserAPIKeyAuth(
         api_key=api_key,
         user_role=LitellmUserRoles.PROXY_ADMIN,
         expires=expired_time,
         token=hashed_key,
     )
-    
+
     # Mock cache to return the expired token
     mock_cache = AsyncMock()
     mock_cache.async_get_cache = AsyncMock(return_value=expired_token)
     mock_cache.delete_cache = MagicMock()
-    
+
     # Mock proxy_logging_obj
     mock_proxy_logging_obj = MagicMock()
     mock_proxy_logging_obj.internal_usage_cache = MagicMock()
@@ -280,22 +280,22 @@ async def test_proxy_admin_expired_key_from_cache():
     mock_proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
     # Mock post_call_failure_hook as async function returning None (no transformation)
     mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
-    
+
     # Mock prisma_client
     mock_prisma_client = MagicMock()
-    
+
     # Mock get_key_object to return expired token from cache
     with patch(
         "litellm.proxy.auth.user_api_key_auth.get_key_object",
         new_callable=AsyncMock,
     ) as mock_get_key_object, \
          patch("litellm.proxy.auth.user_api_key_auth._delete_cache_key_object", new_callable=AsyncMock) as mock_delete_cache:
-        
+
         mock_get_key_object.return_value = expired_token
-        
+
         # Set attributes on proxy_server module (these are imported inside _user_api_key_auth_builder)
         import litellm.proxy.proxy_server
-        
+
         setattr(litellm.proxy.proxy_server, "prisma_client", mock_prisma_client)
         setattr(litellm.proxy.proxy_server, "user_api_key_cache", mock_cache)
         setattr(litellm.proxy.proxy_server, "proxy_logging_obj", mock_proxy_logging_obj)
@@ -308,14 +308,14 @@ async def test_proxy_admin_expired_key_from_cache():
         setattr(litellm.proxy.proxy_server, "user_custom_auth", None)
         setattr(litellm.proxy.proxy_server, "jwt_handler", None)
         setattr(litellm.proxy.proxy_server, "litellm_proxy_admin_name", "admin")
-        
+
         try:
-            
+
             # Create a mock request
             request = Request(scope={"type": "http"})
             request._url = URL(url="/chat/completions")
             request_data = {}
-            
+
             # Call the auth builder - should raise ProxyException for expired key
             # Note: api_key needs "Bearer " prefix for get_api_key() to process it correctly
             with pytest.raises(ProxyException) as exc_info:
@@ -328,7 +328,7 @@ async def test_proxy_admin_expired_key_from_cache():
                     azure_apim_header=None,
                     request_data=request_data,
                 )
-            
+
             # Verify that ProxyException was raised with expired_key type
             assert hasattr(exc_info.value, "type"), "Exception should have 'type' attribute"
             assert exc_info.value.type == ProxyErrorTypes.expired_key, (
@@ -337,7 +337,7 @@ async def test_proxy_admin_expired_key_from_cache():
             assert "Expired Key" in str(exc_info.value.message), (
                 f"Exception message should mention 'Expired Key', got: {exc_info.value.message}"
             )
-            
+
             # Verify that cache deletion was called
             mock_delete_cache.assert_called_once()
             call_args = mock_delete_cache.call_args
@@ -347,3 +347,60 @@ async def test_proxy_admin_expired_key_from_cache():
         finally:
             # Clean up - restore original values if needed
             pass
+
+
+class TestAuthenticationMode:
+    """Tests for the authentication_mode setting."""
+
+    def test_get_effective_authentication_mode_explicit_off(self):
+        """When authentication_mode is explicitly 'off', should return OFF regardless of master_key."""
+        from litellm.proxy._types import AuthenticationMode
+        from litellm.proxy.auth.user_api_key_auth import get_effective_authentication_mode
+
+        # Explicit off, no master key
+        result = get_effective_authentication_mode({"authentication_mode": "off"}, None)
+        assert result == AuthenticationMode.OFF
+
+        # Explicit off, with master key (explicit setting takes precedence)
+        result = get_effective_authentication_mode(
+            {"authentication_mode": "off"}, "sk-master-key"
+        )
+        assert result == AuthenticationMode.OFF
+
+        # Explicit off as enum
+        result = get_effective_authentication_mode(
+            {"authentication_mode": AuthenticationMode.OFF}, None
+        )
+        assert result == AuthenticationMode.OFF
+
+    def test_get_effective_authentication_mode_explicit_secure(self):
+        """When authentication_mode is explicitly 'secure', should return SECURE."""
+        from litellm.proxy._types import AuthenticationMode
+        from litellm.proxy.auth.user_api_key_auth import get_effective_authentication_mode
+
+        result = get_effective_authentication_mode(
+            {"authentication_mode": "secure"}, "sk-master-key"
+        )
+        assert result == AuthenticationMode.SECURE
+
+        # Explicit secure as enum
+        result = get_effective_authentication_mode(
+            {"authentication_mode": AuthenticationMode.SECURE}, "sk-master-key"
+        )
+        assert result == AuthenticationMode.SECURE
+
+    def test_get_effective_authentication_mode_default_with_master_key(self):
+        """When no explicit mode but master_key is set, should default to SECURE."""
+        from litellm.proxy._types import AuthenticationMode
+        from litellm.proxy.auth.user_api_key_auth import get_effective_authentication_mode
+
+        result = get_effective_authentication_mode({}, "sk-master-key")
+        assert result == AuthenticationMode.SECURE
+
+    def test_get_effective_authentication_mode_default_without_master_key(self):
+        """When no explicit mode and no master_key, should default to OFF."""
+        from litellm.proxy._types import AuthenticationMode
+        from litellm.proxy.auth.user_api_key_auth import get_effective_authentication_mode
+
+        result = get_effective_authentication_mode({}, None)
+        assert result == AuthenticationMode.OFF


### PR DESCRIPTION
## Problem

The proxy auth has confusing behavior when no `master_key` is set: it requires an API key header but accepts any value, granting admin access regardless. You have to pass *something* but it's not validated. Useless.

This is annoying for deployments on trusted internal networks where you don't want auth but still have to provide a dummy token.

## Solution

Add `general_settings.authentication_mode` with two options:

| Mode | Behavior |
|------|----------|
| `off` | No auth required, all requests allowed |
| `secure` | Full validation against master_key/database |

Defaults:
- `master_key` set → `secure`
- `master_key` not set → `off` (logs a warning)

## Usage

Trusted network, no auth needed:
```yaml
general_settings:
  authentication_mode: "off"
```

Production with proper auth:
```yaml
general_settings:
  master_key: sk-whatever
  # authentication_mode defaults to secure
```

## Backwards compatible

Existing deployments work the same. The only visible change is a startup warning if you're running without auth and haven't explicitly acknowledged it with `authentication_mode: off`.