### PR TITLE
refactor: lazy load DatadogLLMObsInitParams to reduce import time

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -26,7 +26,6 @@ from typing import (
     overload,
     Type,
 )
-from litellm.types.integrations.datadog_llm_obs import DatadogLLMObsInitParams
 from litellm.types.integrations.datadog import DatadogInitParams
 from litellm._logging import (
     set_verbose,
@@ -1532,6 +1531,9 @@ if TYPE_CHECKING:
 
     # Custom logger class (lazy-loaded)
     from litellm.integrations.custom_logger import CustomLogger
+    
+    # Datadog LLM observability params (lazy-loaded)
+    from litellm.types.integrations.datadog_llm_obs import DatadogLLMObsInitParams
     
     # Logging callback manager class and instance (lazy-loaded)
     from litellm.litellm_core_utils.logging_callback_manager import LoggingCallbackManager

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -282,6 +282,7 @@ TYPES_NAMES = (
     "PriorityReservationSettings",
     "CustomLogger",
     "LoggingCallbackManager",
+    "DatadogLLMObsInitParams",
     # Note: LlmProviders is NOT lazy-loaded because it's imported during import time
     # in multiple places including openai.py (via main import)
     # Note: KeyManagementSettings is NOT lazy-loaded because _key_management_settings
@@ -393,6 +394,7 @@ _TYPES_IMPORT_MAP = {
     "PriorityReservationSettings": ("litellm.types.utils", "PriorityReservationSettings"),
     "CustomLogger": ("litellm.integrations.custom_logger", "CustomLogger"),
     "LoggingCallbackManager": ("litellm.litellm_core_utils.logging_callback_manager", "LoggingCallbackManager"),
+    "DatadogLLMObsInitParams": ("litellm.types.integrations.datadog_llm_obs", "DatadogLLMObsInitParams"),
 }
 
 _LLM_PROVIDER_LOGIC_IMPORT_MAP = {


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53261/workflows/f8a02ade-ae96-4129-9b72-10ee3ffc740e

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53264/workflows/ac3853e9-6815-4efb-a5e9-d0f156a816eb

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- Added DatadogLLMObsInitParams to TYPES_NAMES in _lazy_imports_registry.py
- Added import map entry for DatadogLLMObsInitParams in _TYPES_IMPORT_MAP
- Moved DatadogLLMObsInitParams import from module level to TYPE_CHECKING block in __init__.py
- Follows existing lazy import patterns for type classes
- Automatically tested by existing test_types_lazy_imports() function