### PR TITLE
Add dedicated xai_key and fallback logic for xAI API key

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -199,6 +199,7 @@ api_key: Optional[str] = None
 openai_key: Optional[str] = None
 groq_key: Optional[str] = None
 gigachat_key: Optional[str] = None
+xai_key: Optional[str] = None
 databricks_key: Optional[str] = None
 openai_like_key: Optional[str] = None
 azure_key: Optional[str] = None

--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -4,6 +4,7 @@ import httpx
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm.llms.xai.common_utils import XAIModelInfo
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     filter_value_from_dict,
     strip_name_from_messages,
@@ -26,7 +27,7 @@ class XAIChatConfig(OpenAIGPTConfig):
         self, api_base: Optional[str], api_key: Optional[str]
     ) -> Tuple[Optional[str], Optional[str]]:
         api_base = api_base or get_secret_str("XAI_API_BASE") or XAI_API_BASE  # type: ignore
-        dynamic_api_key = api_key or get_secret_str("XAI_API_KEY")
+        dynamic_api_key = XAIModelInfo.get_api_key(api_key)
         return api_base, dynamic_api_key
 
     def get_supported_openai_params(self, model: str) -> list:

--- a/litellm/llms/xai/common_utils.py
+++ b/litellm/llms/xai/common_utils.py
@@ -46,7 +46,12 @@ class XAIModelInfo(BaseLLMModelInfo):
 
     @staticmethod
     def get_api_key(api_key: Optional[str] = None) -> Optional[str]:
-        return api_key or get_secret_str("XAI_API_KEY")
+        return (
+            api_key
+            or litellm.xai_key
+            or get_secret_str("XAI_API_KEY")
+            or litellm.api_key
+        )
 
     @staticmethod
     def get_base_model(model: str) -> Optional[str]:

--- a/litellm/llms/xai/responses/transformation.py
+++ b/litellm/llms/xai/responses/transformation.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm.llms.xai.common_utils import XAIModelInfo
 from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import ResponsesAPIOptionalRequestParams
@@ -103,11 +104,7 @@ class XAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         Uses XAI_API_KEY from environment or litellm_params.
         """
         litellm_params = litellm_params or GenericLiteLLMParams()
-        api_key = (
-            litellm_params.api_key
-            or litellm.api_key
-            or get_secret_str("XAI_API_KEY")
-        )
+        api_key = XAIModelInfo.get_api_key(litellm_params.api_key)
         
         if not api_key:
             raise ValueError(
@@ -143,4 +140,3 @@ class XAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         api_base = api_base.rstrip("/")
         
         return f"{api_base}/responses"
-

--- a/tests/litellm/llms/xai/test_xai_key_fallback.py
+++ b/tests/litellm/llms/xai/test_xai_key_fallback.py
@@ -1,0 +1,100 @@
+import os
+import litellm
+from litellm.llms.xai.chat.transformation import XAIChatConfig
+from litellm.llms.xai.common_utils import XAIModelInfo
+from litellm.llms.xai.responses.transformation import XAIResponsesAPIConfig
+
+
+def test_get_api_key_priority():
+    """
+    Test the fallback order of XAI API key resolution:
+    1. api_key parameter
+    2. litellm.xai_key
+    3. XAI_API_KEY environment variable
+    4. litellm.api_key
+    5. None
+    """
+
+    original_env = os.environ.get("XAI_API_KEY")
+    had_env = "XAI_API_KEY" in os.environ
+    original_xai_key = litellm.xai_key
+    original_api_key = litellm.api_key
+
+    try:
+        # Case 1: api_key parameter is passed
+        litellm.xai_key = "xai_key_value"
+        litellm.api_key = "common_api_key"
+        os.environ["XAI_API_KEY"] = "env_api_key"
+        result = XAIModelInfo.get_api_key("param_api_key")
+        assert result == "param_api_key"
+
+        # Case 2: api_key not passed, use litellm.xai_key
+        result = XAIModelInfo.get_api_key(None)
+        assert result == "xai_key_value"
+
+        # Case 3: api_key and xai_key not set, prefer XAI_API_KEY over litellm.api_key
+        litellm.xai_key = None
+        result = XAIModelInfo.get_api_key(None)
+        assert result == "env_api_key"
+
+        # Case 4: Empty XAI_API_KEY falls through to litellm.api_key
+        os.environ["XAI_API_KEY"] = ""
+        result = XAIModelInfo.get_api_key(None)
+        assert result == "common_api_key"
+
+        # Case 5: None of the above, return None
+        os.environ.pop("XAI_API_KEY", None)
+        litellm.api_key = None
+        result = XAIModelInfo.get_api_key(None)
+        assert result is None
+    finally:
+        if had_env:
+            os.environ["XAI_API_KEY"] = original_env
+        else:
+            os.environ.pop("XAI_API_KEY", None)
+        litellm.xai_key = original_xai_key
+        litellm.api_key = original_api_key
+
+
+def test_chat_config_uses_xai_key_fallback():
+    original_env = os.environ.get("XAI_API_KEY")
+    had_env = "XAI_API_KEY" in os.environ
+    original_xai_key = litellm.xai_key
+    original_api_key = litellm.api_key
+
+    try:
+        litellm.xai_key = "xai_key_value"
+        litellm.api_key = None
+        os.environ.pop("XAI_API_KEY", None)
+        _, api_key = XAIChatConfig()._get_openai_compatible_provider_info(None, None)
+        assert api_key == "xai_key_value"
+    finally:
+        if had_env:
+            os.environ["XAI_API_KEY"] = original_env
+        else:
+            os.environ.pop("XAI_API_KEY", None)
+        litellm.xai_key = original_xai_key
+        litellm.api_key = original_api_key
+
+
+def test_responses_config_uses_xai_key_fallback():
+    original_env = os.environ.get("XAI_API_KEY")
+    had_env = "XAI_API_KEY" in os.environ
+    original_xai_key = litellm.xai_key
+    original_api_key = litellm.api_key
+
+    try:
+        litellm.xai_key = "xai_key_value"
+        litellm.api_key = None
+        os.environ.pop("XAI_API_KEY", None)
+        headers = XAIResponsesAPIConfig().validate_environment(
+            {}, "xai/grok-3-mini", None
+        )
+        assert headers["Authorization"] == "Bearer xai_key_value"
+    finally:
+        if had_env:
+            os.environ["XAI_API_KEY"] = original_env
+        else:
+            os.environ.pop("XAI_API_KEY", None)
+        litellm.xai_key = original_xai_key
+        litellm.api_key = original_api_key


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - Ran: `poetry run pytest tests/test_litellm -x -vv -n 4 --import-mode=importlib`
  - Failed: `ModuleNotFoundError: litellm_enterprise.proxy.common_utils.check_responses_cost` (enterprise package not installed)
  - Failed: `tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py::test_bedrock_converse_budget_tokens_preserved` (`mock_post` not called)

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

- Add xai_key fallback for xAI API key resolution
- Ensure xAI API key fallback test restores global/environment state