### PR TITLE
fix: prevent proxy startup failures from case-sensitive tool permission guardrail validation

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
@@ -108,8 +108,9 @@ class ToolPermissionGuardrail(CustomGuardrail):
                     if compiled_patterns:
                         self._compiled_rule_patterns[rule.id] = compiled_patterns
 
-        self.default_action = default_action
-        self.on_disallowed_action = on_disallowed_action
+        # Normalize to lowercase for case-insensitive handling
+        self.default_action = default_action.lower() if isinstance(default_action, str) else default_action
+        self.on_disallowed_action = on_disallowed_action.lower() if isinstance(on_disallowed_action, str) else on_disallowed_action
 
         verbose_proxy_logger.debug(
             "Tool Permission Guardrail initialized with %d rules, default_action: %s",

--- a/litellm/types/proxy/guardrails/guardrail_hooks/tool_permission.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/tool_permission.py
@@ -40,6 +40,14 @@ class ToolPermissionRule(BaseModel):
             return stripped
         return value
 
+    @field_validator("decision", mode="before")
+    @classmethod
+    def normalize_decision(cls, v):
+        """Normalize decision to lowercase to handle case-insensitive input."""
+        if isinstance(v, str):
+            return v.lower()
+        return v
+
     @model_validator(mode="after")
     def _ensure_target_present(self):
         if self.tool_name is None and self.tool_type is None:
@@ -86,6 +94,22 @@ class ToolPermissionGuardrailConfigModel(GuardrailConfigModel):
         default="block",
         description="Choose whether disallowed tools block the request or get rewritten out of the payload",
     )
+
+    @field_validator("default_action", mode="before")
+    @classmethod
+    def normalize_default_action(cls, v):
+        """Normalize default_action to lowercase to handle case-insensitive input."""
+        if isinstance(v, str):
+            return v.lower()
+        return v
+
+    @field_validator("on_disallowed_action", mode="before")
+    @classmethod
+    def normalize_on_disallowed_action(cls, v):
+        """Normalize on_disallowed_action to lowercase to handle case-insensitive input."""
+        if isinstance(v, str):
+            return v.lower()
+        return v
 
     @staticmethod
     def ui_friendly_name() -> str:


### PR DESCRIPTION
## Relevant issues

<img width="2844" height="428" alt="Screenshot 2026-01-05 112054" src="https://github.com/user-attachments/assets/4077f8d9-9107-41c0-b945-aa24420c97ab" />

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53264/workflows/ac3853e9-6815-4efb-a5e9-d0f156a816eb

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53276/workflows/d0be63c0-b01d-4e30-9db8-50e48bc245a6

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix

## Changes


This fixes a critical issue where capitalized values in tool_permission guardrail configurations (e.g., "Deny" instead of "deny") caused Pydantic validation errors during proxy startup, leading to repeated initialization failures and latency issues.

Problem:
- Users could save guardrails with capitalized values through UI/API
- Data was written to database without validation (e.g., default_action: "Deny")
- On proxy startup, loading from DB triggered strict Pydantic validation
- ValidationError caused guardrail initialization to fail in a retry loop
- This resulted in startup delays and repeated error logging

Root Cause:
- Write path had no case normalization
- Read path enforced strict lowercase Literal validation
- Asymmetry between write and read caused latent data corruption

Solution:
Added field validators to normalize case before Pydantic validation:

1. ToolPermissionRule.decision ("allow"/"deny")
   - Normalizes decision field in rules array

2. ToolPermissionGuardrailConfigModel.default_action ("allow"/"deny")
   - Normalizes default fallback action

3. ToolPermissionGuardrailConfigModel.on_disallowed_action ("block"/"rewrite")
   - Normalizes disallowed tool behavior

4. ToolPermissionGuardrail.__init__ normalization
   - Defensive normalization for direct instantiation
   - Ensures normalization regardless of code path

Impact:
- Prevents validation errors during guardrail initialization
- Eliminates startup retry loops and latency issues
- Handles existing database records with capitalized values
- Accepts case-insensitive input from all sources (UI, API, direct calls)
- Fully backward compatible with existing lowercase configurations

Testing:
- Added 3 comprehensive tests for case-insensitive handling
- All 27 existing tests still pass
- Tests verify normalization across all affected fields

Files Changed:
- litellm/types/proxy/guardrails/guardrail_hooks/tool_permission.py Added @field_validator decorators for case normalization
- litellm/proxy/guardrails/guardrail_hooks/tool_permission.py Added runtime normalization in __init__ method
- tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py Added case-insensitive validation tests

