### PR TITLE
fix: extend case normalization to ALL guardrail types 

### DIFF
--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import Required, TypedDict
 
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolCallChunk, ChatCompletionToolParam
@@ -671,12 +671,29 @@ class LitellmParams(
         description="When to apply the guardrail (pre_call, post_call, during_call, logging_only)"
     )
 
+    @field_validator("default_action", mode="before", check_fields=False)
+    @classmethod
+    def normalize_default_action_litellm_params(cls, v):
+        """Normalize default_action to lowercase for ALL guardrail types."""
+        if isinstance(v, str):
+            return v.lower()
+        return v
+
+    @field_validator("on_disallowed_action", mode="before", check_fields=False)
+    @classmethod
+    def normalize_on_disallowed_action_litellm_params(cls, v):
+        """Normalize on_disallowed_action to lowercase for ALL guardrail types."""
+        if isinstance(v, str):
+            return v.lower()
+        return v
+
     def __init__(self, **kwargs):
         default_on = kwargs.pop("default_on", None)
         if default_on is not None:
             kwargs["default_on"] = default_on
         else:
             kwargs["default_on"] = False
+        
         super().__init__(**kwargs)
 
     def __contains__(self, key):

--- a/tests/test_litellm/types/test_guardrails_case_normalization.py
+++ b/tests/test_litellm/types/test_guardrails_case_normalization.py
@@ -1,0 +1,90 @@
+"""
+Test case normalization in LitellmParams for all guardrail types
+"""
+import pytest
+from litellm.types.guardrails import LitellmParams
+
+
+class TestLitellmParamsCaseNormalization:
+    """Test that LitellmParams normalizes case for all guardrail types"""
+
+    def test_presidio_guardrail_with_capitalized_default_action(self):
+        """Test Presidio guardrail with capitalized default_action"""
+        params = LitellmParams(
+            guardrail="presidio",
+            mode="post_call",
+            default_action="Deny",  # Capitalized
+        )
+        assert params.default_action == "deny"
+
+    def test_azure_guardrail_with_capitalized_default_action(self):
+        """Test Azure guardrail with capitalized default_action"""
+        params = LitellmParams(
+            guardrail="azure/text_moderations",
+            mode="pre_call",
+            default_action="Allow",  # Capitalized
+        )
+        assert params.default_action == "allow"
+
+    def test_tool_permission_with_capitalized_fields(self):
+        """Test tool_permission with capitalized fields"""
+        params = LitellmParams(
+            guardrail="tool_permission",
+            mode="post_call",
+            default_action="DENY",  # Uppercase
+            on_disallowed_action="BLOCK",  # Uppercase
+        )
+        assert params.default_action == "deny"
+        assert params.on_disallowed_action == "block"
+
+    def test_lakera_with_capitalized_default_action(self):
+        """Test Lakera guardrail with capitalized default_action"""
+        params = LitellmParams(
+            guardrail="lakera_v2",
+            mode="pre_call",
+            default_action="Deny",  # Capitalized
+        )
+        assert params.default_action == "deny"
+
+    def test_bedrock_with_capitalized_default_action(self):
+        """Test Bedrock guardrail with capitalized default_action"""
+        params = LitellmParams(
+            guardrail="bedrock",
+            mode="pre_call",
+            default_action="Allow",  # Capitalized
+        )
+        assert params.default_action == "allow"
+
+    def test_multiple_guardrails_all_normalized(self):
+        """Test that all guardrail types benefit from normalization"""
+        test_cases = [
+            ("presidio", "Deny"),
+            ("azure/text_moderations", "Allow"),
+            ("tool_permission", "DENY"),
+            ("lakera_v2", "allow"),  # Already lowercase - should still work
+            ("bedrock", "Deny"),
+        ]
+        
+        for guardrail_type, default_action_input in test_cases:
+            params = LitellmParams(
+                guardrail=guardrail_type,
+                mode="pre_call",
+                default_action=default_action_input,
+            )
+            # Should always be lowercase
+            assert params.default_action.lower() == params.default_action
+            # Should match the expected lowercase value
+            assert params.default_action in ["allow", "deny"]
+
+    def test_on_disallowed_action_all_cases(self):
+        """Test on_disallowed_action normalization across all cases"""
+        test_cases = ["block", "Block", "BLOCK", "rewrite", "Rewrite", "REWRITE"]
+        
+        for action in test_cases:
+            params = LitellmParams(
+                guardrail="tool_permission",
+                mode="post_call",
+                on_disallowed_action=action,
+            )
+            assert params.on_disallowed_action in ["block", "rewrite"]
+            assert params.on_disallowed_action.islower()


### PR DESCRIPTION


## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53279/workflows/925f73e4-8ad9-4d21-b13c-0ffcc5264c6f

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53279/workflows/925f73e4-8ad9-4d21-b13c-0ffcc5264c6f

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

This extends the previous fix to handle capitalized fields across ALL guardrail types, including Presidio, Azure, Lakera, Bedrock, etc.

Discovery:
- Database investigation revealed the issue affects multiple guardrail types
- Found 4 affected guardrails in staging: 3 Presidio + 1 Azure
- All had default_action: 'Deny' causing the same validation failures
- The initial fix only covered ToolPermissionGuardrailConfigModel

Root Cause (Deeper):
- LitellmParams inherits from 13+ different guardrail config models
- Models use ConfigDict(extra="allow") allowing any field to be set
- Users can set default_action/on_disallowed_action on ANY guardrail type
- Only ToolPermissionGuardrailConfigModel was validating these fields

Solution:
- Added field validators to LitellmParams class (parent of all guardrails)
- Validators run for ALL guardrail types: Presidio, Azure, Bedrock, Lakera, etc.
- Added comprehensive tests covering multiple guardrail types
