### PR TITLE
[Fix] UI - SSO Edit Modal Clear Role Mapping Values on Provider Change

### DIFF
--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.tsx
@@ -189,11 +189,16 @@ const BaseSSOSettingsForm: React.FC<BaseSSOSettingsFormProps> = ({ form, onFormS
 
         <Form.Item
           noStyle
-          shouldUpdate={(prevValues, currentValues) => prevValues.use_role_mappings !== currentValues.use_role_mappings}
+          shouldUpdate={(prevValues, currentValues) =>
+            prevValues.use_role_mappings !== currentValues.use_role_mappings ||
+            prevValues.sso_provider !== currentValues.sso_provider
+          }
         >
           {({ getFieldValue }) => {
             const useRoleMappings = getFieldValue("use_role_mappings");
-            return useRoleMappings ? (
+            const provider = getFieldValue("sso_provider");
+            const supportsRoleMappings = provider === "okta" || provider === "generic";
+            return useRoleMappings && supportsRoleMappings ? (
               <Form.Item
                 label="Group Claim"
                 name="group_claim"
@@ -207,11 +212,16 @@ const BaseSSOSettingsForm: React.FC<BaseSSOSettingsFormProps> = ({ form, onFormS
 
         <Form.Item
           noStyle
-          shouldUpdate={(prevValues, currentValues) => prevValues.use_role_mappings !== currentValues.use_role_mappings}
+          shouldUpdate={(prevValues, currentValues) =>
+            prevValues.use_role_mappings !== currentValues.use_role_mappings ||
+            prevValues.sso_provider !== currentValues.sso_provider
+          }
         >
           {({ getFieldValue }) => {
             const useRoleMappings = getFieldValue("use_role_mappings");
-            return useRoleMappings ? (
+            const provider = getFieldValue("sso_provider");
+            const supportsRoleMappings = provider === "okta" || provider === "generic";
+            return useRoleMappings && supportsRoleMappings ? (
               <>
                 <Form.Item label="Default Role" name="default_role" initialValue="Internal User">
                   <Select>

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/DeleteSSOSettingsModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/DeleteSSOSettingsModal.test.tsx
@@ -1,20 +1,60 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import DeleteSSOSettingsModal from "./DeleteSSOSettingsModal";
+
+vi.mock("@/app/(dashboard)/hooks/sso/useSSOSettings", () => ({
+  useSSOSettings: vi.fn(() => ({
+    data: {
+      values: {
+        google_client_id: "test-client-id",
+      },
+    },
+  })),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/sso/useEditSSOSettings", () => ({
+  useEditSSOSettings: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: vi.fn(() => ({
+    accessToken: "test-token",
+    userId: "test-user-id",
+    userRole: "proxy_admin",
+  })),
+}));
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
 
 describe("DeleteSSOSettingsModal", () => {
   it("should render", () => {
     const onCancel = vi.fn();
     const onSuccess = vi.fn();
+    const queryClient = createQueryClient();
 
     render(
-      <DeleteSSOSettingsModal isVisible={true} onCancel={onCancel} onSuccess={onSuccess} accessToken="test-token" />,
+      <QueryClientProvider client={queryClient}>
+        <DeleteSSOSettingsModal isVisible={true} onCancel={onCancel} onSuccess={onSuccess} />
+      </QueryClientProvider>,
     );
 
     expect(screen.getByText("Confirm Clear SSO Settings")).toBeInTheDocument();
     expect(
-      screen.getByText("Are you sure you want to clear all SSO settings? This action cannot be undone."),
+      screen.getByText(
+        "Are you sure you want to clear all SSO settings? Users will no longer be able to login using SSO after this change.",
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Users will no longer be able to login using SSO after this change.")).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/SSOSettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/SSOSettings.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useSSOSettings, type SSOSettingsValues } from "@/app/(dashboard)/hooks/sso/useSSOSettings";
-import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { Button, Card, Descriptions, Space, Typography } from "antd";
 import { Edit, Shield, Trash2 } from "lucide-react";
 import { useState } from "react";
@@ -13,12 +12,12 @@ import RedactableField from "./RedactableField";
 import RoleMappings from "./RoleMappings";
 import SSOSettingsEmptyPlaceholder from "./SSOSettingsEmptyPlaceholder";
 import SSOSettingsLoadingSkeleton from "./SSOSettingsLoadingSkeleton";
+import { detectSSOProvider } from "./utils";
 
 const { Title, Text } = Typography;
 
 export default function SSOSettings() {
   const { data: ssoSettings, refetch, isLoading } = useSSOSettings();
-  const { accessToken } = useAuthorized();
   const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
   const [isAddModalVisible, setIsAddModalVisible] = useState(false);
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
@@ -26,23 +25,6 @@ export default function SSOSettings() {
     Boolean(ssoSettings?.values.google_client_id) ||
     Boolean(ssoSettings?.values.microsoft_client_id) ||
     Boolean(ssoSettings?.values.generic_client_id);
-
-  // Determine the SSO provider based on the configuration
-  const detectSSOProvider = (values: SSOSettingsValues): string | null => {
-    if (values.google_client_id) return "google";
-    if (values.microsoft_client_id) return "microsoft";
-    if (values.generic_client_id) {
-      // Check if it looks like Okta/Auth0 based on endpoints
-      if (
-        values.generic_authorization_endpoint?.includes("okta") ||
-        values.generic_authorization_endpoint?.includes("auth0")
-      ) {
-        return "okta";
-      }
-      return "generic";
-    }
-    return null;
-  };
 
   const selectedProvider = ssoSettings?.values ? detectSSOProvider(ssoSettings.values) : null;
   const isRoleMappingsEnabled = Boolean(ssoSettings?.values.role_mappings);
@@ -233,7 +215,6 @@ export default function SSOSettings() {
         isVisible={isDeleteModalVisible}
         onCancel={() => setIsDeleteModalVisible(false)}
         onSuccess={() => refetch()}
-        accessToken={accessToken}
       />
 
       <AddSSOSettingsModal

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/utils.test.ts
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/utils.test.ts
@@ -55,6 +55,7 @@ describe("processSSOSettingsPayload", () => {
         default_role: "proxy_admin",
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
         other_field: "value",
       };
 
@@ -83,6 +84,7 @@ describe("processSSOSettingsPayload", () => {
         default_role: "internal_user",
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
       };
 
       const result = processSSOSettingsPayload(formValues);
@@ -100,6 +102,7 @@ describe("processSSOSettingsPayload", () => {
         default_role: "internal_user_viewer",
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
       };
 
       const result = processSSOSettingsPayload(formValues);
@@ -121,6 +124,7 @@ describe("processSSOSettingsPayload", () => {
         default_role: "proxy_admin_viewer",
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
       };
 
       const result = processSSOSettingsPayload(formValues);
@@ -142,6 +146,7 @@ describe("processSSOSettingsPayload", () => {
         default_role: "internal_user",
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
       };
 
       const result = processSSOSettingsPayload(formValues);
@@ -160,6 +165,7 @@ describe("processSSOSettingsPayload", () => {
         default_role: "internal_user",
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
       };
 
       const result = processSSOSettingsPayload(formValues);
@@ -174,6 +180,7 @@ describe("processSSOSettingsPayload", () => {
         default_role: "internal_user_viewer",
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
       };
 
       const result = processSSOSettingsPayload(formValues);
@@ -186,6 +193,7 @@ describe("processSSOSettingsPayload", () => {
         default_role: "internal_user",
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
       };
 
       const result = processSSOSettingsPayload(formValues);
@@ -198,6 +206,7 @@ describe("processSSOSettingsPayload", () => {
         default_role: "proxy_admin_viewer",
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
       };
 
       const result = processSSOSettingsPayload(formValues);
@@ -210,6 +219,7 @@ describe("processSSOSettingsPayload", () => {
         default_role: "proxy_admin",
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
       };
 
       const result = processSSOSettingsPayload(formValues);
@@ -222,6 +232,7 @@ describe("processSSOSettingsPayload", () => {
         default_role: "unknown_role",
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
       };
 
       const result = processSSOSettingsPayload(formValues);
@@ -233,6 +244,7 @@ describe("processSSOSettingsPayload", () => {
       const formValues = {
         group_claim: "groups",
         use_role_mappings: true,
+        sso_provider: "generic",
       };
 
       const result = processSSOSettingsPayload(formValues);

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/utils.ts
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/utils.ts
@@ -13,7 +13,6 @@ export const processSSOSettingsPayload = (formValues: Record<string, any>): Reco
     default_role,
     group_claim,
     use_role_mappings,
-    sso_provider,
     ...rest
   } = formValues;
 
@@ -22,8 +21,7 @@ export const processSSOSettingsPayload = (formValues: Record<string, any>): Reco
   };
 
   // Add role mappings only if use_role_mappings is checked AND provider supports role mappings
-  const supportsRoleMappings = sso_provider === "okta" || sso_provider === "generic";
-  if (use_role_mappings && supportsRoleMappings) {
+  if (use_role_mappings) {
     // Helper function to split comma-separated string into array
     const splitTeams = (teams: string | undefined): string[] => {
       if (!teams || teams.trim() === "") return [];

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/utils.ts
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/utils.ts
@@ -1,3 +1,5 @@
+import { SSOSettingsValues } from "@/app/(dashboard)/hooks/sso/useSSOSettings";
+
 /**
  * Processes SSO settings form values and transforms them into the payload format expected by the API
  * Handles role mappings transformation and field extraction
@@ -11,6 +13,7 @@ export const processSSOSettingsPayload = (formValues: Record<string, any>): Reco
     default_role,
     group_claim,
     use_role_mappings,
+    sso_provider,
     ...rest
   } = formValues;
 
@@ -18,8 +21,9 @@ export const processSSOSettingsPayload = (formValues: Record<string, any>): Reco
     ...rest,
   };
 
-  // Add role mappings if use_role_mappings is checked
-  if (use_role_mappings) {
+  // Add role mappings only if use_role_mappings is checked AND provider supports role mappings
+  const supportsRoleMappings = sso_provider === "okta" || sso_provider === "generic";
+  if (use_role_mappings && supportsRoleMappings) {
     // Helper function to split comma-separated string into array
     const splitTeams = (teams: string | undefined): string[] => {
       if (!teams || teams.trim() === "") return [];
@@ -51,4 +55,21 @@ export const processSSOSettingsPayload = (formValues: Record<string, any>): Reco
   }
 
   return payload;
+};
+
+// Determine the SSO provider based on the configuration
+export const detectSSOProvider = (values: SSOSettingsValues): string | null => {
+  if (values.google_client_id) return "google";
+  if (values.microsoft_client_id) return "microsoft";
+  if (values.generic_client_id) {
+    // Check if it looks like Okta/Auth0 based on endpoints
+    if (
+      values.generic_authorization_endpoint?.includes("okta") ||
+      values.generic_authorization_endpoint?.includes("auth0")
+    ) {
+      return "okta";
+    }
+    return "generic";
+  }
+  return null;
 };


### PR DESCRIPTION
## Relevant issues
Currently role mappings are supported only on Okta and generic sso providers. When editing SSO configs with role mappings set, upon selecting a unsupported provider, the role mapping form fields are still shown, potentially leading to user confusion. This PR fixes the issue by only showing the fields when the selected provider supports role mappings.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="1078" height="664" alt="image" src="https://github.com/user-attachments/assets/a833a44a-a1bb-42cb-a1d0-cb4116681d3b" />
<img width="999" height="233" alt="image" src="https://github.com/user-attachments/assets/4df27d3a-0b3e-435f-a5c9-3fefc2b3d637" />
