### PR TITLE
[Infra] UI - E2E Test: Can View Admin Setting Page

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/tests/modelsPage/addModel.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/modelsPage/addModel.spec.ts
@@ -5,7 +5,7 @@ test.describe("Add Model", () => {
   test.use({ storageState: ADMIN_STORAGE_PATH });
 
   test("Able to see all models for a specific provider in the model dropdown", async ({ page }) => {
-    await page.goto("http://localhost:4000/ui");
+    await page.goto("/ui");
 
     await page.getByText("Models + Endpoints").click();
     await page.getByRole("tab", { name: "Add Model" }).click();

--- a/ui/litellm-dashboard/e2e_tests/tests/navigation/sidebar.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/navigation/sidebar.spec.ts
@@ -24,7 +24,7 @@ for (const { role, storage } of roles) {
     test.use({ storageState: storage });
 
     test("can see and navigate all sidebar buttons", async ({ page }) => {
-      await page.goto("http://localhost:4000/ui");
+      await page.goto("/ui");
       for (const button of sidebarButtons[role as keyof typeof sidebarButtons]) {
         const tab = page.getByRole("menuitem", { name: button });
         await expect(tab).toBeVisible();

--- a/ui/litellm-dashboard/e2e_tests/tests/settings/adminSettings.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/settings/adminSettings.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+import { ADMIN_STORAGE_PATH } from "../../constants";
+
+test.describe("Add Model", () => {
+  test.use({ storageState: ADMIN_STORAGE_PATH });
+
+  test("admin settings test", async ({ page }) => {
+    await page.goto("/ui");
+    await page.getByRole("menuitem", { name: /Settings/ }).click();
+    await page.getByRole("menuitem", { name: /Admin Settings/ }).click();
+    await page.getByRole("tab", { name: "UI Settings" }).click();
+    await expect(page.getByText("Configuration for UI-specific")).toBeVisible();
+  });
+});

--- a/ui/litellm-dashboard/e2e_tests/tests/users/searchUsers.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/users/searchUsers.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect, Page } from "@playwright/test";
+import { ADMIN_STORAGE_PATH } from "../../constants";
 test.describe("Internal Users Search", () => {
-  test.use({ storageState: "admin.storageState.json" });
+  test.use({ storageState: ADMIN_STORAGE_PATH });
 
   async function goToInternalUsers(page: Page) {
-    await page.goto("http://localhost:4000/ui");
+    await page.goto("/ui");
 
     const tab = page.getByRole("menuitem", { name: "Internal User" });
     await expect(tab).toBeVisible();

--- a/ui/litellm-dashboard/e2e_tests/tests/users/viewInternalUsers.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/users/viewInternalUsers.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect, Page } from "@playwright/test";
+import { ADMIN_STORAGE_PATH } from "../../constants";
 
 test.describe("Internal Users Page", () => {
-  test.use({ storageState: "admin.storageState.json" });
+  test.use({ storageState: ADMIN_STORAGE_PATH });
 
   async function goToInternalUsers(page: Page) {
-    await page.goto("http://localhost:4000/ui");
+    await page.goto("/ui");
 
     const internalUserTab = page.getByRole("menuitem", { name: "Internal User" });
     await expect(internalUserTab).toBeVisible();


### PR DESCRIPTION
## Relevant issues
This PR implements the E2E Test to test if an admin can view the Admin Settings Page. This also refactors links so that they are not hardcoded. E2E tests passes locally
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure
✅ Test

## Changes
<img width="1123" height="288" alt="image" src="https://github.com/user-attachments/assets/b5a8f329-0653-41bb-a1d1-70585481c84a" />
