### PR TITLE
Revert "Add redisvl in requirements.txt"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ starlette==0.49.1 # starlette fastapi dep
 backoff==2.2.1 # server dep
 pyyaml==6.0.2 # server dep
 uvicorn==0.31.1 # server dep
-gunicorn==23.0.0 # server depredisvl
-redisvl==0.4.1 # redis semantic cache
+gunicorn==23.0.0 # server dep
 fastuuid==0.13.5 # for uuid4
 uvloop==0.21.0 # uvicorn dep, gives us much better performance under load
 boto3==1.36.0 # aws bedrock/sagemaker calls


### PR DESCRIPTION
Reverts BerriAI/litellm#18177

- Symptom: The Lasso guardrail test tests/guardrails_tests/test_lasso_guardrails.py::test_api_error_handling fails before exercising the guardrail logic, raising AttributeError: module 'ulid' has no attribute 'new' from _generate_ulid().

- Root cause: The commit(a75e75ae1a8af517337daf20244635a00976f431) that moved Lasso to API v3 switched _generate_ulid() to call ulid.new() assuming the ulid-py package, but no dependency update accompanied it. After the redisvl dependency was added to CI (and for any environment that installs redisvl), python-ulid is pulled in and provides an ulid module without new(), so the guardrail blows up as soon as it tries to generate a ULID unless ulid-py is explicitly installed.