### PR TITLE
fix: preserve client error status codes in streaming mode #18690

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2000,24 +2000,56 @@ class CustomStreamWrapper:
                 )
             ## Map to OpenAI Exception
             try:
-                raise exception_type(
+                mapped_exception = exception_type(
                     model=self.model,
                     custom_llm_provider=self.custom_llm_provider,
                     original_exception=e,
                     completion_kwargs={},
                     extra_kwargs={},
                 )
-            except Exception as e:
-                from litellm.exceptions import MidStreamFallbackError
+            except Exception as mapping_error:
+                mapped_exception = mapping_error
 
-                raise MidStreamFallbackError(
-                    message=str(e),
-                    model=self.model,
-                    llm_provider=self.custom_llm_provider or "anthropic",
-                    original_exception=e,
-                    generated_content=self.response_uptil_now,
-                    is_pre_first_chunk=not self.sent_first_chunk,
-                )
+            def _normalize_status_code(exc: Exception) -> Optional[int]:
+                """
+                Best-effort status_code extraction.
+                Uses status_code on the exception, then falls back to the response.
+                """
+                try:
+                    code = getattr(exc, "status_code", None)
+                    if code is not None:
+                        return int(code)
+                except Exception:
+                    pass
+
+                response = getattr(exc, "response", None)
+                if response is not None:
+                    try:
+                        status_code = getattr(response, "status_code", None)
+                        if status_code is not None:
+                            return int(status_code)
+                    except Exception:
+                        pass
+                return None
+
+            mapped_status_code = _normalize_status_code(mapped_exception)
+            original_status_code = _normalize_status_code(e)
+
+            if mapped_status_code is not None and 400 <= mapped_status_code < 500:
+                raise mapped_exception
+            if original_status_code is not None and 400 <= original_status_code < 500:
+                raise mapped_exception
+
+            from litellm.exceptions import MidStreamFallbackError
+
+            raise MidStreamFallbackError(
+                message=str(mapped_exception),
+                model=self.model,
+                llm_provider=self.custom_llm_provider or "anthropic",
+                original_exception=mapped_exception,
+                generated_content=self.response_uptil_now,
+                is_pre_first_chunk=not self.sent_first_chunk,
+            )
 
     @staticmethod
     def _strip_sse_data_from_chunk(chunk: Optional[str]) -> Optional[str]:

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_function_call_args_serialization.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_function_call_args_serialization.py
@@ -1,0 +1,355 @@
+"""
+Test cases for functionCall args serialization in Vertex AI Gemini.
+
+This test file specifically tests the edge cases where Vertex AI might return
+functionCall args in unexpected formats that could lead to invalid JSON strings
+like: {"x":"x"}{"a":"a"}
+"""
+import json
+from typing import List, Optional
+
+import pytest
+
+from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+    VertexGeminiConfig,
+)
+from litellm.types.llms.vertex_ai import HttpxPartType
+
+
+class TestFunctionCallArgsSerialization:
+    """Test cases for functionCall args serialization edge cases."""
+
+    def test_normal_dict_args(self):
+        """Test normal case: args is a dict."""
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": {"location": "Boston", "unit": "celsius"},
+                }
+            }
+        ]
+
+        function, tools, idx = VertexGeminiConfig._transform_parts(
+            parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+        )
+
+        assert tools is not None
+        assert len(tools) == 1
+        assert tools[0]["function"]["name"] == "get_weather"
+        
+        # Verify arguments is a valid JSON string
+        arguments = tools[0]["function"]["arguments"]
+        assert isinstance(arguments, str)
+        # Should be valid JSON
+        parsed = json.loads(arguments)
+        assert parsed == {"location": "Boston", "unit": "celsius"}
+
+    def test_none_args(self):
+        """Test case: args is None."""
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": None,
+                }
+            }
+        ]
+
+        function, tools, idx = VertexGeminiConfig._transform_parts(
+            parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+        )
+
+        assert tools is not None
+        assert len(tools) == 1
+        arguments = tools[0]["function"]["arguments"]
+        # Should serialize None to "null" or empty dict
+        assert isinstance(arguments, str)
+        parsed = json.loads(arguments)
+        # json.dumps(None) returns "null"
+        assert parsed is None or parsed == {}
+
+    def test_args_as_string_valid_json(self):
+        """Test case: args is already a valid JSON string."""
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": '{"location": "Boston"}',  # String, not dict
+                }
+            }
+        ]
+
+        function, tools, idx = VertexGeminiConfig._transform_parts(
+            parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+        )
+
+        assert tools is not None
+        assert len(tools) == 1
+        arguments = tools[0]["function"]["arguments"]
+        # If args is a string, json.dumps will double-encode it
+        # This would result in: "{\"location\": \"Boston\"}"
+        assert isinstance(arguments, str)
+        # This is the problematic case - string gets double-encoded
+        # The result would be a JSON string containing a JSON string
+        parsed = json.loads(arguments)
+        # If it's double-encoded, parsed would be a string, not a dict
+        if isinstance(parsed, str):
+            # Double-encoded case
+            inner_parsed = json.loads(parsed)
+            assert inner_parsed == {"location": "Boston"}
+        else:
+            # Normal case (shouldn't happen if args is string)
+            assert parsed == {"location": "Boston"}
+
+    def test_args_as_string_invalid_json_concatenated(self):
+        """Test case: args is a string with concatenated JSON objects (the bug case).
+        
+        When args is a string like '{"x":"x"}{"a":"a"}', json.dumps() will serialize it
+        as a JSON string, resulting in: "{\"x\":\"x\"}{\"a\":\"a\"}"
+        This is a valid JSON string (the outer quotes), but the content inside is invalid JSON.
+        When you try to parse the inner content, it fails.
+        """
+        # This simulates the case where Vertex might return something like:
+        # args = '{"x":"x"}{"a":"a"}'  # Two JSON objects concatenated
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": '{"x":"x"}{"a":"a"}',  # Invalid concatenated JSON
+                }
+            }
+        ]
+
+        function, tools, idx = VertexGeminiConfig._transform_parts(
+            parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+        )
+
+        assert tools is not None
+        assert len(tools) == 1
+        arguments = tools[0]["function"]["arguments"]
+        assert isinstance(arguments, str)
+        
+        # json.dumps() on a string will escape it, so we get:
+        # arguments = '"{\\"x\\":\\"x\\"}{\\"a\\":\\"a\\"}"'
+        # This is a valid JSON string (the outer quotes), but the inner content is invalid
+        parsed_outer = json.loads(arguments)
+        assert isinstance(parsed_outer, str)
+        
+        # The inner string is invalid JSON (two objects concatenated)
+        # This is the bug: the inner content cannot be parsed as valid JSON
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(parsed_outer)
+        
+        # The arguments string would be: "{\"x\":\"x\"}{\"a\":\"a\"}"
+        # Which when parsed gives: '{"x":"x"}{"a":"a"}' (invalid JSON)
+
+    def test_args_as_array(self):
+        """Test case: args is an array (unexpected but possible)."""
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": [{"x": "x"}, {"a": "a"}],  # Array of objects
+                }
+            }
+        ]
+
+        function, tools, idx = VertexGeminiConfig._transform_parts(
+            parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+        )
+
+        assert tools is not None
+        assert len(tools) == 1
+        arguments = tools[0]["function"]["arguments"]
+        assert isinstance(arguments, str)
+        # Should serialize array correctly
+        parsed = json.loads(arguments)
+        assert parsed == [{"x": "x"}, {"a": "a"}]
+
+    def test_args_missing_key(self):
+        """Test case: args key is missing from functionCall.
+        
+        This will raise a KeyError because the code directly accesses part["functionCall"]["args"]
+        without checking if the key exists. This is a bug that should be fixed.
+        """
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    # args key missing
+                }
+            }
+        ]
+
+        # This should raise KeyError because args key is missing
+        with pytest.raises(KeyError):
+            VertexGeminiConfig._transform_parts(
+                parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+            )
+
+    def test_multiple_function_calls(self):
+        """Test case: multiple function calls in parts."""
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": {"location": "Boston"},
+                }
+            },
+            {
+                "functionCall": {
+                    "name": "get_time",
+                    "args": {"timezone": "EST"},
+                }
+            },
+        ]
+
+        function, tools, idx = VertexGeminiConfig._transform_parts(
+            parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+        )
+
+        assert tools is not None
+        assert len(tools) == 2
+        assert tools[0]["function"]["name"] == "get_weather"
+        assert tools[1]["function"]["name"] == "get_time"
+        
+        # Both should have valid JSON arguments
+        args1 = json.loads(tools[0]["function"]["arguments"])
+        args2 = json.loads(tools[1]["function"]["arguments"])
+        assert args1 == {"location": "Boston"}
+        assert args2 == {"timezone": "EST"}
+
+    def test_args_with_vertex_protobuf_format(self):
+        """Test case: args in Vertex protobuf format with string_value, etc."""
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": {
+                        "location": {"string_value": "Boston, MA"},
+                        "unit": {"string_value": "celsius"},
+                    },
+                }
+            }
+        ]
+
+        function, tools, idx = VertexGeminiConfig._transform_parts(
+            parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+        )
+
+        assert tools is not None
+        assert len(tools) == 1
+        arguments = tools[0]["function"]["arguments"]
+        assert isinstance(arguments, str)
+        # Should serialize the nested structure correctly
+        parsed = json.loads(arguments)
+        assert "location" in parsed
+        assert "unit" in parsed
+
+    def test_args_as_empty_dict(self):
+        """Test case: args is an empty dict."""
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": {},
+                }
+            }
+        ]
+
+        function, tools, idx = VertexGeminiConfig._transform_parts(
+            parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+        )
+
+        assert tools is not None
+        assert len(tools) == 1
+        arguments = tools[0]["function"]["arguments"]
+        assert isinstance(arguments, str)
+        parsed = json.loads(arguments)
+        assert parsed == {}
+
+    def test_args_with_special_characters(self):
+        """Test case: args contains special characters that need escaping."""
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": {
+                        "location": 'Boston, MA "downtown"',
+                        "note": "Line 1\nLine 2",
+                    },
+                }
+            }
+        ]
+
+        function, tools, idx = VertexGeminiConfig._transform_parts(
+            parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+        )
+
+        assert tools is not None
+        assert len(tools) == 1
+        arguments = tools[0]["function"]["arguments"]
+        assert isinstance(arguments, str)
+        # Should handle special characters correctly
+        parsed = json.loads(arguments)
+        assert parsed["location"] == 'Boston, MA "downtown"'
+        assert parsed["note"] == "Line 1\nLine 2"
+
+    def test_args_as_list_of_strings_that_look_like_json(self):
+        """Test case: args is a list containing strings that look like JSON objects."""
+        # This could potentially cause issues if not handled correctly
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": ['{"x":"x"}', '{"a":"a"}'],  # List of JSON strings
+                }
+            }
+        ]
+
+        function, tools, idx = VertexGeminiConfig._transform_parts(
+            parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+        )
+
+        assert tools is not None
+        assert len(tools) == 1
+        arguments = tools[0]["function"]["arguments"]
+        assert isinstance(arguments, str)
+        # Should serialize list correctly
+        parsed = json.loads(arguments)
+        assert isinstance(parsed, list)
+        assert parsed == ['{"x":"x"}', '{"a":"a"}']
+
+    def test_args_as_dict_with_nested_structures(self):
+        """Test case: args contains nested dicts and lists."""
+        parts: List[HttpxPartType] = [
+            {
+                "functionCall": {
+                    "name": "complex_function",
+                    "args": {
+                        "nested": {"key": "value"},
+                        "list": [1, 2, 3],
+                        "mixed": [{"a": 1}, {"b": 2}],
+                    },
+                }
+            }
+        ]
+
+        function, tools, idx = VertexGeminiConfig._transform_parts(
+            parts=parts, cumulative_tool_call_idx=0, is_function_call=False
+        )
+
+        assert tools is not None
+        assert len(tools) == 1
+        arguments = tools[0]["function"]["arguments"]
+        assert isinstance(arguments, str)
+        parsed = json.loads(arguments)
+        assert parsed["nested"] == {"key": "value"}
+        assert parsed["list"] == [1, 2, 3]
+        assert parsed["mixed"] == [{"a": 1}, {"b": 2}]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+


### PR DESCRIPTION
When handling streaming processing errors, add status code normalization logic to ensure that 4xx client errors are directly thrown instead of being wrapped into MidStreamFallbackError.

- Add the `_normalize_status_code` function to extract the status code from the exception object.

- Preferably obtain the status code from the exception's `status_code` attribute, and then from `response.status_code`.

- When the status code of the mapped exception or the original exception is within the range of 400-499, directly throw the mapped exception.

- Add unit tests to verify that Vertex AI 400 errors are correctly thrown as BadRequestError.

- Ensure that client errors in streaming processing can be correctly propagated without triggering the fallback mechanism.

## Relevant issues

Fixes #18690 

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="2892" height="1816" alt="image" src="https://github.com/user-attachments/assets/10e332d3-2c66-4d90-85f5-796f31847fa4" />

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
