### PR TITLE
SAP Hot Fix

### DIFF
--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -202,12 +202,8 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        supported_params = self.get_supported_openai_params(model)
-        # Include extra params that passed validation (e.g., thinking_config for Gemini models via allowed_openai_params)
-        extra_params = [k for k in optional_params if k not in supported_params and k not in {"tools", "model_version"}]
-        supported_params = supported_params + extra_params
         model_params = {
-            k: v for k, v in optional_params.items() if k in supported_params
+            k: v for k, v in optional_params.items() if k not in {"tools", "model_version", "deployment_url"}
         }
 
         model_version = optional_params.pop("model_version", "latest")


### PR DESCRIPTION
## Relevant issues

After PR [18432](https://github.com/BerriAI/litellm/pull/18432 ) deployment_url started appearing in the parameters for all SAP models requests. All completion runs fro SAP models fail at the JSON building stage, before sending the API request, because deployment_url is an auxiliary function for authorization, not a model parameter. This hotfix ensures deployment_url is not sent as part of model parameters.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Filter deployment_url from modal params for SAP