### PR TITLE
fix: prevent duplicate User-Agent tags in request_tags

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4823,9 +4823,9 @@ class StandardLoggingPayloadSetup:
         metadata = litellm_params.get("metadata") or {}
         litellm_metadata = litellm_params.get("litellm_metadata") or {}
         if metadata.get("tags", []):
-            request_tags = metadata.get("tags", [])
+            request_tags = metadata.get("tags", []).copy()
         elif litellm_metadata.get("tags", []):
-            request_tags = litellm_metadata.get("tags", [])
+            request_tags = litellm_metadata.get("tags", []).copy()
         else:
             request_tags = []
         user_agent_tags = StandardLoggingPayloadSetup._get_user_agent_tags(


### PR DESCRIPTION
## Summary

- Fixed a bug where `_get_request_tags()` was mutating the original `metadata["tags"]` list, causing User-Agent tags to be duplicated when the function was called multiple times during a single request lifecycle
- The function now uses `.copy()` to create a new list before extending, ensuring the original metadata tags are not mutated

## Root Cause

The `_get_request_tags` function was returning a reference to the original tags list:

```python
request_tags = metadata.get("tags", [])  # Reference, not copy!
request_tags.extend(user_agent_tags)      # Mutates the original list
```

Since `litellm_params["metadata"]` is assigned by reference (not copied) in `function_setup`, all callers share the same underlying list. When multiple callbacks (logging, prometheus, guardrails) call `_get_request_tags`, each extends the same list, causing duplicates.

## Fix

```python
request_tags = metadata.get("tags", []).copy()  # Create a copy first
```

## Test Plan

- [x] Added regression test `test_get_request_tags_does_not_mutate_original_tags` that verifies:
  - Original tags list is not mutated after multiple calls
  - Each returned list has exactly 2 User-Agent tags (not duplicated)
  - Returned lists are independent objects
- [x] Verified test fails without the fix, passes with the fix
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)