### PR TITLE
[Feature] UI - Reusable Duration Select + Team Update Member Budget Duration

### DIFF
--- a/ui/litellm-dashboard/src/components/common_components/DurationSelect.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DurationSelect.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import DurationSelect from "./DurationSelect";
+
+describe("DurationSelect", () => {
+  it("should render", () => {
+    render(<DurationSelect />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("should render all three duration options", async () => {
+    const user = userEvent.setup();
+    render(<DurationSelect />);
+
+    const select = screen.getByRole("combobox");
+    await user.click(select);
+
+    expect(screen.getByText("Daily")).toBeInTheDocument();
+    expect(screen.getByText("Weekly")).toBeInTheDocument();
+    expect(screen.getByText("Monthly")).toBeInTheDocument();
+  });
+
+  it("should apply className prop", () => {
+    render(<DurationSelect className="test-class" />);
+    const select = screen.getByRole("combobox");
+    expect(select.closest(".test-class")).toBeInTheDocument();
+  });
+
+  it("should call onChange when an option is selected", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<DurationSelect onChange={onChange} />);
+
+    const select = screen.getByRole("combobox");
+    await user.click(select);
+
+    const dailyOption = screen.getByText("Daily");
+    await user.click(dailyOption);
+
+    expect(onChange).toHaveBeenCalledWith("24h", expect.any(Object));
+  });
+
+  it("should accept and pass value prop to Select", () => {
+    render(<DurationSelect value="7d" />);
+    const select = screen.getByRole("combobox");
+    expect(select).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/common_components/DurationSelect.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DurationSelect.tsx
@@ -1,0 +1,17 @@
+import { Select } from "antd";
+
+interface DurationSelectProps {
+  className?: string;
+  value?: string;
+  onChange?: (value: string) => void;
+}
+
+export default function DurationSelect({ className, value, onChange }: DurationSelectProps) {
+  return (
+    <Select className={className} value={value} onChange={onChange}>
+      <Select.Option value="24h">Daily</Select.Option>
+      <Select.Option value="7d">Weekly</Select.Option>
+      <Select.Option value="30d">Monthly</Select.Option>
+    </Select>
+  );
+}

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -48,6 +48,7 @@ import EditLoggingSettings from "./EditLoggingSettings";
 import MemberModal from "./EditMembership";
 import MemberPermissions from "./member_permissions";
 import TeamMembersComponent from "./team_member_view";
+import DurationSelect from "../common_components/DurationSelect";
 
 export interface TeamMembership {
   user_id: string;
@@ -413,6 +414,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
       };
 
       updateData.max_budget = mapEmptyStringToNull(updateData.max_budget);
+      updateData.team_member_budget_duration = values.team_member_budget_duration;
 
       if (values.team_member_budget !== undefined) {
         updateData.team_member_budget = Number(values.team_member_budget);
@@ -650,6 +652,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     budget_duration: info.budget_duration,
                     team_member_tpm_limit: info.team_member_budget_table?.tpm_limit,
                     team_member_rpm_limit: info.team_member_budget_table?.rpm_limit,
+                    team_member_budget: info.team_member_budget_table?.max_budget,
+                    team_member_budget_duration: info.team_member_budget_table?.budget_duration,
                     guardrails: info.metadata?.guardrails || [],
                     disable_global_guardrails: info.metadata?.disable_global_guardrails || false,
                     metadata: info.metadata
@@ -745,6 +749,13 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     tooltip="This is the individual budget for a user in the team."
                   >
                     <NumericalInput step={0.01} precision={2} style={{ width: "100%" }} />
+                  </Form.Item>
+
+                  <Form.Item label="Team Member Budget Duration" name="team_member_budget_duration">
+                    <DurationSelect
+                      onChange={(value) => form.setFieldValue("team_member_budget_duration", value)}
+                      value={form.getFieldValue("team_member_budget_duration")}
+                    />
                   </Form.Item>
 
                   <Form.Item
@@ -991,6 +1002,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       </Tooltip>
                     </Text>
                     <div>Max Budget: {info.team_member_budget_table?.max_budget || "No Limit"}</div>
+                    <div>Budget Duration: {info.team_member_budget_table?.budget_duration || "No Limit"}</div>
                     <div>Key Duration: {info.metadata?.team_member_key_duration || "No Limit"}</div>
                     <div>TPM Limit: {info.team_member_budget_table?.tpm_limit || "No Limit"}</div>
                     <div>RPM Limit: {info.team_member_budget_table?.rpm_limit || "No Limit"}</div>


### PR DESCRIPTION
## Relevant issues
This PR implements allowing the user to edit the team member budget duration inside of team settings. This is done using a new usable component called Duration Select, which follows a standard pattern used in the UI. Subsequent PRs to follow to replace those selects with the new reusable component
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="1578" height="786" alt="image" src="https://github.com/user-attachments/assets/de1d3ef2-1899-4a0a-85fa-307c77f8dd98" />
<img width="1577" height="936" alt="image" src="https://github.com/user-attachments/assets/94d47f6e-45d3-4366-b145-2b50c3ebec96" />
<img width="996" height="317" alt="image" src="https://github.com/user-attachments/assets/6aecf794-ff82-462a-b68a-b2b7bf4b52a2" />
