### PR TITLE
Fix component label automation to prevent false positives

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,6 +27,7 @@ body:
     attributes:
       label: What part of LiteLLM is this about?
       options:
+        - ''
         - "SDK (litellm Python package)"
         - "Proxy"
         - "UI Dashboard"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -27,6 +27,7 @@ body:
     attributes:
       label: What part of LiteLLM is this about?
       options:
+        - ''
         - "SDK (litellm Python package)"
         - "Proxy"
         - "UI Dashboard"

--- a/.github/workflows/label-component.yml
+++ b/.github/workflows/label-component.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
     steps:
       - name: Add SDK label
-        if: contains(github.event.issue.body, 'SDK (litellm Python package)')
+        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?') && contains(github.event.issue.body, 'SDK (litellm Python package)')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
             });
 
       - name: Add Proxy label
-        if: contains(github.event.issue.body, 'Proxy')
+        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?') && contains(github.event.issue.body, 'Proxy')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -78,7 +78,7 @@ jobs:
             });
 
       - name: Add UI Dashboard label
-        if: contains(github.event.issue.body, 'UI Dashboard')
+        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?') && contains(github.event.issue.body, 'UI Dashboard')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -111,7 +111,7 @@ jobs:
             });
 
       - name: Add Docs label
-        if: contains(github.event.issue.body, 'Docs')
+        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?') && contains(github.event.issue.body, 'Docs')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-component.yml
+++ b/.github/workflows/label-component.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
     steps:
       - name: Add SDK label
-        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?') && contains(github.event.issue.body, 'SDK (litellm Python package)')
+        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?\n\nSDK (litellm Python package)')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
             });
 
       - name: Add Proxy label
-        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?') && contains(github.event.issue.body, 'Proxy')
+        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?\n\nProxy')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -78,7 +78,7 @@ jobs:
             });
 
       - name: Add UI Dashboard label
-        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?') && contains(github.event.issue.body, 'UI Dashboard')
+        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?\n\nUI Dashboard')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -111,7 +111,7 @@ jobs:
             });
 
       - name: Add Docs label
-        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?') && contains(github.event.issue.body, 'Docs')
+        if: contains(github.event.issue.body, 'What part of LiteLLM is this about?\n\nDocs')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Relevant issues

Fixes issues where component labels (SDK, Proxy, UI Dashboard, Docs) were being applied incorrectly to issues that mentioned these terms in their descriptions rather than selecting them from the dropdown.

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [N/A] Tests not required - this is a GitHub Actions workflow configuration change with no code changes

## Type

🚄 Infrastructure

## Changes

The GitHub Actions workflow `.github/workflows/label-component.yml` was applying component labels incorrectly by checking if component names appeared anywhere in the issue body, causing false positives.

**What changed:**
Updated all 4 component label conditions (SDK, Proxy, UI Dashboard, Docs) to use a more specific pattern that matches the dropdown header immediately followed by the selected value (with exact newline formatting).

**Before:**
```yaml
if: contains(github.event.issue.body, 'Docs')
```

**After:**
```yaml
if: contains(github.event.issue.body, 'What part of LiteLLM is this about?\n\nDocs')
```

**Why this works:**
- GitHub issue templates with dropdowns generate the body with the format: `### Field Label\n\nSelected Value`
- By matching the exact pattern including newlines, we ensure labels are only applied when users actually select that option from the dropdown
- This prevents false positives from users casually mentioning component names in their issue descriptions

**Impact:**
- Labels will only be applied when users select the component from the dropdown
- Eliminates false positives from mentions in issue descriptions
- Applies to all component labels: SDK, Proxy, UI Dashboard, and Docs