### PR TITLE
feat: pass server_tool_use and tool_search_tool_result blocks to anthropic

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2137,6 +2137,14 @@ def anthropic_messages_pt(  # noqa: PLR0915
                         assistant_content.append(
                             cast(AnthropicMessagesTextParam, _cached_message)
                         )
+                    # handle server_tool_use blocks (tool search, web search, etc.)
+                    # Pass through as-is since these are Anthropic-native content types
+                    elif m.get("type", "") == "server_tool_use":
+                        assistant_content.append(m)  # type: ignore
+                    # handle tool_search_tool_result blocks
+                    # Pass through as-is since these are Anthropic-native content types
+                    elif m.get("type", "") == "tool_search_tool_result":
+                        assistant_content.append(m)  # type: ignore
             elif (
                 "content" in assistant_content_block
                 and isinstance(assistant_content_block["content"], str)


### PR DESCRIPTION
What happens when the tools list changes, and we do not want to invalidate the cache since the conversation history is identical?

With the anthropic API, we have found a way to set tools as defer loading = True, and in subsequent messages, manually pass search tool use blocks without actually having to include the search tool that anthropic provides.

For example:
`
{
            "role": "assistant",
            "content": [
                # server_tool_use: the assistant's search request
                {
                    "type": "server_tool_use",
                    "id": "srvtoolu_ph",
                    "name": "tool_search_tool_regex",
                    "input": {"query": ".*time.*"}
                },
                # tool_search_tool_result: the search result
                {
                    "type": "tool_search_tool_result",
                    "tool_use_id": "srvtoolu_ph",
                    "content": {
                        "type": "tool_search_tool_search_result",
                        "tool_references": [
                            { "type": "tool_reference", "tool_name": "get_time" }
                        ]
                    }
                },
                {
                    "type": "text",
                    "text": "I found the time tool. How can I help you?"
                }
            ],
        }
`

To ensure this works with Litellm, we simply need to pass these blocks to anthropic in addition to thinking and text blocks.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes
