### PR TITLE
fix: add allowClear to dropdown components for better UX

### DIFF
--- a/ui/litellm-dashboard/src/components/agent_management/AgentSelector.tsx
+++ b/ui/litellm-dashboard/src/components/agent_management/AgentSelector.tsx
@@ -103,6 +103,7 @@ const AgentSelector: React.FC<AgentSelectorProps> = ({
         value={selectedValues}
         loading={loading}
         className={className}
+        allowClear
         showSearch
         style={{ width: "100%" }}
         disabled={disabled}

--- a/ui/litellm-dashboard/src/components/common_components/PassThroughRoutesSelector.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/PassThroughRoutesSelector.tsx
@@ -53,6 +53,7 @@ const PassThroughRoutesSelector: React.FC<PassThroughRoutesSelectorProps> = ({
       value={value}
       loading={loading}
       className={className}
+      allowClear
       options={passThroughRoutes.map((route) => ({
         label: route,
         value: route,

--- a/ui/litellm-dashboard/src/components/common_components/budget_duration_dropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/budget_duration_dropdown.tsx
@@ -23,6 +23,7 @@ const BudgetDurationDropdown: React.FC<BudgetDurationDropdownProps> = ({
       onChange={onChange}
       className={className}
       placeholder="n/a"
+      allowClear
     >
       <Option value="24h">daily</Option>
       <Option value="7d">weekly</Option>

--- a/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
@@ -18,6 +18,7 @@ const TeamDropdown: React.FC<TeamDropdownProps> = ({ teams, value, onChange, dis
       value={value}
       onChange={onChange}
       disabled={disabled}
+      allowClear
       filterOption={(input, option) => {
         if (!option) return false;
         // Get team data from the option key

--- a/ui/litellm-dashboard/src/components/guardrails/GuardrailSelector.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/GuardrailSelector.tsx
@@ -52,6 +52,7 @@ const GuardrailSelector: React.FC<GuardrailSelectorProps> = ({ onChange, value, 
         value={value}
         loading={loading}
         className={className}
+        allowClear
         options={guardrails.map((guardrail) => {
           console.log("Mapping guardrail:", guardrail);
           return {

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
@@ -87,6 +87,7 @@ const MCPServerSelector: React.FC<MCPServerSelectorProps> = ({
         value={selectedValues}
         loading={loading}
         className={className}
+        allowClear
         showSearch
         style={{ width: "100%" }}
         disabled={disabled}

--- a/ui/litellm-dashboard/src/components/vector_store_management/VectorStoreSelector.tsx
+++ b/ui/litellm-dashboard/src/components/vector_store_management/VectorStoreSelector.tsx
@@ -51,6 +51,7 @@ const VectorStoreSelector: React.FC<VectorStoreSelectorProps> = ({
         value={value}
         loading={loading}
         className={className}
+        allowClear
         options={vectorStores.map((store) => ({
           label: `${store.vector_store_name || store.vector_store_id} (${store.vector_store_id})`,
           value: store.vector_store_id,


### PR DESCRIPTION
## Relevant issues

Fixes #18777 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix


## Changes
- Added `allowClear` prop to reusable dropdown selector components:
  - `team_dropdown.tsx`
  - `budget_duration_dropdown.tsx`
  - `VectorStoreSelector.tsx`
  - `AgentSelector.tsx`
  - `MCPServerSelector.tsx`
  - `PassThroughRoutesSelector.tsx`
  - `GuardrailSelector.tsx`
- Enables clearing optional dropdown selections
- Aligns behavior with 40+ existing components using `allowClear`
- Low-risk UI-only change (single-line per component)