### PR TITLE
Fix: Clarify database_connection_pool_limit applies per worker, not per instance

### DIFF
--- a/docs/my-website/docs/proxy/configs.md
+++ b/docs/my-website/docs/proxy/configs.md
@@ -576,9 +576,30 @@ custom_tokenizer:
 
 ```yaml
 general_settings: 
-  database_connection_pool_limit: 10 # sets connection pool for prisma client to postgres db (default: 10, recommended: 10-20)
+  database_connection_pool_limit: 10 # sets connection pool per worker for prisma client to postgres db (default: 10, recommended: 10-20)
   database_connection_timeout: 60 # sets a 60s timeout for any connection call to the db 
 ```
+
+**How to calculate the right value:**
+
+The connection limit is applied **per worker process**, not per instance. This means if you have multiple workers, each worker will create its own connection pool.
+
+**Formula:**
+```
+database_connection_pool_limit = MAX_DB_CONNECTIONS ÷ (number_of_instances × number_of_workers_per_instance)
+```
+
+**Example:**
+- Your database allows a maximum of **100 connections**
+- You're running **1 instance** of LiteLLM
+- Each instance has **8 workers** (set via `--num_workers 8`)
+
+Calculation: `100 ÷ (1 × 8) = 12.5`
+
+Since you shouldn't use 12.5, round down to **10** to leave a safety buffer. This means:
+- Each of the 8 workers will have a connection pool limit of 10
+- Total maximum connections: 8 workers × 10 connections = 80 connections
+- This stays safely under your database's 100 connection limit
 
 ## Extras
 

--- a/docs/my-website/docs/proxy/prod.md
+++ b/docs/my-website/docs/proxy/prod.md
@@ -19,7 +19,11 @@ general_settings:
   master_key: sk-1234      # enter your own master key, ensure it starts with 'sk-'
   alerting: ["slack"]      # Setup slack alerting - get alerts on LLM exceptions, Budget Alerts, Slow LLM Responses
   proxy_batch_write_at: 60 # Batch write spend updates every 60s
-  database_connection_pool_limit: 10 # limit the number of database connections to = MAX Number of DB Connections/Number of instances of litellm proxy (Around 10-20 is good number)
+  database_connection_pool_limit: 10 # connection pool limit per worker process. Total connections = limit × workers × instances. Calculate: MAX_DB_CONNECTIONS / (instances × workers). Default: 10.
+
+:::warning
+**Multiple instances:** If running multiple LiteLLM instances (e.g., Kubernetes pods), remember each instance multiplies your total connections. Example: 3 instances × 4 workers × 10 connections = 120 total connections.
+:::
 
   # OPTIONAL Best Practices
   disable_error_logs: True # turn off writing LLM Exceptions to DB

--- a/litellm/proxy/common_utils/performance_utils.py
+++ b/litellm/proxy/common_utils/performance_utils.py
@@ -160,7 +160,9 @@ def wrap_function_with_line_profiler(module: Any, function_name: str) -> bool:
     Returns:
         True if wrapping was successful, False otherwise
     """
-    if not enable_line_profiler():
+    try:
+        enable_line_profiler()  # May raise ImportError if not available
+    except ImportError:
         return False
     
     if _line_profiler is None:


### PR DESCRIPTION
## Relevant issues

Since each LiteLLM worker runs as a separate process, they don’t share state—except for data stored in Redis or the database. As a result, the Prisma client’s database connection pool limit applies per worker process, not per LiteLLM server instance.

I believe this should address many of the database connection issues reported.

**Proof:**
<img width="2535" height="958" alt="Screenshot 2026-01-07 130626" src="https://github.com/user-attachments/assets/a62bb85a-74e3-4a97-9484-e073899011e9" />

**Current Documentation:**
<img width="2080" height="1486" alt="Screenshot 2026-01-07 134351" src="https://github.com/user-attachments/assets/6410a968-abd8-4864-8921-4359dde5460c" />


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53553/workflows/97232a7e-cc3f-49d0-b5f7-3346ff00e96a

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53561/workflows/f2928c35-5882-4df3-a093-069e63376169

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring
📖 Documentation


## Changes

- Updated the documentation to reflect the actual behavior.
- Fixed a mypy_linting error.