### PR TITLE
refactor(prometheus): skip metrics for invalid API key requests

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -14,6 +14,7 @@ from typing import (
     Literal,
     Optional,
     Tuple,
+    Union,
     cast,
 )
 
@@ -791,6 +792,11 @@ class PrometheusLogger(CustomLogger):
                 f"standard_logging_object is required, got={standard_logging_payload}"
             )
 
+        if self._should_skip_metrics_for_invalid_key(
+            kwargs=kwargs, standard_logging_payload=standard_logging_payload
+        ):
+            return
+
         model = kwargs.get("model", "")
         litellm_params = kwargs.get("litellm_params", {}) or {}
         _metadata = litellm_params.get("metadata", {})
@@ -1189,11 +1195,17 @@ class PrometheusLogger(CustomLogger):
             f"prometheus Logging - Enters failure logging function for kwargs {kwargs}"
         )
 
-        # unpack kwargs
-        model = kwargs.get("model", "")
         standard_logging_payload: StandardLoggingPayload = kwargs.get(
             "standard_logging_object", {}
         )
+        
+        if self._should_skip_metrics_for_invalid_key(
+            kwargs=kwargs, standard_logging_payload=standard_logging_payload
+        ):
+            return
+        
+        model = kwargs.get("model", "")
+        
         litellm_params = kwargs.get("litellm_params", {}) or {}
         get_end_user_id_for_cost_tracking = _get_cached_end_user_id_for_cost_tracking()
         
@@ -1207,7 +1219,6 @@ class PrometheusLogger(CustomLogger):
         user_api_team_alias = standard_logging_payload["metadata"][
             "user_api_key_team_alias"
         ]
-        kwargs.get("exception", None)
 
         try:
             self.litellm_llm_api_failed_requests_metric.labels(
@@ -1226,6 +1237,139 @@ class PrometheusLogger(CustomLogger):
             )
             pass
         pass
+
+    def _extract_status_code(
+        self,
+        kwargs: Optional[dict] = None,
+        enum_values: Optional[Any] = None,
+        exception: Optional[Exception] = None,
+    ) -> Optional[int]:
+        """
+        Extract HTTP status code from various input formats for validation.
+        
+        This is a centralized helper to extract status code from different
+        callback function signatures. Handles both ProxyException (uses 'code')
+        and standard exceptions (uses 'status_code').
+        
+        Args:
+            kwargs: Dictionary potentially containing 'exception' key
+            enum_values: Object with 'status_code' attribute
+            exception: Exception object to extract status code from directly
+            
+        Returns:
+            Status code as integer if found, None otherwise
+        """
+        status_code = None
+        
+        # Try from enum_values first (most common in our callbacks)
+        if enum_values and hasattr(enum_values, "status_code") and enum_values.status_code:
+            try:
+                status_code = int(enum_values.status_code)
+            except (ValueError, TypeError):
+                pass
+        
+        if not status_code and exception:
+            # ProxyException uses 'code' attribute, other exceptions may use 'status_code'
+            status_code = getattr(exception, "status_code", None) or getattr(exception, "code", None)
+            if status_code is not None:
+                try:
+                    status_code = int(status_code)
+                except (ValueError, TypeError):
+                    status_code = None
+        
+        if not status_code and kwargs:
+            exception_in_kwargs = kwargs.get("exception")
+            if exception_in_kwargs:
+                status_code = getattr(exception_in_kwargs, "status_code", None) or getattr(exception_in_kwargs, "code", None)
+                if status_code is not None:
+                    try:
+                        status_code = int(status_code)
+                    except (ValueError, TypeError):
+                        status_code = None
+        
+        return status_code
+    
+    def _is_invalid_api_key_request(
+        self,
+        status_code: Optional[int],
+        exception: Optional[Exception] = None,
+    ) -> bool:
+        """
+        Determine if a request has an invalid API key based on status code and exception.
+        
+        This method prevents invalid authentication attempts from being recorded in
+        Prometheus metrics. A 401 status code is the definitive indicator of authentication
+        failure. Additionally, we check exception messages for authentication error patterns
+        to catch cases where the exception hasn't been converted to a ProxyException yet.
+        
+        Args:
+            status_code: HTTP status code (401 indicates authentication error)
+            exception: Exception object to check for auth-related error messages
+            
+        Returns:
+            True if the request has an invalid API key and metrics should be skipped,
+            False otherwise
+        """
+        if status_code == 401:
+            return True
+        
+        # Handle cases where AssertionError is raised before conversion to ProxyException
+        if exception is not None:
+            exception_str = str(exception).lower()
+            auth_error_patterns = [
+                "virtual key expected",
+                "expected to start with 'sk-'",
+                "authentication error",
+                "invalid api key",
+                "api key not valid",
+            ]
+            if any(pattern in exception_str for pattern in auth_error_patterns):
+                return True
+        
+        return False
+    
+    def _should_skip_metrics_for_invalid_key(
+        self,
+        kwargs: Optional[dict] = None,
+        user_api_key_dict: Optional[Any] = None,
+        enum_values: Optional[Any] = None,
+        standard_logging_payload: Optional[Union[dict, StandardLoggingPayload]] = None,
+        exception: Optional[Exception] = None,
+    ) -> bool:
+        """
+        Determine if Prometheus metrics should be skipped for invalid API key requests.
+        
+        This is a centralized validation method that extracts status code and exception
+        information from various callback function signatures and determines if the request
+        represents an invalid API key attempt that should be filtered from metrics.
+        
+        Args:
+            kwargs: Dictionary potentially containing exception and other data
+            user_api_key_dict: User API key authentication object (currently unused)
+            enum_values: Object with status_code attribute
+            standard_logging_payload: Standard logging payload dictionary
+            exception: Exception object to check directly
+            
+        Returns:
+            True if metrics should be skipped (invalid key detected), False otherwise
+        """
+        status_code = self._extract_status_code(
+            kwargs=kwargs,
+            enum_values=enum_values,
+            exception=exception,
+        )
+        
+        if exception is None and kwargs:
+            exception = kwargs.get("exception")
+        
+        if self._is_invalid_api_key_request(status_code, exception=exception):
+            verbose_logger.debug(
+                "Skipping Prometheus metrics for invalid API key request: "
+                f"status_code={status_code}, exception={type(exception).__name__ if exception else None}"
+            )
+            return True
+        
+        return False
 
     async def async_post_call_failure_hook(
         self,
@@ -1252,6 +1396,14 @@ class PrometheusLogger(CustomLogger):
             StandardLoggingPayloadSetup,
         )
 
+        if self._should_skip_metrics_for_invalid_key(
+            user_api_key_dict=user_api_key_dict,
+            exception=original_exception,
+        ):
+            return
+
+        status_code = self._extract_status_code(exception=original_exception)
+
         try:
             _tags = StandardLoggingPayloadSetup._get_request_tags(
                 litellm_params=request_data,
@@ -1266,8 +1418,8 @@ class PrometheusLogger(CustomLogger):
                 team=user_api_key_dict.team_id,
                 team_alias=user_api_key_dict.team_alias,
                 requested_model=request_data.get("model", ""),
-                status_code=str(getattr(original_exception, "status_code", None)),
-                exception_status=str(getattr(original_exception, "status_code", None)),
+                status_code=str(status_code),
+                exception_status=str(status_code),
                 exception_class=self._get_exception_class_name(original_exception),
                 tags=_tags,
                 route=user_api_key_dict.request_route,
@@ -1304,6 +1456,11 @@ class PrometheusLogger(CustomLogger):
             from litellm.litellm_core_utils.litellm_logging import (
                 StandardLoggingPayloadSetup,
             )
+
+            if self._should_skip_metrics_for_invalid_key(
+                user_api_key_dict=user_api_key_dict
+            ):
+                return
 
             enum_values = UserAPIKeyLabelValues(
                 end_user=user_api_key_dict.end_user_id,
@@ -1360,6 +1517,15 @@ class PrometheusLogger(CustomLogger):
             exception = request_kwargs.get("exception", None)
 
             llm_provider = _litellm_params.get("custom_llm_provider", None)
+            
+            if self._should_skip_metrics_for_invalid_key(
+                kwargs=request_kwargs,
+                standard_logging_payload=standard_logging_payload,
+            ):
+                return
+            hashed_api_key = standard_logging_payload.get("metadata", {}).get(
+                "user_api_key_hash"
+            )
 
             # Create enum_values for the label factory (always create for use in different metrics)
             enum_values = UserAPIKeyLabelValues(
@@ -1374,9 +1540,7 @@ class PrometheusLogger(CustomLogger):
                     self._get_exception_class_name(exception) if exception else None
                 ),
                 requested_model=model_group,
-                hashed_api_key=standard_logging_payload["metadata"][
-                    "user_api_key_hash"
-                ],
+                hashed_api_key=hashed_api_key,
                 api_key_alias=standard_logging_payload["metadata"][
                     "user_api_key_alias"
                 ],
@@ -1439,6 +1603,14 @@ class PrometheusLogger(CustomLogger):
             )
 
             if standard_logging_payload is None:
+                return
+
+            # Skip recording metrics for invalid API key requests
+            if self._should_skip_metrics_for_invalid_key(
+                kwargs=request_kwargs,
+                enum_values=enum_values,
+                standard_logging_payload=standard_logging_payload,
+            ):
                 return
 
             api_base = standard_logging_payload["api_base"]

--- a/tests/test_litellm/integrations/test_prometheus_invalid_key_filtering.py
+++ b/tests/test_litellm/integrations/test_prometheus_invalid_key_filtering.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for Prometheus invalid API key request filtering.
+
+Tests functionality that prevents invalid API key requests (401 status codes)
+from being recorded in Prometheus metrics.
+"""
+
+import os
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+from prometheus_client import REGISTRY
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+@pytest.fixture(scope="function")
+def prometheus_logger():
+    """Create a PrometheusLogger instance for testing."""
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        REGISTRY.unregister(collector)
+    return PrometheusLogger()
+
+
+class ExceptionWithCode:
+    """Exception-like object with 'code' attribute (ProxyException pattern)."""
+    def __init__(self, code):
+        self.code = code
+
+
+class ExceptionWithStatusCode:
+    """Exception-like object with 'status_code' attribute."""
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+class TestExtractStatusCode:
+    """Test status code extraction from various sources."""
+
+    @pytest.mark.parametrize("exception_class,code_value,expected", [
+        (ExceptionWithCode, "401", 401),
+        (ExceptionWithStatusCode, 401, 401),
+    ])
+    def test_extract_from_exception(self, prometheus_logger, exception_class, code_value, expected):
+        exception = exception_class(code_value)
+        assert prometheus_logger._extract_status_code(exception=exception) == expected
+
+    def test_extract_from_kwargs(self, prometheus_logger):
+        exception = ExceptionWithCode("401")
+        assert prometheus_logger._extract_status_code(kwargs={"exception": exception}) == 401
+
+    def test_extract_from_enum_values(self, prometheus_logger):
+        enum_values = Mock(status_code="401")
+        assert prometheus_logger._extract_status_code(enum_values=enum_values) == 401
+
+
+class TestInvalidAPIKeyDetection:
+    """Test invalid API key request detection logic."""
+
+    @pytest.mark.parametrize("status_code,expected", [
+        (401, True),
+        (200, False),
+        (500, False),
+        (None, False),
+    ])
+    def test_status_code_detection(self, prometheus_logger, status_code, expected):
+        assert prometheus_logger._is_invalid_api_key_request(status_code=status_code) == expected
+
+    def test_auth_error_message_detection(self, prometheus_logger):
+        exception = AssertionError("LiteLLM Virtual Key expected. Received=invalid-key-12345, expected to start with 'sk-'.")
+        assert prometheus_logger._is_invalid_api_key_request(status_code=None, exception=exception) is True
+
+    def test_non_auth_exception_not_detected(self, prometheus_logger):
+        exception = ValueError("Some other error")
+        assert prometheus_logger._is_invalid_api_key_request(status_code=None, exception=exception) is False
+
+
+class TestSkipMetricsValidation:
+    """Test high-level validation method that orchestrates detection and extraction."""
+
+    def test_skip_for_401_exception(self, prometheus_logger):
+        """Test full flow: extraction -> detection -> skip decision."""
+        exception = ExceptionWithCode("401")
+        assert prometheus_logger._should_skip_metrics_for_invalid_key(exception=exception) is True
+
+    def test_skip_for_auth_error_message(self, prometheus_logger):
+        """Test full flow: exception message -> detection -> skip decision."""
+        exception = AssertionError("expected to start with 'sk-'")
+        assert prometheus_logger._should_skip_metrics_for_invalid_key(exception=exception) is True
+
+    def test_no_skip_for_valid_request(self, prometheus_logger):
+        assert prometheus_logger._should_skip_metrics_for_invalid_key() is False
+
+
+class TestAsyncHooks:
+    """Test async hook methods skip metrics for invalid API keys."""
+
+    @pytest.fixture
+    def mock_user_api_key(self):
+        """Create a mock UserAPIKeyAuth object."""
+        user_key = Mock(spec=UserAPIKeyAuth)
+        user_key.api_key = "test-key"
+        user_key.end_user_id = None
+        user_key.user_id = None
+        user_key.user_email = None
+        user_key.key_alias = None
+        user_key.team_id = None
+        user_key.team_alias = None
+        user_key.request_route = "/test"
+        return user_key
+
+    @pytest.mark.asyncio
+    async def test_post_call_failure_hook_skips_401(self, prometheus_logger, mock_user_api_key):
+        exception = ExceptionWithCode("401")
+        exception.__class__.__name__ = "ProxyException"
+
+        with patch.object(prometheus_logger, 'litellm_proxy_failed_requests_metric') as mock_failed, \
+             patch.object(prometheus_logger, 'litellm_proxy_total_requests_metric') as mock_total:
+
+            await prometheus_logger.async_post_call_failure_hook(
+                request_data={"model": "test-model"},
+                original_exception=exception,
+                user_api_key_dict=mock_user_api_key
+            )
+
+            mock_failed.labels.assert_not_called()
+            mock_total.labels.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_log_failure_event_skips_401(self, prometheus_logger):
+        exception = ExceptionWithCode("401")
+        kwargs = {
+            "model": "test-model",
+            "standard_logging_object": {
+                "metadata": {
+                    "user_api_key_hash": "test-key",
+                    "user_api_key_user_id": "test-user",
+                },
+                "model_group": "test-model",
+            },
+            "exception": exception,
+            "litellm_params": {},
+        }
+
+        with patch.object(prometheus_logger, 'litellm_llm_api_failed_requests_metric') as mock_failed, \
+             patch.object(prometheus_logger, 'set_llm_deployment_failure_metrics') as mock_deployment:
+
+            await prometheus_logger.async_log_failure_event(
+                kwargs=kwargs,
+                response_obj=None,
+                start_time=None,
+                end_time=None
+            )
+
+            mock_failed.labels.assert_not_called()
+            mock_deployment.assert_not_called()


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53571/workflows/fbf980b4-d136-415f-bce2-eae756732a6b

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53572/workflows/11230c01-31c8-4ca8-9e0f-d548c70e6bff

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

Prevent invalid API key requests (401 status code) from being recorded in Prometheus metrics to avoid polluting metrics with authentication failures.

- Add helper methods to detect invalid API key requests:
  - _extract_status_code: Centralized status code extraction
  - _is_invalid_api_key_request: Check for 401 or auth error patterns
  - _should_skip_metrics_for_invalid_key: Main validation method

- Integrate validation checks into all metric recording entry points:
  - async_post_call_failure_hook
  - async_post_call_success_hook
  - async_log_failure_event
  - async_log_success_event
  - set_llm_deployment_failure_metrics

- Handles both ProxyException (uses 'code') and standard exceptions
- Also checks exception messages for auth error patterns to catch AssertionError cases before conversion to ProxyException

## Tests

**Before**:
<img width="2595" height="2042" alt="Screenshot 2026-01-07 151344" src="https://github.com/user-attachments/assets/d8ff0c70-5ae6-4686-9fb4-cceaac8e0e6a" />

**After**:

<img width="2581" height="1335" alt="Screenshot 2026-01-07 164058" src="https://github.com/user-attachments/assets/fc7220a0-9c2b-4e51-811d-4b6ae5b2864d" />
