### PR TITLE
[fix] OpenTelemetry keep parent spans alive with multiple integrations

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 import litellm
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.secret_managers.main import get_secret_bool
 from litellm.types.services import ServiceLoggerPayload
@@ -270,7 +271,6 @@ class OpenTelemetry(CustomLogger):
 
         def create_tracer_provider():
             provider = TracerProvider(resource=self._get_litellm_resource(self.config))
-            provider.add_span_processor(self._get_span_processor())
             return provider
 
         tracer_provider = self._get_or_create_provider(
@@ -281,6 +281,7 @@ class OpenTelemetry(CustomLogger):
             create_new_provider_fn=create_tracer_provider,
             set_provider_fn=trace.set_tracer_provider,
         )
+        tracer_provider.add_span_processor(self._get_span_processor())
 
         # Grab our tracer from the TracerProvider (not from global context)
         # This ensures we use the provided TracerProvider (e.g., for testing)
@@ -306,7 +307,7 @@ class OpenTelemetry(CustomLogger):
                 metric_readers=[metric_reader],
                 resource=self._get_litellm_resource(self.config),
             )
-
+        
         meter_provider = self._get_or_create_provider(
             provider=meter_provider,
             provider_name="MeterProvider",
@@ -358,17 +359,12 @@ class OpenTelemetry(CustomLogger):
         from opentelemetry.sdk._logs import LoggerProvider as OTLoggerProvider
         from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
-        def create_logger_provider():
-            provider = OTLoggerProvider(
-                resource=self._get_litellm_resource(self.config)
-            )
-            log_exporter = self._get_log_exporter()
-            provider.add_log_record_processor(
-                BatchLogRecordProcessor(log_exporter)  # type: ignore[arg-type]
-            )
-            return provider
+        log_exporter = self._get_log_exporter()
 
-        self._get_or_create_provider(
+        def create_logger_provider():
+            return OTLoggerProvider(resource=self._get_litellm_resource(self.config))
+
+        logger_provider = self._get_or_create_provider(
             provider=logger_provider,
             provider_name="LoggerProvider",
             get_existing_provider_fn=get_logger_provider,
@@ -376,6 +372,10 @@ class OpenTelemetry(CustomLogger):
             create_new_provider_fn=create_logger_provider,
             set_provider_fn=set_logger_provider,
         )
+        logger_provider.add_log_record_processor(
+            BatchLogRecordProcessor(log_exporter)  # type: ignore[arg-type]
+        )
+
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
         self._handle_success(kwargs, response_obj, start_time, end_time)
@@ -688,12 +688,6 @@ class OpenTelemetry(CustomLogger):
 
         # 6. Do NOT end parent span - it should be managed by its creator
         # External spans (from Langfuse, user code, HTTP headers, global context) must not be closed by LiteLLM
-        # However, proxy-created spans should be closed here
-        if (
-            parent_span is not None
-            and parent_span.name == LITELLM_PROXY_REQUEST_SPAN_NAME
-        ):
-            parent_span.end(end_time=self._to_ns(end_time))
 
     def _start_primary_span(
         self,
@@ -1176,12 +1170,6 @@ class OpenTelemetry(CustomLogger):
 
         # Do NOT end parent span - it should be managed by its creator
         # External spans (from Langfuse, user code, HTTP headers, global context) must not be closed by LiteLLM
-        # However, proxy-created spans should be closed here
-        if (
-            parent_otel_span is not None
-            and parent_otel_span.name == LITELLM_PROXY_REQUEST_SPAN_NAME
-        ):
-            parent_otel_span.end(end_time=self._to_ns(end_time))
 
     def _record_exception_on_span(self, span: Span, kwargs: dict):
         """
@@ -2246,3 +2234,25 @@ class OpenTelemetry(CustomLogger):
             context=self.get_traceparent_from_header(headers=headers),
             kind=self.span_kind.SERVER,
         )
+
+    def close_litellm_proxy_request_span(
+        self,
+        kwargs: Optional[dict],
+        end_time: datetime,
+    ) -> None:
+        """End the proxy-created parent span after all callbacks finish."""
+
+        if kwargs is None:
+            return
+
+        try:
+            parent_span = _get_parent_otel_span_from_kwargs(kwargs)
+            if parent_span is None:
+                return
+            if getattr(parent_span, "name", None) != LITELLM_PROXY_REQUEST_SPAN_NAME:
+                return
+            parent_span.end(end_time=self._to_ns(end_time))
+        except Exception as exc:
+            verbose_logger.debug(
+                "OpenTelemetry: Failed to end proxy parent span: %s", str(exc)
+            )

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -266,6 +266,7 @@ class TestOpenTelemetry(unittest.TestCase):
         self.assertEqual(config.deployment_environment, "production")
         self.assertEqual(config.model_id, "litellm")
 
+
     @patch.dict(os.environ, {}, clear=True)
     def test_open_telemetry_config_custom_service_name(self):
         """Model ID should inherit provided service name when not explicitly set."""

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1,6 +1,8 @@
 import json
 import os
 import sys
+import time
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,8 +10,6 @@ import pytest
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
-
-import time
 
 from litellm.constants import SENTRY_DENYLIST, SENTRY_PII_DENYLIST
 from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
@@ -159,6 +159,95 @@ def test_logging_prevent_double_logging(logging_obj):
     assert logging_obj.should_run_logging(event_type="sync_failure") == True
     assert logging_obj.should_run_logging(event_type="async_success") == True
     assert logging_obj.should_run_logging(event_type="async_failure") == True
+
+
+def _set_base_model_call_details(logging_obj, litellm_params=None):
+    logging_obj.model_call_details = {
+        "litellm_params": litellm_params or {},
+        "messages": [],
+        "input": [],
+        "optional_params": {},
+        "model": logging_obj.model,
+    }
+    logging_obj.sync_streaming_chunks = []
+    logging_obj.dynamic_success_callbacks = []
+
+
+def test_success_handler_finalizes_parent_span_for_async_requests(logging_obj):
+    logging_obj.stream = False
+    _set_base_model_call_details(logging_obj, litellm_params={})
+    start = datetime.utcnow()
+    result_payload = {"id": "resp"}
+
+    with patch.object(
+        LitellmLogging,
+        "_success_handler_helper_fn",
+        return_value=(start, start, result_payload),
+    ), patch.object(
+        LitellmLogging, "_get_assembled_streaming_response", return_value=None
+    ), patch.object(
+        LitellmLogging, "get_combined_callback_list", return_value=[]
+    ), patch.object(
+        LitellmLogging, "_finalize_proxy_parent_span"
+    ) as finalize_mock:
+        logging_obj.success_handler(result=result_payload)
+        finalize_mock.assert_called_once_with(end_time=start)
+
+
+def test_success_handler_skips_parent_span_for_override_requests(logging_obj):
+    logging_obj.stream = False
+    _set_base_model_call_details(logging_obj, litellm_params={"acompletion": True})
+    start = datetime.utcnow()
+
+    with patch.object(
+        LitellmLogging,
+        "_success_handler_helper_fn",
+        return_value=(start, start, {}),
+    ), patch.object(
+        LitellmLogging, "_get_assembled_streaming_response", return_value=None
+    ), patch.object(
+        LitellmLogging, "get_combined_callback_list", return_value=[]
+    ), patch.object(
+        LitellmLogging, "_finalize_proxy_parent_span"
+    ) as finalize_mock:
+        logging_obj.success_handler(result={})
+        finalize_mock.assert_not_called()
+
+
+def test_failure_handler_finalizes_parent_span_for_async_requests(logging_obj):
+    _set_base_model_call_details(logging_obj, litellm_params={})
+    start = datetime.utcnow()
+    exception = Exception("boom")
+
+    with patch.object(
+        LitellmLogging,
+        "_failure_handler_helper_fn",
+        return_value=(start, start),
+    ), patch.object(
+        LitellmLogging, "get_combined_callback_list", return_value=[]
+    ), patch.object(
+        LitellmLogging, "_finalize_proxy_parent_span"
+    ) as finalize_mock:
+        logging_obj.failure_handler(exception=exception, traceback_exception="trace")
+        finalize_mock.assert_called_once_with(end_time=start)
+
+
+def test_failure_handler_skips_parent_span_for_override_requests(logging_obj):
+    _set_base_model_call_details(logging_obj, litellm_params={"aembedding": True})
+    start = datetime.utcnow()
+    exception = Exception("boom")
+
+    with patch.object(
+        LitellmLogging,
+        "_failure_handler_helper_fn",
+        return_value=(start, start),
+    ), patch.object(
+        LitellmLogging, "get_combined_callback_list", return_value=[]
+    ), patch.object(
+        LitellmLogging, "_finalize_proxy_parent_span"
+    ) as finalize_mock:
+        logging_obj.failure_handler(exception=exception, traceback_exception="trace")
+        finalize_mock.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53581/workflows/c9dc1825-a500-4c4a-ac3b-f350e43e666c

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53580/workflows/8c59655e-72c8-4d93-9229-78a461a90339

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes
- Switch proxy-created parent spans to close only after every callback finishes instead of closing inside each callback.
- Run add_span_processor within each callback so every integration installs its own processor.
