### PR TITLE
Fix: Always remap choice none zero to zero for Anthropic tool_call streaming

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -902,6 +902,17 @@ class CustomStreamWrapper:
                                     choices.append(StreamingChoices(**choice_json))
                             except Exception:
                                 choices.append(StreamingChoices())
+
+                        ## issue 18535: remap anthropic tool call streaming single choice index from not zero to zero.
+                        if (
+                            len(choices) == 1
+                            and choices[0].index != 0
+                            and "delta" in choices[0]
+                            and "tool_calls" in choices[0].delta
+                            and choices[0].delta.tool_calls is not None
+                        ):
+                            choices[0].index = 0
+
                         print_verbose(f"choices in streaming: {choices}")
                         setattr(model_response, "choices", choices)
                     else:


### PR DESCRIPTION
## Relevant issues
Fixes Issue [#18535](https://github.com/BerriAI/litellm/issues/18535)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added tests in the tests/litellm/ directory.
- [x] My PR passes all unit tests on tests/test_litellm/litellm_core_utils/test_streaming_handler.py 
- [x] My PR’s scope is isolated and solves only one specific problem.


## Type
🐛 Bug Fix

## Changes
- Reset choice.index from 1 → 0 for Anthropic tool call streaming events.
- Prevents index error caused by mismatch in expected index positions in ddtrace integration.
- Verified fix on ddtrace v3.8.1 and LiteLLM v1.80.11 at local docker environment.