### PR TITLE
fix: add custom litellm params handling via config.yaml

### DIFF
--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -148,4 +148,3 @@ def get_litellm_params(
             litellm_params[key] = value
 
     return litellm_params
-

--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -139,4 +139,13 @@ def get_litellm_params(
         "aws_external_id": kwargs.get("aws_external_id"),
         "aws_bedrock_runtime_endpoint": kwargs.get("aws_bedrock_runtime_endpoint"),
     }
+
+    # Preserve any extra/custom params passed via kwargs
+    # This ensures custom params defined in config.yaml (e.g., context_id, use_case)
+    # are passed through to custom handlers. Fixes issue #18216.
+    for key, value in kwargs.items():
+        if key not in litellm_params and value is not None:
+            litellm_params[key] = value
+
     return litellm_params
+

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1466,6 +1466,16 @@ def completion(  # type: ignore # noqa: PLR0915
             max_retries=max_retries,
             timeout=timeout,
             litellm_request_debug=kwargs.get("litellm_request_debug", False),
+            # Pass through any extra/custom params from kwargs (fixes #18216)
+            # Filter out params already explicitly passed to avoid duplicate keyword argument errors
+            **{k: v for k, v in kwargs.items() if k not in {
+                "litellm_call_id", "text_completion", "azure_ad_token_provider",
+                "user_continue_message", "litellm_trace_id", "litellm_session_id",
+                "litellm_metadata", "drop_params", "merge_reasoning_content_in_choices",
+                "use_litellm_proxy", "azure_ad_token", "tenant_id", "client_id",
+                "client_secret", "azure_username", "azure_password", "azure_scope",
+                "litellm_request_debug",
+            }},
         )
         cast(LiteLLMLoggingObj, logging).update_environment_variables(
             model=model,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1468,14 +1468,76 @@ def completion(  # type: ignore # noqa: PLR0915
             litellm_request_debug=kwargs.get("litellm_request_debug", False),
             # Pass through any extra/custom params from kwargs (fixes #18216)
             # Filter out params already explicitly passed to avoid duplicate keyword argument errors
-            **{k: v for k, v in kwargs.items() if k not in {
-                "litellm_call_id", "text_completion", "azure_ad_token_provider",
-                "user_continue_message", "litellm_trace_id", "litellm_session_id",
-                "litellm_metadata", "drop_params", "merge_reasoning_content_in_choices",
-                "use_litellm_proxy", "azure_ad_token", "tenant_id", "client_id",
-                "client_secret", "azure_username", "azure_password", "azure_scope",
-                "litellm_request_debug",
-            }},
+            # This set contains all params that are either:
+            # 1. Passed via kwargs.get(...) above
+            # 2. Passed from function signature args
+            # 3. Known params in get_litellm_params function signature
+            **{
+                k: v
+                for k, v in kwargs.items()
+                if k
+                not in {
+                    # Function signature args passed explicitly
+                    "model",
+                    "messages",
+                    "metadata",
+                    "api_key",
+                    "api_base",
+                    "api_version",
+                    "timeout",
+                    "max_retries",
+                    "custom_llm_provider",
+                    # Kwargs accessed via kwargs.get(...) above
+                    "litellm_call_id",
+                    "text_completion",
+                    "azure_ad_token_provider",
+                    "user_continue_message",
+                    "litellm_trace_id",
+                    "litellm_session_id",
+                    "litellm_metadata",
+                    "drop_params",
+                    "merge_reasoning_content_in_choices",
+                    "use_litellm_proxy",
+                    "azure_ad_token",
+                    "tenant_id",
+                    "client_id",
+                    "client_secret",
+                    "azure_username",
+                    "azure_password",
+                    "azure_scope",
+                    "litellm_request_debug",
+                    # Other known get_litellm_params signature params
+                    "model_info",
+                    "force_timeout",
+                    "azure",
+                    "logger_fn",
+                    "verbose",
+                    "hugging_face",
+                    "replicate",
+                    "together_ai",
+                    "model_alias_map",
+                    "completion_call_id",
+                    "proxy_server_request",
+                    "acompletion",
+                    "aembedding",
+                    "preset_cache_key",
+                    "no_log",
+                    "input_cost_per_second",
+                    "input_cost_per_token",
+                    "output_cost_per_token",
+                    "output_cost_per_second",
+                    "cost_per_query",
+                    "cooldown_time",
+                    "base_model",
+                    "hf_model_name",
+                    "custom_prompt_dict",
+                    "disable_add_transform_inline_image_block",
+                    "prompt_id",
+                    "prompt_variables",
+                    "async_call",
+                    "ssl_verify",
+                }
+            },
         )
         cast(LiteLLMLoggingObj, logging).update_environment_variables(
             model=model,
@@ -2301,11 +2363,7 @@ def completion(  # type: ignore # noqa: PLR0915
                 input=messages, api_key=api_key, original_response=response
             )
         elif custom_llm_provider == "minimax":
-            api_key = (
-                api_key
-                or get_secret_str("MINIMAX_API_KEY")
-                or litellm.api_key
-            )
+            api_key = api_key or get_secret_str("MINIMAX_API_KEY") or litellm.api_key
 
             api_base = (
                 api_base
@@ -2353,7 +2411,9 @@ def completion(  # type: ignore # noqa: PLR0915
             or custom_llm_provider == "wandb"
             or custom_llm_provider == "clarifai"
             or custom_llm_provider in litellm.openai_compatible_providers
-            or JSONProviderRegistry.exists(custom_llm_provider)  # JSON-configured providers
+            or JSONProviderRegistry.exists(
+                custom_llm_provider
+            )  # JSON-configured providers
             or "ft:gpt-3.5-turbo" in model  # finetune gpt-3.5-turbo
         ):  # allow user to make an openai call with a custom base
             # note: if a user sets a custom base - we should ensure this works
@@ -4599,7 +4659,7 @@ def embedding(  # noqa: PLR0915
 
             if extra_headers is not None:
                 optional_params["extra_headers"] = extra_headers
-            
+
             if encoding_format is not None:
                 optional_params["encoding_format"] = encoding_format
             else:
@@ -6591,9 +6651,7 @@ def speech(  # noqa: PLR0915
         if text_to_speech_provider_config is None:
             text_to_speech_provider_config = MinimaxTextToSpeechConfig()
 
-        minimax_config = cast(
-            MinimaxTextToSpeechConfig, text_to_speech_provider_config
-        )
+        minimax_config = cast(MinimaxTextToSpeechConfig, text_to_speech_provider_config)
 
         if api_base is not None:
             litellm_params_dict["api_base"] = api_base
@@ -6733,7 +6791,7 @@ async def ahealth_check(
         custom_llm_provider_from_params = model_params.get("custom_llm_provider", None)
         api_base_from_params = model_params.get("api_base", None)
         api_key_from_params = model_params.get("api_key", None)
-        
+
         model, custom_llm_provider, _, _ = get_llm_provider(
             model=model,
             custom_llm_provider=custom_llm_provider_from_params,
@@ -7107,6 +7165,7 @@ def __getattr__(name: str) -> Any:
         _encoding = tiktoken.get_encoding("cl100k_base")
         # Cache it in the module's __dict__ for subsequent accesses
         import sys
+
         sys.modules[__name__].__dict__["encoding"] = _encoding
         global _encoding_cache
         _encoding_cache = _encoding

--- a/tests/test_litellm/test_custom_params_bug_18216.py
+++ b/tests/test_litellm/test_custom_params_bug_18216.py
@@ -1,0 +1,176 @@
+"""
+Test to reproduce issue #18216: Custom litellm_params in config.yaml not passed to custom_handler.py
+
+This test verifies that custom parameters defined in litellm_params are passed through to custom handlers.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typing import Any, Optional, Union, Callable
+
+import litellm
+from litellm import CustomLLM, ModelResponse
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
+from litellm.litellm_core_utils.get_litellm_params import get_litellm_params
+import httpx
+
+
+class TestCustomLLM(CustomLLM):
+    """A test custom LLM handler that captures litellm_params for inspection."""
+
+    captured_litellm_params: Optional[dict] = None
+
+    def completion(
+        self,
+        model: str,
+        messages: list,
+        api_base: str,
+        custom_prompt_dict: dict,
+        model_response: ModelResponse,
+        print_verbose: Callable,
+        encoding,
+        api_key,
+        logging_obj,
+        optional_params: dict,
+        acompletion=None,
+        litellm_params=None,
+        logger_fn=None,
+        headers={},
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
+        client: Optional[HTTPHandler] = None,
+    ):
+        # Capture the litellm_params for inspection
+        TestCustomLLM.captured_litellm_params = litellm_params
+        print(f"\n🔍 Captured litellm_params: {litellm_params}")
+
+        # Return a mock response with proper structure
+        from litellm.types.utils import Choices, Message
+
+        model_response.choices = [
+            Choices(
+                message=Message(role="assistant", content="Test response"),
+                index=0,
+                finish_reason="stop",
+            )
+        ]
+        model_response.model = model
+        return model_response
+
+
+class TestCustomParamsBug18216:
+    """Test suite to reproduce and verify the custom params bug."""
+
+    def test_get_litellm_params_drops_custom_params(self):
+        """
+        Test that demonstrates get_litellm_params() drops unknown/custom parameters.
+
+        This is the core of issue #18216 - custom params like 'context_id' are passed
+        in via kwargs but are NOT included in the returned dictionary.
+        """
+        # Simulate params that would come from config.yaml litellm_params
+        result = get_litellm_params(
+            api_key="test-key",
+            custom_llm_provider="my-custom-provider",
+            metadata={"user": "test"},
+            # These are custom params that a user might define in config.yaml
+            context_id="gemini-2.5-pro",  # Custom param from config
+            use_case="my-use-case",  # Another custom param
+            rpm=1,  # This is actually a known param but let's check
+        )
+
+        print(f"\n📋 Result from get_litellm_params():")
+        print(f"   api_key: {result.get('api_key')}")
+        print(f"   custom_llm_provider: {result.get('custom_llm_provider')}")
+        print(f"   metadata: {result.get('metadata')}")
+        print(f"   context_id: {result.get('context_id')}")
+        print(f"   use_case: {result.get('use_case')}")
+
+        # These should be present (known params)
+        assert result.get("api_key") == "test-key", "api_key should be present"
+        assert (
+            result.get("custom_llm_provider") == "my-custom-provider"
+        ), "custom_llm_provider should be present"
+        assert result.get("metadata") == {"user": "test"}, "metadata should be present"
+
+        # AFTER FIX: These custom params should now be present!
+        context_id = result.get("context_id")
+        use_case = result.get("use_case")
+
+        print(f"\n✅ FIX VERIFICATION:")
+        print(f"   context_id in result: {context_id is not None}")
+        print(f"   use_case in result: {use_case is not None}")
+
+        # These assertions verify the fix works
+        assert context_id == "gemini-2.5-pro", "context_id should be preserved after fix"
+        assert use_case == "my-use-case", "use_case should be preserved after fix"
+        
+        print("\n🎉 SUCCESS: Custom params are now correctly passed through!")
+
+    def test_custom_handler_receives_incomplete_params(self):
+        """
+        End-to-end test showing that custom handlers don't receive custom params.
+        """
+        # Register our test custom handler
+        my_custom_llm = TestCustomLLM()
+        litellm.custom_provider_map = [
+            {"provider": "test-custom-provider", "custom_handler": my_custom_llm}
+        ]
+        litellm._custom_providers.append("test-custom-provider")
+
+        try:
+            # Make a completion call with custom params
+            # In real usage, these would come from config.yaml
+            response = litellm.completion(
+                model="test-custom-provider/test-model",
+                messages=[{"role": "user", "content": "Hello"}],
+                # Custom params that should be passed through
+                context_id="my-context-id",
+                use_case="my-use-case",
+            )
+
+            # Check what the handler received
+            captured = TestCustomLLM.captured_litellm_params
+            print(f"\n📦 Handler received litellm_params: {captured}")
+
+            assert captured is not None, "Handler should have received litellm_params"
+            
+            context_id = captured.get("context_id")
+            use_case = captured.get("use_case")
+
+            print(f"\n🔍 Checking for custom params in handler:")
+            print(f"   context_id: {context_id}")
+            print(f"   use_case: {use_case}")
+
+            # AFTER FIX: These should now be present
+            assert context_id == "my-context-id", "context_id should be passed to custom handler"
+            assert use_case == "my-use-case", "use_case should be passed to custom handler"
+            
+            print("\n🎉 SUCCESS: Custom handler received all custom params!")
+
+        except Exception as e:
+            print(f"\n⚠️ Error during test: {e}")
+            # The test might fail for other reasons, but we still want to see the params issue
+            if TestCustomLLM.captured_litellm_params:
+                print(f"   Captured params before error: {TestCustomLLM.captured_litellm_params}")
+            raise
+
+        finally:
+            # Cleanup
+            litellm.custom_provider_map = []
+            if "test-custom-provider" in litellm._custom_providers:
+                litellm._custom_providers.remove("test-custom-provider")
+
+
+if __name__ == "__main__":
+    # Run the tests directly
+    test = TestCustomParamsBug18216()
+
+    print("=" * 60)
+    print("TEST 1: get_litellm_params drops custom params")
+    print("=" * 60)
+    test.test_get_litellm_params_drops_custom_params()
+
+    print("\n" + "=" * 60)
+    print("TEST 2: Custom handler receives incomplete params")
+    print("=" * 60)
+    test.test_custom_handler_receives_incomplete_params()


### PR DESCRIPTION
## Relevant issues

Fixes #18216

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### Problem
Custom [litellm_params](cci:1://file:///d:/OSS/litellm/litellm/litellm_core_utils/get_litellm_params.py:19:0-149:25) defined in [config.yaml](cci:7://file:///d:/OSS/litellm/scripts/issue_18216_config.yaml:0:0-0:0) (e.g., `context_id`, `use_case`) were not being passed to custom handlers. The handler received [litellm_params](cci:1://file:///d:/OSS/litellm/litellm/litellm_core_utils/get_litellm_params.py:19:0-149:25) but custom keys returned `None`.

### Root Cause
Two-part bug:
1. [get_litellm_params()](cci:1://file:///d:/OSS/litellm/litellm/litellm_core_utils/get_litellm_params.py:19:0-149:25) in [litellm/litellm_core_utils/get_litellm_params.py](cci:7://file:///d:/OSS/litellm/litellm/litellm_core_utils/get_litellm_params.py:0:0-0:0) ignored `**kwargs` - custom params were dropped
2. [completion()](cci:1://file:///d:/OSS/litellm/litellm/llms/custom_llm.py:50:4-69:77) in [litellm/main.py](cci:7://file:///d:/OSS/litellm/litellm/main.py:0:0-0:0) didn't pass `**kwargs` to [get_litellm_params()](cci:1://file:///d:/OSS/litellm/litellm/litellm_core_utils/get_litellm_params.py:19:0-149:25)

### Fix
1. **[get_litellm_params.py](cci:7://file:///d:/OSS/litellm/litellm/litellm_core_utils/get_litellm_params.py:0:0-0:0)**: Added loop to preserve extra kwargs in returned dict
2. **[main.py](cci:7://file:///d:/OSS/litellm/litellm/main.py:0:0-0:0)**: Added filtered `**kwargs` to the [get_litellm_params()](cci:1://file:///d:/OSS/litellm/litellm/litellm_core_utils/get_litellm_params.py:19:0-149:25) call

### Files Changed
- [litellm/litellm_core_utils/get_litellm_params.py](cci:7://file:///d:/OSS/litellm/litellm/litellm_core_utils/get_litellm_params.py:0:0-0:0)
- [litellm/main.py](cci:7://file:///d:/OSS/litellm/litellm/main.py:0:0-0:0)
- [tests/test_litellm/test_custom_params_bug_18216.py](cci:7://file:///d:/OSS/litellm/tests/test_litellm/test_custom_params_bug_18216.py:0:0-0:0) (new tests to check handling of params)


