### PR TITLE
docs: fix PDF documentation inconsistency in Anthropic page

### DIFF
--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -1692,9 +1692,9 @@ Assistant:
 ```
 
 
-## Usage - PDF 
+## Usage - PDF
 
-Pass base64 encoded PDF files to Anthropic models using the `image_url` field.
+Pass base64 encoded PDF files to Anthropic models using the `file` content type with a `file_data` field.
 
 <Tabs>
 <TabItem value="sdk" label="SDK">


### PR DESCRIPTION
## Relevant issues

Fixes #18774

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - **N/A** - This is a documentation-only change, no tests required
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - **N/A** - Documentation change only
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

Fixed documentation inconsistency in the Anthropic provider page where the description mentioned using `image_url` field but the code example correctly used `file` content type with `file_data` field.

**Before:** "Pass base64 encoded PDF files to Anthropic models using the `image_url` field."

**After:** "Pass base64 encoded PDF files to Anthropic models using the `file` content type with a `file_data` field."

This change aligns the documentation text with the actual code example and Anthropic's official API documentation.