### PR TITLE
fix: Mask extra header secrets in model info

### DIFF
--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -75,3 +75,47 @@ def test_excluded_keys_exact_match():
     assert masked["api_key"] == "sk-1234567890abcdef"  # Should NOT be masked
     assert masked["access_token"] != "token-12345"  # Should still be masked
     assert "*" in masked["access_token"]
+
+
+def test_extra_headers_are_masked_recursively():
+    """
+    Ensure nested dictionaries (like extra_headers) are masked.
+    """
+    masker = SensitiveDataMasker()
+
+    data = {
+        "litellm_params": {
+            "model": "openai/gpt-4",
+            "extra_headers": {
+                "rits_api_key": "sk-secret-12345-very-sensitive",
+                "Authorization": "Bearer token123",
+            },
+        }
+    }
+
+    masked = masker.mask_dict(data)
+    extra_headers = masked["litellm_params"]["extra_headers"]
+
+    assert extra_headers["rits_api_key"] != "sk-secret-12345-very-sensitive"
+    assert "*" in extra_headers["rits_api_key"]
+    assert extra_headers["Authorization"] != "Bearer token123"
+    assert "*" in extra_headers["Authorization"]
+
+
+def test_lists_with_sensitive_keys_are_masked():
+    """
+    Lists belonging to sensitive keys should have their values masked.
+    """
+    masker = SensitiveDataMasker()
+    data = {
+        "api_key": ["sk-123", "sk-456"],
+        "tags": ["prod", "test"],
+    }
+
+    masked = masker.mask_dict(data)
+    # sensitive key list entries should be masked
+    assert masked["api_key"][0] != "sk-123"
+    assert "*" in masked["api_key"][0]
+
+    # non-sensitive list should remain unchanged
+    assert masked["tags"] == ["prod", "test"]


### PR DESCRIPTION
## Relevant issues
  Fixes #18818

  ## Pre-Submission checklist
  - [x] I have Added testing in the tests/litellm/ directory, Adding at least 1 test is a hard requirement – added regression tests for SensitiveDataMasker.
  - [ ] My PR passes all unit tests on make test-unit
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## CI (LiteLLM team)
  - [ ] Branch creation CI run – Link:
  - [ ] CI run for the last commit – Link:
  - [ ] Merge / cherry-pick CI run – Links:

  ## Type
  🐛 Bug Fix

  ## Changes
  - Update SensitiveDataMasker to walk nested dicts/lists (e.g. extra_headers) so the /model/info endpoint stops leaking values that look like credentials.
  - Extend the sensitive keyword set (e.g. authorization) and introduce list-handling logic, ensuring only keys matching the patterns are masked while the rest of the
  configuration remains untouched.
  - Add regression tests in tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py proving nested headers/lists are masked and non-sensitive values stay visible.

  ### Example (GET /model/info)
  **Before (bug):**
```json
  {
    "litellm_params": {
      "model": "openai/gpt-4",
      "extra_headers": {
        "rits_api_key": "sk-secret-12345-very-sensitive",
        "Authorization": "Bearer token123"
      }
    }
  }
```
**After (fix):**
```json
  {
    "litellm_params": {
      "model": "openai/gpt-4",
      "extra_headers": {
        "rits_api_key": "sk-s**********************tive",
        "Authorization": "Bear*******n123"
      }
    }
  }
```