### PR TITLE
fix: add idx on LOWER(user_email) for faster duplicate email checks l…

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260108_add_user_email_lower_idx/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260108_add_user_email_lower_idx/migration.sql
@@ -1,0 +1,9 @@
+-- CreateIndex
+-- Fixes performance issue in _check_duplicate_user_email function
+-- by enabling fast case-insensitive email lookups.
+-- 
+-- Without this index, queries with mode: "insensitive" cause full table scans.
+-- With this index, PostgreSQL can use an Index Scan for O(log n) performance.
+--
+-- Related: GitHub Issue #18411
+CREATE INDEX "LiteLLM_UserTable_user_email_lower_idx" ON "LiteLLM_UserTable"(LOWER("user_email"));


### PR DESCRIPTION
## Relevant issues

Fixes #18411

## Type

🐛 Bug Fix

## Changes

### Problem
The [_check_duplicate_user_email](cci:1://file:///d:/OSS/litellm/litellm/proxy/management_endpoints/internal_user_endpoints.py:147:0-159:5) function causes severe performance degradation and database crashes when the user count exceeds ~200,000 users. This is because the case-insensitive email check uses `mode: "insensitive"` which generates `WHERE LOWER(user_email) = LOWER(?)` queries that force a full table scan.

Flow of sequential scan

<img width="629" height="501" alt="image" src="https://github.com/user-attachments/assets/9947324f-4370-4c1c-b581-8a8ce97e1093" />


### Solution
Added a PostgreSQL expression index on `LOWER(user_email)` to enable fast O(log n) lookups using a B-tree index scan instead of O(n) sequential scans.

<img width="441" height="507" alt="image" src="https://github.com/user-attachments/assets/d6ddc169-9313-4f26-8c23-aff3c9249ad7" />


```sql
CREATE INDEX "LiteLLM_UserTable_user_email_lower_idx" ON "LiteLLM_UserTable"(LOWER("user_email"));
```

I tested this by creating 200,000 dummy records
```md
┌────────────────────────────────────────────────────────────────────────────────┐
│                    LIVE INDEX SEARCH DEMO - 200,000 RECORDS                     │
├────────────────────────────────────────────────────────────────────────────────┤
│                                                                                 │
│  Search 1: TEST99999@GMAIL.COM                                                  │
│  ─────────────────────────────────────────────────────                          │
│  Method:    Index Scan using LiteLLM_UserTable_user_email_lower_idx             │
│  Time:      0.019 ms  ⚡                                 │
│                                                                                 │
│  Search 2: test200000@gmail.com (last record)                                   │
│  ─────────────────────────────────────────────────────                          │
│  Method:    Index Scan                                                          │
│  Time:      0.014 ms  ⚡                                                        │
│                                                                                 │
└────────────────────────────────────────────────────────────────────────────────┘
```