### PR TITLE
Fix: google_genai streaming adapter provider handling

### DIFF
--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -130,6 +130,9 @@ class GenerateContentHelper:
             api_key=litellm_params.api_key,
         )
 
+        if litellm_params.custom_llm_provider is None:
+            litellm_params.custom_llm_provider = custom_llm_provider
+
         # get provider config
         generate_content_provider_config: Optional[
             BaseGoogleGenAIGenerateContentConfig
@@ -407,6 +410,9 @@ async def agenerate_content_stream(
 
         # Check if we should use the adapter (when provider config is None)
         if setup_result.generate_content_provider_config is None:
+            if "stream" in kwargs:
+                kwargs.pop("stream", None)
+
             # Use the adapter to convert to completion format
             return (
                 await GenerateContentToCompletionHandler.async_generate_content_handler(
@@ -490,6 +496,9 @@ def generate_content_stream(
 
         # Check if we should use the adapter (when provider config is None)
         if setup_result.generate_content_provider_config is None:
+            if "stream" in kwargs:
+                kwargs.pop("stream", None)
+
             # Use the adapter to convert to completion format
             return GenerateContentToCompletionHandler.generate_content_handler(
                 model=model,


### PR DESCRIPTION
## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

### What this PR does

- Forces stream=True in Google GenAI streaming entrypoints to avoid conflicting stream args and ensure correct streaming behavior.
- Propagates resolved custom_llm_provider into litellm_params so adapter paths pass provider to completion/acompletion.

### Why

- Fixes got multiple values for keyword argument 'stream' errors in streaming generate_content adapter calls.
- Fixes LLM Provider NOT provided errors when adapter falls back to completion with models like glm-4.6.

### Changes

- main.py: pop kwargs["stream"] in generate_content_stream and agenerate_content_stream.
- main.py: set litellm_params.custom_llm_provider after get_llm_provider() when missing.
