### PR TITLE
[Infra] UI - E2E Test: Refactor Page Settings + Test for Page Navigation

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/fixtures/menuMappings.ts
+++ b/ui/litellm-dashboard/e2e_tests/fixtures/menuMappings.ts
@@ -1,0 +1,38 @@
+import { Page } from "./pages";
+
+/**
+ * Maps sidebar menu item labels to their corresponding page enum values.
+ * This mapping is for the admin role.
+ */
+export const menuLabelToPage: Record<string, Page> = {
+  "Virtual Keys": Page.ApiKeys,
+  Playground: Page.LlmPlayground,
+  Models: Page.Models,
+  "Models + Endpoints": Page.Models,
+  Usage: Page.NewUsage,
+  Teams: Page.Teams,
+  "Internal Users": Page.Users,
+  "Internal User": Page.Users, // Legacy label support
+  Organizations: Page.Organizations,
+  "API Reference": Page.ApiRef,
+  "AI Hub": Page.ModelHubTable,
+  "Model Hub": Page.ModelHubTable,
+  Logs: Page.Logs,
+  Guardrails: Page.Guardrails,
+  // Settings submenu items
+  "Router Settings": Page.RouterSettings,
+  "Logging & Alerts": Page.LoggingAndAlerts,
+  "Admin Settings": Page.AdminPanel,
+  "Cost Tracking": Page.CostTracking,
+  "UI Theme": Page.UiTheme,
+  // Experimental submenu items
+  Caching: Page.Caching,
+  Prompts: Page.Prompts,
+  Budgets: Page.Budgets,
+  "API Playground": Page.TransformRequest,
+  "Tag Management": Page.TagManagement,
+  "Old Usage": Page.Usage,
+  // Tools submenu items
+  "MCP Servers": Page.McpServers,
+  "Vector Stores": Page.VectorStores,
+};

--- a/ui/litellm-dashboard/e2e_tests/fixtures/pages.ts
+++ b/ui/litellm-dashboard/e2e_tests/fixtures/pages.ts
@@ -1,0 +1,33 @@
+/**
+ * Enum for all page query parameters supported in the app.
+ * These values correspond to the `page` query parameter used in the URL.
+ */
+export enum Page {
+  ApiKeys = "api-keys",
+  Models = "models",
+  LlmPlayground = "llm-playground",
+  Users = "users",
+  Teams = "teams",
+  Organizations = "organizations",
+  AdminPanel = "admin-panel",
+  ApiRef = "api_ref",
+  LoggingAndAlerts = "logging-and-alerts",
+  Budgets = "budgets",
+  Guardrails = "guardrails",
+  Agents = "agents",
+  Prompts = "prompts",
+  TransformRequest = "transform-request",
+  RouterSettings = "router-settings",
+  UiTheme = "ui-theme",
+  CostTracking = "cost-tracking",
+  ModelHubTable = "model-hub-table",
+  Caching = "caching",
+  PassThroughSettings = "pass-through-settings",
+  Logs = "logs",
+  McpServers = "mcp-servers",
+  SearchTools = "search-tools",
+  TagManagement = "tag-management",
+  VectorStores = "vector-stores",
+  NewUsage = "new_usage",
+  Usage = "usage",
+}

--- a/ui/litellm-dashboard/e2e_tests/helpers/navigation.ts
+++ b/ui/litellm-dashboard/e2e_tests/helpers/navigation.ts
@@ -1,0 +1,12 @@
+import { Page } from "../fixtures/pages";
+import { Page as PlaywrightPage } from "@playwright/test";
+
+/**
+ * Navigates to a specific page using the page query parameter.
+ * Uses relative path which will be resolved against the baseURL configured in playwright.config.ts
+ * @param page - The Playwright page object
+ * @param pageEnum - The page enum value to navigate to
+ */
+export async function navigateToPage(page: PlaywrightPage, pageEnum: Page): Promise<void> {
+  await page.goto(`/ui?page=${pageEnum}`);
+}

--- a/ui/litellm-dashboard/e2e_tests/tests/modelsPage/addModel.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/modelsPage/addModel.spec.ts
@@ -14,7 +14,7 @@ test.describe("Add Model", () => {
     await providerInputDropdown.fill("Anthropic");
     await page.waitForTimeout(1000);
     await providerInputDropdown.press("Enter");
-    await page.waitForTimeout(1000);
+    await page.waitForTimeout(2000);
 
     const providerModelsDropdown = page.locator(".ant-select-selection-overflow").first();
     await providerModelsDropdown.click();

--- a/ui/litellm-dashboard/e2e_tests/tests/navigation/sidebar.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/navigation/sidebar.spec.ts
@@ -1,6 +1,9 @@
 import test, { expect } from "@playwright/test";
 import { Role } from "../../fixtures/roles";
 import { ADMIN_STORAGE_PATH } from "../../constants";
+import { Page } from "../../fixtures/pages";
+import { menuLabelToPage } from "../../fixtures/menuMappings";
+import { navigateToPage } from "../../helpers/navigation";
 
 const sidebarButtons = {
   [Role.ProxyAdmin]: [
@@ -9,9 +12,7 @@ const sidebarButtons = {
     "Models",
     "Usage",
     "Teams",
-    "Internal User",
-    "Settings",
-    "Experimental",
+    "Internal Users",
     "API Reference",
     "AI Hub",
   ],
@@ -23,13 +24,36 @@ for (const { role, storage } of roles) {
   test.describe(`${role} sidebar`, () => {
     test.use({ storageState: storage });
 
-    test("can see and navigate all sidebar buttons", async ({ page }) => {
+    test("should navigate to correct URL when clicking sidebar menu items from homepage", async ({ page }) => {
       await page.goto("/ui");
-      for (const button of sidebarButtons[role as keyof typeof sidebarButtons]) {
-        const tab = page.getByRole("menuitem", { name: button });
+
+      for (const buttonLabel of sidebarButtons[role as keyof typeof sidebarButtons]) {
+        const expectedPage = menuLabelToPage[buttonLabel];
+
+        if (!expectedPage) {
+          throw new Error(`No page mapping found for menu label: ${buttonLabel}`);
+        }
+
+        const tab = page.getByRole("menuitem", { name: buttonLabel });
         await expect(tab).toBeVisible();
+
         await tab.click();
+
+        // Verify URL contains the correct page query parameter
+        await expect(page).toHaveURL(new RegExp(`[?&]page=${expectedPage}(&|$)`));
       }
+    });
+
+    test("should navigate directly to page using navigation helper", async ({ page }) => {
+      // Test direct navigation to verify the helper function works
+      await navigateToPage(page, Page.ApiKeys);
+      await expect(page).toHaveURL(new RegExp(`[?&]page=${Page.ApiKeys}(&|$)`));
+
+      await navigateToPage(page, Page.Models);
+      await expect(page).toHaveURL(new RegExp(`[?&]page=${Page.Models}(&|$)`));
+
+      await navigateToPage(page, Page.LlmPlayground);
+      await expect(page).toHaveURL(new RegExp(`[?&]page=${Page.LlmPlayground}(&|$)`));
     });
   });
 }


### PR DESCRIPTION
## Relevant issues
This PR refactors the navigation tests and creates util functions to navigate to a certain page directly. This is to verify the user has landed on the correct page after they clicked a left nav menu item. The util functions will allow for other tests to visit a page directly, without clicking on the leftnav menu item.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure
✅ Test

## Changes
<img width="703" height="370" alt="image" src="https://github.com/user-attachments/assets/b6d4f60a-5f70-4477-92a4-5d3c4b206cea" />
