### PR TITLE
fix(azure): add logprobs support for Azure OpenAI GPT-5.2 model

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -25,7 +25,23 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         return "gpt-5" in model or "gpt5_series" in model
 
     def get_supported_openai_params(self, model: str) -> List[str]:
-        return OpenAIGPT5Config.get_supported_openai_params(self, model=model)
+        """Get supported parameters for Azure OpenAI GPT-5 models.
+
+        Azure OpenAI GPT-5 models support logprobs, unlike OpenAI's GPT-5.
+        This overrides the parent class to add logprobs support back.
+
+        Reference:
+        - Tested with Azure OpenAI GPT-5.2 (api-version: 2025-01-01-preview)
+        - Azure returns logprobs successfully despite Microsoft's general
+          documentation stating reasoning models don't support it.
+        """
+        params = OpenAIGPT5Config.get_supported_openai_params(self, model=model)
+
+        # Azure GPT-5 models support logprobs, add them back
+        azure_supported_params = ["logprobs", "top_logprobs"]
+        params.extend(azure_supported_params)
+
+        return params
 
     def map_openai_params(
         self,

--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -27,8 +27,8 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
     def get_supported_openai_params(self, model: str) -> List[str]:
         """Get supported parameters for Azure OpenAI GPT-5 models.
 
-        Azure OpenAI GPT-5 models support logprobs, unlike OpenAI's GPT-5.
-        This overrides the parent class to add logprobs support back.
+        Azure OpenAI GPT-5.2 models support logprobs, unlike OpenAI's GPT-5.
+        This overrides the parent class to add logprobs support back for gpt-5.2.
 
         Reference:
         - Tested with Azure OpenAI GPT-5.2 (api-version: 2025-01-01-preview)
@@ -37,9 +37,10 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         """
         params = OpenAIGPT5Config.get_supported_openai_params(self, model=model)
 
-        # Azure GPT-5 models support logprobs, add them back
-        azure_supported_params = ["logprobs", "top_logprobs"]
-        params.extend(azure_supported_params)
+        # Only gpt-5.2 has been verified to support logprobs on Azure
+        if self.is_model_gpt_5_2_model(model):
+            azure_supported_params = ["logprobs", "top_logprobs"]
+            params.extend(azure_supported_params)
 
         return params
 

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -205,11 +205,11 @@ def test_azure_gpt5_reasoning_effort_none_dropped(config: AzureOpenAIGPT5Config)
     assert "reasoning_effort" not in params or params.get("reasoning_effort") != "none"
 
 
-# Logprobs support tests for Azure GPT-5
-def test_azure_gpt5_supports_logprobs(config: AzureOpenAIGPT5Config):
-    """Test that Azure GPT-5 models support logprobs parameters.
+# Logprobs support tests for Azure GPT-5.2
+def test_azure_gpt5_2_supports_logprobs(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5.2 models support logprobs parameters.
 
-    Azure OpenAI GPT-5 models support logprobs, unlike OpenAI's GPT-5.
+    Only Azure OpenAI GPT-5.2 supports logprobs, unlike OpenAI's GPT-5 or Azure's gpt-5/gpt-5.1.
     Tested with gpt-5.2 on api-version 2025-01-01-preview.
     """
     supported_params = config.get_supported_openai_params(model="gpt-5.2")
@@ -217,22 +217,22 @@ def test_azure_gpt5_supports_logprobs(config: AzureOpenAIGPT5Config):
     assert "top_logprobs" in supported_params
 
 
-def test_azure_gpt5_2_supports_logprobs(config: AzureOpenAIGPT5Config):
-    """Test that Azure GPT-5.2 specifically supports logprobs parameters."""
+def test_azure_gpt5_2_with_prefix_supports_logprobs(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5.2 with azure/ prefix supports logprobs parameters."""
     supported_params = config.get_supported_openai_params(model="azure/gpt-5.2")
     assert "logprobs" in supported_params
     assert "top_logprobs" in supported_params
 
 
-def test_azure_gpt5_series_supports_logprobs(config: AzureOpenAIGPT5Config):
-    """Test that Azure GPT-5 with gpt5_series prefix supports logprobs."""
+def test_azure_gpt5_2_series_supports_logprobs(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5.2 with gpt5_series prefix supports logprobs."""
     supported_params = config.get_supported_openai_params(model="gpt5_series/gpt-5.2")
     assert "logprobs" in supported_params
     assert "top_logprobs" in supported_params
 
 
-def test_azure_gpt5_logprobs_params_passed_through(config: AzureOpenAIGPT5Config):
-    """Test that logprobs parameters are correctly passed through to the API."""
+def test_azure_gpt5_2_logprobs_params_passed_through(config: AzureOpenAIGPT5Config):
+    """Test that logprobs parameters are correctly passed through to the API for gpt-5.2."""
     params = config.map_openai_params(
         non_default_params={"logprobs": True, "top_logprobs": 5},
         optional_params={},
@@ -242,4 +242,24 @@ def test_azure_gpt5_logprobs_params_passed_through(config: AzureOpenAIGPT5Config
     )
     assert params["logprobs"] is True
     assert params["top_logprobs"] == 5
+
+
+def test_azure_gpt5_base_does_not_support_logprobs(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5 (non-5.2) does not support logprobs parameters.
+
+    Only gpt-5.2 has been verified to support logprobs on Azure.
+    """
+    supported_params = config.get_supported_openai_params(model="gpt-5")
+    assert "logprobs" not in supported_params
+    assert "top_logprobs" not in supported_params
+
+
+def test_azure_gpt5_1_does_not_support_logprobs(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5.1 does not support logprobs parameters.
+
+    Only gpt-5.2 has been verified to support logprobs on Azure.
+    """
+    supported_params = config.get_supported_openai_params(model="gpt-5.1")
+    assert "logprobs" not in supported_params
+    assert "top_logprobs" not in supported_params
 

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -204,3 +204,42 @@ def test_azure_gpt5_reasoning_effort_none_dropped(config: AzureOpenAIGPT5Config)
     )
     assert "reasoning_effort" not in params or params.get("reasoning_effort") != "none"
 
+
+# Logprobs support tests for Azure GPT-5
+def test_azure_gpt5_supports_logprobs(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5 models support logprobs parameters.
+
+    Azure OpenAI GPT-5 models support logprobs, unlike OpenAI's GPT-5.
+    Tested with gpt-5.2 on api-version 2025-01-01-preview.
+    """
+    supported_params = config.get_supported_openai_params(model="gpt-5.2")
+    assert "logprobs" in supported_params
+    assert "top_logprobs" in supported_params
+
+
+def test_azure_gpt5_2_supports_logprobs(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5.2 specifically supports logprobs parameters."""
+    supported_params = config.get_supported_openai_params(model="azure/gpt-5.2")
+    assert "logprobs" in supported_params
+    assert "top_logprobs" in supported_params
+
+
+def test_azure_gpt5_series_supports_logprobs(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5 with gpt5_series prefix supports logprobs."""
+    supported_params = config.get_supported_openai_params(model="gpt5_series/gpt-5.2")
+    assert "logprobs" in supported_params
+    assert "top_logprobs" in supported_params
+
+
+def test_azure_gpt5_logprobs_params_passed_through(config: AzureOpenAIGPT5Config):
+    """Test that logprobs parameters are correctly passed through to the API."""
+    params = config.map_openai_params(
+        non_default_params={"logprobs": True, "top_logprobs": 5},
+        optional_params={},
+        model="azure/gpt-5.2",
+        drop_params=False,
+        api_version="2025-01-01-preview",
+    )
+    assert params["logprobs"] is True
+    assert params["top_logprobs"] == 5
+


### PR DESCRIPTION
# Fix: Add logprobs support for Azure OpenAI GPT-5.2

## Problem

Azure OpenAI GPT-5.2 was unable to return `logprobs` when called through LiteLLM, even though direct Azure API calls successfully return logprobs data.

### Root Cause

The `AzureOpenAIGPT5Config` class inherited from `OpenAIGPT5Config` without overriding `get_supported_openai_params()`. This caused Azure GPT-5.2 to incorrectly exclude `logprobs` and `top_logprobs` from supported parameters, based on OpenAI's GPT-5 restrictions.

## Solution

Override `get_supported_openai_params()` in `AzureOpenAIGPT5Config` to explicitly add `logprobs` and `top_logprobs` back to the supported parameters list for **gpt-5.2 specifically**.

### Why Azure GPT-5.2 is Different

While OpenAI's GPT-5 reasoning models don't support logprobs, **Azure's GPT-5.2 implementation does**. This was verified through direct testing:

**Direct API Testing:**
```bash
curl "https://<azure-endpoint>/openai/deployments/gpt-5.2/chat/completions?api-version=2025-01-01-preview" \
  -H "api-key: $AZURE_OPENAI_API_KEY" \
  -d '{"messages": [{"role": "user", "content": "Test"}], "logprobs": true, "top_logprobs": 5}'
```
✅ Returns full logprobs data

### Important Note

**Only GPT-5.2 has been tested and verified.** This fix does NOT enable logprobs for:
- `gpt-5` (base model)
- `gpt-5.1`
- Other GPT-5 variants

These models retain the original behavior (no logprobs support) until they can be tested.

## Changes Made

### Code Changes

**File: `litellm/llms/azure/chat/gpt_5_transformation.py`**
- Overrode `get_supported_openai_params()` method
- Added conditional check: only enable logprobs if `is_model_gpt_5_2_model(model)` returns `True`
- Added detailed docstring explaining the gpt-5.2 specific behavior

### Test Changes

**File: `tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py`**

**Positive tests (gpt-5.2 support):**
- `test_azure_gpt5_2_supports_logprobs()` - Verifies gpt-5.2 supports logprobs
- `test_azure_gpt5_2_with_prefix_supports_logprobs()` - Tests azure/gpt-5.2 prefix
- `test_azure_gpt5_2_series_supports_logprobs()` - Tests gpt5_series/gpt-5.2 prefix
- `test_azure_gpt5_2_logprobs_params_passed_through()` - Verifies params pass through to API

**Negative tests (gpt-5/gpt-5.1 do NOT support):**
- `test_azure_gpt5_base_does_not_support_logprobs()` - Verifies gpt-5 does NOT have logprobs
- `test_azure_gpt5_1_does_not_support_logprobs()` - Verifies gpt-5.1 does NOT have logprobs

## Testing

### Unit Tests
```bash
pytest tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py -k logprobs
```

### Integration Test Results

**Before Fix:**
```python
response = litellm.completion(
    model="azure/gpt-5.2",
    messages=[{"role": "user", "content": "Hello"}],
    logprobs=True,
    top_logprobs=5
)
response.choices[0].logprobs  # None ❌
```

**After Fix:**
```python
response = litellm.completion(
    model="azure/gpt-5.2",
    messages=[{"role": "user", "content": "Hello"}],
    logprobs=True,
    top_logprobs=5
)
response.choices[0].logprobs  # Full logprobs data ✅
```

## Backwards Compatibility

✅ This change is fully backwards compatible:
- Only affects Azure GPT-5.2 specifically
- Does not change behavior for OpenAI GPT-5 models
- Does not change behavior for Azure gpt-5 or gpt-5.1
- Does not affect other model families
- Existing code without logprobs continues to work unchanged

## Documentation References

- Azure API Version: `2025-01-01-preview`
- Tested with: `gpt-5.2-2025-12-11`
- Related: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning

## Checklist

- [x] Code changes implemented
- [x] Unit tests added (positive and negative cases)
- [x] Integration testing completed with direct Azure API
- [x] Backwards compatibility verified
- [x] Documentation updated in code comments
- [x] Scoped to only verified model (gpt-5.2)

## Related Issues

Related: #7974, #4022