### PR TITLE
fix: prevent Prisma migration workflow from running in forks

### DIFF
--- a/.github/workflows/publish-migrations.yml
+++ b/.github/workflows/publish-migrations.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   publish-migrations:
+    if: github.repository == 'BerriAI/litellm'
     runs-on: ubuntu-latest
     services:
       postgres:


### PR DESCRIPTION
## Relevant issues

N/A - Workflow improvement to prevent unnecessary execution in forks

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] No tests needed (workflow configuration change only)

## Type

🚄 Infrastructure

## Changes

Added repository check to prevent the Prisma migration workflow from running in forked repositories.

**Summary:**
The `publish-migrations.yml` workflow currently runs on all forks when changes to `schema.prisma` are pushed to `main`. This causes workflow failures when trying to create PRs (forks lack write permissions), wastes GitHub Actions resources, and confuses external contributors.

**Solution:**
Added `if: github.repository == 'BerriAI/litellm'` condition to the workflow job to restrict execution to the upstream repository only.

**Modified files:**
- `.github/workflows/publish-migrations.yml` - Added repository check at line 16