### PR TITLE
feat: Add Cerebras zai-glm-4.7 model support and deprecate zai-glm-4.6

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6598,6 +6598,20 @@
         "supports_tool_choice": true
     },
     "cerebras/zai-glm-4.6": {
+        "deprecation_date": "2026-01-20",
+        "input_cost_per_token": 2.25e-06,
+        "litellm_provider": "cerebras",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-06,
+        "source": "https://www.cerebras.ai/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "cerebras/zai-glm-4.7": {
         "input_cost_per_token": 2.25e-06,
         "litellm_provider": "cerebras",
         "max_input_tokens": 128000,


### PR DESCRIPTION
## Relevant issues

N/A - Adding new model version announced by Cerebras on Jan 8, 2026

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

- Added `cerebras/zai-glm-4.7` model configuration with same specifications as 4.6:
  - 128K context window (input/output)
  - $2.25/M input tokens, $2.75/M output tokens
  - Supports function calling, reasoning, and tool choice
- Added `deprecation_date: 2026-01-20` to `cerebras/zai-glm-4.6` (deprecated per Cerebras announcement)
- Updated `model_prices_and_context_window.json`

**Note:** zai-glm-4.7 is the upgraded version of zai-glm-4.6 with enhanced coding performance, stronger reasoning capabilities, and improved role play/chat quality. According to Cerebras, it's now the top open-source model on AA's Intelligence Index.