### PR TITLE
fix(rate-limiter): correctly count tokens for /v1/responses endpoint …

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1627,11 +1627,7 @@ class Logging(LiteLLMLoggingBaseClass):
             setattr(
                 result,
                 "usage",
-                (
-                    transformed_usage.model_dump()
-                    if hasattr(transformed_usage, "model_dump")
-                    else dict(transformed_usage)
-                ),
+                transformed_usage,  # Keep as Usage object for unified handling in callbacks
             )
             if (
                 standard_logging_payload := self.model_call_details.get(
@@ -4815,7 +4811,9 @@ class StandardLoggingPayloadSetup:
         """
         Extract additional header tags for spend tracking based on config.
         """
-        extra_headers: List[str] = getattr(litellm, "extra_spend_tag_headers", None) or []
+        extra_headers: List[str] = (
+            getattr(litellm, "extra_spend_tag_headers", None) or []
+        )
         if not extra_headers:
             return None
 


### PR DESCRIPTION
## Relevant issues

Fixes #18671

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### Problem
The rate limiter's [_get_total_tokens_from_usage()](cci:1://file:///d:/OSS/litellm/litellm/proxy/hooks/parallel_request_limiter_v3.py:1237:4-1274:27) method incorrectly counts tokens for `/v1/responses` endpoint. Instead of counting actual tokens (e.g., 104), it only counted ~2 tokens.

<img width="455" height="438" alt="image" src="https://github.com/user-attachments/assets/642475f8-a5e7-4f81-910d-2d157f09436f" />


**Root Cause:** 
- [ResponsesAPIResponse](cci:2://file:///d:/OSS/litellm/litellm/types/llms/openai.py:1160:0-1230:29) uses [ResponseAPIUsage](cci:2://file:///d:/OSS/litellm/litellm/types/llms/openai.py:1129:0-1148:37) with `input_tokens`/`output_tokens` field names
- Rate limiter only checked for standard [Usage](cci:2://file:///d:/OSS/litellm/litellm/types/llms/openai.py:1129:0-1148:37) object with `prompt_tokens`/`completion_tokens`
- Dict fallback also used wrong field names

### Solution
Updated [_get_total_tokens_from_usage()](cci:1://file:///d:/OSS/litellm/litellm/proxy/hooks/parallel_request_limiter_v3.py:1237:4-1274:27) in [parallel_request_limiter_v3.py](cci:7://file:///d:/OSS/litellm/litellm/proxy/hooks/parallel_request_limiter_v3.py:0:0-0:0) to:
1. Add [ResponseAPIUsage](cci:2://file:///d:/OSS/litellm/litellm/types/llms/openai.py:1129:0-1148:37) type check with correct field names (`input_tokens`, `output_tokens`)
2. Update dict handling to check both standard AND Responses API field names for backward compatibility

<img width="537" height="399" alt="image" src="https://github.com/user-attachments/assets/78d5c35c-47f0-4dfd-b139-9dceb1130be8" />




### Testing
Added [test_async_log_success_event_with_responses_api_usage](cci:1://file:///d:/OSS/litellm/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py:1977:0-2062:118) test that verifies:
- `input` rate limit type → correctly extracts `input_tokens`
- [output](cci:1://file:///d:/OSS/litellm/litellm/types/llms/openai.py:1199:4-1230:29) rate limit type → correctly extracts `output_tokens`  
- [total](cci:1://file:///d:/OSS/litellm/litellm/proxy/hooks/parallel_request_limiter_v3.py:1237:4-1274:27) rate limit type → correctly extracts `total_tokens`