### PR TITLE
fix: sync Helm chart versioning with production standards and Docker versions

### DIFF
--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       tag:
         description: "The tag version you want to build"
+        required: true
       release_type:
         description: "The release type you want to build. Can be 'latest', 'stable', 'dev', 'rc'"
         type: string
@@ -354,24 +355,38 @@ jobs:
           version-fragment: 'bug'
 
       # Add suffix for non-stable releases (semantic versioning)
-      - name: Calculate chart version with prerelease suffix
+      - name: Calculate chart and app versions
         id: chart_version
         shell: bash
         run: |
           BASE_VERSION="${{ steps.bump_version.outputs.next-version || '1.0.0' }}"
           RELEASE_TYPE="${{ github.event.inputs.release_type }}"
+          INPUT_TAG="${{ github.event.inputs.tag }}"
+
+          # Chart version (independent Helm chart versioning with release type suffix)
           if [ "$RELEASE_TYPE" = "stable" ]; then
             echo "version=${BASE_VERSION}" | tee -a $GITHUB_OUTPUT
           else
             echo "version=${BASE_VERSION}-${RELEASE_TYPE}" | tee -a $GITHUB_OUTPUT
           fi
 
+          # App version (must match Docker tags that actually exist)
+          # stable/rc releases: Docker creates main-{tag}, so use the tag
+          # latest/dev releases: Docker only creates main-{release_type}, so use release_type
+          if [ "$RELEASE_TYPE" = "stable" ] || [ "$RELEASE_TYPE" = "rc" ]; then
+            APP_VERSION="${INPUT_TAG}"
+          else
+            APP_VERSION="${RELEASE_TYPE}"
+          fi
+
+          echo "app_version=${APP_VERSION}" | tee -a $GITHUB_OUTPUT
+
       - uses: ./.github/actions/helm-oci-chart-releaser
         with:
           name: ${{ env.CHART_NAME }}
           repository: ${{ env.REPO_OWNER }}
           tag: ${{ github.event.inputs.chartVersion || steps.chart_version.outputs.version || '1.0.0' }}
-          app_version: ${{ steps.current_app_tag.outputs.latest_tag }}
+          app_version: ${{ steps.chart_version.outputs.app_version }}
           path: deploy/charts/${{ env.CHART_NAME }}
           registry: ${{ env.REGISTRY }}
           registry_username: ${{ github.actor }}

--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -336,9 +336,9 @@ jobs:
         run: |
           CHART_LIST=$(helm show chart oci://${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ env.CHART_NAME }} 2>/dev/null || true)
           if [ -z "${CHART_LIST}" ]; then
-            echo "current-version=0.1.0" | tee -a $GITHUB_OUTPUT
+            echo "current-version=1.0.0" | tee -a $GITHUB_OUTPUT
           else
-            # Extract version and strip any prerelease suffix (e.g., 0.1.827-latest -> 0.1.827)
+            # Extract version and strip any prerelease suffix (e.g., 1.0.5-latest -> 1.0.5)
             VERSION=$(printf '%s' "${CHART_LIST}" | grep '^version:' | awk 'BEGIN{FS=":"}{print $2}' | tr -d " " | cut -d'-' -f1)
             echo "current-version=${VERSION}" | tee -a $GITHUB_OUTPUT
           fi
@@ -350,7 +350,7 @@ jobs:
         id: bump_version
         uses: christian-draeger/increment-semantic-version@1.1.0
         with:
-          current-version: ${{ steps.current_version.outputs.current-version || '0.1.0' }}
+          current-version: ${{ steps.current_version.outputs.current-version || '1.0.0' }}
           version-fragment: 'bug'
 
       # Add suffix for non-stable releases (semantic versioning)
@@ -358,7 +358,7 @@ jobs:
         id: chart_version
         shell: bash
         run: |
-          BASE_VERSION="${{ steps.bump_version.outputs.next-version || '0.1.0' }}"
+          BASE_VERSION="${{ steps.bump_version.outputs.next-version || '1.0.0' }}"
           RELEASE_TYPE="${{ github.event.inputs.release_type }}"
           if [ "$RELEASE_TYPE" = "stable" ]; then
             echo "version=${BASE_VERSION}" | tee -a $GITHUB_OUTPUT
@@ -370,7 +370,7 @@ jobs:
         with:
           name: ${{ env.CHART_NAME }}
           repository: ${{ env.REPO_OWNER }}
-          tag: ${{ github.event.inputs.chartVersion || steps.chart_version.outputs.version || '0.1.0' }}
+          tag: ${{ github.event.inputs.chartVersion || steps.chart_version.outputs.version || '1.0.0' }}
           app_version: ${{ steps.current_app_tag.outputs.latest_tag }}
           path: deploy/charts/${{ env.CHART_NAME }}
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -370,7 +370,7 @@ jobs:
             echo "version=${BASE_VERSION}-${RELEASE_TYPE}" | tee -a $GITHUB_OUTPUT
           fi
 
-          # App version (must match Docker tags that actually exist)
+          # App version (must match Docker tags)
           # stable/rc releases: Docker creates main-{tag}, so use the tag
           # latest/dev releases: Docker only creates main-{release_type}, so use release_type
           if [ "$RELEASE_TYPE" = "stable" ] || [ "$RELEASE_TYPE" = "rc" ]; then

--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.10
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v1.50.2
+appVersion: v1.80.12
 
 dependencies:
   - name: "postgresql"


### PR DESCRIPTION
## Relevant issues

Fixes the Helm chart version sync issue where chart versioning (0.4.10) was out of sync with Docker versioning (v1.80.12), and ensures future releases automatically sync appVersion with Docker tags.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - N/A: This is a configuration/metadata change only, no code logic changes
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - N/A: No code changes, only metadata and workflow files
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
  - Yes: Only fixes Helm chart versioning

## Type

🐛 Bug Fix

## Changes

### Summary
- Helm chart was using version `0.4.10`. Per [SemVer specification](https://semver.org/): "Major version zero (0.y.z) is for initial development. If your software is being used in production, it should probably already be 1.0.0."
- appVersion was `v1.50.2` (severely outdated, Docker is at v1.80.12)
- Workflow had no mechanism to sync appVersion with published Docker tags
- Workflow defaults were set to `0.1.0` (inconsistent with Chart.yaml)

    
### Solution

**Chart.yaml:**
- Updated `version` from `0.4.10` → `1.0.0` 
  - Follows [SemVer](https://semver.org/): 1.0+ means production-ready software
- Updated `appVersion` from `v1.50.2` → `v1.80.12`
  - Now matches current Docker image version

**Workflow (.github/workflows/ghcr_deploy.yml):**
- Updated chart version defaults from `0.1.0` → `1.0.0`
- **Added automatic appVersion sync**: Ensures chart appVersion matches published Docker tags
  - stable/rc releases: Uses workflow input tag (e.g., `v1.80.12`)
  - latest/dev releases: Uses release type to match `main-{type}` tags  
- Made `tag` parameter required to prevent accidental releases with wrong versions
- Maintains independent chart versioning per [Helm best practices](https://helm.sh/docs/chart_best_practices/conventions/)

### Benefits

- ✅ **Follows Helm best practices**: Chart version independent from app version per [Helm conventions](https://helm.sh/docs/chart_best_practices/conventions/)
- ✅ **Proper SemVer**: 1.x means production-ready software per [SemVer specification](https://semver.org/)
- ✅ **Automated sync**: appVersion automatically matches Docker tags on every release

### Next Steps

When the next release is triggered, Helm chart will publish as:
- Chart version: `1.0.0-latest` (or `1.0.1-latest` if 1.0.0 already exists)
- App version: Automatically synced with the Docker tag (e.g., `v1.80.13` for stable, `latest` for latest releases)