### PR TITLE
Add fix for bedrock_cache, metadata and max_model_budget

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -167,7 +167,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             self.token_increment_script = None
 
         self.window_size = int(os.getenv("LITELLM_RATE_LIMIT_WINDOW_SIZE", 60))
-        
+
         # Batch rate limiter (lazy loaded)
         self._batch_rate_limiter: Optional[Any] = None
 
@@ -1013,7 +1013,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             )
             # Fail safe: enforce limits if we can't check
             return True
-    
+
     def get_rate_limiter_for_call_type(self, call_type: str) -> Optional[Any]:
         """Get the rate limiter for the call type."""
         if call_type == "acreate_batch":
@@ -1095,9 +1095,9 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
 
                 now = self._get_current_time().timestamp()
                 reset_time = now + self.window_size
-                reset_time_formatted = datetime.fromtimestamp(
-                    reset_time
-                ).strftime("%Y-%m-%d %H:%M:%S UTC")
+                reset_time_formatted = datetime.fromtimestamp(reset_time).strftime(
+                    "%Y-%m-%d %H:%M:%S UTC"
+                )
 
                 remaining_display = max(0, status["limit_remaining"])
                 rate_limit_type = status["rate_limit_type"]
@@ -1137,7 +1137,9 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         # Check if the call type has a specific rate limiter
         # eg. for Batch APIs we need to use the batch rate limiter to read the input file and count the tokens and requests
         #########################################################
-        call_type_specific_rate_limiter = self.get_rate_limiter_for_call_type(call_type=call_type)
+        call_type_specific_rate_limiter = self.get_rate_limiter_for_call_type(
+            call_type=call_type
+        )
         if call_type_specific_rate_limiter:
             return await call_type_specific_rate_limiter.async_pre_call_hook(
                 user_api_key_dict=user_api_key_dict,
@@ -1233,26 +1235,58 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
 
         return pipeline_operations
 
-    def _get_total_tokens_from_usage(self, usage: Any | None, rate_limit_type: Literal["output", "input", "total"]) -> int:
-        # Get total tokens from response
+    def _get_total_tokens_from_usage(
+        self, usage: Any | None, rate_limit_type: Literal["output", "input", "total"]
+    ) -> int:
+        """
+        Get total tokens from response usage for rate limiting.
+
+        For 'input' and 'total' rate limit types, cached tokens are excluded
+        because providers like AWS Bedrock don't count cached tokens toward
+        rate limits. This aligns LiteLLM's TPM calculation with provider behavior.
+        """
         total_tokens = 0
-        # spot fix for /responses api
+        cached_tokens = 0
+
         if usage:
             if isinstance(usage, Usage):
                 if rate_limit_type == "output":
-                    total_tokens = usage.completion_tokens
+                    total_tokens = usage.completion_tokens or 0
                 elif rate_limit_type == "input":
-                    total_tokens = usage.prompt_tokens
+                    total_tokens = usage.prompt_tokens or 0
                 elif rate_limit_type == "total":
-                    total_tokens = usage.total_tokens
+                    total_tokens = usage.total_tokens or 0
+
+                # Get cached tokens to exclude from input/total
+                if rate_limit_type in ("input", "total"):
+                    if (
+                        hasattr(usage, "prompt_tokens_details")
+                        and usage.prompt_tokens_details is not None
+                    ):
+                        cached_tokens = (
+                            getattr(usage.prompt_tokens_details, "cached_tokens", 0)
+                            or 0
+                        )
+
             elif isinstance(usage, dict):
-                # Responses API usage comes as a dict in ResponsesAPIResponse
+                # Responses API usage comes as a dict
                 if rate_limit_type == "output":
-                    total_tokens = usage.get("completion_tokens", 0)
+                    total_tokens = usage.get("completion_tokens", 0) or 0
                 elif rate_limit_type == "input":
-                    total_tokens = usage.get("prompt_tokens", 0)
+                    total_tokens = usage.get("prompt_tokens", 0) or 0
                 elif rate_limit_type == "total":
-                    total_tokens = usage.get("total_tokens", 0)
+                    total_tokens = usage.get("total_tokens", 0) or 0
+
+                # Get cached tokens from dict
+                if rate_limit_type in ("input", "total"):
+                    prompt_details = usage.get("prompt_tokens_details") or {}
+                    if isinstance(prompt_details, dict):
+                        cached_tokens = prompt_details.get("cached_tokens", 0) or 0
+
+        # Subtract cached tokens for input/total (providers don't count them)
+        if cached_tokens > 0:
+            total_tokens = max(0, total_tokens - cached_tokens)
+
         return total_tokens
 
     async def _execute_token_increment_script(
@@ -1336,6 +1370,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
 
     def get_rate_limit_type(self) -> Literal["output", "input", "total"]:
         from litellm.proxy.proxy_server import general_settings
+
         specified_rate_limit_type = general_settings.get(
             "token_rate_limit_type", "total"
         )
@@ -1381,9 +1416,9 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             user_api_key_organization_id = standard_logging_metadata.get(
                 "user_api_key_org_id"
             )
-            user_api_key_end_user_id = kwargs.get("user") or standard_logging_metadata.get(
-                "user_api_key_end_user_id"
-            )
+            user_api_key_end_user_id = kwargs.get(
+                "user"
+            ) or standard_logging_metadata.get("user_api_key_end_user_id")
             model_group = get_model_group_from_litellm_kwargs(kwargs)
 
             # Get total tokens from response
@@ -1393,7 +1428,9 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                 response_obj, BaseLiteLLMOpenAIResponseObject
             ):
                 _usage = getattr(response_obj, "usage", None)
-                total_tokens = self._get_total_tokens_from_usage(usage=_usage, rate_limit_type=rate_limit_type)
+                total_tokens = self._get_total_tokens_from_usage(
+                    usage=_usage, rate_limit_type=rate_limit_type
+                )
 
             # Create pipeline operations for TPM increments
             pipeline_operations: List[RedisPipelineIncrementOperation] = []
@@ -1518,9 +1555,9 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         from litellm.types.caching import RedisPipelineIncrementOperation
 
         try:
-            litellm_parent_otel_span: Union[
-                Span, None
-            ] = _get_parent_otel_span_from_kwargs(kwargs)
+            litellm_parent_otel_span: Union[Span, None] = (
+                _get_parent_otel_span_from_kwargs(kwargs)
+            )
             # Get metadata from standard_logging_object - this correctly handles both
             # 'metadata' and 'litellm_metadata' fields from litellm_params
             standard_logging_object = kwargs.get("standard_logging_object") or {}
@@ -1554,7 +1591,6 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             verbose_proxy_logger.exception(
                 f"Error in rate limit failure event: {str(e)}"
             )
-
 
     async def async_post_call_success_hook(
         self, data: dict, user_api_key_dict: UserAPIKeyAuth, response

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -1,0 +1,131 @@
+"""
+Unit tests for auth_utils functions related to rate limiting.
+"""
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.auth_utils import (
+    get_key_model_rpm_limit,
+    get_key_model_tpm_limit,
+)
+
+
+class TestGetKeyModelRpmLimit:
+    """Tests for get_key_model_rpm_limit function."""
+
+    def test_returns_key_metadata_when_present(self):
+        """Key metadata takes priority over team metadata."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-123",
+            metadata={"model_rpm_limit": {"gpt-4": 100}},
+            team_metadata={"model_rpm_limit": {"gpt-4": 50}},
+        )
+        result = get_key_model_rpm_limit(user_api_key_dict)
+        assert result == {"gpt-4": 100}
+
+    def test_falls_back_to_team_metadata_when_key_has_other_metadata(self):
+        """Should fall back to team metadata when key metadata exists but has no model_rpm_limit."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-123",
+            metadata={
+                "some_other_key": "value"
+            },  # Has metadata, but not model_rpm_limit
+            team_metadata={"model_rpm_limit": {"gpt-4": 50}},
+        )
+        result = get_key_model_rpm_limit(user_api_key_dict)
+        assert result == {"gpt-4": 50}
+
+    def test_extracts_from_model_max_budget(self):
+        """Should extract rpm_limit from model_max_budget when metadata is empty."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-123",
+            model_max_budget={
+                "gpt-4": {"rpm_limit": 100, "tpm_limit": 1000},
+                "gpt-3.5-turbo": {"rpm_limit": 200},
+            },
+        )
+        result = get_key_model_rpm_limit(user_api_key_dict)
+        assert result == {"gpt-4": 100, "gpt-3.5-turbo": 200}
+
+    def test_skips_models_without_rpm_limit(self):
+        """Should skip models that don't have rpm_limit in model_max_budget."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-123",
+            model_max_budget={
+                "gpt-4": {"rpm_limit": 100},
+                "gpt-3.5-turbo": {"tpm_limit": 1000},  # No rpm_limit
+            },
+        )
+        result = get_key_model_rpm_limit(user_api_key_dict)
+        assert result == {"gpt-4": 100}
+
+    def test_returns_none_when_no_limits_configured(self):
+        """Should return None when no rate limits are configured."""
+        user_api_key_dict = UserAPIKeyAuth(api_key="sk-123")
+        result = get_key_model_rpm_limit(user_api_key_dict)
+        assert result is None
+
+
+class TestGetKeyModelTpmLimit:
+    """Tests for get_key_model_tpm_limit function."""
+
+    def test_returns_key_metadata_when_present(self):
+        """Key metadata takes priority over team metadata."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-123",
+            metadata={"model_tpm_limit": {"gpt-4": 10000}},
+            team_metadata={"model_tpm_limit": {"gpt-4": 5000}},
+        )
+        result = get_key_model_tpm_limit(user_api_key_dict)
+        assert result == {"gpt-4": 10000}
+
+    def test_falls_back_to_team_metadata_when_key_has_other_metadata(self):
+        """Should fall back to team metadata when key metadata exists but has no model_tpm_limit."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-123",
+            metadata={
+                "some_other_key": "value"
+            },  # Has metadata, but not model_tpm_limit
+            team_metadata={"model_tpm_limit": {"gpt-4": 5000}},
+        )
+        result = get_key_model_tpm_limit(user_api_key_dict)
+        assert result == {"gpt-4": 5000}
+
+    def test_extracts_from_model_max_budget(self):
+        """Should extract tpm_limit from model_max_budget when metadata is empty."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-123",
+            model_max_budget={
+                "gpt-4": {"tpm_limit": 10000, "rpm_limit": 100},
+                "gpt-3.5-turbo": {"tpm_limit": 20000},
+            },
+        )
+        result = get_key_model_tpm_limit(user_api_key_dict)
+        assert result == {"gpt-4": 10000, "gpt-3.5-turbo": 20000}
+
+    def test_skips_models_without_tpm_limit(self):
+        """Should skip models that don't have tpm_limit in model_max_budget."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-123",
+            model_max_budget={
+                "gpt-4": {"tpm_limit": 10000},
+                "gpt-3.5-turbo": {"rpm_limit": 100},  # No tpm_limit
+            },
+        )
+        result = get_key_model_tpm_limit(user_api_key_dict)
+        assert result == {"gpt-4": 10000}
+
+    def test_returns_none_when_no_limits_configured(self):
+        """Should return None when no rate limits are configured."""
+        user_api_key_dict = UserAPIKeyAuth(api_key="sk-123")
+        result = get_key_model_tpm_limit(user_api_key_dict)
+        assert result is None
+
+    def test_model_max_budget_priority_over_team(self):
+        """model_max_budget should take priority over team_metadata."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-123",
+            model_max_budget={"gpt-4": {"tpm_limit": 10000}},
+            team_metadata={"model_tpm_limit": {"gpt-4": 5000}},
+        )
+        result = get_key_model_tpm_limit(user_api_key_dict)
+        assert result == {"gpt-4": 10000}


### PR DESCRIPTION
## Relevant issues

Follow up PR to https://github.com/BerriAI/litellm/pull/18803

Fixes issues with TPM rate limiting:
1. Cache tokens (e.g., AWS Bedrock's `cacheReadInputTokens`) were incorrectly included in TPM calculation, causing up to 10x mismatch with provider rate limits
2. Fixes #17707 - Per-model TPM limits blocked when API key had any metadata (elif chain bug)
3. [model_max_budget](cci:1://file:///d:/OSS/litellm/tests/test_litellm/proxy/auth/test_auth_utils.py:36:4-46:61) TPM limits were completely ignored (incorrect lookup pattern)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

### 1. Exclude cached tokens from TPM calculation ([parallel_request_limiter_v3.py](cci:7://file:///d:/OSS/litellm/litellm/proxy/hooks/parallel_request_limiter_v3.py:0:0-0:0))

**Problem:** Providers like AWS Bedrock exclude cached tokens from their TPM rate limits, but LiteLLM was including them. This caused LiteLLM's TPM to be up to 10x higher than the provider's actual rate limit.

**Fix:** Modified [_get_total_tokens_from_usage()](cci:1://file:///d:/OSS/litellm/litellm/proxy/hooks/parallel_request_limiter_v3.py:1237:4-1289:27) to subtract `prompt_tokens_details.cached_tokens` from the total when calculating TPM for [input](cci:1://file:///d:/OSS/litellm/litellm/llms/openai/chat/guardrail_translation/handler.py:120:4-168:81) and [total](cci:1://file:///d:/OSS/litellm/litellm/proxy/hooks/parallel_request_limiter_v3.py:1237:4-1289:27) rate limit types.

### 2. Fix elif chain blocking team-level per-model limits ([auth_utils.py](cci:7://file:///d:/OSS/litellm/litellm/proxy/auth/auth_utils.py:0:0-0:0))

**Problem:** In [get_key_model_rpm_limit()](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/auth_utils.py:424:0-454:15) and [get_key_model_tpm_limit()](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/auth_utils.py:457:0-487:15), an `elif` chain prevented checking team metadata when the API key had any metadata (even unrelated metadata). This meant per-model limits set at the team level were ignored.

**Fix:** Changed `elif` to independent [if](cci:2://file:///d:/OSS/litellm/litellm/types/utils.py:3115:0-3117:23) checks with proper fallback order:
1. Key metadata (priority)
2. model_max_budget
3. Team metadata (fallback)

### 3. Fix model_max_budget TPM lookup ([auth_utils.py](cci:7://file:///d:/OSS/litellm/litellm/proxy/auth/auth_utils.py:0:0-0:0))

**Problem:** [get_key_model_tpm_limit()](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/auth_utils.py:457:0-487:15) was checking `model_max_budget["tpm_limit"]` directly instead of iterating per-model like [get_key_model_rpm_limit()](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/auth_utils.py:424:0-454:15) does. This caused model_max_budget TPM limits to be completely ignored.

**Fix:** Updated to iterate per-model: `for model, budget in model_max_budget.items()` and extract `budget["tpm_limit"]`.

### Tests Added

- **[tests/test_litellm/proxy/auth/test_auth_utils.py](cci:7://file:///d:/OSS/litellm/tests/test_litellm/proxy/auth/test_auth_utils.py:0:0-0:0)** (NEW): 11 unit tests covering [get_key_model_rpm_limit](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/auth_utils.py:424:0-454:15) and [get_key_model_tpm_limit](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/auth_utils.py:457:0-487:15) priority/fallback logic
- **[tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py](cci:7://file:///d:/OSS/litellm/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py:0:0-0:0)**: 6 new unit tests for [_get_total_tokens_from_usage](cci:1://file:///d:/OSS/litellm/litellm/proxy/hooks/parallel_request_limiter_v3.py:1237:4-1289:27) cache token exclusion