### PR TITLE
fix(redis): Fix redis env var parsing for redis-py v7.x+

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -25,7 +25,7 @@ from ._logging import verbose_logger
 
 
 def _get_redis_kwargs():
-    arg_spec = inspect.getfullargspec(redis.Redis)
+    sig = inspect.signature(redis.Redis)
 
     # Only allow primitive arguments
     exclude_args = {
@@ -36,7 +36,7 @@ def _get_redis_kwargs():
 
     include_args = ["url", "redis_connect_func", "gcp_service_account", "gcp_ssl_ca_certs"]
 
-    available_args = [x for x in arg_spec.args if x not in exclude_args] + include_args
+    available_args = [x for x in sig.parameters.keys() if x not in exclude_args] + include_args
 
     return available_args
 
@@ -44,7 +44,7 @@ def _get_redis_kwargs():
 def _get_redis_url_kwargs(client=None):
     if client is None:
         client = redis.Redis.from_url
-    arg_spec = inspect.getfullargspec(redis.Redis.from_url)
+    sig = inspect.signature(redis.Redis.from_url)
 
     # Only allow primitive arguments
     exclude_args = {
@@ -55,7 +55,7 @@ def _get_redis_url_kwargs(client=None):
 
     include_args = ["url"]
 
-    available_args = [x for x in arg_spec.args if x not in exclude_args] + include_args
+    available_args = [x for x in sig.parameters.keys() if x not in exclude_args] + include_args
 
     return available_args
 
@@ -63,12 +63,12 @@ def _get_redis_url_kwargs(client=None):
 def _get_redis_cluster_kwargs(client=None):
     if client is None:
         client = redis.Redis.from_url
-    arg_spec = inspect.getfullargspec(redis.RedisCluster)
+    sig = inspect.signature(redis.RedisCluster)
 
     # Only allow primitive arguments
     exclude_args = {"self", "connection_pool", "retry", "host", "port", "startup_nodes"}
 
-    available_args = [x for x in arg_spec.args if x not in exclude_args]
+    available_args = [x for x in sig.parameters.keys() if x not in exclude_args]
     available_args.append("password")
     available_args.append("username")
     available_args.append("ssl")

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2692,7 +2692,7 @@ class ProxyConfig:
         router_settings = config.get("router_settings", None)
 
         if router_settings and isinstance(router_settings, dict):
-            arg_spec = inspect.getfullargspec(litellm.Router)
+            sig = inspect.signature(litellm.Router)
             # model list and search_tools already set
             exclude_args = {
                 "self",
@@ -2700,7 +2700,7 @@ class ProxyConfig:
                 "search_tools",
             }
 
-            available_args = [x for x in arg_spec.args if x not in exclude_args]
+            available_args = [x for x in sig.parameters.keys() if x not in exclude_args]
 
             for k, v in router_settings.items():
                 if k in available_args:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -431,7 +431,7 @@ class ProxyLogging:
             proxy_hook = get_proxy_hook(hook)
             import inspect
 
-            expected_args = inspect.getfullargspec(proxy_hook).args
+            expected_args = list(inspect.signature(proxy_hook).parameters.keys())
             passed_in_args: Dict[str, Any] = {}
             if "internal_usage_cache" in expected_args:
                 passed_in_args["internal_usage_cache"] = self.internal_usage_cache

--- a/tests/documentation_tests/test_router_settings.py
+++ b/tests/documentation_tests/test_router_settings.py
@@ -26,10 +26,10 @@ def get_init_params(cls: Type) -> list[str]:
         )
 
     init_method = cls.__init__
-    argspec = inspect.getfullargspec(init_method)
+    sig = inspect.signature(init_method)
 
     # The first argument is usually 'self', so we exclude it
-    return argspec.args[1:]  # Exclude 'self'
+    return [x for x in sig.parameters.keys() if x != 'self']
 
 
 router_init_params = set(get_init_params(litellm.router.Router))

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -1,8 +1,16 @@
-from litellm._redis import get_redis_url_from_environment, _get_redis_cluster_kwargs, get_redis_async_client
+from litellm._redis import (
+    get_redis_url_from_environment,
+    _get_redis_kwargs,
+    _get_redis_url_kwargs,
+    _get_redis_cluster_kwargs,
+    get_redis_async_client,
+)
 import os
 import pytest
 from unittest.mock import MagicMock, patch
 import redis.asyncio as async_redis
+import inspect
+from functools import wraps
 
 def test_get_redis_url_from_environment_single_url(monkeypatch):
     """Test when REDIS_URL is directly provided"""
@@ -120,10 +128,246 @@ def test_get_redis_url_from_environment_missing_port(monkeypatch):
     # Check the error message
     assert "Either 'REDIS_URL' or both 'REDIS_HOST' and 'REDIS_PORT' must be specified" in str(excinfo.value)
 
+# Tests for signature introspection functions
+def test_get_redis_kwargs_returns_list():
+    """Test that _get_redis_kwargs returns a list of parameter names"""
+    kwargs = _get_redis_kwargs()
+    assert isinstance(kwargs, list), "_get_redis_kwargs should return a list"
+    assert len(kwargs) > 0, "_get_redis_kwargs should return non-empty list"
+
+def test_get_redis_kwargs_excludes_args():
+    """Test that _get_redis_kwargs excludes specific arguments"""
+    kwargs = _get_redis_kwargs()
+    # These should be excluded
+    assert "self" not in kwargs, "'self' should be excluded from Redis kwargs"
+    assert "connection_pool" not in kwargs, "'connection_pool' should be excluded from Redis kwargs"
+    assert "retry" not in kwargs, "'retry' should be excluded from Redis kwargs"
+
+def test_get_redis_kwargs_includes_custom_args():
+    """Test that _get_redis_kwargs includes custom arguments"""
+    kwargs = _get_redis_kwargs()
+    # These should be explicitly included
+    assert "url" in kwargs, "'url' should be in Redis kwargs"
+    assert "redis_connect_func" in kwargs, "'redis_connect_func' should be in Redis kwargs"
+    assert "gcp_service_account" in kwargs, "'gcp_service_account' should be in Redis kwargs"
+    assert "gcp_ssl_ca_certs" in kwargs, "'gcp_ssl_ca_certs' should be in Redis kwargs"
+
+def test_get_redis_url_kwargs_returns_list():
+    """Test that _get_redis_url_kwargs returns a list of parameter names"""
+    kwargs = _get_redis_url_kwargs()
+    assert isinstance(kwargs, list), "_get_redis_url_kwargs should return a list"
+    assert len(kwargs) > 0, "_get_redis_url_kwargs should return non-empty list"
+
+def test_get_redis_url_kwargs_excludes_args():
+    """Test that _get_redis_url_kwargs excludes specific arguments"""
+    kwargs = _get_redis_url_kwargs()
+    # These should be excluded
+    assert "self" not in kwargs, "'self' should be excluded from Redis URL kwargs"
+    assert "connection_pool" not in kwargs, "'connection_pool' should be excluded from Redis URL kwargs"
+    assert "retry" not in kwargs, "'retry' should be excluded from Redis URL kwargs"
+
+def test_get_redis_url_kwargs_includes_url():
+    """Test that _get_redis_url_kwargs includes 'url' argument"""
+    kwargs = _get_redis_url_kwargs()
+    assert "url" in kwargs, "'url' should be in Redis URL kwargs"
+
+def test_get_redis_cluster_kwargs_returns_list():
+    """Test that _get_redis_cluster_kwargs returns a list of parameter names"""
+    kwargs = _get_redis_cluster_kwargs()
+    assert isinstance(kwargs, list), "_get_redis_cluster_kwargs should return a list"
+    assert len(kwargs) > 0, "_get_redis_cluster_kwargs should return non-empty list"
+
+def test_get_redis_cluster_kwargs_excludes_args():
+    """Test that _get_redis_cluster_kwargs excludes specific arguments"""
+    kwargs = _get_redis_cluster_kwargs()
+    # These should be excluded
+    assert "self" not in kwargs, "'self' should be excluded from Redis cluster kwargs"
+    assert "connection_pool" not in kwargs, "'connection_pool' should be excluded from Redis cluster kwargs"
+    assert "retry" not in kwargs, "'retry' should be excluded from Redis cluster kwargs"
+    assert "host" not in kwargs, "'host' should be excluded from Redis cluster kwargs"
+    assert "port" not in kwargs, "'port' should be excluded from Redis cluster kwargs"
+    assert "startup_nodes" not in kwargs, "'startup_nodes' should be excluded from Redis cluster kwargs"
+
+def test_get_redis_cluster_kwargs_includes_custom_args():
+    """Test that _get_redis_cluster_kwargs includes all custom arguments"""
+    kwargs = _get_redis_cluster_kwargs()
+    # These should be explicitly included
+    required_args = [
+        "password",
+        "username",
+        "ssl",
+        "ssl_cert_reqs",
+        "ssl_check_hostname",
+        "ssl_ca_certs",
+        "redis_connect_func",
+        "gcp_service_account",
+        "gcp_ssl_ca_certs",
+        "max_connections"
+    ]
+    for arg in required_args:
+        assert arg in kwargs, f"'{arg}' should be in Redis cluster kwargs"
+
 def test_max_connections_in_cluster_kwargs():
     """Test that max_connections is included in Redis cluster kwargs"""
     kwargs = _get_redis_cluster_kwargs()
     assert "max_connections" in kwargs, "max_connections should be in available Redis cluster kwargs"
+
+def test_signature_vs_getfullargspec_with_redis_decorator():
+    """
+    Regression test for Redis 7.1+ compatibility.
+
+    Redis-py 7.1 introduced a @deprecated_args decorator on Redis.__init__ that wraps
+    the method. Even though it uses functools.wraps, inspect.getfullargspec() cannot
+    properly introspect through the wrapper and returns an empty args list, while
+    inspect.signature() correctly unwraps and returns all parameters.
+
+    This test replicates the exact decorator pattern to document why we migrated
+    from getfullargspec() to signature().
+    """
+    from functools import wraps
+    from typing import Callable, TypeVar
+
+    C = TypeVar("C", bound=Callable)
+
+    # Replicate redis-py's @deprecated_args decorator pattern
+    def deprecated_args(args_to_warn=None, reason="", version=""):
+        def decorator(func: C) -> C:
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+            return wrapper
+        return decorator
+
+    # Create a mock Redis class with the decorator (like redis-py 7.1+)
+    class MockRedisWithDecorator:
+        @deprecated_args(args_to_warn=["retry_on_timeout"], version="6.0.0")
+        def __init__(self, host='localhost', port=6379, db=0, password=None):
+            self.host = host
+            self.port = port
+
+    # Test getfullargspec - it fails to see through the wrapper
+    spec = inspect.getfullargspec(MockRedisWithDecorator.__init__)
+    getfullargspec_args = spec.args
+
+    # Test signature - it properly unwraps and sees the real parameters
+    sig = inspect.signature(MockRedisWithDecorator.__init__)
+    signature_params = list(sig.parameters.keys())
+
+    # Document the issue: getfullargspec sees only the wrapper's (*args, **kwargs)
+    # which results in 0 named args, while signature sees the original 5 parameters
+    assert len(getfullargspec_args) == 0, "getfullargspec incorrectly returns 0 args for decorated function"
+    assert len(signature_params) == 5, "signature correctly returns 5 parameters"
+    assert 'self' in signature_params, "signature finds 'self' parameter"
+    assert 'host' in signature_params, "signature finds 'host' parameter"
+    assert 'port' in signature_params, "signature finds 'port' parameter"
+    assert 'host' not in getfullargspec_args, "getfullargspec fails to find 'host' parameter"
+
+    # This is why we use signature() instead of getfullargspec() in:
+    # - _get_redis_kwargs()
+    # - _get_redis_url_kwargs()
+    # - _get_redis_cluster_kwargs()
+
+def test_get_redis_kwargs_works_with_actual_redis_class():
+    """
+    Integration test: Verify _get_redis_kwargs() works with real redis.Redis class.
+
+    This catches regressions when redis-py library updates add decorators or
+    change class structure that might break our introspection.
+    """
+    import redis
+
+    # Get kwargs from the actual Redis class
+    kwargs = _get_redis_kwargs()
+
+    # Critical: Should NOT be empty
+    assert len(kwargs) > 0, (
+        "CRITICAL: _get_redis_kwargs() returned empty list! "
+        "This likely means redis-py updated their decorators/class structure. "
+        f"Redis version: {redis.__version__}"
+    )
+
+    # Should have at least these common Redis parameters
+    expected_params = ['host', 'port', 'db', 'password']
+    for param in expected_params:
+        assert param in kwargs, (
+            f"Expected parameter '{param}' missing from Redis kwargs. "
+            f"Redis version: {redis.__version__}. "
+            "This may indicate redis-py structural changes."
+        )
+
+    # Excluded params should NOT be present
+    excluded_params = ['self', 'connection_pool', 'retry']
+    for param in excluded_params:
+        assert param not in kwargs, (
+            f"Parameter '{param}' should be excluded but was found in kwargs"
+        )
+
+def test_get_redis_url_kwargs_works_with_actual_redis_class():
+    """
+    Integration test: Verify _get_redis_url_kwargs() works with real redis.Redis.from_url.
+
+    This catches regressions when redis-py library updates might break our introspection.
+    """
+    import redis
+
+    # Get kwargs from the actual Redis.from_url method
+    kwargs = _get_redis_url_kwargs()
+
+    # Critical: Should NOT be empty
+    assert len(kwargs) > 0, (
+        "CRITICAL: _get_redis_url_kwargs() returned empty list! "
+        "This likely means redis-py updated their decorators/class structure. "
+        f"Redis version: {redis.__version__}"
+    )
+
+    # Should definitely include 'url' parameter
+    assert 'url' in kwargs, (
+        "'url' parameter missing from Redis.from_url kwargs. "
+        f"Redis version: {redis.__version__}"
+    )
+
+    # Excluded params should NOT be present
+    excluded_params = ['self', 'connection_pool', 'retry']
+    for param in excluded_params:
+        assert param not in kwargs, (
+            f"Parameter '{param}' should be excluded but was found in kwargs"
+        )
+
+def test_get_redis_cluster_kwargs_works_with_actual_redis_class():
+    """
+    Integration test: Verify _get_redis_cluster_kwargs() works with real redis.RedisCluster.
+
+    This catches regressions when redis-py library updates might break our introspection.
+    """
+    import redis
+
+    # Get kwargs from the actual RedisCluster class
+    kwargs = _get_redis_cluster_kwargs()
+
+    # Critical: Should NOT be empty
+    assert len(kwargs) > 0, (
+        "CRITICAL: _get_redis_cluster_kwargs() returned empty list! "
+        "This likely means redis-py updated their decorators/class structure. "
+        f"Redis version: {redis.__version__}"
+    )
+
+    # Should have these cluster-specific parameters we explicitly add
+    expected_custom_params = [
+        'max_connections', 'password', 'username', 'ssl',
+        'ssl_cert_reqs', 'ssl_check_hostname', 'ssl_ca_certs'
+    ]
+    for param in expected_custom_params:
+        assert param in kwargs, (
+            f"Expected parameter '{param}' missing from RedisCluster kwargs. "
+            f"Redis version: {redis.__version__}"
+        )
+
+    # Excluded params should NOT be present
+    excluded_params = ['self', 'connection_pool', 'retry', 'host', 'port', 'startup_nodes']
+    for param in excluded_params:
+        assert param not in kwargs, (
+            f"Parameter '{param}' should be excluded but was found in kwargs"
+        )
 
 def test_get_redis_async_client_with_connection_pool():
     """Test that connection_pool parameter is properly passed to Redis client"""


### PR DESCRIPTION
Fixes redis arguments loading from environment when redis client is bumped to 7.1.0 due to inspect fullargspec not handling decorators properly.
The fix is generic for any other place that may run into the same problem.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link:

- [x] **CI run for the last commit**  
       Link:

- [x] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes
inspect.fullargspec does not handle all scenarios and in case of wrapped functions returns empty. Python community suggests moving to the newer inspect.signature