### PR TITLE
[Fix] UI Login Case Sensitivity 

### DIFF
--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -188,7 +188,7 @@ async def authenticate_user(  # noqa: PLR0915
         _user_row = cast(
             Optional[LiteLLM_UserTable],
             await prisma_client.db.litellm_usertable.find_first(
-                where={"user_email": {"equals": username}}
+                where={"user_email": {"equals": username, "mode": "insensitive"}}
             ),
         )
 


### PR DESCRIPTION
## Relevant issues
This PR fixes the /v2/login route to be case insensitive for emails passed in via POST body. Now emails such as `testInternalUser@test.com` and `testinternaluser@test.com` maps to the same user. This behavior is consistent with /user/new where it checks for the existence of an existing email with case insensitivity 
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53772

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/53773

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="906" height="74" alt="image" src="https://github.com/user-attachments/assets/fe855946-181b-41d2-9ec4-ea028d9e2b54" />
