### PR TITLE
[Infra] Router Fields Endpoint + React Query for Router Fields

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_router_settings_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_router_settings_endpoints.py
@@ -1,0 +1,71 @@
+"""
+Tests for router settings management endpoints.
+
+Tests the GET endpoints for router settings and router fields.
+"""
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)
+
+from litellm.proxy.proxy_server import app
+
+client = TestClient(app)
+
+
+class TestRouterSettingsEndpoints:
+    """Test suite for router settings endpoints"""
+
+    @pytest.mark.asyncio
+    async def test_get_router_fields_success(self):
+        """
+        Test GET /router/fields endpoint successfully returns field definitions without values.
+        """
+        # Make request to router fields endpoint
+        response = client.get(
+            "/router/fields",
+            headers={"Authorization": "Bearer sk-1234"}
+        )
+
+        # Verify response
+        assert response.status_code == 200
+        
+        response_data = response.json()
+        
+        # Verify response structure
+        assert "fields" in response_data
+        assert "routing_strategy_descriptions" in response_data
+        
+        # Verify fields is a list
+        assert isinstance(response_data["fields"], list)
+        assert len(response_data["fields"]) > 0
+        
+        # Verify each field has required properties and field_value is None
+        for field in response_data["fields"]:
+            assert "field_name" in field
+            assert "field_type" in field
+            assert "field_description" in field
+            assert "field_default" in field
+            assert "ui_field_name" in field
+            assert "field_value" in field
+            assert field["field_value"] is None  # Ensure field_value is None
+        
+        # Verify routing_strategy_descriptions is a dict
+        assert isinstance(response_data["routing_strategy_descriptions"], dict)
+        assert len(response_data["routing_strategy_descriptions"]) > 0
+        
+        # Verify routing_strategy field has options populated
+        routing_strategy_field = next(
+            (f for f in response_data["fields"] if f["field_name"] == "routing_strategy"),
+            None
+        )
+        assert routing_strategy_field is not None
+        assert "options" in routing_strategy_field
+        assert isinstance(routing_strategy_field["options"], list)
+        assert len(routing_strategy_field["options"]) > 0

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/router/useRouterFields.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/router/useRouterFields.test.ts
@@ -1,0 +1,387 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React, { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useRouterFields, RouterFieldsResponse, RouterSettingsField } from "./useRouterFields";
+
+// Mock the networking module
+vi.mock("@/components/networking", () => ({
+  proxyBaseUrl: null,
+}));
+
+// Mock useAuthorized hook
+const mockUseAuthorized = vi.fn();
+vi.mock("../useAuthorized", () => ({
+  default: () => mockUseAuthorized(),
+}));
+
+// Mock global fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock console methods to avoid noise in tests
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+// Mock data
+const mockRouterFieldsResponse: RouterFieldsResponse = {
+  fields: [
+    {
+      field_name: "routing_strategy",
+      field_type: "String",
+      field_description: "Routing strategy to use for load balancing across deployments",
+      field_default: "simple-shuffle",
+      options: ["simple-shuffle", "least-busy", "latency-based-routing"],
+      ui_field_name: "Routing Strategy",
+      link: null,
+    },
+    {
+      field_name: "num_retries",
+      field_type: "Integer",
+      field_description: "Number of retries for failed requests",
+      field_default: 0,
+      options: null,
+      ui_field_name: "Number of Retries",
+      link: null,
+    },
+  ],
+  routing_strategy_descriptions: {
+    "simple-shuffle": "Randomly picks a deployment from the list. Simple and fast.",
+    "least-busy": "Routes to the deployment with the lowest number of ongoing requests.",
+    "latency-based-routing": "Routes to the deployment with the lowest latency over a sliding window.",
+  },
+};
+
+describe("useRouterFields", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    // Reset all mocks
+    vi.clearAllMocks();
+
+    // Set default mock for useAuthorized (enabled state)
+    mockUseAuthorized.mockReturnValue({
+      accessToken: "test-access-token",
+      userRole: "Admin",
+      userId: "test-user-id",
+      token: "test-token",
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it("should render", () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockRouterFieldsResponse,
+    });
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    expect(result.current).toBeDefined();
+  });
+
+  it("should return router fields data when query is successful", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockRouterFieldsResponse,
+    });
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    // Initially loading
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+
+    // Wait for success
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockRouterFieldsResponse);
+    expect(result.current.error).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/router/fields", {
+      method: "GET",
+      headers: {
+        Authorization: "Bearer test-access-token",
+        "Content-Type": "application/json",
+      },
+    });
+  });
+
+  it("should handle error when fetch fails", async () => {
+    const errorMessage = "Failed to fetch router fields";
+    const errorResponse = { error: errorMessage };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => errorResponse,
+    });
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    // Initially loading
+    expect(result.current.isLoading).toBe(true);
+
+    // Wait for error
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.data).toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not execute query when accessToken is missing", () => {
+    mockUseAuthorized.mockReturnValue({
+      accessToken: null,
+      userRole: "Admin",
+      userId: "test-user-id",
+      token: null,
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    // Query should not execute
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetched).toBe(false);
+
+    // API should not be called
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("should not execute query when userId is missing", () => {
+    mockUseAuthorized.mockReturnValue({
+      accessToken: "test-access-token",
+      userRole: "Admin",
+      userId: null,
+      token: "test-token",
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    // Query should not execute
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetched).toBe(false);
+
+    // API should not be called
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("should not execute query when userRole is missing", () => {
+    mockUseAuthorized.mockReturnValue({
+      accessToken: "test-access-token",
+      userRole: null,
+      userId: "test-user-id",
+      token: "test-token",
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    // Query should not execute
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetched).toBe(false);
+
+    // API should not be called
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("should handle network error", async () => {
+    const networkError = new Error("Network error");
+    mockFetch.mockRejectedValueOnce(networkError);
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    // Wait for error
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should use relative URL when proxyBaseUrl is null", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockRouterFieldsResponse,
+    });
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // When proxyBaseUrl is null, should use relative URL
+    expect(mockFetch).toHaveBeenCalledWith("/router/fields", {
+      method: "GET",
+      headers: {
+        Authorization: "Bearer test-access-token",
+        "Content-Type": "application/json",
+      },
+    });
+  });
+
+  it("should handle error response with different error formats", async () => {
+    const errorFormats = [
+      { error: { message: "Error message" } },
+      { message: "Error message" },
+      { detail: "Error detail" },
+      { error: "Error string" },
+      { unknown: "format" },
+    ];
+
+    for (const errorFormat of errorFormats) {
+      vi.clearAllMocks();
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: async () => errorFormat,
+      });
+
+      const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBeDefined();
+    }
+  });
+
+  it("should return empty fields array when API returns empty fields", async () => {
+    const emptyResponse: RouterFieldsResponse = {
+      fields: [],
+      routing_strategy_descriptions: {},
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => emptyResponse,
+    });
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.fields).toEqual([]);
+    expect(result.current.data?.routing_strategy_descriptions).toEqual({});
+  });
+
+  it("should have correct query configuration", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockRouterFieldsResponse,
+    });
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // Verify the query was called
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // The hook should have the expected properties from useQuery
+    expect(result.current).toHaveProperty("data");
+    expect(result.current).toHaveProperty("isLoading");
+    expect(result.current).toHaveProperty("isError");
+    expect(result.current).toHaveProperty("isSuccess");
+    expect(result.current).toHaveProperty("error");
+  });
+
+  it("should handle fields with null options", async () => {
+    const responseWithNullOptions: RouterFieldsResponse = {
+      fields: [
+        {
+          field_name: "timeout",
+          field_type: "Float",
+          field_description: "Timeout for requests in seconds",
+          field_default: null,
+          options: null,
+          ui_field_name: "Timeout",
+          link: null,
+        },
+      ],
+      routing_strategy_descriptions: {},
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => responseWithNullOptions,
+    });
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.fields[0].options).toBeNull();
+  });
+
+  it("should handle fields with link property", async () => {
+    const responseWithLink: RouterFieldsResponse = {
+      fields: [
+        {
+          field_name: "enable_tag_filtering",
+          field_type: "Boolean",
+          field_description: "Enable tag-based routing",
+          field_default: false,
+          options: null,
+          ui_field_name: "Enable Tag Filtering",
+          link: "https://docs.litellm.ai/docs/proxy/tag_routing",
+        },
+      ],
+      routing_strategy_descriptions: {},
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => responseWithLink,
+    });
+
+    const { result } = renderHook(() => useRouterFields(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.fields[0].link).toBe("https://docs.litellm.ai/docs/proxy/tag_routing");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/router/useRouterFields.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/router/useRouterFields.test.ts
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import React, { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useRouterFields, RouterFieldsResponse, RouterSettingsField } from "./useRouterFields";
+import { RouterFieldsResponse, useRouterFields } from "./useRouterFields";
 
 // Mock the networking module
 vi.mock("@/components/networking", () => ({

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/router/useRouterFields.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/router/useRouterFields.ts
@@ -1,0 +1,69 @@
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { createQueryKeys } from "../common/queryKeysFactory";
+import { proxyBaseUrl } from "@/components/networking";
+
+export interface RouterSettingsField {
+  field_name: string;
+  field_type: string;
+  field_description: string;
+  field_default: any;
+  options: string[] | null;
+  ui_field_name: string;
+  link: string | null;
+}
+
+export interface RouterFieldsResponse {
+  fields: RouterSettingsField[];
+  routing_strategy_descriptions: Record<string, string>;
+}
+
+const routerFieldsKeys = createQueryKeys("routerFields");
+
+const deriveErrorMessage = (errorData: any): string => {
+  return (
+    (errorData?.error && (errorData.error.message || errorData.error)) ||
+    errorData?.message ||
+    errorData?.detail ||
+    errorData?.error ||
+    JSON.stringify(errorData)
+  );
+};
+
+const getRouterFields = async (accessToken: string): Promise<RouterFieldsResponse> => {
+  try {
+    const url = proxyBaseUrl ? `${proxyBaseUrl}/router/fields` : `/router/fields`;
+
+    console.log("Fetching router fields from:", url);
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      throw new Error(errorMessage);
+    }
+
+    const data: RouterFieldsResponse = await response.json();
+    console.log("Fetched router fields:", data);
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch router fields:", error);
+    throw error;
+  }
+};
+
+export const useRouterFields = (): UseQueryResult<RouterFieldsResponse> => {
+  const { accessToken, userId, userRole } = useAuthorized();
+  return useQuery<RouterFieldsResponse>({
+    queryKey: routerFieldsKeys.detail("fields"),
+    queryFn: async () => await getRouterFields(accessToken!),
+    enabled: Boolean(accessToken && userId && userRole),
+  });
+};


### PR DESCRIPTION
## Relevant issues
This our architecture for getting router fields depends on the backend and the router/settings endpoint returns the set values, I am introducing a new endpoint that only returns the router fields. This will allow the new key and team router settings to have the same options as the global router settings the user can set inside of Settings in the UI.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure
✅ Test

## Changes
<img width="902" height="158" alt="image" src="https://github.com/user-attachments/assets/24b26f3d-19da-45dc-ae9f-e63400a4cfdf" />
<img width="814" height="343" alt="image" src="https://github.com/user-attachments/assets/ec375063-8080-47b5-a7a5-ba78bc1e6848" />
