### PR TITLE
fix(model_prices): sync DeepSeek chat/reasoner to V3.2 pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -7795,14 +7795,14 @@
         "supports_vision": true
     },
     "deepseek-chat": {
-        "cache_read_input_token_cost": 6e-08,
-        "input_cost_per_token": 6e-07,
+        "cache_read_input_token_cost": 2.8e-08,
+        "input_cost_per_token": 2.8e-07,
         "litellm_provider": "deepseek",
         "max_input_tokens": 131072,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 1.7e-06,
+        "output_cost_per_token": 4.2e-07,
         "source": "https://api-docs.deepseek.com/quick_start/pricing",
         "supported_endpoints": [
             "/v1/chat/completions"
@@ -7816,14 +7816,14 @@
         "supports_tool_choice": true
     },
     "deepseek-reasoner": {
-        "cache_read_input_token_cost": 6e-08,
-        "input_cost_per_token": 6e-07,
+        "cache_read_input_token_cost": 2.8e-08,
+        "input_cost_per_token": 2.8e-07,
         "litellm_provider": "deepseek",
         "max_input_tokens": 131072,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
-        "output_cost_per_token": 1.7e-06,
+        "output_cost_per_token": 4.2e-07,
         "source": "https://api-docs.deepseek.com/quick_start/pricing",
         "supported_endpoints": [
             "/v1/chat/completions"
@@ -10027,15 +10027,15 @@
     },
     "deepseek/deepseek-chat": {
         "cache_creation_input_token_cost": 0.0,
-        "cache_read_input_token_cost": 7e-08,
-        "input_cost_per_token": 2.7e-07,
-        "input_cost_per_token_cache_hit": 7e-08,
+        "cache_read_input_token_cost": 2.8e-08,
+        "input_cost_per_token": 2.8e-07,
+        "input_cost_per_token_cache_hit": 2.8e-08,
         "litellm_provider": "deepseek",
-        "max_input_tokens": 65536,
+        "max_input_tokens": 128000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 1.1e-06,
+        "output_cost_per_token": 4.2e-07,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
@@ -10071,14 +10071,15 @@
         "supports_tool_choice": true
     },
     "deepseek/deepseek-reasoner": {
-        "input_cost_per_token": 5.5e-07,
-        "input_cost_per_token_cache_hit": 1.4e-07,
+	"cache_read_input_token_cost": 2.8e-08,
+        "input_cost_per_token": 2.8e-07,
+        "input_cost_per_token_cache_hit": 2.8e-08,
         "litellm_provider": "deepseek",
-        "max_input_tokens": 65536,
+        "max_input_tokens": 128000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.19e-06,
+        "output_cost_per_token": 4.2e-07,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,


### PR DESCRIPTION
## Problem
DeepSeek API endpoints now use V3.2 model, but pricing shows old rates.

Output costs are 2.6x-5x higher than actual:
- `deepseek-chat`: $1.70/1M → should be $0.42/1M
- `deepseek-reasoner`: $2.19/1M → should be $0.42/1M

## Changes
Updated 4 model entries:
- `deepseek-chat`
- `deepseek-reasoner`  
- `deepseek/deepseek-chat`
- `deepseek/deepseek-reasoner`

## Source
https://api-docs.deepseek.com/quick_start/pricing