### PR TITLE
docs: add Redis requirement warning for high-traffic deployments

### DIFF
--- a/docs/my-website/docs/proxy/db_deadlocks.md
+++ b/docs/my-website/docs/proxy/db_deadlocks.md
@@ -4,6 +4,12 @@ import TabItem from '@theme/TabItem';
 
 # High Availability Setup (Resolve DB Deadlocks)
 
+:::tip Essential for Production
+
+This configuration is **required** for production deployments handling 1000+ requests per second. Without Redis configured, you may experience PostgreSQL connection exhaustion (`FATAL: sorry, too many clients already`).
+
+:::
+
 Resolve any Database Deadlocks you see in high traffic by using this setup
 
 ## What causes the problem?

--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -359,6 +359,26 @@ LiteLLM is compatible with several SDKs - including OpenAI SDK, Anthropic SDK, M
 ### Deploy with Database
 ##### Docker, Kubernetes, Helm Chart
 
+:::warning High Traffic Deployments (1000+ RPS)
+
+If you expect high traffic (1000+ requests per second), **Redis is required** to prevent database connection exhaustion and deadlocks.
+
+Add this to your config:
+```yaml
+general_settings:
+  use_redis_transaction_buffer: true
+
+litellm_settings:
+  cache: true
+  cache_params:
+    type: redis
+    host: your-redis-host
+```
+
+See [Resolve DB Deadlocks](/docs/proxy/db_deadlocks) for details.
+
+:::
+
 Requirements:
 - Need a postgres database (e.g. [Supabase](https://supabase.com/), [Neon](https://neon.tech/), etc) Set `DATABASE_URL=postgresql://<user>:<password>@<host>:<port>/<dbname>` in your env 
 - Set a `LITELLM_MASTER_KEY`, this is your Proxy Admin key - you can use this to create other keys (🚨 must start with `sk-`)


### PR DESCRIPTION
## Summary

Adds clear documentation warning that Redis is **required** for high-traffic deployments (1000+ RPS) to prevent PostgreSQL connection exhaustion.

Fixes #18708

## Changes

- **[deploy.md](cci:7://file:///d:/OSS/litellm/docs/my-website/docs/proxy/deploy.md:0:0-0:0)**: Added warning admonition in "Deploy with Database" section
- **[db_deadlocks.md](cci:7://file:///d:/OSS/litellm/docs/my-website/docs/proxy/db_deadlocks.md:0:0-0:0)**: Added tip at top indicating this is essential for production

## Why

Users deploying without Redis hit PostgreSQL connection exhaustion (`FATAL: sorry, too many clients already`) under high load. The `use_redis_transaction_buffer` feature requires Redis, but this wasn't clearly documented in the main deployment guide.

## Screenshot

The warning looks like this in the docs:

> ⚠️ **High Traffic Deployments (1000+ RPS)**
> If you expect high traffic (1000+ requests per second), **Redis is required** to prevent database connection exhaustion and deadlocks.