### PR TITLE
fix: correct pricing for openrouter/openai/gpt-oss-20b

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -23340,13 +23340,13 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-oss-20b": {
-        "input_cost_per_token": 1.8e-07,
+        "input_cost_per_token": 2e-08,
         "litellm_provider": "openrouter",
         "max_input_tokens": 131072,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
-        "output_cost_per_token": 8e-07,
+        "output_cost_per_token": 1e-07,
         "source": "https://openrouter.ai/openai/gpt-oss-20b",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23340,13 +23340,13 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-oss-20b": {
-        "input_cost_per_token": 1.8e-07,
+        "input_cost_per_token": 2e-08,
         "litellm_provider": "openrouter",
         "max_input_tokens": 131072,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
-        "output_cost_per_token": 8e-07,
+        "output_cost_per_token": 1e-07,
         "source": "https://openrouter.ai/openai/gpt-oss-20b",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,


### PR DESCRIPTION
## Relevant issues

Closes https://github.com/BerriAI/litellm/issues/18889

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have Added testing in the `tests/litellm/` directory (N/A - pricing configuration fix)
- [ ] My PR passes all unit tests on `make test-unit`

## Type

🐛 Bug Fix

## Changes

Updated pricing for `openrouter/openai/gpt-oss-20b` to match OpenRouter's official rates:

**Before (incorrect):**
- Input: $0.18/M tokens (1.8e-07)
- Output: $0.80/M tokens (8e-07)

**After (correct):**
- Input: $0.02/M tokens (2e-08)
- Output: $0.10/M tokens (1e-07)

Source: https://openrouter.ai/openai/gpt-oss-20b

**Files modified:**
- `model_prices_and_context_window.json`
- `litellm/model_prices_and_context_window_backup.json`
