### PR TITLE
[Fix] UI - Endpoint Activity Trend X-Axis and Time Range

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/EndpointUsage/components/EndpointUsageLineChart.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EndpointUsage/components/EndpointUsageLineChart.test.tsx
@@ -23,38 +23,12 @@ vi.mock("@tremor/react", async () => {
   return { Card, Title, LineChart };
 });
 
-vi.mock("antd", async () => {
-  const React = await import("react");
-
-  function Segmented({ options, value, onChange }: any) {
-    return React.createElement(
-      "div",
-      { "data-testid": "antd-segmented", "data-value": value },
-      options?.map((opt: any) =>
-        React.createElement(
-          "button",
-          {
-            key: opt.value,
-            onClick: () => onChange?.(opt.value),
-            "data-selected": value === opt.value,
-          },
-          opt.label,
-        ),
-      ),
-    );
-  }
-  (Segmented as any).displayName = "Segmented";
-
-  return { Segmented };
-});
-
 describe("EndpointUsageLineChart", () => {
   it("should render", () => {
     render(<EndpointUsageLineChart />);
 
     expect(screen.getByTestId("tremor-card")).toBeInTheDocument();
     expect(screen.getByText("Endpoint Usage Trends")).toBeInTheDocument();
-    expect(screen.getByTestId("antd-segmented")).toBeInTheDocument();
     expect(screen.getByTestId("tremor-line-chart")).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/UsagePage/components/EndpointUsage/components/EndpointUsageLineChart.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EndpointUsage/components/EndpointUsageLineChart.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from "react";
 import { Card, LineChart, Title } from "@tremor/react";
+import { useMemo } from "react";
 import { DailyData } from "../../../types";
 
 interface EndpointUsageLineChartProps {

--- a/ui/litellm-dashboard/src/components/UsagePage/components/EndpointUsage/components/EndpointUsageLineChart.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EndpointUsage/components/EndpointUsageLineChart.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { Card, LineChart, Title } from "@tremor/react";
-import { Segmented } from "antd";
 import { DailyData } from "../../../types";
 
 interface EndpointUsageLineChartProps {
@@ -8,11 +7,8 @@ interface EndpointUsageLineChartProps {
   endpointData?: Record<string, any>;
 }
 
-type TimePeriod = "7" | "30" | "90";
-
-
 // Transform daily data into chart format
-function transformDailyDataToChart(dailyData: DailyData[], days: number): Array<Record<string, string | number>> {
+function transformDailyDataToChart(dailyData: DailyData[]): Array<Record<string, string | number>> {
   const chartData: Array<Record<string, string | number>> = [];
 
   // Get all unique endpoint names
@@ -23,10 +19,7 @@ function transformDailyDataToChart(dailyData: DailyData[], days: number): Array<
     }
   });
 
-  // Filter to the last N days based on time period
-  const filteredData = dailyData.slice(-days);
-
-  filteredData.forEach((day) => {
+  dailyData.forEach((day) => {
     const date = new Date(day.date);
     const dateStr = date.toLocaleDateString("en-US", {
       month: "short",
@@ -45,20 +38,18 @@ function transformDailyDataToChart(dailyData: DailyData[], days: number): Array<
     chartData.push(dataPoint);
   });
 
-  return chartData;
+  // Reverse the array so most recent dates appear on the right
+  return chartData.reverse();
 }
 
 export function EndpointUsageLineChart({ dailyData, endpointData }: EndpointUsageLineChartProps) {
-  const [timePeriod, setTimePeriod] = useState<TimePeriod>("7");
-  const days = parseInt(timePeriod);
-
   const chartData = useMemo(() => {
     if (!dailyData?.results || dailyData.results.length === 0) {
       return [];
     }
 
-    return transformDailyDataToChart(dailyData.results, days);
-  }, [dailyData, days]);
+    return transformDailyDataToChart(dailyData.results);
+  }, [dailyData]);
 
   // Get endpoint names from chart data
   const categories = useMemo(() => {
@@ -74,27 +65,6 @@ export function EndpointUsageLineChart({ dailyData, endpointData }: EndpointUsag
     <Card className="mb-6">
       <div className="flex items-center justify-between mb-4">
         <Title>Endpoint Usage Trends</Title>
-        <Segmented
-          options={[
-            {
-              label: "7 Days",
-              value: "7",
-            },
-            {
-              label: "30 Days",
-              value: "30",
-            },
-            {
-              label: "90 Days",
-              value: "90",
-            },
-          ]}
-          value={timePeriod}
-          onChange={(value) => setTimePeriod(value as TimePeriod)}
-          style={{
-            backgroundColor: "#f3f4f6",
-          }}
-        />
       </div>
       <LineChart
         className="h-80"


### PR DESCRIPTION
## Relevant issues
This PR flips the x axis on the Trend graph for Endpoint Activity. The most recent will be on the rightmost which is in line with other trend charts on the UI. This PR also removes the time picker on the trend graph as time frame is chosen by another component.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="1672" height="473" alt="image" src="https://github.com/user-attachments/assets/b32c25cd-9241-4f31-a847-edb3bf35834e" />
<img width="976" height="277" alt="image" src="https://github.com/user-attachments/assets/021c8a94-76b2-4a3d-a910-d74ae4ff40b7" />
