### PR TITLE
[fix] respect pangea guardrail default_on during initialization

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/pangea/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/pangea/__init__.py
@@ -21,6 +21,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
         pangea_output_recipe=litellm_params.pangea_output_recipe,
         api_base=litellm_params.api_base,
         api_key=litellm_params.api_key,
+        event_hook=litellm_params.mode,
         default_on=litellm_params.default_on,
     )
     litellm.logging_callback_manager.add_litellm_callback(_pangea_callback)

--- a/litellm/proxy/guardrails/guardrail_hooks/pangea/pangea.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/pangea/pangea.py
@@ -95,8 +95,17 @@ class PangeaHandler(CustomGuardrail):
         self.pangea_input_recipe = pangea_input_recipe
         self.pangea_output_recipe = pangea_output_recipe
 
+        supported_event_hooks = [
+            GuardrailEventHooks.pre_call,
+            GuardrailEventHooks.post_call,
+        ]
+
         # Pass relevant kwargs to the parent class
-        super().__init__(guardrail_name=guardrail_name, **kwargs)
+        super().__init__(
+            guardrail_name=guardrail_name,
+            supported_event_hooks=supported_event_hooks,
+            **kwargs
+        )
         verbose_proxy_logger.debug(
             f"Initialized Pangea Guardrail: name={guardrail_name}, recipe={pangea_input_recipe}, api_base={self.api_base}"
         )


### PR DESCRIPTION
## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes
