### PR TITLE
fix(exception_mapping): handle exceptions without response parameter

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -197,12 +197,22 @@ def extract_and_raise_litellm_exception(
         exception_name = exception_name.strip().replace("litellm.", "")
         raised_exception_obj = getattr(litellm, exception_name, None)
         if raised_exception_obj:
-            raise raised_exception_obj(
-                message=error_str,
-                llm_provider=custom_llm_provider,
-                model=model,
-                response=response,
-            )
+            # Try with response parameter first, fall back to without it
+            # Some exceptions (e.g., APIConnectionError) don't accept response param
+            try:
+                raise raised_exception_obj(
+                    message=error_str,
+                    llm_provider=custom_llm_provider,
+                    model=model,
+                    response=response,
+                )
+            except TypeError:
+                # Exception doesn't accept response parameter
+                raise raised_exception_obj(
+                    message=error_str,
+                    llm_provider=custom_llm_provider,
+                    model=model,
+                )
 
 
 def exception_type(  # type: ignore  # noqa: PLR0915


### PR DESCRIPTION
When extract_and_raise_litellm_exception tries to raise a LiteLLM exception from an error string, it was always passing the response parameter. However, some exceptions like APIConnectionError don't accept this parameter, causing a TypeError.

This fix tries to raise the exception with the response parameter first, and falls back to raising without it if a TypeError occurs.

This fixes the error:
TypeError: APIConnectionError.__init__() got an unexpected keyword argument 'response'

Which was occurring when Gemini returned UNEXPECTED_TOOL_CALL finish reason and LiteLLM tried to convert the error to an APIConnectionError.

Fixes: cascading error when Gemini uses thinking feature (__thought__ tool calls)

## Relevant issues

Fixes #18918

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
