### PR TITLE
Add ScrapeGraph MCP server configuration

### DIFF
--- a/mcp_servers.json
+++ b/mcp_servers.json
@@ -14,5 +14,10 @@
     "linear": {
         "sse_url": "https://mcp.linear.app/sse",
         "description": "The Linear MCP server provides programmatic access to Linear's issue tracking capabilities."
+    },
+    "scrapegraph": {
+        "http_url": "https://smithery.ai/api/mcp/scrapegraph-mcp",
+        "sse_url": "https://smithery.ai/api/mcp/scrapegraph-mcp/sse",
+        "description": "The ScrapeGraph MCP server provides programmatic access to ScrapeGraph AI's web scraping capabilities, including smart scraping, web crawling, search scraping, and agentic scraping workflows."
     }
 }


### PR DESCRIPTION
## Description

This PR adds the ScrapeGraph MCP server configuration to `mcp_servers.json`.

The ScrapeGraph MCP server provides programmatic access to ScrapeGraph AI's web scraping capabilities, including:
- Smart scraping with AI-powered data extraction
- Web crawling for multi-page sites
- Search scraping for research workflows
- Agentic scraping for complex automation workflows

## Changes

- Added `scrapegraph` entry to `mcp_servers.json` with HTTP and SSE endpoints
- Included description of ScrapeGraph's capabilities

## Related

- ScrapeGraph MCP Server: https://github.com/ScrapeGraphAI/scrapegraph-mcp
- ScrapeGraph deployed via Smithery

## Testing

- Verified JSON syntax is valid
- Follows the same format as other MCP server entries (zapier, deepwiki, jira, linear)