### PR TITLE
fix(anthropic): prevent dropping thinking when any message has thinking_blocks

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -62,6 +62,7 @@ from litellm.utils import (
     ModelResponse,
     Usage,
     add_dummy_tool,
+    any_assistant_message_has_thinking_blocks,
     get_max_tokens,
     has_tool_call_blocks,
     last_assistant_with_tool_calls_has_no_thinking_blocks,
@@ -1013,10 +1014,16 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         # Drop thinking param if thinking is enabled but thinking_blocks are missing
         # This prevents the error: "Expected thinking or redacted_thinking, but found tool_use"
+        #
+        # IMPORTANT: Only drop thinking if NO assistant messages have thinking_blocks.
+        # If any message has thinking_blocks, we must keep thinking enabled, otherwise
+        # Anthropic errors with: "When thinking is disabled, an assistant message cannot contain thinking"
+        # Related issue: https://github.com/BerriAI/litellm/issues/18926
         if (
             optional_params.get("thinking") is not None
             and messages is not None
             and last_assistant_with_tool_calls_has_no_thinking_blocks(messages)
+            and not any_assistant_message_has_thinking_blocks(messages)
         ):
             if litellm.modify_params:
                 optional_params.pop("thinking", None)

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -2805,3 +2805,117 @@ def test_azure_ai_claude_provider_config():
         provider=LlmProviders.AZURE_AI,
     )
     assert isinstance(config, AzureAIStudioConfig)
+
+
+# Tests for thinking blocks helper functions
+# Related to issue: https://github.com/BerriAI/litellm/issues/18926
+
+
+def test_any_assistant_message_has_thinking_blocks_with_thinking():
+    """Test that function returns True when any assistant message has thinking_blocks."""
+    from litellm.utils import any_assistant_message_has_thinking_blocks
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {
+            "role": "assistant",
+            "thinking_blocks": [{"type": "thinking", "thinking": "Let me think..."}],
+            "tool_calls": [{"id": "123", "function": {"name": "test"}}],
+        },
+        {"role": "tool", "tool_call_id": "123", "content": "result"},
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "456", "function": {"name": "test2"}}],
+            # No thinking_blocks here - Claude sometimes doesn't include them
+        },
+    ]
+
+    assert any_assistant_message_has_thinking_blocks(messages) is True
+
+
+def test_any_assistant_message_has_thinking_blocks_without_thinking():
+    """Test that function returns False when no assistant message has thinking_blocks."""
+    from litellm.utils import any_assistant_message_has_thinking_blocks
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "123", "function": {"name": "test"}}],
+        },
+        {"role": "tool", "tool_call_id": "123", "content": "result"},
+    ]
+
+    assert any_assistant_message_has_thinking_blocks(messages) is False
+
+
+def test_any_assistant_message_has_thinking_blocks_empty_list():
+    """Test that function returns False when thinking_blocks is an empty list."""
+    from litellm.utils import any_assistant_message_has_thinking_blocks
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {
+            "role": "assistant",
+            "thinking_blocks": [],  # Empty list
+            "tool_calls": [{"id": "123", "function": {"name": "test"}}],
+        },
+    ]
+
+    assert any_assistant_message_has_thinking_blocks(messages) is False
+
+
+def test_last_assistant_with_tool_calls_has_no_thinking_blocks_issue_18926():
+    """
+    Test the scenario from issue #18926 where:
+    - First assistant message HAS thinking_blocks
+    - Second assistant message has NO thinking_blocks
+
+    The old logic would drop thinking because the LAST tool_call message
+    has no thinking_blocks, but this breaks because the first message
+    still has thinking blocks in the conversation.
+    """
+    from litellm.utils import (
+        any_assistant_message_has_thinking_blocks,
+        last_assistant_with_tool_calls_has_no_thinking_blocks,
+    )
+
+    messages = [
+        {"role": "user", "content": "Build a feature"},
+        {
+            "role": "assistant",
+            "thinking_blocks": [
+                {"type": "thinking", "thinking": "Let me analyze the requirements..."}
+            ],
+            "tool_calls": [
+                {"id": "toolu_1", "function": {"name": "file_editor", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "toolu_1",
+            "content": "File contents here...",
+        },
+        {
+            "role": "assistant",
+            # NO thinking_blocks - Claude sometimes doesn't include them
+            "content": [{"type": "text", "text": "Let me explore more..."}],
+            "tool_calls": [
+                {"id": "toolu_2", "function": {"name": "file_editor", "arguments": "{}"}}
+            ],
+        },
+    ]
+
+    # Last assistant with tool_calls has no thinking_blocks
+    assert last_assistant_with_tool_calls_has_no_thinking_blocks(messages) is True
+
+    # But ANY assistant message has thinking_blocks
+    assert any_assistant_message_has_thinking_blocks(messages) is True
+
+    # So we should NOT drop thinking - the combination tells us thinking is in use
+    # The fix uses both checks: only drop if last has none AND no message has any
+    should_drop_thinking = (
+        last_assistant_with_tool_calls_has_no_thinking_blocks(messages)
+        and not any_assistant_message_has_thinking_blocks(messages)
+    )
+    assert should_drop_thinking is False


### PR DESCRIPTION
## Fix: Opus thinking dropped unpredictably in multi-turn conversations

**Fixes #18926**

### Summary

When using Claude models with `thinking` enabled and `modify_params=True`, the thinking parameter was being incorrectly dropped mid-conversation, causing this error:

```
"When thinking is disabled, an assistant message cannot contain thinking"
```

This only affected multi-turn conversations where Claude's behavior varied between turns.

---

### Root Cause

The existing logic checked only the **last** assistant message with tool_calls:

```python
# Old logic
if last_assistant_with_tool_calls_has_no_thinking_blocks(messages):
    optional_params.pop("thinking", None)  # Drop thinking
```

**The problem:** Claude doesn't always include `thinking_blocks` with every response. In a multi-turn conversation:

```
Turn 1: Assistant responds WITH thinking_blocks + tool_calls
Turn 2: Tool result
Turn 3: Assistant responds with tool_calls but NO thinking_blocks  ← Claude varies here
Turn 4: Tool result
Turn 5: Assistant tries to respond → ERROR
```

The old logic saw Turn 3 had no thinking_blocks, dropped the thinking param, but Turn 1 still had thinking_blocks in the conversation history. Anthropic then correctly errored because thinking was disabled but thinking blocks existed.

---

### The Fix

Added a new check that scans **all** assistant messages:

```python
# New logic
if (
    last_assistant_with_tool_calls_has_no_thinking_blocks(messages)
    and not any_assistant_message_has_thinking_blocks(messages)  # NEW
):
    optional_params.pop("thinking", None)
```

Thinking is now only dropped when:
1. The last tool_call message has no thinking_blocks, AND
2. NO message in the entire conversation has thinking_blocks

---

### Why Both Checks Are Needed

A reviewer might notice that if condition (2) is true (no message has thinking), then condition (1) is automatically true. This appears redundant, but both checks serve different purposes:

| Check | Purpose |
|-------|---------|
| `last_assistant_with_tool_calls_has_no_thinking_blocks()` | **Gates on tool_calls context.** Returns `False` if there are no tool_calls at all, preventing the optimization from triggering in non-tool-call scenarios. |
| `any_assistant_message_has_thinking_blocks()` | **Gates on thinking presence.** Ensures we never drop thinking when thinking_blocks exist anywhere in the conversation. |

Without check (1), we'd drop thinking for *any* conversation without thinking_blocks, even if no tool_calls were involved. The first check ensures this optimization only applies to the "tool_calls without thinking" scenario that the original code intended to handle.

---

### Changes

**`litellm/utils.py`**

Added new helper function `any_assistant_message_has_thinking_blocks()` that scans all assistant messages for thinking_blocks.

**`litellm/llms/anthropic/chat/transformation.py`**

Updated condition to use both checks (lines 1017-1027).

**`tests/test_litellm/test_utils.py`**

Added 4 new tests (114 lines):
- `test_any_assistant_message_has_thinking_blocks_with_thinking`
- `test_any_assistant_message_has_thinking_blocks_without_thinking`
- `test_any_assistant_message_has_thinking_blocks_empty_list`
- `test_last_assistant_with_tool_calls_has_no_thinking_blocks_issue_18926`

---

### Testing

- ✅ Unit tests pass
- ✅ Integration tested with exact issue #18926 reproduction case
- ✅ Regression tested to ensure original use case still works

### Backwards Compatibility

| Scenario | Before | After |
|----------|--------|-------|
| No thinking_blocks anywhere | Thinking dropped ✓ | Thinking dropped ✓ |
| Thinking_blocks in earlier message, none in last | Thinking dropped ✗ (BUG) | Thinking kept ✓ |
| Thinking_blocks in last message | Thinking kept ✓ | Thinking kept ✓ |

The fix only affects the buggy case (row 2). All other behavior is preserved.