### PR TITLE
fix: add created_at/updated_at fields to LiteLLM_ProxyModelTable

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -993,7 +993,9 @@ class LiteLLM_ProxyModelTable(LiteLLMPydanticObjectBase):
     model_name: str
     litellm_params: dict
     model_info: dict
+    created_at: Optional[datetime] = None
     created_by: str
+    updated_at: Optional[datetime] = None
     updated_by: str
 
     @model_validator(mode="before")


### PR DESCRIPTION
This PR fixes the "Created at" and "Updated at" date fields showing as empty or "Unknown date" in the Models + Endpoints > All Models UI for database-added models.

## What changed

Added `created_at` and `updated_at` fields to the `LiteLLM_ProxyModelTable` Pydantic model in `litellm/proxy/_types.py`.

## Why it failed before

The Prisma schema defines `created_at` and `updated_at` columns on the `LiteLLM_ProxyModelTable` table, and these values are correctly stored when models are created via the UI. However, the Pydantic model was missing these fields, so when `get_model_info_with_id()` called `getattr(model, "created_at", None)`, it always returned `None` because the attribute didn't exist on the model object.

## Why this fix works

By adding the fields to the Pydantic model with `Optional[datetime] = None`, Prisma will now populate them when loading model records from the database. The existing code in `get_model_info_with_id()` that reads these attributes will then work correctly.

## Risk assessment

Low risk. This is an additive change to a Pydantic model that adds fields already present in the database schema. The fields have sensible defaults (`None`) so existing code paths are unaffected.

---

To make this production-safe, the remaining work is:
- Add similar timestamp fields to other table models that may be missing them (LiteLLM_ModelTable, etc.)
- Add UI tests to verify date display works correctly
- Consider adding "Updated by" display to the UI as well

This is ~2-3 days.
I can own this as a short paid engagement; otherwise this PR stands on its own.