### PR TITLE
Add: missing anthropic tool results in response

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -719,19 +719,28 @@ class ModelResponseIterator:
                         content_block_start=content_block_start,
                         provider_specific_fields=provider_specific_fields,
                     )
-                elif (
-                    content_block_start["content_block"]["type"]
-                    == "web_search_tool_result"
-                ):
-                    # Capture web_search_tool_result for multi-turn reconstruction
-                    # The full content comes in content_block_start, not in deltas
-                    # See: https://github.com/BerriAI/litellm/issues/17737
-                    self.web_search_results.append(
-                        content_block_start["content_block"]
-                    )
-                    provider_specific_fields["web_search_results"] = (
-                        self.web_search_results
-                    )
+                elif content_block_start["content_block"]["type"].endswith("_tool_result"):
+                    # Handle all tool result types (web_search, bash_code_execution, text_editor, etc.)
+                    content_type = content_block_start["content_block"]["type"]
+                    
+                    # Special handling for web_search_tool_result for backwards compatibility
+                    if content_type == "web_search_tool_result":
+                        # Capture web_search_tool_result for multi-turn reconstruction
+                        # The full content comes in content_block_start, not in deltas
+                        # See: https://github.com/BerriAI/litellm/issues/17737
+                        self.web_search_results.append(
+                            content_block_start["content_block"]
+                        )
+                        provider_specific_fields["web_search_results"] = (
+                            self.web_search_results
+                        )
+                    elif content_type != "tool_search_tool_result":
+                        # Handle other tool results (code execution, etc.)
+                        # Skip tool_search_tool_result as it's internal metadata
+                        if not hasattr(self, "tool_results"):
+                            self.tool_results = []
+                        self.tool_results.append(content_block_start["content_block"])
+                        provider_specific_fields["tool_results"] = self.tool_results
             elif type_chunk == "content_block_stop":
                 ContentBlockStop(**chunk)  # type: ignore
                 # check if tool call content block - only for tool_use and server_tool_use blocks

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1812,3 +1812,242 @@ def test_calculate_usage_completion_tokens_details_with_reasoning():
     expected_text_tokens = 500 - usage.completion_tokens_details.reasoning_tokens
     assert usage.completion_tokens_details.text_tokens == expected_text_tokens
     assert usage.completion_tokens == 500
+
+
+def test_code_execution_tool_results_extraction():
+    """
+    Test that code execution tool results (bash_code_execution_tool_result, 
+    text_editor_code_execution_tool_result) are properly extracted and exposed 
+    in provider_specific_fields.
+    
+    Related to: https://github.com/BerriAI/litellm/issues/xxxxx
+    """
+    import httpx
+    from litellm.types.utils import ModelResponse
+    
+    config = AnthropicConfig()
+    
+    # Mock Anthropic response with code execution tool results
+    mock_anthropic_response = {
+        "id": "msg_01XYZ",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5-20250929",
+        "content": [
+            {
+                "type": "text",
+                "text": "I'll calculate that for you."
+            },
+            {
+                "type": "server_tool_use",
+                "id": "srvtoolu_01ABC",
+                "name": "bash_code_execution",
+                "input": {
+                    "command": "python3 << 'EOF'\nprint(2 + 2)\nEOF\n"
+                }
+            },
+            {
+                "type": "bash_code_execution_tool_result",
+                "tool_use_id": "srvtoolu_01ABC",
+                "content": {
+                    "type": "bash_code_execution_result",
+                    "stdout": "4\n",
+                    "stderr": "",
+                    "return_code": 0
+                }
+            },
+            {
+                "type": "server_tool_use",
+                "id": "srvtoolu_01DEF",
+                "name": "text_editor_code_execution",
+                "input": {
+                    "command": "create",
+                    "path": "test.txt",
+                    "file_text": "Hello"
+                }
+            },
+            {
+                "type": "text_editor_code_execution_tool_result",
+                "tool_use_id": "srvtoolu_01DEF",
+                "content": {
+                    "type": "text_editor_code_execution_result",
+                    "is_file_update": False
+                }
+            },
+            {
+                "type": "text",
+                "text": "Done!"
+            }
+        ],
+        "stop_reason": "stop",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50
+        }
+    }
+    
+    # Create mock HTTP response
+    mock_raw_response = MagicMock(spec=httpx.Response)
+    mock_raw_response.json.return_value = mock_anthropic_response
+    mock_raw_response.status_code = 200
+    mock_raw_response.headers = {}
+    
+    model_response = ModelResponse()
+    
+    transformed_response = config.transform_parsed_response(
+        completion_response=mock_anthropic_response,
+        raw_response=mock_raw_response,
+        model_response=model_response,
+        json_mode=False,
+        prefix_prompt=None,
+    )
+    
+    # Verify tool calls are present
+    assert transformed_response.choices[0].message.tool_calls is not None
+    assert len(transformed_response.choices[0].message.tool_calls) == 2
+    
+    # Verify first tool call
+    assert transformed_response.choices[0].message.tool_calls[0].id == "srvtoolu_01ABC"
+    assert transformed_response.choices[0].message.tool_calls[0].function.name == "bash_code_execution"
+    
+    # Verify second tool call
+    assert transformed_response.choices[0].message.tool_calls[1].id == "srvtoolu_01DEF"
+    assert transformed_response.choices[0].message.tool_calls[1].function.name == "text_editor_code_execution"
+    
+    # Verify tool results are in provider_specific_fields
+    provider_fields = transformed_response.choices[0].message.provider_specific_fields
+    assert provider_fields is not None
+    assert "tool_results" in provider_fields
+    assert provider_fields["tool_results"] is not None
+    assert len(provider_fields["tool_results"]) == 2
+    
+    # Verify bash_code_execution_tool_result
+    bash_result = provider_fields["tool_results"][0]
+    assert bash_result["type"] == "bash_code_execution_tool_result"
+    assert bash_result["tool_use_id"] == "srvtoolu_01ABC"
+    assert bash_result["content"]["stdout"] == "4\n"
+    assert bash_result["content"]["return_code"] == 0
+    
+    # Verify text_editor_code_execution_tool_result
+    editor_result = provider_fields["tool_results"][1]
+    assert editor_result["type"] == "text_editor_code_execution_tool_result"
+    assert editor_result["tool_use_id"] == "srvtoolu_01DEF"
+    assert editor_result["content"]["is_file_update"] is False
+    
+    # Verify text content is properly concatenated
+    assert "I'll calculate that for you." in transformed_response.choices[0].message.content
+    assert "Done!" in transformed_response.choices[0].message.content
+
+
+def test_tool_search_tool_result_not_in_tool_results():
+    """
+    Test that tool_search_tool_result is NOT included in tool_results
+    since it's internal metadata, not actual tool execution results.
+    """
+    import httpx
+    from litellm.types.utils import ModelResponse
+    
+    config = AnthropicConfig()
+    
+    mock_anthropic_response = {
+        "id": "msg_01XYZ",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5-20250929",
+        "content": [
+            {
+                "type": "text",
+                "text": "Found tools."
+            },
+            {
+                "type": "tool_search_tool_result",
+                "tool_references": ["tool1", "tool2"]
+            }
+        ],
+        "stop_reason": "stop",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50
+        }
+    }
+    
+    mock_raw_response = MagicMock(spec=httpx.Response)
+    mock_raw_response.json.return_value = mock_anthropic_response
+    mock_raw_response.status_code = 200
+    mock_raw_response.headers = {}
+    
+    model_response = ModelResponse()
+    
+    transformed_response = config.transform_parsed_response(
+        completion_response=mock_anthropic_response,
+        raw_response=mock_raw_response,
+        model_response=model_response,
+        json_mode=False,
+        prefix_prompt=None,
+    )
+    
+    # Verify tool_search_tool_result is NOT in tool_results
+    provider_fields = transformed_response.choices[0].message.provider_specific_fields
+    assert provider_fields.get("tool_results") is None
+
+
+def test_web_search_tool_result_backwards_compatibility():
+    """
+    Test that web_search_tool_result continues to be stored in web_search_results
+    for backwards compatibility, not in tool_results.
+    """
+    import httpx
+    from litellm.types.utils import ModelResponse
+    
+    config = AnthropicConfig()
+    
+    mock_anthropic_response = {
+        "id": "msg_01XYZ",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5-20250929",
+        "content": [
+            {
+                "type": "text",
+                "text": "Here are the results."
+            },
+            {
+                "type": "web_search_tool_result",
+                "search_query": "test query",
+                "results": [{"title": "Result 1", "url": "https://example.com"}]
+            }
+        ],
+        "stop_reason": "stop",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50
+        }
+    }
+    
+    mock_raw_response = MagicMock(spec=httpx.Response)
+    mock_raw_response.json.return_value = mock_anthropic_response
+    mock_raw_response.status_code = 200
+    mock_raw_response.headers = {}
+    
+    model_response = ModelResponse()
+    
+    transformed_response = config.transform_parsed_response(
+        completion_response=mock_anthropic_response,
+        raw_response=mock_raw_response,
+        model_response=model_response,
+        json_mode=False,
+        prefix_prompt=None,
+    )
+    
+    # Verify web_search_tool_result is in web_search_results (not tool_results)
+    provider_fields = transformed_response.choices[0].message.provider_specific_fields
+    assert "web_search_results" in provider_fields
+    assert provider_fields["web_search_results"] is not None
+    assert len(provider_fields["web_search_results"]) == 1
+    assert provider_fields["web_search_results"][0]["type"] == "web_search_tool_result"
+    
+    # Should NOT be in tool_results
+    assert provider_fields.get("tool_results") is None

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -185,7 +185,7 @@ def test_extract_response_content_with_citations():
         },
     }
 
-    _, citations, _, _, _, _ = config.extract_response_content(completion_response)
+    _, citations, _, _, _, _ , _= config.extract_response_content(completion_response)
     assert citations == [
         [
             {
@@ -342,7 +342,7 @@ def test_web_search_tool_result_extraction():
         }
     }
 
-    text, citations, thinking_blocks, reasoning_content, tool_calls, web_search_results = config.extract_response_content(
+    text, citations, thinking_blocks, reasoning_content, tool_calls, web_search_results, tool_results = config.extract_response_content(
         completion_response
     )
 
@@ -474,7 +474,7 @@ def test_multiple_web_search_tool_results():
         ]
     }
 
-    text, citations, thinking_blocks, reasoning_content, tool_calls, web_search_results = config.extract_response_content(
+    text, citations, thinking_blocks, reasoning_content, tool_calls, web_search_results, tool_results = config.extract_response_content(
         completion_response
     )
 
@@ -923,7 +923,7 @@ def test_server_tool_use_in_response():
         ]
     }
     
-    text, citations, thinking_blocks, reasoning_content, tool_calls, web_search_results = config.extract_response_content(
+    text, citations, thinking_blocks, reasoning_content, tool_calls, web_search_results, tool_results = config.extract_response_content(
         completion_response
     )
 
@@ -1051,7 +1051,7 @@ def test_tool_search_complete_response_parsing():
     }
     
     # Extract content
-    text, citations, thinking_blocks, reasoning_content, tool_calls, web_search_results = config.extract_response_content(
+    text, citations, thinking_blocks, reasoning_content, tool_calls, web_search_results, tool_results = config.extract_response_content(
         completion_response
     )
 
@@ -1171,7 +1171,7 @@ def test_caller_field_in_response():
         "usage": {"input_tokens": 100, "output_tokens": 50}
     }
     
-    text, citations, thinking, reasoning, tool_calls, web_search_results = config.extract_response_content(completion_response)
+    text, citations, thinking, reasoning, tool_calls, web_search_results, tool_results = config.extract_response_content(completion_response)
 
     assert len(tool_calls) == 1
     assert tool_calls[0]["id"] == "toolu_123"
@@ -1823,6 +1823,7 @@ def test_code_execution_tool_results_extraction():
     Related to: https://github.com/BerriAI/litellm/issues/xxxxx
     """
     import httpx
+
     from litellm.types.utils import ModelResponse
     
     config = AnthropicConfig()
@@ -1946,6 +1947,7 @@ def test_tool_search_tool_result_not_in_tool_results():
     since it's internal metadata, not actual tool execution results.
     """
     import httpx
+
     from litellm.types.utils import ModelResponse
     
     config = AnthropicConfig()
@@ -1999,6 +2001,7 @@ def test_web_search_tool_result_backwards_compatibility():
     for backwards compatibility, not in tool_results.
     """
     import httpx
+
     from litellm.types.utils import ModelResponse
     
     config = AnthropicConfig()


### PR DESCRIPTION
## Relevant issues

Fixes  #18839

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
Added all the tool call results in provider_specific_field, as openai doesn't allow both assistant message and tool call results in same output

<img width="1017" height="553" alt="image" src="https://github.com/user-attachments/assets/9c5e35a4-a1be-4acc-802c-1ac737e9f243" />

<img width="1017" height="659" alt="image" src="https://github.com/user-attachments/assets/b8ba7d42-2a4b-4835-963b-de4930bc7e85" />

