### PR TITLE
Fix: Prompt deletion fails with Prisma FieldNotFoundError

### DIFF
--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -851,7 +851,7 @@ async def delete_prompt(
             )
 
         # Delete the prompt from the database
-        await prisma_client.db.litellm_prompttable.delete(
+        await prisma_client.db.litellm_prompttable.delete_many(
             where={"prompt_id": prompt_id}
         )
 


### PR DESCRIPTION
The LiteLLM_PromptTable schema allows multiple versions for the same prompt_id (making prompt_id non-unique). However, the delete_prompt endpoint was using prisma...delete(), which requires a unique field in the where clause, causing a FieldNotFoundError.

.delete() to .delete_many() to correctly remove all versions associated with the prompt_id.

Resolves #18964 