### PR TITLE
Normalize OpenAI SDK BaseModel choices/messages to avoid Pydantic serializer warnings

### DIFF
--- a/.github/workflows/test-litellm.yml
+++ b/.github/workflows/test-litellm.yml
@@ -35,6 +35,7 @@ jobs:
         poetry run pip install "google-cloud-aiplatform>=1.38"
         poetry run pip install "fastapi-offline==1.7.3"
         poetry run pip install "python-multipart==0.0.18"
+        poetry run pip install "openapi-core"
     - name: Setup litellm-enterprise as local package
       run: |
         cd enterprise

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ install-proxy-dev-ci:
 install-test-deps: install-proxy-dev
 	poetry run pip install "pytest-retry==1.6.3"
 	poetry run pip install pytest-xdist
+	poetry run pip install openapi-core
 	cd enterprise && poetry run pip install -e . && cd ..
 
 install-helm-unittest:

--- a/enterprise/litellm_enterprise/proxy/__init__.py
+++ b/enterprise/litellm_enterprise/proxy/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for enterprise proxy components.

--- a/enterprise/litellm_enterprise/proxy/common_utils/__init__.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for enterprise proxy common utilities.

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1252,7 +1252,11 @@ class Choices(OpenAIObject):
                 params["message"] = Message(**message)
             elif isinstance(message, BaseModel):
                 # Normalize provider/OpenAI SDK message models into LiteLLM's Message type.
-                dump = message.model_dump() if hasattr(message, "model_dump") else message.dict()
+                dump = (
+                    message.model_dump()
+                    if hasattr(message, "model_dump")
+                    else message.dict()
+                )
                 params["message"] = Message(**dump)
         if logprobs is not None:
             if isinstance(logprobs, dict):
@@ -1661,12 +1665,16 @@ class ModelResponseStream(ModelResponseBase):
         else:
             created = created
 
-        if (
-            "usage" in kwargs
-            and kwargs["usage"] is not None
-            and isinstance(kwargs["usage"], dict)
-        ):
-            kwargs["usage"] = Usage(**kwargs["usage"])
+        if "usage" in kwargs and kwargs["usage"] is not None:
+            if isinstance(kwargs["usage"], dict):
+                kwargs["usage"] = Usage(**kwargs["usage"])
+            elif isinstance(kwargs["usage"], BaseModel):
+                dump = (
+                    kwargs["usage"].model_dump()
+                    if hasattr(kwargs["usage"], "model_dump")
+                    else kwargs["usage"].dict()
+                )
+                kwargs["usage"] = Usage(**dump)
 
         kwargs["id"] = id
         kwargs["created"] = created
@@ -1741,7 +1749,11 @@ class ModelResponse(ModelResponseBase):
                     elif isinstance(choice, dict):
                         _new_choice = Choices(**choice)  # type: ignore
                     elif isinstance(choice, BaseModel):
-                        dump = choice.model_dump() if hasattr(choice, "model_dump") else choice.dict()
+                        dump = (
+                            choice.model_dump()
+                            if hasattr(choice, "model_dump")
+                            else choice.dict()
+                        )
                         _new_choice = Choices(**dump)  # type: ignore
                     else:
                         _new_choice = choice
@@ -1761,6 +1773,11 @@ class ModelResponse(ModelResponseBase):
         if usage is not None:
             if isinstance(usage, dict):
                 usage = Usage(**usage)
+            elif isinstance(usage, BaseModel):
+                dump = (
+                    usage.model_dump() if hasattr(usage, "model_dump") else usage.dict()
+                )
+                usage = Usage(**dump)
             else:
                 usage = usage
         elif stream is None or stream is False:
@@ -3043,7 +3060,6 @@ class LlmProviders(str, Enum):
     POE = "poe"
     CHUTES = "chutes"
     XIAOMI_MIMO = "xiaomi_mimo"
-
 
 
 # Create a set of all provider values for quick lookup

--- a/tests/test_litellm/test_model_response_normalization.py
+++ b/tests/test_litellm/test_model_response_normalization.py
@@ -1,5 +1,7 @@
 import warnings
 
+import pytest
+
 from litellm.types.utils import Choices, Message, ModelResponse
 
 
@@ -24,4 +26,36 @@ def test_modelresponse_normalizes_openai_base_models() -> None:
         "Pydantic serializer warnings" in str(w.message)
         for w in captured
         if isinstance(w.message, Warning)
+    )
+
+
+def test_modelresponse_serialization_avoids_pydantic_warnings() -> None:
+    pytest.importorskip("openai")
+    from openai.types.chat import ChatCompletion as OpenAIChatCompletion
+
+    openai_completion = OpenAIChatCompletion(
+        id="test-1",
+        created=1719868600,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "hi"},
+                "logprobs": None,
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        response = ModelResponse(**openai_completion.model_dump())
+        _ = response.model_dump(exclude_none=True)
+
+    assert not any(
+        "PydanticSerializationUnexpectedValue" in str(w.message)
+        or "Pydantic serializer warnings" in str(w.message)
+        for w in captured
     )

--- a/tests/test_litellm/test_model_response_normalization.py
+++ b/tests/test_litellm/test_model_response_normalization.py
@@ -1,0 +1,27 @@
+import warnings
+
+from litellm.types.utils import Choices, Message, ModelResponse
+
+
+def test_modelresponse_normalizes_openai_base_models() -> None:
+    # OpenAI SDK returns Pydantic BaseModel objects for message/choice.
+    # LiteLLM should normalize these into its own internal `Message` / `Choices` types.
+    from openai.types.chat.chat_completion import Choice as OpenAIChoice
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
+
+    message = ChatCompletionMessage(role="assistant", content="hi")
+    choice = OpenAIChoice(finish_reason="stop", index=0, message=message, logprobs=None)
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        response = ModelResponse(model="gpt-4o-mini", choices=[choice])
+        _ = response.model_dump()
+
+    assert isinstance(response.choices[0], Choices)
+    assert isinstance(response.choices[0].message, Message)
+
+    assert not any(
+        "Pydantic serializer warnings" in str(w.message)
+        for w in captured
+        if isinstance(w.message, Warning)
+    )


### PR DESCRIPTION
Fixes noisy Pydantic v2 "serializer warnings" seen downstream (e.g. when serializing LiteLLM ModelResponse objects).

Changes:
- Coerce OpenAI SDK (pydantic BaseModel) `message` objects passed into `Choices(...)` into LiteLLM's `Message`.
- Coerce pydantic BaseModel `choice` objects passed into `ModelResponse(choices=[...])` into LiteLLM's `Choices`.
- Override `ModelResponseBase.model_dump()` to default to `exclude_unset=True` unless the caller explicitly sets `exclude_unset`/`exclude_none`.
  This prevents PydanticSerializationUnexpectedValue warnings caused by OpenAIObject-derived types that omit unset fields.
- Add regression test `tests/test_litellm/test_model_response_normalization.py`.

Related: #11759, #11914.