### PR TITLE
fix: keep type field in Gemini schema when properties is empty

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -660,11 +660,11 @@ def add_object_type(schema):
         if "required" in schema and schema["required"] is None:
             schema.pop("required", None)
         # Gemini doesn't accept empty properties for object types
-        # If properties is empty, remove it and the type field
+        # If properties is empty, remove it but keep type as object
         if not properties:
             schema.pop("properties", None)
-            schema.pop("type", None)
             schema.pop("required", None)
+            schema["type"] = "object"
         else:
             schema["type"] = "object"
             for name, value in properties.items():

--- a/tests/test_litellm/llms/vertex_ai/test_gemini_empty_properties.py
+++ b/tests/test_litellm/llms/vertex_ai/test_gemini_empty_properties.py
@@ -1,0 +1,16 @@
+"""Test for Gemini schema handling with empty properties."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.llms.vertex_ai.common_utils import add_object_type
+
+
+def test_add_object_type_empty_properties_keeps_type():
+    """Gemini requires type: object even when properties is empty."""
+    schema = {"properties": {}, "type": "object"}
+    add_object_type(schema)
+    assert schema.get("type") == "object"
+    assert "properties" not in schema

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -1254,8 +1254,8 @@ def test_build_vertex_schema_empty_properties():
     # Verify empty properties was removed
     assert "properties" not in go_back_schema, "Empty properties should be removed"
     
-    # Verify type was also removed (since object without properties is invalid in Gemini)
-    assert "type" not in go_back_schema, "Type should be removed when properties is empty"
+    # Verify type is kept as object (Gemini requires type: object even without properties)
+    assert go_back_schema.get("type") == "object", "Type should be kept as object when properties is empty"
     
     # Verify required was also removed
     assert "required" not in go_back_schema, "Required should be removed when properties is empty"


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/pydantic/pydantic-ai/issues/3935
Fixes https://github.com/BerriAI/litellm/issues/18442

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix


## Changes

Gemini requires type: object even for functions with no parameters. The current code removes it when properties is empty.
