### PR TITLE
fix(realtime_api): pass litellm_params.api_key to realtime handler

### DIFF
--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -97,21 +97,15 @@ async def _arealtime(
         # set API KEY
         api_key = (
             dynamic_api_key
+            or kwargs.get("litellm_params", {}).get("api_key")
             or litellm.api_key
             or litellm.openai_key
             or get_secret_str("AZURE_API_KEY")
         )
 
-        api_version = (
-            api_version
-            or litellm_params.api_version
-            or "2024-10-01-preview"
-        )
-        
-        realtime_protocol = (
-            kwargs.get("realtime_protocol")
-            or "beta"
-        )
+        api_version = api_version or litellm_params.api_version or "2024-10-01-preview"
+
+        realtime_protocol = kwargs.get("realtime_protocol") or "beta"
         await azure_realtime.async_realtime(
             model=model,
             websocket=websocket,
@@ -134,6 +128,7 @@ async def _arealtime(
         # set API KEY
         api_key = (
             dynamic_api_key
+            or kwargs.get("litellm_params", {}).get("api_key")
             or litellm.api_key
             or litellm.openai_key
             or get_secret_str("OPENAI_API_KEY")
@@ -189,7 +184,8 @@ async def _realtime_health_check(
         )
     elif custom_llm_provider == "openai":
         url = openai_realtime._construct_url(
-            api_base=api_base or "https://api.openai.com/", query_params={"model": model}
+            api_base=api_base or "https://api.openai.com/",
+            query_params={"model": model},
         )
     else:
         raise ValueError(f"Unsupported model: {model}")


### PR DESCRIPTION
## Related Issue
Fixes #18231

## What does this PR do?
Fixes a bug where the Realtime API endpoint (`/v1/realtime`) ignored the `api_key` configured in `litellm_params` (e.g., from database models).

The [_arealtime](cci:1://file:///d:/OSS/litellm/litellm/realtime_api/main.py:27:0-147:55) function only checked:
- `dynamic_api_key` (request args)
- Environment variables (`OPENAI_API_KEY`)

It now correctly checks:
- `kwargs["litellm_params"]["api_key"]` (The database/router configuration)

## Why is this change important?
Without this, database-configured models (which rely on `litellm_params` for credentials) fail with `ValueError: api_key is required for OpenAI realtime calls`.

## How was this tested?
- Verified with a reproduction script simulating a call with `litellm_params`.
- Ran existing regression tests [tests/llm_translation/test_openai_realtime.py](cci:7://file:///d:/OSS/litellm/tests/llm_translation/test_openai_realtime.py:0:0-0:0).
