### PR TITLE
[test] remove flaky azure oidc embedding test

### DIFF
--- a/tests/local_testing/test_embedding.py
+++ b/tests/local_testing/test_embedding.py
@@ -317,34 +317,6 @@ def test_openai_azure_embedding():
         pytest.fail(f"Error occurred: {e}")
 
 
-@pytest.mark.skipif(
-    os.environ.get("CIRCLE_OIDC_TOKEN") is None,
-    reason="Cannot run without being in CircleCI Runner",
-)
-def test_aaaaaa_openai_azure_embedding_with_oidc_and_cf():
-    # TODO: Switch to our own Azure account, currently using ai.moda's account
-    os.environ["AZURE_TENANT_ID"] = "17c0a27a-1246-4aa1-a3b6-d294e80e783c"
-    os.environ["AZURE_CLIENT_ID"] = "4faf5422-b2bd-45e8-a6d7-46543a38acd0"
-
-    old_key = os.environ["AZURE_API_KEY"]
-    os.environ.pop("AZURE_API_KEY", None)
-
-    try:
-        response = embedding(
-            model="azure/text-embedding-ada-002",
-            input=["Hello"],
-            azure_ad_token="oidc/circleci/",
-            api_base="https://eastus2-litellm.openai.azure.com/",
-            api_version="2024-06-01",
-        )
-        print(response)
-
-    except Exception as e:
-        pytest.fail(f"Error occurred: {e}")
-    finally:
-        os.environ["AZURE_API_KEY"] = old_key
-
-
 from openai.types.embedding import Embedding
 
 


### PR DESCRIPTION
## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

✅ Test

## Changes

`test_aaaaaa_openai_azure_embedding_with_oidc_and_cf` intermittently fails with the Azure OIDC authentication error below, so the test is removed.

```
  FAILED ... - litellm.AuthenticationError: AzureException AuthenticationError - {"error":"invalid_client","error_description":"AADSTS700213: No matching federated identity record found for presented assertion subject 'org/<redacted>/project/<redacted>/user/<redacted>'. Check your federated identity credential Subject, Audience and Issuer against the presented assertion. https://learn.microsoft.com/entra/workload-id/workload-identity-federation Trace ID: <redacted> Correlation ID: <redacted> Timestamp: 2026-01-12 18:45:05Z","error_codes":[700213],"timestamp":"2026-01-12 18:45:05Z","trace_id":"<redacted>","correlation_id":"<redacted>","error_uri":"https://login.microsoftonline.com/error?code=700213"}
```