### PR TITLE
[Feature] UI - Simplify Key Generate Permission Error

### DIFF
--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -38,6 +38,7 @@ import {
 } from "../networking";
 import NumericalInput from "../shared/numerical_input";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
+import { simplifyKeyGenerateError } from "./utils";
 
 const { Option } = Select;
 
@@ -406,7 +407,8 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
       localStorage.removeItem("userData" + userID);
     } catch (error) {
       console.log("error in create key:", error);
-      NotificationsManager.fromBackend(`Error creating the key: ${error}`);
+      const simplifiedError = simplifyKeyGenerateError(error);
+      NotificationsManager.fromBackend(simplifiedError);
     }
   };
 

--- a/ui/litellm-dashboard/src/components/organisms/utils.test.ts
+++ b/ui/litellm-dashboard/src/components/organisms/utils.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { simplifyKeyGenerateError } from "./utils";
+
+describe("simplifyKeyGenerateError", () => {
+  const expectedSimplifiedMessage =
+    "Team member does not have permission to generate key for this team. Ask your proxy admin to configure the team member permission settings.";
+
+  describe("when error is NOT related to /key/generate", () => {
+    it("should return the original error message for generic errors", () => {
+      const error = "Some random error";
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe("Error creating the key: Some random error");
+    });
+
+    it("should return the original error message for other endpoint errors", () => {
+      const error = "Error: Failed to fetch /key/list";
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe("Error creating the key: Error: Failed to fetch /key/list");
+    });
+
+    it("should handle Error objects for non-/key/generate errors", () => {
+      const error = new Error("Database connection failed");
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe("Error creating the key: Error: Database connection failed");
+    });
+  });
+
+  describe("when error is related to /key/generate team member permission error", () => {
+    it("should simplify JSON error with team_member_permission_error", () => {
+      const error = JSON.stringify({
+        error: {
+          message:
+            "Team member does not have permissions for endpoint: KeyManagementRoutes.KEY_GENERATE. You only have access to the following endpoints: ['/key/info', '/key/health'] for team 60f6c0db-3ed9-4112-a2ef-8d838b2c8679. To create keys for this team, please ask your proxy admin to check the team member permission settings and update the settings to allow team member users to create keys.",
+          type: "team_member_permission_error",
+          param: "/key/generate",
+          code: "401",
+        },
+      });
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe(expectedSimplifiedMessage);
+    });
+
+    it("should simplify error string containing /key/generate and team_member_permission_error", () => {
+      const error =
+        'Error creating the key: {"error":{"message":"Team member does not have permissions for endpoint: KeyManagementRoutes.KEY_GENERATE. You only have access to the following endpoints: [\'/key/info\', \'/key/health\'] for team 60f6c0db-3ed9-4112-a2ef-8d838b2c8679. To create keys for this team, please ask your proxy admin to check the team member permission settings and update the settings to allow team member users to create keys.","type":"team_member_permission_error","param":"/key/generate","code":"401"}}';
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe(expectedSimplifiedMessage);
+    });
+
+    it("should simplify error with KeyManagementRoutes.KEY_GENERATE in message", () => {
+      const error =
+        "Team member does not have permissions for endpoint: KeyManagementRoutes.KEY_GENERATE. Ask your proxy admin to check the team member permission settings.";
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe(expectedSimplifiedMessage);
+    });
+
+    it("should handle nested error object structure", () => {
+      const error = {
+        error: {
+          message:
+            "Team member does not have permissions for endpoint: KeyManagementRoutes.KEY_GENERATE. You only have access to the following endpoints: ['/key/info', '/key/health'].",
+          type: "team_member_permission_error",
+        },
+      };
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe(expectedSimplifiedMessage);
+    });
+
+    it("should handle error with team_member_permission_error type in string", () => {
+      const error =
+        'Some prefix {"error":{"type":"team_member_permission_error","message":"Team member does not have permissions for endpoint: KeyManagementRoutes.KEY_GENERATE"}} some suffix';
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe(expectedSimplifiedMessage);
+    });
+  });
+
+  describe("when error is related to /key/generate but NOT a permission error", () => {
+    it("should return original error message for /key/generate validation errors", () => {
+      const error = "Invalid request to /key/generate: missing required field";
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe("Error creating the key: Invalid request to /key/generate: missing required field");
+    });
+
+    it("should return original error message for /key/generate server errors", () => {
+      const error = JSON.stringify({
+        error: {
+          message: "Internal server error occurred while processing /key/generate",
+          type: "server_error",
+          code: "500",
+        },
+      });
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe(`Error creating the key: ${error}`);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle malformed JSON gracefully", () => {
+      const error =
+        '{"error":{"message":"Team member does not have permissions for endpoint: KeyManagementRoutes.KEY_GENERATE", invalid json';
+      const result = simplifyKeyGenerateError(error);
+      // Should still detect the permission error from the string content
+      expect(result).toBe(expectedSimplifiedMessage);
+    });
+
+    it("should handle empty string", () => {
+      const error = "";
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe("Error creating the key: ");
+    });
+
+    it("should handle null", () => {
+      const error = null;
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe("Error creating the key: null");
+    });
+
+    it("should handle undefined", () => {
+      const error = undefined;
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe("Error creating the key: undefined");
+    });
+
+    it("should handle Error object with /key/generate permission error", () => {
+      const error = new Error(
+        '{"error":{"message":"Team member does not have permissions for endpoint: KeyManagementRoutes.KEY_GENERATE","type":"team_member_permission_error"}}',
+      );
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe(expectedSimplifiedMessage);
+    });
+
+    it("should handle error with multiple JSON objects", () => {
+      const error =
+        'Prefix {"error":{"message":"Team member does not have permissions for endpoint: KeyManagementRoutes.KEY_GENERATE","type":"team_member_permission_error"}} suffix {"other":"data"}';
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe(expectedSimplifiedMessage);
+    });
+
+    it("should handle error message without explicit team_member_permission_error type but with permission text", () => {
+      const error =
+        "Team member does not have permissions for endpoint: KeyManagementRoutes.KEY_GENERATE. Please contact admin.";
+      const result = simplifyKeyGenerateError(error);
+      expect(result).toBe(expectedSimplifiedMessage);
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/organisms/utils.ts
+++ b/ui/litellm-dashboard/src/components/organisms/utils.ts
@@ -1,0 +1,56 @@
+/**
+ * Helper function to simplify /key/generate permission errors
+ * Extracts a user-friendly error message from team member permission errors
+ * @param error - The error object or message
+ * @returns A simplified error message string
+ */
+export const simplifyKeyGenerateError = (error: any): string => {
+  // Handle plain objects by stringifying them first
+  let errorString: string;
+  if (error && typeof error === "object" && !(error instanceof Error)) {
+    errorString = JSON.stringify(error);
+  } else {
+    errorString = String(error);
+  }
+
+  // Check if this is a /key/generate team member permission error
+  if (!errorString.includes("/key/generate") && !errorString.includes("KeyManagementRoutes.KEY_GENERATE")) {
+    return `Error creating the key: ${error}`;
+  }
+
+  // Try to parse JSON if the message contains JSON or extract from object
+  let errorMessage = errorString;
+  try {
+    // If error is already an object, extract message directly
+    if (error && typeof error === "object" && !(error instanceof Error)) {
+      const errorObj = error?.error || error;
+      if (errorObj?.message) {
+        errorMessage = errorObj.message;
+      }
+    } else {
+      // Try to parse JSON from string
+      const jsonMatch = errorString.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        const parsedError = JSON.parse(jsonMatch[0]);
+        const errorObj = parsedError?.error || parsedError;
+        if (errorObj?.message) {
+          errorMessage = errorObj.message;
+        }
+      }
+    }
+  } catch (e) {
+    // If parsing fails, use the original message
+  }
+
+  // Check if this is a team member permission error
+  if (
+    errorString.includes("team_member_permission_error") ||
+    errorMessage.includes("Team member does not have permissions")
+  ) {
+    // Return the simplified message
+    return "Team member does not have permission to generate key for this team. Ask your proxy admin to configure the team member permission settings.";
+  }
+
+  // If it's not a permission error, return the original error message
+  return `Error creating the key: ${error}`;
+};


### PR DESCRIPTION
## Relevant issues
This PR implements a simplified error message for the key generate permission error on the UI. Currently when a user in a team that does not have the /key/generate permission for team members creates a key, the error message is very unreadable. This PR simplifies the error message in this case to 2 sentences. See screenshots for more information
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="1479" height="708" alt="image" src="https://github.com/user-attachments/assets/fa347da0-64a6-4fd8-aebe-38863692efc5" />
<img width="719" height="322" alt="image" src="https://github.com/user-attachments/assets/4fe03b58-49a3-4112-8a95-46ba0db0f32d" />
