### PR TITLE
Fix: Model matching priority in configuration

### DIFF
--- a/litellm/proxy/route_llm_request.py
+++ b/litellm/proxy/route_llm_request.py
@@ -260,12 +260,9 @@ async def route_request(
         ):
             return getattr(llm_router, f"{route_type}")(**data)
 
-        elif data["model"] in llm_router.deployment_names:
-            return getattr(llm_router, f"{route_type}")(
-                **data, specific_deployment=True
-            )
-
         elif data["model"] not in router_model_names:
+            # Check wildcards before checking deployment_names
+            # Priority: 1. Exact model_name match, 2. Wildcard match, 3. deployment_names match
             if llm_router.router_general_settings.pass_through_all_models:
                 return getattr(litellm, f"{route_type}")(**data)
             elif (
@@ -273,6 +270,11 @@ async def route_request(
                 or len(llm_router.pattern_router.patterns) > 0
             ):
                 return getattr(llm_router, f"{route_type}")(**data)
+            elif data["model"] in llm_router.deployment_names:
+                # Only match deployment_names if no wildcard matched
+                return getattr(llm_router, f"{route_type}")(
+                    **data, specific_deployment=True
+                )
             elif route_type in [
                 "amoderation",
                 "aget_responses",


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix
🧹 Refactoring

## Changes
When using LiteLLM router with wildcard model names, the routing priority was incorrect. The router was matching models against `deployment_names` (which contains `litellm_params.model` values) before checking for wildcard matches.

### Example Scenario

Given this configuration:

```yaml
model_list:
  - model_name: multi-provider-text-embedding-3-small
    litellm_params:
      model: openai/text-embedding-3-small  # This matches the request
      api_base: http://localhost:8080/openai
      api_key: test-key-1
      
  - model_name: "*"
    litellm_params:
      model: "openai/*"
      api_base: http://localhost:8081/openai
      api_key: test-key-2
      
  - model_name: "openai/*"  # This should match!
    litellm_params:
      model: "openai/*"
      api_base: http://localhost:8082/openai
      api_key: test-key-3
```

When calling `openai/text-embedding-3-small`, the router would incorrectly match the first deployment because its `litellm_params.model` field matched, even though the user intended to use the wildcard deployment.

## Solution

Changed the routing priority order to:

1. **Exact `model_name` match** - Highest priority
2. **Wildcard `model_name` match** - Second priority
3. **`deployment_names` match** (litellm_params.model) - Lowest priority

This ensures that wildcard routes are checked before falling back to matching against the `litellm_params.model` field.


### Testing
<img width="1024" height="304" alt="image" src="https://github.com/user-attachments/assets/097f41a6-db94-4e5c-9e78-30f8f5e46e41" />

<img width="797" height="513" alt="image" src="https://github.com/user-attachments/assets/a4099f94-596a-4a38-be64-8d5200781672" />
