### PR TITLE
fix(guardrails): use clean error messages for blocked requests

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -898,9 +898,15 @@ class LiteLLMUnknownProvider(BadRequestError):
 
 
 class GuardrailRaisedException(Exception):
-    def __init__(self, guardrail_name: Optional[str] = None, message: str = ""):
+    def __init__(
+        self,
+        guardrail_name: Optional[str] = None,
+        message: str = "",
+        should_wrap_with_default_message: bool = True,
+    ):
+        default_message = f"Guardrail raised an exception, Guardrail: {guardrail_name}, Message: {message}"
         self.guardrail_name = guardrail_name
-        self.message = f"Guardrail raised an exception, Guardrail: {guardrail_name}, Message: {message}"
+        self.message = default_message if should_wrap_with_default_message else message
         super().__init__(self.message)
 
 

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
@@ -9,6 +9,7 @@ import os
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional
 
 from litellm._logging import verbose_proxy_logger
+from litellm.exceptions import GuardrailRaisedException
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
@@ -247,7 +248,11 @@ class GenericGuardrailAPI(CustomGuardrail):
                 verbose_proxy_logger.warning(
                     "Generic Guardrail API blocked request: %s", error_message
                 )
-                raise Exception(f"Content blocked by guardrail: {error_message}")
+                raise GuardrailRaisedException(
+                    guardrail_name=GUARDRAIL_NAME,
+                    message=error_message,
+                    should_wrap_with_default_message=False,
+                )
 
             # Action is NONE or no modifications needed
             return_inputs = GenericGuardrailAPIInputs(texts=texts)
@@ -263,10 +268,10 @@ class GenericGuardrailAPI(CustomGuardrail):
                 return_inputs["tools"] = tools
             return return_inputs
 
+        except GuardrailRaisedException:
+            # Re-raise guardrail exceptions as-is
+            raise
         except Exception as e:
-            # Check if it's already an exception we raised
-            if "Content blocked by guardrail" in str(e):
-                raise
             verbose_proxy_logger.error(
                 "Generic Guardrail API: failed to make request: %s", str(e)
             )


### PR DESCRIPTION
## Summary

Fixes #19022

- Add `should_wrap_with_default_message` parameter to `GuardrailRaisedException`
- Update Generic Guardrail API to use clean error messages without verbose wrapper
- Blocked content now shows clean message (e.g., "pii detected") instead of full traceback

<img width="1049" height="232" alt="image" src="https://github.com/user-attachments/assets/9ce7636d-1d72-4d84-881f-77a068249028" />
<img width="1038" height="236" alt="image" src="https://github.com/user-attachments/assets/dda5bacf-f463-4aa4-9f21-14775654df0a" />
<img width="1041" height="227" alt="image" src="https://github.com/user-attachments/assets/9a2df8d1-6f49-4abc-af34-8db4cc1a2b51" />


## Test plan

- [x] Run `pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py` - all 20 tests pass
- [x] Run `pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py` - all 27 tests pass (backward compatible)