### PR TITLE
fix: enable JSON logging via configuration and add regression test

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2465,7 +2465,12 @@ class ProxyConfig:
                         raise Exception(
                             f"Invalid value set for upperbound_key_generate_params - value={value}"
                         )
-
+                elif key == "json_logs" and value is True:
+                    litellm.json_logs = True
+                    litellm._turn_on_json()
+                    verbose_proxy_logger.debug(
+                        f"{blue_color_code} Enabled JSON logging via config{reset_color_code}"
+                    )
                 else:
                     verbose_proxy_logger.debug(
                         f"{blue_color_code} setting litellm.{key}={value}{reset_color_code}"


### PR DESCRIPTION
## Relevant issues

Fixes `json_logs: true` in config file not enabling JSON logging when using `CONFIG_FILE_PATH` #19036 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

**Bug:** When using `CONFIG_FILE_PATH` environment variable (common in Helm/Kubernetes/Docker deployments), setting `json_logs: true` under `litellm_settings` in the config YAML file does not enable JSON logging.

**Root cause:** The CLI path (`proxy_cli.py:672-682`) correctly calls `litellm._turn_on_json()`, but the server startup path (`proxy_server.py`) only sets the attribute via `setattr()` without calling `_turn_on_json()` to reconfigure the logging handlers.

**Fix:** Added explicit handling for `json_logs` in `ProxyConfig.load_config()` that calls `litellm._turn_on_json()` when `json_logs: true` is set in the config.

**Test:** Added `test_json_logs_calls_turn_on_json()` regression test that verifies `_turn_on_json()` is called when loading a config with `json_logs: true`.

