### PR TITLE
[bug fix] do not fallback to token counter if disable_token_counter is enabled

### DIFF
--- a/litellm/anthropic_interface/exceptions/__init__.py
+++ b/litellm/anthropic_interface/exceptions/__init__.py
@@ -1,0 +1,19 @@
+"""Anthropic error format utilities."""
+
+from .exception_mapping_utils import (
+    ANTHROPIC_ERROR_TYPE_MAP,
+    AnthropicExceptionMapping,
+)
+from .exceptions import (
+    AnthropicErrorDetail,
+    AnthropicErrorResponse,
+    AnthropicErrorType,
+)
+
+__all__ = [
+    "AnthropicErrorType",
+    "AnthropicErrorDetail",
+    "AnthropicErrorResponse",
+    "ANTHROPIC_ERROR_TYPE_MAP",
+    "AnthropicExceptionMapping",
+]

--- a/litellm/anthropic_interface/exceptions/exception_mapping_utils.py
+++ b/litellm/anthropic_interface/exceptions/exception_mapping_utils.py
@@ -1,0 +1,175 @@
+"""
+Utilities for mapping exceptions to Anthropic error format.
+
+Similar to litellm/litellm_core_utils/exception_mapping_utils.py but for Anthropic response format.
+"""
+
+import json
+from typing import Dict, Optional
+
+from .exceptions import AnthropicErrorResponse, AnthropicErrorType
+
+
+# HTTP status code -> Anthropic error type
+# Source: https://docs.anthropic.com/en/api/errors
+ANTHROPIC_ERROR_TYPE_MAP: Dict[int, AnthropicErrorType] = {
+    400: "invalid_request_error",
+    401: "authentication_error",
+    403: "permission_error",
+    404: "not_found_error",
+    413: "request_too_large",
+    429: "rate_limit_error",
+    500: "api_error",
+    529: "overloaded_error",
+}
+
+
+class AnthropicExceptionMapping:
+    """
+    Helper class for mapping exceptions to Anthropic error format.
+
+    Similar pattern to ExceptionCheckers in litellm_core_utils/exception_mapping_utils.py
+    """
+
+    @staticmethod
+    def get_error_type(status_code: int) -> AnthropicErrorType:
+        """Map HTTP status code to Anthropic error type."""
+        return ANTHROPIC_ERROR_TYPE_MAP.get(status_code, "api_error")
+
+    @staticmethod
+    def create_error_response(
+        status_code: int,
+        message: str,
+        request_id: Optional[str] = None,
+    ) -> AnthropicErrorResponse:
+        """
+        Create an Anthropic-formatted error response dict.
+
+        Anthropic error format:
+        {
+            "type": "error",
+            "error": {"type": "...", "message": "..."},
+            "request_id": "req_..."
+        }
+        """
+        error_type = AnthropicExceptionMapping.get_error_type(status_code)
+
+        response: AnthropicErrorResponse = {
+            "type": "error",
+            "error": {
+                "type": error_type,
+                "message": message,
+            },
+        }
+
+        if request_id:
+            response["request_id"] = request_id
+
+        return response
+
+    @staticmethod
+    def extract_error_message(raw_message: str) -> str:
+        """
+        Extract error message from various provider response formats.
+
+        Handles:
+        - Bedrock: {"detail": {"message": "..."}}
+        - AWS: {"Message": "..."}
+        - Generic: {"message": "..."}
+        - Plain strings
+        """
+        try:
+            parsed = json.loads(raw_message)
+            if isinstance(parsed, dict):
+                # Bedrock format
+                if "detail" in parsed and isinstance(parsed["detail"], dict):
+                    return parsed["detail"].get("message", raw_message)
+                # AWS/generic format
+                return parsed.get("Message") or parsed.get("message") or raw_message
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return raw_message
+
+    @staticmethod
+    def _is_anthropic_error_dict(parsed: dict) -> bool:
+        """
+        Check if a parsed dict is in Anthropic error format.
+
+        Anthropic error format:
+        {
+            "type": "error",
+            "error": {"type": "...", "message": "..."}
+        }
+        """
+        return (
+            parsed.get("type") == "error"
+            and isinstance(parsed.get("error"), dict)
+            and "type" in parsed["error"]
+            and "message" in parsed["error"]
+        )
+
+    @staticmethod
+    def _extract_message_from_dict(parsed: dict, raw_message: str) -> str:
+        """
+        Extract error message from a parsed provider-specific dict.
+
+        Handles:
+        - Bedrock: {"detail": {"message": "..."}}
+        - AWS: {"Message": "..."}
+        - Generic: {"message": "..."}
+        """
+        # Bedrock format
+        if "detail" in parsed and isinstance(parsed["detail"], dict):
+            return parsed["detail"].get("message", raw_message)
+        # AWS/generic format
+        return parsed.get("Message") or parsed.get("message") or raw_message
+
+    @staticmethod
+    def transform_to_anthropic_error(
+        status_code: int,
+        raw_message: str,
+        request_id: Optional[str] = None,
+    ) -> AnthropicErrorResponse:
+        """
+        Transform an error message to Anthropic format.
+
+        - If already in Anthropic format: passthrough unchanged
+        - Otherwise: extract message and create Anthropic error
+
+        Parses JSON only once for efficiency.
+
+        Args:
+            status_code: HTTP status code
+            raw_message: Raw error message (may be JSON string or plain text)
+            request_id: Optional request ID to include
+
+        Returns:
+            AnthropicErrorResponse dict
+        """
+        # Try to parse as JSON once
+        parsed: Optional[dict] = None
+        try:
+            parsed = json.loads(raw_message)
+            if not isinstance(parsed, dict):
+                parsed = None
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # If parsed and already in Anthropic format - passthrough
+        if parsed is not None and AnthropicExceptionMapping._is_anthropic_error_dict(parsed):
+            # Optionally add request_id if provided and not present
+            if request_id and "request_id" not in parsed:
+                parsed["request_id"] = request_id
+            return parsed  # type: ignore
+
+        # Extract message - use parsed dict if available, otherwise raw string
+        if parsed is not None:
+            message = AnthropicExceptionMapping._extract_message_from_dict(parsed, raw_message)
+        else:
+            message = raw_message
+
+        return AnthropicExceptionMapping.create_error_response(
+            status_code=status_code,
+            message=message,
+            request_id=request_id,
+        )

--- a/litellm/anthropic_interface/exceptions/exceptions.py
+++ b/litellm/anthropic_interface/exceptions/exceptions.py
@@ -1,0 +1,41 @@
+"""Anthropic error format type definitions."""
+
+from typing_extensions import Literal, Required, TypedDict
+
+
+# Known Anthropic error types
+# Source: https://docs.anthropic.com/en/api/errors
+AnthropicErrorType = Literal[
+    "invalid_request_error",
+    "authentication_error",
+    "permission_error",
+    "not_found_error",
+    "request_too_large",
+    "rate_limit_error",
+    "api_error",
+    "overloaded_error",
+]
+
+
+class AnthropicErrorDetail(TypedDict):
+    """Inner error detail in Anthropic format."""
+
+    type: AnthropicErrorType
+    message: str
+
+
+class AnthropicErrorResponse(TypedDict, total=False):
+    """
+    Anthropic-formatted error response.
+
+    Format:
+    {
+        "type": "error",
+        "error": {"type": "...", "message": "..."},
+        "request_id": "req_..."  # optional
+    }
+    """
+
+    type: Required[Literal["error"]]
+    error: Required[AnthropicErrorDetail]
+    request_id: str

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -2,15 +2,13 @@
 Unified /v1/messages endpoint - (Anthropic Spec)
 """
 
-import json
-from typing import Optional
-
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
 from litellm._logging import verbose_proxy_logger
+from litellm.anthropic_interface.exceptions import AnthropicExceptionMapping
+from litellm.integrations.custom_guardrail import ModifyResponseException
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.integrations.custom_guardrail import ModifyResponseException
 from litellm.proxy.common_request_processing import (
     ProxyBaseLLMRequestProcessing,
     create_response,
@@ -19,75 +17,6 @@ from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.types.utils import TokenCountResponse
 
 router = APIRouter()
-
-# Anthropic error type mapping based on HTTP status codes
-# https://docs.anthropic.com/en/api/errors
-ANTHROPIC_ERROR_TYPE_MAP = {
-    400: "invalid_request_error",
-    401: "authentication_error",
-    403: "permission_error",
-    404: "not_found_error",
-    413: "request_too_large",
-    429: "rate_limit_error",
-    500: "api_error",
-    529: "overloaded_error",
-}
-
-
-def _create_anthropic_error_response(
-    status_code: int,
-    message: str,
-    request_id: Optional[str] = None,
-) -> dict:
-    """
-    Create an Anthropic-formatted error response.
-
-    Anthropic error format:
-    {
-        "type": "error",
-        "error": {
-            "type": "invalid_request_error",
-            "message": "..."
-        },
-        "request_id": "req_..."
-    }
-    """
-    error_type = ANTHROPIC_ERROR_TYPE_MAP.get(status_code, "api_error")
-
-    response = {
-        "type": "error",
-        "error": {
-            "type": error_type,
-            "message": message,
-        },
-    }
-
-    if request_id:
-        response["request_id"] = request_id
-
-    return response
-
-
-def _extract_error_message(raw_message: str) -> str:
-    """
-    Extract the error message from provider response.
-
-    Handles various formats:
-    - Bedrock: {"detail":{"message":"Input is too long..."}}
-    - Other: {"Message": "..."} or {"message": "..."}
-    - Plain string
-    """
-    try:
-        parsed = json.loads(raw_message)
-        if isinstance(parsed, dict):
-            # Handle Bedrock format: {"detail": {"message": "..."}}
-            if "detail" in parsed and isinstance(parsed["detail"], dict):
-                return parsed["detail"].get("message", raw_message)
-            # Handle other formats: {"Message": "..."} or {"message": "..."}
-            return parsed.get("Message") or parsed.get("message") or raw_message
-    except (json.JSONDecodeError, TypeError):
-        pass
-    return raw_message
 
 
 @router.post(
@@ -294,10 +223,9 @@ async def count_tokens(
         raise
     except ProxyException as e:
         status_code = int(e.code) if e.code and e.code.isdigit() else 500
-        message = _extract_error_message(e.message)
-        detail = _create_anthropic_error_response(
+        detail = AnthropicExceptionMapping.transform_to_anthropic_error(
             status_code=status_code,
-            message=message,
+            raw_message=e.message,
         )
         raise HTTPException(
             status_code=status_code,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3089,6 +3089,12 @@ class TokenCountResponse(LiteLLMPydanticObjectBase):
     """
     Original Response from upstream API call - if an API call was made for token counting
     """
+    error: bool = False
+    error_message: Optional[str] = None
+    """
+    HTTP status code from the token counting API (e.g., 200 for success, 429 for rate limit, 400 for bad request)
+    """
+    status_code: Optional[int] = None
 
 
 class CustomHuggingfaceTokenizer(TypedDict):

--- a/tests/proxy_unit_tests/test_proxy_token_counter.py
+++ b/tests/proxy_unit_tests/test_proxy_token_counter.py
@@ -2,29 +2,43 @@
 # 1. Generate a Key, and use it to make a call
 
 
-import sys, os
+import json
+import logging
+import os
+import sys
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 # this file is to test litellm/proxy
 
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
-import pytest, logging
+
+from fastapi import HTTPException, Request
+
 import litellm
-from litellm.proxy.proxy_server import token_counter
+from litellm import Router
 from litellm._logging import verbose_proxy_logger
+from litellm.llms.bedrock.common_utils import BedrockError
+from litellm.llms.bedrock.count_tokens.bedrock_token_counter import BedrockTokenCounter
+from litellm.llms.bedrock.count_tokens.handler import BedrockCountTokensHandler
+from litellm.proxy._types import ProxyException, TokenCountRequest
+from litellm.proxy.anthropic_endpoints.endpoints import (
+    _create_anthropic_error_response,
+    _extract_error_message,
+    count_tokens as anthropic_count_tokens,
+)
+from litellm.proxy.proxy_server import token_counter
+from litellm.types.utils import TokenCountResponse
 
 verbose_proxy_logger.setLevel(level=logging.DEBUG)
-
-from litellm.proxy._types import TokenCountRequest
-import json, tempfile
-
-
-from litellm import Router
 
 
 def get_vertex_ai_creds_json() -> dict:
@@ -840,3 +854,470 @@ def test_vertex_ai_partner_models_token_counting_endpoint(vertex_location):
         assert endpoint.startswith("https://aiplatform.googleapis.com")
     else:
         assert endpoint.startswith(f"https://{vertex_location}-aiplatform.googleapis.com")
+
+
+@pytest.mark.asyncio
+async def test_bedrock_token_counter_error_propagation_bedrock_error():
+    """
+    Test that BedrockTokenCounter properly returns error response when BedrockError is raised.
+    Verifies that the status code and error message are preserved.
+    """
+    counter = BedrockTokenCounter()
+
+    # Mock the handler to raise BedrockError with specific status code
+    with patch.object(
+        counter, "count_tokens", wraps=counter.count_tokens
+    ) as mock_count:
+        # We need to patch at the handler level
+        with patch(
+            "litellm.llms.bedrock.count_tokens.bedrock_token_counter.BedrockCountTokensHandler"
+        ) as MockHandler:
+            mock_handler_instance = MockHandler.return_value
+            mock_handler_instance.handle_count_tokens_request = AsyncMock(
+                side_effect=BedrockError(
+                    status_code=429, message="Rate limit exceeded"
+                )
+            )
+
+            result = await counter.count_tokens(
+                model_to_use="anthropic.claude-3-sonnet",
+                messages=[{"role": "user", "content": "hello"}],
+                contents=None,
+                deployment={"litellm_params": {}},
+                request_model="bedrock/anthropic.claude-3-sonnet",
+            )
+
+            assert result is not None
+            assert result.error is True
+            assert result.status_code == 429
+            assert "Rate limit exceeded" in result.error_message
+            assert result.tokenizer_type == "bedrock_api"
+            assert result.total_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_bedrock_token_counter_error_propagation_generic_exception():
+    """
+    Test that BedrockTokenCounter returns error response with 500 status for generic exceptions.
+    """
+    counter = BedrockTokenCounter()
+
+    with patch(
+        "litellm.llms.bedrock.count_tokens.bedrock_token_counter.BedrockCountTokensHandler"
+    ) as MockHandler:
+        mock_handler_instance = MockHandler.return_value
+        mock_handler_instance.handle_count_tokens_request = AsyncMock(
+            side_effect=Exception("Unexpected error")
+        )
+
+        result = await counter.count_tokens(
+            model_to_use="anthropic.claude-3-sonnet",
+            messages=[{"role": "user", "content": "hello"}],
+            contents=None,
+            deployment={"litellm_params": {}},
+            request_model="bedrock/anthropic.claude-3-sonnet",
+        )
+
+        assert result is not None
+        assert result.error is True
+        assert result.status_code == 500
+        assert "Unexpected error" in result.error_message
+
+
+@pytest.mark.asyncio
+async def test_bedrock_handler_httpx_error_status_code_propagation():
+    """
+    Test that BedrockCountTokensHandler properly extracts status code from httpx.HTTPStatusError.
+    """
+    handler = BedrockCountTokensHandler()
+
+    # Create a mock httpx response with 403 status
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_response.text = "Forbidden - Invalid credentials"
+
+    # Create HTTPStatusError
+    http_error = httpx.HTTPStatusError(
+        message="Client error '403 Forbidden'",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    with patch.object(handler, "validate_count_tokens_request"):
+        with patch.object(handler, "_get_aws_region_name", return_value="us-west-2"):
+            with patch.object(
+                handler, "transform_anthropic_to_bedrock_count_tokens", return_value={}
+            ):
+                with patch.object(
+                    handler,
+                    "get_bedrock_count_tokens_endpoint",
+                    return_value="https://example.com",
+                ):
+                    with patch.object(handler, "_sign_request", return_value=({}, "{}")):
+                        with patch(
+                            "litellm.llms.bedrock.count_tokens.handler.get_async_httpx_client"
+                        ) as mock_client:
+                            mock_async_client = AsyncMock()
+                            mock_async_client.post = AsyncMock(side_effect=http_error)
+                            mock_client.return_value = mock_async_client
+
+                            with pytest.raises(BedrockError) as exc_info:
+                                await handler.handle_count_tokens_request(
+                                    request_data={
+                                        "model": "test",
+                                        "messages": [
+                                            {"role": "user", "content": "hello"}
+                                        ],
+                                    },
+                                    litellm_params={},
+                                    resolved_model="anthropic.claude-3-sonnet",
+                                )
+
+                            assert exc_info.value.status_code == 403
+                            # Message should be the raw response text
+                            assert exc_info.value.message == "Forbidden - Invalid credentials"
+
+
+@pytest.mark.asyncio
+async def test_proxy_token_counter_error_raises_exception_when_disabled():
+    """
+    Test that proxy token_counter raises ProxyException when disable_token_counter=True
+    and provider returns an error response.
+    """
+    # Create error response
+    error_response = TokenCountResponse(
+        total_tokens=0,
+        request_model="bedrock/anthropic.claude-3-sonnet",
+        model_used="anthropic.claude-3-sonnet",
+        tokenizer_type="bedrock_api",
+        error=True,
+        error_message="Rate limit exceeded",
+        status_code=429,
+    )
+
+    # Create mock router that returns a deployment
+    mock_deployment = {
+        "litellm_params": {
+            "model": "bedrock/anthropic.claude-3-sonnet",
+        },
+        "model_info": {},
+    }
+
+    mock_router = MagicMock()
+    mock_router.async_get_available_deployment = AsyncMock(return_value=mock_deployment)
+
+    setattr(litellm.proxy.proxy_server, "llm_router", mock_router)
+
+    # Save original value and function
+    original_disable = litellm.disable_token_counter
+    original_get_provider_token_counter = litellm.proxy.proxy_server._get_provider_token_counter
+
+    try:
+        litellm.disable_token_counter = True
+
+        # Create a mock counter that returns an error response
+        mock_counter = MagicMock(spec=BedrockTokenCounter)
+        mock_counter.should_use_token_counting_api.return_value = True
+        mock_counter.count_tokens = AsyncMock(return_value=error_response)
+
+        # Replace the function directly
+        def mock_get_provider_token_counter(deployment, model_to_use):
+            return (mock_counter, "anthropic.claude-3-sonnet", "bedrock")
+
+        litellm.proxy.proxy_server._get_provider_token_counter = mock_get_provider_token_counter
+
+        with pytest.raises(ProxyException) as exc_info:
+            await token_counter(
+                request=TokenCountRequest(
+                    model="claude-bedrock",
+                    messages=[{"role": "user", "content": "hello"}],
+                ),
+                call_endpoint=True,
+            )
+
+        assert exc_info.value.code == "429"
+        assert "Rate limit exceeded" in exc_info.value.message
+    finally:
+        litellm.disable_token_counter = original_disable
+        litellm.proxy.proxy_server._get_provider_token_counter = original_get_provider_token_counter
+
+
+@pytest.mark.asyncio
+async def test_proxy_token_counter_error_falls_back_when_enabled():
+    """
+    Test that proxy token_counter falls back to local tokenizer when disable_token_counter=False
+    and provider returns an error response.
+    """
+    # Create error response
+    error_response = TokenCountResponse(
+        total_tokens=0,
+        request_model="bedrock/anthropic.claude-3-sonnet",
+        model_used="anthropic.claude-3-sonnet",
+        tokenizer_type="bedrock_api",
+        error=True,
+        error_message="Rate limit exceeded",
+        status_code=429,
+    )
+
+    # Create mock router that returns a deployment
+    mock_deployment = {
+        "litellm_params": {
+            "model": "bedrock/anthropic.claude-3-sonnet",
+        },
+        "model_info": {},
+    }
+
+    mock_router = MagicMock()
+    mock_router.async_get_available_deployment = AsyncMock(return_value=mock_deployment)
+
+    setattr(litellm.proxy.proxy_server, "llm_router", mock_router)
+
+    # Save original value and function
+    original_disable = litellm.disable_token_counter
+    original_get_provider_token_counter = litellm.proxy.proxy_server._get_provider_token_counter
+
+    try:
+        litellm.disable_token_counter = False
+
+        # Create a mock counter that returns an error response
+        mock_counter = MagicMock(spec=BedrockTokenCounter)
+        mock_counter.should_use_token_counting_api.return_value = True
+        mock_counter.count_tokens = AsyncMock(return_value=error_response)
+
+        # Replace the function directly
+        def mock_get_provider_token_counter(deployment, model_to_use):
+            return (mock_counter, "anthropic.claude-3-sonnet", "bedrock")
+
+        litellm.proxy.proxy_server._get_provider_token_counter = mock_get_provider_token_counter
+
+        # Should not raise, should fall back to local tokenizer
+        result = await token_counter(
+            request=TokenCountRequest(
+                model="claude-bedrock",
+                messages=[{"role": "user", "content": "hello"}],
+            ),
+            call_endpoint=True,
+        )
+
+        # Should have used the fallback tokenizer
+        assert result.error is False
+        assert result.total_tokens > 0
+        assert result.tokenizer_type != "bedrock_api"
+    finally:
+        litellm.disable_token_counter = original_disable
+        litellm.proxy.proxy_server._get_provider_token_counter = original_get_provider_token_counter
+
+
+def test_create_anthropic_error_response_helper():
+    """
+    Test that _create_anthropic_error_response correctly formats errors.
+    """
+    # Test 400 -> invalid_request_error
+    response = _create_anthropic_error_response(400, "Invalid request")
+    assert response["type"] == "error"
+    assert response["error"]["type"] == "invalid_request_error"
+    assert response["error"]["message"] == "Invalid request"
+    assert "request_id" not in response
+
+    # Test 401 -> authentication_error
+    response = _create_anthropic_error_response(401, "Unauthorized")
+    assert response["error"]["type"] == "authentication_error"
+
+    # Test 403 -> permission_error
+    response = _create_anthropic_error_response(403, "Forbidden")
+    assert response["error"]["type"] == "permission_error"
+
+    # Test 429 -> rate_limit_error
+    response = _create_anthropic_error_response(429, "Rate limit exceeded")
+    assert response["error"]["type"] == "rate_limit_error"
+
+    # Test 500 -> api_error
+    response = _create_anthropic_error_response(500, "Internal error")
+    assert response["error"]["type"] == "api_error"
+
+    # Test with request_id
+    response = _create_anthropic_error_response(400, "Error", request_id="req_123")
+    assert response["request_id"] == "req_123"
+
+    # Test unknown status code defaults to api_error
+    response = _create_anthropic_error_response(418, "I'm a teapot")
+    assert response["error"]["type"] == "api_error"
+
+
+def test_extract_error_message_helper():
+    """
+    Test that _extract_error_message correctly extracts messages from various formats.
+    """
+    # Test Bedrock format: {"detail": {"message": "..."}}
+    bedrock_msg = '{"detail":{"message":"Input is too long for requested model."}}'
+    assert _extract_error_message(bedrock_msg) == "Input is too long for requested model."
+
+    # Test {"Message": "..."} format
+    msg = '{"Message":"Bearer Token has expired"}'
+    assert _extract_error_message(msg) == "Bearer Token has expired"
+
+    # Test {"message": "..."} format
+    msg = '{"message":"Some error occurred"}'
+    assert _extract_error_message(msg) == "Some error occurred"
+
+    # Test plain string
+    assert _extract_error_message("Plain error message") == "Plain error message"
+
+    # Test invalid JSON
+    assert _extract_error_message("Not JSON {invalid}") == "Not JSON {invalid}"
+
+    # Test empty dict
+    assert _extract_error_message("{}") == "{}"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_endpoint_returns_anthropic_error_format():
+    """
+    Test that /v1/messages/count_tokens returns errors in Anthropic format.
+    """
+    import litellm.proxy.anthropic_endpoints.endpoints as anthropic_endpoints
+    import litellm.proxy.proxy_server as proxy_server
+
+    # Mock request object
+    mock_request = MagicMock(spec=Request)
+    mock_request_data = {
+        "model": "claude-bedrock",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    }
+
+    async def mock_read_request_body(request):
+        return mock_request_data
+
+    mock_user_api_key_dict = MagicMock()
+
+    original_read_request_body = anthropic_endpoints._read_request_body
+    anthropic_endpoints._read_request_body = mock_read_request_body
+
+    original_token_counter = proxy_server.token_counter
+
+    # Mock token_counter to raise ProxyException with Bedrock-style error
+    async def mock_token_counter_error(request, call_endpoint=False):
+        raise ProxyException(
+            message='{"detail":{"message":"Input is too long for requested model."}}',
+            type="token_counting_error",
+            param="model",
+            code=400,
+        )
+
+    proxy_server.token_counter = mock_token_counter_error
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await anthropic_count_tokens(mock_request, mock_user_api_key_dict)
+
+        # Verify HTTP status code is correct
+        assert exc_info.value.status_code == 400
+
+        # Verify error is in Anthropic format
+        detail = exc_info.value.detail
+        assert detail["type"] == "error"
+        assert detail["error"]["type"] == "invalid_request_error"
+        assert detail["error"]["message"] == "Input is too long for requested model."
+    finally:
+        anthropic_endpoints._read_request_body = original_read_request_body
+        proxy_server.token_counter = original_token_counter
+
+
+@pytest.mark.asyncio
+async def test_anthropic_endpoint_403_permission_error_format():
+    """
+    Test that 403 errors are returned as permission_error in Anthropic format.
+    """
+    import litellm.proxy.anthropic_endpoints.endpoints as anthropic_endpoints
+    import litellm.proxy.proxy_server as proxy_server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request_data = {
+        "model": "claude-bedrock",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    }
+
+    async def mock_read_request_body(request):
+        return mock_request_data
+
+    mock_user_api_key_dict = MagicMock()
+
+    original_read_request_body = anthropic_endpoints._read_request_body
+    anthropic_endpoints._read_request_body = mock_read_request_body
+
+    original_token_counter = proxy_server.token_counter
+
+    # Mock token_counter to raise ProxyException with 403 error
+    async def mock_token_counter_error(request, call_endpoint=False):
+        raise ProxyException(
+            message='{"Message":"Bearer Token has expired"}',
+            type="token_counting_error",
+            param="model",
+            code=403,
+        )
+
+    proxy_server.token_counter = mock_token_counter_error
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await anthropic_count_tokens(mock_request, mock_user_api_key_dict)
+
+        assert exc_info.value.status_code == 403
+
+        detail = exc_info.value.detail
+        assert detail["type"] == "error"
+        assert detail["error"]["type"] == "permission_error"
+        assert detail["error"]["message"] == "Bearer Token has expired"
+    finally:
+        anthropic_endpoints._read_request_body = original_read_request_body
+        proxy_server.token_counter = original_token_counter
+
+
+@pytest.mark.asyncio
+async def test_anthropic_endpoint_429_rate_limit_error_format():
+    """
+    Test that 429 errors are returned as rate_limit_error in Anthropic format.
+    """
+    import litellm.proxy.anthropic_endpoints.endpoints as anthropic_endpoints
+    import litellm.proxy.proxy_server as proxy_server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request_data = {
+        "model": "claude-bedrock",
+        "messages": [{"role": "user", "content": "Hello!"}],
+    }
+
+    async def mock_read_request_body(request):
+        return mock_request_data
+
+    mock_user_api_key_dict = MagicMock()
+
+    original_read_request_body = anthropic_endpoints._read_request_body
+    anthropic_endpoints._read_request_body = mock_read_request_body
+
+    original_token_counter = proxy_server.token_counter
+
+    # Mock token_counter to raise ProxyException with 429 error
+    async def mock_token_counter_error(request, call_endpoint=False):
+        raise ProxyException(
+            message="Rate limit exceeded",
+            type="token_counting_error",
+            param="model",
+            code=429,
+        )
+
+    proxy_server.token_counter = mock_token_counter_error
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await anthropic_count_tokens(mock_request, mock_user_api_key_dict)
+
+        assert exc_info.value.status_code == 429
+
+        detail = exc_info.value.detail
+        assert detail["type"] == "error"
+        assert detail["error"]["type"] == "rate_limit_error"
+        assert detail["error"]["message"] == "Rate limit exceeded"
+    finally:
+        anthropic_endpoints._read_request_body = original_read_request_body
+        proxy_server.token_counter = original_token_counter

--- a/tests/test_litellm/anthropic_interface/exceptions/test_exception_mapping_utils.py
+++ b/tests/test_litellm/anthropic_interface/exceptions/test_exception_mapping_utils.py
@@ -1,0 +1,185 @@
+"""
+Tests for AnthropicExceptionMapping class in litellm/anthropic_interface/exceptions/exception_mapping_utils.py
+"""
+
+import json
+
+from litellm.anthropic_interface.exceptions import AnthropicExceptionMapping
+
+
+class TestCreateErrorResponse:
+    """Tests for AnthropicExceptionMapping.create_error_response()"""
+
+    def test_400_invalid_request_error(self):
+        """Test 400 maps to invalid_request_error."""
+        response = AnthropicExceptionMapping.create_error_response(400, "Invalid request")
+        assert response["type"] == "error"
+        assert response["error"]["type"] == "invalid_request_error"
+        assert response["error"]["message"] == "Invalid request"
+        assert "request_id" not in response
+
+    def test_401_authentication_error(self):
+        """Test 401 maps to authentication_error."""
+        response = AnthropicExceptionMapping.create_error_response(401, "Unauthorized")
+        assert response["error"]["type"] == "authentication_error"
+
+    def test_403_permission_error(self):
+        """Test 403 maps to permission_error."""
+        response = AnthropicExceptionMapping.create_error_response(403, "Forbidden")
+        assert response["error"]["type"] == "permission_error"
+
+    def test_404_not_found_error(self):
+        """Test 404 maps to not_found_error."""
+        response = AnthropicExceptionMapping.create_error_response(404, "Not found")
+        assert response["error"]["type"] == "not_found_error"
+
+    def test_429_rate_limit_error(self):
+        """Test 429 maps to rate_limit_error."""
+        response = AnthropicExceptionMapping.create_error_response(429, "Rate limit exceeded")
+        assert response["error"]["type"] == "rate_limit_error"
+
+    def test_500_api_error(self):
+        """Test 500 maps to api_error."""
+        response = AnthropicExceptionMapping.create_error_response(500, "Internal error")
+        assert response["error"]["type"] == "api_error"
+
+    def test_with_request_id(self):
+        """Test request_id is included when provided."""
+        response = AnthropicExceptionMapping.create_error_response(400, "Error", request_id="req_123")
+        assert response["request_id"] == "req_123"
+
+    def test_unknown_status_defaults_to_api_error(self):
+        """Test unknown status code defaults to api_error."""
+        response = AnthropicExceptionMapping.create_error_response(418, "I'm a teapot")
+        assert response["error"]["type"] == "api_error"
+
+
+class TestExtractErrorMessage:
+    """Tests for AnthropicExceptionMapping.extract_error_message()"""
+
+    def test_bedrock_format(self):
+        """Test extraction from Bedrock format: {"detail": {"message": "..."}}"""
+        bedrock_msg = '{"detail":{"message":"Input is too long for requested model."}}'
+        assert AnthropicExceptionMapping.extract_error_message(bedrock_msg) == "Input is too long for requested model."
+
+    def test_aws_message_format(self):
+        """Test extraction from AWS format: {"Message": "..."}"""
+        msg = '{"Message":"Bearer Token has expired"}'
+        assert AnthropicExceptionMapping.extract_error_message(msg) == "Bearer Token has expired"
+
+    def test_generic_message_format(self):
+        """Test extraction from generic format: {"message": "..."}"""
+        msg = '{"message":"Some error occurred"}'
+        assert AnthropicExceptionMapping.extract_error_message(msg) == "Some error occurred"
+
+    def test_plain_string(self):
+        """Test plain string is returned as-is."""
+        assert AnthropicExceptionMapping.extract_error_message("Plain error message") == "Plain error message"
+
+    def test_invalid_json(self):
+        """Test invalid JSON is returned as-is."""
+        assert AnthropicExceptionMapping.extract_error_message("Not JSON {invalid}") == "Not JSON {invalid}"
+
+    def test_empty_dict(self):
+        """Test empty dict returns original string."""
+        assert AnthropicExceptionMapping.extract_error_message("{}") == "{}"
+
+
+class TestTransformToAnthropicError:
+    """Tests for AnthropicExceptionMapping.transform_to_anthropic_error()"""
+
+    def test_passthrough_anthropic_error(self):
+        """Test that Anthropic errors pass through unchanged."""
+        anthropic_error = {
+            "type": "error",
+            "error": {"type": "rate_limit_error", "message": "Rate limited"}
+        }
+        raw = json.dumps(anthropic_error)
+        result = AnthropicExceptionMapping.transform_to_anthropic_error(
+            status_code=429,
+            raw_message=raw,
+        )
+        assert result["type"] == "error"
+        assert result["error"]["type"] == "rate_limit_error"
+        assert result["error"]["message"] == "Rate limited"
+
+    def test_passthrough_preserves_existing_request_id(self):
+        """Test that existing request_id in Anthropic error is preserved."""
+        anthropic_error = {
+            "type": "error",
+            "error": {"type": "api_error", "message": "Server error"},
+            "request_id": "req_existing"
+        }
+        raw = json.dumps(anthropic_error)
+        result = AnthropicExceptionMapping.transform_to_anthropic_error(
+            status_code=500,
+            raw_message=raw,
+            request_id="req_new",  # Should not override existing
+        )
+        assert result["request_id"] == "req_existing"
+
+    def test_passthrough_adds_request_id_if_missing(self):
+        """Test that request_id is added to Anthropic error if missing."""
+        anthropic_error = {
+            "type": "error",
+            "error": {"type": "api_error", "message": "Server error"}
+        }
+        raw = json.dumps(anthropic_error)
+        result = AnthropicExceptionMapping.transform_to_anthropic_error(
+            status_code=500,
+            raw_message=raw,
+            request_id="req_123",
+        )
+        assert result["request_id"] == "req_123"
+
+    def test_translates_bedrock_error(self):
+        """Test that Bedrock errors are translated to Anthropic format."""
+        bedrock_error = json.dumps({"detail": {"message": "Access denied"}})
+        result = AnthropicExceptionMapping.transform_to_anthropic_error(
+            status_code=403,
+            raw_message=bedrock_error,
+        )
+        assert result["type"] == "error"
+        assert result["error"]["type"] == "permission_error"
+        assert result["error"]["message"] == "Access denied"
+
+    def test_translates_aws_error(self):
+        """Test that AWS errors are translated to Anthropic format."""
+        aws_error = json.dumps({"Message": "Resource not found"})
+        result = AnthropicExceptionMapping.transform_to_anthropic_error(
+            status_code=404,
+            raw_message=aws_error,
+        )
+        assert result["type"] == "error"
+        assert result["error"]["type"] == "not_found_error"
+        assert result["error"]["message"] == "Resource not found"
+
+    def test_handles_plain_string(self):
+        """Test that plain string errors are wrapped in Anthropic format."""
+        result = AnthropicExceptionMapping.transform_to_anthropic_error(
+            status_code=400,
+            raw_message="Invalid request parameters",
+        )
+        assert result["type"] == "error"
+        assert result["error"]["type"] == "invalid_request_error"
+        assert result["error"]["message"] == "Invalid request parameters"
+
+    def test_handles_generic_message_json(self):
+        """Test that generic {"message": "..."} JSON is translated."""
+        generic_error = json.dumps({"message": "Something went wrong"})
+        result = AnthropicExceptionMapping.transform_to_anthropic_error(
+            status_code=500,
+            raw_message=generic_error,
+        )
+        assert result["type"] == "error"
+        assert result["error"]["type"] == "api_error"
+        assert result["error"]["message"] == "Something went wrong"
+
+    def test_handles_non_dict_json(self):
+        """Test that non-dict JSON (e.g., array) is treated as plain string."""
+        result = AnthropicExceptionMapping.transform_to_anthropic_error(
+            status_code=400,
+            raw_message='["error1", "error2"]',
+        )
+        assert result["type"] == "error"
+        assert result["error"]["message"] == '["error1", "error2"]'


### PR DESCRIPTION
## Relevant issues
https://github.com/BerriAI/litellm/issues/18857
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link:https://github.com/BerriAI/litellm/commit/93203cda7c7f9bc0a7762aaf3c0726fff124d7f3

- [x] **CI run for the last commit**  
       Link:https://github.com/BerriAI/litellm/commit/93203cda7c7f9bc0a7762aaf3c0726fff124d7f3

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

## Changes
Follow up to https://github.com/BerriAI/litellm/pull/18858 

`/v1/messages/count_tokens` attempts to use the provider's token counting API. However, when that fails or isn't available, it falls back to the local tokenizer (typically tiktoken). But, there's a setting, `disable_token_counter`, that instantly returns `0` on the local tokenizer: https://github.com/BerriAI/litellm/blob/e230cd0f0d1d32c43dbc4b8c851c425b19943c11/litellm/litellm_core_utils/token_counter.py#L385-L386.

In this case, we shouldn't fallback and return `0` on every failure, because it's not correct. So, we return the error from the provider (or if there's no provider, we error saying there's no provider). 

Here are some test results:
With `disable_token_counter: true`, errors are propagated from the provider:
```
➜  pay-server curl -i -X POST localhost:4000/v1/messages/count_tokens -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-master' \
--data-binary @/Users/raghav/Downloads/test_request.json
HTTP/1.1 403 Forbidden
date: Tue, 13 Jan 2026 20:23:49 GMT
server: uvicorn
content-length: 138
content-type: application/json

{"detail":{"type":"error","error":{"type":"permission_error","message":"Authentication failed: Please make sure your API Key is valid."}}}%
```
Relevant logs in LiteLLM
```
15:23:50 - LiteLLM:ERROR: handler.py:124 - HTTP error in CountTokens handler: Client error '403 Forbidden' for url 'https://bedrock-runtime.us-west-2.amazonaws.com/model/anthropic.claude-haiku-4-5-20251001-v1:0/count-tokens'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
15:23:50 - LiteLLM:WARNING: bedrock_token_counter.py:83 - Bedrock CountTokens API error: status=403, message={"Message":"Authentication failed: Please make sure your API Key is valid."}
INFO:     127.0.0.1:65180 - "POST /v1/messages/count_tokens HTTP/1.1" 403 Forbidden
```
Now if I don't set `disable_token_counter` (defaults to `false`) and run the same request:
```
➜  pay-server curl -i -X POST localhost:4000/v1/messages/count_tokens -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-master' \
--data-binary @/Users/raghav/Downloads/test_request.json
HTTP/1.1 200 OK
date: Tue, 13 Jan 2026 20:24:23 GMT
server: uvicorn
content-length: 19
content-type: application/json

{"input_tokens":10}%
```
Relevant logs in LiteLLM:
```
15:24:25 - LiteLLM:ERROR: handler.py:124 - HTTP error in CountTokens handler: Client error '403 Forbidden' for url 'https://bedrock-runtime.us-west-2.amazonaws.com/model/anthropic.claude-haiku-4-5-20251001-v1:0/count-tokens'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
15:24:25 - LiteLLM:WARNING: bedrock_token_counter.py:83 - Bedrock CountTokens API error: status=403, message={"Message":"Authentication failed: Please make sure your API Key is valid."}
15:24:25 - LiteLLM Proxy:WARNING: proxy_server.py:7075 - Provider token counting failed (403): {"Message":"Authentication failed: Please make sure your API Key is valid."}. Falling back to local tokenizer.
INFO:     127.0.0.1:65479 - "POST /v1/messages/count_tokens HTTP/1.1" 200 OK
```
As a bonus, I also tried a different request that isn't 403, but a 400 on Bedrock due to long input, and the error translation is right:
```
➜  pay-server curl -i -X POST localhost:4000/v1/messages/count_tokens -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-master' \
--data-binary @/Users/raghav/Downloads/bad_request.json
HTTP/1.1 100 Continue

HTTP/1.1 400 Bad Request
date: Tue, 13 Jan 2026 20:35:18 GMT
server: uvicorn
content-length: 119
content-type: application/json

{"detail":{"type":"error","error":{"type":"invalid_request_error","message":"Input is too long for requested model."}}}%
```
Ran all my tests
```
poetry run pytest tests/proxy_unit_tests/test_proxy_token_counter.py::test_bedrock_token_counter_error_propagation_bedrock_error tests/proxy_unit_tests/test_proxy_token_counter.py::test_bedrock_token_counter_error_propagation_generic_exception tests/proxy_unit_tests/test_proxy_token_counter.py::test_bedrock_handler_httpx_error_status_code_propagation tests/proxy_unit_tests/test_proxy_token_counter.py::test_proxy_token_counter_error_raises_exception_when_disabled tests/proxy_unit_tests/test_proxy_token_counter.py::test_proxy_token_counter_error_falls_back_when_enabled tests/proxy_unit_tests/test_proxy_token_counter.py::test_create_anthropic_error_response_helper tests/proxy_unit_tests/test_proxy_token_counter.py::test_extract_error_message_helper tests/proxy_unit_tests/test_proxy_token_counter.py::test_anthropic_endpoint_returns_anthropic_error_format tests/proxy_unit_tests/test_proxy_token_counter.py::test_anthropic_endpoint_403_permission_error_format
  tests/proxy_unit_tests/test_proxy_token_counter.py::test_anthropic_endpoint_429_rate_limit_error_format -v


============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 3.13.0, pytest-7.4.4, pluggy-1.6.0
rootdir: /Users/raghav/stripe/oss/litellm
configfile: pyproject.toml
plugins: respx-0.22.0, mock-3.15.1, anyio-4.11.0, asyncio-0.21.2, requests-mock-1.12.1
asyncio: mode=Mode.AUTO
collected 9 items

tests/proxy_unit_tests/test_proxy_token_counter.py .........                                                                                                                                                                                                             [100%]

============================================================================================================================== 9 passed in 5.05s ===============================================================================================================================
```
