### PR TITLE
[Feature] UI - Model: Anthropic Models QOL

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { Form } from "antd";
+import { describe, expect, it } from "vitest";
+import ConditionalPublicModelName from "./conditional_public_model_name";
+
+describe("ConditionalPublicModelName", () => {
+  it("should render", () => {
+    render(
+      <Form
+        initialValues={{
+          model: ["gpt-4"],
+          model_mappings: [
+            {
+              public_name: "gpt-4",
+              litellm_model: "gpt-4",
+            },
+          ],
+        }}
+      >
+        <ConditionalPublicModelName />
+      </Form>,
+    );
+
+    expect(screen.getByText("Model Mappings")).toBeInTheDocument();
+    expect(screen.getByText("Public Model Name")).toBeInTheDocument();
+    expect(screen.getByText("LiteLLM Model Name")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.tsx
@@ -129,8 +129,31 @@ const ConditionalPublicModelName: React.FC = () => {
           <TextInput
             value={text}
             onChange={(e) => {
+              const newValue = e.target.value;
               const newMappings = [...form.getFieldValue("model_mappings")];
-              newMappings[index].public_name = e.target.value;
+
+              // Check conditions for Anthropic -1m suffix handling
+              const isAnthropic = selectedProvider === Providers.Anthropic;
+              const endsWith1m = newValue.endsWith("-1m");
+              const litellmParams = form.getFieldValue("litellm_extra_params");
+              const isLitellmParamsEmpty = !litellmParams || litellmParams.trim() === "";
+
+              let finalPublicName = newValue;
+
+              if (isAnthropic && endsWith1m && isLitellmParamsEmpty) {
+                // Set litellm params with extra_headers
+                const litellmParamsValue = JSON.stringify(
+                  { extra_headers: { "anthropic-beta": "context-1m-2025-08-07" } },
+                  null,
+                  2,
+                );
+                form.setFieldValue("litellm_extra_params", litellmParamsValue);
+
+                // Remove -1m suffix from public_name
+                finalPublicName = newValue.slice(0, -3); // Remove "-1m" (3 characters)
+              }
+
+              newMappings[index].public_name = finalPublicName;
               form.setFieldValue("model_mappings", newMappings);
             }}
           />


### PR DESCRIPTION
## Relevant issues
This PR implements auto adding of extra headers to use the 1m context window if these conditions are met:
1. Anthropic is selected as the provider
2. The current Public Model Name ends with "-1m"
3. The current LiteLLM Params is empty

Then it removes the "-1m" suffix and adds the extra headers to allow for the 1m context window.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="1151" height="175" alt="image" src="https://github.com/user-attachments/assets/3e438b4f-be0f-4438-ae93-ae14e76881cf" />
<img width="639" height="291" alt="image" src="https://github.com/user-attachments/assets/9ef49835-353c-48f3-9076-971dcf5dcf3b" />
