### PR TITLE
[fix] anthropic during call error

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -649,9 +649,7 @@ class ProxyBaseLLMRequestProcessing:
             proxy_logging_obj.during_call_hook(
                 data=self.data,
                 user_api_key_dict=user_api_key_dict,
-                call_type=ProxyBaseLLMRequestProcessing._get_pre_call_type(
-                    route_type=route_type  # type: ignore
-                ),
+                call_type=route_type,  # type: ignore
             )
         )
 
@@ -1003,19 +1001,6 @@ class ProxyBaseLLMRequestProcessing:
             provider_specific_fields=getattr(e, "provider_specific_fields", None),
             headers=headers,
         )
-
-    @staticmethod
-    def _get_pre_call_type(
-        route_type: Literal["acompletion", "aembedding", "aresponses", "allm_passthrough_route"],
-    ) -> Literal["completion", "embedding", "responses", "allm_passthrough_route"]:
-        if route_type == "acompletion":
-            return "completion"
-        elif route_type == "aembedding":
-            return "embedding"
-        elif route_type == "aresponses":
-            return "responses"
-        elif route_type == "allm_passthrough_route":
-            return "allm_passthrough_route"
 
     #########################################################
     # Proxy Level Streaming Data Generator

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -640,10 +640,6 @@ def test_embedding(mock_aembedding, client_no_auth):
             pre_call_kwargs.get("call_type") == "aembedding"
         ), f"expected pre_call_hook to receive call_type='aembedding', got {pre_call_kwargs.get('call_type')}"
 
-        during_call_kwargs = mock_during_hook.await_args_list[0].kwargs
-        assert (
-            during_call_kwargs.get("call_type") == "embedding"
-        ), f"expected during_call_hook to receive call_type='embedding', got {during_call_kwargs.get('call_type')}"
     except Exception as e:
         pytest.fail(f"LiteLLM Proxy test failed. Exception - {str(e)}")
 

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -492,51 +492,6 @@ class TestCustomGuardrailPassthroughSupport:
         assert result is True
 
 
-class TestPassthroughCallTypeHandling:
-    """Tests for passthrough call type handling in common_request_processing."""
-
-    def test_get_pre_call_type_with_allm_passthrough_route(self):
-        """
-        Test that _get_pre_call_type correctly maps allm_passthrough_route.
-
-        This tests Fix #1: allm_passthrough_route was not being handled, causing call_type to be None.
-        """
-        from litellm.proxy.common_request_processing import (
-            ProxyBaseLLMRequestProcessing,
-        )
-
-        # Test the mapping
-        result = ProxyBaseLLMRequestProcessing._get_pre_call_type(
-            route_type="allm_passthrough_route"
-        )
-
-        # Should return allm_passthrough_route, not None
-        assert result == "allm_passthrough_route"
-
-    def test_get_pre_call_type_preserves_standard_mappings(self):
-        """
-        Test that _get_pre_call_type still correctly maps standard route types.
-
-        Ensures Fix #1 didn't break existing functionality.
-        """
-        from litellm.proxy.common_request_processing import (
-            ProxyBaseLLMRequestProcessing,
-        )
-
-        # Test standard mappings are preserved
-        assert (
-            ProxyBaseLLMRequestProcessing._get_pre_call_type(route_type="acompletion")
-            == "completion"
-        )
-        assert (
-            ProxyBaseLLMRequestProcessing._get_pre_call_type(route_type="aembedding")
-            == "embedding"
-        )
-        assert (
-            ProxyBaseLLMRequestProcessing._get_pre_call_type(route_type="aresponses")
-            == "responses"
-        )
-
 
 class TestEventTypeLogging:
     """Tests for event_type logging in guardrail information."""


### PR DESCRIPTION
## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm?branch=litellm_fix_anthropic-during-call-error

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

Fixed the issue where calling a guardrail during `during_call` from `/v1/messages` requests triggered the following error.

```
traceback:"  File "/usr/lib/python3.13/site-packages/litellm/proxy/anthropic_endpoints/endpoints.py", line 53, in anthropic_response
    result = await base_llm_response_processor.base_process_llm_request(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<16 lines>...
    )
    ^
  File "/usr/lib/python3.13/site-packages/litellm/proxy/common_request_processing.py", line 560, in base_process_llm_request
    responses = await llm_responses
                ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/litellm/proxy/utils.py", line 1305, in during_call_hook
    raise e
  File "/usr/lib/python3.13/site-packages/litellm/proxy/utils.py", line 1302, in during_call_hook
    await asyncio.gather(*guardrail_tasks)
  File "/usr/lib/python3.13/site-packages/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py", line 135, in async_moderation_hook
    CallTypes(call_type)
    ~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3.13/enum.py", line 726, in __call__
    return cls.__new__(cls, value)
           ~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib/python3.13/enum.py", line 1203, in __new__
    raise ve_exc
",
error_code:"",
error_class:"ValueError",
llm_provider:"",
error_message:"None is not a valid CallTypes"
```