### PR TITLE
Make keepalive_timeout parameter work for Gunicorn

### DIFF
--- a/litellm/containers/main.py
+++ b/litellm/containers/main.py
@@ -199,7 +199,13 @@ def create_container(
             return response
 
         # get llm provider logic
-        litellm_params = GenericLiteLLMParams(**kwargs)
+        # Pass credential params explicitly since they're named args, not in kwargs
+        litellm_params = GenericLiteLLMParams(
+            api_key=api_key,
+            api_base=api_base,
+            api_version=api_version,
+            **kwargs,
+        )
         # get provider config
         container_provider_config: Optional[BaseContainerConfig] = (
             ProviderConfigManager.get_provider_container_config(
@@ -406,7 +412,13 @@ def list_containers(
             return response
 
         # get llm provider logic
-        litellm_params = GenericLiteLLMParams(**kwargs)
+        # Pass credential params explicitly since they're named args, not in kwargs
+        litellm_params = GenericLiteLLMParams(
+            api_key=api_key,
+            api_base=api_base,
+            api_version=api_version,
+            **kwargs,
+        )
         # get provider config
         container_provider_config: Optional[BaseContainerConfig] = (
             ProviderConfigManager.get_provider_container_config(
@@ -594,7 +606,13 @@ def retrieve_container(
             return response
 
         # get llm provider logic
-        litellm_params = GenericLiteLLMParams(**kwargs)
+        # Pass credential params explicitly since they're named args, not in kwargs
+        litellm_params = GenericLiteLLMParams(
+            api_key=api_key,
+            api_base=api_base,
+            api_version=api_version,
+            **kwargs,
+        )
         # get provider config
         container_provider_config: Optional[BaseContainerConfig] = (
             ProviderConfigManager.get_provider_container_config(
@@ -774,7 +792,13 @@ def delete_container(
             return response
 
         # get llm provider logic
-        litellm_params = GenericLiteLLMParams(**kwargs)
+        # Pass credential params explicitly since they're named args, not in kwargs
+        litellm_params = GenericLiteLLMParams(
+            api_key=api_key,
+            api_base=api_base,
+            api_version=api_version,
+            **kwargs,
+        )
         # get provider config
         container_provider_config: Optional[BaseContainerConfig] = (
             ProviderConfigManager.get_provider_container_config(
@@ -968,7 +992,13 @@ def list_container_files(
             return response
 
         # get llm provider logic
-        litellm_params = GenericLiteLLMParams(**kwargs)
+        # Pass credential params explicitly since they're named args, not in kwargs
+        litellm_params = GenericLiteLLMParams(
+            api_key=api_key,
+            api_base=api_base,
+            api_version=api_version,
+            **kwargs,
+        )
         # get provider config
         container_provider_config: Optional[BaseContainerConfig] = (
             ProviderConfigManager.get_provider_container_config(
@@ -1203,7 +1233,13 @@ def upload_container_file(
             return response
 
         # get llm provider logic
-        litellm_params = GenericLiteLLMParams(**kwargs)
+        # Pass credential params explicitly since they're named args, not in kwargs
+        litellm_params = GenericLiteLLMParams(
+            api_key=api_key,
+            api_base=api_base,
+            api_version=api_version,
+            **kwargs,
+        )
         # get provider config
         container_provider_config: Optional[BaseContainerConfig] = (
             ProviderConfigManager.get_provider_container_config(

--- a/litellm/llms/openai/containers/transformation.py
+++ b/litellm/llms/openai/containers/transformation.py
@@ -83,8 +83,13 @@ class OpenAIContainerConfig(BaseContainerConfig):
     ) -> str:
         """Get the complete URL for OpenAI container API.
         """
-        if api_base is None:
-            api_base = "https://api.openai.com/v1"
+        api_base = (
+            api_base
+            or litellm.api_base
+            or get_secret_str("OPENAI_BASE_URL")
+            or get_secret_str("OPENAI_API_BASE")
+            or "https://api.openai.com/v1"
+        )
 
         return f"{api_base.rstrip('/')}/containers"
 

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -187,6 +187,7 @@ class ProxyInitializationHelpers:
         ssl_certfile_path: str,
         ssl_keyfile_path: str,
         max_requests_before_restart: Optional[int] = None,
+        keepalive_timeout: Optional[int] = None,
     ):
         """
         Run litellm with `gunicorn`
@@ -266,6 +267,10 @@ class ProxyInitializationHelpers:
             "timeout": 600,  # default to very high number, bedrock/anthropic.claude-v2:1 can take 30+ seconds for the 1st chunk to come in
             "access_log_format": '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s',
         }
+
+        # Optional: set keepalive timeout if specified by user
+        if keepalive_timeout is not None:
+            gunicorn_options["keepalive"] = keepalive_timeout
 
         # Optional: recycle workers after N requests to mitigate memory growth
         if max_requests_before_restart is not None:
@@ -489,7 +494,7 @@ class ProxyInitializationHelpers:
     "--keepalive_timeout",
     default=None,
     type=int,
-    help="Set the uvicorn keepalive timeout in seconds (uvicorn timeout_keep_alive parameter)",
+    help="Set the keepalive timeout in seconds. For Uvicorn: timeout_keep_alive parameter. For Gunicorn: keepalive parameter. Default: Uvicorn uses ~75s, Gunicorn uses 90s",
     envvar="KEEPALIVE_TIMEOUT",
 )
 @click.option(
@@ -859,6 +864,7 @@ def run_server(  # noqa: PLR0915
                 ssl_certfile_path=ssl_certfile_path,
                 ssl_keyfile_path=ssl_keyfile_path,
                 max_requests_before_restart=max_requests_before_restart,
+                keepalive_timeout=keepalive_timeout,
             )
         elif run_hypercorn is True:
             ProxyInitializationHelpers._init_hypercorn_server(

--- a/tests/test_litellm/containers/test_container_regional_api_base.py
+++ b/tests/test_litellm/containers/test_container_regional_api_base.py
@@ -1,0 +1,163 @@
+"""
+Tests for OpenAI Containers API regional api_base support.
+
+Validates that litellm.create_container and litellm.upload_container_file
+correctly use regional endpoints like https://us.api.openai.com/v1 for
+US Data Residency instead of defaulting to https://api.openai.com/v1.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm
+
+
+class TestContainerRegionalApiBase:
+    """Test suite for container API regional api_base support."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        os.environ["OPENAI_API_KEY"] = "sk-test123"
+
+    def teardown_method(self):
+        """Clean up after tests."""
+        if "OPENAI_API_KEY" in os.environ:
+            del os.environ["OPENAI_API_KEY"]
+        if "OPENAI_BASE_URL" in os.environ:
+            del os.environ["OPENAI_BASE_URL"]
+        if "OPENAI_API_BASE" in os.environ:
+            del os.environ["OPENAI_API_BASE"]
+        litellm.api_base = None
+
+    @patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post")
+    def test_create_container_uses_regional_api_base(self, mock_post):
+        """
+        Test that litellm.create_container uses the regional api_base when provided.
+        
+        This validates the fix for US Data Residency support where requests should
+        go to https://us.api.openai.com/v1 instead of https://api.openai.com/v1.
+        """
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "cntr_123456",
+            "object": "container",
+            "created_at": 1747857508,
+            "status": "running",
+            "expires_after": {"anchor": "last_active_at", "minutes": 20},
+            "last_active_at": 1747857508,
+            "name": "Test Container"
+        }
+        mock_post.return_value = mock_response
+
+        litellm.create_container(
+            name="Test Container",
+            custom_llm_provider="openai",
+            api_base="https://us.api.openai.com/v1",
+        )
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        called_url = call_args[1]["url"]
+        
+        assert "us.api.openai.com" in called_url, f"Expected US regional URL, got: {called_url}"
+        assert called_url == "https://us.api.openai.com/v1/containers"
+
+    @patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post")
+    def test_create_container_uses_env_var_openai_base_url(self, mock_post):
+        """
+        Test that litellm.create_container uses OPENAI_BASE_URL env var.
+        """
+        os.environ["OPENAI_BASE_URL"] = "https://us.api.openai.com/v1"
+        
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "cntr_123456",
+            "object": "container",
+            "created_at": 1747857508,
+            "status": "running",
+            "expires_after": {"anchor": "last_active_at", "minutes": 20},
+            "last_active_at": 1747857508,
+            "name": "Test Container"
+        }
+        mock_post.return_value = mock_response
+
+        litellm.create_container(
+            name="Test Container",
+            custom_llm_provider="openai",
+        )
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        called_url = call_args[1]["url"]
+        
+        assert "us.api.openai.com" in called_url, f"Expected US regional URL, got: {called_url}"
+
+    @patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post")
+    def test_create_container_defaults_to_standard_openai(self, mock_post):
+        """
+        Test that litellm.create_container defaults to standard OpenAI URL
+        when no regional api_base is configured.
+        """
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "cntr_123456",
+            "object": "container",
+            "created_at": 1747857508,
+            "status": "running",
+            "expires_after": {"anchor": "last_active_at", "minutes": 20},
+            "last_active_at": 1747857508,
+            "name": "Test Container"
+        }
+        mock_post.return_value = mock_response
+
+        litellm.create_container(
+            name="Test Container",
+            custom_llm_provider="openai",
+        )
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        called_url = call_args[1]["url"]
+        
+        assert called_url == "https://api.openai.com/v1/containers"
+
+    @patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post")
+    def test_upload_container_file_uses_regional_api_base(self, mock_post):
+        """
+        Test that litellm.upload_container_file uses the regional api_base when provided.
+        """
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "file_123456",
+            "object": "container.file",
+            "created_at": 1747857508,
+            "container_id": "cntr_123456",
+            "path": "/mnt/user/data.csv",
+            "source": "user",
+        }
+        mock_post.return_value = mock_response
+
+        litellm.upload_container_file(
+            container_id="cntr_123456",
+            file=("data.csv", b"col1,col2\n1,2", "text/csv"),
+            custom_llm_provider="openai",
+            api_base="https://us.api.openai.com/v1",
+        )
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        called_url = call_args[1]["url"]
+        
+        assert "us.api.openai.com" in called_url, f"Expected US regional URL, got: {called_url}"
+        assert "cntr_123456/files" in called_url
+


### PR DESCRIPTION
## Relevant issues

Fixes: #19091

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🆕 New Feature

## Changes

### Summary

Extend `--keepalive_timeout` CLI parameter to work with Gunicorn mode, preventing 503 errors when running behind load balancers.

### Problem

When running with Gunicorn (`--run_gunicorn`), connections fail with 503 errors behind load balancers due to keepalive mismatch:

**Root cause:**
1. Gunicorn default keepalive: **2 seconds** ([docs](https://docs.gunicorn.org/en/stable/settings.html#keepalive))
2. Load balancer keepalive (APISIX/ALB/Nginx): **60+ seconds**
3. Gunicorn closes idle connections after 2s
4. Load balancer tries to reuse connection after 60s → **Connection closed → 503**

**Current state:**
- `--keepalive_timeout` only works for Uvicorn mode
- Gunicorn mode has no way to configure keepalive via CLI
- Users must fork code or cannot use official Docker images

### Solution

Make `--keepalive_timeout` control keepalive for both Uvicorn and Gunicorn modes. Since these modes are mutually exclusive, reusing the parameter is natural.

### Usage

**Before:**
```bash
litellm --run_gunicorn  # Uses 2s, causes 503 errors
```

**After:**
```bash
# Use custom value (recommended for production behind load balancers)
litellm --run_gunicorn --keepalive_timeout 90

# Or via environment variable
export KEEPALIVE_TIMEOUT=90
litellm --run_gunicorn

# Default behavior (2s) unchanged when not specified
litellm --run_gunicorn
```

### Parameter Mapping

| CLI Parameter | Uvicorn | Gunicorn |
|---------------|---------|----------|
| `--keepalive_timeout` | `timeout_keep_alive` | `keepalive` |
| Default | ~75s | 2s |

### Backward Compatibility

✅ Fully backward compatible:
- Existing Uvicorn usage unchanged
- Gunicorn without parameter uses same 2s default
- No breaking changes

### Testing

```bash
# New tests
pytest tests/test_litellm/proxy/test_proxy_cli.py::TestProxyInitializationHelpers::test_gunicorn_keepalive_timeout_flag -v
pytest tests/test_litellm/proxy/test_proxy_cli.py::TestProxyInitializationHelpers::test_gunicorn_keepalive_default -v

# Verify Uvicorn backward compatibility
pytest tests/test_litellm/proxy/test_proxy_cli.py::TestProxyInitializationHelpers::test_keepalive_timeout_flag -v
```

<img width="4370" height="786" alt="image" src="https://github.com/user-attachments/assets/ecbe6b26-1a12-4341-ac24-4ae65ff877b9" />

### Files Changed

- `litellm/proxy/proxy_cli.py` (4 modifications)
- `tests/test_litellm/proxy/test_proxy_cli.py` (2 tests added)

### Production Impact

Fixes 503 errors when running behind load balancers in Gunicorn mode by allowing keepalive configuration to match infrastructure requirements.
