### PR TITLE
fix(vertex): add type object to tool schemas missing type field

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -655,6 +655,11 @@ def convert_anyof_null_to_nullable(schema, depth=0):
 
 
 def add_object_type(schema):
+    # Gemini requires all function parameters to be type OBJECT
+    # Handle case where schema has no properties and no type (e.g. tools with no arguments)
+    if "type" not in schema and "anyOf" not in schema and "oneOf" not in schema and "allOf" not in schema:
+        schema["type"] = "object"
+
     properties = schema.get("properties", None)
     if properties is not None:
         if "required" in schema and schema["required"] is None:


### PR DESCRIPTION
Tools with no parameters (like EnterPlanMode from Anthropic Agents SDK) send schemas with only $schema and no type field. Gemini rejects these with "functionDeclaration parameters schema should be of type OBJECT".

Adds type: object when schema has no type and no anyOf/oneOf/allOf.

## Relevant issues

Fixes issue where tools with no parameters (like EnterPlanMode from Anthropic Agents SDK) fail on Gemini/Vertex AI.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Tools with no parameters send schemas like `{"$schema": "..."}` with no type field. Gemini requires `type: object` on all function parameter schemas.

Added check at start of `add_object_type()` to add `type: object` when schema has no type and no anyOf/oneOf/allOf.
