### PR TITLE
[Perf] Remove premature model.dump call on the hot path

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4972,7 +4972,17 @@ def _try_create_usage_from_dict(usage: dict) -> Optional[Usage]:
     try:
         return Usage(**usage)
     except (TypeError, ValueError) as e:
-        verbose_logger.debug(f"Error creating Usage from dict: {e}, usage: {usage}")
+        # Avoid logging full dict contents, which may include sensitive data
+        try:
+            usage_keys = list(usage.keys())
+        except Exception:
+            usage_keys = None
+        verbose_logger.debug(
+            "Error creating Usage from dict: %s, usage keys: %s, usage type: %s",
+            e,
+            usage_keys,
+            type(usage),
+        )
         return None
 
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5102,7 +5102,10 @@ def get_standard_logging_object_payload(
             ),
         )
 
-        id = _safe_get_attribute(response_obj, "id", None) or kwargs.get("litellm_call_id")
+        # Preserve falsy values (0, "", False) if they exist in response_obj
+        id = _safe_get_attribute(response_obj, "id", None)
+        if id is None:
+            id = kwargs.get("litellm_call_id")
 
         _model_id = metadata.get("model_info", {}).get("id", "")
         _model_group = metadata.get("model_group", "")

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4506,12 +4506,11 @@ class StandardLoggingPayloadSetup:
             )
 
         if isinstance(response_obj, dict):
-            usage = response_obj.get("usage", None) or {}
+            usage = response_obj.get("usage", None)
         else:
-            usage = getattr(response_obj, "usage", None) or {}
-        if usage is None or (
-            not isinstance(usage, dict) and not isinstance(usage, Usage)
-        ):
+            usage = getattr(response_obj, "usage", None)
+        
+        if usage is None:
             return Usage(
                 prompt_tokens=0,
                 completion_tokens=0,
@@ -4519,13 +4518,12 @@ class StandardLoggingPayloadSetup:
             )
         elif isinstance(usage, Usage):
             return usage
+        elif ResponseAPILoggingUtils._is_response_api_usage(usage):
+            # Handle ResponseAPIUsage (object or dict) from ResponsesAPIResponse
+            return ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+                usage
+            )
         elif isinstance(usage, dict):
-            if ResponseAPILoggingUtils._is_response_api_usage(usage):
-                return (
-                    ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
-                        usage
-                    )
-                )
             return Usage(**usage)
 
         raise ValueError(f"usage is required, got={usage} of type {type(usage)}")

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4525,8 +4525,13 @@ class StandardLoggingPayloadSetup:
             )
         elif isinstance(usage, dict):
             return Usage(**usage)
-
-        raise ValueError(f"usage is required, got={usage} of type {type(usage)}")
+        else:
+            # Unknown type - return 0 tokens (defensive behavior)
+            return Usage(
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+            )
 
     @staticmethod
     def get_model_cost_information(


### PR DESCRIPTION
## Relevant issues

Previously, `_extract_response_obj_and_hidden_params()` called `model_dump()` on `BaseModel` objects immediately, converting them to dicts even when a dict wasn't needed. This caused:

- **Unnecessary serialization overhead** (identified as a bottleneck in profiling)

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/54178/workflows/1985968c-1532-4f4c-9f40-aef08f52ad2d

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/54285/workflows/692c5cc2-b257-4294-a613-a310573aaa7b

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring

## Changes

### Performance Optimization: Lazy BaseModel Serialization

**Core Change:**
- **Removed early `model_dump()` call**: `_extract_response_obj_and_hidden_params()` now returns `Union[dict, BaseModel]` instead of always converting BaseModel to dict
- **Lazy serialization**: `model_dump()` is now only called when a dict is actually required (in `get_final_response_obj()` for redaction/logging)

**Implementation Details:**
- Changed return type of `_extract_response_obj_and_hidden_params()` from `Tuple[dict, Optional[dict]]` to `Tuple[Union[dict, BaseModel], Optional[dict]]`
- Updated `get_final_response_obj()` to call `_safe_model_dump()` only when `response_obj` is a BaseModel
- Updated all downstream functions to handle both `dict` and `BaseModel` types

**Defensive Helper Functions Added:**
- `_safe_model_dump()`: Safely calls `model_dump()` with fallback strategies (`__dict__`, string conversion)
- `_safe_get_attribute()`: Safely extracts attributes from both dict and BaseModel objects
- `_safe_extract_usage_from_obj()`: Safely extracts usage from response objects
- `_try_transform_response_api_usage()`: Attempts ResponseAPIUsage transformation with error handling
- `_try_create_usage_from_dict()`: Attempts Usage creation from dict with error handling


## Unit Test Results

<img width="2708" height="397" alt="Screenshot 2026-01-14 115536" src="https://github.com/user-attachments/assets/ff439bd1-878e-4754-a094-dbf7aff01a90" />

- Failures seem to be unrelated.
