### PR TITLE
[Fix] Claude Code (/messages) - Litellm fix claude code Bedrock Invoke usage, request signing 

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -729,8 +729,6 @@ class BedrockLLM(BaseAWSLLM):
         client: Optional[Union[AsyncHTTPHandler, HTTPHandler]] = None,
     ) -> Union[ModelResponse, CustomStreamWrapper]:
         try:
-            from botocore.auth import SigV4Auth
-            from botocore.awsrequest import AWSRequest
             from botocore.credentials import Credentials
         except ImportError:
             raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
@@ -807,8 +805,6 @@ class BedrockLLM(BaseAWSLLM):
         else:
             endpoint_url = f"{endpoint_url}/model/{modelId}/invoke"
             proxy_endpoint_url = f"{proxy_endpoint_url}/model/{modelId}/invoke"
-
-        sigv4 = SigV4Auth(credentials, "bedrock", aws_region_name)
 
         prompt, chat_history = self.convert_messages_to_prompt(
             model, messages, provider, custom_prompt_dict
@@ -970,15 +966,14 @@ class BedrockLLM(BaseAWSLLM):
         headers = {"Content-Type": "application/json"}
         if extra_headers is not None:
             headers = {"Content-Type": "application/json", **extra_headers}
-        request = AWSRequest(
-            method="POST", url=endpoint_url, data=data, headers=headers
+        prepped = self.get_request_headers(
+            credentials=credentials,
+            aws_region_name=aws_region_name,
+            extra_headers=extra_headers,
+            endpoint_url=endpoint_url,
+            data=data,
+            headers=headers,
         )
-        sigv4.add_auth(request)
-        if (
-            extra_headers is not None and "Authorization" in extra_headers
-        ):  # prevent sigv4 from overwriting the auth header
-            request.headers["Authorization"] = extra_headers["Authorization"]
-        prepped = request.prepare()
 
         ## LOGGING
         logging_obj.pre_call(

--- a/tests/pass_through_unit_tests/test_bedrock_anthropic_messages_test.py
+++ b/tests/pass_through_unit_tests/test_bedrock_anthropic_messages_test.py
@@ -99,3 +99,43 @@ async def test_anthropic_messages_bedrock_converse_with_thinking():
     # Verify response
     INSTANCE_BASE_ANTHROPIC_MESSAGES_TEST._validate_response(response)
 
+
+@pytest.mark.asyncio
+async def test_should_not_fail_with_forwarded_headers_bedrock_invoke_messages():
+    """
+    E2E test for Bedrock invoke messages with header forwarding enabled.
+    This calls the real Bedrock endpoint (no mocks) and should not raise
+    SigV4 signature mismatch errors when forwarded headers are present.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "claude-sonnet-4-5-20250929",
+                "litellm_params": {
+                    "model": "bedrock/invoke/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                    "aws_region_name": os.getenv("AWS_REGION_NAME"),
+                },
+            }
+        ]
+    )
+
+    forwarded_headers = {
+        "x-forwarded-for": "10.11.232.194",
+        "x-forwarded-port": "443",
+        "x-forwarded-proto": "https",
+        "x-app": "cli",
+    }
+
+    response = await router.aanthropic_messages(
+        messages=[{"role": "user", "content": "hi"}],
+        model="claude-sonnet-4-5-20250929",
+        max_tokens=5,
+        stream=False,
+        headers=forwarded_headers,  # simulates forward_client_headers_to_llm_api
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+        aws_region_name=os.getenv("AWS_REGION_NAME"),
+    )
+    print("INVOKE API RESPONSE: ", response)
+
+    INSTANCE_BASE_ANTHROPIC_MESSAGES_TEST._validate_response(response)


### PR DESCRIPTION
## [Fix] Claude Code (/messages) - Litellm fix claude code Bedrock Invoke usage, request signing 

Fixes Bedrock invoke SigV4 signing to match the converse path by filtering headers before signing and keeping forwarded headers unsigned. This prevents signature mismatches when forward_client_headers_to_llm_api is enabled and ALB mutates x-forwarded-* headers.

<img width="1728" height="325" alt="Screenshot 2026-01-14 at 2 22 46 PM" src="https://github.com/user-attachments/assets/27565bb1-e2ae-4012-9b97-d44ad264e709" />


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
