### PR TITLE
[Fix] Containers API - Container API routes return 401 for non-admin users - routes missing from openai_routes

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -360,6 +360,10 @@ class LiteLLMRoutes(enum.Enum):
         # OCR
         "/ocr",
         "/v1/ocr",
+
+        # containers API
+        "/containers/*",
+        "/v1/containers/*",
     ]
 
     mapped_pass_through_routes = [

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -732,6 +732,25 @@ def test_videos_route_is_llm_api_route(route):
     assert RouteChecks.is_llm_api_route(route) is True
 
 
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/containers",
+        "/v1/containers",
+        "/containers/container_123",
+        "/v1/containers/container_123",
+        "/containers/container_123/files",
+        "/v1/containers/container_123/files",
+        "/containers/container_123/files/file_456",
+        "/v1/containers/container_123/files/file_456",
+    ],
+)
+def test_containers_routes_are_llm_api_routes(route):
+    """Test that container routes are recognized as LLM API routes"""
+
+    assert RouteChecks.is_llm_api_route(route) is True
+
+
 def test_videos_route_accessible_to_internal_users():
     """
     Test that internal users can access the videos routes.


### PR DESCRIPTION
## [Fix] Containers API - Container API routes return 401 for non-admin users - routes missing from openai_routes

Fixes https://github.com/BerriAI/litellm/issues/19088

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
