### PR TITLE
[Feat] Claude Code - Add support for Prompt Caching with Bedrock Converse

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,4 +1,36 @@
 model_list:
+  - model_name: claude-sonnet-4-5-20250929
+    litellm_params:
+      model: bedrock/invoke/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+    model_info:
+      cache_creation_input_token_cost: 3.75e-06
+      cache_read_input_token_cost: 3e-07
+      input_cost_per_token: 3e-06
+      input_cost_per_token_above_200k_tokens: 6e-06
+      output_cost_per_token_above_200k_tokens: 2.25e-05
+      cache_creation_input_token_cost_above_200k_tokens: 7.5e-06
+      cache_read_input_token_cost_above_200k_tokens: 6e-07
+      litellm_provider: bedrock_converse
+      max_input_tokens: 200000
+      max_output_tokens: 64000
+      max_tokens: 200000
+      mode: chat
+      output_cost_per_token: 1.5e-05
+      search_context_cost_per_query:
+        search_context_size_high: 0.01
+        search_context_size_low: 0.01
+        search_context_size_medium: 0.01
+      supports_assistant_prefill: true
+      supports_computer_use: true
+      supports_function_calling: true
+      supports_pdf_input: true
+      supports_prompt_caching: true
+      supports_reasoning: true
+      supports_response_schema: true
+      supports_tool_choice: true
+      supports_vision: true
+      tool_use_system_prompt_tokens: 346
+
   - model_name: us.anthropic.claude-sonnet-4-20250514-v1:0
     litellm_params:
       model: bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0
@@ -8,3 +40,4 @@ model_list:
 
 general_settings:
   store_prompts_in_spend_logs: true
+  forward_client_headers_to_llm_api: true

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -475,6 +475,8 @@ class MessageDelta(TypedDict, total=False):
 class UsageDelta(TypedDict, total=False):
     input_tokens: int
     output_tokens: int
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
 
 
 class MessageBlockDelta(TypedDict):

--- a/tests/pass_through_unit_tests/base_anthropic_messages_prompt_caching_test.py
+++ b/tests/pass_through_unit_tests/base_anthropic_messages_prompt_caching_test.py
@@ -1,0 +1,239 @@
+"""
+Base test class for Anthropic Messages API prompt caching E2E tests.
+
+Tests that prompt caching works correctly via litellm.anthropic.messages interface
+by making actual API calls and validating usage metrics.
+
+Per AWS docs (https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html):
+- Converse API uses: cachePoint: { type: "default" }
+- InvokeModel API uses: cache_control: { type: "ephemeral" }
+- Claude 3.7 Sonnet: GA, 1024 min tokens
+- Claude 3.5 Haiku: GA, 2048 min tokens
+"""
+
+import json
+import os
+import sys
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import pytest
+import litellm
+
+
+# Large document for caching tests (needs 1024+ tokens for Claude models)
+LARGE_DOCUMENT_FOR_CACHING = """
+This is a comprehensive legal agreement between Party A and Party B.
+
+ARTICLE 1: DEFINITIONS
+1.1 "Agreement" means this document and all attachments.
+1.2 "Confidential Information" means any non-public information.
+1.3 "Effective Date" means the date of last signature.
+1.4 "Term" means the period during which this Agreement is in effect.
+
+ARTICLE 2: SCOPE OF SERVICES
+2.1 Party A agrees to provide the following services...
+2.2 Party B agrees to compensate Party A for services rendered...
+2.3 All services shall be performed in a professional manner...
+
+ARTICLE 3: PAYMENT TERMS
+3.1 Payment shall be made within 30 days of invoice receipt.
+3.2 Late payments shall accrue interest at 1.5% per month.
+3.3 All fees are non-refundable unless otherwise specified.
+
+ARTICLE 4: INTELLECTUAL PROPERTY
+4.1 All pre-existing IP remains with the original owner.
+4.2 Work product created under this Agreement shall be owned by Party B.
+4.3 Party A grants a license to use any tools or methodologies.
+
+ARTICLE 5: CONFIDENTIALITY
+5.1 Both parties agree to maintain confidentiality of all shared information.
+5.2 Confidential information shall not be disclosed to third parties.
+5.3 This obligation survives termination of the Agreement.
+
+ARTICLE 6: TERMINATION
+6.1 Either party may terminate with 30 days written notice.
+6.2 Immediate termination is permitted for material breach.
+6.3 Upon termination, all confidential information must be returned.
+
+ARTICLE 7: LIMITATION OF LIABILITY
+7.1 Neither party shall be liable for consequential damages.
+7.2 Total liability shall not exceed fees paid in the prior 12 months.
+7.3 This limitation does not apply to willful misconduct.
+
+ARTICLE 8: DISPUTE RESOLUTION
+8.1 Disputes shall first be addressed through good faith negotiation.
+8.2 If negotiation fails, disputes shall be submitted to arbitration.
+8.3 Arbitration shall be conducted under AAA rules.
+
+ARTICLE 9: GENERAL PROVISIONS
+9.1 This Agreement constitutes the entire understanding between parties.
+9.2 Amendments must be in writing and signed by both parties.
+9.3 This Agreement shall be governed by the laws of Delaware.
+9.4 Neither party may assign this Agreement without consent.
+9.5 Waiver of any provision shall not constitute ongoing waiver.
+
+IN WITNESS WHEREOF, the parties have executed this Agreement.
+""" * 8  # Repeat to ensure we have enough tokens (need 1024+ for Claude models)
+
+
+class BaseAnthropicMessagesPromptCachingTest(ABC):
+    """
+    Base test class for prompt caching E2E tests across different providers.
+    
+    Subclasses must implement:
+    - get_model(): Returns the model string to use for tests
+    """
+
+    @abstractmethod
+    def get_model(self) -> str:
+        """
+        Returns the model string to use for tests.
+        
+        Examples:
+        - "bedrock/converse/anthropic.claude-3-7-sonnet-20250219-v1:0"
+        - "bedrock/invoke/anthropic.claude-3-7-sonnet-20250219-v1:0"
+        """
+        pass
+
+    def get_messages_with_cache_control(self) -> List[Dict[str, Any]]:
+        """
+        Returns test messages with cache_control set on content blocks.
+        """
+        return [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": LARGE_DOCUMENT_FOR_CACHING,
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                    {
+                        "type": "text",
+                        "text": "What are the payment terms in this agreement?",
+                    },
+                ],
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_prompt_caching_returns_cache_creation_tokens(self):
+        """
+        E2E test: First call should return cache_creation_input_tokens > 0.
+        
+        This validates that the cache_control field is being passed through
+        correctly and the provider is creating a cache.
+        """
+        litellm._turn_on_debug()
+        
+        messages = self.get_messages_with_cache_control()
+        
+        response = await litellm.anthropic.messages.acreate(
+            model=self.get_model(),
+            messages=messages,
+            max_tokens=100,
+        )
+        
+        print(f"Response: {json.dumps(response, indent=2, default=str)}")
+        
+        # Validate response structure
+        assert "usage" in response, "Response should contain usage"
+        usage = response["usage"]
+        
+        # Check for cache tokens in usage
+        cache_creation = usage.get("cache_creation_input_tokens", 0)
+        cache_read = usage.get("cache_read_input_tokens", 0)
+        
+        print(f"cache_creation_input_tokens: {cache_creation}")
+        print(f"cache_read_input_tokens: {cache_read}")
+        
+        # First call should create cache (cache_creation > 0) OR read from existing cache
+        assert cache_creation > 0 or cache_read > 0, (
+            f"Expected cache_creation_input_tokens > 0 or cache_read_input_tokens > 0, "
+            f"but got cache_creation={cache_creation}, cache_read={cache_read}. "
+            f"This indicates cache_control is not being passed through correctly."
+        )
+
+    @pytest.mark.asyncio
+    async def test_prompt_caching_returns_cache_read_tokens_on_second_call(self):
+        """
+        E2E test: Second call with same content should return cache_read_input_tokens > 0.
+        
+        This validates that caching is working end-to-end.
+        """
+        litellm._turn_on_debug()
+        
+        messages = self.get_messages_with_cache_control()
+        
+        # First call - creates cache
+        response1 = await litellm.anthropic.messages.acreate(
+            model=self.get_model(),
+            messages=messages,
+            max_tokens=100,
+        )
+        
+        print(f"First response usage: {json.dumps(response1.get('usage', {}), indent=2)}")
+        
+        # Second call - should read from cache
+        response2 = await litellm.anthropic.messages.acreate(
+            model=self.get_model(),
+            messages=messages,
+            max_tokens=100,
+        )
+        
+        print(f"Second response usage: {json.dumps(response2.get('usage', {}), indent=2)}")
+        
+        usage = response2.get("usage", {})
+        cache_read = usage.get("cache_read_input_tokens", 0)
+        
+        # Second call should read from cache
+        assert cache_read > 0, (
+            f"Expected cache_read_input_tokens > 0 on second call, "
+            f"but got {cache_read}. Full usage: {usage}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_prompt_caching_with_system_message(self):
+        """
+        E2E test: Prompt caching with system message should work.
+        """
+        litellm._turn_on_debug()
+        
+        messages = [
+            {
+                "role": "user",
+                "content": "What are the key terms?",
+            },
+        ]
+        
+        system = [
+            {
+                "type": "text",
+                "text": LARGE_DOCUMENT_FOR_CACHING,
+                "cache_control": {"type": "ephemeral"},
+            },
+        ]
+        
+        response = await litellm.anthropic.messages.acreate(
+            model=self.get_model(),
+            messages=messages,
+            system=system,
+            max_tokens=100,
+        )
+        
+        print(f"Response: {json.dumps(response, indent=2, default=str)}")
+        
+        usage = response.get("usage", {})
+        cache_creation = usage.get("cache_creation_input_tokens", 0)
+        cache_read = usage.get("cache_read_input_tokens", 0)
+        
+        print(f"cache_creation_input_tokens: {cache_creation}")
+        print(f"cache_read_input_tokens: {cache_read}")
+        
+        assert cache_creation > 0 or cache_read > 0, (
+            f"Expected cache tokens > 0 for system message caching, "
+            f"but got cache_creation={cache_creation}, cache_read={cache_read}"
+        )

--- a/tests/pass_through_unit_tests/test_anthropic_messages_prompt_caching.py
+++ b/tests/pass_through_unit_tests/test_anthropic_messages_prompt_caching.py
@@ -1,0 +1,46 @@
+"""
+E2E Test suite for Anthropic Messages API prompt caching across different providers.
+
+Tests that prompt caching works correctly via litellm.anthropic.messages interface
+by making actual API calls and validating usage metrics.
+
+Per AWS docs (https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html):
+- Converse API uses: cachePoint: { type: "default" }
+- InvokeModel API uses: cache_control: { type: "ephemeral" }
+- Claude 3.7 Sonnet: GA, 1024 min tokens
+- Claude 3.5 Haiku: GA, 2048 min tokens
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import pytest
+from base_anthropic_messages_prompt_caching_test import (
+    BaseAnthropicMessagesPromptCachingTest,
+)
+
+
+class TestBedrockConversePromptCaching(BaseAnthropicMessagesPromptCachingTest):
+    """
+    E2E tests for prompt caching with Bedrock Converse API.
+    
+    Uses the bedrock/converse/ prefix which routes through litellm.completion()
+    and the AmazonConverseConfig transformation.
+    """
+
+    def get_model(self) -> str:
+        return "bedrock/converse/us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+
+
+class TestBedrockInvokePromptCaching(BaseAnthropicMessagesPromptCachingTest):
+    """
+    E2E tests for prompt caching with Bedrock Invoke API.
+    
+    Uses the bedrock/invoke/ prefix which routes through the native
+    Anthropic Messages API format.
+    """
+
+    def get_model(self) -> str:
+        return "bedrock/invoke/us.anthropic.claude-3-7-sonnet-20250219-v1:0"


### PR DESCRIPTION
## [Feat] Claude Code - Add support for Prompt Caching with Bedrock Converse

### Before 
0 cached tokens with Bedrock Converse 

<img width="1264" height="635" alt="Screenshot 2026-01-14 at 4 14 15 PM" src="https://github.com/user-attachments/assets/b471b512-6acf-4bd6-9e75-58d94928f152" />

### After 
150.6k cache read, 67.1k cache write
<img width="938" height="173" alt="Screenshot 2026-01-14 at 5 32 53 PM" src="https://github.com/user-attachments/assets/18016251-dfff-4b23-b52c-303a5735be28" />


Problem:
- LiteLLM Transfrom for bedrock converse was not passing cache_control blocks down to bedrock/converse/anthropic models 
- Claude Code couldn't detect prompt caching for bedrock/converse/... models in streaming mode because the message_start event was missing cache token fields (cache_creation_input_tokens, cache_read_input_tokens).

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
