### PR TITLE
Fix audio cost per second override

### DIFF
--- a/docs/my-website/docs/sdk_custom_pricing.md
+++ b/docs/my-website/docs/sdk_custom_pricing.md
@@ -2,7 +2,10 @@
 
 Register custom pricing for sagemaker completion model. 
 
-For cost per second pricing, you **just** need to register `input_cost_per_second`. 
+For cost per second pricing, register `input_cost_per_second`. If your provider
+charges for audio output duration (e.g., TTS), also set `output_cost_per_second`.
+Values of `0` are treated as not billable, so `output_cost_per_second: 0` will
+not override `input_cost_per_second`.
 
 ```python
 # !pip install boto3 

--- a/litellm/llms/openai/cost_calculation.py
+++ b/litellm/llms/openai/cost_calculation.py
@@ -105,25 +105,21 @@ def cost_per_second(
     prompt_cost = 0.0
     completion_cost = 0.0
     ## Speech / Audio cost calculation
-    if (
-        "output_cost_per_second" in model_info
-        and model_info["output_cost_per_second"] is not None
-    ):
+    output_cost_per_second = model_info.get("output_cost_per_second")
+    input_cost_per_second = model_info.get("input_cost_per_second")
+
+    if output_cost_per_second is not None and output_cost_per_second > 0:
         verbose_logger.debug(
-            f"For model={model} - output_cost_per_second: {model_info.get('output_cost_per_second')}; duration: {duration}"
+            f"For model={model} - output_cost_per_second: {output_cost_per_second}; duration: {duration}"
         )
         ## COST PER SECOND ##
-        completion_cost = model_info["output_cost_per_second"] * duration
-    elif (
-        "input_cost_per_second" in model_info
-        and model_info["input_cost_per_second"] is not None
-    ):
+        completion_cost = output_cost_per_second * duration
+    if input_cost_per_second is not None and input_cost_per_second > 0:
         verbose_logger.debug(
-            f"For model={model} - input_cost_per_second: {model_info.get('input_cost_per_second')}; duration: {duration}"
+            f"For model={model} - input_cost_per_second: {input_cost_per_second}; duration: {duration}"
         )
         ## COST PER SECOND ##
-        prompt_cost = model_info["input_cost_per_second"] * duration
-        completion_cost = 0.0
+        prompt_cost = input_cost_per_second * duration
 
     return prompt_cost, completion_cost
 


### PR DESCRIPTION
## Relevant issues

Fixes #19154

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix  
📖 Documentation  
✅ Test

## Changes

- Fix audio cost-per-second logic so `output_cost_per_second` only applies when > 0, and `input_cost_per_second` still bills even if output is 0.
- Add a regression test for transcription models configured with `input_cost_per_second` and `output_cost_per_second: 0`.
- Clarify custom pricing docs for cost-per-second behavior and zero output cost.