### PR TITLE
add message helper functions for mixed TypedDict/Pydantic lists

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1116,7 +1116,13 @@ from .llms.xai.common_utils import XAIModelInfo
 
 # Import LlmProviders here (before main import) because it's imported during import time
 # in multiple places including openai.py (via main import)
-from litellm.types.utils import LlmProviders
+from litellm.types.utils import (
+    LlmProviders,
+    LiteLLMAnyMessage,
+    get_message_role,
+    get_message_content,
+    get_message_attr,
+)
 
 ## Lazy loading this is not straightforward, will leave it here for now.
 from .main import *  # type: ignore

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3395,3 +3395,29 @@ class GenericGuardrailAPIInputs(TypedDict, total=False):
     structured_messages: List[
         AllMessageValues
     ]  # structured messages sent to the LLM - indicates if text is from system or user
+
+
+# Type alias for mixed message lists (input TypedDict + output Pydantic)
+# Use this when combining user input messages with LLM response messages
+LiteLLMAnyMessage = Union[AllMessageValues, Message]
+
+
+def get_message_role(msg: LiteLLMAnyMessage) -> str:
+    """Get role from either TypedDict (input) or Pydantic Message (output)."""
+    if isinstance(msg, Message):
+        return msg.role
+    return msg["role"]
+
+
+def get_message_content(msg: LiteLLMAnyMessage) -> Any:
+    """Get content from either TypedDict (input) or Pydantic Message (output)."""
+    if isinstance(msg, Message):
+        return msg.content
+    return msg.get("content")
+
+
+def get_message_attr(msg: LiteLLMAnyMessage, key: str, default: Any = None) -> Any:
+    """Get arbitrary attribute from either TypedDict (input) or Pydantic Message (output)."""
+    if isinstance(msg, Message):
+        return getattr(msg, key, default)
+    return msg.get(key, default)

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -127,3 +127,77 @@ def test_usage_completion_tokens_details_text_tokens():
     # Verify round-trip serialization works
     new_usage = Usage(**dump_result)
     assert new_usage.completion_tokens_details.text_tokens == 12
+
+
+def test_get_message_role_with_pydantic_message():
+    """Test get_message_role with Pydantic Message (output from LLM)."""
+    from litellm.types.utils import Message, get_message_role
+
+    msg = Message(content="Hello", role="assistant")
+    assert get_message_role(msg) == "assistant"
+
+
+def test_get_message_role_with_typeddict():
+    """Test get_message_role with TypedDict (input to LLM)."""
+    from litellm.types.utils import get_message_role
+
+    msg = {"role": "user", "content": "Hello"}
+    assert get_message_role(msg) == "user"
+
+
+def test_get_message_content_with_pydantic_message():
+    """Test get_message_content with Pydantic Message (output from LLM)."""
+    from litellm.types.utils import Message, get_message_content
+
+    msg = Message(content="Hello world", role="assistant")
+    assert get_message_content(msg) == "Hello world"
+
+
+def test_get_message_content_with_typeddict():
+    """Test get_message_content with TypedDict (input to LLM)."""
+    from litellm.types.utils import get_message_content
+
+    msg = {"role": "user", "content": "Hello world"}
+    assert get_message_content(msg) == "Hello world"
+
+
+def test_get_message_attr_with_pydantic_message():
+    """Test get_message_attr with Pydantic Message (output from LLM)."""
+    from litellm.types.utils import Message, get_message_attr
+
+    msg = Message(content="Hello", role="assistant")
+    assert get_message_attr(msg, "role") == "assistant"
+    assert get_message_attr(msg, "content") == "Hello"
+    assert get_message_attr(msg, "nonexistent", "default") == "default"
+
+
+def test_get_message_attr_with_typeddict():
+    """Test get_message_attr with TypedDict (input to LLM)."""
+    from litellm.types.utils import get_message_attr
+
+    msg = {"role": "user", "content": "Hello"}
+    assert get_message_attr(msg, "role") == "user"
+    assert get_message_attr(msg, "content") == "Hello"
+    assert get_message_attr(msg, "nonexistent", "default") == "default"
+
+
+def test_mixed_message_list():
+    """Test helpers work with mixed list of TypedDict and Pydantic messages."""
+    from litellm.types.utils import (
+        LiteLLMAnyMessage,
+        Message,
+        get_message_role,
+        get_message_content,
+    )
+
+    messages: list[LiteLLMAnyMessage] = [
+        {"role": "user", "content": "What is 2+2?"},
+        Message(content="4", role="assistant"),
+        {"role": "user", "content": "Thanks!"},
+    ]
+
+    roles = [get_message_role(m) for m in messages]
+    assert roles == ["user", "assistant", "user"]
+
+    contents = [get_message_content(m) for m in messages]
+    assert contents == ["What is 2+2?", "4", "Thanks!"]


### PR DESCRIPTION
Add utilities for working with conversation histories that mix input messages (TypedDict) with LLM response messages (Pydantic):
- LiteLLMAnyMessage type alias
- get_message_role()
- get_message_content()
- get_message_attr()

Fixes typing issues when combining user input with response.choices[0].message.

## Relevant issues

SDK typing mismatch between input (AllMessageValues TypedDict) and output (Message Pydantic) when building conversation histories.


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Added 3 helper functions and 1 type alias to litellm/types/utils.py for handling mixed message lists. Exported from litellm/__init__.py. Added 7 unit tests covering TypedDict input, Pydantic output, and mixed list iteration.