### PR TITLE
Fix Azure embeddings JSON parsing to prevent connection leaks and ensure proper router cooldown

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -679,13 +679,13 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             #    This completely eliminates "Unclosed connection" warnings during high load.
             try:
                 response = raw_response.parse()
-                stringified_response = response.model_dump()
             except json.JSONDecodeError as json_error:
                 raise AzureOpenAIError(
                     status_code=raw_response.status_code or 500,
                     message=f"Failed to parse raw Azure embedding response: {str(json_error)}"
                 ) from json_error
             
+            stringified_response = response.model_dump()
 
             ## LOGGING
             logging_obj.post_call(

--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -664,8 +664,29 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 **data, timeout=timeout
             )
             headers = dict(raw_response.headers)
-            response = raw_response.parse()
-            stringified_response = response.model_dump()
+            
+            # Convert json.JSONDecodeError to AzureOpenAIError for two critical reasons:
+            #
+            # 1. ROUTER BEHAVIOR: The router relies on exception.status_code to determine cooldown logic:
+            #    - JSONDecodeError has no status_code → router skips cooldown evaluation
+            #    - AzureOpenAIError has status_code → router properly evaluates for cooldown
+            #
+            # 2. CONNECTION CLEANUP: When response.parse() throws JSONDecodeError, the response
+            #    body may not be fully consumed, preventing httpx from properly returning the
+            #    connection to the pool. By catching the exception and accessing raw_response.status_code,
+            #    we trigger httpx's internal cleanup logic. Without this:
+            #    - parse() fails → JSONDecodeError bubbles up → httpx never knows response was acknowledged → connection leak
+            #    This completely eliminates "Unclosed connection" warnings during high load.
+            try:
+                response = raw_response.parse()
+                stringified_response = response.model_dump()
+            except json.JSONDecodeError as json_error:
+                raise AzureOpenAIError(
+                    status_code=raw_response.status_code or 500,
+                    message=f"Failed to parse raw Azure embedding response: {str(json_error)}"
+                ) from json_error
+            
+
             ## LOGGING
             logging_obj.post_call(
                 input=input,


### PR DESCRIPTION
## Relevant issues

<img width="2520" height="218" alt="Screenshot 2026-01-15 144512" src="https://github.com/user-attachments/assets/3cf83ccf-f83e-40c0-9078-eb8b9ef9a3e7" />


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/54416/workflows/2aa9d597-835e-4cdb-80de-ad25c72d129d

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/54416/workflows/2aa9d597-835e-4cdb-80de-ad25c72d129d

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

Added explicit json.JSONDecodeError handling in aembedding method to:

1. Convert to AzureOpenAIError with status_code for router cooldown evaluation

2. Trigger httpx connection cleanup by accessing raw_response.status_code

Without this handling, JSONDecodeError would bypass router logic (no status_code attribute) and leave httpx connections open, causing resource leaks during high load.

This completely eliminates 'Unclosed connection' warnings during OOM load testing.
