### PR TITLE
[Refactor] UI - Team Member Icon Buttons

### DIFF
--- a/ui/litellm-dashboard/src/components/team/team_member_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_member_view.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/utils/roles", () => ({
 
 import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { isProxyAdminRole, isUserTeamAdminForSingleTeam } from "@/utils/roles";
 
 describe("TeamMembersComponent", () => {
   const mockHandleMemberDelete = vi.fn();
@@ -161,5 +162,32 @@ describe("TeamMembersComponent", () => {
     );
 
     expect(screen.getByText("Add Member")).toBeInTheDocument();
+  });
+
+  it("should show delete button for proxy admin when canEditTeam is true", () => {
+    vi.mocked(isProxyAdminRole).mockReturnValue(true);
+    vi.mocked(isUserTeamAdminForSingleTeam).mockReturnValue(false);
+
+    const { container } = renderWithProviders(
+      <TeamMembersComponent
+        teamData={mockTeamData}
+        canEditTeam={true}
+        handleMemberDelete={mockHandleMemberDelete}
+        setSelectedEditMember={mockSetSelectedEditMember}
+        setIsEditMemberModalVisible={mockSetIsEditMemberModalVisible}
+        setIsAddMemberModalVisible={mockSetIsAddMemberModalVisible}
+      />,
+    );
+
+    // Verify that action buttons are rendered when canEditTeam is true
+    // For proxy admin, both edit and delete buttons should be visible
+    // Check for clickable icon elements (Tremor Icon components with cursor-pointer class)
+    const clickableIcons = container.querySelectorAll('[class*="cursor-pointer"]');
+    // Should have at least 4 icons: 2 edit buttons + 2 delete buttons for 2 members
+    expect(clickableIcons.length).toBeGreaterThanOrEqual(4);
+
+    // Verify members are rendered
+    expect(screen.getAllByText("user1@test.com").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("user2@test.com").length).toBeGreaterThan(0);
   });
 });

--- a/ui/litellm-dashboard/src/components/team/team_member_view.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_member_view.tsx
@@ -1,25 +1,24 @@
-import React from "react";
+import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { Member } from "@/components/networking";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { isProxyAdminRole, isUserTeamAdminForSingleTeam } from "@/utils/roles";
+import { InfoCircleOutlined } from "@ant-design/icons";
 import {
   Card,
   Table,
-  TableHead,
-  TableRow,
-  TableHeaderCell,
   TableBody,
   TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
   Text,
-  Icon,
   Button as TremorButton,
 } from "@tremor/react";
-import { InfoCircleOutlined } from "@ant-design/icons";
 import { Tooltip } from "antd";
+import React from "react";
+import TableIconActionButton from "../common_components/IconActionButton/TableIconActionButtons/TableIconActionButton";
 import { TeamData } from "./team_info";
-import { PencilAltIcon, TrashIcon } from "@heroicons/react/outline";
-import { formatNumberWithCommas } from "@/utils/dataUtils";
-import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
-import { isUserTeamAdminForSingleTeam, isProxyAdminRole } from "@/utils/roles";
-import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 interface TeamMembersComponentProps {
   teamData: TeamData;
@@ -154,9 +153,9 @@ const TeamMembersComponent: React.FC<TeamMembersComponentProps> = ({
                   <TableCell className="sticky right-0 bg-white z-10 border-l border-gray-200">
                     {canEditTeam && (
                       <div className="flex gap-2">
-                        <Icon
-                          icon={PencilAltIcon}
-                          size="sm"
+                        <TableIconActionButton
+                          variant="Edit"
+                          tooltipText="Edit member"
                           onClick={() => {
                             // Get budget and rate limit data from team membership
                             const membership = teamData.team_memberships.find((tm) => tm.user_id === member.user_id);
@@ -169,14 +168,12 @@ const TeamMembersComponent: React.FC<TeamMembersComponentProps> = ({
                             setSelectedEditMember(enhancedMember);
                             setIsEditMemberModalVisible(true);
                           }}
-                          className="cursor-pointer hover:text-blue-600"
                         />
                         {(isProxyAdmin || (isUserTeamAdmin && !disableTeamAdminDeleteTeamUser)) && (
-                          <Icon
-                            icon={TrashIcon}
-                            size="sm"
+                          <TableIconActionButton
+                            variant="Delete"
+                            tooltipText="Delete member"
                             onClick={() => handleMemberDelete(member)}
-                            className="cursor-pointer hover:text-red-600"
                           />
                         )}
                       </div>


### PR DESCRIPTION
## Relevant issues
This PR refactors the team member table action icons to the reusable component. This reduces code reuse as we have a dedicated reusable component for this. Adds a test also
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring
✅ Test

## Changes
<img width="358" height="279" alt="image" src="https://github.com/user-attachments/assets/dcdc668f-5828-4803-b4cd-d3b769695380" />
<img width="759" height="284" alt="image" src="https://github.com/user-attachments/assets/fbfc2c08-408e-4bce-a12b-f3e2e956ac88" />
