### PR TITLE
fix: models loadbalancing billing issue by filter (#18891)

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -173,12 +173,12 @@ def _get_dynamic_logging_metadata(
     user_api_key_dict: UserAPIKeyAuth, proxy_config: ProxyConfig
 ) -> Optional[TeamCallbackMetadata]:
     callback_settings_obj: Optional[TeamCallbackMetadata] = None
-    key_dynamic_logging_settings: Optional[dict] = (
-        KeyAndTeamLoggingSettings.get_key_dynamic_logging_settings(user_api_key_dict)
-    )
-    team_dynamic_logging_settings: Optional[dict] = (
-        KeyAndTeamLoggingSettings.get_team_dynamic_logging_settings(user_api_key_dict)
-    )
+    key_dynamic_logging_settings: Optional[
+        dict
+    ] = KeyAndTeamLoggingSettings.get_key_dynamic_logging_settings(user_api_key_dict)
+    team_dynamic_logging_settings: Optional[
+        dict
+    ] = KeyAndTeamLoggingSettings.get_team_dynamic_logging_settings(user_api_key_dict)
     #########################################################################################
     # Key-based callbacks
     #########################################################################################
@@ -661,11 +661,11 @@ class LiteLLMProxyRequestSetup:
 
         ## KEY-LEVEL SPEND LOGS / TAGS
         if "tags" in key_metadata and key_metadata["tags"] is not None:
-            data[_metadata_variable_name]["tags"] = (
-                LiteLLMProxyRequestSetup._merge_tags(
-                    request_tags=data[_metadata_variable_name].get("tags"),
-                    tags_to_add=key_metadata["tags"],
-                )
+            data[_metadata_variable_name][
+                "tags"
+            ] = LiteLLMProxyRequestSetup._merge_tags(
+                request_tags=data[_metadata_variable_name].get("tags"),
+                tags_to_add=key_metadata["tags"],
             )
         if "disable_global_guardrails" in key_metadata and isinstance(
             key_metadata["disable_global_guardrails"], bool
@@ -933,9 +933,9 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     data[_metadata_variable_name]["litellm_api_version"] = version
 
     if general_settings is not None:
-        data[_metadata_variable_name]["global_max_parallel_requests"] = (
-            general_settings.get("global_max_parallel_requests", None)
-        )
+        data[_metadata_variable_name][
+            "global_max_parallel_requests"
+        ] = general_settings.get("global_max_parallel_requests", None)
 
     ### KEY-LEVEL Controls
     key_metadata = user_api_key_dict.metadata
@@ -1004,7 +1004,9 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
 
     # User spend, budget - used by prometheus.py
     # Follow same pattern as team and API key budgets
-    data[_metadata_variable_name]["user_api_key_user_spend"] = user_api_key_dict.user_spend
+    data[_metadata_variable_name][
+        "user_api_key_user_spend"
+    ] = user_api_key_dict.user_spend
     data[_metadata_variable_name][
         "user_api_key_user_max_budget"
     ] = user_api_key_dict.user_max_budget

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -173,12 +173,12 @@ def _get_dynamic_logging_metadata(
     user_api_key_dict: UserAPIKeyAuth, proxy_config: ProxyConfig
 ) -> Optional[TeamCallbackMetadata]:
     callback_settings_obj: Optional[TeamCallbackMetadata] = None
-    key_dynamic_logging_settings: Optional[
-        dict
-    ] = KeyAndTeamLoggingSettings.get_key_dynamic_logging_settings(user_api_key_dict)
-    team_dynamic_logging_settings: Optional[
-        dict
-    ] = KeyAndTeamLoggingSettings.get_team_dynamic_logging_settings(user_api_key_dict)
+    key_dynamic_logging_settings: Optional[dict] = (
+        KeyAndTeamLoggingSettings.get_key_dynamic_logging_settings(user_api_key_dict)
+    )
+    team_dynamic_logging_settings: Optional[dict] = (
+        KeyAndTeamLoggingSettings.get_team_dynamic_logging_settings(user_api_key_dict)
+    )
     #########################################################################################
     # Key-based callbacks
     #########################################################################################
@@ -661,11 +661,11 @@ class LiteLLMProxyRequestSetup:
 
         ## KEY-LEVEL SPEND LOGS / TAGS
         if "tags" in key_metadata and key_metadata["tags"] is not None:
-            data[_metadata_variable_name][
-                "tags"
-            ] = LiteLLMProxyRequestSetup._merge_tags(
-                request_tags=data[_metadata_variable_name].get("tags"),
-                tags_to_add=key_metadata["tags"],
+            data[_metadata_variable_name]["tags"] = (
+                LiteLLMProxyRequestSetup._merge_tags(
+                    request_tags=data[_metadata_variable_name].get("tags"),
+                    tags_to_add=key_metadata["tags"],
+                )
             )
         if "disable_global_guardrails" in key_metadata and isinstance(
             key_metadata["disable_global_guardrails"], bool
@@ -933,9 +933,9 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     data[_metadata_variable_name]["litellm_api_version"] = version
 
     if general_settings is not None:
-        data[_metadata_variable_name][
-            "global_max_parallel_requests"
-        ] = general_settings.get("global_max_parallel_requests", None)
+        data[_metadata_variable_name]["global_max_parallel_requests"] = (
+            general_settings.get("global_max_parallel_requests", None)
+        )
 
     ### KEY-LEVEL Controls
     key_metadata = user_api_key_dict.metadata
@@ -1008,6 +1008,37 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     data[_metadata_variable_name][
         "user_api_key_user_max_budget"
     ] = user_api_key_dict.user_max_budget
+
+    # Extract allowed access groups for router filtering (GitHub issue #18333)
+    # This allows the router to filter deployments based on key's and team's access groups
+    # NOTE: We keep key and team access groups SEPARATE because a key doesn't always
+    # inherit all team access groups (per maintainer feedback).
+    if llm_router is not None:
+        from litellm.proxy.auth.model_checks import get_access_groups_from_models
+
+        model_access_groups = llm_router.get_model_access_groups()
+
+        # Key-level access groups (from user_api_key_dict.models)
+        key_models = list(user_api_key_dict.models) if user_api_key_dict.models else []
+        key_allowed_access_groups = get_access_groups_from_models(
+            model_access_groups=model_access_groups, models=key_models
+        )
+        if key_allowed_access_groups:
+            data[_metadata_variable_name][
+                "user_api_key_allowed_access_groups"
+            ] = key_allowed_access_groups
+
+        # Team-level access groups (from user_api_key_dict.team_models)
+        team_models = (
+            list(user_api_key_dict.team_models) if user_api_key_dict.team_models else []
+        )
+        team_allowed_access_groups = get_access_groups_from_models(
+            model_access_groups=model_access_groups, models=team_models
+        )
+        if team_allowed_access_groups:
+            data[_metadata_variable_name][
+                "user_api_key_team_allowed_access_groups"
+            ] = team_allowed_access_groups
 
     data[_metadata_variable_name]["user_api_key_metadata"] = user_api_key_dict.metadata
     _headers = dict(request.headers)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -86,6 +86,7 @@ from litellm.router_utils.clientside_credential_handler import (
     is_clientside_credential,
 )
 from litellm.router_utils.common_utils import (
+    filter_deployments_by_access_groups,
     filter_team_based_models,
     filter_web_search_deployments,
 )
@@ -7846,9 +7847,16 @@ class Router:
             request_kwargs=request_kwargs,
         )
 
-        verbose_router_logger.debug(
-            f"healthy_deployments after web search filter: {healthy_deployments}"
+        verbose_router_logger.debug(f"healthy_deployments after web search filter: {healthy_deployments}")
+
+        # Filter by allowed access groups (GitHub issue #18333)
+        # This prevents cross-team load balancing when teams have models with same name in different access groups
+        healthy_deployments = filter_deployments_by_access_groups(
+            healthy_deployments=healthy_deployments,
+            request_kwargs=request_kwargs,
         )
+
+        verbose_router_logger.debug(f"healthy_deployments after access group filter: {healthy_deployments}")
 
         if isinstance(healthy_deployments, dict):
             return healthy_deployments

--- a/tests/test_litellm/router_unit_tests/test_filter_deployments_by_access_groups.py
+++ b/tests/test_litellm/router_unit_tests/test_filter_deployments_by_access_groups.py
@@ -1,0 +1,227 @@
+"""
+Unit tests for filter_deployments_by_access_groups function.
+
+Tests the fix for GitHub issue #18333: Models loadbalanced outside of Model Access Group.
+"""
+
+import pytest
+
+from litellm.router_utils.common_utils import filter_deployments_by_access_groups
+
+
+class TestFilterDeploymentsByAccessGroups:
+    """Tests for the filter_deployments_by_access_groups function."""
+
+    def test_no_filter_when_no_access_groups_in_metadata(self):
+        """When no allowed_access_groups in metadata, return all deployments."""
+        deployments = [
+            {"model_info": {"id": "1", "access_groups": ["AG1"]}},
+            {"model_info": {"id": "2", "access_groups": ["AG2"]}},
+        ]
+        request_kwargs = {"metadata": {"user_api_key_team_id": "team-1"}}
+
+        result = filter_deployments_by_access_groups(
+            healthy_deployments=deployments,
+            request_kwargs=request_kwargs,
+        )
+
+        assert len(result) == 2  # All deployments returned
+
+    def test_filter_to_single_access_group(self):
+        """Filter to only deployments matching allowed access group."""
+        deployments = [
+            {"model_info": {"id": "1", "access_groups": ["AG1"]}},
+            {"model_info": {"id": "2", "access_groups": ["AG2"]}},
+        ]
+        request_kwargs = {"metadata": {"user_api_key_allowed_access_groups": ["AG2"]}}
+
+        result = filter_deployments_by_access_groups(
+            healthy_deployments=deployments,
+            request_kwargs=request_kwargs,
+        )
+
+        assert len(result) == 1
+        assert result[0]["model_info"]["id"] == "2"
+
+    def test_filter_with_multiple_allowed_groups(self):
+        """Filter with multiple allowed access groups."""
+        deployments = [
+            {"model_info": {"id": "1", "access_groups": ["AG1"]}},
+            {"model_info": {"id": "2", "access_groups": ["AG2"]}},
+            {"model_info": {"id": "3", "access_groups": ["AG3"]}},
+        ]
+        request_kwargs = {
+            "metadata": {"user_api_key_allowed_access_groups": ["AG1", "AG2"]}
+        }
+
+        result = filter_deployments_by_access_groups(
+            healthy_deployments=deployments,
+            request_kwargs=request_kwargs,
+        )
+
+        assert len(result) == 2
+        ids = [d["model_info"]["id"] for d in result]
+        assert "1" in ids
+        assert "2" in ids
+        assert "3" not in ids
+
+    def test_deployment_with_multiple_access_groups(self):
+        """Deployment with multiple access groups should match if any overlap."""
+        deployments = [
+            {"model_info": {"id": "1", "access_groups": ["AG1", "AG2"]}},
+            {"model_info": {"id": "2", "access_groups": ["AG3"]}},
+        ]
+        request_kwargs = {"metadata": {"user_api_key_allowed_access_groups": ["AG2"]}}
+
+        result = filter_deployments_by_access_groups(
+            healthy_deployments=deployments,
+            request_kwargs=request_kwargs,
+        )
+
+        assert len(result) == 1
+        assert result[0]["model_info"]["id"] == "1"
+
+    def test_deployment_without_access_groups_included(self):
+        """Deployments without access groups should be included (not restricted)."""
+        deployments = [
+            {"model_info": {"id": "1", "access_groups": ["AG1"]}},
+            {"model_info": {"id": "2"}},  # No access_groups
+            {"model_info": {"id": "3", "access_groups": []}},  # Empty access_groups
+        ]
+        request_kwargs = {"metadata": {"user_api_key_allowed_access_groups": ["AG2"]}}
+
+        result = filter_deployments_by_access_groups(
+            healthy_deployments=deployments,
+            request_kwargs=request_kwargs,
+        )
+
+        # Should include deployments 2 and 3 (no restrictions)
+        assert len(result) == 2
+        ids = [d["model_info"]["id"] for d in result]
+        assert "2" in ids
+        assert "3" in ids
+
+    def test_dict_deployment_passes_through(self):
+        """When deployment is a dict (specific deployment), pass through."""
+        deployment = {"model_info": {"id": "1", "access_groups": ["AG1"]}}
+        request_kwargs = {"metadata": {"user_api_key_allowed_access_groups": ["AG2"]}}
+
+        result = filter_deployments_by_access_groups(
+            healthy_deployments=deployment,
+            request_kwargs=request_kwargs,
+        )
+
+        assert result == deployment  # Unchanged
+
+    def test_none_request_kwargs_passes_through(self):
+        """When request_kwargs is None, return deployments unchanged."""
+        deployments = [
+            {"model_info": {"id": "1", "access_groups": ["AG1"]}},
+        ]
+
+        result = filter_deployments_by_access_groups(
+            healthy_deployments=deployments,
+            request_kwargs=None,
+        )
+
+        assert result == deployments
+
+    def test_litellm_metadata_fallback(self):
+        """Should also check litellm_metadata for allowed access groups."""
+        deployments = [
+            {"model_info": {"id": "1", "access_groups": ["AG1"]}},
+            {"model_info": {"id": "2", "access_groups": ["AG2"]}},
+        ]
+        request_kwargs = {
+            "litellm_metadata": {"user_api_key_allowed_access_groups": ["AG1"]}
+        }
+
+        result = filter_deployments_by_access_groups(
+            healthy_deployments=deployments,
+            request_kwargs=request_kwargs,
+        )
+
+        assert len(result) == 1
+        assert result[0]["model_info"]["id"] == "1"
+
+
+def test_filter_deployments_by_access_groups_issue_18333():
+    """
+    Regression test for GitHub issue #18333.
+
+    Scenario: Two models named 'gpt-5' in different access groups (AG1, AG2).
+    Team2 has access to AG2 only. When Team2 requests 'gpt-5', only the AG2
+    deployment should be available for load balancing.
+    """
+    deployments = [
+        {
+            "model_name": "gpt-5",
+            "litellm_params": {"model": "gpt-4.1", "api_key": "key-1"},
+            "model_info": {"id": "ag1-deployment", "access_groups": ["AG1"]},
+        },
+        {
+            "model_name": "gpt-5",
+            "litellm_params": {"model": "gpt-4o", "api_key": "key-2"},
+            "model_info": {"id": "ag2-deployment", "access_groups": ["AG2"]},
+        },
+    ]
+
+    # Team2's request with allowed access groups
+    request_kwargs = {
+        "metadata": {
+            "user_api_key_team_id": "team-2",
+            "user_api_key_allowed_access_groups": ["AG2"],
+        }
+    }
+
+    result = filter_deployments_by_access_groups(
+        healthy_deployments=deployments,
+        request_kwargs=request_kwargs,
+    )
+
+    # Only AG2 deployment should be returned
+    assert len(result) == 1
+    assert result[0]["model_info"]["id"] == "ag2-deployment"
+    assert result[0]["litellm_params"]["model"] == "gpt-4o"
+
+
+def test_get_access_groups_from_models():
+    """
+    Test the helper function that extracts access group names from models list.
+    This is used by the proxy to populate user_api_key_allowed_access_groups.
+    """
+    from litellm.proxy.auth.model_checks import get_access_groups_from_models
+
+    # Setup: access groups definition
+    model_access_groups = {
+        "AG1": ["gpt-4", "gpt-5"],
+        "AG2": ["claude-v1", "claude-v2"],
+        "beta-models": ["gpt-5-turbo"],
+    }
+
+    # Test 1: Extract access groups from models list
+    models = ["gpt-4", "AG1", "AG2", "some-other-model"]
+    result = get_access_groups_from_models(
+        model_access_groups=model_access_groups, models=models
+    )
+    assert set(result) == {"AG1", "AG2"}
+
+    # Test 2: No access groups in models list
+    models = ["gpt-4", "claude-v1", "some-model"]
+    result = get_access_groups_from_models(
+        model_access_groups=model_access_groups, models=models
+    )
+    assert result == []
+
+    # Test 3: Empty models list
+    result = get_access_groups_from_models(
+        model_access_groups=model_access_groups, models=[]
+    )
+    assert result == []
+
+    # Test 4: All access groups
+    models = ["AG1", "AG2", "beta-models"]
+    result = get_access_groups_from_models(
+        model_access_groups=model_access_groups, models=models
+    )
+    assert set(result) == {"AG1", "AG2", "beta-models"}


### PR DESCRIPTION
## Relevant issues

Fixes #18333 (models loadbalancing billing issue by filter)

This PR re-applies the fix for models load balancing billing issue by filter (originally #18891, which was reverted in `revert-18891-fix/model_load_balance_handle`).

- Cherry-picked the original commits cleanly onto the latest `main`
- resolved merge conflicts, ensuring **Prometheus metrics code is preserved**
- Both the Prometheus user spend/budget tracking AND the access groups filtering logic are now present

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

### Testing:
All 10 tests in `test_filter_deployments_by_access_groups.py` pass 

---
