### PR TITLE
fix: redact langfuse_secret_key from user_api_key_auth_metadata logging

### DIFF
--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -13,6 +13,7 @@ from litellm.litellm_core_utils.core_helpers import (
 from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.auth_checks import log_db_metrics
+from litellm.proxy.litellm_pre_call_utils import sanitize_metadata_for_logging
 from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.proxy.utils import ProxyUpdateSpend
 from litellm.types.utils import (
@@ -63,7 +64,9 @@ class _ProxyDBLogger(CustomLogger):
                 user_api_key_team_alias=user_api_key_dict.team_alias,
                 user_api_key_end_user_id=user_api_key_dict.end_user_id,
                 user_api_key_request_route=user_api_key_dict.request_route,
-                user_api_key_auth_metadata=user_api_key_dict.metadata,
+                user_api_key_auth_metadata=sanitize_metadata_for_logging(
+                    user_api_key_dict.metadata
+                ),
             )
         )
         _metadata["user_api_key"] = user_api_key_dict.api_key

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -38,6 +38,45 @@ from litellm.types.utils import (
 service_logger_obj = ServiceLogging()  # used for tracking latency on OTEL
 
 
+def sanitize_metadata_for_logging(
+    metadata: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """
+    Remove sensitive fields from metadata before logging.
+
+    Sensitive fields include API keys and secrets from callback configurations.
+    This function should be used whenever user_api_key_dict.metadata is passed
+    to logging systems to prevent secret leakage.
+    """
+    if metadata is None:
+        return None
+
+    # Keys that should be masked in logging output
+    sensitive_keys = {
+        "langfuse_secret_key",
+        "langfuse_secret",
+        "api_key",
+        "secret_key",
+        "secret",
+    }
+
+    def _redact_dict(d: Any) -> Any:
+        if isinstance(d, dict):
+            result = {}
+            for k, v in d.items():
+                if k.lower() in sensitive_keys or "secret" in k.lower():
+                    result[k] = "redacted"
+                else:
+                    result[k] = _redact_dict(v)
+            return result
+        elif isinstance(d, list):
+            return [_redact_dict(item) for item in d]
+        else:
+            return d
+
+    return _redact_dict(copy.deepcopy(metadata))
+
+
 if TYPE_CHECKING:
     from litellm.proxy.proxy_server import ProxyConfig as _ProxyConfig
 
@@ -563,6 +602,17 @@ class LiteLLMProxyRequestSetup:
         return data
 
     @staticmethod
+    def _sanitize_metadata_for_logging(
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Remove sensitive fields from metadata before logging.
+
+        Wrapper around module-level sanitize_metadata_for_logging function.
+        """
+        return sanitize_metadata_for_logging(metadata)
+
+    @staticmethod
     def get_sanitized_user_information_from_key(
         user_api_key_dict: UserAPIKeyAuth,
     ) -> StandardLoggingUserAPIKeyMetadata:
@@ -583,7 +633,9 @@ class LiteLLMProxyRequestSetup:
                 if user_api_key_dict.budget_reset_at
                 else None
             ),
-            user_api_key_auth_metadata=user_api_key_dict.metadata,
+            user_api_key_auth_metadata=LiteLLMProxyRequestSetup._sanitize_metadata_for_logging(
+                user_api_key_dict.metadata
+            ),
         )
         return user_api_key_logged_metadata
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -49,6 +49,7 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.litellm_pre_call_utils import sanitize_metadata_for_logging
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.secret_managers.main import get_secret_str
@@ -504,7 +505,9 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
                     if user_api_key_dict.budget_reset_at
                     else None
                 ),
-                user_api_key_auth_metadata=user_api_key_dict.metadata,
+                user_api_key_auth_metadata=sanitize_metadata_for_logging(
+                    user_api_key_dict.metadata
+                ),
             )
         )
 

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -1181,6 +1181,109 @@ def test_get_sanitized_user_information_from_key_includes_guardrails_metadata():
     assert result["user_api_key_auth_metadata"]["other_field"] == "value"
 
 
+def test_get_sanitized_user_information_from_key_redacts_secret_keys():
+    """
+    Test that get_sanitized_user_information_from_key redacts sensitive fields like langfuse_secret_key
+    from the metadata before logging.
+
+    Related issue: langfuse_secret_key was being logged in trace metadata
+    """
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key-hash",
+        key_alias="test-alias",
+        user_id="test-user",
+        metadata={
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_type": "success",
+                    "callback_vars": {
+                        "langfuse_host": "https://cloud.langfuse.com",
+                        "langfuse_public_key": "pk-lf-test-public-key",
+                        "langfuse_secret_key": "sk-lf-super-secret-key",
+                    },
+                }
+            ],
+            "guardrails": ["presidio"],
+            "other_field": "value",
+        },
+    )
+
+    result = LiteLLMProxyRequestSetup.get_sanitized_user_information_from_key(
+        user_api_key_dict=user_api_key_dict
+    )
+
+    assert result["user_api_key_auth_metadata"] is not None
+
+    # Check that non-sensitive fields are preserved
+    assert result["user_api_key_auth_metadata"]["guardrails"] == ["presidio"]
+    assert result["user_api_key_auth_metadata"]["other_field"] == "value"
+
+    # Check that logging structure is preserved
+    logging_config = result["user_api_key_auth_metadata"]["logging"]
+    assert len(logging_config) == 1
+    assert logging_config[0]["callback_name"] == "langfuse"
+    assert logging_config[0]["callback_type"] == "success"
+
+    # Check that public key is NOT redacted
+    callback_vars = logging_config[0]["callback_vars"]
+    assert callback_vars["langfuse_host"] == "https://cloud.langfuse.com"
+    assert callback_vars["langfuse_public_key"] == "pk-lf-test-public-key"
+
+    # Check that secret key IS redacted
+    assert callback_vars["langfuse_secret_key"] == "redacted"
+
+
+def test_sanitize_metadata_for_logging_handles_nested_secrets():
+    """
+    Test that _sanitize_metadata_for_logging handles deeply nested secret keys
+    """
+    metadata = {
+        "level1": {
+            "level2": {
+                "langfuse_secret": "secret-value",
+                "safe_key": "safe-value",
+            }
+        },
+        "api_key": "should-be-redacted",
+        "normal_field": "normal-value",
+    }
+
+    result = LiteLLMProxyRequestSetup._sanitize_metadata_for_logging(metadata)
+
+    assert result["level1"]["level2"]["langfuse_secret"] == "redacted"
+    assert result["level1"]["level2"]["safe_key"] == "safe-value"
+    assert result["api_key"] == "redacted"
+    assert result["normal_field"] == "normal-value"
+
+
+def test_sanitize_metadata_for_logging_handles_none():
+    """
+    Test that _sanitize_metadata_for_logging handles None input
+    """
+    result = LiteLLMProxyRequestSetup._sanitize_metadata_for_logging(None)
+    assert result is None
+
+
+def test_sanitize_metadata_for_logging_handles_lists():
+    """
+    Test that _sanitize_metadata_for_logging handles lists with dicts containing secrets
+    """
+    metadata = {
+        "callbacks": [
+            {"name": "callback1", "secret_key": "secret1"},
+            {"name": "callback2", "api_key": "secret2"},
+        ]
+    }
+
+    result = LiteLLMProxyRequestSetup._sanitize_metadata_for_logging(metadata)
+
+    assert result["callbacks"][0]["name"] == "callback1"
+    assert result["callbacks"][0]["secret_key"] == "redacted"
+    assert result["callbacks"][1]["name"] == "callback2"
+    assert result["callbacks"][1]["api_key"] == "redacted"
+
+
 @pytest.mark.asyncio
 async def test_team_guardrails_append_to_key_guardrails():
     """


### PR DESCRIPTION
## Relevant issues

Fixed security issue where langfuse_secret_key was being logged in trace metadata 


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Redact sensitive fields (e.g. langfuse_secret_key, api_key, secret_key) from user_api_key_auth_metadata before logging. Previously, the full user_api_key_dict.metadata was passed directly to logging, exposing secrets in Langfuse traces.
