### PR TITLE
[Feature] Status Query for Keys and Teams List

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2229,6 +2229,9 @@ class UserAPIKeyAuth(
     @model_validator(mode="before")
     @classmethod
     def check_api_key(cls, values):
+        # If values is already an instance (not a dict), return it as-is
+        if not isinstance(values, dict):
+            return values
         if values.get("api_key") is not None:
             values.update(
                 {"token": cls._safe_hash_litellm_api_key(values.get("api_key"))}
@@ -3359,7 +3362,7 @@ class TeamListResponseObject(LiteLLM_TeamTable):
 
 
 class KeyListResponseObject(TypedDict, total=False):
-    keys: List[Union[str, UserAPIKeyAuth]]
+    keys: List[Union[str, UserAPIKeyAuth, LiteLLM_DeletedVerificationToken]]
     total_count: Optional[int]
     current_page: Optional[int]
     total_pages: Optional[int]

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3150,12 +3150,14 @@ async def list_keys(
     ),
     sort_order: str = Query(default="desc", description="Sort order ('asc' or 'desc')"),
     expand: Optional[List[str]] = Query(None, description="Expand related objects (e.g. 'user')"),
+    status: Optional[str] = Query(None, description="Filter by status (e.g. 'deleted')"),
 ) -> KeyListResponseObject:
     """
     List all keys for a given user / team / organization.
 
     Parameters:
         expand: Optional[List[str]] - Expand related objects (e.g. 'user' to include user information)
+        status: Optional[str] - Filter by status. Currently supports "deleted" to query deleted keys.
 
     Returns:
         {
@@ -3176,6 +3178,15 @@ async def list_keys(
         if prisma_client is None:
             verbose_proxy_logger.error("Database not connected")
             raise Exception("Database not connected")
+
+        # Validate status parameter
+        if status is not None and status != "deleted":
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"Invalid status value. Currently only 'deleted' is supported."
+                },
+            )
 
         complete_user_info = await validate_key_list_check(
             user_api_key_dict=user_api_key_dict,
@@ -3217,6 +3228,7 @@ async def list_keys(
             sort_by=sort_by,
             sort_order=sort_order,
             expand=expand,
+            status=status,
         )
 
         verbose_proxy_logger.debug("Successfully prepared response")
@@ -3424,6 +3436,7 @@ async def _list_key_helper(
     sort_by: Optional[str] = None,
     sort_order: str = "desc",
     expand: Optional[List[str]] = None,
+    status: Optional[str] = None,
 ) -> KeyListResponseObject:
     """
     Helper function to list keys
@@ -3468,28 +3481,51 @@ async def _list_key_helper(
         else None
     )
 
+    # Determine which table to query based on status
+    use_deleted_table = status == "deleted"
+
     # Fetch keys with pagination
-    keys = await prisma_client.db.litellm_verificationtoken.find_many(
-        where=where,  # type: ignore
-        skip=skip,  # type: ignore
-        take=size,  # type: ignore
-        order=(
-            order_by
-            if order_by
-            else [
-                {"created_at": "desc"},
-                {"token": "desc"},  # fallback sort
-            ]
-        ),
-        include={"object_permission": True},
-    )
+    if use_deleted_table:
+        keys = await prisma_client.db.litellm_deletedverificationtoken.find_many(
+            where=where,  # type: ignore
+            skip=skip,  # type: ignore
+            take=size,  # type: ignore
+            order=(
+                order_by
+                if order_by
+                else [
+                    {"created_at": "desc"},
+                    {"token": "desc"},  # fallback sort
+                ]
+            ),
+        )
+    else:
+        keys = await prisma_client.db.litellm_verificationtoken.find_many(
+            where=where,  # type: ignore
+            skip=skip,  # type: ignore
+            take=size,  # type: ignore
+            order=(
+                order_by
+                if order_by
+                else [
+                    {"created_at": "desc"},
+                    {"token": "desc"},  # fallback sort
+                ]
+            ),
+            include={"object_permission": True},
+        )
 
     verbose_proxy_logger.debug(f"Fetched {len(keys)} keys")
 
     # Get total count of keys
-    total_count = await prisma_client.db.litellm_verificationtoken.count(
-        where=where  # type: ignore
-    )
+    if use_deleted_table:
+        total_count = await prisma_client.db.litellm_deletedverificationtoken.count(
+            where=where  # type: ignore
+        )
+    else:
+        total_count = await prisma_client.db.litellm_verificationtoken.count(
+            where=where  # type: ignore
+        )
 
     verbose_proxy_logger.debug(f"Total count of keys: {total_count}")
 
@@ -3510,8 +3546,9 @@ async def _list_key_helper(
     key_list: List[Union[str, UserAPIKeyAuth]] = []
     for key in keys:
         key_dict = key.dict()
-        # Attach object_permission if object_permission_id is set
-        key_dict = await attach_object_permission_to_dict(key_dict, prisma_client)
+        # Attach object_permission if object_permission_id is set (only for non-deleted keys)
+        if not use_deleted_table:
+            key_dict = await attach_object_permission_to_dict(key_dict, prisma_client)
 
         # Include user information if expand includes "user"
         if expand and "user" in expand and key.user_id and key.user_id in user_map:

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3184,7 +3184,7 @@ async def list_keys(
             raise HTTPException(
                 status_code=400,
                 detail={
-                    "error": f"Invalid status value. Currently only 'deleted' is supported."
+                    "error": "Invalid status value. Currently only 'deleted' is supported."
                 },
             )
 
@@ -3242,7 +3242,7 @@ async def list_keys(
                 message=getattr(e, "detail", f"error({str(e)})"),
                 type=ProxyErrorTypes.internal_server_error,
                 param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
+                code=getattr(e, "status_code", fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
             raise e
@@ -3250,7 +3250,7 @@ async def list_keys(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.internal_server_error,
             param=getattr(e, "param", "None"),
-            code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
 

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -3015,7 +3015,7 @@ def _convert_teams_to_response(
     teams: List[Any], use_deleted_table: bool
 ) -> List[Union[LiteLLM_TeamTable, LiteLLM_DeletedTeamTable]]:
     """Convert Prisma models to Pydantic models."""
-    team_list = []
+    team_list: List[Union[LiteLLM_TeamTable, LiteLLM_DeletedTeamTable]] = []
     if teams:
         for team in teams:
             # Convert Prisma model to dict (supports both Pydantic v1 and v2)

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -3046,7 +3046,7 @@ async def list_team_v2(
         raise HTTPException(
             status_code=400,
             detail={
-                "error": f"Invalid status value. Currently only 'deleted' is supported."
+                "error": "Invalid status value. Currently only 'deleted' is supported."
             },
         )
 

--- a/litellm/types/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/types/proxy/management_endpoints/team_endpoints.py
@@ -1,8 +1,9 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
 from litellm.proxy._types import (
+    LiteLLM_DeletedTeamTable,
     LiteLLM_TeamMembership,
     LiteLLM_TeamTable,
     LiteLLM_UserTable,
@@ -45,7 +46,7 @@ class UpdateTeamMemberPermissionsRequest(BaseModel):
 class TeamListResponse(BaseModel):
     """Response to get the list of teams"""
 
-    teams: List[LiteLLM_TeamTable]
+    teams: List[Union[LiteLLM_TeamTable, LiteLLM_DeletedTeamTable]]
     total: int
     page: int
     page_size: int

--- a/tests/proxy_unit_tests/test_key_generate_prisma.py
+++ b/tests/proxy_unit_tests/test_key_generate_prisma.py
@@ -3517,6 +3517,7 @@ async def test_list_keys(prisma_client):
         sort_by=None,
         sort_order="desc",
         expand=None,
+        status=None,
     )
     print("response=", response)
     assert "keys" in response
@@ -3542,6 +3543,7 @@ async def test_list_keys(prisma_client):
         sort_by=None,
         sort_order="desc",
         expand=None,
+        status=None,
     )
     print("pagination response=", response)
     assert len(response["keys"]) == 2
@@ -3583,6 +3585,7 @@ async def test_list_keys(prisma_client):
         sort_by=None,
         sort_order="desc",
         expand=None,
+        status=None,
     )
     print("filtered user_id response=", response)
     assert len(response["keys"]) == 1
@@ -3605,6 +3608,7 @@ async def test_list_keys(prisma_client):
         sort_by=None,
         sort_order="desc",
         expand=None,
+        status=None,
     )
     assert len(response["keys"]) == 1
     assert _key in response["keys"]

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -2068,6 +2068,7 @@ async def test_list_team_v2_security_check_non_admin_user():
                 http_request=mock_request,
                 user_id=None,  # Non-admin trying to query all teams
                 user_api_key_dict=mock_user_api_key_dict_non_admin,
+                status=None,
             )
 
         assert exc_info.value.status_code == 401
@@ -2108,6 +2109,7 @@ async def test_list_team_v2_security_check_non_admin_user_other_user():
                 http_request=mock_request,
                 user_id="other_user_456",  # Non-admin trying to query other user's teams
                 user_api_key_dict=mock_user_api_key_dict_non_admin,
+                status=None,
             )
 
         assert exc_info.value.status_code == 401
@@ -2166,6 +2168,7 @@ async def test_list_team_v2_security_check_non_admin_user_own_teams():
             team_id=None,
             page=1,
             page_size=10,
+            status=None,
         )
 
         # Should return results without error
@@ -2215,6 +2218,7 @@ async def test_list_team_v2_security_check_admin_user():
             user_api_key_dict=mock_user_api_key_dict_admin,
             page=1,
             page_size=10,
+            status=None,
         )
 
         # Should return results without error

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -2228,6 +2228,110 @@ async def test_list_team_v2_security_check_admin_user():
 
 
 @pytest.mark.asyncio
+async def test_list_team_v2_with_status_deleted():
+    """
+    Test that status="deleted" parameter correctly queries the deleted teams table.
+    """
+    from unittest.mock import AsyncMock, Mock, patch
+    
+    from fastapi import Request
+    
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.team_endpoints import list_team_v2
+    
+    # Mock request
+    mock_request = Mock(spec=Request)
+    
+    # Mock admin user
+    mock_user_api_key_dict_admin = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_123",
+    )
+    
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client:
+        # Mock prisma client and database operations
+        mock_db = Mock()
+        mock_prisma_client.db = mock_db
+        
+        # Mock deleted teams
+        mock_deleted_team1 = Mock(model_dump=lambda: {"team_id": "team_1", "team_alias": "Deleted Team 1"})
+        mock_deleted_team2 = Mock(model_dump=lambda: {"team_id": "team_2", "team_alias": "Deleted Team 2"})
+        
+        # Mock deleted teams table (should be called)
+        mock_db.litellm_deletedteamtable.find_many = AsyncMock(return_value=[mock_deleted_team1, mock_deleted_team2])
+        mock_db.litellm_deletedteamtable.count = AsyncMock(return_value=2)
+        
+        # Mock regular teams table (should NOT be called)
+        mock_db.litellm_teamtable.find_many = AsyncMock(return_value=[])
+        mock_db.litellm_teamtable.count = AsyncMock(return_value=0)
+        
+        # Should NOT raise an exception
+        result = await list_team_v2(
+            http_request=mock_request,
+            user_id=None,  # Admin querying all teams
+            user_api_key_dict=mock_user_api_key_dict_admin,
+            page=1,
+            page_size=10,
+            status="deleted",  # Test the status parameter
+        )
+        
+        # Verify that deleted table was queried
+        mock_db.litellm_deletedteamtable.find_many.assert_called_once()
+        mock_db.litellm_deletedteamtable.count.assert_called_once()
+        
+        # Verify that regular table was NOT queried
+        mock_db.litellm_teamtable.find_many.assert_not_called()
+        mock_db.litellm_teamtable.count.assert_not_called()
+        
+        # Should return results without error
+        assert "teams" in result
+        assert "total" in result
+        assert result["total"] == 2
+        assert len(result["teams"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_team_v2_with_invalid_status():
+    """
+    Test that invalid status parameter raises HTTPException.
+    """
+    from unittest.mock import Mock, patch
+    
+    from fastapi import HTTPException, Request
+    
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.team_endpoints import list_team_v2
+    
+    # Mock request
+    mock_request = Mock(spec=Request)
+    
+    # Mock admin user
+    mock_user_api_key_dict_admin = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_123",
+    )
+    
+    mock_prisma_client = Mock()
+    
+    # Mock prisma_client to be non-None
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
+        # Should raise HTTPException for invalid status
+        with pytest.raises(HTTPException) as exc_info:
+            await list_team_v2(
+                http_request=mock_request,
+                user_id=None,
+                user_api_key_dict=mock_user_api_key_dict_admin,
+                page=1,
+                page_size=10,
+                status="invalid_status",  # Invalid status value
+            )
+        
+        assert exc_info.value.status_code == 400
+        assert "Invalid status value" in str(exc_info.value.detail)
+        assert "deleted" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_team_member_delete_cleans_membership(mock_db_client, mock_admin_auth):
     """
     Verify that /team/member_delete removes the corresponding LiteLLM_TeamMembership row


### PR DESCRIPTION
## Relevant issues
This PR implements the status optional query for keys and team list endpoints. Currently only "deleted" is supported, and passing it in will cause the system to query against the new deleted keys and teams table instead of the normal one. 
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="840" height="1210" alt="image" src="https://github.com/user-attachments/assets/2ba8ec2c-438e-4df0-b143-251d31822342" />
<img width="986" height="1386" alt="image" src="https://github.com/user-attachments/assets/0e391146-a528-43c1-9cfb-c96ed631fedc" />
<img width="1022" height="267" alt="image" src="https://github.com/user-attachments/assets/06f89c6f-18ac-44f7-88a5-32617c0fedbe" />
