### PR TITLE
fix: Model Management UI: Filter non-providers and non-functional 

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -85,11 +85,23 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
     fetchModelAccessGroups();
   }, [accessToken]);
 
+  const nonProviderIdentifiers = new Set([
+    "AIOHTTP_OPENAI",
+    "CUSTOM_OPENAI",
+    "OPENAI_LIKE",
+    "OpenAI_Text",
+    "OpenAI_Compatible",
+    "OpenAI_Text_Compatible",
+  ]);
+
   const sortedProviderMetadata: ProviderCreateInfo[] = useMemo(() => {
     if (!providerMetadata) {
       return [];
     }
-    return [...providerMetadata].sort((a, b) => a.provider_display_name.localeCompare(b.provider_display_name));
+    const filtered = providerMetadata.filter((provider) => {
+      return !nonProviderIdentifiers.has(provider.provider);
+    });
+    return [...filtered].sort((a, b) => a.provider_display_name.localeCompare(b.provider_display_name));
   }, [providerMetadata]);
 
   const providerMetadataErrorText = providerMetadataError

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -211,6 +211,11 @@ export const getPlaceholder = (selectedProvider: string): string => {
   }
 };
 
+const isValidModelName = (modelName: string): boolean => {
+  const resolutionOnlyPattern = /^\d{3,4}-x-\d{3,4}\/dall-e-[23]$/;
+  return !resolutionOnlyPattern.test(modelName);
+};
+
 export const getProviderModels = (provider: Providers, modelMap: any): Array<string> => {
   let providerKey = provider;
   console.log(`Provider key: ${providerKey}`);
@@ -227,7 +232,9 @@ export const getProviderModels = (provider: Providers, modelMap: any): Array<str
           litellmProvider === custom_llm_provider ||
           (typeof litellmProvider === "string" && litellmProvider.includes(custom_llm_provider))
         ) {
-          providerModels.push(key);
+          if (isValidModelName(key)) {
+            providerModels.push(key);
+          }
         }
       }
     });
@@ -242,7 +249,9 @@ export const getProviderModels = (provider: Providers, modelMap: any): Array<str
           "litellm_provider" in (value as object) &&
           (value as any)["litellm_provider"] === "cohere_chat"
         ) {
-          providerModels.push(key);
+          if (isValidModelName(key)) {
+            providerModels.push(key);
+          }
         }
       });
     }
@@ -258,11 +267,13 @@ export const getProviderModels = (provider: Providers, modelMap: any): Array<str
           "litellm_provider" in (value as object) &&
           (value as any)["litellm_provider"] === "sagemaker_chat"
         ) {
-          providerModels.push(key);
+          if (isValidModelName(key)) {
+            providerModels.push(key);
+          }
         }
       });
     }
   }
 
-  return providerModels;
+  return providerModels.sort();
 };


### PR DESCRIPTION
**Type:** Bug Fix

**Description:**

- Clean up the Model Management UI provider dropdown and model list.

1. **Provider dropdown** - Remove connection/compatibility types shown as providers (Aiohttp Openai, Custom Openai, Openai Like, etc.). Show only actual providers.
2. **Model list** - Filter out non-functional resolution-only DALL-E variants (e.g., `1024-x-1024/dall-e-2`). Keep variants with quality prefixes (e.g., `hd/1024-x-1792/dall-e-3`).
3. **Organization** - Sort models alphabetically.

- These changes make the dropdown clearer and remove non-functional options, improving the add model flow.

**Relevant issues:** Fixes #19149