### PR TITLE
fix: ensure guardrail patterns persist on edit and mode toggle

### DIFF
--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
@@ -270,23 +270,15 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
         updateData.litellm_params.pii_entities_config = newPiiEntitiesConfig;
       }
 
-      // Only add Content Filter patterns if there are changes
+      // Always include Content Filter patterns to ensure they persist when other fields change
       if (guardrailData.litellm_params?.guardrail === "litellm_content_filter") {
-        const originalPatterns = guardrailData.litellm_params?.patterns || [];
-        const originalBlockedWords = guardrailData.litellm_params?.blocked_words || [];
-
         const formattedData = formatContentFilterDataForAPI(
-          contentFilterDataRef.current.patterns,
-          contentFilterDataRef.current.blockedWords,
+          contentFilterDataRef.current.patterns || [],
+          contentFilterDataRef.current.blockedWords || [],
         );
 
-        if (JSON.stringify(originalPatterns) !== JSON.stringify(formattedData.patterns)) {
-          updateData.litellm_params.patterns = formattedData.patterns;
-        }
-
-        if (JSON.stringify(originalBlockedWords) !== JSON.stringify(formattedData.blocked_words)) {
-          updateData.litellm_params.blocked_words = formattedData.blocked_words;
-        }
+        updateData.litellm_params.patterns = formattedData.patterns;
+        updateData.litellm_params.blocked_words = formattedData.blocked_words;
       }
 
       if (guardrailData.litellm_params?.guardrail === "tool_permission") {


### PR DESCRIPTION
## Type

🐛 Bug Fix : #19084

## Changes

Fixed bug where custom regex patterns in Content Filter guardrails were cleared when:
- Adding or modifying patterns and saving
- Toggling guardrail mode between "mask" and "block" and saving
- Combined operations (add pattern + toggle mode)

**Root Cause**: Patterns were only included in the update payload when they had changed. When only other fields (like mode) changed, patterns were omitted, causing data loss.

**Solution**: Always include patterns and blocked_words when updating a content filter guardrail, regardless of whether they've changed. This ensures patterns persist when other fields are updated.

**Files Changed**:
- `ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx` - Updated `handleGuardrailUpdate` to always include patterns in the update payload