### PR TITLE
feat(zai): Add web search support for Z.AI GLM models

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -1123,7 +1123,7 @@ class RedisCache(BaseCache):
             redis_client = redis_async.Redis(**self.redis_kwargs)
             
             # Test the connection
-            ping_result = await redis_client.ping()
+            ping_result = await redis_client.ping()  # type: ignore[misc]
 
             # Close the connection
             await redis_client.aclose()  # type: ignore[attr-defined]

--- a/litellm/caching/redis_cluster_cache.py
+++ b/litellm/caching/redis_cluster_cache.py
@@ -83,7 +83,7 @@ class RedisClusterCache(RedisCache):
             )
             
             # Test the connection
-            ping_result = await redis_client.ping()  # type: ignore[attr-defined]
+            ping_result = await redis_client.ping()  # type: ignore[misc, attr-defined]
 
             # Close the connection
             await redis_client.aclose()  # type: ignore[attr-defined]

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -2232,6 +2232,7 @@ class PrometheusLogger(CustomLogger):
         from typing import Union
 
         from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+        from litellm.proxy._types import LiteLLM_DeletedVerificationToken
         from litellm.proxy.management_endpoints.key_management_endpoints import (
             _list_key_helper,
         )
@@ -2245,7 +2246,7 @@ class PrometheusLogger(CustomLogger):
 
         async def fetch_keys(
             page_size: int, page: int
-        ) -> Tuple[List[Union[str, UserAPIKeyAuth]], Optional[int]]:
+        ) -> Tuple[List[Union[str, UserAPIKeyAuth, LiteLLM_DeletedVerificationToken]], Optional[int]]:
             key_list_response = await _list_key_helper(
                 prisma_client=prisma_client,
                 page=page,

--- a/litellm/llms/zai/chat/transformation.py
+++ b/litellm/llms/zai/chat/transformation.py
@@ -1,5 +1,17 @@
-from typing import Optional, Tuple
+"""
+Z.AI (ZhipuAI) GLM Chat Transformation Config
 
+Supports GLM-4.7, GLM-4.6, GLM-4.5 and other Z.AI models with:
+- Tool calling
+- Reasoning/thinking modes
+- Web search integration via tools
+
+Web Search API Reference: https://docs.z.ai/api-reference/tools/web-search
+"""
+
+from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict
+
+import litellm
 from litellm.secret_managers.main import get_secret_str
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
@@ -7,7 +19,49 @@ from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 ZAI_API_BASE = "https://api.z.ai/api/paas/v4"
 
 
+# Z.AI Web Search Tool TypedDict
+class ZAIWebSearchConfig(TypedDict, total=False):
+    """
+    Z.AI web_search tool configuration.
+
+    Reference: https://docs.z.ai/api-reference/llm/chat-completion
+    """
+    search_engine: Literal["search_pro_jina"]
+    enable: bool
+    search_query: Optional[str]
+    count: int  # 1-50, default 10
+    search_domain_filter: Optional[str]  # Whitelist domain
+    search_recency_filter: Literal["oneDay", "oneWeek", "oneMonth", "oneYear", "noLimit"]
+    content_size: Literal["medium", "high"]  # medium=400-600 chars, high=2500 chars
+    result_sequence: Literal["before", "after"]  # When to show results
+    search_result: bool  # Include raw results in response
+    require_search: bool  # Force search-based response
+    search_prompt: Optional[str]  # Custom search prompt
+
+
+class ZAIWebSearchTool(TypedDict):
+    """Z.AI web search tool format for tools array."""
+    type: Literal["web_search"]
+    web_search: ZAIWebSearchConfig
+
+
+# Map OpenAI search_context_size to Z.AI count
+ZAI_WEB_SEARCH_COUNT_MAP: Dict[str, int] = {
+    "low": 5,
+    "medium": 10,
+    "high": 20,
+}
+
+
 class ZAIChatConfig(OpenAIGPTConfig):
+    """
+    Z.AI (ZhipuAI) GLM Chat Configuration.
+
+    Extends OpenAIGPTConfig with Z.AI-specific features:
+    - Web search via tools
+    - Thinking/reasoning modes
+    """
+
     @property
     def custom_llm_provider(self) -> Optional[str]:
         return "zai"
@@ -20,6 +74,11 @@ class ZAIChatConfig(OpenAIGPTConfig):
         return api_base, dynamic_api_key
 
     def get_supported_openai_params(self, model: str) -> list:
+        """
+        Get supported OpenAI-compatible parameters for Z.AI models.
+
+        Includes web_search_options for models that support web search.
+        """
         base_params = [
             "max_tokens",
             "stream",
@@ -31,12 +90,127 @@ class ZAIChatConfig(OpenAIGPTConfig):
             "tool_choice",
         ]
 
-        import litellm
-
+        # Add web_search_options if model supports it
         try:
-            if litellm.supports_reasoning(model=model, custom_llm_provider=self.custom_llm_provider):
+            if litellm.supports_web_search(
+                model=model, custom_llm_provider=self.custom_llm_provider
+            ):
+                base_params.append("web_search_options")
+        except Exception:
+            pass
+
+        # Add thinking/reasoning if model supports it
+        try:
+            if litellm.supports_reasoning(
+                model=model, custom_llm_provider=self.custom_llm_provider
+            ):
                 base_params.append("thinking")
         except Exception:
             pass
 
         return base_params
+
+    def _map_web_search_options(self, value: Dict[str, Any]) -> ZAIWebSearchTool:
+        """
+        Map OpenAI-style web_search_options to Z.AI web_search tool format.
+
+        OpenAI format:
+            {
+                "search_context_size": "low" | "medium" | "high",
+                "user_location": {...}  # Not supported by Z.AI
+            }
+
+        Z.AI format:
+            {
+                "type": "web_search",
+                "web_search": {
+                    "search_engine": "search_pro_jina",
+                    "enable": true,
+                    "count": 10,
+                    "search_recency_filter": "noLimit",
+                    "content_size": "medium"
+                }
+            }
+        """
+        # Get search context size, default to medium
+        search_context_size = value.get("search_context_size", "medium")
+        count = ZAI_WEB_SEARCH_COUNT_MAP.get(search_context_size, 10)
+
+        # Map content_size based on search_context_size
+        # low/medium → medium (shorter summaries), high → high (longer summaries)
+        content_size: Literal["medium", "high"] = (
+            "high" if search_context_size == "high" else "medium"
+        )
+
+        web_search_config: ZAIWebSearchConfig = {
+            "search_engine": "search_pro_jina",
+            "enable": True,
+            "count": count,
+            "search_recency_filter": "noLimit",
+            "content_size": content_size,
+            "result_sequence": "after",
+            "search_result": False,
+            "require_search": False,
+        }
+
+        return ZAIWebSearchTool(
+            type="web_search",
+            web_search=web_search_config,
+        )
+
+    def _add_web_search_to_tools(
+        self,
+        tools: Optional[List[Dict[str, Any]]],
+        web_search_tool: ZAIWebSearchTool
+    ) -> List[Dict[str, Any]]:
+        """
+        Add web search tool to existing tools list.
+
+        Ensures no duplicate web_search tools are added.
+        """
+        if tools is None:
+            tools = []
+
+        # Check if web_search tool already exists
+        has_web_search = any(
+            tool.get("type") == "web_search" for tool in tools
+        )
+
+        if not has_web_search:
+            tools.append(dict(web_search_tool))
+
+        return tools
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        """
+        Map OpenAI-style parameters to Z.AI format.
+
+        Handles web_search_options by adding a web_search tool to the tools array.
+        """
+        # First, call parent to handle standard params
+        optional_params = super().map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=model,
+            drop_params=drop_params,
+        )
+
+        # Handle web_search_options
+        web_search_options = non_default_params.get("web_search_options")
+        if web_search_options and isinstance(web_search_options, dict):
+            # Map to Z.AI web search tool format
+            web_search_tool = self._map_web_search_options(web_search_options)
+
+            # Add to tools array
+            existing_tools = optional_params.get("tools", [])
+            optional_params["tools"] = self._add_web_search_to_tools(
+                existing_tools, web_search_tool
+            )
+
+        return optional_params

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -30317,6 +30317,7 @@
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
+        "supports_web_search": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.6": {
@@ -30328,6 +30329,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_web_search": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5": {
@@ -30339,6 +30341,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_web_search": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5v": {
@@ -30351,6 +30354,7 @@
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_web_search": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5-x": {

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8101,7 +8101,9 @@ class ProviderConfigManager:
         elif LlmProviders.CLARIFAI == provider:
             return litellm.ClarifaiConfig()
         elif LlmProviders.BEDROCK == provider:
-            return litellm.llms.bedrock.common_utils.BedrockModelInfo()
+            from litellm.llms.bedrock.common_utils import BedrockModelInfo
+
+            return BedrockModelInfo()
         return None
 
     @staticmethod

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -30317,6 +30317,7 @@
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
+        "supports_web_search": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.6": {
@@ -30328,6 +30329,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_web_search": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5": {
@@ -30339,6 +30341,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_web_search": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5v": {
@@ -30351,6 +30354,7 @@
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_web_search": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5-x": {


### PR DESCRIPTION
## Summary

Add `web_search_options` support for Z.AI (ZhipuAI) GLM models, enabling web search integration through LiteLLM's unified API.

## Changes

### `litellm/llms/zai/chat/transformation.py`
- Add `ZAIWebSearchConfig` and `ZAIWebSearchTool` TypedDicts for type safety
- Add `web_search_options` to `get_supported_openai_params()` for models with `supports_web_search: true`
- Add `_map_web_search_options()` to transform OpenAI-style parameters to Z.AI format
- Override `map_openai_params()` to inject web search tool into tools array

### `model_prices_and_context_window.json`
- Add `supports_web_search: true` to: `zai/glm-4.7`, `zai/glm-4.6`, `zai/glm-4.5`, `zai/glm-4.5v`

## Parameter Mapping

| OpenAI `search_context_size` | Z.AI `count` | Z.AI `content_size` |
|------------------------------|--------------|---------------------|
| `"low"` | 5 | `"medium"` |
| `"medium"` | 10 | `"medium"` |
| `"high"` | 20 | `"high"` |

## Z.AI Web Search Tool Format

The implementation transforms:
```python
# OpenAI-style input
web_search_options={"search_context_size": "medium"}

# To Z.AI native format
tools=[{
    "type": "web_search",
    "web_search": {
        "search_engine": "search_pro_jina",
        "enable": True,
        "count": 10,
        "search_recency_filter": "noLimit",
        "content_size": "medium"
    }
}]
```

## Usage Example

```yaml
# config.yaml
model_list:
  - model_name: glm-4.7-search
    litellm_params:
      model: zai/glm-4.7
      api_key: os.environ/ZAI_API_KEY
      web_search_options:
        search_context_size: "medium"
```

```python
# SDK usage
response = litellm.completion(
    model="zai/glm-4.7",
    messages=[{"role": "user", "content": "What's the latest news about AI?"}],
    web_search_options={"search_context_size": "medium"}
)
```

## References

- Z.AI Web Search API: https://docs.z.ai/api-reference/tools/web-search
- Z.AI Web Search in Chat: https://docs.z.ai/guides/tools/web-search

## Test Plan

All tests pass (`pytest tests/test_litellm/llms/zai/test_zai_provider.py`):

- [x] `test_zai_models_support_web_search` - Verify `supports_web_search: true` in model_cost
- [x] `test_zai_web_search_options_in_supported_params` - Verify `web_search_options` in supported params
- [x] `test_zai_map_web_search_options_default` - Test default (medium) parameter mapping
- [x] `test_zai_map_web_search_options_low` - Test low search_context_size mapping
- [x] `test_zai_map_web_search_options_high` - Test high search_context_size mapping
- [x] `test_zai_map_openai_params_adds_web_search_tool` - Verify tool injection
- [x] `test_zai_map_openai_params_preserves_existing_tools` - Verify existing tools preserved
- [x] `test_zai_map_openai_params_no_duplicate_web_search` - Verify no duplicate tools

