### PR TITLE
fix: resolve 'does not exist' migration errors as applied in setup_da…

### DIFF
--- a/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
+++ b/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
@@ -94,6 +94,11 @@ class TestIdempotentErrorDetection:
         error_message = "constraint 'fk_user_id' already exists"
         assert ProxyExtrasDBManager._is_idempotent_error(error_message) is True
 
+    def test_is_idempotent_error_does_not_exist(self):
+        """Test detection of 'does not exist' error"""
+        error_message = "ERROR: index 'idx' does not exist"
+        assert ProxyExtrasDBManager._is_idempotent_error(error_message) is True
+
     def test_is_idempotent_error_case_insensitive(self):
         """Test that idempotent error detection is case insensitive"""
         error_message = "COLUMN 'ID' ALREADY EXISTS"


### PR DESCRIPTION
## Relevant issues

Fixes #19204

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix
✅ Test

## Changes

<img width="1141" height="858" alt="image" src="https://github.com/user-attachments/assets/85fd1896-babb-4ea8-a6ae-2cedc1d1448d" />


### [litellm-proxy-extras](cci:7://file:///d:/OSS/litellm/litellm-proxy-extras:0:0-0:0)
- **Logic Fix**: Updated `ProxyExtrasDBManager.setup_database` in [utils.py](cci:7://file:///d:/OSS/litellm/litellm-proxy-extras/litellm_proxy_extras/utils.py:0:0-0:0) to check for idempotent errors (like `"does not exist"`) during `P3009` migration failures.
- **Improved Reliability**: Instead of entering an infinite "Rollback and Retry" loop for errors that mean the work is already done, the code now correctly marks these migrations as `applied`.
- **User Impact**: Prevents proxy startup crashes for users migrating from older versions where certain schema objects might already be modified.

### Tests
- Added [test_is_idempotent_error_does_not_exist](cci:1://file:///d:/OSS/litellm/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py:96:4-99:79) to [tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py](cci:7://file:///d:/OSS/litellm/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py:0:0-0:0) to verify detection of missing index/table errors.