### PR TITLE
fix(helicone): add Gemini and Vertex AI support to HeliconeLogger

### DIFF
--- a/litellm/integrations/helicone.py
+++ b/litellm/integrations/helicone.py
@@ -118,15 +118,20 @@ class HeliconeLogger:
                 f"Helicone Logging - Enters logging function for model {model}"
             )
             litellm_params = kwargs.get("litellm_params", {})
+            custom_llm_provider = litellm_params.get("custom_llm_provider", "")
             kwargs.get("litellm_call_id", None)
             metadata = litellm_params.get("metadata", {}) or {}
             metadata = self.add_metadata_from_header(litellm_params, metadata)
+
+            # Check if model is a vertex_ai model
+            is_vertex_ai = custom_llm_provider == "vertex_ai" or model.startswith("vertex_ai/")
+
             model = (
                 model
                 if any(
                     accepted_model in model
                     for accepted_model in self.helicone_model_list
-                )
+                ) or is_vertex_ai
                 else "gpt-3.5-turbo"
             )
             provider_request = {"model": model, "messages": messages}
@@ -135,7 +140,7 @@ class HeliconeLogger:
             ):
                 response_obj = response_obj.json()
 
-            if "claude" in model:
+            if "claude" in model and not is_vertex_ai:
                 response_obj = self.claude_mapping(
                     model=model, messages=messages, response_obj=response_obj
                 )
@@ -149,12 +154,15 @@ class HeliconeLogger:
             # Code to be executed
             provider_url = self.provider_url
             url = f"{self.api_base}/oai/v1/log"
-            if "claude" in model:
+            if "claude" in model and not is_vertex_ai:
                 url = f"{self.api_base}/anthropic/v1/log"
                 provider_url = "https://api.anthropic.com/v1/messages"
             elif "gemini" in model:
                 url = f"{self.api_base}/custom/v1/log"
                 provider_url = "https://generativelanguage.googleapis.com/v1beta"
+            elif is_vertex_ai:
+                url = f"{self.api_base}/custom/v1/log"
+                provider_url = "https://aiplatform.googleapis.com/v1"
             headers = {
                 "Authorization": f"Bearer {self.key}",
                 "Content-Type": "application/json",

--- a/litellm/integrations/helicone.py
+++ b/litellm/integrations/helicone.py
@@ -11,6 +11,7 @@ class HeliconeLogger:
     helicone_model_list = [
         "gpt",
         "claude",
+        "gemini",
         "command-r",
         "command-r-plus",
         "command-light",
@@ -151,6 +152,9 @@ class HeliconeLogger:
             if "claude" in model:
                 url = f"{self.api_base}/anthropic/v1/log"
                 provider_url = "https://api.anthropic.com/v1/messages"
+            elif "gemini" in model:
+                url = f"{self.api_base}/custom/v1/log"
+                provider_url = "https://generativelanguage.googleapis.com/v1beta"
             headers = {
                 "Authorization": f"Bearer {self.key}",
                 "Content-Type": "application/json",

--- a/tests/litellm/integrations/helicone/test_helicone_gemini.py
+++ b/tests/litellm/integrations/helicone/test_helicone_gemini.py
@@ -1,0 +1,35 @@
+"""
+Test HeliconeLogger Gemini/Vertex AI support.
+Fixes: https://github.com/BerriAI/litellm/issues/19093
+"""
+
+import pytest
+
+
+def test_helicone_gemini_model_in_list():
+    """
+    Test that Gemini models are in the helicone_model_list.
+    """
+    from litellm.integrations.helicone import HeliconeLogger
+
+    logger = HeliconeLogger()
+
+    # Test that "gemini" is in the model list
+    assert "gemini" in logger.helicone_model_list, "gemini should be in helicone_model_list"
+
+
+def test_helicone_gemini_models_recognized():
+    """
+    Test that Gemini models are recognized and not replaced with gpt-3.5-turbo.
+    """
+    from litellm.integrations.helicone import HeliconeLogger
+
+    logger = HeliconeLogger()
+
+    test_models = ["gemini-1.5-pro", "gemini-2.0-flash", "vertex_ai/gemini-1.5-flash"]
+    for model in test_models:
+        is_recognized = any(
+            accepted_model in model
+            for accepted_model in logger.helicone_model_list
+        )
+        assert is_recognized, f"{model} should be recognized by helicone_model_list"

--- a/tests/litellm/integrations/helicone/test_helicone_gemini.py
+++ b/tests/litellm/integrations/helicone/test_helicone_gemini.py
@@ -33,3 +33,32 @@ def test_helicone_gemini_models_recognized():
             for accepted_model in logger.helicone_model_list
         )
         assert is_recognized, f"{model} should be recognized by helicone_model_list"
+
+
+def test_helicone_vertex_ai_models_recognized():
+    """
+    Test that Vertex AI models (GLM, DeepSeek, etc.) are recognized via custom_llm_provider.
+    """
+    # Test models that don't contain "gemini" but are vertex_ai
+    test_models = [
+        "vertex_ai/zai-org/glm-4.7-maas",
+        "vertex_ai/deepseek-ai/deepseek-v3",
+        "vertex_ai/meta/llama-3.1-405b",
+    ]
+    for model in test_models:
+        is_vertex_ai = model.startswith("vertex_ai/")
+        assert is_vertex_ai, f"{model} should be recognized as vertex_ai model"
+
+
+def test_helicone_vertex_ai_via_custom_llm_provider():
+    """
+    Test that vertex_ai models are recognized when custom_llm_provider is set.
+    """
+    # Models without vertex_ai/ prefix but with custom_llm_provider="vertex_ai"
+    test_cases = [
+        ("zai-org/glm-4.7-maas", "vertex_ai"),
+        ("deepseek-ai/deepseek-v3", "vertex_ai"),
+    ]
+    for model, custom_llm_provider in test_cases:
+        is_vertex_ai = custom_llm_provider == "vertex_ai" or model.startswith("vertex_ai/")
+        assert is_vertex_ai, f"{model} with custom_llm_provider={custom_llm_provider} should be recognized as vertex_ai"

--- a/tests/local_testing/test_helicone_integration.py
+++ b/tests/local_testing/test_helicone_integration.py
@@ -162,27 +162,3 @@ def test_helicone_removes_otel_span_from_metadata():
     assert result_metadata["other_metadata"] == "some_value"
     
     print("✅ Test passed: litellm_parent_otel_span was successfully removed from metadata")
-
-
-def test_helicone_gemini_model_in_list():
-    """
-    Test that Gemini models are in the helicone_model_list and use the correct endpoint.
-    Fixes: https://github.com/BerriAI/litellm/issues/19093
-    """
-    from litellm.integrations.helicone import HeliconeLogger
-
-    logger = HeliconeLogger()
-
-    # Test that "gemini" is in the model list
-    assert "gemini" in logger.helicone_model_list, "gemini should be in helicone_model_list"
-
-    # Test that gemini models are recognized (not replaced with gpt-3.5-turbo)
-    test_models = ["gemini-1.5-pro", "gemini-2.0-flash", "vertex_ai/gemini-1.5-flash"]
-    for model in test_models:
-        is_recognized = any(
-            accepted_model in model
-            for accepted_model in logger.helicone_model_list
-        )
-        assert is_recognized, f"{model} should be recognized by helicone_model_list"
-
-    print("✅ Test passed: Gemini models are properly supported in HeliconeLogger")

--- a/tests/local_testing/test_helicone_integration.py
+++ b/tests/local_testing/test_helicone_integration.py
@@ -162,3 +162,27 @@ def test_helicone_removes_otel_span_from_metadata():
     assert result_metadata["other_metadata"] == "some_value"
     
     print("✅ Test passed: litellm_parent_otel_span was successfully removed from metadata")
+
+
+def test_helicone_gemini_model_in_list():
+    """
+    Test that Gemini models are in the helicone_model_list and use the correct endpoint.
+    Fixes: https://github.com/BerriAI/litellm/issues/19093
+    """
+    from litellm.integrations.helicone import HeliconeLogger
+
+    logger = HeliconeLogger()
+
+    # Test that "gemini" is in the model list
+    assert "gemini" in logger.helicone_model_list, "gemini should be in helicone_model_list"
+
+    # Test that gemini models are recognized (not replaced with gpt-3.5-turbo)
+    test_models = ["gemini-1.5-pro", "gemini-2.0-flash", "vertex_ai/gemini-1.5-flash"]
+    for model in test_models:
+        is_recognized = any(
+            accepted_model in model
+            for accepted_model in logger.helicone_model_list
+        )
+        assert is_recognized, f"{model} should be recognized by helicone_model_list"
+
+    print("✅ Test passed: Gemini models are properly supported in HeliconeLogger")


### PR DESCRIPTION
## Relevant issues

Fixes #19093

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

HeliconeLogger now properly supports Gemini and Vertex AI models. Previously, these calls were incorrectly logged as OpenAI requests.

### Usage example

```python
import litellm
import os

os.environ["HELICONE_API_KEY"] = "sk-helicone-..."

litellm.success_callback = ["helicone"]

# Gemini
response = litellm.completion(
    model="gemini/gemini-2.0-flash",
    messages=[{"role": "user", "content": "Hello"}]
)

# Vertex AI
response = litellm.completion(
    model="vertex_ai/provider/glm-4.7-maas",
    messages=[{"role": "user", "content": "Hello"}],
    vertex_project="my-project",
    vertex_location="global"
)
```

### Before vs After

| Model | Before (bug) | After (fix) |
|-------|--------------|-------------|
| gemini-2.0-flash | gpt-3.5-turbo | gemini-2.0-flash |
| vertex_ai/zai-org/glm-4.7-maas | gpt-3.5-turbo | vertex_ai/zai-org/glm-4.7-maas |
| vertex_ai/deepseek-ai/deepseek-v3 | gpt-3.5-turbo | vertex_ai/deepseek-ai/deepseek-v3 |

| Field | Before (bug) | After (fix) |
|-------|--------------|-------------|
| Provider | OPENAI | CUSTOM |
| Target URL (Gemini) | api.openai.com | generativelanguage.googleapis.com |
| Target URL (Vertex AI) | api.openai.com | aiplatform.googleapis.com |

### Code changes

- Add "gemini" to `helicone_model_list` so Gemini models are recognized
- Detect Vertex AI models via `custom_llm_provider` or `vertex_ai/` prefix
- Use `/custom/v1/log` endpoint for Gemini and Vertex AI models
- Set correct `provider_url` for each provider
- Add unit tests for Gemini and Vertex AI models