### PR TITLE
fix: correct us.anthropic.claude-opus-4-5 In-region pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -26700,15 +26700,15 @@
         "tool_use_system_prompt_tokens": 159
     },
     "us.anthropic.claude-opus-4-5-20251101-v1:0": {
-        "cache_creation_input_token_cost": 6.25e-06,
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 5e-06,
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_read_input_token_cost": 5.5e-07,
+        "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-05,
+        "output_cost_per_token": 2.75e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
             "search_context_size_low": 0.01,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -26700,15 +26700,15 @@
         "tool_use_system_prompt_tokens": 159
     },
     "us.anthropic.claude-opus-4-5-20251101-v1:0": {
-        "cache_creation_input_token_cost": 6.25e-06,
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 5e-06,
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_read_input_token_cost": 5.5e-07,
+        "input_cost_per_token": 5.5e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-05,
+        "output_cost_per_token": 2.75e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
             "search_context_size_low": 0.01,


### PR DESCRIPTION
## Relevant issues

Fixes #19308

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory - **N/A, this is a data only change**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Correct the pricing of `us.anthropic.claude-opus-4-5-20251101-v1:0`. It is currently set as global pricing, but it uses In-region pricing (10% higher than global).

References:
- https://aws.amazon.com/bedrock/pricing/
- https://platform.claude.com/docs/en/about-claude/pricing#third-party-platform-pricing