### PR TITLE
fix: correct Groq gpt-oss pricing and add cache pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18808,13 +18808,14 @@
         "supports_tool_choice": true
     },
     "groq/openai/gpt-oss-120b": {
+        "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
         "max_output_tokens": 32766,
         "max_tokens": 32766,
         "mode": "chat",
-        "output_cost_per_token": 7.5e-07,
+        "output_cost_per_token": 6e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_reasoning": true,
@@ -18823,13 +18824,14 @@
         "supports_web_search": true
     },
     "groq/openai/gpt-oss-20b": {
-        "input_cost_per_token": 1e-07,
+        "cache_read_input_token_cost": 3.75e-08,
+        "input_cost_per_token": 7.5e-08,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
-        "output_cost_per_token": 5e-07,
+        "output_cost_per_token": 3e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_reasoning": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18808,13 +18808,14 @@
         "supports_tool_choice": true
     },
     "groq/openai/gpt-oss-120b": {
+        "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
         "max_output_tokens": 32766,
         "max_tokens": 32766,
         "mode": "chat",
-        "output_cost_per_token": 7.5e-07,
+        "output_cost_per_token": 6e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_reasoning": true,
@@ -18823,13 +18824,14 @@
         "supports_web_search": true
     },
     "groq/openai/gpt-oss-20b": {
-        "input_cost_per_token": 1e-07,
+        "cache_read_input_token_cost": 3.75e-08,
+        "input_cost_per_token": 7.5e-08,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
-        "output_cost_per_token": 5e-07,
+        "output_cost_per_token": 3e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_reasoning": true,


### PR DESCRIPTION
## Relevant issues

Fixes #19309 

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory - **N/A this is a data only change**
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Correct the inaccurate input token pricing of the `gpt-oss-120b` model on Groq and correct the inaccurate input and output token pricing of the `gpt-oss-20b` model on Groq. Additionally, add cache read input token cost to both models. Both models support cached input tokens at a 50% discount. Cache writes are free.

References:
- https://groq.com/pricing