### PR TITLE
feat(azure): add support for Azure OpenAI v1 API

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -4,7 +4,13 @@ import time
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Union
 
 import httpx  # type: ignore
-from openai import APITimeoutError, AsyncAzureOpenAI, AzureOpenAI
+from openai import (
+    APITimeoutError,
+    AsyncAzureOpenAI,
+    AsyncOpenAI,
+    AzureOpenAI,
+    OpenAI,
+)
 
 import litellm
 from litellm.constants import AZURE_OPERATION_POLLING_TIMEOUT, DEFAULT_MAX_RETRIES
@@ -128,7 +134,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
 
     def make_sync_azure_openai_chat_completion_request(
         self,
-        azure_client: AzureOpenAI,
+        azure_client: Union[AzureOpenAI, OpenAI],
         data: dict,
         timeout: Union[float, httpx.Timeout],
     ):
@@ -151,7 +157,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
     @track_llm_api_timing()
     async def make_azure_openai_chat_completion_request(
         self,
-        azure_client: AsyncAzureOpenAI,
+        azure_client: Union[AsyncAzureOpenAI, AsyncOpenAI],
         data: dict,
         timeout: Union[float, httpx.Timeout],
         logging_obj: LiteLLMLoggingObj,
@@ -328,10 +334,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     _is_async=False,
                     litellm_params=litellm_params,
                 )
-                if not isinstance(azure_client, AzureOpenAI):
+                if not isinstance(azure_client, (AzureOpenAI, OpenAI)):
                     raise AzureOpenAIError(
                         status_code=500,
-                        message="azure_client is not an instance of AzureOpenAI",
+                        message="azure_client is not an instance of AzureOpenAI or OpenAI",
                     )
 
                 headers, response = self.make_sync_azure_openai_chat_completion_request(
@@ -401,8 +407,8 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 _is_async=True,
                 litellm_params=litellm_params,
             )
-            if not isinstance(azure_client, AsyncAzureOpenAI):
-                raise ValueError("Azure client is not an instance of AsyncAzureOpenAI")
+            if not isinstance(azure_client, (AsyncAzureOpenAI, AsyncOpenAI)):
+                raise ValueError("Azure client is not an instance of AsyncAzureOpenAI or AsyncOpenAI")
             ## LOGGING
             logging_obj.pre_call(
                 input=data["messages"],
@@ -412,7 +418,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                         "api_key": api_key,
                         "azure_ad_token": azure_ad_token,
                     },
-                    "api_base": azure_client._base_url._uri_reference,
+                    "api_base": api_base,
                     "acompletion": True,
                     "complete_input_dict": data,
                 },
@@ -520,10 +526,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             _is_async=False,
             litellm_params=litellm_params,
         )
-        if not isinstance(azure_client, AzureOpenAI):
+        if not isinstance(azure_client, (AzureOpenAI, OpenAI)):
             raise AzureOpenAIError(
                 status_code=500,
-                message="azure_client is not an instance of AzureOpenAI",
+                message="azure_client is not an instance of AzureOpenAI or OpenAI",
             )
         ## LOGGING
         logging_obj.pre_call(
@@ -534,7 +540,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     "api_key": api_key,
                     "azure_ad_token": azure_ad_token,
                 },
-                "api_base": azure_client._base_url._uri_reference,
+                "api_base": api_base,
                 "acompletion": True,
                 "complete_input_dict": data,
             },
@@ -578,8 +584,8 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 _is_async=True,
                 litellm_params=litellm_params,
             )
-            if not isinstance(azure_client, AsyncAzureOpenAI):
-                raise ValueError("Azure client is not an instance of AsyncAzureOpenAI")
+            if not isinstance(azure_client, (AsyncAzureOpenAI, AsyncOpenAI)):
+                raise ValueError("Azure client is not an instance of AsyncAzureOpenAI or AsyncOpenAI")
 
             ## LOGGING
             logging_obj.pre_call(
@@ -590,7 +596,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                         "api_key": api_key,
                         "azure_ad_token": azure_ad_token,
                     },
-                    "api_base": azure_client._base_url._uri_reference,
+                    "api_base": api_base,
                     "acompletion": True,
                     "complete_input_dict": data,
                 },
@@ -657,8 +663,8 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 client=client,
                 litellm_params=litellm_params,
             )
-            if not isinstance(openai_aclient, AsyncAzureOpenAI):
-                raise ValueError("Azure client is not an instance of AsyncAzureOpenAI")
+            if not isinstance(openai_aclient, (AsyncAzureOpenAI, AsyncOpenAI)):
+                raise ValueError("Azure client is not an instance of AsyncAzureOpenAI or AsyncOpenAI")
 
             raw_response = await openai_aclient.embeddings.with_raw_response.create(
                 **data, timeout=timeout
@@ -755,10 +761,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 client=client,
                 litellm_params=litellm_params,
             )
-            if not isinstance(azure_client, AzureOpenAI):
+            if not isinstance(azure_client, (AzureOpenAI, OpenAI)):
                 raise AzureOpenAIError(
                     status_code=500,
-                    message="azure_client is not an instance of AzureOpenAI",
+                    message="azure_client is not an instance of AzureOpenAI or OpenAI",
                 )
 
             ## COMPLETION CALL

--- a/litellm/llms/azure/batches/handler.py
+++ b/litellm/llms/azure/batches/handler.py
@@ -6,6 +6,8 @@ from typing import Any, Coroutine, Optional, Union, cast
 
 import httpx
 
+from openai import AsyncOpenAI, OpenAI
+
 from litellm.llms.azure.azure import AsyncAzureOpenAI, AzureOpenAI
 from litellm.types.llms.openai import (
     Batch,
@@ -47,11 +49,11 @@ class AzureBatchesAPI(BaseAzureLLM):
         api_version: Optional[str],
         timeout: Union[float, httpx.Timeout],
         max_retries: Optional[int],
-        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI]] = None,
+        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]] = None,
         litellm_params: Optional[dict] = None,
     ) -> Union[LiteLLMBatch, Coroutine[Any, Any, LiteLLMBatch]]:
         azure_client: Optional[
-            Union[AzureOpenAI, AsyncAzureOpenAI]
+            Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]
         ] = self.get_azure_openai_client(
             api_key=api_key,
             api_base=api_base,
@@ -66,14 +68,14 @@ class AzureBatchesAPI(BaseAzureLLM):
             )
 
         if _is_async is True:
-            if not isinstance(azure_client, AsyncAzureOpenAI):
+            if not isinstance(azure_client, (AsyncAzureOpenAI, AsyncOpenAI)):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
             return self.acreate_batch(  # type: ignore
                 create_batch_data=create_batch_data, azure_client=azure_client
             )
-        response = cast(AzureOpenAI, azure_client).batches.create(**create_batch_data)
+        response = cast(Union[AzureOpenAI, OpenAI], azure_client).batches.create(**create_batch_data)
         return LiteLLMBatch(**response.model_dump())
 
     async def aretrieve_batch(
@@ -93,11 +95,11 @@ class AzureBatchesAPI(BaseAzureLLM):
         api_version: Optional[str],
         timeout: Union[float, httpx.Timeout],
         max_retries: Optional[int],
-        client: Optional[AzureOpenAI] = None,
+        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]] = None,
         litellm_params: Optional[dict] = None,
     ):
         azure_client: Optional[
-            Union[AzureOpenAI, AsyncAzureOpenAI]
+            Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]
         ] = self.get_azure_openai_client(
             api_key=api_key,
             api_base=api_base,
@@ -112,14 +114,14 @@ class AzureBatchesAPI(BaseAzureLLM):
             )
 
         if _is_async is True:
-            if not isinstance(azure_client, AsyncAzureOpenAI):
+            if not isinstance(azure_client, (AsyncAzureOpenAI, AsyncOpenAI)):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
             return self.aretrieve_batch(  # type: ignore
                 retrieve_batch_data=retrieve_batch_data, client=azure_client
             )
-        response = cast(AzureOpenAI, azure_client).batches.retrieve(
+        response = cast(Union[AzureOpenAI, OpenAI], azure_client).batches.retrieve(
             **retrieve_batch_data
         )
         return LiteLLMBatch(**response.model_dump())
@@ -141,11 +143,11 @@ class AzureBatchesAPI(BaseAzureLLM):
         api_version: Optional[str],
         timeout: Union[float, httpx.Timeout],
         max_retries: Optional[int],
-        client: Optional[AzureOpenAI] = None,
+        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]] = None,
         litellm_params: Optional[dict] = None,
     ):
         azure_client: Optional[
-            Union[AzureOpenAI, AsyncAzureOpenAI]
+            Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]
         ] = self.get_azure_openai_client(
             api_key=api_key,
             api_base=api_base,
@@ -180,11 +182,11 @@ class AzureBatchesAPI(BaseAzureLLM):
         max_retries: Optional[int],
         after: Optional[str] = None,
         limit: Optional[int] = None,
-        client: Optional[AzureOpenAI] = None,
+        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]] = None,
         litellm_params: Optional[dict] = None,
     ):
         azure_client: Optional[
-            Union[AzureOpenAI, AsyncAzureOpenAI]
+            Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]
         ] = self.get_azure_openai_client(
             api_key=api_key,
             api_base=api_base,
@@ -199,7 +201,7 @@ class AzureBatchesAPI(BaseAzureLLM):
             )
 
         if _is_async is True:
-            if not isinstance(azure_client, AsyncAzureOpenAI):
+            if not isinstance(azure_client, (AsyncAzureOpenAI, AsyncOpenAI)):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )

--- a/litellm/llms/azure/batches/handler.py
+++ b/litellm/llms/azure/batches/handler.py
@@ -35,7 +35,7 @@ class AzureBatchesAPI(BaseAzureLLM):
     async def acreate_batch(
         self,
         create_batch_data: CreateBatchRequest,
-        azure_client: AsyncAzureOpenAI,
+        azure_client: Union[AsyncAzureOpenAI, AsyncOpenAI],
     ) -> LiteLLMBatch:
         response = await azure_client.batches.create(**create_batch_data)
         return LiteLLMBatch(**response.model_dump())
@@ -81,7 +81,7 @@ class AzureBatchesAPI(BaseAzureLLM):
     async def aretrieve_batch(
         self,
         retrieve_batch_data: RetrieveBatchRequest,
-        client: AsyncAzureOpenAI,
+        client: Union[AsyncAzureOpenAI, AsyncOpenAI],
     ) -> LiteLLMBatch:
         response = await client.batches.retrieve(**retrieve_batch_data)
         return LiteLLMBatch(**response.model_dump())
@@ -129,7 +129,7 @@ class AzureBatchesAPI(BaseAzureLLM):
     async def acancel_batch(
         self,
         cancel_batch_data: CancelBatchRequest,
-        client: AsyncAzureOpenAI,
+        client: Union[AsyncAzureOpenAI, AsyncOpenAI],
     ) -> Batch:
         response = await client.batches.cancel(**cancel_batch_data)
         return response
@@ -165,7 +165,7 @@ class AzureBatchesAPI(BaseAzureLLM):
 
     async def alist_batches(
         self,
-        client: AsyncAzureOpenAI,
+        client: Union[AsyncAzureOpenAI, AsyncOpenAI],
         after: Optional[str] = None,
         limit: Optional[int] = None,
     ):

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -484,7 +484,7 @@ class BaseAzureLLM(BaseOpenAILLM):
                 verbose_logger.debug(f"Using Azure v1 API with base_url: {v1_params['base_url']}")
 
                 if _is_async is True:
-                    openai_client = AsyncOpenAI(**v1_params)
+                    openai_client = AsyncOpenAI(**v1_params)  # type: ignore
                 else:
                     openai_client = OpenAI(**v1_params)  # type: ignore
             else:

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -3,7 +3,7 @@ import os
 from typing import Any, Callable, Dict, Literal, Optional, Union, cast
 
 import httpx
-from openai import AsyncAzureOpenAI, AzureOpenAI
+from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
 
 import litellm
 from litellm._logging import verbose_logger
@@ -439,12 +439,12 @@ class BaseAzureLLM(BaseOpenAILLM):
         api_key: Optional[str],
         api_base: Optional[str],
         api_version: Optional[str] = None,
-        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI]] = None,
+        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]] = None,
         litellm_params: Optional[dict] = None,
         _is_async: bool = False,
         model: Optional[str] = None,
-    ) -> Optional[Union[AzureOpenAI, AsyncAzureOpenAI]]:
-        openai_client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI]] = None
+    ) -> Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]]:
+        openai_client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]] = None
         client_initialization_params: dict = locals()
         client_initialization_params["is_async"] = _is_async
         if client is None:
@@ -453,9 +453,7 @@ class BaseAzureLLM(BaseOpenAILLM):
                 client_type="azure",
             )
             if cached_client:
-                if isinstance(cached_client, AzureOpenAI) or isinstance(
-                    cached_client, AsyncAzureOpenAI
-                ):
+                if isinstance(cached_client, (AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI)):
                     return cached_client
 
             azure_client_params = self.initialize_azure_sdk_client(
@@ -466,15 +464,40 @@ class BaseAzureLLM(BaseOpenAILLM):
                 api_version=api_version,
                 is_async=_is_async,
             )
-            if _is_async is True:
-                openai_client = AsyncAzureOpenAI(**azure_client_params)
+
+            # For Azure v1 API, use standard OpenAI client instead of AzureOpenAI
+            # See: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs
+            if self._is_azure_v1_api_version(api_version):
+                # Extract only params that OpenAI client accepts
+                # Always use /openai/v1/ regardless of whether user passed "v1", "latest", or "preview"
+                v1_params = {
+                    "api_key": azure_client_params.get("api_key"),
+                    "base_url": f"{api_base}/openai/v1/",
+                }
+                if "timeout" in azure_client_params:
+                    v1_params["timeout"] = azure_client_params["timeout"]
+                if "max_retries" in azure_client_params:
+                    v1_params["max_retries"] = azure_client_params["max_retries"]
+                if "http_client" in azure_client_params:
+                    v1_params["http_client"] = azure_client_params["http_client"]
+
+                verbose_logger.debug(f"Using Azure v1 API with base_url: {v1_params['base_url']}")
+
+                if _is_async is True:
+                    openai_client = AsyncOpenAI(**v1_params)
+                else:
+                    openai_client = OpenAI(**v1_params)  # type: ignore
             else:
-                openai_client = AzureOpenAI(**azure_client_params)  # type: ignore
+                # Traditional Azure API uses AzureOpenAI client
+                if _is_async is True:
+                    openai_client = AsyncAzureOpenAI(**azure_client_params)
+                else:
+                    openai_client = AzureOpenAI(**azure_client_params)  # type: ignore
         else:
             openai_client = client
             if api_version is not None and isinstance(
-                openai_client._custom_query, dict
-            ):
+                openai_client, (AzureOpenAI, AsyncAzureOpenAI)
+            ) and isinstance(openai_client._custom_query, dict):
                 # set api_version to version passed by user
                 openai_client._custom_query.setdefault("api-version", api_version)
 

--- a/litellm/llms/azure/files/handler.py
+++ b/litellm/llms/azure/files/handler.py
@@ -40,7 +40,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
     async def acreate_file(
         self,
         create_file_data: CreateFileRequest,
-        openai_client: AsyncAzureOpenAI,
+        openai_client: Union[AsyncAzureOpenAI, AsyncOpenAI],
     ) -> OpenAIFileObject:
         verbose_logger.debug("create_file_data=%s", create_file_data)
         response = await openai_client.files.create(**self._prepare_create_file_data(create_file_data))  # type: ignore[arg-type]
@@ -88,7 +88,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
     async def afile_content(
         self,
         file_content_request: FileContentRequest,
-        openai_client: AsyncAzureOpenAI,
+        openai_client: Union[AsyncAzureOpenAI, AsyncOpenAI],
     ) -> HttpxBinaryResponseContent:
         response = await openai_client.files.content(**file_content_request)
         return HttpxBinaryResponseContent(response=response.response)
@@ -140,7 +140,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
     async def aretrieve_file(
         self,
         file_id: str,
-        openai_client: AsyncAzureOpenAI,
+        openai_client: Union[AsyncAzureOpenAI, AsyncOpenAI],
     ) -> FileObject:
         response = await openai_client.files.retrieve(file_id=file_id)
         return response
@@ -188,7 +188,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
     async def adelete_file(
         self,
         file_id: str,
-        openai_client: AsyncAzureOpenAI,
+        openai_client: Union[AsyncAzureOpenAI, AsyncOpenAI],
     ) -> FileDeleted:
         response = await openai_client.files.delete(file_id=file_id)
 

--- a/litellm/llms/azure/files/handler.py
+++ b/litellm/llms/azure/files/handler.py
@@ -1,7 +1,7 @@
 from typing import Any, Coroutine, Optional, Union, cast
 
 import httpx
-from openai import AsyncAzureOpenAI, AzureOpenAI
+from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
 from openai.types.file_deleted import FileDeleted
 
 from litellm._logging import verbose_logger
@@ -56,11 +56,11 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
         api_version: Optional[str],
         timeout: Union[float, httpx.Timeout],
         max_retries: Optional[int],
-        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI]] = None,
+        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]] = None,
         litellm_params: Optional[dict] = None,
     ) -> Union[OpenAIFileObject, Coroutine[Any, Any, OpenAIFileObject]]:
         openai_client: Optional[
-            Union[AzureOpenAI, AsyncAzureOpenAI]
+            Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]
         ] = self.get_azure_openai_client(
             litellm_params=litellm_params or {},
             api_key=api_key,
@@ -75,14 +75,14 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
             )
 
         if _is_async is True:
-            if not isinstance(openai_client, AsyncAzureOpenAI):
+            if not isinstance(openai_client, (AsyncAzureOpenAI, AsyncOpenAI)):
                 raise ValueError(
                     "AzureOpenAI client is not an instance of AsyncAzureOpenAI. Make sure you passed an AsyncAzureOpenAI client."
                 )
             return self.acreate_file(
                 create_file_data=create_file_data, openai_client=openai_client
             )
-        response = cast(AzureOpenAI, openai_client).files.create(**self._prepare_create_file_data(create_file_data))  # type: ignore[arg-type]
+        response = cast(Union[AzureOpenAI, OpenAI], openai_client).files.create(**self._prepare_create_file_data(create_file_data))  # type: ignore[arg-type]
         return OpenAIFileObject(**response.model_dump())
 
     async def afile_content(
@@ -102,13 +102,13 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
         timeout: Union[float, httpx.Timeout],
         max_retries: Optional[int],
         api_version: Optional[str] = None,
-        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI]] = None,
+        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]] = None,
         litellm_params: Optional[dict] = None,
     ) -> Union[
         HttpxBinaryResponseContent, Coroutine[Any, Any, HttpxBinaryResponseContent]
     ]:
         openai_client: Optional[
-            Union[AzureOpenAI, AsyncAzureOpenAI]
+            Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]
         ] = self.get_azure_openai_client(
             litellm_params=litellm_params or {},
             api_key=api_key,
@@ -123,7 +123,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
             )
 
         if _is_async is True:
-            if not isinstance(openai_client, AsyncAzureOpenAI):
+            if not isinstance(openai_client, (AsyncAzureOpenAI, AsyncOpenAI)):
                 raise ValueError(
                     "AzureOpenAI client is not an instance of AsyncAzureOpenAI. Make sure you passed an AsyncAzureOpenAI client."
                 )
@@ -131,7 +131,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
                 file_content_request=file_content_request,
                 openai_client=openai_client,
             )
-        response = cast(AzureOpenAI, openai_client).files.content(
+        response = cast(Union[AzureOpenAI, OpenAI], openai_client).files.content(
             **file_content_request
         )
 
@@ -154,11 +154,11 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
         timeout: Union[float, httpx.Timeout],
         max_retries: Optional[int],
         api_version: Optional[str] = None,
-        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI]] = None,
+        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]] = None,
         litellm_params: Optional[dict] = None,
     ):
         openai_client: Optional[
-            Union[AzureOpenAI, AsyncAzureOpenAI]
+            Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]
         ] = self.get_azure_openai_client(
             litellm_params=litellm_params or {},
             api_key=api_key,
@@ -173,7 +173,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
             )
 
         if _is_async is True:
-            if not isinstance(openai_client, AsyncAzureOpenAI):
+            if not isinstance(openai_client, (AsyncAzureOpenAI, AsyncOpenAI)):
                 raise ValueError(
                     "AzureOpenAI client is not an instance of AsyncAzureOpenAI. Make sure you passed an AsyncAzureOpenAI client."
                 )
@@ -206,11 +206,11 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
         max_retries: Optional[int],
         organization: Optional[str] = None,
         api_version: Optional[str] = None,
-        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI]] = None,
+        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]] = None,
         litellm_params: Optional[dict] = None,
     ):
         openai_client: Optional[
-            Union[AzureOpenAI, AsyncAzureOpenAI]
+            Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]
         ] = self.get_azure_openai_client(
             litellm_params=litellm_params or {},
             api_key=api_key,
@@ -225,7 +225,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
             )
 
         if _is_async is True:
-            if not isinstance(openai_client, AsyncAzureOpenAI):
+            if not isinstance(openai_client, (AsyncAzureOpenAI, AsyncOpenAI)):
                 raise ValueError(
                     "AzureOpenAI client is not an instance of AsyncAzureOpenAI. Make sure you passed an AsyncAzureOpenAI client."
                 )
@@ -242,7 +242,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
 
     async def alist_files(
         self,
-        openai_client: AsyncAzureOpenAI,
+        openai_client: Union[AsyncAzureOpenAI, AsyncOpenAI],
         purpose: Optional[str] = None,
     ):
         if isinstance(purpose, str):
@@ -260,11 +260,11 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
         max_retries: Optional[int],
         purpose: Optional[str] = None,
         api_version: Optional[str] = None,
-        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI]] = None,
+        client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]] = None,
         litellm_params: Optional[dict] = None,
     ):
         openai_client: Optional[
-            Union[AzureOpenAI, AsyncAzureOpenAI]
+            Union[AzureOpenAI, AsyncAzureOpenAI, OpenAI, AsyncOpenAI]
         ] = self.get_azure_openai_client(
             litellm_params=litellm_params or {},
             api_key=api_key,
@@ -279,7 +279,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
             )
 
         if _is_async is True:
-            if not isinstance(openai_client, AsyncAzureOpenAI):
+            if not isinstance(openai_client, (AsyncAzureOpenAI, AsyncOpenAI)):
                 raise ValueError(
                     "AzureOpenAI client is not an instance of AsyncAzureOpenAI. Make sure you passed an AsyncAzureOpenAI client."
                 )

--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -1541,3 +1541,119 @@ def test_is_azure_v1_api_version(api_version, expected):
     """
     result = BaseAzureLLM._is_azure_v1_api_version(api_version=api_version)
     assert result == expected
+
+
+@pytest.mark.parametrize("api_version", ["v1", "latest", "preview"])
+def test_azure_v1_api_uses_openai_client(api_version):
+    """
+    Test that Azure v1 API versions use OpenAI client instead of AzureOpenAI.
+
+    When api_version is 'v1', 'latest', or 'preview', the client should be
+    instantiated as OpenAI/AsyncOpenAI with base_url pointing to /openai/v1/
+    instead of the traditional AzureOpenAI client with /deployments/ URL pattern.
+
+    See: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs
+    """
+    from openai import AsyncOpenAI, OpenAI
+
+    base_llm = BaseAzureLLM()
+    api_base = "https://test.openai.azure.com"
+
+    # Test sync client
+    with patch.object(base_llm, "initialize_azure_sdk_client") as mock_init:
+        mock_init.return_value = {
+            "api_key": "test-key",
+            "azure_endpoint": api_base,
+            "api_version": api_version,
+            "azure_ad_token": None,
+            "azure_ad_token_provider": None,
+        }
+
+        client = base_llm.get_azure_openai_client(
+            api_key="test-key",
+            api_base=api_base,
+            api_version=api_version,
+            _is_async=False,
+        )
+
+        # Should be OpenAI client, not AzureOpenAI
+        assert isinstance(client, OpenAI), f"Expected OpenAI client for api_version={api_version}"
+        # base_url should be /openai/v1/ (not /deployments/)
+        assert "/openai/v1/" in str(client.base_url), f"base_url should contain /openai/v1/, got {client.base_url}"
+
+    # Test async client
+    with patch.object(base_llm, "initialize_azure_sdk_client") as mock_init:
+        mock_init.return_value = {
+            "api_key": "test-key",
+            "azure_endpoint": api_base,
+            "api_version": api_version,
+            "azure_ad_token": None,
+            "azure_ad_token_provider": None,
+        }
+
+        async_client = base_llm.get_azure_openai_client(
+            api_key="test-key",
+            api_base=api_base,
+            api_version=api_version,
+            _is_async=True,
+        )
+
+        # Should be AsyncOpenAI client, not AsyncAzureOpenAI
+        assert isinstance(async_client, AsyncOpenAI), f"Expected AsyncOpenAI client for api_version={api_version}"
+        # base_url should be /openai/v1/
+        assert "/openai/v1/" in str(async_client.base_url), f"base_url should contain /openai/v1/, got {async_client.base_url}"
+
+
+def test_azure_traditional_api_uses_azure_openai_client():
+    """
+    Test that traditional Azure API versions still use AzureOpenAI client.
+
+    When api_version is a dated version like '2023-05-15', the client should
+    be instantiated as AzureOpenAI/AsyncAzureOpenAI with the traditional
+    /deployments/ URL pattern.
+    """
+    from openai import AsyncAzureOpenAI, AzureOpenAI
+
+    base_llm = BaseAzureLLM()
+    api_base = "https://test.openai.azure.com"
+    api_version = "2023-05-15"
+
+    # Test sync client
+    with patch.object(base_llm, "initialize_azure_sdk_client") as mock_init:
+        mock_init.return_value = {
+            "api_key": "test-key",
+            "azure_endpoint": api_base,
+            "api_version": api_version,
+            "azure_ad_token": None,
+            "azure_ad_token_provider": None,
+        }
+
+        client = base_llm.get_azure_openai_client(
+            api_key="test-key",
+            api_base=api_base,
+            api_version=api_version,
+            _is_async=False,
+        )
+
+        # Should be AzureOpenAI client
+        assert isinstance(client, AzureOpenAI), f"Expected AzureOpenAI client for api_version={api_version}"
+
+    # Test async client
+    with patch.object(base_llm, "initialize_azure_sdk_client") as mock_init:
+        mock_init.return_value = {
+            "api_key": "test-key",
+            "azure_endpoint": api_base,
+            "api_version": api_version,
+            "azure_ad_token": None,
+            "azure_ad_token_provider": None,
+        }
+
+        async_client = base_llm.get_azure_openai_client(
+            api_key="test-key",
+            api_base=api_base,
+            api_version=api_version,
+            _is_async=True,
+        )
+
+        # Should be AsyncAzureOpenAI client
+        assert isinstance(async_client, AsyncAzureOpenAI), f"Expected AsyncAzureOpenAI client for api_version={api_version}"


### PR DESCRIPTION
## Relevant issues

Adds support for Azure OpenAI v1 API endpoint format.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

When using `api_version="v1"`, `"latest"`, or `"preview"`, requests fail because LiteLLM constructs an incorrect URL.

**Before (broken):**
```python
import litellm

response = litellm.completion(
    model="azure/gpt-4.1",
    messages=[{"role": "user", "content": "Hello"}],
    api_key="your-key",
    api_base="https://your-resource.openai.azure.com",
    api_version="v1"
)
# ❌ Error: Resource not found
# URL constructed: /openai/deployments/gpt-4.1/chat/completions?api-version=v1
```

### Solution

With this fix, the same request works correctly by using the standard `OpenAI` client with the proper `/openai/v1/` base URL.

**After (works):**
```python
import litellm

response = litellm.completion(
    model="azure/gpt-4.1",
    messages=[{"role": "user", "content": "Hello"}],
    api_key="your-key",
    api_base="https://your-resource.openai.azure.com",
    api_version="v1"
)
# ✅
# URL constructed: /openai/v1/chat/completions
```

See: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs

## Test plan

- [x] Unit tests for `_is_azure_v1_api_version()` 
- [x] Unit tests for v1 API client creation
- [x] Unit tests for traditional API still working
- [x] Manual testing with real Azure OpenAI endpoint