### PR TITLE
Fix: _handle_failure method getting called 2 times

### DIFF
--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -170,7 +170,6 @@ class BaseResponsesAPIStreamingIterator:
             return None
         except Exception as e:
             # Ensure failures trigger failure hooks
-            self._handle_failure(e)
             raise
 
     def _handle_logging_completed_response(self):

--- a/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
+++ b/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
@@ -247,3 +247,51 @@ class TestBaseResponsesAPIStreamingIterator:
         # Test with None chunk
         result = iterator._process_chunk(None)
         assert result is None
+
+    def test_process_chunk_exception_does_not_call_handle_failure(self):
+        """
+        Test that _process_chunk raises exceptions without calling _handle_failure.
+        
+        This ensures _handle_failure is only called once in the outer exception handler
+        (in __next__ or __anext__), preventing duplicate failure logging.
+        
+        Previously, _handle_failure was called both in _process_chunk and in the outer
+        exception handler, causing duplicate logs. This test verifies the fix.
+        """
+        # Mock dependencies
+        mock_response = Mock()
+        mock_response.headers = {}
+        mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+        mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_config = Mock(spec=BaseResponsesAPIConfig)
+        
+        # Set up the mock transform method to raise an exception
+        test_exception = ValueError("Test exception in transform")
+        mock_config.transform_streaming_response.side_effect = test_exception
+        
+        # Create the iterator instance
+        iterator = BaseResponsesAPIStreamingIterator(
+            response=mock_response,
+            model="gpt-4",
+            responses_api_provider_config=mock_config,
+            logging_obj=mock_logging_obj
+        )
+        
+        # Mock _handle_failure to track if it's called
+        with patch.object(iterator, '_handle_failure') as mock_handle_failure:
+            # Prepare valid JSON chunk that will trigger transform_streaming_response
+            test_chunk_data = {
+                "type": "response.output_text.delta",
+                "delta": "Hello"
+            }
+            
+            # _process_chunk should raise the exception without calling _handle_failure
+            with pytest.raises(ValueError) as exc_info:
+                iterator._process_chunk(json.dumps(test_chunk_data))
+            
+            # Verify the exception was raised
+            assert str(exc_info.value) == "Test exception in transform"
+            
+            # Verify _handle_failure was NOT called in _process_chunk
+            # It should only be called by the outer exception handler in __next__/__anext__
+            mock_handle_failure.assert_not_called()


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
**Before**
<img width="362" height="196" alt="image" src="https://github.com/user-attachments/assets/eff0306e-6780-499f-8c37-a280c4f518b6" />

**After**
<img width="362" height="196" alt="image" src="https://github.com/user-attachments/assets/694e80fe-1414-4e2f-926e-57500eb54976" />


