### PR TITLE
chore: map Vertex IMAGE_PROHIBITED_CONTENT to content_filter

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1150,6 +1150,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             "PROHIBITED_CONTENT": "The token generation was stopped as the response was flagged for the prohibited contents.",
             "SPII": "The token generation was stopped as the response was flagged for Sensitive Personally Identifiable Information (SPII) contents.",
             "IMAGE_SAFETY": "The token generation was stopped as the response was flagged for image safety reasons.",
+            "IMAGE_PROHIBITED_CONTENT": "The token generation was stopped as the response was flagged for prohibited image content.",
         }
 
     @staticmethod
@@ -1172,6 +1173,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             "SPII": "content_filter",
             "MALFORMED_FUNCTION_CALL": "stop",  # openai doesn't have a way of representing this
             "IMAGE_SAFETY": "content_filter",
+            "IMAGE_PROHIBITED_CONTENT": "content_filter",
         }
 
     def translate_exception_str(self, exception_string: str):


### PR DESCRIPTION
### What this PR does
Adds a missing finish reason mapping for Vertex AI image responses:
`IMAGE_PROHIBITED_CONTENT` → `content_filter`.

### Why this is needed
Vertex AI may return `IMAGE_PROHIBITED_CONTENT` when an image generation request
is blocked by safety policies.  
Currently, this finish reason is not included in `get_finish_reason_mapping`,
which causes such responses to bypass LiteLLM’s unified content filtering logic.

### Scope of change
- Minimal change (single mapping entry)
- No breaking behavior
- Aligns image safety handling with existing text safety mappings

### Context
Observed during real-world usage of Vertex AI image generation via LiteLLM proxy,
where blocked image responses were not categorized as `content_filter`.
