### PR TITLE
fix: drop_params not dropping prompt_cache_key for non-OpenAI providers

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -532,6 +532,10 @@ DEFAULT_CHAT_COMPLETION_PARAM_VALUES = {
     "web_search_options": None,
     "service_tier": None,
     "safety_identifier": None,
+    "prompt_cache_key": None,
+    "prompt_cache_retention": None,
+    "store": None,
+    "metadata": None,
 }
 
 openai_compatible_endpoints: List = [

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4578,6 +4578,8 @@ def add_provider_specific_params_to_optional_params(
     else:
         for k in passed_params.keys():
             if k not in openai_params and passed_params[k] is not None:
+                if _should_drop_param(k=k, additional_drop_params=additional_drop_params):
+                    continue
                 optional_params[k] = passed_params[k]
     return optional_params
 


### PR DESCRIPTION
## Relevant issues

Fixes #19225

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem

OpenAI has a `prompt_cache_key` parameter for [prompt caching](https://platform.openai.com/docs/guides/prompt-caching) - it route requests to the same server:

```python
# OpenAI request with prompt_cache_key
response = client.chat.completions.create(
    model="gpt-4o",
    messages=[
        {"role": "system", "content": "You are a helpful assistant..."},
        {"role": "user", "content": "Hello!"}
    ],
    prompt_cache_key="my-app-v1"  # Routes similar requests to same server for caching
)
```

When using LiteLLM proxy with fallback from OpenAI to Bedrock, this parameter was being sent to Bedrock even with `drop_params: true` configured:

```yaml
# Proxy config
litellm_settings:
  drop_params: true

model_list:
  - model_name: gpt-4o
    litellm_params:
      model: openai/gpt-4o
  - model_name: bedrock-claude
    litellm_params:
      model: bedrock/anthropic.claude-3-sonnet
```

Bedrock doesn't support `prompt_cache_key`, so requests failed with:
```
BedrockException - {"message":"The model returned the following errors: prompt_cache_key: Extra inputs are not permitted"}
```

`prompt_cache_key` is an [official OpenAI Chat Completions parameter](https://platform.openai.com/docs/api-reference/chat/create#chat-create-prompt_cache_key), but it was missing from LiteLLM's `DEFAULT_CHAT_COMPLETION_PARAM_VALUES`. 

The parameter bypassed the validation that checks against each provider's supported params - so `drop_params: true` had no effect on it.

### Solution

1. **Add missing OpenAI params to `DEFAULT_CHAT_COMPLETION_PARAM_VALUES`:**
   - `prompt_cache_key`
   - `prompt_cache_retention` 
   - `store`
   - `metadata`

2. **Fix `additional_drop_params` for non-OpenAI providers** in `add_provider_specific_params_to_optional_params()`

With `drop_params: true`, LiteLLM correctly checks if `prompt_cache_key` is in Bedrock's supported params list - it's not, so it gets dropped automatically.

## Test plan

- [x] Added `TestDropParamsWithPromptCacheKey` - verifies `drop_params: true` removes `prompt_cache_key` for Bedrock
- [x] Added `TestAdditionalDropParamsForNonOpenAIProviders` - verifies `additional_drop_params` works for all providers
- [x] All existing tests pass