### PR TITLE
fix(ui): clean-up provider list from UI and logo fixes

### DIFF
--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -411,7 +411,7 @@
     "default_model_placeholder": "azure/my-deployment"
   },
   {
-    "provider": "Azure_AI_Studio",
+    "provider": "AZURE_AI",
     "provider_display_name": "Azure AI Foundry (Studio)",
     "litellm_provider": "azure_ai",
     "credential_fields": [
@@ -1663,7 +1663,7 @@
     "default_model_placeholder": "gpt-3.5-turbo"
   },
   {
-    "provider": "MistralAI",
+    "provider": "MISTRAL",
     "provider_display_name": "Mistral AI",
     "litellm_provider": "mistral",
     "credential_fields": [

--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -411,7 +411,7 @@
     "default_model_placeholder": "azure/my-deployment"
   },
   {
-    "provider": "AZURE_AI",
+    "provider": "Azure_AI_Studio",
     "provider_display_name": "Azure AI Foundry (Studio)",
     "litellm_provider": "azure_ai",
     "credential_fields": [
@@ -1663,7 +1663,7 @@
     "default_model_placeholder": "gpt-3.5-turbo"
   },
   {
-    "provider": "MISTRAL",
+    "provider": "MistralAI",
     "provider_display_name": "Mistral AI",
     "litellm_provider": "mistral",
     "credential_fields": [

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -85,11 +85,23 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
     fetchModelAccessGroups();
   }, [accessToken]);
 
+  const nonProviderIdentifiers = new Set([
+    "AIOHTTP_OPENAI",
+    "CUSTOM_OPENAI",
+    "OPENAI_LIKE",
+    "OpenAI_Text",
+    "OpenAI_Compatible",
+    "OpenAI_Text_Compatible",
+  ]);
+
   const sortedProviderMetadata: ProviderCreateInfo[] = useMemo(() => {
     if (!providerMetadata) {
       return [];
     }
-    return [...providerMetadata].sort((a, b) => a.provider_display_name.localeCompare(b.provider_display_name));
+    const filtered = providerMetadata.filter((provider) => {
+      return !nonProviderIdentifiers.has(provider.provider);
+    });
+    return [...filtered].sort((a, b) => a.provider_display_name.localeCompare(b.provider_display_name));
   }, [providerMetadata]);
 
   const providerMetadataErrorText = providerMetadataError

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -92,6 +92,11 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
     "OpenAI_Text",
     "OpenAI_Compatible",
     "OpenAI_Text_Compatible",
+    "ANTHROPIC_TEXT",
+    "AZURE_TEXT",
+    "COHERE_CHAT",
+    "OLLAMA_CHAT",
+    "VERTEX_AI_BETA",
   ]);
 
   const sortedProviderMetadata: ProviderCreateInfo[] = useMemo(() => {

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -368,6 +368,11 @@ export const getPlaceholder = (selectedProvider: string): string => {
   }
 };
 
+const isValidModelName = (modelName: string): boolean => {
+  const resolutionOnlyPattern = /^\d{3,4}-x-\d{3,4}\/dall-e-[23]$/;
+  return !resolutionOnlyPattern.test(modelName);
+};
+
 export const getProviderModels = (provider: Providers, modelMap: any): Array<string> => {
   let providerKey = provider;
   console.log(`Provider key: ${providerKey}`);
@@ -384,7 +389,9 @@ export const getProviderModels = (provider: Providers, modelMap: any): Array<str
           litellmProvider === custom_llm_provider ||
           (typeof litellmProvider === "string" && litellmProvider.includes(custom_llm_provider))
         ) {
-          providerModels.push(key);
+          if (isValidModelName(key)) {
+            providerModels.push(key);
+          }
         }
       }
     });
@@ -399,7 +406,9 @@ export const getProviderModels = (provider: Providers, modelMap: any): Array<str
           "litellm_provider" in (value as object) &&
           (value as any)["litellm_provider"] === "cohere_chat"
         ) {
-          providerModels.push(key);
+          if (isValidModelName(key)) {
+            providerModels.push(key);
+          }
         }
       });
     }
@@ -415,11 +424,13 @@ export const getProviderModels = (provider: Providers, modelMap: any): Array<str
           "litellm_provider" in (value as object) &&
           (value as any)["litellm_provider"] === "sagemaker_chat"
         ) {
-          providerModels.push(key);
+          if (isValidModelName(key)) {
+            providerModels.push(key);
+          }
         }
       });
     }
   }
 
-  return providerModels;
+  return providerModels.sort();
 };

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -222,7 +222,7 @@ export const providerLogoMap: Record<string, string> = {
   [Providers.ANTHROPIC_TEXT]: `${asset_logos_folder}anthropic.svg`,
   [Providers.AssemblyAI]: `${asset_logos_folder}assemblyai_small.png`,
   [Providers.Azure]: `${asset_logos_folder}microsoft_azure.svg`,
-  [Providers.Azure_AI_Studio]: `${asset_logos_folder}microsoft_azure.svg`,
+  [Providers.Azure_AI_Studio]: `${asset_logos_folder}azure_ai_foundry.png`,
   [Providers.AZURE_TEXT]: `${asset_logos_folder}microsoft_azure.svg`,
   [Providers.BASETEN]: `${asset_logos_folder}baseten.svg`,
   [Providers.Bedrock]: `${asset_logos_folder}bedrock.svg`,
@@ -369,8 +369,10 @@ export const getPlaceholder = (selectedProvider: string): string => {
 };
 
 const isValidModelName = (modelName: string): boolean => {
-  const resolutionOnlyPattern = /^\d{3,4}-x-\d{3,4}\/dall-e-[23]$/;
-  return !resolutionOnlyPattern.test(modelName);
+  // Filter out image model variants with resolution/quality prefixes
+  // Examples: "1024-x-1024/gpt-image-1.5", "high/1024-x-1024/gpt-image-1", "standard/1024-x-1024/gpt-image-1"
+  const invalidImageModelPattern = /^(high|low|medium|standard|hd)?\/?\d{3,4}-x-\d{3,4}\/(dall-e-|gpt-image-)/;
+  return !invalidImageModelPattern.test(modelName);
 };
 
 export const getProviderModels = (provider: Providers, modelMap: any): Array<string> => {


### PR DESCRIPTION
## Relevant issues

Follow-up to #19264

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Provider Filters
Filter redundant/duplicate providers from the Add Model dropdown:
- `ANTHROPIC_TEXT`, `AZURE_TEXT`, `COHERE_CHAT`, `OLLAMA_CHAT`, `VERTEX_AI_BETA`


### Logo Fixes
- Fix logo display for Mistral AI and Azure AI Foundry by normalizing provider identifiers (`MistralAI` → `MISTRAL`, `Azure_AI_Studio` → `AZURE_AI`)
- Update Azure AI Foundry to use its dedicated logo (`azure_ai_foundry.png`)

### Model Filter
Filter invalid image model variants with resolution/quality prefixes from model suggestions:
- Examples: `1024-x-1024/gpt-image-1.5`, `standard/1024-x-1024/gpt-image-1`, `high/1024-x-1024/dall-e-3`

<img width="1439" height="653" alt="Screenshot 2026-01-19 at 09 30 24" src="https://github.com/user-attachments/assets/4514744c-d123-4367-a57b-05e130fcd412" />
