### PR TITLE
fix: avoid unknown targets in HPA

### DIFF
--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/litellm-helm/templates/_helpers.tpl
+++ b/deploy/charts/litellm-helm/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Common labels
 */}}
 {{- define "litellm.labels" -}}
 helm.sh/chart: {{ include "litellm.chart" . }}
-{{ include "litellm.selectorLabels" . }}
+{{ include "litellm.appLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -43,11 +43,19 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+App labels
+*/}}
+{{- define "litellm.appLabels" -}}
+app.kubernetes.io/name: {{ include "litellm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "litellm.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "litellm.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "litellm.appLabels" . }}
+app.kubernetes.io/component: proxy
 {{- end }}
 
 {{/*

--- a/deploy/charts/litellm-helm/tests/pdb_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/pdb_tests.yaml
@@ -14,6 +14,7 @@ tests:
       - equal:
           path: spec.selector.matchLabels
           value:
+            app.kubernetes.io/component: proxy
             app.kubernetes.io/name: litellm
             app.kubernetes.io/instance: RELEASE-NAME
 

--- a/deploy/charts/litellm-helm/tests/service_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/service_tests.yaml
@@ -112,5 +112,6 @@ tests:
       - equal:
           path: spec.selector
           value:
+            app.kubernetes.io/component: proxy
             app.kubernetes.io/name: litellm
             app.kubernetes.io/instance: RELEASE-NAME


### PR DESCRIPTION
Pods created by Jobs are targeted by Deployment, hence by HorizontalPodAutoscaler, during Pods existence.

Once Pods are Completed and garbage collected, HPA targets become operational again.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
