### PR TITLE
fix: remove count tokens optional param before request is sent to vertex

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -317,6 +317,7 @@ class AnthropicChatCompletion(BaseLLM):
         stream = optional_params.pop("stream", None)
         json_mode: bool = optional_params.pop("json_mode", False)
         is_vertex_request: bool = optional_params.pop("is_vertex_request", False)
+        optional_params.pop("vertex_count_tokens_location", None)
         _is_function_call = False
         messages = copy.deepcopy(messages)
         headers = AnthropicConfig().validate_environment(


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Removed optional `vertex_count_tokens_location` param before request is sent to vertex

Reason:
Receiving bad request on `/chat/completions` and `/responses` routes when `vertex_count_tokens_location` param is set

`litellm.BadRequestError: Vertex_aiException BadRequestError - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"vertex_count_tokens_location: Extra inputs are not permitted\"}`

```
  - model_name: "claude-opus-4-5-20251101"
    model_info:
      supported_environments: ["production", "development"]
    litellm_params:
      model: vertex_ai/claude-opus-4-5@20251101
      litellm_credential_name: default_vertex_ai_credentials
      vertex_location: "global" #only available on global location
      vertex_count_tokens_location: "us-central1"  👈🏻 
      tpm: 10000000
      rpm: 400
```