### PR TITLE
feat: add retry_delay, exponential_backoff, and jitter to completion()

### DIFF
--- a/docs/my-website/docs/completion/input.md
+++ b/docs/my-website/docs/completion/input.md
@@ -264,6 +264,12 @@ messages=[{"role": "user", "content": [
 
 - `num_retries`: *int (optional)* - The number of times to retry the API call if an APIError, TimeoutError or ServiceUnavailableError occurs 
 
+- `retry_delay`: *float (optional)* - Time in seconds to wait between retries.
+
+- `exponential_backoff`: *float (optional)* - If true, wait time doubles after each failure (1s, 2s, 4s...)
+
+- `jitter`: *float (optional)* - If true, adds randomness to the wait time to prevent thundering herd. 
+
 - `context_window_fallback_dict`: *dict (optional)* - A mapping of model to use if call fails due to context window error
 
 - `fallbacks`: *list (optional)* - A list of model names + params to be used, in case the initial call fails

--- a/docs/my-website/docs/completion/reliable_completions.md
+++ b/docs/my-website/docs/completion/reliable_completions.md
@@ -31,6 +31,36 @@ response = completion(
         )
 ```
 
+### Configurable Retries (Exponential Backoff, Jitter)
+
+You can also specify the `retry_delay` and `exponential_backoff` or `jitter` to the completion call.
+
+* `retry_delay`: (float) Time in seconds to wait between retries.
+* `exponential_backoff`: (bool) If true, wait time doubles after each failure (1s, 2s, 4s...).
+* `jitter`: (bool) If true, adds randomness to the wait time to prevent thundering herd.
+
+```python
+import litellm
+
+# Exponential Backoff
+response = litellm.completion(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "Hi"}],
+    num_retries=3,
+    retry_delay=1.0,        # Start with 1s wait
+    exponential_backoff=True # Wait 1s, 2s, 4s...
+)
+
+# Jitter
+response = litellm.completion(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "Hi"}],
+    num_retries=3,
+    retry_delay=1.0,
+    jitter=True             # Randomize wait times
+)
+```
+
 ## Fallbacks (SDK)
 
 :::info

--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -64,6 +64,9 @@ def get_litellm_params(
     api_version: Optional[str] = None,
     max_retries: Optional[int] = None,
     litellm_request_debug: Optional[bool] = None,
+    retry_delay: Optional[float] = None,
+    exponential_backoff: Optional[bool] = None,
+    jitter: Optional[bool] = None,
     **kwargs,
 ) -> dict:
     litellm_params = {
@@ -116,6 +119,9 @@ def get_litellm_params(
         "azure_password": kwargs.get("azure_password"),
         "azure_scope": kwargs.get("azure_scope"),
         "max_retries": max_retries,
+        "retry_delay": retry_delay,
+        "exponential_backoff": exponential_backoff,
+        "jitter": jitter,
         "timeout": kwargs.get("timeout"),
         "bucket_name": kwargs.get("bucket_name"),
         "vertex_credentials": kwargs.get("vertex_credentials"),

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -415,6 +415,11 @@ async def acompletion(
     web_search_options: Optional[OpenAIWebSearchOptions] = None,
     # Session management
     shared_session: Optional["ClientSession"] = None,
+    # Retry params
+    retry_delay: Optional[float] = None,
+    exponential_backoff: Optional[bool] = None,
+    jitter: Optional[bool] = None,
+    num_retries: Optional[int] = None,
     **kwargs,
 ) -> Union[ModelResponse, CustomStreamWrapper]:
     """
@@ -460,6 +465,16 @@ async def acompletion(
         - The `completion` function is called using `run_in_executor` to execute synchronously in the event loop.
         - If `stream` is True, the function returns an async generator that yields completion lines.
     """
+    if _update_kwargs_with_retry_params(
+        retry_delay,
+        exponential_backoff,
+        jitter,
+        num_retries,
+        locals().get("max_retries"),
+        kwargs,
+    ):
+        return await acompletion_with_retries(model=model, messages=messages, **kwargs)
+
     fallbacks = kwargs.get("fallbacks", None)
     mock_timeout = kwargs.get("mock_timeout", None)
 
@@ -988,8 +1003,32 @@ def _drop_input_examples_from_tools(
     return cleaned_tools
 
 
-@tracer.wrap()
-@client
+def _update_kwargs_with_retry_params(
+    retry_delay: Optional[float],
+    exponential_backoff: Optional[bool],
+    jitter: Optional[bool],
+    num_retries: Optional[int],
+    max_retries: Optional[int],
+    kwargs: dict,
+) -> bool:
+    """
+    Updates kwargs with retry parameters if any are provided.
+    Returns True if retry logic should be triggered, False otherwise.
+    """
+    if retry_delay is not None or exponential_backoff is not None or jitter is not None:
+        kwargs["retry_delay"] = retry_delay
+        kwargs["exponential_backoff"] = exponential_backoff
+        kwargs["jitter"] = jitter
+
+        if num_retries is not None:
+            kwargs["num_retries"] = num_retries
+        elif max_retries is not None and "num_retries" not in kwargs:
+            kwargs["num_retries"] = max_retries
+
+        return True
+    return False
+
+
 def completion(  # type: ignore # noqa: PLR0915
     model: str,
     # Optional OpenAI params: see https://platform.openai.com/docs/api-reference/chat/create
@@ -1039,6 +1078,11 @@ def completion(  # type: ignore # noqa: PLR0915
     thinking: Optional[AnthropicThinkingParam] = None,
     # Session management
     shared_session: Optional["ClientSession"] = None,
+    # Retry params
+    retry_delay: Optional[float] = None,
+    exponential_backoff: Optional[bool] = None,
+    jitter: Optional[bool] = None,
+    num_retries: Optional[int] = None,
     **kwargs,
 ) -> Union[ModelResponse, CustomStreamWrapper]:
     """
@@ -1086,6 +1130,20 @@ def completion(  # type: ignore # noqa: PLR0915
         - It supports various optional parameters for customizing the completion behavior.
         - If 'mock_response' is provided, a mock completion response is returned for testing or debugging.
     """
+    if _update_kwargs_with_retry_params(
+        retry_delay,
+        exponential_backoff,
+        jitter,
+        num_retries,
+        locals().get("max_retries"),
+        kwargs,
+    ):
+        # check if this is an async call (acompletion=True in kwargs)
+        if kwargs.get("acompletion", False) is True:
+            return acompletion_with_retries(model=model, messages=messages, **kwargs)
+
+        return completion_with_retries(model=model, messages=messages, **kwargs)
+
     ### VALIDATE Request ###
     if model is None:
         raise ValueError("model param not passed in.")
@@ -1111,7 +1169,9 @@ def completion(  # type: ignore # noqa: PLR0915
         # Check if MCP tools are present (following responses pattern)
         # Cast tools to Optional[Iterable[ToolParam]] for type checking
         tools_for_mcp = cast(Optional[Iterable[ToolParam]], tools)
-        if LiteLLM_Proxy_MCP_Handler._should_use_litellm_mcp_gateway(tools=tools_for_mcp):
+        if LiteLLM_Proxy_MCP_Handler._should_use_litellm_mcp_gateway(
+            tools=tools_for_mcp
+        ):
             # Return coroutine - acompletion will await it
             # completion() can return a coroutine when MCP tools are present, which acompletion() awaits
             return acompletion_with_mcp(  # type: ignore[return-value]
@@ -2337,11 +2397,7 @@ def completion(  # type: ignore # noqa: PLR0915
                 input=messages, api_key=api_key, original_response=response
             )
         elif custom_llm_provider == "minimax":
-            api_key = (
-                api_key
-                or get_secret_str("MINIMAX_API_KEY")
-                or litellm.api_key
-            )
+            api_key = api_key or get_secret_str("MINIMAX_API_KEY") or litellm.api_key
 
             api_base = (
                 api_base
@@ -2389,7 +2445,9 @@ def completion(  # type: ignore # noqa: PLR0915
             or custom_llm_provider == "wandb"
             or custom_llm_provider == "clarifai"
             or custom_llm_provider in litellm.openai_compatible_providers
-            or JSONProviderRegistry.exists(custom_llm_provider)  # JSON-configured providers
+            or JSONProviderRegistry.exists(
+                custom_llm_provider
+            )  # JSON-configured providers
             or "ft:gpt-3.5-turbo" in model  # finetune gpt-3.5-turbo
         ):  # allow user to make an openai call with a custom base
             # note: if a user sets a custom base - we should ensure this works
@@ -4229,24 +4287,51 @@ def completion_with_retries(*args, **kwargs):
     retry_strategy: Literal["exponential_backoff_retry", "constant_retry"] = kwargs.pop(
         "retry_strategy", "constant_retry"
     )  # type: ignore
+    retry_delay = kwargs.pop("retry_delay", None)
+    exponential_backoff = kwargs.pop("exponential_backoff", False)
+    jitter = kwargs.pop("jitter", False)
+
     original_function = kwargs.pop("original_function", completion)
-    if retry_strategy == "exponential_backoff_retry":
+
+    # +1 because stop_after_attempt includes the initial attempt
+    stop_after = tenacity.stop_after_attempt(num_retries + 1)
+
+    if retry_strategy == "exponential_backoff_retry" or exponential_backoff:
+        # Defaults for exponential backoff
+        multiplier = 1
+        min_wait = 0
+        if retry_delay is not None:
+            multiplier = retry_delay
+            min_wait = retry_delay
+
+        wait_args = {"multiplier": multiplier, "min": min_wait, "max": 10}
+
+        if jitter:
+            wait_strategy = tenacity.wait_random_exponential(**wait_args)
+        else:
+            wait_strategy = tenacity.wait_exponential(**wait_args)
+
         retryer = tenacity.Retrying(
-            wait=tenacity.wait_exponential(multiplier=1, max=10),
-            stop=tenacity.stop_after_attempt(num_retries),
+            wait=wait_strategy,
+            stop=stop_after,
             reraise=True,
         )
     else:
+        wait_strategy = tenacity.wait_none()
+        if retry_delay:
+            wait_strategy = tenacity.wait_fixed(retry_delay)
+
         retryer = tenacity.Retrying(
-            stop=tenacity.stop_after_attempt(num_retries), reraise=True
+            wait=wait_strategy,
+            stop=stop_after,
+            reraise=True,
         )
     return retryer(original_function, *args, **kwargs)
 
 
 async def acompletion_with_retries(*args, **kwargs):
     """
-    [DEPRECATED]. Use 'acompletion' or router.acompletion instead!
-    Executes a litellm.completion() with 3 retries
+    Executes a litellm.completion() with retries.
     """
     try:
         import tenacity
@@ -4259,18 +4344,65 @@ async def acompletion_with_retries(*args, **kwargs):
     kwargs["max_retries"] = 0
     kwargs["num_retries"] = 0
     retry_strategy = kwargs.pop("retry_strategy", "constant_retry")
+    retry_delay = kwargs.pop("retry_delay", None)
+    exponential_backoff = kwargs.pop("exponential_backoff", False)
+    jitter = kwargs.pop("jitter", False)
     original_function = kwargs.pop("original_function", completion)
-    if retry_strategy == "exponential_backoff_retry":
+
+    # +1 because stop_after_attempt includes the initial attempt
+    stop_after = tenacity.stop_after_attempt(num_retries + 1)
+
+    # If the original function is completion but we are doing async retries
+    # we need to ensure it's treated as an async function if it returns a coroutine
+    # or wraps it.
+    # However, since we are in acompletion_with_retries, we expect to be waiting.
+    # If original_function is completion(acompletion=True), it returns a coro.
+    # Tenacity AsyncRetrying expects the function to be awaitable or return awaitable?
+    # Actually AsyncRetrying works with async def functions.
+    # If original_function is sync (but returns coro), we might need a wrapper.
+
+    async def _async_original_function(*args, **kwargs):
+        # Ensure we await the result if it is a coroutine
+        result = original_function(*args, **kwargs)
+        if asyncio.iscoroutine(result):
+            return await result
+        return result
+
+    if retry_strategy == "exponential_backoff_retry" or exponential_backoff:
+        # Defaults for exponential backoff
+        multiplier = 1
+        min_wait = 0
+        if retry_delay is not None:
+            multiplier = retry_delay
+            min_wait = retry_delay
+
+        wait_args = {"multiplier": multiplier, "min": min_wait, "max": 10}
+
+        if jitter:
+            # Use wait_random_exponential if available or combine
+            # Using wait_exponential + wait_random is one way, or wait_random_exponential
+            # tenacity.wait_random_exponential(multiplier=1, max=10)
+            wait_strategy = tenacity.wait_random_exponential(**wait_args)
+        else:
+            wait_strategy = tenacity.wait_exponential(**wait_args)
+
         retryer = tenacity.AsyncRetrying(
-            wait=tenacity.wait_exponential(multiplier=1, max=10),
-            stop=tenacity.stop_after_attempt(num_retries),
+            wait=wait_strategy,
+            stop=stop_after,
             reraise=True,
         )
     else:
+        wait_strategy = tenacity.wait_none()
+        if retry_delay:
+            wait_strategy = tenacity.wait_fixed(retry_delay)
+
         retryer = tenacity.AsyncRetrying(
-            stop=tenacity.stop_after_attempt(num_retries), reraise=True
+            wait=wait_strategy,
+            stop=stop_after,
+            reraise=True,
         )
-    return await retryer(original_function, *args, **kwargs)
+
+    return await retryer(_async_original_function, *args, **kwargs)
 
 
 def responses_with_retries(*args, **kwargs):
@@ -4700,7 +4832,7 @@ def embedding(  # noqa: PLR0915
 
             if headers is not None and headers != {}:
                 optional_params["extra_headers"] = headers
-            
+
             if encoding_format is not None:
                 optional_params["encoding_format"] = encoding_format
             else:
@@ -6735,9 +6867,7 @@ def speech(  # noqa: PLR0915
         if text_to_speech_provider_config is None:
             text_to_speech_provider_config = MinimaxTextToSpeechConfig()
 
-        minimax_config = cast(
-            MinimaxTextToSpeechConfig, text_to_speech_provider_config
-        )
+        minimax_config = cast(MinimaxTextToSpeechConfig, text_to_speech_provider_config)
 
         if api_base is not None:
             litellm_params_dict["api_base"] = api_base
@@ -6877,7 +7007,7 @@ async def ahealth_check(
         custom_llm_provider_from_params = model_params.get("custom_llm_provider", None)
         api_base_from_params = model_params.get("api_base", None)
         api_key_from_params = model_params.get("api_key", None)
-        
+
         model, custom_llm_provider, _, _ = get_llm_provider(
             model=model,
             custom_llm_provider=custom_llm_provider_from_params,
@@ -7251,6 +7381,7 @@ def __getattr__(name: str) -> Any:
         _encoding = tiktoken.get_encoding("cl100k_base")
         # Cache it in the module's __dict__ for subsequent accesses
         import sys
+
         sys.modules[__name__].__dict__["encoding"] = _encoding
         global _encoding_cache
         _encoding_cache = _encoding

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -112,13 +112,14 @@ class SearchContextCostPerQuery(TypedDict, total=False):
 class AgenticLoopParams(TypedDict, total=False):
     """
     Parameters passed to agentic loop hooks (e.g., WebSearch interception).
-    
+
     Stored in logging_obj.model_call_details["agentic_loop_params"] to provide
     agentic hooks with the original request context needed for follow-up calls.
     """
+
     model: str
     """The model string with provider prefix (e.g., 'bedrock/invoke/...')"""
-    
+
     custom_llm_provider: str
     """The LLM provider name (e.g., 'bedrock', 'anthropic')"""
 
@@ -2910,6 +2911,9 @@ all_litellm_params = (
         "shared_session",
         "search_tool_name",
         "order",
+        "retry_delay",
+        "exponential_backoff",
+        "jitter",
     ]
     + list(StandardCallbackDynamicParams.__annotations__.keys())
     + list(CustomPricingLiteLLMParams.model_fields.keys())


### PR DESCRIPTION
## Relevant issues
fixes https://github.com/BerriAI/litellm/issues/16068
addresses feature request: Configurable retry delay and exponential backoff/jitter for [completion()](cci:1://file:///d:/OSS/litellm/litellm/main.py:1031:0-4268:9) API.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🧹 Refactoring
📖 Documentation

## Changes

- **Core Logic**: Added `retry_delay` (float), [exponential_backoff](cci:1://file:///d:/OSS/litellm/reproduce_backoff_jitter.py:50:0-83:63) (bool), and [jitter](cci:1://file:///d:/OSS/litellm/reproduce_backoff_jitter.py:85:0-109:47) (bool) parameters to both [completion()](cci:1://file:///d:/OSS/litellm/litellm/main.py:1031:0-4268:9) and [acompletion()](cci:1://file:///d:/OSS/litellm/litellm/main.py:367:0-649:9).
- **Refactoring**: Created a new helper function [_update_kwargs_with_retry_params](cci:1://file:///d:/OSS/litellm/litellm/main.py:1005:0-1028:16) in [litellm/main.py](cci:7://file:///d:/OSS/litellm/litellm/main.py:0:0-0:0) to consolidate retry parameter extraction and reduce code duplication between sync and async implementations.
- **Tenacity Integration**: Updated [completion_with_retries](cci:1://file:///d:/OSS/litellm/litellm/main.py:4271:0-4328:54) and [acompletion_with_retries](cci:1://file:///d:/OSS/litellm/litellm/main.py:4331:0-4404:67) to dynamically configure `tenacity` retry strategies (`wait_fixed`, `wait_exponential`, `wait_random_exponential`) based on the new parameters.
- **Documentation**: Updated [reliable_completions.md](cci:7://file:///d:/OSS/litellm/docs/my-website/docs/completion/reliable_completions.md:0:0-0:0) with usage examples and [input.md](cci:7://file:///d:/OSS/litellm/docs/my-website/docs/completion/input.md:0:0-0:0) with the new parameter definitions.
- **Types**: Added new parameters to `all_litellm_params` in `types/utils.py` and `get_litellm_params.py` to ensure correct parameter propagation.

<img width="1073" height="697" alt="image" src="https://github.com/user-attachments/assets/24cb6ebb-2648-420f-aa60-9afbafe3b640" />
