### PR TITLE
[Fix] Claude Code x Bedrock Invoke fails with `advanced-tool-use-2025-11-20`

### DIFF
--- a/tests/pass_through_unit_tests/test_bedrock_tool_use_beta_header.py
+++ b/tests/pass_through_unit_tests/test_bedrock_tool_use_beta_header.py
@@ -1,0 +1,69 @@
+"""
+Simple E2E test for Bedrock with advanced-tool-use beta header.
+
+Tests that LiteLLM correctly filters out the advanced-tool-use-2025-11-20 beta header
+for Bedrock Invoke API, which doesn't support it and returns a 400 "invalid beta flag" error.
+"""
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+
+
+@pytest.mark.asyncio
+async def test_bedrock_sonnet_4_5_with_advanced_tool_use_beta_header():
+    """
+    Simple E2E test: Call Bedrock Sonnet 4.5 with advanced-tool-use beta header.
+
+    This should work without throwing "invalid beta flag" error because LiteLLM
+    filters out the advanced-tool-use beta header for Bedrock Invoke API.
+    """
+    litellm._turn_on_debug()
+    response = await litellm.anthropic.messages.acreate(
+        model="bedrock/invoke/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        messages=[{"role": "user", "content": "What is 2+2?"}],
+        max_tokens=100,
+        provider_specific_header={
+            "custom_llm_provider": "bedrock",
+            "extra_headers": {
+                "anthropic-beta": "advanced-tool-use-2025-11-20",
+            },
+        },
+    )
+
+    # Verify response
+    assert response is not None
+    assert "content" in response
+    print(f"✅ Test passed! Response: {response}")
+
+
+@pytest.mark.asyncio
+async def test_bedrock_claude_3_5_with_advanced_tool_use_beta_header_filtered():
+    """
+    Simple E2E test: Call Bedrock Claude 3.5 with advanced-tool-use beta header.
+
+    This should work because the beta header is filtered out by LiteLLM before
+    sending the request to Bedrock Invoke API.
+    """
+
+    response = await litellm.anthropic.messages.acreate(
+        model="bedrock/invoke/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+        messages=[{"role": "user", "content": "What is 2+2?"}],
+        max_tokens=100,
+        provider_specific_header={
+            "custom_llm_provider": "bedrock",
+            "extra_headers": {
+                "anthropic-beta": "advanced-tool-use-2025-11-20",
+            },
+        },
+    )
+
+    # Verify response
+    assert response is not None
+    assert "content" in response
+    print(f"✅ Test passed! Claude 3.5 response (beta header filtered): {response}")
+
+


### PR DESCRIPTION
## [Fix] Claude Code x Bedrock Invoke fails with `advanced-tool-use-2025-11-20`

Fixes Claude Code failing when calling Bedrock Invoke with certain beta headers. Bedrock would return a 400 "invalid beta flag" error because it doesn't support all the beta headers that Anthropic's direct API does.                                                                                                                                                                                                           
                                                                                                                                                                                                                   
  ## The Issue                                                                                                                                                                                                     
                                                                                                                                                                                                                   
  Claude Code was sending `advanced-tool-use-2025-11-20` beta header to Bedrock Invoke, which would fail with:                                                                                                     
  400 {"message":"invalid beta flag"}                                                                                                                                                                              
                                                                                                                                                                                                                   
  Bedrock Invoke has limited beta header support compared to hitting Anthropic directly, so we need to filter out unsupported headers.


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
