### PR TITLE
Fix for Prometheus Metric Cardinality Issue with /responses Endpoint

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -28,8 +28,8 @@ from litellm.proxy.auth.auth_checks import (
     _delete_cache_key_object,
     _get_user_role,
     _is_user_proxy_admin,
-    _virtual_key_max_budget_check,
     _virtual_key_max_budget_alert_check,
+    _virtual_key_max_budget_check,
     _virtual_key_soft_budget_check,
     can_key_call_model,
     common_checks,
@@ -45,6 +45,7 @@ from litellm.proxy.auth.auth_utils import (
     get_end_user_id_from_request_body,
     get_model_from_request,
     get_request_route,
+    normalize_request_route,
     pre_db_read_auth_checks,
     route_in_additonal_public_routes,
 )
@@ -1261,7 +1262,7 @@ async def user_api_key_auth(
     if end_user_id is not None:
         user_api_key_auth_obj.end_user_id = end_user_id
 
-    user_api_key_auth_obj.request_route = route
+    user_api_key_auth_obj.request_route = normalize_request_route(route)
 
     return user_api_key_auth_obj
 

--- a/tests/test_litellm/integrations/test_prometheus_labels.py
+++ b/tests/test_litellm/integrations/test_prometheus_labels.py
@@ -3,7 +3,7 @@ Unit tests for prometheus metric labels configuration
 """
 from litellm.types.integrations.prometheus import (
     PrometheusMetricLabels,
-    UserAPIKeyLabelNames
+    UserAPIKeyLabelNames,
 )
 
 
@@ -42,8 +42,9 @@ def test_user_email_label_exists():
 
 def test_prometheus_metric_labels_structure():
     """Test that all required prometheus metrics have proper label structure"""
-    from litellm.types.integrations.prometheus import DEFINED_PROMETHEUS_METRICS
     from typing import get_args
+
+    from litellm.types.integrations.prometheus import DEFINED_PROMETHEUS_METRICS
 
     # Test a few key metrics to ensure they have proper label structure
     test_metrics = [
@@ -69,8 +70,161 @@ def test_prometheus_metric_labels_structure():
         print(f"✅ {metric_name} has proper label structure with user_email")
 
 
+def test_route_normalization_for_responses_api():
+    """
+    Test that route normalization prevents high cardinality in Prometheus metrics
+    for the /v1/responses/{response_id} endpoint.
+    
+    Issue: https://github.com/BerriAI/litellm/issues/XXXX
+    Each unique response ID was creating a separate metric line, causing the
+    /metrics endpoint to grow to ~30MB and take ~40 seconds to respond.
+    
+    Fix: Routes are normalized to collapse dynamic IDs into placeholders.
+    """
+    from litellm.proxy.auth.auth_utils import normalize_request_route
+
+    # Test responses API routes
+    responses_routes = [
+        ("/v1/responses/1234567890", "/v1/responses/{response_id}"),
+        ("/v1/responses/9876543210", "/v1/responses/{response_id}"),
+        ("/v1/responses/abcdefghij", "/v1/responses/{response_id}"),
+        ("/v1/responses/resp_abc123", "/v1/responses/{response_id}"),
+        ("/v1/responses/litellm_poll_xyz", "/v1/responses/{response_id}"),
+    ]
+    
+    for original, expected in responses_routes:
+        normalized = normalize_request_route(original)
+        assert normalized == expected, \
+            f"Failed: {original} -> {normalized} (expected {expected})"
+    
+    # Verify cardinality reduction
+    unique_normalized = set(normalize_request_route(route) for route, _ in responses_routes)
+    assert len(unique_normalized) == 1, \
+        f"Expected 1 unique normalized route, got {len(unique_normalized)}: {unique_normalized}"
+    
+    print(f"✅ Responses API routes: {len(responses_routes)} different IDs normalized to 1 metric label")
+    
+
+def test_route_normalization_for_sub_routes():
+    """Test that sub-routes like /cancel and /input_items are normalized correctly"""
+    from litellm.proxy.auth.auth_utils import normalize_request_route
+    
+    sub_routes = [
+        ("/v1/responses/id1/cancel", "/v1/responses/{response_id}/cancel"),
+        ("/v1/responses/id2/cancel", "/v1/responses/{response_id}/cancel"),
+        ("/v1/responses/id3/input_items", "/v1/responses/{response_id}/input_items"),
+        ("/openai/v1/responses/id4/input_items", "/openai/v1/responses/{response_id}/input_items"),
+    ]
+    
+    for original, expected in sub_routes:
+        normalized = normalize_request_route(original)
+        assert normalized == expected, \
+            f"Failed: {original} -> {normalized} (expected {expected})"
+    
+    print("✅ Sub-routes normalized correctly")
+
+
+def test_route_normalization_preserves_static_routes():
+    """Test that static routes are not affected by normalization"""
+    from litellm.proxy.auth.auth_utils import normalize_request_route
+    
+    static_routes = [
+        "/chat/completions",
+        "/v1/chat/completions",
+        "/v1/embeddings",
+        "/health",
+        "/metrics",
+        "/v1/models",
+        "/v1/responses",  # List endpoint without ID
+    ]
+    
+    for route in static_routes:
+        normalized = normalize_request_route(route)
+        assert normalized == route, \
+            f"Static route should not be modified: {route} -> {normalized}"
+    
+    print(f"✅ {len(static_routes)} static routes preserved")
+
+
+def test_route_normalization_other_dynamic_apis():
+    """Test normalization for other OpenAI-compatible APIs with dynamic IDs"""
+    from litellm.proxy.auth.auth_utils import normalize_request_route
+    
+    test_cases = [
+        # Threads API
+        ("/v1/threads/thread_123", "/v1/threads/{thread_id}"),
+        ("/v1/threads/thread_abc/messages", "/v1/threads/{thread_id}/messages"),
+        ("/v1/threads/thread_abc/runs/run_123", "/v1/threads/{thread_id}/runs/{run_id}"),
+        
+        # Vector Stores API
+        ("/v1/vector_stores/vs_123", "/v1/vector_stores/{vector_store_id}"),
+        ("/v1/vector_stores/vs_123/files", "/v1/vector_stores/{vector_store_id}/files"),
+        
+        # Assistants API
+        ("/v1/assistants/asst_123", "/v1/assistants/{assistant_id}"),
+        
+        # Files API
+        ("/v1/files/file_123", "/v1/files/{file_id}"),
+        ("/v1/files/file_123/content", "/v1/files/{file_id}/content"),
+        
+        # Batches API
+        ("/v1/batches/batch_123", "/v1/batches/{batch_id}"),
+        ("/v1/batches/batch_123/cancel", "/v1/batches/{batch_id}/cancel"),
+    ]
+    
+    for original, expected in test_cases:
+        normalized = normalize_request_route(original)
+        assert normalized == expected, \
+            f"Failed: {original} -> {normalized} (expected {expected})"
+    
+    print(f"✅ {len(test_cases)} other API routes normalized correctly")
+
+
+def test_prometheus_metrics_use_normalized_routes():
+    """
+    Test that Prometheus metrics use the normalized route in labels
+    to prevent high cardinality.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.integrations.prometheus import (
+        PrometheusLogger,
+        UserAPIKeyLabelValues,
+        prometheus_label_factory,
+    )
+
+    # Create a mock PrometheusLogger
+    prometheus_logger = MagicMock()
+    prometheus_logger.get_labels_for_metric = PrometheusLogger.get_labels_for_metric.__get__(prometheus_logger)
+    
+    # Test with a normalized route
+    enum_values = UserAPIKeyLabelValues(
+        route="/v1/responses/{response_id}",  # Normalized route
+        status_code="200",
+        requested_model="gpt-4",
+    )
+    
+    labels = prometheus_label_factory(
+        supported_enum_labels=prometheus_logger.get_labels_for_metric(
+            metric_name="litellm_proxy_total_requests_metric"
+        ),
+        enum_values=enum_values,
+    )
+    
+    # Verify the route is normalized in labels
+    assert labels["route"] == "/v1/responses/{response_id}", \
+        f"Expected normalized route in labels, got: {labels.get('route')}"
+    
+    print("✅ Prometheus metrics use normalized routes in labels")
+
+
 if __name__ == "__main__":
     test_user_email_in_required_metrics()
     test_user_email_label_exists()
     test_prometheus_metric_labels_structure()
-    print("All prometheus label tests passed!")
+    test_route_normalization_for_responses_api()
+    test_route_normalization_for_sub_routes()
+    test_route_normalization_preserves_static_routes()
+    test_route_normalization_other_dynamic_apis()
+    test_prometheus_metrics_use_normalized_routes()
+    print("\n✅ All prometheus label tests passed!")


### PR DESCRIPTION
## Relevant issues

Fixes  #19393

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix


## Changes
The `litellm_proxy_total_requests_metric` includes a `route` label by default. When making requests to endpoints with dynamic path parameters like:
- `/v1/responses/1234567890`
- `/v1/responses/9876543210`
- `/v1/responses/abcdefghij`

Each unique response ID created a **separate metric line**, leading to:
```
litellm_proxy_total_requests_metric{route="/v1/responses/1234567890",...} 1
litellm_proxy_total_requests_metric{route="/v1/responses/9876543210",...} 1
litellm_proxy_total_requests_metric{route="/v1/responses/abcdefghij",...} 1
...
```

For batch workflows processing thousands of unique response IDs, this caused metric cardinality explosion.

## Solution

### Approach: Route Normalization

Routes with dynamic path parameters are now normalized before being used as metric labels:
- `/v1/responses/1234567890` → `/v1/responses/{response_id}`
- `/v1/responses/9876543210` → `/v1/responses/{response_id}`
- `/v1/responses/abcdefghij` → `/v1/responses/{response_id}`

All requests now share the **same metric line**:
```
litellm_proxy_total_requests_metric{route="/v1/responses/{response_id}",...} 3
```
<img width="1470" height="306" alt="image" src="https://github.com/user-attachments/assets/1f0fd19d-3d86-46ec-b121-d7fd27f57e94" />

