### PR TITLE
fix(ui): increase model selector width in playground Compare view

### DIFF
--- a/ui/litellm-dashboard/src/components/playground/compareUI/components/UnifiedSelector.tsx
+++ b/ui/litellm-dashboard/src/components/playground/compareUI/components/UnifiedSelector.tsx
@@ -32,7 +32,7 @@ export function UnifiedSelector({
         (option?.label ?? "").toLowerCase().includes(input.toLowerCase())
       }
       options={options}
-      className="w-48"
+      className="w-48 md:w-64 lg:w-72"
       notFoundContent={
         loading ? (
           <div className="flex items-center justify-center py-2">


### PR DESCRIPTION
## Relevant issues

Addresses user request from Discord (vCra) to make the model dropdown bigger in the Compare view so full model names are visible (e.g., `vertex_ai/gemini-2.5-pro-...`).

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

> Note: This is a CSS-only change (responsive width classes), no logic changes. Test coverage may not be applicable.

## Type

🐛 Bug Fix

## Changes

- Changed `UnifiedSelector` width from fixed `w-48` (192px) to responsive `w-48 md:w-64 lg:w-72`
- Mobile: 192px
- Tablet (md): 256px  
- Desktop (lg): 288px

**Before:**
<img width="1340" height="1212" alt="image" src="https://github.com/user-attachments/assets/32d99fb6-2cc8-4ccf-9d0b-e9cc031ec88f" />


**After:**
<img width="1420" height="690" alt="Screenshot 2026-01-20 at 15 30 04" src="https://github.com/user-attachments/assets/519d686d-6237-4e83-814e-cbaa320d2be1" />



This allows users to see fuller model names like `vertex_ai/gemini-2.5-pro` instead of truncated text.