### PR TITLE
Fix: Langfuse OTEL prompt management matching issue (#16976)

### DIFF
--- a/litellm/integrations/langfuse/langfuse_prompt_management.py
+++ b/litellm/integrations/langfuse/langfuse_prompt_management.py
@@ -100,7 +100,9 @@ def langfuse_client_init(
         ),  # flush interval in seconds
     }
 
-    if Version(langfuse.version.__version__) >= Version("2.6.0"):
+    # sdk_integration was removed in langfuse v3, so only add it for v2.x
+    langfuse_version = Version(langfuse.version.__version__)
+    if langfuse_version >= Version("2.6.0") and langfuse_version < Version("3.0.0"):
         parameters["sdk_integration"] = "litellm"
 
     client = Langfuse(**parameters)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -754,8 +754,13 @@ class Logging(LiteLLMLoggingBaseClass):
         """
         # First check if model starts with a known custom logger compatible callback
         # This takes precedence for backward compatibility
-        for callback_name in litellm._known_custom_logger_compatible_callbacks:
-            if model.startswith(callback_name):
+        # Need to check longer names first to avoid matching "langfuse" when model is "langfuse_otel/..."
+        callback_list = list(litellm._known_custom_logger_compatible_callbacks)
+        callback_list.sort(key=len, reverse=True)
+
+        for callback_name in callback_list:
+            # Match exact prefix with "/" or exact match
+            if model.startswith(callback_name + "/") or model == callback_name:
                 custom_logger = _init_custom_logger_compatible_class(
                     logging_integration=callback_name,
                     internal_usage_cache=None,

--- a/tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py
+++ b/tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py
@@ -1,9 +1,12 @@
 import os
-from unittest.mock import patch
+from datetime import datetime
+from unittest.mock import patch, MagicMock
 
 from litellm.integrations.langfuse.langfuse_prompt_management import (
     LangfusePromptManagement,
 )
+import litellm
+from litellm.litellm_core_utils.litellm_logging import Logging
 
 
 class TestLangfusePromptManagement:
@@ -48,3 +51,69 @@ class TestLangfusePromptManagement:
                 mock_run_async.call_args[0][0]
                 == langfuse_prompt_management.async_log_failure_event
             )
+
+    def test_langfuse_otel_model_does_not_match_langfuse_callback(self):
+        """Test that langfuse_otel/gemini-2.5-pro matches langfuse_otel, not langfuse."""
+        logging_obj = Logging(
+            model="test-model",
+            messages=[],
+            stream=False,
+            call_type="completion",
+            start_time=datetime.now(),
+            litellm_call_id="test-call-id",
+            function_id="test-function-id",
+        )
+        
+        with patch('litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class') as mock_init:
+            # Return LangfuseOtelLogger for langfuse_otel
+            from litellm.integrations.langfuse.langfuse_otel import LangfuseOtelLogger
+            mock_otel_logger = MagicMock(spec=LangfuseOtelLogger)
+            
+            def init_side_effect(logging_integration, **kwargs):
+                if logging_integration == "langfuse_otel":
+                    return mock_otel_logger
+                elif logging_integration == "langfuse":
+                    return MagicMock(spec=LangfusePromptManagement)
+                return None
+            
+            mock_init.side_effect = init_side_effect
+            
+            # Test langfuse_otel model - should match langfuse_otel, not langfuse
+            result = logging_obj.get_custom_logger_for_prompt_management(
+                model="langfuse_otel/gemini-2.5-pro",
+                non_default_params={},
+            )
+            
+            # Verify it was called with langfuse_otel, not langfuse
+            assert mock_init.called, "Mock should have been called"
+            # Extract logging_integration from keyword arguments
+            called_with = [call.kwargs.get('logging_integration') for call in mock_init.call_args_list]
+            assert "langfuse_otel" in called_with, f"Expected langfuse_otel in calls, got {called_with}"
+            # Verify langfuse_otel was called first (not langfuse)
+            assert called_with[0] == "langfuse_otel", f"Expected first call to be langfuse_otel, got {called_with[0]}"
+
+    def test_langfuse_model_matches_langfuse_callback(self):
+        """Test that langfuse/gemini-2.5-pro correctly matches langfuse callback."""
+        logging_obj = Logging(
+            model="test-model",
+            messages=[],
+            stream=False,
+            call_type="completion",
+            start_time=datetime.now(),
+            litellm_call_id="test-call-id",
+            function_id="test-function-id",
+        )
+        
+        with patch('litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class') as mock_init:
+            mock_langfuse_logger = MagicMock(spec=LangfusePromptManagement)
+            mock_init.return_value = mock_langfuse_logger
+            
+            result = logging_obj.get_custom_logger_for_prompt_management(
+                model="langfuse/gemini-2.5-pro",
+                non_default_params={},
+            )
+            
+            # Verify it was called with langfuse
+            mock_init.assert_called()
+            call_kwargs = mock_init.call_args.kwargs
+            assert call_kwargs.get('logging_integration') == "langfuse"


### PR DESCRIPTION
## Relevant issues

Fixes #16976

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### Problem
When using `langfuse_otel/gemini-2.5-pro` as the model name, LiteLLM incorrectly matched it to the `langfuse` callback instead of `langfuse_otel` because the callback matching logic in `get_custom_logger_for_prompt_management()` checked shorter callback names first. This prevented the Langfuse OTEL integration from working with prompt management. Additionally, the `sdk_integration` parameter was being added for Langfuse v3, where it has been removed, causing compatibility issues.

### Solution
1. **Callback matching fix** (`litellm/litellm_core_utils/litellm_logging.py`):
   - Modified `get_custom_logger_for_prompt_management()` to sort known callbacks by length in descending order
   - Updated matching logic to check longer callback names first (e.g., `langfuse_otel` before `langfuse`)
   - Ensures precise prefix matching with `/` separator or exact match

2. **Langfuse v3 compatibility** (`litellm/integrations/langfuse/langfuse_prompt_management.py`):
   - Added version check using `packaging.version.Version` to only include `sdk_integration` parameter for Langfuse v2.6.0 to v2.x (excludes v3.0.0+)
   - Prevents errors when using Langfuse v3 where this parameter was removed

3. **Test updates** (`tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py`):
   - Added `test_langfuse_otel_model_does_not_match_langfuse_callback()` to verify `langfuse_otel/gemini-2.5-pro` correctly matches `langfuse_otel` callback
   - Updated `test_langfuse_model_matches_langfuse_callback()` to properly initialize `Logging` class with required parameters
   - Fixed mock assertions to correctly verify callback selection logic using `call.kwargs` instead of `call.args`