### PR TITLE
[Internal Tooling] Add custom auth header support and increase default prompt size to 100k chars 

### DIFF
--- a/scripts/health_check/health_check_client_README.md
+++ b/scripts/health_check/health_check_client_README.md
@@ -30,6 +30,14 @@ export LITELLM_MODELS_YAML="/path/to/config.yaml"
 python scripts/health_check/health_check_client.py
 ```
 
+**Option 3: Use custom authentication header**
+```bash
+export LITELLM_BASE_URL="https://litellm.example.com"
+export LITELLM_API_KEY="your-api-key"
+export LITELLM_CUSTOM_AUTH_HEADER="x-custom-auth-header"
+python scripts/health_check/health_check_client.py
+```
+
 ### As a Docker Container
 
 1. Build the Docker image:
@@ -44,6 +52,16 @@ docker build -f docker/Dockerfile.health_check -t litellm/litellm-health-check:l
 docker run --rm \
   -e LITELLM_BASE_URL="https://litellm.example.com" \
   -e LITELLM_API_KEY="your-api-key" \
+  litellm/litellm-health-check:latest
+```
+
+3. Run with custom authentication header:
+
+```bash
+docker run --rm \
+  -e LITELLM_BASE_URL="https://litellm.example.com" \
+  -e LITELLM_API_KEY="your-api-key" \
+  -e LITELLM_CUSTOM_AUTH_HEADER="x-custom-auth-header" \
   litellm/litellm-health-check:latest
 ```
 
@@ -65,6 +83,30 @@ export LITELLM_API_KEY="your-api-key"
 ./scripts/health_check/run_parallel_health_checks.sh 16
 ```
 
+**With Custom Auth Header:**
+```powershell
+$env:LITELLM_BASE_URL="https://litellm.example.com"
+$env:LITELLM_API_KEY="your-api-key"
+$env:LITELLM_CUSTOM_AUTH_HEADER="x-custom-auth-header"
+.\scripts\health_check\run_parallel_health_checks.ps1 16
+```
+
+**With Custom Docker Image:**
+```powershell
+$env:LITELLM_BASE_URL="https://litellm.example.com"
+$env:LITELLM_API_KEY="your-api-key"
+$env:LITELLM_CUSTOM_AUTH_HEADER="x-custom-auth-header"
+.\scripts\health_check\run_parallel_health_checks.ps1 -NumParallelJobs 16 -ImageName "your-registry/your-image:tag"
+```
+
+**Bash with Custom Image:**
+```bash
+export LITELLM_BASE_URL="https://litellm.example.com"
+export LITELLM_API_KEY="your-api-key"
+export LITELLM_CUSTOM_AUTH_HEADER="x-custom-auth-header"
+./scripts/health_check/run_parallel_health_checks.sh 16 "your-registry/your-image:tag"
+```
+
 
 ## Configuration
 
@@ -73,13 +115,28 @@ export LITELLM_API_KEY="your-api-key"
 - `LITELLM_BASE_URL` (required): Base URL of the LiteLLM proxy
   - Example: `https://litellm.example.com`
 - `LITELLM_API_KEY` (required): API key for authentication
+- `LITELLM_CUSTOM_AUTH_HEADER` (optional): Custom header name for authentication
+  - Use this when your LiteLLM proxy uses a custom authentication header instead of the standard `Authorization` header
+  - Example: `x-custom-auth-header` (the API key will be sent as `Bearer <api_key>` in this header)
 - `LITELLM_MODELS_YAML` (optional): Path to YAML config file with model_list
   - If provided, reads models from YAML instead of fetching from API
   - Example: `/path/to/config.yaml`
 - `LITELLM_TIMEOUT` (optional): Request timeout in seconds (default: 120)
-- `LITELLM_COMPLETION_PROMPT` (optional): Test prompt for chat/completion models (default: "Say this is a test")
-- `LITELLM_EMBEDDING_TEXT` (optional): Test text for embedding models (default: "This is a test for vectorization.")
+- `LITELLM_COMPLETION_PROMPT` (optional): Test prompt for chat/completion models (default: ~100k characters)
+- `LITELLM_EMBEDDING_TEXT` (optional): Test text for embedding models (default: ~100k characters)
 - `LITELLM_JSON_OUTPUT` (optional): Output results as JSON (default: false)
+
+### Parallel Script Parameters
+
+**PowerShell (`run_parallel_health_checks.ps1`):**
+- `-NumParallelJobs` (optional): Number of parallel containers to run (default: 16)
+- `-ImageName` (optional): Docker image to use (default: `litellm/litellm-health-check:latest`)
+- `-ContainerRuntime` (optional): Container runtime to use (default: `docker`)
+
+**Bash (`run_parallel_health_checks.sh`):**
+- `[num_parallel_jobs]` (optional): Number of parallel containers to run (default: 16)
+- `[image_name]` (optional): Docker image to use (default: `litellm/litellm-health-check:latest`)
+- `[container_runtime]` (optional): Container runtime to use (default: `docker`)
 
 ## Output
 
@@ -166,7 +223,20 @@ Run multiple health checks in parallel:
 
 **PowerShell:**
 ```powershell
+# Using default image
 .\scripts\health_check\run_parallel_health_checks.ps1 16
+
+# Using custom image
+.\scripts\health_check\run_parallel_health_checks.ps1 -NumParallelJobs 16 -ImageName "your-registry/your-image:tag"
+```
+
+**Bash:**
+```bash
+# Using default image
+./scripts/health_check/run_parallel_health_checks.sh 16
+
+# Using custom image
+./scripts/health_check/run_parallel_health_checks.sh 16 "your-registry/your-image:tag"
 ```
 
 ### 3. CI/CD Integration

--- a/scripts/health_check/run_parallel_health_checks.sh
+++ b/scripts/health_check/run_parallel_health_checks.sh
@@ -54,11 +54,18 @@ echo ""
 
 # Function to run a single health check container
 run_health_check() {
-    "$CONTAINER_RUNTIME" run --rm \
-        -e LITELLM_BASE_URL="$LITELLM_BASE_URL" \
-        -e LITELLM_API_KEY="$LITELLM_API_KEY" \
-        -e LITELLM_JSON_OUTPUT="true" \
-        "$IMAGE_NAME"
+    local env_vars=(
+        -e "LITELLM_BASE_URL=$LITELLM_BASE_URL"
+        -e "LITELLM_API_KEY=$LITELLM_API_KEY"
+        -e "LITELLM_JSON_OUTPUT=true"
+    )
+    
+    # Pass through custom auth header if set
+    if [ -n "$LITELLM_CUSTOM_AUTH_HEADER" ]; then
+        env_vars+=(-e "LITELLM_CUSTOM_AUTH_HEADER=$LITELLM_CUSTOM_AUTH_HEADER")
+    fi
+    
+    "$CONTAINER_RUNTIME" run --rm "${env_vars[@]}" "$IMAGE_NAME"
 }
 
 # Run parallel health checks


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- Add LITELLM_CUSTOM_AUTH_HEADER support to health check client
- Increase default completion prompt and embedding text to 100k characters
- Fix PowerShell parallel script to properly pass environment variables
- Add custom auth header support to bash parallel script
- Update documentation with custom image and auth header examples