### PR TITLE
Fix duplicate OpenTelemetry traces for aresponses after Gemini calls (#16016)

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1,6 +1,7 @@
 # What is this?
 ## Common Utility file for Logging handler
 # Logging function -> log the exact model details + what's being sent | Non-Blocking
+import contextvars
 import copy
 import datetime
 import json
@@ -3039,7 +3040,11 @@ class Logging(LiteLLMLoggingBaseClass):
         if self._should_run_sync_callbacks_for_async_calls() is False:
             return
 
+        # Copy the current context to propagate it to the background thread
+        # This is essential for OpenTelemetry span context propagation
+        ctx = contextvars.copy_context()
         executor.submit(
+            ctx.run,
             self.success_handler,
             result,
             start_time,

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import json
 import traceback
 from datetime import datetime
@@ -309,7 +310,9 @@ class BaseResponsesAPIStreamingIterator:
             pass
 
         try:
+            ctx = contextvars.copy_context()
             executor.submit(
+                ctx.run,
                 self.logging_obj.failure_handler,
                 exception,
                 traceback_exception,
@@ -415,12 +418,14 @@ class ResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
             )
         )
 
+        ctx = contextvars.copy_context()
         executor.submit(
+            ctx.run,
             self.logging_obj.success_handler,
-            result=logging_response,
-            cache_hit=None,
-            start_time=self.start_time,
-            end_time=datetime.now(),
+            logging_response,
+            self.start_time,
+            datetime.now(),
+            None,
         )
         self._run_post_success_hooks(end_time=datetime.now())
 
@@ -509,12 +514,14 @@ class SyncResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
             cache_hit=None,
         )
 
+        ctx = contextvars.copy_context()
         executor.submit(
+            ctx.run,
             self.logging_obj.success_handler,
-            result=logging_response,
-            cache_hit=None,
-            start_time=self.start_time,
-            end_time=datetime.now(),
+            logging_response,
+            self.start_time,
+            datetime.now(),
+            None,
         )
         self._run_post_success_hooks(end_time=datetime.now())
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2063,6 +2063,7 @@ def _is_async_request(
         or kwargs.get("atext_completion", False) is True
         or kwargs.get("atranscription", False) is True
         or kwargs.get("arerank", False) is True
+        or kwargs.get("aresponses", False) is True
         or kwargs.get("_arealtime", False) is True
         or kwargs.get("acreate_batch", False) is True
         or kwargs.get("acreate_fine_tuning_job", False) is True
@@ -4647,7 +4648,9 @@ def add_provider_specific_params_to_optional_params(
     else:
         for k in passed_params.keys():
             if k not in openai_params and passed_params[k] is not None:
-                if _should_drop_param(k=k, additional_drop_params=additional_drop_params):
+                if _should_drop_param(
+                    k=k, additional_drop_params=additional_drop_params
+                ):
                     continue
                 optional_params[k] = passed_params[k]
     return optional_params
@@ -8151,7 +8154,10 @@ class ProviderConfigManager:
             # Note: GPT models (gpt-3.5, gpt-4, gpt-5, etc.) support temperature parameter
             # O-series models (o1, o3) do not contain "gpt" and have different parameter restrictions
             is_gpt_model = model and "gpt" in model.lower()
-            is_o_series = model and ("o_series" in model.lower() or (supports_reasoning(model) and not is_gpt_model))
+            is_o_series = model and (
+                "o_series" in model.lower()
+                or (supports_reasoning(model) and not is_gpt_model)
+            )
 
             is_o_series = model and (
                 "o_series" in model.lower()


### PR DESCRIPTION
## Relevant issues

Fixes #16016

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

### Problem

Calling `litellm.aresponses` after a Gemini completion call resulted in duplicate OpenTelemetry traces - one normal trace within opentelemetry context (as expected), and one identical trace with no parent trace. This caused issues with langfuse's cost tracking because a single LLM call was being recorded twice.

### Root Cause

The issue occurred due to the following sequence:

1. A Gemini call internally loads `vertex_ai_context_caching.py` which creates `local_cache_obj`
2. `local_cache_obj` is a `Cache` object which during its `__init__` adds "cache" to the list of litellm success callbacks
3. During the success callback handling process, the "cache" callback satisfies the condition `_should_run_sync_callbacks_for_async_calls()` and results in running `executor.submit(self.success_handler, ...)`
4. Running the synchronous `success_handler` using `executor.submit()` did not preserve opentelemetry context because it's a separate thread, resulting in a trace with no parent context

### Solution

This PR fixes the issue by preserving OpenTelemetry context when submitting callbacks to executor threads using `contextvars.copy_context()` and `ctx.run()`, following the same pattern already used in `utils.py` for sync completion calls.

### Files Changed

1. **`litellm/litellm_core_utils/litellm_logging.py`**:
   - Added `contextvars` import
   - Updated `handle_sync_success_callbacks_for_async_calls()` to preserve context when submitting to executor

2. **`litellm/responses/streaming_iterator.py`**:
   - Added `contextvars` import
   - Fixed 3 `executor.submit()` calls to preserve context (failure handler and 2 success handlers)

3. **`litellm/utils.py`**:
   - Added `aresponses` check to `_is_async_request()` function for proper async detection

4. **`tests/test_litellm/integrations/test_langfuse_otel.py`**:
   - Added `TestContextPreservation` test class with 2 tests to verify context preservation
   - Tests verify that contextvars are preserved when callbacks run in executor threads

### Testing

- ✅ Added 2 new tests in `tests/test_litellm/integrations/test_langfuse_otel.py`
- ✅ All 22 tests in `test_langfuse_otel.py` passing
- ✅ Tests verify context preservation works correctly
- ✅ No regressions in existing functionality

### Test Results
