### PR TITLE
[Infra] Changing Google Tests to use Gemini 3 Flash Preview

### DIFF
--- a/tests/unified_google_tests/test_vertex_ai_native.py
+++ b/tests/unified_google_tests/test_vertex_ai_native.py
@@ -6,5 +6,5 @@ class TestVertexAIGenerateContent(BaseGoogleGenAITest):
     @property
     def model_config(self):
         return {
-            "model": "vertex_ai/gemini-2.5-flash-lite",
+            "model": "vertex_ai/gemini-3-flash-preview",
         }


### PR DESCRIPTION
## Relevant issues
This should fix the 429 errors we are seeing in CI/CD
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure


## Changes
