### PR TITLE
fix(ui): Fix Virtual Keys table sorting and page size issues

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
@@ -53,7 +53,7 @@ const keyListCall = async (
    */
   try {
     const baseUrl = getProxyBaseUrl();
-    
+
     const params = new URLSearchParams(
       Object.entries({
         team_id: options.teamID,
@@ -93,10 +93,8 @@ const keyListCall = async (
     }
 
     const data = await response.json();
-    console.log("/key/list API Response:", data);
     return data;
   } catch (error) {
-    console.error("Failed to list keys:", error);
     throw error;
   }
 };

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -3312,7 +3312,6 @@ export const keyListCall = async (
    */
   try {
     let url = proxyBaseUrl ? `${proxyBaseUrl}/key/list` : `/key/list`;
-    console.log("in keyListCall");
     const queryParams = new URLSearchParams();
 
     if (teamID) {
@@ -3384,11 +3383,8 @@ export const keyListCall = async (
     }
 
     const data = await response.json();
-    console.log("/team/list API Response:", data);
     return data;
-    // Handle success - you might want to update some state or UI based on the created key
   } catch (error) {
-    console.error("Failed to create key:", error);
     throw error;
   }
 };


### PR DESCRIPTION
## Summary

  Fixed multiple issues with the Virtual Keys table sorting functionality:

  - **Page size mismatch**: Table displayed 50 rows but `useFilterLogic` used hardcoded `defaultPageSize` (25), causing the table to show only 25 keys
  after sorting
  - **Race condition**: Client-side `useEffect` was overwriting server-side sorted results from `debouncedSearch`
  - **Sorting mode conflict**: Table had both client-side (`getSortedRowModel()`) and server-side sorting enabled, causing incorrect keys to appear after
  sort
  - **Pagination not resetting**: When sorting changed, pagination stayed on current page instead of resetting to page 1

  ## Changes

  ### `filter_logic.tsx`
  - Added `pageSize` parameter to accept table's actual page size
  - Added `isServerSideFilterActive` ref to prevent race condition between useEffect and debouncedSearch
  - Fixed comment typo (userListCall → keyListCall)

  ### `VirtualKeysTable.tsx`
  - Pass `pageSize` to `useFilterLogic` hook
  - Changed to pure server-side sorting (`manualSorting: true`)
  - Removed `getSortedRowModel()` since sorting is handled server-side
  - Added pagination reset to page 1 when sort changes

  ### `useKeys.ts` & `networking.tsx`
  - Cleaned up console.log statements

  ## Testing

  This is a frontend-only bug fix that was manually tested. The fix addresses React state management and TanStack Table configuration issues.

  **Manual testing confirmed:**
  - Table now maintains correct page size (50) after sorting
  - Sorting by "Key Alias" shows correct keys in sorted order
  - Pagination resets to page 1 when sort changes
  - No race conditions between client-side and server-side filtering

  ## Relevant issues

  N/A

  ## Pre-Submission checklist

  - [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
  - [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## Type

  🐛 Bug Fix
