### PR TITLE
fix: correct gemini-2.5-flash-lite audio input and cache read pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12696,8 +12696,8 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-lite": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "input_cost_per_audio_token": 5e-07,
+        "cache_read_input_token_cost": 1e-08,
+        "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-language-models",
         "max_audio_length_hours": 8.4,
@@ -12741,7 +12741,7 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-lite-preview-09-2025": {
-        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost": 1e-08,
         "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-language-models",
@@ -14532,8 +14532,8 @@
         "supports_web_search": true
     },
     "gemini/gemini-2.5-flash-lite": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "input_cost_per_audio_token": 5e-07,
+        "cache_read_input_token_cost": 1e-08,
+        "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "gemini",
         "max_audio_length_hours": 8.4,
@@ -14579,7 +14579,7 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-lite-preview-09-2025": {
-        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost": 1e-08,
         "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "gemini",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12696,8 +12696,8 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-lite": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "input_cost_per_audio_token": 5e-07,
+        "cache_read_input_token_cost": 1e-08,
+        "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-language-models",
         "max_audio_length_hours": 8.4,
@@ -12741,7 +12741,7 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-lite-preview-09-2025": {
-        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost": 1e-08,
         "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-language-models",
@@ -14532,8 +14532,8 @@
         "supports_web_search": true
     },
     "gemini/gemini-2.5-flash-lite": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "input_cost_per_audio_token": 5e-07,
+        "cache_read_input_token_cost": 1e-08,
+        "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "gemini",
         "max_audio_length_hours": 8.4,
@@ -14579,7 +14579,7 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-lite-preview-09-2025": {
-        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost": 1e-08,
         "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "gemini",


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes #19488

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **N/A, this is a data only change**
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Correct the inaccurate cache read input token cost for `gemini-2.5-flash-lite` and `gemini-2.5-flash-lite-preview-09-2025` and fix the inaccurate audio input token cost for `gemini-2.5-flash-lite`.

References:
 - https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models-2.5
 - https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash-lite