### PR TITLE
fix(pricing): correct audio token costs for gpt-4o-audio-preview models

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16732,14 +16732,14 @@
         "supports_vision": true
     },
     "gpt-4o-audio-preview": {
-        "input_cost_per_audio_token": 0.0001,
+        "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
-        "output_cost_per_audio_token": 0.0002,
+        "output_cost_per_audio_token": 8e-05,
         "output_cost_per_token": 1e-05,
         "supports_audio_input": true,
         "supports_audio_output": true,
@@ -16749,14 +16749,14 @@
         "supports_tool_choice": true
     },
     "gpt-4o-audio-preview-2024-10-01": {
-        "input_cost_per_audio_token": 0.0001,
+        "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
-        "output_cost_per_audio_token": 0.0002,
+        "output_cost_per_audio_token": 8e-05,
         "output_cost_per_token": 1e-05,
         "supports_audio_input": true,
         "supports_audio_output": true,


### PR DESCRIPTION
## Relevant issues

Related to #19490

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory - N/A (data-only change to pricing JSON)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Update audio token pricing for `gpt-4o-audio-preview` and `gpt-4o-audio-preview-2024-10-01` to match [OpenAI's official pricing](https://platform.openai.com/docs/pricing):

| Model | Field | Before | After |
|-------|-------|--------|-------|
| gpt-4o-audio-preview | input_cost_per_audio_token | 0.0001 ($100/1M) | 4e-05 ($40/1M) |
| gpt-4o-audio-preview | output_cost_per_audio_token | 0.0002 ($200/1M) | 8e-05 ($80/1M) |
| gpt-4o-audio-preview-2024-10-01 | input_cost_per_audio_token | 0.0001 ($100/1M) | 4e-05 ($40/1M) |
| gpt-4o-audio-preview-2024-10-01 | output_cost_per_audio_token | 0.0002 ($200/1M) | 8e-05 ($80/1M) |

The previous values were 2.5x higher than OpenAI's actual pricing, causing incorrect cost calculations for audio token usage.