### PR TITLE
docs(custom_pricing): add base_model usage for OpenAI dated model versions

### DIFF
--- a/docs/my-website/docs/proxy/custom_pricing.md
+++ b/docs/my-website/docs/proxy/custom_pricing.md
@@ -127,6 +127,28 @@ model_list:
       base_model: azure/gpt-4-1106-preview
 ```
 
+### OpenAI Models with Dated Versions
+
+`base_model` is also useful when OpenAI returns a dated model name in the response that differs from your configured model name.
+
+**Example**: You configure custom pricing for `gpt-4o-mini-audio-preview`, but OpenAI returns `gpt-4o-mini-audio-preview-2024-12-17` in the response. Since LiteLLM uses the response model name for pricing lookup, your custom pricing won't be applied.
+
+**Solution** ✅: Set `base_model` to the key you want LiteLLM to use for pricing lookup.
+
+```yaml
+model_list:
+  - model_name: my-audio-model
+    litellm_params:
+      model: openai/gpt-4o-mini-audio-preview
+      api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      base_model: gpt-4o-mini-audio-preview  # 👈 Used for pricing lookup
+      input_cost_per_token: 0.0000006
+      output_cost_per_token: 0.0000024
+      input_cost_per_audio_token: 0.00001
+      output_cost_per_audio_token: 0.00002
+```
+
 
 ## Debugging 
 


### PR DESCRIPTION
## Relevant issues

Related to #19490 - Helps users understand how to configure custom pricing when OpenAI returns dated model names.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - N/A (documentation only)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) - N/A (documentation only)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

Added documentation explaining how to use `base_model` when OpenAI returns dated model names (e.g., `gpt-4o-mini-audio-preview-2024-12-17`) that differ from the configured model name.

This helps users understand why their custom pricing might not be applied and how to fix it by setting `base_model` in their `model_info` configuration.