### PR TITLE
fix: scrub langfuse_secret_key from Langfuse traces

### DIFF
--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -1,0 +1,116 @@
+"""
+Tests for litellm.litellm_core_utils.redact_messages
+"""
+
+import pytest
+
+
+def test_redact_sensitive_keys():
+    """
+    Test that redact_sensitive_keys recursively redacts keys matching the predicate.
+    """
+    from litellm.litellm_core_utils.redact_messages import redact_sensitive_keys
+
+    metadata = {
+        "user_api_key_auth_metadata": {
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_vars": {
+                        "langfuse_public_key": "pk-lf-xxx",
+                        "langfuse_secret_key": "sk-lf-secret",
+                        "langfuse_secret": "another-secret",
+                    },
+                }
+            ],
+            "other_key": "keep_this",
+        },
+        "user_api_key_auth": {
+            "token": "abc123",
+            "metadata": {
+                "logging": [
+                    {
+                        "callback_name": "langfuse",
+                        "callback_vars": {"langfuse_secret_key": "secret"},
+                    }
+                ],
+            },
+        },
+    }
+
+    predicate = lambda k: k.endswith("_secret_key") or k.endswith("_secret")
+    result = redact_sensitive_keys(metadata, predicate)
+
+    assert result["user_api_key_auth_metadata"]["logging"][0]["callback_vars"] == {
+        "langfuse_public_key": "pk-lf-xxx",
+        "langfuse_secret_key": "scrubbed_by_litellm",
+        "langfuse_secret": "scrubbed_by_litellm",
+    }
+    assert result["user_api_key_auth_metadata"]["other_key"] == "keep_this"
+    assert result["user_api_key_auth"]["token"] == "abc123"
+    assert result["user_api_key_auth"]["metadata"]["logging"][0]["callback_vars"] == {
+        "langfuse_secret_key": "scrubbed_by_litellm",
+    }
+
+
+def test_redact_sensitive_keys_with_list():
+    """
+    Test that redact_sensitive_keys handles lists correctly.
+    """
+    from litellm.litellm_core_utils.redact_messages import redact_sensitive_keys
+
+    data = [
+        {"api_secret": "secret1", "name": "first"},
+        {"api_secret": "secret2", "name": "second"},
+    ]
+
+    predicate = lambda k: k.endswith("_secret")
+    result = redact_sensitive_keys(data, predicate)
+
+    assert result[0] == {"api_secret": "scrubbed_by_litellm", "name": "first"}
+    assert result[1] == {"api_secret": "scrubbed_by_litellm", "name": "second"}
+
+
+def test_redact_sensitive_keys_with_primitives():
+    """
+    Test that redact_sensitive_keys returns primitives unchanged.
+    """
+    from litellm.litellm_core_utils.redact_messages import redact_sensitive_keys
+
+    predicate = lambda k: k.endswith("_secret")
+
+    assert redact_sensitive_keys("string", predicate) == "string"
+    assert redact_sensitive_keys(123, predicate) == 123
+    assert redact_sensitive_keys(None, predicate) is None
+    assert redact_sensitive_keys(True, predicate) is True
+
+
+def test_redact_sensitive_keys_with_pydantic_model():
+    """
+    Test that redact_sensitive_keys handles Pydantic models correctly.
+    """
+    from pydantic import BaseModel
+    from litellm.litellm_core_utils.redact_messages import redact_sensitive_keys
+
+    class InnerModel(BaseModel):
+        langfuse_public_key: str
+        langfuse_secret_key: str
+
+    class OuterModel(BaseModel):
+        name: str
+        metadata: InnerModel
+
+    model = OuterModel(
+        name="test",
+        metadata=InnerModel(
+            langfuse_public_key="pk-xxx",
+            langfuse_secret_key="sk-secret"
+        )
+    )
+
+    predicate = lambda k: k.endswith("_secret_key")
+    result = redact_sensitive_keys(model, predicate)
+
+    assert result["name"] == "test"
+    assert result["metadata"]["langfuse_public_key"] == "pk-xxx"
+    assert result["metadata"]["langfuse_secret_key"] == "scrubbed_by_litellm"


### PR DESCRIPTION
Prevent team-based Langfuse callback secrets from leaking to traces by scrubbing the logging key from user_api_key_auth_metadata and user_api_key_auth.metadata paths in scrub_sensitive_keys_in_metadata().

## Relevant issues

N/A - discovered during internal security review

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

- Extended `scrub_sensitive_keys_in_metadata()` in `litellm/litellm_core_utils/litellm_logging.py` to scrub secrets from two additional metadata paths:
  - `metadata.user_api_key_auth_metadata.logging`
  - `metadata.user_api_key_auth.metadata.logging`
- Added unit test `test_scrub_sensitive_keys_in_metadata` to verify both paths are properly scrubbed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances redaction to prevent secret leakage into Langfuse traces and logs.
> 
> - Adds recursive `redact_sensitive_keys` to scrub keys matching `*_secret_key`/`*_secret`
> - Applies redaction to Langfuse logging metadata in `integrations/langfuse.py` before emitting traces
> - Extends `scrub_sensitive_keys_in_metadata()` to scrub `metadata.user_api_key_auth_metadata.logging` and `metadata.user_api_key_auth.metadata.logging`
> - Adds unit tests for both redaction utility and metadata scrubbing paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cfabac97900503885eb0d68fa346b8aa3f4856e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->