### PR TITLE
fix(ui): Change default key type from 'Default' to 'LLM API' for impr…

### DIFF
--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -159,7 +159,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
   const [userSearchLoading, setUserSearchLoading] = useState<boolean>(false);
   const [mcpAccessGroups, setMcpAccessGroups] = useState<string[]>([]);
   const [disabledCallbacks, setDisabledCallbacks] = useState<string[]>([]);
-  const [keyType, setKeyType] = useState<string>("default");
+  const [keyType, setKeyType] = useState<string>("llm_api");
   const [modelAliases, setModelAliases] = useState<{ [key: string]: string }>({});
   const [autoRotationEnabled, setAutoRotationEnabled] = useState<boolean>(false);
   const [rotationInterval, setRotationInterval] = useState<string>("30d");
@@ -168,7 +168,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
     form.resetFields();
     setLoggingSettings([]);
     setDisabledCallbacks([]);
-    setKeyType("default");
+    setKeyType("llm_api");
     setModelAliases({});
     setAutoRotationEnabled(false);
     setRotationInterval("30d");
@@ -181,7 +181,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
     form.resetFields();
     setLoggingSettings([]);
     setDisabledCallbacks([]);
-    setKeyType("default");
+    setKeyType("llm_api");
     setModelAliases({});
     setAutoRotationEnabled(false);
     setRotationInterval("30d");
@@ -676,11 +676,11 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
                   </span>
                 }
                 name="key_type"
-                initialValue="default"
+                initialValue="llm_api"
                 className="mt-4"
               >
                 <Select
-                  defaultValue="default"
+                  defaultValue="llm_api"
                   placeholder="Select key type"
                   style={{ width: "100%" }}
                   optionLabelProp="label"


### PR DESCRIPTION
## Summary
Addresses #19492 - Changes the default key type for virtual keys created via the admin UI from "Default" to "LLM API" to improve security posture.

## Problem
Previously, keys created via the admin UI defaulted to "Default" type, which grants both:
- LLM API access (chat/completions, embeddings, etc.)
- Management access (read logs, change settings, manage users/teams/keys)

This created a security risk where compromised keys could be used to manage the entire LiteLLM instance.

## Solution
Changed the default key type to "LLM API" in the create key modal. Admins must now explicitly select "Default" or "Management" key types if they need management access.

## Changes Made
- Changed initial `keyType` state from `"default"` to `"llm_api"`
- Updated `handleOk()` and `handleCancel()` reset functions to use `"llm_api"`
- Updated form `initialValue` and Select `defaultValue` to `"llm_api"`

## Files Changed
- `ui/litellm-dashboard/src/components/organisms/create_key_button.tsx`

## Impact
- **Security**: Reduces attack surface - compromised keys can only access LLM API by default
- **Backwards Compatible**: Existing keys unaffected, only new keys use the safer default
- **User Experience**: Minimal impact - admins can still select any key type

## Relevant issues
Fixes #19492

## Pre-Submission checklist
- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory (UI-only change, no backend tests needed)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) (UI-only change)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)
_Maintainers will fill this section_

## Type
🐛 Bug Fix