### PR TITLE
Fix(Azure): Support OpenAI-format nested tool definitions for Responses API

### DIFF
--- a/tests/test_litellm/llms/azure/response/test_azure_transformation.py
+++ b/tests/test_litellm/llms/azure/response/test_azure_transformation.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
@@ -191,12 +192,12 @@ def test_o_series_model_detection():
     config = AzureOpenAIOSeriesResponsesAPIConfig()
 
     # Test explicit o_series naming
-    assert config.is_o_series_model("o_series/gpt-o1") == True
-    assert config.is_o_series_model("azure/o_series/gpt-o3") == True
+    assert config.is_o_series_model("o_series/gpt-o1")
+    assert config.is_o_series_model("azure/o_series/gpt-o3")
 
     # Test regular models
-    assert config.is_o_series_model("gpt-4o") == False
-    assert config.is_o_series_model("gpt-3.5-turbo") == False
+    assert not config.is_o_series_model("gpt-4o")
+    assert not config.is_o_series_model("gpt-3.5-turbo")
 
 
 @pytest.mark.serial
@@ -297,19 +298,19 @@ class TestAzureResponsesAPIConfig:
     def test_azure_cancel_response_api_request(self):
         """Test Azure cancel response API request transformation"""
         from litellm.types.router import GenericLiteLLMParams
-        
+
         response_id = "resp_test123"
         api_base = "https://test.openai.azure.com/openai/responses?api-version=2024-05-01-preview"
         litellm_params = GenericLiteLLMParams(api_version="2024-05-01-preview")
         headers = {"Authorization": "Bearer test-key"}
-        
+
         url, data = self.config.transform_cancel_response_api_request(
             response_id=response_id,
             api_base=api_base,
             litellm_params=litellm_params,
             headers=headers,
         )
-        
+
         expected_url = "https://test.openai.azure.com/openai/responses/resp_test123/cancel?api-version=2024-05-01-preview"
         assert url == expected_url
         assert data == {}
@@ -318,7 +319,7 @@ class TestAzureResponsesAPIConfig:
         """Test Azure cancel response API response transformation"""
         from unittest.mock import Mock
         from litellm.types.llms.openai import ResponsesAPIResponse
-        
+
         # Mock response
         mock_response = Mock()
         mock_response.json.return_value = {
@@ -330,18 +331,164 @@ class TestAzureResponsesAPIConfig:
             "tool_choice": "auto",
             "tools": [],
             "top_p": 1.0,
-            "status": "cancelled"
+            "status": "cancelled",
         }
         mock_response.text = "test response"
         mock_response.status_code = 200
-        
+
         # Mock logging object
         mock_logging_obj = Mock()
-        
+
         result = self.config.transform_cancel_response_api_response(
             raw_response=mock_response,
             logging_obj=mock_logging_obj,
         )
-        
+
         assert isinstance(result, ResponsesAPIResponse)
         assert result.id == "resp_test123"
+
+    def test_azure_responses_api_tool_flattening_nested_to_flat(self):
+        """Test that nested tools are flattened correctly"""
+        from litellm.types.router import GenericLiteLLMParams
+
+        # Setup
+        nested_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather for a location",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+        response_api_params = {"tools": nested_tools}
+        litellm_params = GenericLiteLLMParams()
+
+        # Execute
+        self.config.transform_responses_api_request(
+            model=self.model,
+            input="test input",
+            response_api_optional_request_params=response_api_params,
+            litellm_params=litellm_params,
+            headers={},
+        )
+
+        # Verify
+        expected_tools = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get weather for a location",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+        assert response_api_params["tools"] == expected_tools
+
+    def test_azure_responses_api_tool_flattening_already_flat(self):
+        """Test that already flat tools are passed through unchanged"""
+        from litellm.types.router import GenericLiteLLMParams
+
+        # Setup
+        flat_tools = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get weather for a location",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+
+        # Make a copy to check it doesn't change
+        response_api_params = {"tools": list(flat_tools)}
+        litellm_params = GenericLiteLLMParams()
+
+        # Execute
+        self.config.transform_responses_api_request(
+            model=self.model,
+            input="test input",
+            response_api_optional_request_params=response_api_params,
+            litellm_params=litellm_params,
+            headers={},
+        )
+
+        # Verify
+        assert response_api_params["tools"] == flat_tools
+
+    def test_azure_responses_api_tool_flattening_preserves_original(self):
+        """Test that the original tool dictionary is not mutated"""
+        from litellm.types.router import GenericLiteLLMParams
+
+        # Setup
+        original_tool = {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {}},
+        }
+        original_tool_copy = deepcopy(original_tool)
+
+        response_api_params = {"tools": [original_tool]}
+        litellm_params = GenericLiteLLMParams()
+
+        # Execute
+        self.config.transform_responses_api_request(
+            model=self.model,
+            input="test input",
+            response_api_optional_request_params=response_api_params,
+            litellm_params=litellm_params,
+            headers={},
+        )
+
+        assert original_tool == original_tool_copy
+
+    def test_azure_responses_api_tool_flattening_mixed_tools(self):
+        """Test mixed nested and flat tools"""
+        from litellm.types.router import GenericLiteLLMParams
+
+        # Setup
+        nested_tool = {
+            "type": "function",
+            "function": {"name": "nested", "parameters": {}},
+        }
+        flat_tool = {"type": "function", "name": "flat", "parameters": {}}
+
+        response_api_params = {"tools": [nested_tool, flat_tool]}
+        litellm_params = GenericLiteLLMParams()
+
+        # Execute
+        self.config.transform_responses_api_request(
+            model=self.model,
+            input="test input",
+            response_api_optional_request_params=response_api_params,
+            litellm_params=litellm_params,
+            headers={},
+        )
+
+        # Verify
+        assert len(response_api_params["tools"]) == 2
+
+        # First tool should be flattened
+        assert "function" not in response_api_params["tools"][0]
+        assert response_api_params["tools"][0]["name"] == "nested"
+
+        # Second tool should remain as is
+        assert response_api_params["tools"][1] == flat_tool
+
+    def test_azure_responses_api_tool_flattening_no_tools(self):
+        """Test handling when no tools are present"""
+        from litellm.types.router import GenericLiteLLMParams
+
+        # Setup
+        response_api_params = {}
+        litellm_params = GenericLiteLLMParams()
+
+        # Execute - should not crash
+        self.config.transform_responses_api_request(
+            model=self.model,
+            input="test input",
+            response_api_optional_request_params=response_api_params,
+            litellm_params=litellm_params,
+            headers={},
+        )
+
+        assert "tools" not in response_api_params


### PR DESCRIPTION
## Relevant issues

Fixes #19523 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
### 1. The Problem

The Azure Responses API requires a flattened tool schema (name at root), whereas the standard Chat Completions API (OpenAI & Azure) uses a nested schema (function: { name: ... }).

### Standard OpenAI / Chat Completions Tool Structure (Nested)

```python
tools = [
    {
        "type": "function",
        "function": {
            "name": "get_weather",
            "description": "Get weather for a location",
            "parameters": {
                "type": "object",
                "properties": {
                    "location": {"type": "string"}
                }
            }
        }
    }
]
```

This structure works for:

* OpenAI Chat Completions
* Azure Chat Completions
* LiteLLM with models like `gpt-4o`

---

### Azure Responses API Tool Structure (Flattened)

```python
tools = [
    {
        "type": "function",
        "name": "get_weather",
        "description": "Get weather for a location",
        "parameters": {
            "type": "object",
            "properties": {
                "location": {"type": "string"}
            }
        }
    }
]
```

This structure is **required** by:

* Azure Responses API
* `litellm.responses(model="azure/gpt-5", ...)`

---
When users pass standard, OpenAI-compatible nested tool definitions to `litellm.responses(model="azure/gpt-5", ...)`, the request fails with:

```
BadRequestError: Missing required parameter: 'tools[0].name'.
```

This breaks the "Unified Interface" promise of LiteLLM, forcing users to write provider-specific tool definitions.

---

### 2. The Solution

I modified `AzureOpenAIResponsesAPIConfig.transform_responses_api_request` in `litellm/llms/azure/responses/transformation.py` to automatically detect and flatten nested tool definitions:

* It checks if `tools` are present.
* If a tool has a `function` key (nested format), it extracts the inner dictionary and merges it to the top level.
* It uses `deepcopy` to ensure the original input dictionary remains immutable, preventing side effects in user code.

This allows users to reuse the exact same tool definitions for `gpt-4o` (OpenAI/Azure) and `azure/gpt-5` (Responses API).

---

### 3. Testing

I added a new test class `TestAzureResponsesAPIConfig` in `tests/test_litellm/llms/azure/response/test_azure_transformation.py`
with comprehensive test cases:

* `test_azure_responses_api_tool_flattening_nested_to_flat`: Verifies transformation of standard OpenAI tools.
* `test_azure_responses_api_tool_flattening_already_flat`: Verifies flat tools pass through unchanged.
* `test_azure_responses_api_tool_flattening_preserves_original`: Ensures original input list is not mutated.
* `test_azure_responses_api_tool_flattening_mixed_tools`: Verifies support for mixed formats.

Ran local verification with:
`pytest tests/test_litellm/llms/azure/response/test_azure_transformation.py -v (20 passed)`
