### PR TITLE
fix: restrict /team/info endpoint to team admins only

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_team_info_security.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_info_security.py
@@ -1,0 +1,97 @@
+"""
+Test for team info access control - ensures only team admins can view team info
+"""
+import pytest
+from fastapi import HTTPException
+from litellm.proxy._types import UserAPIKeyAuth, LiteLLM_TeamTable, Member, LitellmUserRoles
+from litellm.proxy.management_endpoints.team_endpoints import validate_team_admin
+
+
+@pytest.mark.parametrize(
+    "user_role,expected_pass",
+    [
+        (LitellmUserRoles.PROXY_ADMIN.value, True),
+        (LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY.value, True),
+    ],
+)
+def test_validate_team_admin_proxy_admins(user_role, expected_pass):
+    """Proxy admins should always have access"""
+    user_api_key_dict = UserAPIKeyAuth(user_role=user_role)
+    team_table = LiteLLM_TeamTable(
+        team_id="test-team",
+        members_with_roles=[]
+    )
+    
+    if expected_pass:
+        validate_team_admin(user_api_key_dict, team_table)
+    else:
+        with pytest.raises(HTTPException):
+            validate_team_admin(user_api_key_dict, team_table)
+
+
+@pytest.mark.parametrize(
+    "user_role,member_role,should_pass",
+    [
+        (LitellmUserRoles.INTERNAL_USER.value, "admin", True),   # Team admin can access
+        (LitellmUserRoles.INTERNAL_USER.value, "user", False),   # Regular user blocked
+    ],
+)
+def test_validate_team_admin_member_roles(user_role, member_role, should_pass):
+    """Test different team member roles"""
+    user_api_key_dict = UserAPIKeyAuth(
+        user_id="test-user",
+        user_role=user_role
+    )
+    team_table = LiteLLM_TeamTable(
+        team_id="test-team",
+        members_with_roles=[
+            Member(user_id="test-user", role=member_role)
+        ]
+    )
+    
+    if should_pass:
+        validate_team_admin(user_api_key_dict, team_table)
+    else:
+        with pytest.raises(HTTPException) as exc_info:
+            validate_team_admin(user_api_key_dict, team_table)
+        assert exc_info.value.status_code == 403
+        assert "must be team admin" in str(exc_info.value.detail)
+
+
+def test_validate_team_admin_non_member():
+    """Non-members should be blocked"""
+    user_api_key_dict = UserAPIKeyAuth(
+        user_id="outsider-user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value
+    )
+    team_table = LiteLLM_TeamTable(
+        team_id="test-team",
+        members_with_roles=[
+            Member(user_id="admin-user", role="admin")
+        ]
+    )
+    
+    with pytest.raises(HTTPException) as exc_info:
+        validate_team_admin(user_api_key_dict, team_table)
+    
+    assert exc_info.value.status_code == 403
+    assert "not authorized" in str(exc_info.value.detail)
+
+
+def test_validate_team_admin_team_key_blocked():
+    """Team keys accessing other teams should be blocked"""
+    user_api_key_dict = UserAPIKeyAuth(
+        user_id=None,
+        team_id="other-team",
+        user_role=LitellmUserRoles.INTERNAL_USER.value
+    )
+    team_table = LiteLLM_TeamTable(
+        team_id="test-team",
+        members_with_roles=[]
+    )
+    
+    with pytest.raises(HTTPException) as exc_info:
+        validate_team_admin(user_api_key_dict, team_table)
+    
+    assert exc_info.value.status_code == 403
+    assert "Team keys cannot access other teams" in str(exc_info.value.detail)


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring
✅ Test

## Changes

- Add `validate_team_admin()` function to check admin role                                                                                                                             
- Update /team/info to use `validate_team_admin()` instead of `validate_membership()`                                                                                                        
- Add unit tests for admin access control                                                                                                                                            
- Fixes team information disclosure vulnerability"
