### PR TITLE
Cut chat_completion latency by ~21% by reducing pre-call processing time

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -142,7 +142,12 @@ class BadRequestError(openai.BadRequestError):  # type: ignore
         self.litellm_debug_info = litellm_debug_info
         self.max_retries = max_retries
         self.num_retries = num_retries
-        if response is not None and isinstance(response, httpx.Response):
+        if (
+            response is not None
+            and isinstance(response, httpx.Response)
+            and hasattr(response, "request")
+            and response.request is not None
+        ):
             self.response = response
         else:
             self.response = _get_minimal_error_response()

--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -93,8 +93,9 @@ def get_litellm_params(
         "text_completion": text_completion,
         "azure_ad_token_provider": azure_ad_token_provider,
         "user_continue_message": user_continue_message,
-        "base_model": base_model
-        or _get_base_model_from_litellm_call_metadata(metadata=metadata),
+        "base_model": base_model or (
+            _get_base_model_from_litellm_call_metadata(metadata=metadata) if metadata else None
+        ),
         "litellm_trace_id": litellm_trace_id,
         "litellm_session_id": litellm_session_id,
         "hf_model_name": hf_model_name,

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -1,7 +1,5 @@
 from typing import Optional, Tuple
 
-import httpx
-
 import litellm
 from litellm.constants import REPLICATE_MODEL_NAME_WITH_ID_LENGTH
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
@@ -453,11 +451,7 @@ def get_llm_provider(  # noqa: PLR0915
             raise litellm.exceptions.BadRequestError(  # type: ignore
                 message=error_str,
                 model=model,
-                response=httpx.Response(
-                    status_code=400,
-                    content=error_str,
-                    request=httpx.Request(method="completion", url="https://github.com/BerriAI/litellm"),  # type: ignore
-                ),
+                response=None,
                 llm_provider="",
             )
         if api_base is not None and not isinstance(api_base, str):
@@ -481,11 +475,7 @@ def get_llm_provider(  # noqa: PLR0915
             raise litellm.exceptions.BadRequestError(  # type: ignore
                 message=f"GetLLMProvider Exception - {str(e)}\n\noriginal model: {model}",
                 model=model,
-                response=httpx.Response(
-                    status_code=400,
-                    content=error_str,
-                    request=httpx.Request(method="completion", url="https://github.com/BerriAI/litellm"),  # type: ignore
-                ),
+                response=None,
                 llm_provider="",
             )
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -325,12 +325,12 @@ class Logging(LiteLLMLoggingBaseClass):
                 messages = new_messages
 
         self.model = model
-        self.messages = copy.deepcopy(messages)
+        self.messages = copy.deepcopy(messages) if messages is not None else None
         self.stream = stream
         self.start_time = start_time  # log the call start time
         self.call_type = call_type
         self.litellm_call_id = litellm_call_id
-        self.litellm_trace_id: str = litellm_trace_id or str(uuid.uuid4())
+        self.litellm_trace_id: str = litellm_trace_id if litellm_trace_id else str(uuid.uuid4())
         self.function_id = function_id
         self.streaming_chunks: List[Any] = []  # for generating complete stream response
         self.sync_streaming_chunks: List[

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -771,7 +771,8 @@ def function_setup(  # noqa: PLR0915
         function_id: Optional[str] = kwargs["id"] if "id" in kwargs else None
 
         ## LAZY LOAD COROUTINE CHECKER ##
-        get_coroutine_checker = getattr(sys.modules[__name__], "get_coroutine_checker")
+        get_coroutine_checker_fn = getattr(sys.modules[__name__], "get_coroutine_checker")
+        coroutine_checker = get_coroutine_checker_fn()
 
         ## DYNAMIC CALLBACKS ##
         dynamic_callbacks: Optional[
@@ -825,7 +826,7 @@ def function_setup(  # noqa: PLR0915
         if len(litellm.input_callback) > 0:
             removed_async_items = []
             for index, callback in enumerate(litellm.input_callback):  # type: ignore
-                if get_coroutine_checker().is_async_callable(callback):
+                if coroutine_checker.is_async_callable(callback):
                     litellm._async_input_callback.append(callback)
                     removed_async_items.append(index)
 
@@ -835,7 +836,7 @@ def function_setup(  # noqa: PLR0915
         if len(litellm.success_callback) > 0:
             removed_async_items = []
             for index, callback in enumerate(litellm.success_callback):  # type: ignore
-                if get_coroutine_checker().is_async_callable(callback):
+                if coroutine_checker.is_async_callable(callback):
                     litellm.logging_callback_manager.add_litellm_async_success_callback(
                         callback
                     )
@@ -860,7 +861,7 @@ def function_setup(  # noqa: PLR0915
         if len(litellm.failure_callback) > 0:
             removed_async_items = []
             for index, callback in enumerate(litellm.failure_callback):  # type: ignore
-                if get_coroutine_checker().is_async_callable(callback):
+                if coroutine_checker.is_async_callable(callback):
                     litellm.logging_callback_manager.add_litellm_async_failure_callback(
                         callback
                     )
@@ -893,7 +894,7 @@ def function_setup(  # noqa: PLR0915
             removed_async_items = []
             for index, callback in enumerate(kwargs["success_callback"]):
                 if (
-                    get_coroutine_checker().is_async_callable(callback)
+                    coroutine_checker.is_async_callable(callback)
                     or callback == "dynamodb"
                     or callback == "s3"
                 ):


### PR DESCRIPTION
## Relevant issues

Pre-call logic accounts for a significant portion of request time. This PR addressed overhead from creating unused dummy HTTP objects for error handling.

**Before**
<img width="2801" height="803" alt="Screenshot 2026-01-21 143222" src="https://github.com/user-attachments/assets/be712922-dd1b-421d-9df8-58cc88a48602" />

**After**
<img width="2540" height="553" alt="Screenshot 2026-01-21 143405" src="https://github.com/user-attachments/assets/e1167c7b-0610-4752-afc6-f221af1ba8f5" />



<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/55203/workflows/23afbb87-0cb3-46ce-9039-893323a436a4

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/55264/workflows/8918ad00-b2a3-41dc-878f-d8e5872dbaf5

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- Cache minimal httpx.Response object in BadRequestError to avoid expensive object creation
- Pass response=None from get_llm_provider_logic to leverage cached response
- Lazy evaluate base_model extraction only when needed
- Conditionally deepcopy messages and generate UUIDs in logging
- Cache coroutine checker instance in function_setup to avoid repeated calls

## Extra Context

* A dummy response object was being passed to `BadRequestError`. That error only reads the request headers and then creates its own dummy response object internally. In the `get_llm_provider` function, we weren’t actually passing any headers into the response object, so the response object being provided was effectively ignored.

* Now, if a response object is provided, we use it; otherwise, we fall back to a single dummy response created at the module level. Since this object is never modified, it can be safely reused. Previously, we were creating six HTTP objects per call: two `httpx.Response` and two `httpx.Request` objects in `get_llm_provider`, plus two more in `BadRequestError.__init__`. With this change, we now create just two HTTP objects at the module level instead of creating them per request.


<img width="3105" height="1360" alt="Screenshot 2026-01-21 145639" src="https://github.com/user-attachments/assets/43caa061-765f-4012-9e2a-f1578683500d" />

<img width="3212" height="1491" alt="Screenshot 2026-01-21 145705" src="https://github.com/user-attachments/assets/c58cb910-21ec-4a17-9a91-c08f3999e8f7" />

