### PR TITLE
[Feature] UI - Create Team: Reusable Model Select

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
@@ -379,7 +379,11 @@ describe("useAllProxyModels", () => {
       "test-access-token",
       "test-user-id",
       "Admin",
-      true
+      true,
+      null,
+      true,
+      false,
+      "expand"
     );
     expect(modelAvailableCall).toHaveBeenCalledTimes(1);
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -56,7 +56,7 @@ export const useAllProxyModels = () => {
   const { accessToken, userId, userRole } = useAuthorized();
   return useQuery<AllProxyModelsResponse>({
     queryKey: allProxyModelsKeys.list({}),
-    queryFn: async () => await modelAvailableCall(accessToken!, userId!, userRole!, true),
+    queryFn: async () => await modelAvailableCall(accessToken!, userId!, userRole!, true, null, true, false, "expand"),
     enabled: Boolean(accessToken && userId && userRole),
   });
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/teams/components/modals/CreateTeamModal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/teams/components/modals/CreateTeamModal.tsx
@@ -526,7 +526,7 @@ const CreateTeamModal = ({
                 valuePropName="checked"
                 help="Bypass global guardrails for this team"
               >
-                <Switch 
+                <Switch
                   checkedChildren="Yes"
                   unCheckedChildren="No"
                 />

--- a/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx
+++ b/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx
@@ -53,14 +53,13 @@ const contextFilters: Record<ModelSelectProps["context"], (args: FilterContextAr
 
   team: ({ allProxyModels, selectedOrganization, userModels }) => {
     if (selectedOrganization) {
-      if (selectedOrganization.models.includes(MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value)) {
+      if (selectedOrganization.models.includes(MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value) || selectedOrganization.models.length === 0) {
         return allProxyModels;
       }
-      // Return organization's models (filtered from allProxyModels)
       return allProxyModels.filter((model) => selectedOrganization.models.includes(model));
     }
 
-    return userModels ?? [];
+    return allProxyModels ?? [];
   },
 
   organization: ({ allProxyModels, selectedOrganization, options }) => {
@@ -102,9 +101,12 @@ export const ModelSelect = (props: ModelSelectProps) => {
   const isSpecialOption = (value: string) => MODEL_SELECT_SPECIAL_VALUES_ARRAY.some((sv) => sv.value === value);
   const hasSpecialOptionSelected = value.some(isSpecialOption);
   const isLoading = isLoadingAllProxyModels || isLoadingTeam || isLoadingOrganization || isCurrentUserLoading;
+  const organizationHasAllProxyModels = organization?.models.includes(MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value) || organization?.models.length === 0;
+  console.log("organization:", organization);
+  console.log("organizationHasAllProxyModels:", organizationHasAllProxyModels);
   const shouldShowAllProxyModels =
     showAllProxyModelsOverride ||
-    (organization?.models.includes(MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value) && includeSpecialOptions);
+    (organizationHasAllProxyModels && includeSpecialOptions);
 
   if (isLoading) {
     return <Skeleton.Input active block />;
@@ -143,51 +145,51 @@ export const ModelSelect = (props: ModelSelectProps) => {
       options={[
         includeSpecialOptions
           ? {
-              label: <span>Special Options</span>,
-              title: "Special Options",
-              options: [
-                ...(shouldShowAllProxyModels
-                  ? [
-                      {
-                        label: <span>All Proxy Models</span>,
-                        value: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
-                        disabled:
-                          value.length > 0 &&
-                          value.some(
-                            (v) => isSpecialOption(v) && v !== MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
-                          ),
-                        key: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
-                      },
-                    ]
-                  : []),
-                {
-                  label: <span>No Default Models</span>,
-                  value: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value,
-                  disabled:
-                    value.length > 0 &&
-                    value.some((v) => isSpecialOption(v) && v !== MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value),
-                  key: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value,
-                },
-              ],
-            }
+            label: <span>Special Options</span>,
+            title: "Special Options",
+            options: [
+              ...(shouldShowAllProxyModels
+                ? [
+                  {
+                    label: <span>All Proxy Models</span>,
+                    value: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
+                    disabled:
+                      value.length > 0 &&
+                      value.some(
+                        (v) => isSpecialOption(v) && v !== MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
+                      ),
+                    key: MODEL_SELECT_ALL_PROXY_MODELS_SPECIAL_VALUE.value,
+                  },
+                ]
+                : []),
+              {
+                label: <span>No Default Models</span>,
+                value: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value,
+                disabled:
+                  value.length > 0 &&
+                  value.some((v) => isSpecialOption(v) && v !== MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value),
+                key: MODEL_SELECT_NO_DEFAULT_MODELS_SPECIAL_VALUE.value,
+              },
+            ],
+          }
           : [],
         ...(wildcard.length > 0
           ? [
-              {
-                label: <span>Wildcard Options</span>,
-                title: "Wildcard Options",
-                options: wildcard.map((model) => {
-                  const provider = model.replace("/*", "");
-                  const capitalizedProvider = provider.charAt(0).toUpperCase() + provider.slice(1);
+            {
+              label: <span>Wildcard Options</span>,
+              title: "Wildcard Options",
+              options: wildcard.map((model) => {
+                const provider = model.replace("/*", "");
+                const capitalizedProvider = provider.charAt(0).toUpperCase() + provider.slice(1);
 
-                  return {
-                    label: <span>{`All ${capitalizedProvider} models`}</span>,
-                    value: model,
-                    disabled: hasSpecialOptionSelected,
-                  };
-                }),
-              },
-            ]
+                return {
+                  label: <span>{`All ${capitalizedProvider} models`}</span>,
+                  value: model,
+                  disabled: hasSpecialOptionSelected,
+                };
+              }),
+            },
+          ]
           : []),
         {
           label: <span>Models</span>,

--- a/ui/litellm-dashboard/src/components/OldTeams.test.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.test.tsx
@@ -60,6 +60,27 @@ vi.mock("@/components/team/team_info", () => ({
   },
 }));
 
+vi.mock("./ModelSelect/ModelSelect", () => ({
+  ModelSelect: React.forwardRef(({ value, onChange, dataTestId, id }: any, ref: any) => {
+    return (
+      <input
+        ref={ref}
+        id={id}
+        type="text"
+        data-testid={dataTestId || "model-select"}
+        value={Array.isArray(value) ? value.join(", ") : ""}
+        onChange={(e) => {
+          // Mock onChange - in real usage this would be handled by Ant Design Select
+          if (onChange) {
+            onChange(value || []);
+          }
+        }}
+        readOnly
+      />
+    );
+  }),
+}));
+
 vi.mock("@/app/(dashboard)/hooks/organizations/useOrganizations", () => ({
   useOrganizations: () => mockUseOrganizations(),
 }));

--- a/ui/litellm-dashboard/src/components/OldTeams.test.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.test.tsx
@@ -60,8 +60,8 @@ vi.mock("@/components/team/team_info", () => ({
   },
 }));
 
-vi.mock("./ModelSelect/ModelSelect", () => ({
-  ModelSelect: React.forwardRef(({ value, onChange, dataTestId, id }: any, ref: any) => {
+vi.mock("./ModelSelect/ModelSelect", () => {
+  const ModelSelect = React.forwardRef(({ value, onChange, dataTestId, id }: any, ref: any) => {
     return (
       <input
         ref={ref}
@@ -78,8 +78,12 @@ vi.mock("./ModelSelect/ModelSelect", () => ({
         readOnly
       />
     );
-  }),
-}));
+  });
+  ModelSelect.displayName = "ModelSelect";
+  return {
+    ModelSelect,
+  };
+});
 
 vi.mock("@/app/(dashboard)/hooks/organizations/useOrganizations", () => ({
   useOrganizations: () => mockUseOrganizations(),
@@ -334,6 +338,7 @@ describe("OldTeams - handleCreate organization handling", () => {
             created_at: new Date().toISOString(),
             keys: [],
             members_with_roles: [],
+            spend: 0,
           },
         ]}
         searchParams={{}}
@@ -408,6 +413,7 @@ describe("OldTeams - empty state", () => {
             created_at: new Date().toISOString(),
             keys: [],
             members_with_roles: [],
+            spend: 0,
           },
         ]}
         searchParams={{}}
@@ -576,6 +582,7 @@ describe("OldTeams - premium props", () => {
             created_at: new Date().toISOString(),
             keys: [],
             members_with_roles: [],
+            spend: 0,
           },
         ]}
         searchParams={{}}
@@ -624,6 +631,7 @@ describe("OldTeams - Default Team Settings tab visibility", () => {
             created_at: new Date().toISOString(),
             keys: [],
             members_with_roles: [],
+            spend: 0,
           },
         ]}
         searchParams={{}}
@@ -654,6 +662,7 @@ describe("OldTeams - Default Team Settings tab visibility", () => {
             created_at: new Date().toISOString(),
             keys: [],
             members_with_roles: [],
+            spend: 0,
           },
         ]}
         searchParams={{}}
@@ -684,6 +693,7 @@ describe("OldTeams - Default Team Settings tab visibility", () => {
             created_at: new Date().toISOString(),
             keys: [],
             members_with_roles: [],
+            spend: 0,
           },
         ]}
         searchParams={{}}
@@ -714,6 +724,7 @@ describe("OldTeams - Default Team Settings tab visibility", () => {
             created_at: new Date().toISOString(),
             keys: [],
             members_with_roles: [],
+            spend: 0,
           },
         ]}
         searchParams={{}}
@@ -812,6 +823,7 @@ describe("OldTeams - organization alias display", () => {
             created_at: new Date().toISOString(),
             keys: [],
             members_with_roles: [],
+            spend: 0,
           },
         ]}
         searchParams={{}}
@@ -845,6 +857,7 @@ describe("OldTeams - organization alias display", () => {
             created_at: new Date().toISOString(),
             keys: [],
             members_with_roles: [],
+            spend: 0,
           },
         ]}
         searchParams={{}}
@@ -877,6 +890,7 @@ describe("OldTeams - organization alias display", () => {
             created_at: new Date().toISOString(),
             keys: [],
             members_with_roles: [],
+            spend: 0,
           },
         ]}
         searchParams={{}}

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -85,6 +85,7 @@ import { updateExistingKeys } from "@/utils/dataUtils";
 import DeleteResourceModal from "./common_components/DeleteResourceModal";
 import TableIconActionButton from "./common_components/IconActionButton/TableIconActionButtons/TableIconActionButton";
 import { Member, teamCreateCall, v2TeamListCall } from "./networking";
+import { ModelSelect } from "./ModelSelect/ModelSelect";
 
 interface TeamInfo {
   members_with_roles: Member[];
@@ -1064,11 +1065,11 @@ const Teams: React.FC<TeamProps> = ({
                           rules={
                             isOrgAdmin
                               ? [
-                                  {
-                                    required: true,
-                                    message: "Please select an organization",
-                                  },
-                                ]
+                                {
+                                  required: true,
+                                  message: "Please select an organization",
+                                },
+                              ]
                               : []
                           }
                           help={
@@ -1135,16 +1136,17 @@ const Teams: React.FC<TeamProps> = ({
                     ]}
                     name="models"
                   >
-                    <Select2 mode="multiple" placeholder="Select models" style={{ width: "100%" }}>
-                      <Select2.Option key="no-default-models" value="no-default-models">
-                        No Default Models
-                      </Select2.Option>
-                      {modelsToPick.map((model) => (
-                        <Select2.Option key={model} value={model}>
-                          {getModelDisplayName(model)}
-                        </Select2.Option>
-                      ))}
-                    </Select2>
+                    <ModelSelect
+                      value={form.getFieldValue("models") || []}
+                      onChange={(values) => form.setFieldValue("models", values)}
+                      organizationID={form.getFieldValue("organization_id")}
+                      options={{
+                        includeSpecialOptions: true,
+                        showAllProxyModelsOverride: !form.getFieldValue("organization_id"),
+                      }}
+                      context="team"
+                      dataTestId="create-team-models-select"
+                    />
                   </Form.Item>
 
                   <Form.Item label="Max Budget (USD)" name="max_budget">

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2457,6 +2457,7 @@ export const modelAvailableCall = async (
   teamID: string | null = null,
   include_model_access_groups: boolean = false,
   only_model_access_groups: boolean = false,
+  scope?: string
 ) => {
   /**
    * Get all the models user has access to
@@ -2474,6 +2475,9 @@ export const modelAvailableCall = async (
     }
     if (teamID) {
       params.append("team_id", teamID.toString());
+    }
+    if (scope) {
+      params.append("scope", scope);
     }
     if (params.toString()) {
       url += `?${params.toString()}`;


### PR DESCRIPTION
## Relevant issues
This PR changes the create team model select to use the reusable component. There are several benefits to using the reusable one including:
1. Loading states
2. Automatic determination of which models to show

For the create team case here are the things I tested:
1. Proxy admin creating a team in an organization / outside of an organization
2. Org admin creating a team in an organization / outside of an organization


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="1041" height="692" alt="image" src="https://github.com/user-attachments/assets/788e9a5a-5c33-4853-954f-745ef8565e1d" />
<img width="1164" height="241" alt="image" src="https://github.com/user-attachments/assets/fa170c33-c2f3-4cb0-95f4-d7cbb0278fe0" />
