### PR TITLE
feat: add feature to make silent calls

### DIFF
--- a/docs/my-website/docs/routing.md
+++ b/docs/my-website/docs/routing.md
@@ -833,65 +833,7 @@ asyncio.run(router_acompletion())
 
 Traffic mirroring allows you to "mimic" production traffic to a secondary (silent) model for evaluation purposes. The silent model's response is gathered in the background and does not affect the latency or result of the primary request.
 
-### Usage
-To enable traffic mirroring, add `silent_model` to the `litellm_params` of a deployment.
-
-<Tabs>
-<TabItem value="sdk" label="SDK">
-
-```python
-from litellm import Router
-
-model_list = [
-    {
-        "model_name": "gpt-3.5-turbo",
-        "litellm_params": {
-            "model": "azure/chatgpt-v-2",
-            "api_key": "...",
-            "silent_model": "gpt-4" # 👈 Mirror traffic to gpt-4
-        },
-    },
-    {
-        "model_name": "gpt-4",
-        "litellm_params": {
-            "model": "openai/gpt-4",
-            "api_key": "..."
-        },
-    }
-]
-
-router = Router(model_list=model_list)
-
-# The request to "gpt-3.5-turbo" will trigger a background call to "gpt-4"
-response = await router.acompletion(
-    model="gpt-3.5-turbo",
-    messages=[{"role": "user", "content": "How does traffic mirroring work?"}]
-)
-```
-
-</TabItem>
-<TabItem value="proxy" label="PROXY">
-
-```yaml
-model_list:
-  - model_name: primary-model
-    litellm_params:
-      model: azure/gpt-35-turbo
-      api_key: os.environ/AZURE_API_KEY
-      silent_model: evaluation-model # 👈 Mirror traffic here
-  - model_name: evaluation-model
-    litellm_params:
-      model: openai/gpt-4o
-      api_key: os.environ/OPENAI_API_KEY
-```
-
-</TabItem>
-</Tabs>
-
-### Key Features
-- **Latency Isolation**: The primary request returns as soon as it's ready. The background (silent) call does not block.
-- **Unified Logging**: Background calls are processed via the Router, meaning they are automatically logged to your configured observability tools (Langfuse, S3, etc.) with a `metadata={"is_silent_experiment": True}` flag.
-- **Resource Efficient**: Synchronous calls use a shared thread pool, while asynchronous calls use non-blocking background tasks.
+[**See detailed guide on A/B Testing - Traffic Mirroring here**](./traffic_mirroring.md)
 
 ## Basic Reliability
 

--- a/docs/my-website/docs/routing.md
+++ b/docs/my-website/docs/routing.md
@@ -828,7 +828,70 @@ asyncio.run(router_acompletion())
 ```
 
 </TabItem>
+
+## Traffic Mirroring / Silent Experiments
+
+Traffic mirroring allows you to "mimic" production traffic to a secondary (silent) model for evaluation purposes. The silent model's response is gathered in the background and does not affect the latency or result of the primary request.
+
+### Usage
+To enable traffic mirroring, add `silent_model` to the `litellm_params` of a deployment.
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import Router
+
+model_list = [
+    {
+        "model_name": "gpt-3.5-turbo",
+        "litellm_params": {
+            "model": "azure/chatgpt-v-2",
+            "api_key": "...",
+            "silent_model": "gpt-4" # 👈 Mirror traffic to gpt-4
+        },
+    },
+    {
+        "model_name": "gpt-4",
+        "litellm_params": {
+            "model": "openai/gpt-4",
+            "api_key": "..."
+        },
+    }
+]
+
+router = Router(model_list=model_list)
+
+# The request to "gpt-3.5-turbo" will trigger a background call to "gpt-4"
+response = await router.acompletion(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "How does traffic mirroring work?"}]
+)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```yaml
+model_list:
+  - model_name: primary-model
+    litellm_params:
+      model: azure/gpt-35-turbo
+      api_key: os.environ/AZURE_API_KEY
+      silent_model: evaluation-model # 👈 Mirror traffic here
+  - model_name: evaluation-model
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+```
+
+</TabItem>
 </Tabs>
+
+### Key Features
+- **Latency Isolation**: The primary request returns as soon as it's ready. The background (silent) call does not block.
+- **Unified Logging**: Background calls are processed via the Router, meaning they are automatically logged to your configured observability tools (Langfuse, S3, etc.) with a `metadata={"is_silent_experiment": True}` flag.
+- **Resource Efficient**: Synchronous calls use a shared thread pool, while asynchronous calls use non-blocking background tasks.
 
 ## Basic Reliability
 

--- a/docs/my-website/docs/traffic_mirroring.md
+++ b/docs/my-website/docs/traffic_mirroring.md
@@ -1,0 +1,83 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# A/B Testing - Traffic Mirroring
+
+Traffic mirroring allows you to "mimic" production traffic to a secondary (silent) model for evaluation purposes. The silent model's response is gathered in the background and does not affect the latency or result of the primary request.
+
+This is useful for:
+- Testing a new model's performance on production prompts before switching.
+- Comparing costs and latency between different providers.
+- Debugging issues by mirroring traffic to a more verbose model.
+
+## Quick Start
+
+To enable traffic mirroring, add `silent_model` to the `litellm_params` of a deployment.
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import Router
+
+model_list = [
+    {
+        "model_name": "gpt-3.5-turbo",
+        "litellm_params": {
+            "model": "azure/chatgpt-v-2",
+            "api_key": "...",
+            "silent_model": "gpt-4" # 👈 Mirror traffic to gpt-4
+        },
+    },
+    {
+        "model_name": "gpt-4",
+        "litellm_params": {
+            "model": "openai/gpt-4",
+            "api_key": "..."
+        },
+    }
+]
+
+router = Router(model_list=model_list)
+
+# The request to "gpt-3.5-turbo" will trigger a background call to "gpt-4"
+response = await router.acompletion(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "How does traffic mirroring work?"}]
+)
+```
+
+</TabItem>
+<TabItem value="proxy" label="Proxy">
+
+Add `silent_model` to your `config.yaml`:
+
+```yaml
+model_list:
+  - model_name: primary-model
+    litellm_params:
+      model: azure/gpt-35-turbo
+      api_key: os.environ/AZURE_API_KEY
+      silent_model: evaluation-model # 👈 Mirror traffic here
+  - model_name: evaluation-model
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+```
+
+</TabItem>
+</Tabs>
+
+## How it works
+1. **Request Received**: A request is made to a model group (e.g. `primary-model`).
+2. **Deployment Picked**: LiteLLM picks a deployment from the group.
+3. **Primary Call**: LiteLLM makes the call to the primary deployment.
+4. **Mirroring**: If `silent_model` is present, LiteLLM triggers a background call to that model. 
+   - For **Sync** calls: Uses a shared thread pool.
+   - For **Async** calls: Uses `asyncio.create_task`.
+5. **Isolation**: The background call uses a `deepcopy` of the original request parameters and sets `metadata["is_silent_experiment"] = True`. It also strips out logging IDs to prevent collisions in usage tracking.
+
+## Key Features
+- **Latency Isolation**: The primary request returns as soon as it's ready. The background (silent) call does not block.
+- **Unified Logging**: Background calls are processed via the Router, meaning they are automatically logged to your configured observability tools (Langfuse, S3, etc.).
+- **Evaluation**: Use the `is_silent_experiment: True` flag in your logs to filter and compare results between the primary and mirrored calls.

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -351,6 +351,7 @@ const sidebars = {
           label: "Load Balancing, Routing, Fallbacks",
           href: "https://docs.litellm.ai/docs/routing-load-balancing",
         },
+        "traffic_mirroring",
         {
           type: "category",
           label: "Logging, Alerting, Metrics",

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1317,10 +1317,8 @@ class Router:
         Prepare kwargs for a silent experiment by ensuring isolation from the primary call.
         """
         # Copy kwargs to ensure isolation
-        silent_kwargs = kwargs.copy()
-        if "metadata" in silent_kwargs:
-            silent_kwargs["metadata"] = silent_kwargs["metadata"].copy()
-        else:
+        silent_kwargs = copy.deepcopy(kwargs)
+        if "metadata" not in silent_kwargs:
             silent_kwargs["metadata"] = {}
 
         silent_kwargs["metadata"]["is_silent_experiment"] = True
@@ -1344,6 +1342,8 @@ class Router:
             # Prevent infinite recursion if silent model also has a silent model
             if kwargs.get("metadata", {}).get("is_silent_experiment", False):
                 return
+
+            messages = copy.deepcopy(messages)
 
             verbose_router_logger.info(
                 f"Starting silent experiment for model {silent_model}"
@@ -1580,6 +1580,8 @@ class Router:
             # Prevent infinite recursion if silent model also has a silent model
             if kwargs.get("metadata", {}).get("is_silent_experiment", False):
                 return
+
+            messages = copy.deepcopy(messages)
 
             verbose_router_logger.info(
                 f"Starting silent experiment for model {silent_model}"

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -1,0 +1,157 @@
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import litellm
+from litellm.router import Router
+
+
+@pytest.mark.asyncio
+async def test_router_silent_experiment_acompletion():
+    """
+    Test that silent_model triggers a background acompletion call
+    and that the silent_model parameter is stripped from both calls.
+    """
+    model_list = [
+        {
+            "model_name": "primary-model",
+            "litellm_params": {
+                "model": "openai/gpt-3.5-turbo",
+                "api_key": "fake-key",
+                "silent_model": "silent-model",
+            },
+        },
+        {
+            "model_name": "silent-model",
+            "litellm_params": {
+                "model": "openai/gpt-4",
+                "api_key": "fake-key",
+            },
+        },
+    ]
+
+    router = Router(model_list=model_list)
+
+    # Mock litellm.acompletion
+    mock_acompletion = MagicMock()
+    # Create a future that resolves to a ModelResponse
+    mock_response = litellm.ModelResponse(choices=[{"message": {"content": "hello"}}])
+    future = asyncio.Future()
+    future.set_result(mock_response)
+    mock_acompletion.return_value = future
+
+    with patch("litellm.acompletion", mock_acompletion):
+        response = await router.acompletion(
+            model="primary-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert response.choices[0].message.content == "hello"
+
+        # Give the background task a moment to trigger (it's an asyncio task)
+        await asyncio.sleep(0.1)
+
+        # Should have 2 calls: one for primary, one for silent
+        assert mock_acompletion.call_count == 2
+
+        # Check call arguments
+        call_args_list = mock_acompletion.call_args_list
+
+        # Verify no silent_model in any call to litellm.acompletion
+        for call in call_args_list:
+            args, kwargs = call
+            assert "silent_model" not in kwargs
+            if "metadata" in kwargs:
+                # One call should have is_silent_experiment=True
+                pass
+
+        # Find the silent call
+        silent_call = next(
+            (
+                c
+                for c in call_args_list
+                if c[1].get("metadata", {}).get("is_silent_experiment") is True
+            ),
+            None,
+        )
+        assert silent_call is not None
+        assert silent_call[1]["model"] == "openai/gpt-4"
+
+        # Find the primary call
+        primary_call = next(
+            (
+                c
+                for c in call_args_list
+                if not c[1].get("metadata", {}).get("is_silent_experiment")
+            ),
+            None,
+        )
+        assert primary_call is not None
+        assert primary_call[1]["model"] == "openai/gpt-3.5-turbo"
+
+
+def test_router_silent_experiment_completion():
+    """
+    Test that silent_model triggers a background completion call (sync)
+    and that the silent_model parameter is stripped.
+    """
+    model_list = [
+        {
+            "model_name": "primary-model",
+            "litellm_params": {
+                "model": "openai/gpt-3.5-turbo",
+                "api_key": "fake-key",
+                "silent_model": "silent-model",
+            },
+        },
+        {
+            "model_name": "silent-model",
+            "litellm_params": {
+                "model": "openai/gpt-4",
+                "api_key": "fake-key",
+            },
+        },
+    ]
+
+    router = Router(model_list=model_list)
+
+    # Mock litellm.completion
+    mock_completion = MagicMock()
+    mock_response = litellm.ModelResponse(choices=[{"message": {"content": "hello"}}])
+    mock_completion.return_value = mock_response
+
+    with patch("litellm.completion", mock_completion):
+        response = router.completion(
+            model="primary-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert response.choices[0].message.content == "hello"
+
+        # The sync background call uses a thread pool. We might need to wait a bit.
+        import time
+
+        time.sleep(0.5)
+
+        # Should have 2 calls
+        assert mock_completion.call_count == 2
+
+        call_args_list = mock_completion.call_args_list
+
+        # Verify no silent_model in any call
+        for call in call_args_list:
+            args, kwargs = call
+            assert "silent_model" not in kwargs
+
+        # Find the silent call
+        silent_call = next(
+            (
+                c
+                for c in call_args_list
+                if c[1].get("metadata", {}).get("is_silent_experiment") is True
+            ),
+            None,
+        )
+        assert silent_call is not None
+        assert silent_call[1]["model"] == "openai/gpt-4"


### PR DESCRIPTION
## Relevant issues

fixes https://github.com/BerriAI/litellm/issues/19537

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
🧹 Refactoringz
📃Docs

## Changes

<img width="892" height="625" alt="image" src="https://github.com/user-attachments/assets/94bf0233-3054-4858-b172-9d98c96fb917" />

Implemented the **Silent Experiment (Traffic Mirroring)** feature for the LiteLLM Router. This allows requests to be asynchronously mirrored to a secondary model for evaluation/quality monitoring without affecting the latency of the primary response.

### Key Improvements:
- **Shared Resource Management**: Synchronous background calls now utilize the centralized [litellm](cci:1://file:///d:/OSS/speedup-litellm-2/litellm/litellm/router.py:7739:4-7743:84) `ThreadPoolExecutor` instead of creating ad-hoc threads, improving resource efficiency.
- **Parameter Hygiene**: Implemented robust stripping of the `silent_model` parameter from both the [Router](cci:2://file:///d:/OSS/speedup-litellm-2/litellm/litellm/router.py:200:0-8759:26) kwargs and the deployment's [litellm_params](cci:1://file:///d:/OSS/speedup-litellm-2/litellm/litellm/router.py:1796:4-1815:79). This ensures the parameter does not leak to downstream LLM providers (e.g., OpenRouter, OpenAI), which previously caused "unsupported parameter" errors.
- **State Isolation**: Background tasks now use isolated deep copies of the [metadata](cci:1://file:///d:/OSS/speedup-litellm-2/litellm/litellm/router.py:5363:4-5377:61) dictionary, preventing race conditions and ensuring accurate logging for mirrored traffic.
- **Recursion Protection**: Added safeguards to prevent infinite recursion if a silent model is recursively configured to mirror traffic back to itself or another model.
- **Verified with Proxy**: Successfully verified the implementation using the LiteLLM Proxy with real OpenRouter models.

