### PR TITLE
feat(core): enforce strict schema validation for Usage via TypeAdapter to improve SDK quality

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -18,7 +18,14 @@ from openai.types.moderation import (
     CategoryScores,
 )
 from openai.types.moderation_create_response import Moderation, ModerationCreateResponse
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    model_validator,
+    TypeAdapter,
+)
 from typing_extensions import Callable, Dict, Required, TypedDict, override
 
 import litellm
@@ -1814,8 +1821,14 @@ class ModelResponse(ModelResponseBase):
                     usage.model_dump() if hasattr(usage, "model_dump") else usage.dict()
                 )
                 usage = Usage(**dump)
-            else:
-                usage = usage
+            try:
+                usage = UsageAdapter.validate_python(usage)
+            except Exception as e:
+                raise ValueError(
+                    f"Invalid 'usage' object received. Expected strictly typed Usage object.\n"
+                    f"Received type: {type(usage)}\n"
+                    f"Error: {str(e)}"
+                )
         elif stream is None or stream is False:
             usage = Usage()
         if hidden_params:
@@ -3426,3 +3439,6 @@ class GenericGuardrailAPIInputs(TypedDict, total=False):
     structured_messages: List[
         AllMessageValues
     ]  # structured messages sent to the LLM - indicates if text is from system or user
+
+
+UsageAdapter = TypeAdapter(Usage)

--- a/tests/test_litellm/types/test_conformance.py
+++ b/tests/test_litellm/types/test_conformance.py
@@ -1,0 +1,115 @@
+"""
+Provider-agnostic conformance tests for Usage validation.
+
+These tests ensure that regardless of which provider returns data,
+LiteLLM enforces a consistent schema at the ingestion boundary.
+"""
+import pytest
+from pydantic import ValidationError
+from litellm.types.utils import Usage, ModelResponse, UsageAdapter
+
+
+class TestUsageConformance:
+    """Test that Usage validation catches all schema violations."""
+
+    # Valid Input Conformance
+
+    def test_valid_usage_dict_complete(self):
+        """Complete dict with all required fields should pass."""
+        data = {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+        usage = UsageAdapter.validate_python(data)
+        assert usage.prompt_tokens == 10
+        assert usage.completion_tokens == 20
+        assert usage.total_tokens == 30
+
+    def test_valid_usage_dict_with_optional_fields(self):
+        """Dict with optional fields should pass and map correctly."""
+        data = {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+            "reasoning_tokens": 5,
+            "cost": 0.0001,
+        }
+        usage = UsageAdapter.validate_python(data)
+
+        # Check Cost (Usage class keeps it if not None)
+        assert usage.cost == 0.0001
+
+        # Check Reasoning Tokens (Mapped to completion_tokens_details by Usage class)
+        assert usage.completion_tokens_details.reasoning_tokens == 5
+
+    def test_valid_usage_object(self):
+        """Pre-constructed Usage object should pass."""
+        usage_obj = Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+        usage = UsageAdapter.validate_python(usage_obj)
+        assert usage.prompt_tokens == 10
+
+    #  Type Violation Detection
+
+    def test_modelresponse_rejects_invalid_usage_types(self):
+        """
+        Ensures ModelResponse throws an error if usage is a string/int.
+        This closes the 'else: usage = usage' problem.
+        """
+        invalid_inputs = [
+            "100 tokens",  # String
+            123,  # Integer
+            ["tokens"],  # List
+            object(),  # Random object
+        ]
+
+        for bad_input in invalid_inputs:
+            # This MUST raise ValueError now (due to our try/except block in utils.py)
+            with pytest.raises(ValueError, match="Invalid 'usage' object"):
+                ModelResponse(id="test", usage=bad_input)
+
+    #  Adapter Unit Tests
+
+    def test_adapter_coerces_valid_strings(self):
+        """Pydantic standard behavior: string ints ('15') are coerced to ints (15)."""
+        data = {"prompt_tokens": "15", "completion_tokens": 25, "total_tokens": 40}
+        usage = UsageAdapter.validate_python(data)
+        assert usage.prompt_tokens == 15  # Coercion successful
+        assert isinstance(usage.prompt_tokens, int)
+
+    def test_adapter_rejects_invalid_strings(self):
+        """Adapter should fail if string cannot be coerced to int."""
+        data = {
+            "prompt_tokens": "ten",  # Invalid int
+            "completion_tokens": 25,
+            "total_tokens": 40,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            UsageAdapter.validate_python(data)
+
+        assert "prompt_tokens" in str(exc_info.value)
+
+    def test_usage_defaults_for_missing_fields(self):
+        """
+        Usage class allows missing fields (defaults to 0).
+        This test confirms we didn't break that behavior.
+        """
+        data = {"prompt_tokens": 10}  # Missing others
+        usage = UsageAdapter.validate_python(data)
+
+        # Usage.__init__ sets defaults to 0
+        assert usage.prompt_tokens == 10
+        assert usage.completion_tokens == 0
+        assert usage.total_tokens == 0
+
+    def test_cost_field_none_behavior(self):
+        """
+        Usage.__init__ deletes 'cost' attribute if it is None.
+        We verify this behavior is preserved.
+        """
+        data = {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+            "cost": None,
+        }
+        usage = UsageAdapter.validate_python(data)
+
+        # Usage logic: if cost is None, del self.cost
+        assert not hasattr(usage, "cost")


### PR DESCRIPTION
## Enforce strict schema validation for Usage via TypeAdapter to improve SDK quality



**Summary**

This PR proposes a **Conformance Testing Philosophy** to improve SDK quality by catching schema and typing regressions at the provider boundary, rather than letting them leak into user code.

As discussed regarding "improving SDK quality," I am introducing the **TypeAdapter pattern**  to enforce strict schema validation. This PR implements this pattern for the `usage` field as a proof-of-concept.

**The Problem:**

Currently, `ModelResponse` is highly permissive to support 100+ providers. However, this creates a risk: if a provider handler returns a malformed type (e.g., `usage="100 tokens"` string instead of an object), it falls through the initialization logic (`else: usage = usage`) and the object is created successfully.

The error only happens **later** in the user's code (`AttributeError: 'str' object has no attribute...`), making debugging difficult and making it look like a user error rather than a library/provider issue.

**The Solution: Strict Validation Gate**
I have introduced a `TypeAdapter` in `litellm/types/utils.py` that acts as a gatekeeper.
1.  **Ingestion Time Validation:** Validates data *immediately* upon object creation.
2.  **Clear Error Messages:** Converts confusing runtime crashes into clear `ValueError`s pointing to the invalid schema.
3.  **Backward Compatibility:** Existing valid dicts and objects work exactly as before; only invalid types are rejected.

**Impact of this Fix:**

Beyond fixing runtime crashes, strict validation prevents:
1.  **Silent Billing Failures:** Ensures `usage` always contains valid integers for cost calculation, preventing cases where malformed data leads to `$0` cost logs because checks like `hasattr(str, 'prompt_tokens')` fail silently.
2.  **Data Pipeline Integrity:** Guarantees that `response.model_dump()` always produces a consistent JSON schema for downstream observability tools (Datadog, Langfuse).

**Proof of Fix:**

I used a reproduction script to simulate a provider returning invalid data (a string) for usage.
```python 
from litellm.types.utils import ModelResponse, Usage

def simulate_provider_response():
    """
    Simulates a provider returning a string for usage instead of an object.
    This bypasses current checks in ModelResponse.__init__.
    """
    return ModelResponse(
        id="chatcmpl-123",
        model="gpt-4",
        choices=[],
        usage="100 tokens"  # INVALID TYPE (String instead of Usage Object)
    )


print("Scenario: A provider returns usage='100 tokens' (String) instead of a dict/object.")

# --- ISSUE 1: delayed explosion ---
print("\n---Issue 1---\n")
try:
    response = simulate_provider_response()
    print(f"Step 1: ModelResponse created successfully (This is BAD).")
    print(f"   Internal usage value: {repr(response.usage)}")
    
    print("\nStep 2: User tries to access token count...")
    _ = response.usage.total_tokens
except AttributeError as e:
    print(f" Error: {e}")

# --- ISSUE 2: silent billing failure (Business Logic) ---
print("\n---Issue 2---\n")
try:
    response = simulate_provider_response()
    
    
    # SIMULATION: A user's production logging function.
    # Many users write defensive code to prevent logging from crashing their app.

    def user_side_cost_calculation(obj):
        # User checks if the field exists before accessing
        if hasattr(obj.usage, "prompt_tokens"):
            return obj.usage.prompt_tokens * 0.003
        
        # Fallback: If usage is missing/malformed, log 0 to avoid crashing the app
        return 0.0 

    cost = user_side_cost_calculation(response)
    
    print(f"   Calculated Cost: ${cost}")
    if cost == 0.0:
        print("failure: Cost calculated as $0.00.")
        print("   Analysis: Malformed data bypassed user checks, resulting in free usage logging.")

except Exception as e:
    print(f"   Error: {e}")

# --- ISSUE 3: Inconsistent serialization (Observability) ---
print("\n---Issue 3---\n")
try:
    # Valid Response
    valid_res = ModelResponse(id="1", usage={"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20})
    valid_json = valid_res.model_dump()
    
    # Invalid Response
    invalid_res = simulate_provider_response()
    invalid_json = invalid_res.model_dump()

    print(f"   Valid Schema Usage:   {type(valid_json['usage'])} -> {valid_json['usage']}")
    print(f"   Invalid Schema Usage: {type(invalid_json['usage'])}          -> {invalid_json['usage']}")
    
    print("\n failure: JSON Schema is unstable.")
    print("   Analysis: Downstream tools (Datadog/Langfuse) expecting an Object will crash")
    print("             or corrupt data when they receive a String.")

except Exception as e:
    print(f"   Error: {e}")

# SUMMARY
# If the PR is applied, Step 1 will raise a clear 'ValueError' immediately
# preventing issues 2, 3, and 4 from ever happening.
```

**Before Change**
The invalid object is created silently, leading to downstream crashes and data corruption.
<img width="1410" height="550" alt="image" src="https://github.com/user-attachments/assets/fa6fec75-f369-42cd-a31f-fc554d0ee96c" />

**After Change**
The SDK catches the regression immediately at instantiation.
<img width="1407" height="680" alt="image" src="https://github.com/user-attachments/assets/d847a450-fb90-427d-a4a5-c675f18b2449" />

**Changes**
1.  **Core Logic:** Modified `ModelResponse.__init__` in `litellm/types/utils.py` to use `UsageAdapter`.
2.  **Testing:** Added `tests/test_litellm/types/test_conformance.py`. This is a provider-agnostic test suite that verifies the invariant: *"If a ModelResponse exists, its fields are strictly valid."*

<img width="1413" height="233" alt="image" src="https://github.com/user-attachments/assets/99bb9048-5197-4333-8f33-d8ba89a3d0a4" />


**Future Extension**

This pattern is designed to be extended across the SDK:
- [ ] **Choices & Messages:** Ensure `choices` is always a list of objects, never raw dicts.
- [ ] **Streaming Deltas:** Enforce strict schema on streaming chunks.

***