### PR TITLE
fix(rag): use router for completion in RAG query pipeline

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -349,9 +349,9 @@ def filter_exceptions_from_params(data: Any, max_depth: int = 20) -> Any:
     # Skip callable objects (functions, methods, lambdas) but not classes (type objects)
     if callable(data) and not isinstance(data, type):
         return None
-    # Skip known non-serializable object types (Logging, etc.)
+    # Skip known non-serializable object types (Logging, Router, etc.)
     obj_type_name = type(data).__name__
-    if obj_type_name in ["Logging", "LiteLLMLoggingObj"]:
+    if obj_type_name in ["Logging", "LiteLLMLoggingObj", "Router"]:
         return None
 
     if isinstance(data, dict):


### PR DESCRIPTION
## Summary

The RAG query endpoint (`/v1/rag/query`) was failing with `Object of type Router is not JSON serializable` when called through the proxy. This fix addresses two related issues:

1. **Router serialization error**: The Router object passed via kwargs was leaking into the request payload sent to providers like Bedrock, causing JSON serialization errors.

2. **Model name resolution**: The RAG query pipeline was calling `litellm.acompletion()` directly instead of using the router, so virtual model names configured in the proxy weren't being resolved to actual provider model IDs.

Tested RAG query endpoint with Bedrock and OpenAI providers through the proxy