### PR TITLE
[feat] Add MCP tools response to chat completions

### DIFF
--- a/litellm/responses/mcp/chat_completions_handler.py
+++ b/litellm/responses/mcp/chat_completions_handler.py
@@ -15,6 +15,69 @@ from litellm.types.utils import ModelResponse
 from litellm.utils import CustomStreamWrapper
 
 
+def _add_mcp_metadata_to_response(
+    response: Union[ModelResponse, CustomStreamWrapper],
+    openai_tools: Optional[List],
+    tool_calls: Optional[List] = None,
+    tool_results: Optional[List] = None,
+) -> None:
+    """
+    Add MCP metadata to response's provider_specific_fields.
+    
+    This function adds MCP-related information to the response so that
+    clients can access which tools were available, which were called, and
+    what results were returned.
+    
+    For ModelResponse: adds to choices[].message.provider_specific_fields
+    For CustomStreamWrapper: stores in _hidden_params and automatically adds to 
+    final chunk's delta.provider_specific_fields via CustomStreamWrapper._add_mcp_metadata_to_final_chunk()
+    """
+    if isinstance(response, CustomStreamWrapper):
+        # For streaming, store MCP metadata in _hidden_params
+        # CustomStreamWrapper._add_mcp_metadata_to_final_chunk() will automatically
+        # add it to the final chunk's delta.provider_specific_fields
+        if not hasattr(response, "_hidden_params"):
+            response._hidden_params = {}
+        
+        mcp_metadata = {}
+        if openai_tools:
+            mcp_metadata["mcp_list_tools"] = openai_tools
+        if tool_calls:
+            mcp_metadata["mcp_tool_calls"] = tool_calls
+        if tool_results:
+            mcp_metadata["mcp_call_results"] = tool_results
+        
+        if mcp_metadata:
+            response._hidden_params["mcp_metadata"] = mcp_metadata
+        return
+    
+    if not isinstance(response, ModelResponse):
+        return
+    
+    if not hasattr(response, "choices") or not response.choices:
+        return
+    
+    # Add MCP metadata to all choices' messages
+    for choice in response.choices:
+        message = getattr(choice, "message", None)
+        if message is not None:
+            # Get existing provider_specific_fields or create new dict
+            provider_fields = (
+                getattr(message, "provider_specific_fields", None) or {}
+            )
+            
+            # Add MCP metadata
+            if openai_tools:
+                provider_fields["mcp_list_tools"] = openai_tools
+            if tool_calls:
+                provider_fields["mcp_tool_calls"] = tool_calls
+            if tool_results:
+                provider_fields["mcp_call_results"] = tool_results
+            
+            # Set the provider_specific_fields
+            setattr(message, "provider_specific_fields", provider_fields)
+
+
 async def acompletion_with_mcp(
     model: str,
     messages: List,
@@ -103,7 +166,13 @@ async def acompletion_with_mcp(
 
     # If not auto-executing, just make the call with transformed tools
     if not should_auto_execute:
-        return await litellm_acompletion(**base_call_args)
+        response = await litellm_acompletion(**base_call_args)
+        if isinstance(response, (ModelResponse, CustomStreamWrapper)):
+            _add_mcp_metadata_to_response(
+                response=response,
+                openai_tools=openai_tools,
+            )
+        return response
 
     # For auto-execute: disable streaming for initial call
     stream = kwargs.get("stream", False)
@@ -130,7 +199,17 @@ async def acompletion_with_mcp(
         if stream:
             retry_args = dict(base_call_args)
             retry_args["stream"] = stream
-            return await litellm_acompletion(**retry_args)
+            response = await litellm_acompletion(**retry_args)
+            if isinstance(response, (ModelResponse, CustomStreamWrapper)):
+                _add_mcp_metadata_to_response(
+                    response=response,
+                    openai_tools=openai_tools,
+                )
+            return response
+        _add_mcp_metadata_to_response(
+            response=initial_response,
+            openai_tools=openai_tools,
+        )
         return initial_response
 
     # Execute tool calls
@@ -147,6 +226,11 @@ async def acompletion_with_mcp(
     )
 
     if not tool_results:
+        _add_mcp_metadata_to_response(
+            response=initial_response,
+            openai_tools=openai_tools,
+            tool_calls=tool_calls,
+        )
         return initial_response
 
     # Create follow-up messages with tool results
@@ -161,4 +245,12 @@ async def acompletion_with_mcp(
     follow_up_call_args["messages"] = follow_up_messages
     follow_up_call_args["stream"] = stream
 
-    return await litellm_acompletion(**follow_up_call_args)
+    response = await litellm_acompletion(**follow_up_call_args)
+    if isinstance(response, (ModelResponse, CustomStreamWrapper)):
+        _add_mcp_metadata_to_response(
+            response=response,
+            openai_tools=openai_tools,
+            tool_calls=tool_calls,
+            tool_results=tool_results,
+        )
+    return response


### PR DESCRIPTION
## Relevant issues

LIT-1665

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm?branch=litellm_feat_completions_mcp_output

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
✅ Test

## Changes

Add MCP execution results to the response so they are visible for /chat/completions as well.
