### PR TITLE
fix(auth): resolve passthrough endpoint access_groups permission check

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1960,6 +1960,21 @@ def _can_object_call_model(
         if _model:
             potential_models.append(_model)
 
+    # Resolve URL model name to config model_name for passthrough endpoints
+    # e.g., "gemini-2.5-pro" (from URL) -> "gcp/google/gemini-2.5-pro" (config model_name)
+    # This enables access_groups validation when the URL model name differs from config name
+    if llm_router:
+        for deployment in llm_router.model_list:
+            litellm_model = deployment.get("litellm_params", {}).get("model", "")
+            if "/" in litellm_model:
+                # Extract underlying model: "vertex_ai/gemini-2.5-pro" -> "gemini-2.5-pro"
+                underlying_model = litellm_model.split("/")[-1]
+                if underlying_model == model:  # Exact match only to avoid false positives
+                    config_model_name = deployment.get("model_name")
+                    if config_model_name and config_model_name not in potential_models:
+                        potential_models.append(config_model_name)
+                    break
+
     ## check model access for alias + underlying model - allow if either is in allowed models
     for m in potential_models:
         if _check_model_access_helper(

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1277,3 +1277,258 @@ async def test_virtual_key_max_budget_alert_check_scenarios(
     assert (
         alert_triggered == expect_alert
     ), f"Expected alert_triggered to be {expect_alert} for spend={spend}, max_budget={max_budget}"
+
+
+# Passthrough Access Groups Tests
+
+
+def test_can_object_call_model_passthrough_with_access_group():
+    """
+    Test that a key with access to an access_group can call a model via passthrough endpoint
+    where the URL model name differs from the config model_name.
+
+    This tests the scenario:
+    - Config has model_name="gcp/google/gemini-2.5-pro", litellm_params.model="vertex_ai/gemini-2.5-pro"
+    - Model has access_groups=["default-models"]
+    - Key has access to models=["default-models"]
+    - URL extracts "gemini-2.5-pro"
+    - Expected: Access allowed because we resolve "gemini-2.5-pro" -> "gcp/google/gemini-2.5-pro" -> access_groups
+    """
+    from litellm import Router
+    from litellm.proxy.auth.auth_checks import _can_object_call_model
+
+    # URL extracts "gemini-2.5-pro" from passthrough endpoint
+    model = "gemini-2.5-pro"
+
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": "gcp/google/gemini-2.5-pro",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-2.5-pro",
+                    "api_key": "test-api-key",
+                },
+                "model_info": {
+                    "id": "gcp/google/gemini-2.5-pro",
+                    "access_groups": ["default-models"],
+                },
+            }
+        ],
+    )
+
+    # Key has access to the access_group that contains this model
+    result = _can_object_call_model(
+        model=model,
+        llm_router=llm_router,
+        models=["default-models"],  # Key has access to access_group
+        team_model_aliases=None,
+        object_type="key",
+        fallback_depth=0,
+    )
+
+    # Should return True because:
+    # 1. "gemini-2.5-pro" resolves to "gcp/google/gemini-2.5-pro" via litellm_params.model suffix match
+    # 2. "gcp/google/gemini-2.5-pro" has access_groups=["default-models"]
+    # 3. Key has access to "default-models"
+    assert result is True
+
+
+def test_can_object_call_model_passthrough_with_direct_model_access():
+    """
+    Test that direct model access continues to work for passthrough endpoints.
+    """
+    from litellm import Router
+    from litellm.proxy.auth.auth_checks import _can_object_call_model
+
+    model = "gemini-2.5-pro"
+
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": "gcp/google/gemini-2.5-pro",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-2.5-pro",
+                    "api_key": "test-api-key",
+                },
+            }
+        ],
+    )
+
+    # Key has direct access to the config model_name
+    result = _can_object_call_model(
+        model=model,
+        llm_router=llm_router,
+        models=["gcp/google/gemini-2.5-pro"],  # Direct access to config model_name
+        team_model_aliases=None,
+        object_type="key",
+        fallback_depth=0,
+    )
+
+    assert result is True
+
+
+def test_can_object_call_model_passthrough_denied_without_access():
+    """
+    Test that a key WITHOUT access to the model or its access_group is properly denied.
+    """
+    from litellm import Router
+    from litellm.proxy._types import ProxyErrorTypes, ProxyException
+    from litellm.proxy.auth.auth_checks import _can_object_call_model
+
+    model = "gemini-2.5-pro"
+
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": "gcp/google/gemini-2.5-pro",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-2.5-pro",
+                    "api_key": "test-api-key",
+                },
+                "model_info": {
+                    "access_groups": ["default-models"],
+                },
+            }
+        ],
+    )
+
+    # Key has access to a different access_group
+    with pytest.raises(ProxyException) as exc_info:
+        _can_object_call_model(
+            model=model,
+            llm_router=llm_router,
+            models=["other-models"],  # Different access_group
+            team_model_aliases=None,
+            object_type="key",
+            fallback_depth=0,
+        )
+
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+    assert "key not allowed to access model" in str(exc_info.value.message)
+
+
+def test_can_object_call_model_passthrough_multiple_deployments():
+    """
+    Test that URL model resolution works correctly when multiple deployments exist.
+    First matching deployment wins.
+    """
+    from litellm import Router
+    from litellm.proxy.auth.auth_checks import _can_object_call_model
+
+    model = "gemini-2.5-pro"
+
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": "team-a/gemini-2.5-pro",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-2.5-pro",
+                    "api_key": "test-api-key-a",
+                },
+                "model_info": {
+                    "access_groups": ["team-a-models"],
+                },
+            },
+            {
+                "model_name": "team-b/gemini-2.5-pro",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-2.5-pro",
+                    "api_key": "test-api-key-b",
+                },
+                "model_info": {
+                    "access_groups": ["team-b-models"],
+                },
+            },
+        ],
+    )
+
+    # Key has access to team-a-models (first deployment)
+    result = _can_object_call_model(
+        model=model,
+        llm_router=llm_router,
+        models=["team-a-models"],
+        team_model_aliases=None,
+        object_type="key",
+        fallback_depth=0,
+    )
+
+    assert result is True
+
+
+def test_can_object_call_model_no_provider_prefix_still_works():
+    """
+    Test that models without provider prefix (e.g., just "gpt-4") continue to work.
+    The URL model resolution should only apply when there's a "/" in the litellm_params.model.
+    """
+    from litellm import Router
+    from litellm.proxy.auth.auth_checks import _can_object_call_model
+
+    model = "gpt-4"
+
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {
+                    "model": "gpt-4",  # No provider prefix
+                    "api_key": "test-api-key",
+                },
+                "model_info": {
+                    "access_groups": ["openai-models"],
+                },
+            }
+        ],
+    )
+
+    # Key has access to the access_group
+    result = _can_object_call_model(
+        model=model,
+        llm_router=llm_router,
+        models=["openai-models"],
+        team_model_aliases=None,
+        object_type="key",
+        fallback_depth=0,
+    )
+
+    assert result is True
+
+
+def test_can_object_call_model_exact_match_required():
+    """
+    Test that URL model resolution requires exact match, not suffix match.
+    This prevents "pro" from matching "gemini-2.5-pro".
+    """
+    from litellm import Router
+    from litellm.proxy._types import ProxyErrorTypes, ProxyException
+    from litellm.proxy.auth.auth_checks import _can_object_call_model
+
+    # "pro" should NOT match "vertex_ai/gemini-2.5-pro"
+    model = "pro"
+
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": "gcp/google/gemini-2.5-pro",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-2.5-pro",
+                    "api_key": "test-api-key",
+                },
+                "model_info": {
+                    "access_groups": ["default-models"],
+                },
+            }
+        ],
+    )
+
+    # Key has access to the access_group, but model name doesn't match
+    with pytest.raises(ProxyException) as exc_info:
+        _can_object_call_model(
+            model=model,
+            llm_router=llm_router,
+            models=["default-models"],
+            team_model_aliases=None,
+            object_type="key",
+            fallback_depth=0,
+        )
+
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied


### PR DESCRIPTION
When using passthrough endpoints with virtual keys that have access to access_groups, the permission check was failing incorrectly. The system extracted the model name from the URL (e.g., "gemini-2.5-pro") but couldn't resolve it to the config model_name (e.g., "gcp/google/gemini-2.5-pro") to check access_groups.

This fix adds URL model name resolution in _can_object_call_model() by matching the extracted model name against litellm_params.model suffix across all deployments. This allows proper access_groups validation for passthrough endpoints.

Example scenario that now works:
- Config: model_name="gcp/google/gemini-2.5-pro", litellm_params.model="vertex_ai/gemini-2.5-pro", access_groups=["default-models"]
- Key: models=["default-models"]
- URL: /vertex_ai/.../models/gemini-2.5-pro:generateContent
- Result: Access allowed (was incorrectly denied before)

Fixes the regression introduced in v1.80.15 where model extraction was added for passthrough URLs but access_groups resolution was incomplete.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

- Added URL model name resolution in `_can_object_call_model()` (`litellm/proxy/auth/auth_checks.py`)
- Added 6 unit tests for passthrough access groups scenarios (`tests/test_litellm/proxy/auth/test_auth_checks.py`)