### PR TITLE
fix(retrieve): Bedrock KB retrieve passthrough signing

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1004,6 +1004,10 @@ async def bedrock_proxy_route(
     if not encoded_endpoint.startswith("/"):
         encoded_endpoint = "/" + encoded_endpoint
 
+    # Construct the full target URL using httpx
+    base_url = httpx.URL(base_target_url)
+    updated_url = base_url.copy_with(path=encoded_endpoint)
+
     # Add or update query parameters
     from litellm.llms.bedrock.chat import BedrockConverseLLM
 
@@ -1015,9 +1019,6 @@ async def bedrock_proxy_route(
         data = await request.json()
     except Exception as e:
         raise HTTPException(status_code=400, detail={"error": e})
-
-    # Construct the full target URL using httpx
-    updated_url = httpx.URL(base_target_url).copy_with(path=encoded_endpoint)
 
     if _is_bedrock_kb_retrieve_route(endpoint=endpoint):
         return await _bedrock_kb_retrieve_passthrough(
@@ -1047,7 +1048,7 @@ async def bedrock_proxy_route(
         target=str(prepped.url),
         custom_headers=prepped.headers,  # type: ignore
         is_streaming_request=is_streaming_request,
-        _forward_headers=True,
+        _forward_headers=True
     )  # dynamically construct pass-through endpoint based on incoming path
     received_value = await endpoint_func(
         request,

--- a/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
+++ b/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
@@ -420,6 +420,28 @@ def test_is_bedrock_agent_runtime_route():
     assert _is_bedrock_agent_runtime_route("/some/random/endpoint") is False
 
 
+def test_is_bedrock_kb_retrieve_route():
+    """
+    Test that _is_bedrock_kb_retrieve_route correctly identifies KB retrieve endpoints
+    """
+    from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+        _is_bedrock_kb_retrieve_route,
+    )
+
+    # Test KB retrieve endpoints (should return True)
+    assert _is_bedrock_kb_retrieve_route("/knowledgebases/kb-123/retrieve") is True
+    assert _is_bedrock_kb_retrieve_route("knowledgebases/kb-123/retrieve") is True
+    assert _is_bedrock_kb_retrieve_route("/knowledgebases/kb-123/retrieve/") is True
+
+    # Test non-retrieve KB endpoints (should return False)
+    assert _is_bedrock_kb_retrieve_route("/knowledgebases/kb-123/query") is False
+    assert _is_bedrock_kb_retrieve_route("/knowledgebases/kb-123") is False
+
+    # Test non-KB endpoints (should return False)
+    assert _is_bedrock_kb_retrieve_route("/model/test/converse") is False
+    assert _is_bedrock_kb_retrieve_route("/some/random/endpoint") is False
+
+
 def test_init_kwargs_filters_pricing_params(mock_request, mock_user_api_key_dict):
     """
     Test that pricing parameters are properly filtered out from the request body


### PR DESCRIPTION
Add a retrieve-only Bedrock Knowledge Base passthrough helper that signs and sends the exact JSON body to bedrock-agent-runtime. Keep non-retrieve agent-runtime passthrough behavior unchanged.

The KB retrieve path was using generic passthrough, which re-serialized the body and forwarded inbound Authorization, causing SigV4 mismatch / 403s.
