### PR TITLE
Fix unsafe access to request attribute

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -145,12 +145,15 @@ class BadRequestError(openai.BadRequestError):  # type: ignore
         if (
             response is not None
             and isinstance(response, httpx.Response)
-            and hasattr(response, "request")
-            and response.request is not None
         ):
-            self.response = response
-        else:
-            self.response = _get_minimal_error_response()
+            # Check if response has a request attribute safely
+            # httpx.Response.request is a property that raises RuntimeError if _request is None
+            # We check the private _request attribute to avoid triggering the property getter
+            if hasattr(response, "_request") and getattr(response, "_request", None) is not None:
+                self.response = response
+            else:
+                # Response doesn't have a valid request, use minimal error response
+                self.response = _get_minimal_error_response()
         super().__init__(
             self.message, response=self.response, body=body
         )  # Call the base class constructor with the parameters it needs

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -142,18 +142,17 @@ class BadRequestError(openai.BadRequestError):  # type: ignore
         self.litellm_debug_info = litellm_debug_info
         self.max_retries = max_retries
         self.num_retries = num_retries
+        # Use response if it's a valid httpx.Response with a request, otherwise use minimal error response
+        # Note: We check _request (not .request property) to avoid RuntimeError when _request is None
         if (
             response is not None
             and isinstance(response, httpx.Response)
+            and hasattr(response, "_request")
+            and getattr(response, "_request", None) is not None
         ):
-            # Check if response has a request attribute safely
-            # httpx.Response.request is a property that raises RuntimeError if _request is None
-            # We check the private _request attribute to avoid triggering the property getter
-            if hasattr(response, "_request") and getattr(response, "_request", None) is not None:
-                self.response = response
-            else:
-                # Response doesn't have a valid request, use minimal error response
-                self.response = _get_minimal_error_response()
+            self.response = response
+        else:
+            self.response = _get_minimal_error_response()
         super().__init__(
             self.message, response=self.response, body=body
         )  # Call the base class constructor with the parameters it needs


### PR DESCRIPTION
## Relevant issues

<img width="2500" height="611" alt="Screenshot 2026-01-22 084715" src="https://github.com/user-attachments/assets/b446d7ce-0471-4ca9-84cb-b0b234053696" />

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/55359/workflows/ae3e14d8-374f-46b4-b63b-fa3fd80cbb1b

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/55360/workflows/71c00048-016f-456b-a7b1-41fb5e68e97c

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

* Accessing the request object directly caused a runtime error; updated to use safe access.