### PR TITLE
feat(datadog): add agent support for LLM Observability

### DIFF
--- a/docs/my-website/docs/observability/datadog.md
+++ b/docs/my-website/docs/observability/datadog.md
@@ -73,7 +73,7 @@ Send logs through a local DataDog agent (useful for containerized environments):
 ```shell
 LITELLM_DD_AGENT_HOST="localhost"         # hostname or IP of DataDog agent
 LITELLM_DD_AGENT_PORT="10518"             # [OPTIONAL] port of DataDog agent (default: 10518)
-DD_API_KEY="5f2d0f310***********"         # [OPTIONAL] your datadog API Key (agent handles auth)
+DD_API_KEY="5f2d0f310***********"         # [OPTIONAL] your datadog API Key (Agent handles auth for Logs. REQUIRED for LLM Observability)
 DD_SOURCE="litellm_dev"                   # [OPTIONAL] your datadog source
 ```
 
@@ -83,6 +83,9 @@ When `LITELLM_DD_AGENT_HOST` is set, logs are sent to the agent instead of direc
 - Leveraging agent-side processing and filtering
 
 **Note:** We use `LITELLM_DD_AGENT_HOST` instead of `DD_AGENT_HOST` to avoid conflicts with `ddtrace` which automatically sets `DD_AGENT_HOST` for APM tracing.
+
+> [!IMPORTANT]
+> **Datadog LLM Observability**: `DD_API_KEY` is **REQUIRED** even when using the Datadog Agent (`LITELLM_DD_AGENT_HOST`). The agent acts as a proxy but the API key header is mandatory for the LLM Observability endpoint.
 
 **Step 3**: Start the proxy, make a test request
 
@@ -203,5 +206,5 @@ LiteLLM supports customizing the following Datadog environment variables
 | `POD_NAME` | Pod name tag (useful for Kubernetes deployments) | "unknown" | ❌ No |
 
 \* **Required when using Direct API** (default): `DD_API_KEY` and `DD_SITE` are required  
-\* **Optional when using DataDog Agent**: Set `LITELLM_DD_AGENT_HOST` to use agent mode; `DD_API_KEY` and `DD_SITE` are not required
+\* **Optional when using DataDog Agent**: Set `LITELLM_DD_AGENT_HOST` to use agent mode; `DD_API_KEY` and `DD_SITE` are not required for **Datadog Logs**. (**Note: `DD_API_KEY` IS REQUIRED for Datadog LLM Observability**)
 

--- a/litellm/integrations/datadog/datadog_handler.py
+++ b/litellm/integrations/datadog/datadog_handler.py
@@ -20,6 +20,14 @@ def get_datadog_hostname() -> str:
     return os.getenv("HOSTNAME", "")
 
 
+def get_datadog_base_url_from_env() -> Optional[str]:
+    """
+    Get base URL override from common DD_BASE_URL env var.
+    This is useful for testing or custom endpoints.
+    """
+    return os.getenv("DD_BASE_URL")
+
+
 def get_datadog_env() -> str:
     return os.getenv("DD_ENV", "unknown")
 

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_obs_agent.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_obs_agent.py
@@ -1,0 +1,62 @@
+import os
+from unittest.mock import patch
+from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
+
+
+def test_datadog_llm_obs_agent_configuration():
+    """
+    Test that DataDog LLM Obs logger correctly configures agent endpoint.
+    """
+    test_env = {
+        "LITELLM_DD_AGENT_HOST": "localhost",
+        "LITELLM_DD_LLM_OBS_PORT": "10518",
+        "DD_API_KEY": "test-api-key",  # Optional, but checking if it's preserved
+    }
+
+    # Ensure DD_SITE is NOT set to verify we don't need it in agent mode
+
+    with patch.dict(os.environ, test_env, clear=True):
+        with patch("asyncio.create_task"):  # Prevent periodic flush task from running
+            dd_logger = DataDogLLMObsLogger()
+
+        expected_url = "http://localhost:10518/api/intake/llm-obs/v1/trace/spans"
+        assert dd_logger.intake_url == expected_url
+        assert dd_logger.DD_API_KEY == "test-api-key"
+
+
+def test_datadog_llm_obs_agent_no_api_key_ok():
+    """
+    Test that agent mode works WITHOUT DD_API_KEY (agent handles auth).
+    """
+    test_env = {
+        "LITELLM_DD_AGENT_HOST": "localhost",
+        # No DD_API_KEY
+    }
+
+    with patch.dict(os.environ, test_env, clear=True):
+        with patch("asyncio.create_task"):
+            # Should NOT raise exception anymore
+            dd_logger = DataDogLLMObsLogger()
+
+            assert dd_logger.DD_API_KEY is None
+            # Default port is 8126 if not set
+            expected_url = "http://localhost:8126/api/intake/llm-obs/v1/trace/spans"
+            assert dd_logger.intake_url == expected_url
+
+
+def test_datadog_llm_obs_direct_api_configuration():
+    """
+    Test that direct API configuration still works as expected.
+    """
+    test_env = {
+        "DD_API_KEY": "direct-api-key",
+        "DD_SITE": "us5.datadoghq.com",
+    }
+
+    with patch.dict(os.environ, test_env, clear=True):
+        with patch("asyncio.create_task"):
+            dd_logger = DataDogLLMObsLogger()
+
+        expected_url = "https://api.us5.datadoghq.com/api/intake/llm-obs/v1/trace/spans"
+        assert dd_logger.intake_url == expected_url
+        assert dd_logger.DD_API_KEY == "direct-api-key"


### PR DESCRIPTION
add agent support for LLM Observability

<!-- e.g. "Fixes #000" -->
## Pre-Submission checklist
- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

## Type
🆕 New Feature
🧹 Refactoring
📖 Documentation
✅ Test

## Changes

<img width="1086" height="560" alt="image" src="https://github.com/user-attachments/assets/ac6e6682-e85c-404a-ba17-e523915b2648" />


**Core Feature: Datadog Agent Support for LLM Observability**
- Added support for routing Datadog LLM Observability traces through the Datadog Agent using `LITELLM_DD_AGENT_HOST`.
- Enforced strict requirement for `DD_API_KEY` header even in Agent mode, as required by the Datadog Intake API.
- Verified integration with local Datadog Agent and open-source models.

**Refactoring: DRY for Datadog Configuration**
- Created [get_datadog_base_url_from_env()](cci:1://file:///d:/OSS/litellm/litellm/integrations/datadog/datadog_handler.py:52:0-61:5) in [./litellm/integrations/datadog/datadog_handler.py](cci:7://file:///d:/OSS/litellm/litellm/integrations/datadog/datadog_handler.py:0:0-0:0).
- Updated both [datadog.py](cci:7://file:///d:/OSS/litellm/litellm/integrations/datadog/datadog.py:0:0-0:0) (Logs) and [datadog_llm_obs.py](cci:7://file:///d:/OSS/litellm/litellm/integrations/datadog/datadog_llm_obs.py:0:0-0:0) (LLM Obs) to use this shared utility for base URL configuration, reducing code duplication.

**Testing & Docs**
- Added [tests/test_litellm/integrations/datadog/test_datadog_llm_obs_agent.py](cci:7://file:///d:/OSS/litellm/tests/test_litellm/integrations/datadog/test_datadog_llm_obs_agent.py:0:0-0:0) to verify Agent configuration logic.
- Updated Datadog documentation to explicitly state Agent setup steps and API key requirements.