### PR TITLE
fix(websearch_interception): filter internal kwargs before follow-up request

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -413,6 +413,13 @@ class WebSearchInterceptionLogger(CustomLogger):
                 if k != 'max_tokens'
             }
 
+            # Remove internal websearch interception flags from kwargs before follow-up request
+            # These flags are used internally and should not be passed to the LLM provider
+            kwargs_for_followup = {
+                k: v for k, v in kwargs.items()
+                if not k.startswith('_websearch_interception')
+            }
+
             # Get model from logging_obj.model_call_details["agentic_loop_params"]
             # This preserves the full model name with provider prefix (e.g., "bedrock/invoke/...")
             full_model_name = model
@@ -428,7 +435,7 @@ class WebSearchInterceptionLogger(CustomLogger):
                 messages=follow_up_messages,
                 model=full_model_name,
                 **optional_params_without_max_tokens,
-                **kwargs,
+                **kwargs_for_followup,
             )
             verbose_logger.debug(
                 f"WebSearchInterception: Follow-up request completed, response type: {type(final_response)}"


### PR DESCRIPTION
## Summary
- Fix bug where internal `_websearch_interception_*` kwargs were passed to follow-up LLM requests
- This caused "Extra inputs are not permitted" errors from providers like Bedrock that use strict Pydantic validation
- Added regression test to verify internal flags are filtered

Example claude code session against litellm `v1.81.1-nightly` with `websearch_interception` callback enabled:
```
                                                                                                                                                                                              
 ▐▛███▜▌   Claude Code v2.1.15                                                                                                                                                                
▝▜█████▛▘  claude-opus-4-5 · API Usage Billing                                                                                                                                                
  ▘▘ ▝▝    ~/                                                                                                                                                                        
                                                                                                                                                                                              
  Welcome to Opus 4.5                                                                                                                                                                         
                                                                                                                                                                                              
❯ What are the latest developments in quantum computing in 2025? Please search the web for current information.                                                                               
  ⎿ API Error: 400 {"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: _websearch_interception_converted_stream: Extra   
    inputs are not permitted\"}. Received Model Group=claude-opus-4-5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}                                          
```

## Root Cause
The `async_pre_request_hook` sets `kwargs["_websearch_interception_converted_stream"] = True` when converting stream requests. In `_execute_agentic_loop`, these kwargs were passed directly to `anthropic_messages.acreate()`, causing Bedrock to reject the request.

## Fix
Filter out all kwargs starting with `_websearch_interception` prefix before making the follow-up request.

## Test plan
- [x] Added unit test `test_internal_flags_filtered_from_followup_kwargs`
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)