### PR TITLE
[Infra] CI/CD - Adding node-tar CVE to Allowlist

### DIFF
--- a/ci_cd/security_scans.sh
+++ b/ci_cd/security_scans.sh
@@ -137,6 +137,7 @@ run_grype_scans() {
         "CVE-2019-1010025" # glibc pthread heap address leak - awaiting patched Wolfi glibc build
         "CVE-2026-22184" # zlib untgz buffer overflow - untgz unused + no fixed Wolfi build yet
         "GHSA-58pv-8j8x-9vj2" # jaraco.context path traversal - setuptools vendored only (v5.3.0), not used in application code (using v6.1.0+)
+        "GHSA-r6q2-hw4h-h46w" # node-tar not used by application runtime, Linux-only container, not affect by macOS APFS-specific exploit
     )
 
     # Build JSON array of allowlisted CVE IDs for jq


### PR DESCRIPTION
## Relevant issues
This vulnerability only affects macOS APFS systems, and node is not used during runtime.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🚄 Infrastructure


## Changes
