### PR TITLE
[Fix] Team Update with Organization having All Proxy Models

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -496,14 +496,18 @@ async def _check_org_team_limits(
 
     # Validate team models against organization's allowed models
     if data.models is not None and len(org_table.models) > 0:
-        for m in data.models:
-            if m not in org_table.models:
-                raise HTTPException(
-                    status_code=400,
-                    detail={
-                        "error": f"Model '{m}' not in organization's allowed models. Organization allowed models={org_table.models}. Organization: {org_table.organization_id}"
-                    },
-                )
+        # If organization has 'all-proxy-models', skip validation as it allows all models
+        if SpecialModelNames.all_proxy_models.value in org_table.models:
+            pass
+        else:
+            for m in data.models:
+                if m not in org_table.models:
+                    raise HTTPException(
+                        status_code=400,
+                        detail={
+                            "error": f"Model '{m}' not in organization's allowed models. Organization allowed models={org_table.models}. Organization: {org_table.organization_id}"
+                        },
+                    )
 
     # Validate team TPM/RPM against organization's TPM/RPM limits (direct comparison)
     if (


### PR DESCRIPTION
## Relevant issues
Then a POST request to /team/update selects only a subset of models when inside of an organization with All Proxy Models, it returns an error because the All Proxy Model special case was not handled properly. This PR implements the check for All Proxy Models specifically
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
Before:
<img width="415" height="276" alt="image" src="https://github.com/user-attachments/assets/1d624b15-485d-4955-962c-56eb1a8a2fa3" />
---
<img width="1320" height="156" alt="image" src="https://github.com/user-attachments/assets/85b53a36-043d-418b-a4c7-dc15297481f0" />
After: 

<img width="1918" height="347" alt="image" src="https://github.com/user-attachments/assets/411d1934-a82e-44c0-8eb9-93fc6bd58cc0" />


