### PR TITLE
perf: Add LRU caching to get_model_info for faster cost lookups

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5135,9 +5135,14 @@ def _invalidate_model_cost_lowercase_map() -> None:
     """Invalidate the case-insensitive lookup map for model_cost.
 
     Call this whenever litellm.model_cost is modified to ensure the map is rebuilt.
+    Also clears related LRU caches that depend on model_cost data.
     """
     global _model_cost_lowercase_map
     _model_cost_lowercase_map = None
+
+    # Clear LRU caches that depend on model_cost data
+    get_model_info.cache_clear()
+    _cached_get_model_info_helper.cache_clear()
 
 
 def _rebuild_model_cost_lowercase_map() -> Dict[str, str]:
@@ -5352,6 +5357,7 @@ def _get_max_position_embeddings(model_name: str) -> Optional[int]:
         return None
 
 
+@lru_cache(maxsize=DEFAULT_MAX_LRU_CACHE_SIZE)
 def _cached_get_model_info_helper(
     model: str, custom_llm_provider: Optional[str]
 ) -> ModelInfoBase:
@@ -5699,6 +5705,7 @@ def _get_model_info_helper(  # noqa: PLR0915
         )
 
 
+@lru_cache(maxsize=DEFAULT_MAX_LRU_CACHE_SIZE)
 def get_model_info(model: str, custom_llm_provider: Optional[str] = None) -> ModelInfo:
     """
     Get a dict for the maximum tokens (context window), input_cost_per_token, output_cost_per_token  for a given model.

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -70,8 +70,6 @@ def test_cost_calculator_with_response_cost_in_additional_headers():
 
 
 def test_cost_calculator_with_usage(monkeypatch):
-    from litellm import get_model_info
-
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
 
@@ -122,6 +120,10 @@ def test_cost_calculator_with_usage(monkeypatch):
             "gemini-2.0-flash-001": temp_model_info_object
         },
     )
+
+    # Invalidate caches after modifying litellm.model_cost
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+    _invalidate_model_cost_lowercase_map()
 
     result = response_cost_calculator(
         response_object=mr,


### PR DESCRIPTION
- Add @lru_cache decorator to get_model_info() and _cached_get_model_info_helper()
- Update _invalidate_model_cost_lowercase_map() to clear these caches when model_cost changes
- Update test to call cache invalidation after modifying litellm.model_cost

| Function | Before | After |
  |----------|--------|-------|
  | `get_standard_logging_object_payload()` | 22.3% | <1% |
  | `customLogger.async_log_event()` | 32.7% | 19.5% |
  | `_success_handler_helper_fn()` | 22.9% | 19.5% |

Also reduces get_model_cost_information from 46% to <1% of request handling time.

**get_model_cost_information (before):**:

<img width="1036" height="153" alt="Screenshot 2026-01-22 at 4 44 24 PM" src="https://github.com/user-attachments/assets/44e73a1f-47ab-47a3-b21f-c579858d2bd7" />


**get_model_cost_information (after):**

<img width="1079" height="148" alt="Screenshot 2026-01-22 at 4 44 45 PM" src="https://github.com/user-attachments/assets/8798b308-b0d1-47a6-a62e-095b09af06a7" />

**async_success_handler (before):**

<img width="670" height="150" alt="Screenshot 2026-01-23 at 10 44 07 AM" src="https://github.com/user-attachments/assets/636e4581-8147-4d3e-9fe9-6171ac57d888" />


**async_success_handler (after):**

<img width="973" height="154" alt="Screenshot 2026-01-23 at 10 43 41 AM" src="https://github.com/user-attachments/assets/1e298e92-16d6-480a-b394-b00fb1abbce0" />


## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
Performance 

## Changes
