### PR TITLE
[Feature] CI/CD Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1853,7 +1853,6 @@ jobs:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
     working_directory: ~/project
-    parallelism: 4
     steps:
       - checkout
       - setup_google_dns

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
             echo "$TEST_FILES" | circleci tests run \
               --split-by=filesize \
               --verbose \
-              --command="xargs python -m pytest \
+              --command="xargs python -m pytest -o junit_family=legacy \
                 -vv \
                 --cov=litellm \
                 --cov-report=xml \
@@ -555,7 +555,7 @@ jobs:
             echo "$TEST_FILES" | circleci tests run \
               --split-by=filesize \
               --verbose \
-              --command="xargs python -m pytest \
+              --command="xargs python -m pytest -o junit_family=legacy \
                 -k 'router' \
                 --cov=litellm \
                 --cov-report=xml \
@@ -1881,20 +1881,8 @@ jobs:
             pwd
             ls
             mkdir test-results
-
-            # Discover logging callback test files
             TEST_FILES=$(circleci tests glob "tests/logging_callback_tests/**/test_*.py")
-
-            echo "$TEST_FILES" | circleci tests run \
-              --split-by=filesize \
-              --verbose \
-              --command="xargs python -m pytest \
-                -vv \
-                --cov=litellm \
-                --cov-report=xml \
-                -s \
-                --junitxml=test-results/junit.xml \
-                --durations=5"
+            echo "$TEST_FILES" | circleci tests run --command="xargs python -m pytest -o junit_family=legacy -vv --cov=litellm --cov-report=xml -s -v --junitxml=test-results/junit.xml --durations=5" --verbose
           no_output_timeout: 120m
       - run:
           name: Rename the coverage files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,7 @@ jobs:
                 --junitxml=test-results/junit.xml \
                 --durations=20 \
                 -k \"not test_python_38.py and not test_basic_python_version.py and not router and not assistants and not langfuse and not caching and not cache\" \
+                -n 4 \
                 --timeout=300 \
                 --timeout_method=thread"
           no_output_timeout: 120m
@@ -546,6 +547,7 @@ jobs:
                 -k 'router' \
                 --cov=litellm \
                 --cov-report=xml \
+                -n 4 \
                 --junitxml=test-results/junit.xml \
                 --durations=5 \
                 -vv"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,6 +499,7 @@ jobs:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
     working_directory: ~/project
+    parallelism: 4
 
     steps:
       - checkout
@@ -520,9 +521,22 @@ jobs:
       - run:
           name: Run tests
           command: |
-            pwd
-            ls
-            python -m pytest tests/local_testing --cov=litellm --cov-report=xml -vv -k "router" -v --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+
+            # Find test files only in local_testing
+            TEST_FILES=$(circleci tests glob "tests/local_testing/**/test_*.py")
+
+            echo "$TEST_FILES" | circleci tests run \
+              --split-by=timings \
+              --timings-type=filename \
+              --verbose \
+              --command="xargs python -m pytest \
+                -k 'router' \
+                --cov=litellm \
+                --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=5 \
+                -vv"
           no_output_timeout: 120m
       - run:
           name: Rename the coverage files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
 
             echo "$TEST_FILES" | circleci tests run \
               --split-by=timings \
-              --timings-type=filename \
+              --timings-type=file \
               --verbose \
               --command="xargs python -m pytest \
                 -vv \
@@ -1835,7 +1835,7 @@ jobs:
 
             echo "$TEST_FILES" | circleci tests run \
               --split-by=timings \
-              --timings-type=filename \
+              --timings-type=file \
               --verbose \
               --command="xargs python -m pytest \
                 -vv \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,13 +209,13 @@ jobs:
           command: |
             pwd
             ls
-            mkdir -p test-results
+            mkdir test-results
 
             # Discover test files
             TEST_FILES=$(circleci tests glob "tests/local_testing/**/test_*.py")
 
             echo "$TEST_FILES" | circleci tests run \
-              --split-by=timings \
+              --split-by=filesize \
               --verbose \
               --command="xargs python -m pytest \
                 -vv \
@@ -432,9 +432,21 @@ jobs:
       - run:
           name: Run tests
           command: |
-            pwd
-            ls
-            python -m pytest -vv tests/local_testing --cov=litellm --cov-report=xml -x --junitxml=test-results/junit.xml --durations=5 -k "caching or cache"
+            mkdir test-results
+            TEST_FILES=$(circleci tests glob "tests/local_testing/**/test_*.py")
+
+            echo "$TEST_FILES" | circleci tests run \
+              --command="xargs python -m pytest \
+                tests/local_testing \
+                -vv \
+                --cov=litellm \
+                --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                -n 4 \
+                --durations=5 \
+                -x \
+                -k 'caching or cache'" \
+              --verbose
           no_output_timeout: 120m
       - run:
           name: Rename the coverage files
@@ -535,13 +547,13 @@ jobs:
       - run:
           name: Run tests
           command: |
-            mkdir -p test-results
+            mkdir test-results
 
             # Find test files only in local_testing
             TEST_FILES=$(circleci tests glob "tests/local_testing/**/test_*.py")
 
             echo "$TEST_FILES" | circleci tests run \
-              --split-by=timings \
+              --split-by=filesize \
               --verbose \
               --command="xargs python -m pytest \
                 -k 'router' \
@@ -1119,6 +1131,7 @@ jobs:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
     working_directory: ~/project
+    parallelism: 4
 
     steps:
       - checkout
@@ -1141,9 +1154,24 @@ jobs:
           command: |
             pwd
             ls
-            # Add --timeout to kill hanging tests after 120s (2 min)
-            # Add --durations=20 to show 20 slowest tests for debugging
-            python -m pytest -vv tests/llm_translation --cov=litellm --cov-report=xml -v --junitxml=test-results/junit.xml --durations=20 -n 4 --timeout=120 --timeout_method=thread
+
+            mkdir test-results
+
+            # Collect test files for CircleCI test splitting / rerun failed tests
+            TEST_FILES=$(circleci tests glob "tests/llm_translation/**/test_*.py")
+
+            echo "$TEST_FILES" | circleci tests run \
+              --split-by=filesize \
+              --verbose \
+              --command="xargs python -m pytest \
+                -vv \
+                --cov=litellm \
+                --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=20 \
+                -n 4 \
+                --timeout=120 \
+                --timeout_method=thread" \
           no_output_timeout: 120m
       - run:
           name: Rename the coverage files
@@ -1487,13 +1515,38 @@ jobs:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
     working_directory: ~/project
+    parallelism: 4
     resource_class: xlarge
     steps:
       - setup_litellm_test_deps
       - run:
           name: Run core tests
           command: |
-            python -m pytest tests/test_litellm --ignore=tests/test_litellm/proxy --ignore=tests/test_litellm/llms --ignore=tests/test_litellm/integrations --ignore=tests/test_litellm/litellm_core_utils --cov=litellm --cov-report=xml --junitxml=test-results/junit-core.xml --durations=10 -n 16 --maxfail=5 --timeout=300 -vv --log-cli-level=WARNING
+            pwd
+            ls
+
+            mkdir test-results
+
+            # Collect core test files for CircleCI rerun/splitting
+            CORE_TEST_FILES=$(circleci tests glob "tests/test_litellm/**/test_*.py")
+
+            echo "$CORE_TEST_FILES" | circleci tests run \
+              --split-by=filesize \
+              --verbose \
+              --command="xargs python -m pytest \
+                -vv \
+                --ignore=tests/test_litellm/proxy \
+                --ignore=tests/test_litellm/llms \
+                --ignore=tests/test_litellm/integrations \
+                --ignore=tests/test_litellm/litellm_core_utils \
+                --cov=litellm \
+                --cov-report=xml \
+                --junitxml=test-results/junit-core.xml \
+                --durations=10 \
+                -n 4 \
+                --maxfail=5 \
+                --timeout=300 \
+                --log-cli-level=WARNING" \
           no_output_timeout: 120m
       - run:
           name: Rename the coverage files
@@ -1827,13 +1880,13 @@ jobs:
           command: |
             pwd
             ls
-            mkdir -p test-results
+            mkdir test-results
 
             # Discover logging callback test files
             TEST_FILES=$(circleci tests glob "tests/logging_callback_tests/**/test_*.py")
 
             echo "$TEST_FILES" | circleci tests run \
-              --split-by=timings \
+              --split-by=filesize \
               --verbose \
               --command="xargs python -m pytest \
                 -vv \
@@ -2310,7 +2363,7 @@ jobs:
           command: |
             pwd
             ls
-            python -m pytest -s -vv tests/*.py -x --junitxml=test-results/junit.xml --durations=5 --ignore=tests/otel_tests --ignore=tests/spend_tracking_tests --ignore=tests/pass_through_tests --ignore=tests/proxy_admin_ui_tests --ignore=tests/load_tests --ignore=tests/llm_translation --ignore=tests/llm_responses_api_testing --ignore=tests/mcp_tests --ignore=tests/guardrails_tests --ignore=tests/image_gen_tests --ignore=tests/pass_through_unit_tests
+            python -m pytest -s -vv tests/*.py -x --junitxml=test-results/junit.xml -n 4 --durations=5 --ignore=tests/otel_tests --ignore=tests/spend_tracking_tests --ignore=tests/pass_through_tests --ignore=tests/proxy_admin_ui_tests --ignore=tests/load_tests --ignore=tests/llm_translation --ignore=tests/llm_responses_api_testing --ignore=tests/mcp_tests --ignore=tests/guardrails_tests --ignore=tests/image_gen_tests --ignore=tests/pass_through_unit_tests
           no_output_timeout: 120m
 
       # Store test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,11 +216,9 @@ jobs:
 
             echo "$TEST_FILES" | circleci tests run \
               --split-by=timings \
-              --timings-type=file \
               --verbose \
               --command="xargs python -m pytest \
                 -vv \
-                tests/local_testing \
                 --cov=litellm \
                 --cov-report=xml \
                 --junitxml=test-results/junit.xml \
@@ -543,7 +541,6 @@ jobs:
 
             echo "$TEST_FILES" | circleci tests run \
               --split-by=timings \
-              --timings-type=file \
               --verbose \
               --command="xargs python -m pytest \
                 -k 'router' \
@@ -1835,7 +1832,6 @@ jobs:
 
             echo "$TEST_FILES" | circleci tests run \
               --split-by=timings \
-              --timings-type=file \
               --verbose \
               --command="xargs python -m pytest \
                 -vv \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1835,7 +1835,6 @@ jobs:
               --verbose \
               --command="xargs python -m pytest \
                 -vv \
-                tests/logging_callback_tests \
                 --cov=litellm \
                 --cov-report=xml \
                 -s \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
     working_directory: ~/project
-
+    parallelism: 4
     steps:
       - checkout
       - setup_google_dns
@@ -209,10 +209,25 @@ jobs:
           command: |
             pwd
             ls
-            # Add --timeout to kill hanging tests after 300s (5 min)
-            # Add -v to show test names as they run for debugging
-            # Add --tb=short for shorter tracebacks
-            python -m pytest -vv tests/local_testing --cov=litellm --cov-report=xml --junitxml=test-results/junit.xml --durations=20 -k "not test_python_38.py and not test_basic_python_version.py and not router and not assistants and not langfuse and not caching and not cache" -n 4 --timeout=300 --timeout_method=thread
+            mkdir -p test-results
+
+            # Discover test files
+            TEST_FILES=$(circleci tests glob "tests/local_testing/**/test_*.py")
+
+            echo "$TEST_FILES" | circleci tests run \
+              --split-by=timings \
+              --timings-type=filename \
+              --verbose \
+              --command="xargs python -m pytest \
+                -vv \
+                tests/local_testing \
+                --cov=litellm \
+                --cov-report=xml \
+                --junitxml=test-results/junit.xml \
+                --durations=20 \
+                -k \"not test_python_38.py and not test_basic_python_version.py and not router and not assistants and not langfuse and not caching and not cache\" \
+                --timeout=300 \
+                --timeout_method=thread"
           no_output_timeout: 120m
       - run:
           name: Rename the coverage files
@@ -528,7 +543,7 @@ jobs:
 
             echo "$TEST_FILES" | circleci tests run \
               --split-by=timings \
-              --timings-type=filename \
+              --timings-type=file \
               --verbose \
               --command="xargs python -m pytest \
                 -k 'router' \
@@ -1786,7 +1801,7 @@ jobs:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
     working_directory: ~/project
-
+    parallelism: 4
     steps:
       - checkout
       - setup_google_dns
@@ -1813,7 +1828,23 @@ jobs:
           command: |
             pwd
             ls
-            python -m pytest -vv tests/logging_callback_tests --cov=litellm --cov-report=xml -s -v --junitxml=test-results/junit.xml --durations=5
+            mkdir -p test-results
+
+            # Discover logging callback test files
+            TEST_FILES=$(circleci tests glob "tests/logging_callback_tests/**/test_*.py")
+
+            echo "$TEST_FILES" | circleci tests run \
+              --split-by=timings \
+              --timings-type=filename \
+              --verbose \
+              --command="xargs python -m pytest \
+                -vv \
+                tests/logging_callback_tests \
+                --cov=litellm \
+                --cov-report=xml \
+                -s \
+                --junitxml=test-results/junit.xml \
+                --durations=5"
           no_output_timeout: 120m
       - run:
           name: Rename the coverage files

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -496,14 +496,18 @@ async def _check_org_team_limits(
 
     # Validate team models against organization's allowed models
     if data.models is not None and len(org_table.models) > 0:
-        for m in data.models:
-            if m not in org_table.models:
-                raise HTTPException(
-                    status_code=400,
-                    detail={
-                        "error": f"Model '{m}' not in organization's allowed models. Organization allowed models={org_table.models}. Organization: {org_table.organization_id}"
-                    },
-                )
+        # If organization has 'all-proxy-models', skip validation as it allows all models
+        if SpecialModelNames.all_proxy_models.value in org_table.models:
+            pass
+        else:
+            for m in data.models:
+                if m not in org_table.models:
+                    raise HTTPException(
+                        status_code=400,
+                        detail={
+                            "error": f"Model '{m}' not in organization's allowed models. Organization allowed models={org_table.models}. Organization: {org_table.organization_id}"
+                        },
+                    )
 
     # Validate team TPM/RPM against organization's TPM/RPM limits (direct comparison)
     if (


### PR DESCRIPTION
## Relevant issues
This PR implements some CI/CD improvements including:

1. Splitting long running tests. CI/CD Jobs such as `local_testing`, `logging_testing`, etc take ~20 minutes to complete. I added parallelism=4 to these to (hopefully) bring down the time to ~5
2. Re-run failed tests only. Currently when a CI/CD job fails, we have to rerun the ENTIRE job. Following CircleCI's own [documentation](https://circleci.com/docs/guides/test/rerun-failed-tests/) we can re-run only the failed tests. This saves time and compute cycles 
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure


## Changes
