### PR TITLE
feat(ui): Add send_invite_email toggle to Invite User modal

### DIFF
--- a/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
@@ -215,6 +215,23 @@ describe("CreateUserButton", { timeout: 20000 }, () => {
     });
   });
 
+  it("should render send invite email toggle in modal with default off", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CreateUserButton {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /\+ invite user/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
+
+    const dialog = screen.getByRole("dialog", { name: /invite user/i });
+    expect(within(dialog).getByText("Send Invite Email")).toBeInTheDocument();
+
+    const switchToggle = within(dialog).getByRole("switch");
+    expect(switchToggle).toBeInTheDocument();
+    expect(switchToggle).not.toBeChecked();
+  });
+
   it("should close modal when cancel is clicked in standalone mode", async () => {
     const user = userEvent.setup();
     renderWithProviders(<CreateUserButton {...defaultProps} />);

--- a/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
@@ -19,6 +19,13 @@ vi.mock("./networking", () => ({
   getProxyBaseUrl: vi.fn().mockReturnValue("http://localhost"),
 }));
 
+vi.mock("./onboarding_link", () => ({
+  __esModule: true,
+  default: ({ isInvitationLinkModalVisible }: { isInvitationLinkModalVisible: boolean }) =>
+    isInvitationLinkModalVisible ? <div data-testid="onboarding-modal">Onboarding Modal</div> : null,
+  InvitationLink: {},
+}));
+
 vi.mock("./bulk_create_users_button", () => ({
   default: () => <div data-testid="bulk-create-users">Bulk Create Users</div>,
 }));

--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -248,7 +248,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
             label={
               <span>
                 Send Invite Email{" "}
-                <Tooltip title="Send an invitation email to the user with login instructions.">
+                <Tooltip title="Send an invitation email to the user with login instructions. Requires email settings to be configured.">
                   <InfoCircleOutlined />
                 </Tooltip>
               </span>

--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -255,9 +255,9 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
             }
             name="send_invite_email"
             valuePropName="checked"
-            initialValue={true}
+            initialValue={false}
           >
-            <Switch defaultChecked />
+            <Switch />
           </Form.Item>
           <Form.Item
             label={

--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -8,7 +8,7 @@ import {
   SelectItem,
   TextInput,
 } from "@tremor/react";
-import { Alert, Button, Form, Input, Modal, Select, Select as Select2, Space, Tooltip, Typography } from "antd";
+import { Alert, Button, Form, Input, Modal, Select, Select as Select2, Space, Switch, Tooltip, Typography } from "antd";
 import React, { useEffect, useState } from "react";
 import BulkCreateUsers from "./bulk_create_users_button";
 import TeamDropdown from "./common_components/team_dropdown";
@@ -98,7 +98,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
     form.resetFields();
   };
 
-  const handleCreate = async (formValues: { user_id: string; models?: string[]; user_role: string }) => {
+  const handleCreate = async (formValues: { user_id: string; models?: string[]; user_role: string; send_invite_email?: boolean }) => {
     try {
       NotificationsManager.info("Making API Call");
       if (!isEmbedded) {
@@ -243,6 +243,21 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
         <Form form={form} onFinish={handleCreate} labelCol={{ span: 8 }} wrapperCol={{ span: 16 }} labelAlign="left">
           <Form.Item label="User Email" name="user_email">
             <Input />
+          </Form.Item>
+          <Form.Item
+            label={
+              <span>
+                Send Invite Email{" "}
+                <Tooltip title="Send an invitation email to the user with login instructions.">
+                  <InfoCircleOutlined />
+                </Tooltip>
+              </span>
+            }
+            name="send_invite_email"
+            valuePropName="checked"
+            initialValue={true}
+          >
+            <Switch defaultChecked />
           </Form.Item>
           <Form.Item
             label={


### PR DESCRIPTION
## Summary
- Adds a "Send Invite Email" toggle switch to the Invite User modal in the Admin UI
- The toggle is disabled by default (`initialValue={false}`)
- Includes a tooltip explaining the feature: "Send an invitation email to the user with login instructions"

This completes the UI implementation for the `send_invite_email` parameter that was added to the `/user/new` API endpoint.

## Related Issues
- Related to #3942 (API implementation, merged)
- Related to #18524 (email notification fix, merged)

## Changes
- Modified `ui/litellm-dashboard/src/components/create_user_button.tsx`:
  - Added `Switch` import from antd
  - Added `send_invite_email` to the form type signature
  - Added new Form.Item with Switch component between "User Email" and "Global Proxy Role" fields
<img width="1035" height="275" alt="image" src="https://github.com/user-attachments/assets/fb79ff8f-21bb-4f33-a9e4-85368e337fe1" />

## Test Plan
- [x] Existing unit tests pass (193/193)
- [x] Manual testing: Verify toggle appears in Invite User modal
- [x] Manual testing: Verify API receives `send_invite_email` parameter correctly

## Screenshots
The new toggle appears in the Invite User modal, positioned after the User Email field.
<img width="1257" height="739" alt="image" src="https://github.com/user-attachments/assets/4e1c151f-a756-4fa0-b51a-d90c048a1825" />
