### PR TITLE
[Feat] New LiteLLM Policy engine - create policies to manage guardrails, conditions - permissions per Key, Team

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/guardrail_policies.md
+++ b/docs/my-website/docs/proxy/guardrails/guardrail_policies.md
@@ -1,0 +1,244 @@
+# Guardrail Policies
+
+Use policies to group guardrails and control which ones run for specific teams, keys, or models.
+
+## Why use policies?
+
+- Enable/disable specific guardrails for teams, keys, or models
+- Group guardrails into a single policy
+- Inherit from existing policies and override what you need
+
+## Quick Start
+
+### 1. Define your guardrails
+
+```yaml showLineNumbers title="config.yaml"
+guardrails:
+  - guardrail_name: pii_masking
+    litellm_params:
+      guardrail: presidio
+      mode: pre_call
+
+  - guardrail_name: prompt_injection
+    litellm_params:
+      guardrail: lakera
+      mode: pre_call
+      api_key: os.environ/LAKERA_API_KEY
+```
+
+### 2. Create a policy
+
+```yaml showLineNumbers title="config.yaml"
+policies:
+  my-policy:
+    guardrails:
+      add:
+        - pii_masking
+        - prompt_injection
+```
+
+### 3. Attach the policy
+
+```yaml showLineNumbers title="config.yaml"
+policy_attachments:
+  - policy: my-policy
+    scope: "*"  # apply to all requests
+```
+
+Response headers show what ran:
+
+```
+x-litellm-applied-policies: my-policy
+x-litellm-applied-guardrails: pii_masking,prompt_injection
+```
+
+## Add guardrails for a specific team
+
+You have a global baseline, but want to add extra guardrails for a specific team.
+
+```yaml showLineNumbers title="config.yaml"
+policies:
+  global-baseline:
+    guardrails:
+      add:
+        - pii_masking
+
+  finance-team-policy:
+    inherit: global-baseline
+    guardrails:
+      add:
+        - strict_compliance_check
+        - audit_logger
+
+policy_attachments:
+  - policy: global-baseline
+    scope: "*"
+
+  - policy: finance-team-policy
+    teams:
+      - finance  # team alias from /team/new
+```
+
+Now the `finance` team gets `pii_masking` + `strict_compliance_check` + `audit_logger`, while everyone else just gets `pii_masking`.
+
+## Remove guardrails for a specific team
+
+You have guardrails running globally, but want to disable some for a specific team (e.g., internal testing).
+
+```yaml showLineNumbers title="config.yaml"
+policies:
+  global-baseline:
+    guardrails:
+      add:
+        - pii_masking
+        - prompt_injection
+
+  internal-team-policy:
+    inherit: global-baseline
+    guardrails:
+      remove:
+        - pii_masking  # don't need PII masking for internal testing
+
+policy_attachments:
+  - policy: global-baseline
+    scope: "*"
+
+  - policy: internal-team-policy
+    teams:
+      - internal-testing  # team alias from /team/new
+```
+
+Now the `internal-testing` team only gets `prompt_injection`, while everyone else gets both guardrails.
+
+## Inheritance
+
+Start with a base policy and build on it:
+
+```yaml showLineNumbers title="config.yaml"
+policies:
+  base:
+    guardrails:
+      add:
+        - pii_masking
+        - toxicity_filter
+
+  strict:
+    inherit: base
+    guardrails:
+      add:
+        - prompt_injection
+
+  relaxed:
+    inherit: base
+    guardrails:
+      remove:
+        - toxicity_filter
+```
+
+What you get:
+- `base` → `[pii_masking, toxicity_filter]`
+- `strict` → `[pii_masking, toxicity_filter, prompt_injection]`
+- `relaxed` → `[pii_masking]`
+
+## Model Conditions
+
+Run guardrails only for specific models:
+
+```yaml showLineNumbers title="config.yaml"
+policies:
+  gpt4-safety:
+    guardrails:
+      add:
+        - strict_content_filter
+    condition:
+      model: "gpt-4.*"  # regex - matches gpt-4, gpt-4-turbo, gpt-4o
+
+  bedrock-compliance:
+    guardrails:
+      add:
+        - audit_logger
+    condition:
+      model:  # exact match list
+        - bedrock/claude-3
+        - bedrock/claude-2
+```
+
+## Attachments
+
+Policies don't do anything until you attach them. Attachments tell LiteLLM *where* to apply each policy.
+
+**Global** - runs on every request:
+
+```yaml showLineNumbers title="config.yaml"
+policy_attachments:
+  - policy: default
+    scope: "*"
+```
+
+**Team-specific** (uses team alias from `/team/new`):
+
+```yaml showLineNumbers title="config.yaml"
+policy_attachments:
+  - policy: hipaa-compliance
+    teams:
+      - healthcare-team  # team alias
+      - medical-research  # team alias
+```
+
+**Key-specific** (uses key alias from `/key/generate`, wildcards supported):
+
+```yaml showLineNumbers title="config.yaml"
+policy_attachments:
+  - policy: internal-testing
+    keys:
+      - "dev-*"  # key alias pattern
+      - "test-*"  # key alias pattern
+```
+
+## Config Reference
+
+### `policies`
+
+```yaml
+policies:
+  <policy-name>:
+    description: ...
+    inherit: ...
+    guardrails:
+      add: [...]
+      remove: [...]
+    condition:
+      model: ...
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | `string` | Optional. What this policy does. |
+| `inherit` | `string` | Optional. Parent policy to inherit guardrails from. |
+| `guardrails.add` | `list[string]` | Guardrails to enable. |
+| `guardrails.remove` | `list[string]` | Guardrails to disable (useful with inheritance). |
+| `condition.model` | `string` or `list[string]` | Optional. Only apply when model matches. Supports regex. |
+
+### `policy_attachments`
+
+```yaml
+policy_attachments:
+  - policy: ...
+    scope: ...
+    teams: [...]
+    keys: [...]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `policy` | `string` | **Required.** Name of the policy to attach. |
+| `scope` | `string` | Use `"*"` to apply globally. |
+| `teams` | `list[string]` | Team aliases (from `/team/new`). |
+| `keys` | `list[string]` | Key aliases (from `/key/generate`). Supports `*` wildcard. |
+
+### Response Headers
+
+| Header | Description |
+|--------|-------------|
+| `x-litellm-applied-policies` | Policies that matched this request |
+| `x-litellm-applied-guardrails` | Guardrails that actually ran |

--- a/docs/my-website/docs/proxy/guardrails/quick_start.md
+++ b/docs/my-website/docs/proxy/guardrails/quick_start.md
@@ -203,8 +203,12 @@ Your response headers will include `x-litellm-applied-guardrails` with the guard
 x-litellm-applied-guardrails: aporia-pre-guard
 ```
 
+### Guardrail Policies
 
-
+Need more control? Use [Guardrail Policies](./guardrail_policies.md) to:
+- Group guardrails into reusable policies
+- Enable/disable guardrails for specific teams, keys, or models
+- Inherit from existing policies and override specific guardrails
 
 ## **Using Guardrails Client Side**
 

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -42,6 +42,7 @@ const sidebars = {
       label: "Guardrails",
       items: [
         "proxy/guardrails/quick_start",
+        "proxy/guardrails/guardrail_policies",
         "proxy/guardrails/guardrail_load_balancing",
         {
           type: "category",

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -376,7 +376,8 @@ public_model_groups_links: Dict[str, Union[str, Dict[str, Any]]] = {}
 priority_reservation: Optional[
     Dict[str, Union[float, "PriorityReservationDict"]]
 ] = None
-# priority_reservation_settings is lazy-loaded via __getattr__
+# priority_reservation_settings is lazy-loaded via __getattr__, but declared here for type checking
+priority_reservation_settings: Optional["PriorityReservationSettings"] = None
 
 
 ######## Networking Settings ########
@@ -1273,6 +1274,7 @@ def set_global_gitlab_config(config: Dict[str, Any]) -> None:
 
 if TYPE_CHECKING:
     from litellm.types.utils import ModelInfo as _ModelInfoType
+    from litellm.types.utils import PriorityReservationSettings
     from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
     from litellm.caching.caching import Cache
 

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -376,8 +376,10 @@ public_model_groups_links: Dict[str, Union[str, Dict[str, Any]]] = {}
 priority_reservation: Optional[
     Dict[str, Union[float, "PriorityReservationDict"]]
 ] = None
-# priority_reservation_settings is lazy-loaded via __getattr__, but declared here for type checking
-priority_reservation_settings: Optional["PriorityReservationSettings"] = None
+# priority_reservation_settings is lazy-loaded via __getattr__
+# Only declare for type checking - at runtime __getattr__ handles it
+if TYPE_CHECKING:
+    priority_reservation_settings: Optional["PriorityReservationSettings"] = None
 
 
 ######## Networking Settings ########

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -16094,6 +16094,181 @@
         "output_cost_per_token": 0.0,
         "output_vector_size": 2560
     },
+    "gmi/anthropic/claude-opus-4.5": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 409600,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "supports_function_calling": true,
+        "supports_vision": true
+    },
+    "gmi/anthropic/claude-sonnet-4.5": {
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 409600,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_vision": true
+    },
+    "gmi/anthropic/claude-sonnet-4": {
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 409600,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_vision": true
+    },
+    "gmi/anthropic/claude-opus-4": {
+        "input_cost_per_token": 1.5e-05,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 409600,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-05,
+        "supports_function_calling": true,
+        "supports_vision": true
+    },
+    "gmi/openai/gpt-5.2": {
+        "input_cost_per_token": 1.75e-06,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 409600,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "supports_function_calling": true
+    },
+    "gmi/openai/gpt-5.1": {
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 409600,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true
+    },
+    "gmi/openai/gpt-5": {
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 409600,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true
+    },
+    "gmi/openai/gpt-4o": {
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true,
+        "supports_vision": true
+    },
+    "gmi/openai/gpt-4o-mini": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_function_calling": true,
+        "supports_vision": true
+    },
+    "gmi/deepseek-ai/DeepSeek-V3.2": {
+        "input_cost_per_token": 2.8e-07,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "supports_function_calling": true
+    },
+    "gmi/deepseek-ai/DeepSeek-V3-0324": {
+        "input_cost_per_token": 2.8e-07,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 8.8e-07,
+        "supports_function_calling": true
+    },
+    "gmi/google/gemini-3-pro-preview": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-05,
+        "supports_function_calling": true,
+        "supports_vision": true
+    },
+    "gmi/google/gemini-3-flash-preview": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "supports_function_calling": true,
+        "supports_vision": true
+    },
+    "gmi/moonshotai/Kimi-K2-Thinking": {
+        "input_cost_per_token": 8e-07,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06
+    },
+    "gmi/MiniMaxAI/MiniMax-M2.1": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 196608,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06
+    },
+    "gmi/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-06,
+        "supports_vision": true
+    },
+    "gmi/zai-org/GLM-4.7-FP8": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "gmi",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06
+    },
     "google.gemma-3-12b-it": {
         "input_cost_per_token": 9e-08,
         "litellm_provider": "bedrock_converse",

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -380,6 +380,11 @@ def get_logging_caching_headers(request_data: Dict) -> Optional[Dict]:
             _metadata["applied_guardrails"]
         )
 
+    if "applied_policies" in _metadata:
+        headers["x-litellm-applied-policies"] = ",".join(
+            _metadata["applied_policies"]
+        )
+
     if "semantic-similarity" in _metadata:
         headers["x-litellm-semantic-similarity"] = str(_metadata["semantic-similarity"])
 
@@ -402,6 +407,27 @@ def add_guardrail_to_applied_guardrails_header(
         _metadata["applied_guardrails"].append(guardrail_name)
     else:
         _metadata["applied_guardrails"] = [guardrail_name]
+    # Ensure metadata is set back to request_data (important when metadata didn't exist)
+    request_data["metadata"] = _metadata
+
+
+def add_policy_to_applied_policies_header(
+    request_data: Dict, policy_name: Optional[str]
+):
+    """
+    Add a policy name to the applied_policies list in request metadata.
+
+    This is used to track which policies were applied to a request,
+    similar to how applied_guardrails tracks guardrails.
+    """
+    if policy_name is None:
+        return
+    _metadata = request_data.get("metadata", None) or {}
+    if "applied_policies" in _metadata:
+        if policy_name not in _metadata["applied_policies"]:
+            _metadata["applied_policies"].append(policy_name)
+    else:
+        _metadata["applied_policies"] = [policy_name]
     # Ensure metadata is set back to request_data (important when metadata didn't exist)
     request_data["metadata"] = _metadata
 

--- a/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
@@ -4,7 +4,7 @@ Dynamic rate limiter v3 - Saturation-aware priority-based rate limiting
 
 import os
 from datetime import datetime
-from typing import Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 from fastapi import HTTPException
 
@@ -23,6 +23,25 @@ from litellm.proxy.hooks.rate_limiter_utils import convert_priority_to_percent
 from litellm.proxy.utils import InternalUsageCache
 from litellm.types.router import ModelGroupInfo
 from litellm.types.utils import CallTypesLiteral
+
+if TYPE_CHECKING:
+    from litellm.types.utils import PriorityReservationSettings
+
+
+def _get_priority_settings() -> "PriorityReservationSettings":
+    """
+    Get the priority reservation settings, guaranteed to be non-None.
+
+    The settings are lazy-loaded in litellm.__init__ and always return an instance.
+    This helper provides proper type narrowing for mypy.
+    """
+    settings = litellm.priority_reservation_settings
+    if settings is None:
+        # This should never happen due to lazy loading, but satisfy mypy
+        from litellm.types.utils import PriorityReservationSettings
+
+        return PriorityReservationSettings()
+    return settings
 
 
 class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
@@ -60,7 +79,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
 
     def _get_saturation_check_cache_ttl(self) -> int:
         """Get the configurable TTL for local cache when reading saturation values."""
-        return litellm.priority_reservation_settings.saturation_check_cache_ttl
+        return _get_priority_settings().saturation_check_cache_ttl
 
     async def _get_saturation_value_from_cache(
         self,
@@ -91,7 +110,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         self, priority: Optional[str], model_info: Optional[ModelGroupInfo] = None
     ) -> float:
         """Get the weight for a given priority from litellm.priority_reservation"""
-        weight: float = litellm.priority_reservation_settings.default_priority
+        weight: float = _get_priority_settings().default_priority
         if (
             litellm.priority_reservation is None
             or priority not in litellm.priority_reservation
@@ -201,7 +220,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
             priority_key = f"{model}:{priority}"
         else:
             # No explicit priority: share the default_priority pool with ALL other default keys
-            priority_weight = litellm.priority_reservation_settings.default_priority
+            priority_weight = _get_priority_settings().default_priority
             # Use shared key for all default-priority requests
             priority_key = f"{model}:default_pool"
 
@@ -418,9 +437,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         """
         import json
 
-        saturation_threshold = (
-            litellm.priority_reservation_settings.saturation_threshold
-        )
+        saturation_threshold = _get_priority_settings().saturation_threshold
         should_enforce_priority = saturation >= saturation_threshold
 
         # Build ALL descriptors upfront
@@ -593,9 +610,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
             # STEP 1: Check current saturation level
             saturation = await self._check_model_saturation(model, model_group_info)
 
-            saturation_threshold = (
-                litellm.priority_reservation_settings.saturation_threshold
-            )
+            saturation_threshold = _get_priority_settings().saturation_threshold
 
             verbose_proxy_logger.debug(
                 f"[Dynamic Rate Limiter] Model={model}, Saturation={saturation:.1%}, "

--- a/litellm/proxy/management_endpoints/policy_endpoints.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints.py
@@ -185,9 +185,9 @@ async def get_policy_info(
         policy_name=policy_name,
         inherit=policy.inherit,
         scope=PolicyScopeResponse(
-            teams=policy.scope.get_teams(),
-            keys=policy.scope.get_keys(),
-            models=policy.scope.get_models(),
+            teams=[],
+            keys=[],
+            models=[],
         ),
         guardrails=PolicyGuardrailsResponse(
             add=policy.guardrails.get_add(),
@@ -245,9 +245,7 @@ async def test_policy_matching(
     policies = registry.get_all_policies()
 
     # Get matching policies
-    matching_policy_names = PolicyMatcher.get_matching_policies(
-        policies=policies, context=context
-    )
+    matching_policy_names = PolicyMatcher.get_matching_policies(context=context)
 
     # Resolve guardrails
     resolved_guardrails = PolicyResolver.resolve_guardrails_for_context(

--- a/litellm/proxy/management_endpoints/policy_endpoints.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints.py
@@ -1,0 +1,243 @@
+"""
+POLICY MANAGEMENT
+
+All /policy management endpoints
+
+/policy/validate - Validate a policy configuration
+/policy/list - List all loaded policies
+/policy/info - Get information about a specific policy
+"""
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.management_helpers.utils import management_endpoint_wrapper
+from litellm.types.proxy.policy_engine import (
+    PolicyMatchContext,
+    PolicyValidateRequest,
+    PolicyValidationResponse,
+    ResolvedPolicy,
+)
+
+router = APIRouter()
+
+
+@router.post(
+    "/policy/validate",
+    tags=["policy management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=PolicyValidationResponse,
+)
+@management_endpoint_wrapper
+async def validate_policy(
+    request: Request,
+    data: PolicyValidateRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+) -> PolicyValidationResponse:
+    """
+    Validate a policy configuration before applying it.
+
+    Checks:
+    - All referenced guardrails exist in the guardrail registry
+    - All non-wildcard team aliases exist in the database
+    - All non-wildcard key aliases exist in the database
+    - Inheritance chains are valid (no cycles, parents exist)
+    - Scope patterns are syntactically valid
+
+    Returns:
+    - valid: True if the policy configuration is valid (no blocking errors)
+    - errors: List of blocking validation errors
+    - warnings: List of non-blocking validation warnings
+
+    Example request:
+    ```json
+    {
+        "policies": {
+            "global-baseline": {
+                "guardrails": {
+                    "add": ["pii_blocker", "phi_blocker"]
+                },
+                "scope": {
+                    "teams": ["*"],
+                    "keys": ["*"],
+                    "models": ["*"]
+                }
+            },
+            "healthcare-compliance": {
+                "inherit": "global-baseline",
+                "guardrails": {
+                    "add": ["hipaa_audit"]
+                },
+                "scope": {
+                    "teams": ["healthcare-team"]
+                }
+            }
+        }
+    }
+    ```
+    """
+    from litellm.proxy.policy_engine.policy_validator import PolicyValidator
+    from litellm.proxy.proxy_server import prisma_client
+
+    verbose_proxy_logger.debug(
+        f"Validating policy configuration with {len(data.policies)} policies"
+    )
+
+    validator = PolicyValidator(prisma_client=prisma_client)
+
+    result = await validator.validate_policy_config(
+        data.policies,
+        validate_db=prisma_client is not None,
+    )
+
+    return result
+
+
+@router.get(
+    "/policy/list",
+    tags=["policy management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+@management_endpoint_wrapper
+async def list_policies(
+    request: Request,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+) -> Dict[str, Any]:
+    """
+    List all loaded policies with their resolved guardrails.
+
+    Returns information about each policy including:
+    - Inheritance configuration
+    - Scope (teams, keys, models)
+    - Guardrails to add/remove
+    - Resolved guardrails (after inheritance)
+    - Inheritance chain
+    """
+    from litellm.proxy.policy_engine.init_policies import get_policies_summary
+
+    return get_policies_summary()
+
+
+@router.get(
+    "/policy/info/{policy_name}",
+    tags=["policy management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+@management_endpoint_wrapper
+async def get_policy_info(
+    request: Request,
+    policy_name: str,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+) -> Dict[str, Any]:
+    """
+    Get detailed information about a specific policy.
+
+    Returns:
+    - Policy configuration
+    - Resolved guardrails (after inheritance)
+    - Inheritance chain
+    """
+    from litellm.proxy.policy_engine.policy_registry import get_policy_registry
+    from litellm.proxy.policy_engine.policy_resolver import PolicyResolver
+
+    registry = get_policy_registry()
+
+    if not registry.is_initialized():
+        raise HTTPException(
+            status_code=404,
+            detail="Policy engine not initialized. No policies loaded.",
+        )
+
+    policy = registry.get_policy(policy_name)
+    if policy is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Policy '{policy_name}' not found",
+        )
+
+    resolved = PolicyResolver.resolve_policy_guardrails(
+        policy_name, registry.get_all_policies()
+    )
+
+    return {
+        "policy_name": policy_name,
+        "inherit": policy.inherit,
+        "scope": {
+            "teams": policy.scope.get_teams(),
+            "keys": policy.scope.get_keys(),
+            "models": policy.scope.get_models(),
+        },
+        "guardrails": {
+            "add": policy.guardrails.get_add(),
+            "remove": policy.guardrails.get_remove(),
+        },
+        "resolved_guardrails": resolved.guardrails,
+        "inheritance_chain": resolved.inheritance_chain,
+    }
+
+
+@router.post(
+    "/policy/test",
+    tags=["policy management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+@management_endpoint_wrapper
+async def test_policy_matching(
+    request: Request,
+    context: PolicyMatchContext,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+) -> Dict[str, Any]:
+    """
+    Test which policies would match a given request context.
+
+    This is useful for debugging and understanding policy behavior.
+
+    Request body:
+    ```json
+    {
+        "team_alias": "healthcare-team",
+        "key_alias": "my-api-key",
+        "model": "gpt-4"
+    }
+    ```
+
+    Returns:
+    - matching_policies: List of policy names that match
+    - resolved_guardrails: Final list of guardrails that would be applied
+    """
+    from litellm.proxy.policy_engine.policy_matcher import PolicyMatcher
+    from litellm.proxy.policy_engine.policy_registry import get_policy_registry
+    from litellm.proxy.policy_engine.policy_resolver import PolicyResolver
+
+    registry = get_policy_registry()
+
+    if not registry.is_initialized():
+        return {
+            "matching_policies": [],
+            "resolved_guardrails": [],
+            "message": "Policy engine not initialized. No policies loaded.",
+        }
+
+    policies = registry.get_all_policies()
+
+    # Get matching policies
+    matching_policy_names = PolicyMatcher.get_matching_policies(policies, context)
+
+    # Resolve guardrails
+    resolved_guardrails = PolicyResolver.resolve_guardrails_for_context(
+        context, policies
+    )
+
+    return {
+        "context": {
+            "team_alias": context.team_alias,
+            "key_alias": context.key_alias,
+            "model": context.model,
+        },
+        "matching_policies": matching_policy_names,
+        "resolved_guardrails": resolved_guardrails,
+    }

--- a/litellm/proxy/policy_engine/__init__.py
+++ b/litellm/proxy/policy_engine/__init__.py
@@ -1,0 +1,23 @@
+"""
+LiteLLM Policy Engine
+
+The Policy Engine allows administrators to define policies that combine guardrails
+with scoping rules. Policies can target specific teams, API keys, and models using
+wildcard patterns, and support inheritance from base policies.
+"""
+
+from litellm.proxy.policy_engine.policy_matcher import PolicyMatcher
+from litellm.proxy.policy_engine.policy_registry import (
+    PolicyRegistry,
+    get_policy_registry,
+)
+from litellm.proxy.policy_engine.policy_resolver import PolicyResolver
+from litellm.proxy.policy_engine.policy_validator import PolicyValidator
+
+__all__ = [
+    "PolicyRegistry",
+    "get_policy_registry",
+    "PolicyMatcher",
+    "PolicyResolver",
+    "PolicyValidator",
+]

--- a/litellm/proxy/policy_engine/__init__.py
+++ b/litellm/proxy/policy_engine/__init__.py
@@ -4,8 +4,43 @@ LiteLLM Policy Engine
 The Policy Engine allows administrators to define policies that combine guardrails
 with scoping rules. Policies can target specific teams, API keys, and models using
 wildcard patterns, and support inheritance from base policies.
+
+Configuration structure:
+- `policies`: Define WHAT guardrails to apply (with inheritance and statements)
+- `policy_attachments`: Define WHERE policies apply (teams, keys, models)
+
+Example:
+```yaml
+policies:
+  global-baseline:
+    description: "Base guardrails for all requests"
+    guardrails:
+      add: [pii_blocker]
+
+  healthcare-compliance:
+    inherit: global-baseline
+    guardrails:
+      add: [hipaa_audit]
+    statements:
+      - sid: "GPT4Only"
+        guardrails: [toxicity_filter]
+        condition:
+          model:
+            in: ["gpt-4", "gpt-4-turbo"]
+
+policy_attachments:
+  - policy: global-baseline
+    scope: "*"
+  - policy: healthcare-compliance
+    teams: [healthcare-team]
+```
 """
 
+from litellm.proxy.policy_engine.attachment_registry import (
+    AttachmentRegistry,
+    get_attachment_registry,
+)
+from litellm.proxy.policy_engine.condition_evaluator import ConditionEvaluator
 from litellm.proxy.policy_engine.policy_matcher import PolicyMatcher
 from litellm.proxy.policy_engine.policy_registry import (
     PolicyRegistry,
@@ -15,9 +50,14 @@ from litellm.proxy.policy_engine.policy_resolver import PolicyResolver
 from litellm.proxy.policy_engine.policy_validator import PolicyValidator
 
 __all__ = [
+    # Registries
     "PolicyRegistry",
     "get_policy_registry",
+    "AttachmentRegistry",
+    "get_attachment_registry",
+    # Core components
     "PolicyMatcher",
     "PolicyResolver",
     "PolicyValidator",
+    "ConditionEvaluator",
 ]

--- a/litellm/proxy/policy_engine/__init__.py
+++ b/litellm/proxy/policy_engine/__init__.py
@@ -6,7 +6,7 @@ with scoping rules. Policies can target specific teams, API keys, and models usi
 wildcard patterns, and support inheritance from base policies.
 
 Configuration structure:
-- `policies`: Define WHAT guardrails to apply (with inheritance and statements)
+- `policies`: Define WHAT guardrails to apply (with inheritance and conditions)
 - `policy_attachments`: Define WHERE policies apply (teams, keys, models)
 
 Example:
@@ -17,22 +17,19 @@ policies:
     guardrails:
       add: [pii_blocker]
 
-  healthcare-compliance:
+  gpt4-safety:
     inherit: global-baseline
+    description: "Extra safety for GPT-4"
     guardrails:
-      add: [hipaa_audit]
-    statements:
-      - sid: "GPT4Only"
-        guardrails: [toxicity_filter]
-        condition:
-          model:
-            in: ["gpt-4", "gpt-4-turbo"]
+      add: [toxicity_filter]
+    condition:
+      model: "gpt-4.*"  # regex pattern
 
 policy_attachments:
   - policy: global-baseline
     scope: "*"
-  - policy: healthcare-compliance
-    teams: [healthcare-team]
+  - policy: gpt4-safety
+    scope: "*"
 ```
 """
 

--- a/litellm/proxy/policy_engine/architecture.md
+++ b/litellm/proxy/policy_engine/architecture.md
@@ -1,0 +1,54 @@
+# Policy Engine Architecture
+
+## Overview
+
+The Policy Engine allows administrators to define policies that combine guardrails with scoping rules. Policies can target specific teams, API keys, and models using wildcard patterns, and support inheritance from base policies.
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+    subgraph Config["config.yaml"]
+        PC[policies config]
+    end
+
+    subgraph PolicyEngine["Policy Engine"]
+        PR[PolicyRegistry]
+        PV[PolicyValidator]
+        PM[PolicyMatcher]
+        PRe[PolicyResolver]
+    end
+
+    subgraph Request["Incoming Request"]
+        CTX[Context: team_alias, key_alias, model]
+    end
+
+    subgraph Output["Output"]
+        GR[Guardrails to Apply]
+    end
+
+    PC -->|load| PR
+    PC -->|validate| PV
+    PV -->|errors/warnings| PR
+    
+    CTX -->|match| PM
+    PM -->|matching policies| PRe
+    PR -->|policies| PM
+    PR -->|policies| PRe
+    PRe -->|resolve inheritance + add/remove| GR
+```
+
+## Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| **PolicyRegistry** | `policy_registry.py` | In-memory singleton store for parsed policies |
+| **PolicyValidator** | `policy_validator.py` | Validates configs (guardrails, inheritance, teams/keys/models) |
+| **PolicyMatcher** | `policy_matcher.py` | Matches request context against policy scopes |
+| **PolicyResolver** | `policy_resolver.py` | Resolves final guardrails via inheritance chain |
+
+## Flow
+
+1. **Startup**: `init_policies()` loads policies from config, validates, and populates `PolicyRegistry`
+2. **Request**: `PolicyMatcher` finds policies matching the request's team/key/model
+3. **Resolution**: `PolicyResolver` traverses inheritance and applies add/remove to get final guardrails

--- a/litellm/proxy/policy_engine/attachment_registry.py
+++ b/litellm/proxy/policy_engine/attachment_registry.py
@@ -11,7 +11,6 @@ from litellm._logging import verbose_proxy_logger
 from litellm.types.proxy.policy_engine import (
     PolicyAttachment,
     PolicyMatchContext,
-    PolicyScope,
 )
 
 

--- a/litellm/proxy/policy_engine/attachment_registry.py
+++ b/litellm/proxy/policy_engine/attachment_registry.py
@@ -1,0 +1,207 @@
+"""
+Attachment Registry - Manages policy attachments from YAML config.
+
+Attachments define WHERE policies apply, separate from the policy definitions.
+This allows the same policy to be attached to multiple scopes.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from litellm._logging import verbose_proxy_logger
+from litellm.types.proxy.policy_engine import (
+    PolicyAttachment,
+    PolicyMatchContext,
+    PolicyScope,
+)
+
+
+class AttachmentRegistry:
+    """
+    In-memory registry for storing and managing policy attachments.
+
+    Attachments define the relationship between policies and their scopes.
+    A single policy can have multiple attachments (applied to different scopes).
+
+    Example YAML:
+    ```yaml
+    attachments:
+      - policy: global-baseline
+        scope: "*"
+      - policy: healthcare-compliance
+        teams: [healthcare-team]
+      - policy: dev-safety
+        keys: ["dev-key-*"]
+    ```
+    """
+
+    def __init__(self):
+        self._attachments: List[PolicyAttachment] = []
+        self._initialized: bool = False
+
+    def load_attachments(self, attachments_config: List[Dict[str, Any]]) -> None:
+        """
+        Load attachments from a configuration list.
+
+        Args:
+            attachments_config: List of attachment dictionaries from YAML.
+        """
+        self._attachments = []
+
+        for attachment_data in attachments_config:
+            try:
+                attachment = self._parse_attachment(attachment_data)
+                self._attachments.append(attachment)
+                verbose_proxy_logger.debug(
+                    f"Loaded attachment for policy: {attachment.policy}"
+                )
+            except Exception as e:
+                verbose_proxy_logger.error(
+                    f"Error loading attachment: {str(e)}"
+                )
+                raise ValueError(f"Invalid attachment: {str(e)}") from e
+
+        self._initialized = True
+        verbose_proxy_logger.info(f"Loaded {len(self._attachments)} policy attachments")
+
+    def _parse_attachment(self, attachment_data: Dict[str, Any]) -> PolicyAttachment:
+        """
+        Parse an attachment from raw configuration data.
+
+        Args:
+            attachment_data: Raw attachment configuration
+
+        Returns:
+            Parsed PolicyAttachment object
+        """
+        return PolicyAttachment(
+            policy=attachment_data.get("policy", ""),
+            scope=attachment_data.get("scope"),
+            teams=attachment_data.get("teams"),
+            keys=attachment_data.get("keys"),
+            models=attachment_data.get("models"),
+        )
+
+    def get_attached_policies(self, context: PolicyMatchContext) -> List[str]:
+        """
+        Get list of policy names attached to the given context.
+
+        Args:
+            context: The request context to match against
+
+        Returns:
+            List of policy names that are attached to matching scopes
+        """
+        from litellm.proxy.policy_engine.policy_matcher import PolicyMatcher
+
+        attached_policies: List[str] = []
+
+        for attachment in self._attachments:
+            scope = attachment.to_policy_scope()
+            if PolicyMatcher.scope_matches(scope=scope, context=context):
+                if attachment.policy not in attached_policies:
+                    attached_policies.append(attachment.policy)
+                    verbose_proxy_logger.debug(
+                        f"Attachment matched: policy={attachment.policy}, "
+                        f"context=(team={context.team_alias}, key={context.key_alias}, model={context.model})"
+                    )
+
+        return attached_policies
+
+    def is_policy_attached(
+        self, policy_name: str, context: PolicyMatchContext
+    ) -> bool:
+        """
+        Check if a specific policy is attached to the given context.
+
+        Args:
+            policy_name: Name of the policy to check
+            context: The request context to match against
+
+        Returns:
+            True if the policy is attached to a matching scope
+        """
+        attached = self.get_attached_policies(context)
+        return policy_name in attached
+
+    def get_all_attachments(self) -> List[PolicyAttachment]:
+        """
+        Get all loaded attachments.
+
+        Returns:
+            List of all PolicyAttachment objects
+        """
+        return self._attachments.copy()
+
+    def get_attachments_for_policy(self, policy_name: str) -> List[PolicyAttachment]:
+        """
+        Get all attachments for a specific policy.
+
+        Args:
+            policy_name: Name of the policy
+
+        Returns:
+            List of attachments for the policy
+        """
+        return [a for a in self._attachments if a.policy == policy_name]
+
+    def is_initialized(self) -> bool:
+        """
+        Check if the registry has been initialized with attachments.
+
+        Returns:
+            True if attachments have been loaded, False otherwise
+        """
+        return self._initialized
+
+    def clear(self) -> None:
+        """
+        Clear all attachments from the registry.
+        """
+        self._attachments = []
+        self._initialized = False
+
+    def add_attachment(self, attachment: PolicyAttachment) -> None:
+        """
+        Add a single attachment.
+
+        Args:
+            attachment: PolicyAttachment object to add
+        """
+        self._attachments.append(attachment)
+        verbose_proxy_logger.debug(f"Added attachment for policy: {attachment.policy}")
+
+    def remove_attachments_for_policy(self, policy_name: str) -> int:
+        """
+        Remove all attachments for a specific policy.
+
+        Args:
+            policy_name: Name of the policy
+
+        Returns:
+            Number of attachments removed
+        """
+        original_count = len(self._attachments)
+        self._attachments = [a for a in self._attachments if a.policy != policy_name]
+        removed_count = original_count - len(self._attachments)
+        if removed_count > 0:
+            verbose_proxy_logger.debug(
+                f"Removed {removed_count} attachment(s) for policy: {policy_name}"
+            )
+        return removed_count
+
+
+# Global singleton instance
+_attachment_registry: Optional[AttachmentRegistry] = None
+
+
+def get_attachment_registry() -> AttachmentRegistry:
+    """
+    Get the global AttachmentRegistry singleton.
+
+    Returns:
+        The global AttachmentRegistry instance
+    """
+    global _attachment_registry
+    if _attachment_registry is None:
+        _attachment_registry = AttachmentRegistry()
+    return _attachment_registry

--- a/litellm/proxy/policy_engine/condition_evaluator.py
+++ b/litellm/proxy/policy_engine/condition_evaluator.py
@@ -1,0 +1,217 @@
+"""
+Condition Evaluator - Evaluates AWS IAM-style conditions.
+
+Supports operators like equals, in, prefix, not_equals, not_in for
+fine-grained policy statement matching.
+"""
+
+from typing import Any, Dict, Optional
+
+from litellm._logging import verbose_proxy_logger
+from litellm.types.proxy.policy_engine import (
+    ConditionOperator,
+    PolicyCondition,
+    PolicyMatchContext,
+)
+
+
+class ConditionEvaluator:
+    """
+    Evaluates policy conditions against request context.
+
+    Supports AWS IAM-style condition operators:
+    - equals: Exact string match
+    - in: Value must be in the list
+    - prefix: Value must start with the prefix
+    - not_equals: Value must NOT equal
+    - not_in: Value must NOT be in the list
+
+    All conditions in a PolicyCondition must match (AND logic).
+    """
+
+    @staticmethod
+    def evaluate(
+        condition: Optional[PolicyCondition],
+        context: PolicyMatchContext,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """
+        Evaluate a policy condition against a request context.
+
+        Args:
+            condition: The condition to evaluate (None = always matches)
+            context: The request context with team, key, model
+            metadata: Optional request metadata for metadata conditions
+
+        Returns:
+            True if condition matches, False otherwise
+        """
+        # No condition means always matches
+        if condition is None:
+            return True
+
+        # Check model condition
+        if condition.model is not None:
+            if not ConditionEvaluator.evaluate_operator(
+                operator=condition.model,
+                value=context.model,
+            ):
+                verbose_proxy_logger.debug(
+                    f"Condition failed: model={context.model} did not match {condition.model}"
+                )
+                return False
+
+        # Check team condition
+        if condition.team is not None:
+            if not ConditionEvaluator.evaluate_operator(
+                operator=condition.team,
+                value=context.team_alias,
+            ):
+                verbose_proxy_logger.debug(
+                    f"Condition failed: team={context.team_alias} did not match {condition.team}"
+                )
+                return False
+
+        # Check key condition
+        if condition.key is not None:
+            if not ConditionEvaluator.evaluate_operator(
+                operator=condition.key,
+                value=context.key_alias,
+            ):
+                verbose_proxy_logger.debug(
+                    f"Condition failed: key={context.key_alias} did not match {condition.key}"
+                )
+                return False
+
+        # Check metadata conditions
+        if condition.metadata is not None and metadata is not None:
+            for field_name, field_operator in condition.metadata.items():
+                field_value = metadata.get(field_name)
+                # Convert to string for comparison
+                field_value_str = str(field_value) if field_value is not None else None
+                if not ConditionEvaluator.evaluate_operator(
+                    operator=field_operator,
+                    value=field_value_str,
+                ):
+                    verbose_proxy_logger.debug(
+                        f"Condition failed: metadata.{field_name}={field_value} "
+                        f"did not match {field_operator}"
+                    )
+                    return False
+
+        return True
+
+    @staticmethod
+    def evaluate_operator(
+        operator: ConditionOperator,
+        value: Optional[str],
+    ) -> bool:
+        """
+        Evaluate a single condition operator against a value.
+
+        Args:
+            operator: The condition operator to evaluate
+            value: The value to check (None if not provided)
+
+        Returns:
+            True if the value matches the operator, False otherwise
+        """
+        # Handle None value
+        if value is None:
+            # For positive operators (equals, in, prefix), None never matches
+            if operator.equals is not None:
+                return False
+            if operator.in_ is not None:
+                return False
+            if operator.prefix is not None:
+                return False
+            # For negative operators (not_equals, not_in), None always matches
+            # (None is not equal to anything, and not in any list)
+            if operator.not_equals is not None:
+                return True
+            if operator.not_in is not None:
+                return True
+            # No operators specified = matches
+            return True
+
+        # Check equals
+        if operator.equals is not None:
+            if value != operator.equals:
+                return False
+
+        # Check in (value must be in list)
+        if operator.in_ is not None:
+            if value not in operator.in_:
+                return False
+
+        # Check prefix
+        if operator.prefix is not None:
+            if not value.startswith(operator.prefix):
+                return False
+
+        # Check not_equals
+        if operator.not_equals is not None:
+            if value == operator.not_equals:
+                return False
+
+        # Check not_in
+        if operator.not_in is not None:
+            if value in operator.not_in:
+                return False
+
+        return True
+
+    @staticmethod
+    def evaluate_all_conditions(
+        conditions: list,
+        context: PolicyMatchContext,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """
+        Evaluate multiple conditions (AND logic - all must match).
+
+        Args:
+            conditions: List of PolicyCondition objects
+            context: The request context
+            metadata: Optional request metadata
+
+        Returns:
+            True if ALL conditions match, False otherwise
+        """
+        for condition in conditions:
+            if not ConditionEvaluator.evaluate(
+                condition=condition,
+                context=context,
+                metadata=metadata,
+            ):
+                return False
+        return True
+
+    @staticmethod
+    def evaluate_any_condition(
+        conditions: list,
+        context: PolicyMatchContext,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """
+        Evaluate multiple conditions (OR logic - any must match).
+
+        Args:
+            conditions: List of PolicyCondition objects
+            context: The request context
+            metadata: Optional request metadata
+
+        Returns:
+            True if ANY condition matches, False otherwise
+        """
+        if not conditions:
+            return True
+
+        for condition in conditions:
+            if ConditionEvaluator.evaluate(
+                condition=condition,
+                context=context,
+                metadata=metadata,
+            ):
+                return True
+        return False

--- a/litellm/proxy/policy_engine/init_policies.py
+++ b/litellm/proxy/policy_engine/init_policies.py
@@ -1,0 +1,163 @@
+"""
+Policy Initialization - Loads policies from config and validates on startup.
+"""
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy.policy_engine.policy_registry import get_policy_registry
+from litellm.proxy.policy_engine.policy_validator import PolicyValidator
+from litellm.types.proxy.policy_engine import PolicyValidationResponse
+
+if TYPE_CHECKING:
+    from litellm.proxy.utils import PrismaClient
+
+
+async def init_policies(
+    policies_config: Dict[str, Any],
+    prisma_client: Optional["PrismaClient"] = None,
+    validate_db: bool = True,
+    fail_on_error: bool = True,
+) -> PolicyValidationResponse:
+    """
+    Initialize policies from configuration.
+
+    This function:
+    1. Parses the policy configuration
+    2. Validates policies (guardrails exist, teams/keys exist in DB)
+    3. Loads policies into the global registry
+
+    Args:
+        policies_config: Dictionary mapping policy names to policy definitions
+        prisma_client: Optional Prisma client for database validation
+        validate_db: Whether to validate team/key aliases against database
+        fail_on_error: If True, raise exception on validation errors
+
+    Returns:
+        PolicyValidationResponse with validation results
+
+    Raises:
+        ValueError: If fail_on_error is True and validation errors are found
+    """
+    verbose_proxy_logger.info(f"Initializing {len(policies_config)} policies...")
+
+    # Get the global registry
+    registry = get_policy_registry()
+
+    # Create validator
+    validator = PolicyValidator(prisma_client=prisma_client)
+
+    # Validate the configuration
+    validation_result = await validator.validate_policy_config(
+        policies_config,
+        validate_db=validate_db,
+    )
+
+    # Log validation results
+    if validation_result.errors:
+        for error in validation_result.errors:
+            verbose_proxy_logger.error(
+                f"Policy validation error in '{error.policy_name}': "
+                f"[{error.error_type}] {error.message}"
+            )
+
+    if validation_result.warnings:
+        for warning in validation_result.warnings:
+            verbose_proxy_logger.warning(
+                f"Policy validation warning in '{warning.policy_name}': "
+                f"[{warning.error_type}] {warning.message}"
+            )
+
+    # Fail if there are errors and fail_on_error is True
+    if not validation_result.valid and fail_on_error:
+        error_messages = [
+            f"[{e.policy_name}] {e.message}" for e in validation_result.errors
+        ]
+        raise ValueError(
+            f"Policy validation failed with {len(validation_result.errors)} error(s):\n"
+            + "\n".join(error_messages)
+        )
+
+    # Load policies into registry (even with warnings)
+    try:
+        registry.load_policies(policies_config)
+        verbose_proxy_logger.info(
+            f"Successfully loaded {len(policies_config)} policies"
+        )
+    except Exception as e:
+        verbose_proxy_logger.error(f"Failed to load policies: {str(e)}")
+        raise
+
+    return validation_result
+
+
+def init_policies_sync(
+    policies_config: Dict[str, Any],
+    fail_on_error: bool = True,
+) -> None:
+    """
+    Synchronous version of init_policies (without DB validation).
+
+    Use this when async is not available or DB validation is not needed.
+
+    Args:
+        policies_config: Dictionary mapping policy names to policy definitions
+        fail_on_error: If True, raise exception on validation errors
+    """
+    import asyncio
+
+    # Run the async function without DB validation
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    loop.run_until_complete(
+        init_policies(
+            policies_config=policies_config,
+            prisma_client=None,
+            validate_db=False,
+            fail_on_error=fail_on_error,
+        )
+    )
+
+
+def get_policies_summary() -> Dict[str, Any]:
+    """
+    Get a summary of loaded policies for debugging/display.
+
+    Returns:
+        Dictionary with policy information
+    """
+    from litellm.proxy.policy_engine.policy_resolver import PolicyResolver
+
+    registry = get_policy_registry()
+
+    if not registry.is_initialized():
+        return {"initialized": False, "policies": {}}
+
+    resolved = PolicyResolver.get_all_resolved_policies()
+
+    summary = {
+        "initialized": True,
+        "policy_count": len(resolved),
+        "policies": {},
+    }
+
+    for policy_name, resolved_policy in resolved.items():
+        policy = registry.get_policy(policy_name)
+        summary["policies"][policy_name] = {
+            "inherit": policy.inherit if policy else None,
+            "scope": {
+                "teams": policy.scope.get_teams() if policy else [],
+                "keys": policy.scope.get_keys() if policy else [],
+                "models": policy.scope.get_models() if policy else [],
+            },
+            "guardrails_add": policy.guardrails.get_add() if policy else [],
+            "guardrails_remove": policy.guardrails.get_remove() if policy else [],
+            "resolved_guardrails": resolved_policy.guardrails,
+            "inheritance_chain": resolved_policy.inheritance_chain,
+        }
+
+    return summary

--- a/litellm/proxy/policy_engine/policy_matcher.py
+++ b/litellm/proxy/policy_engine/policy_matcher.py
@@ -1,0 +1,133 @@
+"""
+Policy Matcher - Matches requests against policy scopes.
+
+Uses existing wildcard pattern matching helpers to determine which policies
+apply to a given request based on team alias, key alias, and model.
+"""
+
+from typing import Dict, List, Optional
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy.auth.route_checks import RouteChecks
+from litellm.types.proxy.policy_engine import Policy, PolicyMatchContext, PolicyScope
+
+
+class PolicyMatcher:
+    """
+    Matches incoming requests against policy scopes.
+
+    Supports wildcard patterns:
+    - "*" matches everything
+    - "prefix-*" matches anything starting with "prefix-"
+    """
+
+    @staticmethod
+    def matches_pattern(value: Optional[str], patterns: List[str]) -> bool:
+        """
+        Check if a value matches any of the given patterns.
+
+        Uses the existing RouteChecks._route_matches_wildcard_pattern helper.
+
+        Args:
+            value: The value to check (e.g., team alias, key alias, model)
+            patterns: List of patterns to match against
+
+        Returns:
+            True if value matches any pattern, False otherwise
+        """
+        # If no value provided, only match if patterns include "*"
+        if value is None:
+            return "*" in patterns
+
+        for pattern in patterns:
+            # Use existing wildcard pattern matching helper
+            if RouteChecks._route_matches_wildcard_pattern(
+                route=value, pattern=pattern
+            ):
+                return True
+
+        return False
+
+    @staticmethod
+    def scope_matches(scope: PolicyScope, context: PolicyMatchContext) -> bool:
+        """
+        Check if a policy scope matches the given context.
+
+        A scope matches if ALL of its fields match:
+        - teams matches context.team_alias
+        - keys matches context.key_alias
+        - models matches context.model
+
+        Args:
+            scope: The policy scope to check
+            context: The request context
+
+        Returns:
+            True if scope matches context, False otherwise
+        """
+        # Check teams
+        if not PolicyMatcher.matches_pattern(context.team_alias, scope.get_teams()):
+            return False
+
+        # Check keys
+        if not PolicyMatcher.matches_pattern(context.key_alias, scope.get_keys()):
+            return False
+
+        # Check models
+        if not PolicyMatcher.matches_pattern(context.model, scope.get_models()):
+            return False
+
+        return True
+
+    @staticmethod
+    def get_matching_policies(
+        policies: Dict[str, Policy],
+        context: PolicyMatchContext,
+    ) -> List[str]:
+        """
+        Get list of policy names that match the given context.
+
+        Args:
+            policies: Dictionary of all policies
+            context: The request context to match against
+
+        Returns:
+            List of policy names that match the context
+        """
+        matching: List[str] = []
+
+        for policy_name, policy in policies.items():
+            if PolicyMatcher.scope_matches(scope=policy.scope, context=context):
+                matching.append(policy_name)
+                verbose_proxy_logger.debug(
+                    f"Policy '{policy_name}' matches context: "
+                    f"team_alias={context.team_alias}, "
+                    f"key_alias={context.key_alias}, "
+                    f"model={context.model}"
+                )
+
+        return matching
+
+    @staticmethod
+    def get_matching_policies_from_registry(
+        context: PolicyMatchContext,
+    ) -> List[str]:
+        """
+        Get list of policy names that match the given context from the global registry.
+
+        Args:
+            context: The request context to match against
+
+        Returns:
+            List of policy names that match the context
+        """
+        from litellm.proxy.policy_engine.policy_registry import get_policy_registry
+
+        registry = get_policy_registry()
+        if not registry.is_initialized():
+            return []
+
+        return PolicyMatcher.get_matching_policies(
+            policies=registry.get_all_policies(),
+            context=context,
+        )

--- a/litellm/proxy/policy_engine/policy_registry.py
+++ b/litellm/proxy/policy_engine/policy_registry.py
@@ -11,12 +11,10 @@ from typing import Any, Dict, List, Optional
 
 from litellm._logging import verbose_proxy_logger
 from litellm.types.proxy.policy_engine import (
-    ConditionOperator,
     Policy,
     PolicyCondition,
     PolicyConfig,
     PolicyGuardrails,
-    PolicyStatement,
 )
 
 
@@ -30,7 +28,7 @@ class PolicyRegistry:
     Policies define WHAT guardrails to apply:
     - Base guardrails via guardrails.add/remove
     - Inheritance via inherit field
-    - Conditional guardrails via statements
+    - Conditional guardrails via condition.model
     """
 
     def __init__(self):
@@ -83,102 +81,18 @@ class PolicyRegistry:
             # Handle legacy format where guardrails might be a list
             guardrails = PolicyGuardrails(add=guardrails_data if guardrails_data else None)
 
-        # Parse statements (conditional guardrails)
-        statements = None
-        statements_data = policy_data.get("statements")
-        if statements_data:
-            statements = [
-                self._parse_statement(stmt_data) for stmt_data in statements_data
-            ]
+        # Parse condition (simple model-based condition)
+        condition = None
+        condition_data = policy_data.get("condition")
+        if condition_data:
+            condition = PolicyCondition(model=condition_data.get("model"))
 
         return Policy(
             inherit=policy_data.get("inherit"),
-            guardrails=guardrails,
-            statements=statements,
             description=policy_data.get("description"),
-        )
-
-    def _parse_statement(self, stmt_data: Dict[str, Any]) -> PolicyStatement:
-        """
-        Parse a policy statement from raw configuration data.
-
-        Args:
-            stmt_data: Raw statement configuration
-
-        Returns:
-            Parsed PolicyStatement object
-        """
-        condition = None
-        condition_data = stmt_data.get("condition")
-        if condition_data:
-            condition = self._parse_condition(condition_data)
-
-        return PolicyStatement(
-            sid=stmt_data.get("sid"),
-            guardrails=stmt_data.get("guardrails", []),
+            guardrails=guardrails,
             condition=condition,
         )
-
-    def _parse_condition(self, condition_data: Dict[str, Any]) -> PolicyCondition:
-        """
-        Parse a policy condition from raw configuration data.
-
-        Args:
-            condition_data: Raw condition configuration
-
-        Returns:
-            Parsed PolicyCondition object
-        """
-        model_op = None
-        team_op = None
-        key_op = None
-        metadata_ops = None
-
-        if "model" in condition_data:
-            model_op = self._parse_operator(condition_data["model"])
-        if "team" in condition_data:
-            team_op = self._parse_operator(condition_data["team"])
-        if "key" in condition_data:
-            key_op = self._parse_operator(condition_data["key"])
-        if "metadata" in condition_data:
-            metadata_ops = {
-                field: self._parse_operator(op_data)
-                for field, op_data in condition_data["metadata"].items()
-            }
-
-        return PolicyCondition(
-            model=model_op,
-            team=team_op,
-            key=key_op,
-            metadata=metadata_ops,
-        )
-
-    def _parse_operator(self, op_data: Dict[str, Any]) -> ConditionOperator:
-        """
-        Parse a condition operator from raw configuration data.
-
-        Args:
-            op_data: Raw operator configuration
-
-        Returns:
-            Parsed ConditionOperator object
-        """
-        # Build dict with alias names for Pydantic
-        operator_dict: Dict[str, Any] = {}
-        if "equals" in op_data:
-            operator_dict["equals"] = op_data["equals"]
-        if "in" in op_data:
-            operator_dict["in"] = op_data["in"]
-        if "prefix" in op_data:
-            operator_dict["prefix"] = op_data["prefix"]
-        if "not_equals" in op_data:
-            operator_dict["not_equals"] = op_data["not_equals"]
-        if "notIn" in op_data:
-            operator_dict["notIn"] = op_data["notIn"]
-        elif "not_in" in op_data:
-            operator_dict["notIn"] = op_data["not_in"]
-
-        return ConditionOperator.model_validate(operator_dict)
 
     def get_policy(self, policy_name: str) -> Optional[Policy]:
         """

--- a/litellm/proxy/policy_engine/policy_registry.py
+++ b/litellm/proxy/policy_engine/policy_registry.py
@@ -1,0 +1,190 @@
+"""
+Policy Registry - In-memory storage for policies.
+
+Handles storing, retrieving, and managing policies.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from litellm._logging import verbose_proxy_logger
+from litellm.types.proxy.policy_engine import (
+    Policy,
+    PolicyConfig,
+    PolicyGuardrails,
+    PolicyScope,
+)
+
+
+class PolicyRegistry:
+    """
+    In-memory registry for storing and managing policies.
+
+    This is a singleton that holds all loaded policies and provides
+    methods to access them.
+    """
+
+    def __init__(self):
+        self._policies: Dict[str, Policy] = {}
+        self._initialized: bool = False
+
+    def load_policies(self, policies_config: Dict[str, Any]) -> None:
+        """
+        Load policies from a configuration dictionary.
+
+        Args:
+            policies_config: Dictionary mapping policy names to policy definitions.
+                            This is the raw config from the YAML file.
+        """
+        self._policies = {}
+
+        for policy_name, policy_data in policies_config.items():
+            try:
+                policy = self._parse_policy(policy_name, policy_data)
+                self._policies[policy_name] = policy
+                verbose_proxy_logger.debug(f"Loaded policy: {policy_name}")
+            except Exception as e:
+                verbose_proxy_logger.error(
+                    f"Error loading policy '{policy_name}': {str(e)}"
+                )
+                raise ValueError(f"Invalid policy '{policy_name}': {str(e)}") from e
+
+        self._initialized = True
+        verbose_proxy_logger.info(f"Loaded {len(self._policies)} policies")
+
+    def _parse_policy(self, policy_name: str, policy_data: Dict[str, Any]) -> Policy:
+        """
+        Parse a policy from raw configuration data.
+
+        Args:
+            policy_name: Name of the policy
+            policy_data: Raw policy configuration
+
+        Returns:
+            Parsed Policy object
+        """
+        # Parse guardrails
+        guardrails_data = policy_data.get("guardrails", {})
+        if isinstance(guardrails_data, dict):
+            guardrails = PolicyGuardrails(
+                add=guardrails_data.get("add"),
+                remove=guardrails_data.get("remove"),
+            )
+        else:
+            # Handle legacy format where guardrails might be a list
+            guardrails = PolicyGuardrails(add=guardrails_data if guardrails_data else None)
+
+        # Parse scope
+        scope_data = policy_data.get("scope", {})
+        scope = PolicyScope(
+            teams=scope_data.get("teams"),
+            keys=scope_data.get("keys"),
+            models=scope_data.get("models"),
+        )
+
+        return Policy(
+            inherit=policy_data.get("inherit"),
+            guardrails=guardrails,
+            scope=scope,
+        )
+
+    def get_policy(self, policy_name: str) -> Optional[Policy]:
+        """
+        Get a policy by name.
+
+        Args:
+            policy_name: Name of the policy to retrieve
+
+        Returns:
+            Policy object if found, None otherwise
+        """
+        return self._policies.get(policy_name)
+
+    def get_all_policies(self) -> Dict[str, Policy]:
+        """
+        Get all loaded policies.
+
+        Returns:
+            Dictionary mapping policy names to Policy objects
+        """
+        return self._policies.copy()
+
+    def get_policy_names(self) -> List[str]:
+        """
+        Get list of all policy names.
+
+        Returns:
+            List of policy names
+        """
+        return list(self._policies.keys())
+
+    def has_policy(self, policy_name: str) -> bool:
+        """
+        Check if a policy exists.
+
+        Args:
+            policy_name: Name of the policy to check
+
+        Returns:
+            True if policy exists, False otherwise
+        """
+        return policy_name in self._policies
+
+    def is_initialized(self) -> bool:
+        """
+        Check if the registry has been initialized with policies.
+
+        Returns:
+            True if policies have been loaded, False otherwise
+        """
+        return self._initialized
+
+    def clear(self) -> None:
+        """
+        Clear all policies from the registry.
+        """
+        self._policies = {}
+        self._initialized = False
+
+    def add_policy(self, policy_name: str, policy: Policy) -> None:
+        """
+        Add or update a single policy.
+
+        Args:
+            policy_name: Name of the policy
+            policy: Policy object to add
+        """
+        self._policies[policy_name] = policy
+        verbose_proxy_logger.debug(f"Added/updated policy: {policy_name}")
+
+    def remove_policy(self, policy_name: str) -> bool:
+        """
+        Remove a policy by name.
+
+        Args:
+            policy_name: Name of the policy to remove
+
+        Returns:
+            True if policy was removed, False if it didn't exist
+        """
+        if policy_name in self._policies:
+            del self._policies[policy_name]
+            verbose_proxy_logger.debug(f"Removed policy: {policy_name}")
+            return True
+        return False
+
+
+# Global singleton instance
+_policy_registry: Optional[PolicyRegistry] = None
+
+
+def get_policy_registry() -> PolicyRegistry:
+    """
+    Get the global PolicyRegistry singleton.
+
+    Returns:
+        The global PolicyRegistry instance
+    """
+    global _policy_registry
+    if _policy_registry is None:
+        _policy_registry = PolicyRegistry()
+    return _policy_registry

--- a/litellm/proxy/policy_engine/policy_registry.py
+++ b/litellm/proxy/policy_engine/policy_registry.py
@@ -13,7 +13,6 @@ from litellm._logging import verbose_proxy_logger
 from litellm.types.proxy.policy_engine import (
     Policy,
     PolicyCondition,
-    PolicyConfig,
     PolicyGuardrails,
 )
 

--- a/litellm/proxy/policy_engine/policy_resolver.py
+++ b/litellm/proxy/policy_engine/policy_resolver.py
@@ -2,12 +2,13 @@
 Policy Resolver - Resolves final guardrail list from policies.
 
 Handles:
-- Inheritance chain resolution
+- Inheritance chain resolution (inherit with add/remove)
 - Applying add/remove guardrails
+- Evaluating conditional statements
 - Combining guardrails from multiple matching policies
 """
 
-from typing import Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 from litellm._logging import verbose_proxy_logger
 from litellm.types.proxy.policy_engine import (
@@ -21,7 +22,9 @@ class PolicyResolver:
     """
     Resolves the final list of guardrails from policies.
 
-    Handles inheritance chains and add/remove operations.
+    Handles:
+    - Inheritance chains with add/remove operations
+    - Conditional statements with AWS IAM-style conditions
     """
 
     @staticmethod
@@ -68,13 +71,22 @@ class PolicyResolver:
     def resolve_policy_guardrails(
         policy_name: str,
         policies: Dict[str, Policy],
+        context: Optional[PolicyMatchContext] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> ResolvedPolicy:
         """
         Resolve the final guardrails for a single policy, including inheritance.
 
+        This method:
+        1. Resolves the inheritance chain
+        2. Applies add/remove from each policy in the chain
+        3. Evaluates conditional statements (if context provided)
+
         Args:
             policy_name: Name of the policy to resolve
             policies: Dictionary of all policies
+            context: Optional request context for evaluating statement conditions
+            metadata: Optional request metadata for condition evaluation
 
         Returns:
             ResolvedPolicy with final guardrails list
@@ -92,13 +104,26 @@ class PolicyResolver:
             if policy is None:
                 continue
 
-            # Add guardrails
+            # Add guardrails from guardrails.add
             for guardrail in policy.guardrails.get_add():
                 guardrails.add(guardrail)
 
-            # Remove guardrails
+            # Remove guardrails from guardrails.remove
             for guardrail in policy.guardrails.get_remove():
                 guardrails.discard(guardrail)
+
+            # Evaluate statements (if context provided)
+            if context is not None and policy.statements:
+                statement_guardrails = PolicyResolver._evaluate_statements(
+                    statements=policy.statements,
+                    context=context,
+                    metadata=metadata,
+                )
+                guardrails.update(statement_guardrails)
+                if statement_guardrails:
+                    verbose_proxy_logger.debug(
+                        f"Policy '{chain_policy_name}' statements contributed: {statement_guardrails}"
+                    )
 
         return ResolvedPolicy(
             policy_name=policy_name,
@@ -107,21 +132,60 @@ class PolicyResolver:
         )
 
     @staticmethod
+    def _evaluate_statements(
+        statements: list,
+        context: PolicyMatchContext,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Set[str]:
+        """
+        Evaluate policy statements and return guardrails from matching statements.
+
+        Args:
+            statements: List of PolicyStatement objects
+            context: The request context
+            metadata: Optional request metadata
+
+        Returns:
+            Set of guardrail names from matching statements
+        """
+        from litellm.proxy.policy_engine.condition_evaluator import ConditionEvaluator
+
+        guardrails: Set[str] = set()
+
+        for statement in statements:
+            # Evaluate the statement's condition
+            if ConditionEvaluator.evaluate(
+                condition=statement.condition,
+                context=context,
+                metadata=metadata,
+            ):
+                guardrails.update(statement.guardrails)
+                verbose_proxy_logger.debug(
+                    f"Statement '{statement.sid or 'unnamed'}' matched, "
+                    f"adding guardrails: {statement.guardrails}"
+                )
+
+        return guardrails
+
+    @staticmethod
     def resolve_guardrails_for_context(
         context: PolicyMatchContext,
         policies: Optional[Dict[str, Policy]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> List[str]:
         """
         Resolve the final list of guardrails for a request context.
 
         This:
-        1. Finds all policies that match the context
+        1. Finds all policies that match the context via policy_attachments
         2. Resolves each policy's guardrails (including inheritance)
-        3. Combines all guardrails (union)
+        3. Evaluates conditional statements
+        4. Combines all guardrails (union)
 
         Args:
             context: The request context
             policies: Dictionary of all policies (if None, uses global registry)
+            metadata: Optional request metadata for condition evaluation
 
         Returns:
             List of guardrail names to apply
@@ -135,10 +199,8 @@ class PolicyResolver:
                 return []
             policies = registry.get_all_policies()
 
-        # Get matching policies
-        matching_policy_names = PolicyMatcher.get_matching_policies(
-            policies=policies, context=context
-        )
+        # Get matching policies via attachments
+        matching_policy_names = PolicyMatcher.get_matching_policies(context=context)
 
         if not matching_policy_names:
             verbose_proxy_logger.debug(
@@ -152,7 +214,10 @@ class PolicyResolver:
 
         for policy_name in matching_policy_names:
             resolved = PolicyResolver.resolve_policy_guardrails(
-                policy_name=policy_name, policies=policies
+                policy_name=policy_name,
+                policies=policies,
+                context=context,
+                metadata=metadata,
             )
             all_guardrails.update(resolved.guardrails)
             verbose_proxy_logger.debug(
@@ -169,6 +234,8 @@ class PolicyResolver:
     @staticmethod
     def get_all_resolved_policies(
         policies: Optional[Dict[str, Policy]] = None,
+        context: Optional[PolicyMatchContext] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, ResolvedPolicy]:
         """
         Resolve all policies and return their final guardrails.
@@ -177,6 +244,8 @@ class PolicyResolver:
 
         Args:
             policies: Dictionary of all policies (if None, uses global registry)
+            context: Optional context for evaluating statement conditions
+            metadata: Optional metadata for condition evaluation
 
         Returns:
             Dictionary mapping policy names to ResolvedPolicy objects
@@ -193,7 +262,10 @@ class PolicyResolver:
 
         for policy_name in policies:
             resolved[policy_name] = PolicyResolver.resolve_policy_guardrails(
-                policy_name=policy_name, policies=policies
+                policy_name=policy_name,
+                policies=policies,
+                context=context,
+                metadata=metadata,
             )
 
         return resolved

--- a/litellm/proxy/policy_engine/policy_resolver.py
+++ b/litellm/proxy/policy_engine/policy_resolver.py
@@ -8,7 +8,7 @@ Handles:
 - Combining guardrails from multiple matching policies
 """
 
-from typing import Any, Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set
 
 from litellm._logging import verbose_proxy_logger
 from litellm.types.proxy.policy_engine import (

--- a/litellm/proxy/policy_engine/policy_resolver.py
+++ b/litellm/proxy/policy_engine/policy_resolver.py
@@ -1,0 +1,199 @@
+"""
+Policy Resolver - Resolves final guardrail list from policies.
+
+Handles:
+- Inheritance chain resolution
+- Applying add/remove guardrails
+- Combining guardrails from multiple matching policies
+"""
+
+from typing import Dict, List, Optional, Set
+
+from litellm._logging import verbose_proxy_logger
+from litellm.types.proxy.policy_engine import (
+    Policy,
+    PolicyMatchContext,
+    ResolvedPolicy,
+)
+
+
+class PolicyResolver:
+    """
+    Resolves the final list of guardrails from policies.
+
+    Handles inheritance chains and add/remove operations.
+    """
+
+    @staticmethod
+    def resolve_inheritance_chain(
+        policy_name: str,
+        policies: Dict[str, Policy],
+        visited: Optional[Set[str]] = None,
+    ) -> List[str]:
+        """
+        Get the inheritance chain for a policy (from root to policy).
+
+        Args:
+            policy_name: Name of the policy
+            policies: Dictionary of all policies
+            visited: Set of visited policies (for cycle detection)
+
+        Returns:
+            List of policy names from root ancestor to the given policy
+        """
+        if visited is None:
+            visited = set()
+
+        if policy_name in visited:
+            verbose_proxy_logger.warning(
+                f"Circular inheritance detected for policy '{policy_name}'"
+            )
+            return []
+
+        policy = policies.get(policy_name)
+        if policy is None:
+            return []
+
+        visited.add(policy_name)
+
+        if policy.inherit:
+            parent_chain = PolicyResolver.resolve_inheritance_chain(
+                policy_name=policy.inherit, policies=policies, visited=visited
+            )
+            return parent_chain + [policy_name]
+
+        return [policy_name]
+
+    @staticmethod
+    def resolve_policy_guardrails(
+        policy_name: str,
+        policies: Dict[str, Policy],
+    ) -> ResolvedPolicy:
+        """
+        Resolve the final guardrails for a single policy, including inheritance.
+
+        Args:
+            policy_name: Name of the policy to resolve
+            policies: Dictionary of all policies
+
+        Returns:
+            ResolvedPolicy with final guardrails list
+        """
+        inheritance_chain = PolicyResolver.resolve_inheritance_chain(
+            policy_name=policy_name, policies=policies
+        )
+
+        # Start with empty set of guardrails
+        guardrails: Set[str] = set()
+
+        # Apply each policy in the chain (from root to leaf)
+        for chain_policy_name in inheritance_chain:
+            policy = policies.get(chain_policy_name)
+            if policy is None:
+                continue
+
+            # Add guardrails
+            for guardrail in policy.guardrails.get_add():
+                guardrails.add(guardrail)
+
+            # Remove guardrails
+            for guardrail in policy.guardrails.get_remove():
+                guardrails.discard(guardrail)
+
+        return ResolvedPolicy(
+            policy_name=policy_name,
+            guardrails=list(guardrails),
+            inheritance_chain=inheritance_chain,
+        )
+
+    @staticmethod
+    def resolve_guardrails_for_context(
+        context: PolicyMatchContext,
+        policies: Optional[Dict[str, Policy]] = None,
+    ) -> List[str]:
+        """
+        Resolve the final list of guardrails for a request context.
+
+        This:
+        1. Finds all policies that match the context
+        2. Resolves each policy's guardrails (including inheritance)
+        3. Combines all guardrails (union)
+
+        Args:
+            context: The request context
+            policies: Dictionary of all policies (if None, uses global registry)
+
+        Returns:
+            List of guardrail names to apply
+        """
+        from litellm.proxy.policy_engine.policy_matcher import PolicyMatcher
+        from litellm.proxy.policy_engine.policy_registry import get_policy_registry
+
+        if policies is None:
+            registry = get_policy_registry()
+            if not registry.is_initialized():
+                return []
+            policies = registry.get_all_policies()
+
+        # Get matching policies
+        matching_policy_names = PolicyMatcher.get_matching_policies(
+            policies=policies, context=context
+        )
+
+        if not matching_policy_names:
+            verbose_proxy_logger.debug(
+                f"No policies match context: team_alias={context.team_alias}, "
+                f"key_alias={context.key_alias}, model={context.model}"
+            )
+            return []
+
+        # Resolve each matching policy and combine guardrails
+        all_guardrails: Set[str] = set()
+
+        for policy_name in matching_policy_names:
+            resolved = PolicyResolver.resolve_policy_guardrails(
+                policy_name=policy_name, policies=policies
+            )
+            all_guardrails.update(resolved.guardrails)
+            verbose_proxy_logger.debug(
+                f"Policy '{policy_name}' contributes guardrails: {resolved.guardrails}"
+            )
+
+        result = list(all_guardrails)
+        verbose_proxy_logger.debug(
+            f"Final guardrails for context: {result}"
+        )
+
+        return result
+
+    @staticmethod
+    def get_all_resolved_policies(
+        policies: Optional[Dict[str, Policy]] = None,
+    ) -> Dict[str, ResolvedPolicy]:
+        """
+        Resolve all policies and return their final guardrails.
+
+        Useful for debugging and displaying policy configurations.
+
+        Args:
+            policies: Dictionary of all policies (if None, uses global registry)
+
+        Returns:
+            Dictionary mapping policy names to ResolvedPolicy objects
+        """
+        from litellm.proxy.policy_engine.policy_registry import get_policy_registry
+
+        if policies is None:
+            registry = get_policy_registry()
+            if not registry.is_initialized():
+                return {}
+            policies = registry.get_all_policies()
+
+        resolved: Dict[str, ResolvedPolicy] = {}
+
+        for policy_name in policies:
+            resolved[policy_name] = PolicyResolver.resolve_policy_guardrails(
+                policy_name=policy_name, policies=policies
+            )
+
+        return resolved

--- a/litellm/proxy/policy_engine/policy_validator.py
+++ b/litellm/proxy/policy_engine/policy_validator.py
@@ -1,0 +1,377 @@
+"""
+Policy Validator - Validates policy configurations.
+
+Validates:
+- Guardrail names exist in the guardrail registry
+- Non-wildcard team aliases exist in the database
+- Non-wildcard key aliases exist in the database
+- Non-wildcard model names exist in the router or match a wildcard route
+- Inheritance chains are valid (no cycles, parents exist)
+"""
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy.auth.route_checks import RouteChecks
+from litellm.types.proxy.policy_engine import (
+    Policy,
+    PolicyValidationError,
+    PolicyValidationErrorType,
+    PolicyValidationResponse,
+)
+
+if TYPE_CHECKING:
+    from litellm.proxy.utils import PrismaClient
+    from litellm.router import Router
+
+
+class PolicyValidator:
+    """
+    Validates policy configurations against actual data.
+    """
+
+    def __init__(
+        self,
+        prisma_client: Optional["PrismaClient"] = None,
+        llm_router: Optional["Router"] = None,
+    ):
+        """
+        Initialize the validator.
+
+        Args:
+            prisma_client: Optional Prisma client for database validation
+            llm_router: Optional LLM router for model validation
+        """
+        self.prisma_client = prisma_client
+        self.llm_router = llm_router
+
+    @staticmethod
+    def is_wildcard_pattern(pattern: str) -> bool:
+        """
+        Check if a pattern contains wildcards.
+
+        Args:
+            pattern: The pattern to check
+
+        Returns:
+            True if the pattern contains wildcard characters
+        """
+        return "*" in pattern or "?" in pattern
+
+    def get_available_guardrails(self) -> Set[str]:
+        """
+        Get set of available guardrail names from the guardrail registry.
+
+        Returns:
+            Set of guardrail names
+        """
+        try:
+            from litellm.proxy.guardrails.guardrail_registry import (
+                IN_MEMORY_GUARDRAIL_HANDLER,
+            )
+
+            guardrails = IN_MEMORY_GUARDRAIL_HANDLER.list_in_memory_guardrails()
+            return {g.get("guardrail_name", "") for g in guardrails if g.get("guardrail_name")}
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                f"Could not get guardrails from registry: {str(e)}"
+            )
+            return set()
+
+    async def check_team_alias_exists(self, team_alias: str) -> bool:
+        """
+        Check if a specific team alias exists in the database.
+
+        Args:
+            team_alias: The team alias to check
+
+        Returns:
+            True if the team alias exists
+        """
+        if self.prisma_client is None:
+            return True  # Can't validate without DB, assume valid
+
+        try:
+            team = await self.prisma_client.db.litellm_teamtable.find_first(
+                where={"team_alias": team_alias},
+            )
+            return team is not None
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                f"Could not check team alias '{team_alias}': {str(e)}"
+            )
+            return True  # Assume valid on error
+
+    async def check_key_alias_exists(self, key_alias: str) -> bool:
+        """
+        Check if a specific key alias exists in the database.
+
+        Args:
+            key_alias: The key alias to check
+
+        Returns:
+            True if the key alias exists
+        """
+        if self.prisma_client is None:
+            return True  # Can't validate without DB, assume valid
+
+        try:
+            key = await self.prisma_client.db.litellm_verificationtoken.find_first(
+                where={"key_alias": key_alias},
+            )
+            return key is not None
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                f"Could not check key alias '{key_alias}': {str(e)}"
+            )
+            return True  # Assume valid on error
+
+    def check_model_exists(self, model: str) -> bool:
+        """
+        Check if a model exists in the router or matches a wildcard pattern.
+
+        Args:
+            model: The model name to check
+
+        Returns:
+            True if the model exists or matches a pattern in the router
+        """
+        if self.llm_router is None:
+            return True  # Can't validate without router, assume valid
+
+        try:
+            # Check if model is in router's model names
+            if model in self.llm_router.model_names:
+                return True
+
+            # Check if model matches any pattern via pattern router
+            if hasattr(self.llm_router, "pattern_router"):
+                pattern_deployments = self.llm_router.pattern_router.get_deployments_by_pattern(
+                    model=model
+                )
+                if pattern_deployments:
+                    return True
+
+            return False
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                f"Could not check model '{model}': {str(e)}"
+            )
+            return True  # Assume valid on error
+
+    def _validate_inheritance_chain(
+        self,
+        policy_name: str,
+        policies: Dict[str, Policy],
+        visited: Optional[Set[str]] = None,
+    ) -> List[PolicyValidationError]:
+        """
+        Validate the inheritance chain for a policy.
+
+        Checks for:
+        - Parent policy exists
+        - No circular inheritance
+
+        Args:
+            policy_name: Name of the policy to validate
+            policies: All policies
+            visited: Set of already visited policy names (for cycle detection)
+
+        Returns:
+            List of validation errors
+        """
+        errors: List[PolicyValidationError] = []
+
+        if visited is None:
+            visited = set()
+
+        if policy_name in visited:
+            errors.append(
+                PolicyValidationError(
+                    policy_name=policy_name,
+                    error_type=PolicyValidationErrorType.CIRCULAR_INHERITANCE,
+                    message=f"Circular inheritance detected: {' -> '.join(visited)} -> {policy_name}",
+                    field="inherit",
+                )
+            )
+            return errors
+
+        policy = policies.get(policy_name)
+        if policy is None:
+            return errors
+
+        if policy.inherit:
+            if policy.inherit not in policies:
+                errors.append(
+                    PolicyValidationError(
+                        policy_name=policy_name,
+                        error_type=PolicyValidationErrorType.INVALID_INHERITANCE,
+                        message=f"Parent policy '{policy.inherit}' not found",
+                        field="inherit",
+                        value=policy.inherit,
+                    )
+                )
+            else:
+                # Recursively check parent
+                visited.add(policy_name)
+                errors.extend(
+                    self._validate_inheritance_chain(policy.inherit, policies, visited)
+                )
+
+        return errors
+
+    async def validate_policies(
+        self,
+        policies: Dict[str, Policy],
+        validate_db: bool = True,
+    ) -> PolicyValidationResponse:
+        """
+        Validate a set of policies.
+
+        Args:
+            policies: Dictionary mapping policy names to Policy objects
+            validate_db: Whether to validate against database (teams, keys)
+
+        Returns:
+            PolicyValidationResponse with errors and warnings
+        """
+        errors: List[PolicyValidationError] = []
+        warnings: List[PolicyValidationError] = []
+
+        # Get available guardrails
+        available_guardrails = self.get_available_guardrails()
+
+        for policy_name, policy in policies.items():
+            # Validate guardrails
+            for guardrail in policy.guardrails.get_add():
+                if available_guardrails and guardrail not in available_guardrails:
+                    errors.append(
+                        PolicyValidationError(
+                            policy_name=policy_name,
+                            error_type=PolicyValidationErrorType.INVALID_GUARDRAIL,
+                            message=f"Guardrail '{guardrail}' not found in guardrail registry",
+                            field="guardrails.add",
+                            value=guardrail,
+                        )
+                    )
+
+            for guardrail in policy.guardrails.get_remove():
+                if available_guardrails and guardrail not in available_guardrails:
+                    warnings.append(
+                        PolicyValidationError(
+                            policy_name=policy_name,
+                            error_type=PolicyValidationErrorType.INVALID_GUARDRAIL,
+                            message=f"Guardrail '{guardrail}' in remove list not found in guardrail registry",
+                            field="guardrails.remove",
+                            value=guardrail,
+                        )
+                    )
+
+            # Validate team aliases (non-wildcard only, query per alias)
+            if validate_db and self.prisma_client:
+                for team_pattern in policy.scope.get_teams():
+                    if not self.is_wildcard_pattern(team_pattern):
+                        exists = await self.check_team_alias_exists(team_alias=team_pattern)
+                        if not exists:
+                            warnings.append(
+                                PolicyValidationError(
+                                    policy_name=policy_name,
+                                    error_type=PolicyValidationErrorType.INVALID_TEAM,
+                                    message=f"Team alias '{team_pattern}' not found in database",
+                                    field="scope.teams",
+                                    value=team_pattern,
+                                )
+                            )
+
+            # Validate key aliases (non-wildcard only, query per alias)
+            if validate_db and self.prisma_client:
+                for key_pattern in policy.scope.get_keys():
+                    if not self.is_wildcard_pattern(key_pattern):
+                        exists = await self.check_key_alias_exists(key_alias=key_pattern)
+                        if not exists:
+                            warnings.append(
+                                PolicyValidationError(
+                                    policy_name=policy_name,
+                                    error_type=PolicyValidationErrorType.INVALID_KEY,
+                                    message=f"Key alias '{key_pattern}' not found in database",
+                                    field="scope.keys",
+                                    value=key_pattern,
+                                )
+                            )
+
+            # Validate models (non-wildcard only, check against router)
+            if self.llm_router:
+                for model_pattern in policy.scope.get_models():
+                    if not self.is_wildcard_pattern(model_pattern):
+                        exists = self.check_model_exists(model=model_pattern)
+                        if not exists:
+                            warnings.append(
+                                PolicyValidationError(
+                                    policy_name=policy_name,
+                                    error_type=PolicyValidationErrorType.INVALID_MODEL,
+                                    message=f"Model '{model_pattern}' not found in router",
+                                    field="scope.models",
+                                    value=model_pattern,
+                                )
+                            )
+
+            # Validate inheritance
+            inheritance_errors = self._validate_inheritance_chain(
+                policy_name=policy_name, policies=policies
+            )
+            errors.extend(inheritance_errors)
+
+        return PolicyValidationResponse(
+            valid=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+        )
+
+    async def validate_policy_config(
+        self,
+        policy_config: Dict[str, Any],
+        validate_db: bool = True,
+    ) -> PolicyValidationResponse:
+        """
+        Validate a raw policy configuration dictionary.
+
+        This parses the config and then validates it.
+
+        Args:
+            policy_config: Raw policy configuration from YAML
+            validate_db: Whether to validate against database
+
+        Returns:
+            PolicyValidationResponse with errors and warnings
+        """
+        from litellm.proxy.policy_engine.policy_registry import PolicyRegistry
+
+        # First, try to parse the policies
+        errors: List[PolicyValidationError] = []
+        policies: Dict[str, Policy] = {}
+
+        temp_registry = PolicyRegistry()
+
+        for policy_name, policy_data in policy_config.items():
+            try:
+                policy = temp_registry._parse_policy(policy_name, policy_data)
+                policies[policy_name] = policy
+            except Exception as e:
+                errors.append(
+                    PolicyValidationError(
+                        policy_name=policy_name,
+                        error_type=PolicyValidationErrorType.INVALID_SYNTAX,
+                        message=f"Failed to parse policy: {str(e)}",
+                    )
+                )
+
+        # If there were parsing errors, return early
+        if errors:
+            return PolicyValidationResponse(
+                valid=False,
+                errors=errors,
+                warnings=[],
+            )
+
+        # Validate the parsed policies
+        return await self.validate_policies(policies, validate_db=validate_db)

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,42 +1,101 @@
 model_list:
-  # Anthropic direct
-  - model_name: anthropic-claude
+  - model_name: "*"
     litellm_params:
-      model: anthropic/claude-sonnet-4-20250514
-      api_key: os.environ/ANTHROPIC_API_KEY
-
-  # Azure AI Anthropic
-  - model_name: azure-ai-claude
+      model: "*"
+  - model_name: "gpt-4"
     litellm_params:
-      model: azure_ai/claude-3-5-sonnet
-      api_base: https://krish-mh44t553-eastus2.services.ai.azure.com/
-      api_key: os.environ/AZURE_ANTHROPIC_API_KEY
-
-  # Azure AI Anthropic (alternate endpoint format)
-  - model_name: claude-4.5-haiku
+      model: "gpt-4"
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: "gpt-3.5-turbo"
     litellm_params:
-      model: anthropic/claude-haiku-4-5
-      api_base: https://krish-mh44t553-eastus2.services.ai.azure.com/anthropic/v1/messages
-      api_version: "2023-06-01"
-      api_key: os.environ/AZURE_ANTHROPIC_API_KEY
-
-
-
-# Search Tools Configuration - Define search providers for WebSearch interception
-# search_tools:
-#   - search_tool_name: "my-perplexity-search"
-#     litellm_params:
-#       search_provider: "perplexity"  # Can be: perplexity, brave, etc.
-
-litellm_settings:
-  callbacks: ["websearch_interception"]
-  # WebSearch Interception - Automatically intercepts and executes WebSearch tool calls
-  # for models that don't natively support web search (e.g., Bedrock/Claude)
-  websearch_interception_params:
-    enabled_providers: ["bedrock"]  # List of providers to enable interception for
-    search_tool_name: "my-perplexity-search"  # Optional: Name of search tool from search_tools config
+      model: "gpt-3.5-turbo"
+      api_key: os.environ/OPENAI_API_KEY
 
 general_settings:
-  store_prompts_in_spend_logs: true
-  forward_client_headers_to_llm_api: true
+  master_key: sk-1234
 
+# ───────────────────────────────────────────────
+# POLICIES - Define WHAT guardrails to apply
+# ───────────────────────────────────────────────
+#
+# Policies define guardrails with:
+# - inherit: Inherit guardrails from another policy
+# - description: Human-readable description
+# - guardrails.add: Add guardrails (on top of inherited)
+# - guardrails.remove: Remove guardrails (from inherited)
+# - condition.model: Model pattern (exact or regex) for when guardrails apply
+#
+policies:
+  # Global baseline policy
+  global-baseline:
+    description: "Base guardrails for all requests"
+    guardrails:
+      add:
+        - pii_blocker
+
+  # Healthcare policy - inherits from global-baseline
+  healthcare-compliance:
+    inherit: global-baseline
+    description: "HIPAA compliance for healthcare teams"
+    guardrails:
+      add:
+        - hipaa_audit
+
+  # Dev policy - inherits but removes PII blocker for testing
+  internal-dev:
+    inherit: global-baseline
+    description: "Relaxed policy for internal development"
+    guardrails:
+      add:
+        - toxicity_filter
+      remove:
+        - pii_blocker
+
+  # Policy with model condition (regex pattern)
+  gpt4-safety:
+    description: "Extra safety for GPT-4 models"
+    guardrails:
+      add:
+        - toxicity_filter
+    condition:
+      model: "gpt-4.*"  # regex: matches gpt-4, gpt-4-turbo, gpt-4o, etc.
+
+  # Policy with model condition (exact match list)
+  bedrock-compliance:
+    description: "Compliance for Bedrock models"
+    guardrails:
+      add:
+        - strict_pii_blocker
+    condition:
+      model: ["bedrock/claude-3", "bedrock/claude-2"]  # exact matches
+
+# ───────────────────────────────────────────────
+# POLICY ATTACHMENTS - Define WHERE policies apply
+# ───────────────────────────────────────────────
+#
+# Attachments are REQUIRED to make policies active.
+# A policy without an attachment will not be applied.
+#
+policy_attachments:
+  # Global attachment - applies to all requests
+  - policy: global-baseline
+    scope: "*"
+
+  # Team-specific attachment
+  - policy: healthcare-compliance
+    teams:
+      - healthcare-team
+      - medical-research
+
+  # Key pattern attachment
+  - policy: internal-dev
+    keys:
+      - "dev-key-*"
+      - "test-key-*"
+
+  # Model-specific policies (attached globally, condition filters by model)
+  - policy: gpt4-safety
+    scope: "*"
+
+  - policy: bedrock-compliance
+    scope: "*"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2869,12 +2869,6 @@ class ProxyConfig:
 
         verbose_proxy_logger.info(f"Policy engine: found {len(policies_config)} policies in config")
 
-        # Create validator with router for model validation
-        validator = PolicyValidator(
-            prisma_client=prisma_client,
-            llm_router=llm_router,
-        )
-
         # Initialize policies
         await init_policies(
             policies_config=policies_config,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2854,11 +2854,15 @@ class ProxyConfig:
             llm_router: Optional LLM router for model validation
         """
         if config is None:
+            verbose_proxy_logger.debug("Policy engine: config is None, skipping")
             return
 
         policies_config = config.get("policies", None)
         if not policies_config:
+            verbose_proxy_logger.debug("Policy engine: no policies in config, skipping")
             return
+
+        verbose_proxy_logger.info(f"Policy engine: found {len(policies_config)} policies in config")
 
         from litellm.proxy.policy_engine.init_policies import init_policies
         from litellm.proxy.policy_engine.policy_validator import PolicyValidator

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2853,6 +2853,9 @@ class ProxyConfig:
             prisma_client: Optional Prisma client for DB validation
             llm_router: Optional LLM router for model validation
         """
+
+        from litellm.proxy.policy_engine.init_policies import init_policies
+        from litellm.proxy.policy_engine.policy_validator import PolicyValidator
         if config is None:
             verbose_proxy_logger.debug("Policy engine: config is None, skipping")
             return
@@ -2862,10 +2865,9 @@ class ProxyConfig:
             verbose_proxy_logger.debug("Policy engine: no policies in config, skipping")
             return
 
-        verbose_proxy_logger.info(f"Policy engine: found {len(policies_config)} policies in config")
+        policy_attachments_config = config.get("policy_attachments", None)
 
-        from litellm.proxy.policy_engine.init_policies import init_policies
-        from litellm.proxy.policy_engine.policy_validator import PolicyValidator
+        verbose_proxy_logger.info(f"Policy engine: found {len(policies_config)} policies in config")
 
         # Create validator with router for model validation
         validator = PolicyValidator(
@@ -2876,6 +2878,7 @@ class ProxyConfig:
         # Initialize policies
         await init_policies(
             policies_config=policies_config,
+            policy_attachments_config=policy_attachments_config,
             prisma_client=prisma_client,
             validate_db=prisma_client is not None,
             fail_on_error=True,

--- a/litellm/types/policy_engine.py
+++ b/litellm/types/policy_engine.py
@@ -1,0 +1,36 @@
+"""
+Type definitions for the LiteLLM Policy Engine.
+
+This module re-exports types from litellm.types.proxy.policy_engine for backward compatibility.
+The canonical location for these types is litellm/types/proxy/policy_engine/.
+"""
+
+# Re-export all types from the new location
+from litellm.types.proxy.policy_engine import (  # Policy types; Validation types; Resolver types
+    Policy,
+    PolicyConfig,
+    PolicyGuardrails,
+    PolicyMatchContext,
+    PolicyScope,
+    PolicyValidateRequest,
+    PolicyValidationError,
+    PolicyValidationErrorType,
+    PolicyValidationResponse,
+    ResolvedPolicy,
+)
+
+__all__ = [
+    # Policy types
+    "Policy",
+    "PolicyConfig",
+    "PolicyGuardrails",
+    "PolicyScope",
+    # Validation types
+    "PolicyValidateRequest",
+    "PolicyValidationError",
+    "PolicyValidationErrorType",
+    "PolicyValidationResponse",
+    # Resolver types
+    "PolicyMatchContext",
+    "ResolvedPolicy",
+]

--- a/litellm/types/proxy/policy_engine/__init__.py
+++ b/litellm/types/proxy/policy_engine/__init__.py
@@ -5,23 +5,18 @@ The Policy Engine allows administrators to define policies that combine guardrai
 with scoping rules. Policies can target specific teams, API keys, and models using
 wildcard patterns, and support inheritance from base policies.
 
-The engine supports two configuration styles:
-
-1. **Simple Style**: Policies with inline scope (original)
-2. **Advanced Style**: Policies with statements and separate attachments
-
-Both styles support the `inherit` field with `guardrails.add` and `guardrails.remove`.
+Configuration:
+- `policies`: Define WHAT guardrails to apply (with inheritance and conditions)
+- `policy_attachments`: Define WHERE policies apply (teams, keys, models)
 """
 
 from litellm.types.proxy.policy_engine.policy_types import (
-    ConditionOperator,
     Policy,
     PolicyAttachment,
     PolicyCondition,
     PolicyConfig,
     PolicyGuardrails,
     PolicyScope,
-    PolicyStatement,
 )
 from litellm.types.proxy.policy_engine.resolver_types import (
     PolicyGuardrailsResponse,
@@ -46,10 +41,7 @@ __all__ = [
     "PolicyConfig",
     "PolicyGuardrails",
     "PolicyScope",
-    # Condition types (new)
-    "ConditionOperator",
     "PolicyCondition",
-    "PolicyStatement",
     "PolicyAttachment",
     # Validation types
     "PolicyValidateRequest",

--- a/litellm/types/proxy/policy_engine/__init__.py
+++ b/litellm/types/proxy/policy_engine/__init__.py
@@ -13,7 +13,13 @@ from litellm.types.proxy.policy_engine.policy_types import (
     PolicyScope,
 )
 from litellm.types.proxy.policy_engine.resolver_types import (
+    PolicyGuardrailsResponse,
+    PolicyInfoResponse,
+    PolicyListResponse,
     PolicyMatchContext,
+    PolicyScopeResponse,
+    PolicySummaryItem,
+    PolicyTestResponse,
     ResolvedPolicy,
 )
 from litellm.types.proxy.policy_engine.validation_types import (
@@ -37,4 +43,11 @@ __all__ = [
     # Resolver types
     "PolicyMatchContext",
     "ResolvedPolicy",
+    # API Response types
+    "PolicyGuardrailsResponse",
+    "PolicyInfoResponse",
+    "PolicyListResponse",
+    "PolicyScopeResponse",
+    "PolicySummaryItem",
+    "PolicyTestResponse",
 ]

--- a/litellm/types/proxy/policy_engine/__init__.py
+++ b/litellm/types/proxy/policy_engine/__init__.py
@@ -4,13 +4,24 @@ Type definitions for the LiteLLM Policy Engine.
 The Policy Engine allows administrators to define policies that combine guardrails
 with scoping rules. Policies can target specific teams, API keys, and models using
 wildcard patterns, and support inheritance from base policies.
+
+The engine supports two configuration styles:
+
+1. **Simple Style**: Policies with inline scope (original)
+2. **Advanced Style**: Policies with statements and separate attachments
+
+Both styles support the `inherit` field with `guardrails.add` and `guardrails.remove`.
 """
 
 from litellm.types.proxy.policy_engine.policy_types import (
+    ConditionOperator,
     Policy,
+    PolicyAttachment,
+    PolicyCondition,
     PolicyConfig,
     PolicyGuardrails,
     PolicyScope,
+    PolicyStatement,
 )
 from litellm.types.proxy.policy_engine.resolver_types import (
     PolicyGuardrailsResponse,
@@ -35,6 +46,11 @@ __all__ = [
     "PolicyConfig",
     "PolicyGuardrails",
     "PolicyScope",
+    # Condition types (new)
+    "ConditionOperator",
+    "PolicyCondition",
+    "PolicyStatement",
+    "PolicyAttachment",
     # Validation types
     "PolicyValidateRequest",
     "PolicyValidationError",

--- a/litellm/types/proxy/policy_engine/__init__.py
+++ b/litellm/types/proxy/policy_engine/__init__.py
@@ -1,0 +1,40 @@
+"""
+Type definitions for the LiteLLM Policy Engine.
+
+The Policy Engine allows administrators to define policies that combine guardrails
+with scoping rules. Policies can target specific teams, API keys, and models using
+wildcard patterns, and support inheritance from base policies.
+"""
+
+from litellm.types.proxy.policy_engine.policy_types import (
+    Policy,
+    PolicyConfig,
+    PolicyGuardrails,
+    PolicyScope,
+)
+from litellm.types.proxy.policy_engine.resolver_types import (
+    PolicyMatchContext,
+    ResolvedPolicy,
+)
+from litellm.types.proxy.policy_engine.validation_types import (
+    PolicyValidateRequest,
+    PolicyValidationError,
+    PolicyValidationErrorType,
+    PolicyValidationResponse,
+)
+
+__all__ = [
+    # Policy types
+    "Policy",
+    "PolicyConfig",
+    "PolicyGuardrails",
+    "PolicyScope",
+    # Validation types
+    "PolicyValidateRequest",
+    "PolicyValidationError",
+    "PolicyValidationErrorType",
+    "PolicyValidationResponse",
+    # Resolver types
+    "PolicyMatchContext",
+    "ResolvedPolicy",
+]

--- a/litellm/types/proxy/policy_engine/policy_types.py
+++ b/litellm/types/proxy/policy_engine/policy_types.py
@@ -1,0 +1,154 @@
+"""
+Core policy type definitions.
+
+These types define the structure of policies in the configuration.
+"""
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PolicyScope(BaseModel):
+    """
+    Defines the scope for a policy - which requests it applies to.
+
+    Scope Fields:
+    | Field  | What it matches | Wildcard support      |
+    |--------|-----------------|----------------------|
+    | teams  | Team aliases    | *, healthcare-*      |
+    | keys   | Key aliases     | *, dev-key-*         |
+    | models | Model names     | *, bedrock/*, gpt-*  |
+
+    If a field is None or empty, it defaults to matching everything (["*"]).
+    A request must match ALL specified scope fields for the policy to apply.
+    """
+
+    teams: Optional[List[str]] = Field(
+        default=None,
+        description="Team aliases or wildcard patterns. Use '*' for all teams.",
+    )
+    keys: Optional[List[str]] = Field(
+        default=None,
+        description="Key aliases or wildcard patterns. Use '*' for all keys.",
+    )
+    models: Optional[List[str]] = Field(
+        default=None,
+        description="Model names or wildcard patterns. Use '*' for all models.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_teams(self) -> List[str]:
+        """Returns teams list, defaulting to ['*'] if not specified."""
+        return self.teams if self.teams else ["*"]
+
+    def get_keys(self) -> List[str]:
+        """Returns keys list, defaulting to ['*'] if not specified."""
+        return self.keys if self.keys else ["*"]
+
+    def get_models(self) -> List[str]:
+        """Returns models list, defaulting to ['*'] if not specified."""
+        return self.models if self.models else ["*"]
+
+
+class PolicyGuardrails(BaseModel):
+    """
+    Defines guardrails to add or remove in a policy.
+
+    - `add`: List of guardrail names to add (on top of inherited guardrails)
+    - `remove`: List of guardrail names to remove (from inherited guardrails)
+    """
+
+    add: Optional[List[str]] = Field(
+        default=None,
+        description="Guardrail names to add to this policy.",
+    )
+    remove: Optional[List[str]] = Field(
+        default=None,
+        description="Guardrail names to remove (typically from inherited policy).",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_add(self) -> List[str]:
+        """Returns add list, defaulting to empty list if not specified."""
+        return self.add if self.add else []
+
+    def get_remove(self) -> List[str]:
+        """Returns remove list, defaulting to empty list if not specified."""
+        return self.remove if self.remove else []
+
+
+class Policy(BaseModel):
+    """
+    A policy that defines which guardrails apply to requests matching its scope.
+
+    Policies can inherit from other policies using the `inherit` field.
+    When inheriting:
+    - Guardrails from `guardrails.add` are added to the inherited guardrails
+    - Guardrails from `guardrails.remove` are removed from the inherited guardrails
+
+    Example configuration:
+    ```yaml
+    policies:
+      global-baseline:
+        guardrails:
+          add:
+            - pii_blocker
+            - phi_blocker
+        scope:
+          teams: ["*"]
+          keys: ["*"]
+          models: ["*"]
+
+      healthcare-compliance:
+        inherit: global-baseline
+        guardrails:
+          add:
+            - hipaa_audit
+        scope:
+          teams: [healthcare-team, medical-research]
+          models: [gpt-4, bedrock/claude-*]
+
+      internal-dev:
+        inherit: global-baseline
+        guardrails:
+          add:
+            - toxicity_filter
+          remove:
+            - phi_blocker
+        scope:
+          keys: [dev-key-*, test-key-*]
+    ```
+    """
+
+    inherit: Optional[str] = Field(
+        default=None,
+        description="Name of the parent policy to inherit from.",
+    )
+    guardrails: PolicyGuardrails = Field(
+        default_factory=PolicyGuardrails,
+        description="Guardrails configuration with add/remove lists.",
+    )
+    scope: PolicyScope = Field(
+        default_factory=PolicyScope,
+        description="Scope defining which requests this policy applies to.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class PolicyConfig(BaseModel):
+    """
+    Root configuration for all policies.
+
+    Maps policy names to their Policy definitions.
+    """
+
+    policies: Dict[str, Policy] = Field(
+        default_factory=dict,
+        description="Map of policy names to Policy objects.",
+    )
+
+    model_config = ConfigDict(extra="forbid")

--- a/litellm/types/proxy/policy_engine/resolver_types.py
+++ b/litellm/types/proxy/policy_engine/resolver_types.py
@@ -1,0 +1,53 @@
+"""
+Policy resolver type definitions.
+
+These types are used for matching requests to policies and resolving
+the final guardrails list.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PolicyMatchContext(BaseModel):
+    """
+    Context used to match a request against policies.
+
+    Contains the team alias, key alias, and model from the incoming request.
+    """
+
+    team_alias: Optional[str] = Field(
+        default=None,
+        description="Team alias from the request.",
+    )
+    key_alias: Optional[str] = Field(
+        default=None,
+        description="API key alias from the request.",
+    )
+    model: Optional[str] = Field(
+        default=None,
+        description="Model name from the request.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ResolvedPolicy(BaseModel):
+    """
+    Result of resolving a policy with its inheritance chain.
+
+    Contains the final list of guardrails after applying all add/remove operations.
+    """
+
+    policy_name: str = Field(description="Name of the resolved policy.")
+    guardrails: List[str] = Field(
+        default_factory=list,
+        description="Final list of guardrail names to apply.",
+    )
+    inheritance_chain: List[str] = Field(
+        default_factory=list,
+        description="List of policy names in the inheritance chain (from root to this policy).",
+    )
+
+    model_config = ConfigDict(extra="forbid")

--- a/litellm/types/proxy/policy_engine/resolver_types.py
+++ b/litellm/types/proxy/policy_engine/resolver_types.py
@@ -5,7 +5,7 @@ These types are used for matching requests to policies and resolving
 the final guardrails list.
 """
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -51,3 +51,60 @@ class ResolvedPolicy(BaseModel):
     )
 
     model_config = ConfigDict(extra="forbid")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# API Response Types
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class PolicyScopeResponse(BaseModel):
+    """Scope configuration for a policy."""
+
+    teams: List[str] = Field(default_factory=list)
+    keys: List[str] = Field(default_factory=list)
+    models: List[str] = Field(default_factory=list)
+
+
+class PolicyGuardrailsResponse(BaseModel):
+    """Guardrails configuration for a policy."""
+
+    add: List[str] = Field(default_factory=list)
+    remove: List[str] = Field(default_factory=list)
+
+
+class PolicyInfoResponse(BaseModel):
+    """Response for /policy/info/{policy_name} endpoint."""
+
+    policy_name: str
+    inherit: Optional[str] = None
+    scope: PolicyScopeResponse
+    guardrails: PolicyGuardrailsResponse
+    resolved_guardrails: List[str]
+    inheritance_chain: List[str]
+
+
+class PolicySummaryItem(BaseModel):
+    """Summary of a single policy for list endpoint."""
+
+    inherit: Optional[str] = None
+    scope: PolicyScopeResponse
+    guardrails: PolicyGuardrailsResponse
+    resolved_guardrails: List[str]
+    inheritance_chain: List[str]
+
+
+class PolicyListResponse(BaseModel):
+    """Response for /policy/list endpoint."""
+
+    policies: Dict[str, PolicySummaryItem]
+    total_count: int
+
+
+class PolicyTestResponse(BaseModel):
+    """Response for /policy/test endpoint."""
+
+    context: PolicyMatchContext
+    matching_policies: List[str]
+    resolved_guardrails: List[str]
+    message: Optional[str] = None

--- a/litellm/types/proxy/policy_engine/validation_types.py
+++ b/litellm/types/proxy/policy_engine/validation_types.py
@@ -1,0 +1,80 @@
+"""
+Policy validation type definitions.
+
+These types are used for validating policy configurations and returning
+validation results.
+"""
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PolicyValidationErrorType(str, Enum):
+    """Types of validation errors that can occur."""
+
+    INVALID_GUARDRAIL = "invalid_guardrail"
+    INVALID_TEAM = "invalid_team"
+    INVALID_KEY = "invalid_key"
+    INVALID_MODEL = "invalid_model"
+    INVALID_INHERITANCE = "invalid_inheritance"
+    CIRCULAR_INHERITANCE = "circular_inheritance"
+    INVALID_SCOPE = "invalid_scope"
+    INVALID_SYNTAX = "invalid_syntax"
+
+
+class PolicyValidationError(BaseModel):
+    """
+    Represents a validation error or warning for a policy.
+    """
+
+    policy_name: str = Field(description="Name of the policy with the issue.")
+    error_type: PolicyValidationErrorType = Field(
+        description="Type of validation error."
+    )
+    message: str = Field(description="Human-readable error message.")
+    field: Optional[str] = Field(
+        default=None,
+        description="Specific field that caused the error (e.g., 'guardrails.add', 'scope.teams').",
+    )
+    value: Optional[str] = Field(
+        default=None,
+        description="The invalid value that caused the error.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class PolicyValidationResponse(BaseModel):
+    """
+    Response from policy validation.
+
+    - `valid`: True if no blocking errors were found
+    - `errors`: List of blocking errors (prevent policy from being applied)
+    - `warnings`: List of non-blocking warnings (policy can still be applied)
+    """
+
+    valid: bool = Field(description="True if the policy configuration is valid.")
+    errors: List[PolicyValidationError] = Field(
+        default_factory=list,
+        description="List of blocking validation errors.",
+    )
+    warnings: List[PolicyValidationError] = Field(
+        default_factory=list,
+        description="List of non-blocking validation warnings.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class PolicyValidateRequest(BaseModel):
+    """
+    Request body for the /policy/validate endpoint.
+    """
+
+    policies: Dict[str, Any] = Field(
+        description="Policy configuration to validate. Map of policy names to policy definitions."
+    )
+
+    model_config = ConfigDict(extra="forbid")

--- a/proxy_config.yaml
+++ b/proxy_config.yaml
@@ -2,6 +2,101 @@ model_list:
   - model_name: "*"
     litellm_params:
       model: "*"
+  - model_name: "gpt-4"
+    litellm_params:
+      model: "gpt-4"
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: "gpt-3.5-turbo"
+    litellm_params:
+      model: "gpt-3.5-turbo"
+      api_key: os.environ/OPENAI_API_KEY
 
 general_settings:
   master_key: sk-1234
+
+# ───────────────────────────────────────────────
+# POLICIES - Define WHAT guardrails to apply
+# ───────────────────────────────────────────────
+#
+# Policies define guardrails with:
+# - inherit: Inherit guardrails from another policy
+# - guardrails.add: Add guardrails (on top of inherited)
+# - guardrails.remove: Remove guardrails (from inherited)
+# - statements: Conditional guardrails with AWS IAM-style conditions
+#
+policies:
+  # Global baseline policy
+  global-baseline:
+    description: "Base guardrails for all requests"
+    guardrails:
+      add:
+        - pii_blocker
+
+  # Healthcare policy - inherits from global-baseline
+  healthcare-compliance:
+    inherit: global-baseline
+    description: "HIPAA compliance for healthcare teams"
+    guardrails:
+      add:
+        - hipaa_audit
+
+  # Dev policy - inherits but removes PII blocker for testing
+  internal-dev:
+    inherit: global-baseline
+    description: "Relaxed policy for internal development"
+    guardrails:
+      add:
+        - toxicity_filter
+      remove:
+        - pii_blocker
+
+  # Policy with conditional statements
+  conditional-safety:
+    description: "Model-specific guardrails using conditions"
+    guardrails:
+      add:
+        - base_safety
+    statements:
+      - sid: "GPT4ToxicityFilter"
+        guardrails:
+          - toxicity_filter
+        condition:
+          model:
+            in: ["gpt-4", "gpt-4-turbo", "gpt-4o"]
+      - sid: "BedrockPIICheck"
+        guardrails:
+          - strict_pii_blocker
+        condition:
+          model:
+            prefix: "bedrock/"
+
+# ───────────────────────────────────────────────
+# POLICY ATTACHMENTS - Define WHERE policies apply
+# ───────────────────────────────────────────────
+#
+# Attachments are REQUIRED to make policies active.
+# A policy without an attachment will not be applied.
+#
+policy_attachments:
+  # Global attachment - applies to all requests
+  - policy: global-baseline
+    scope: "*"
+
+  # Team-specific attachment
+  - policy: healthcare-compliance
+    teams:
+      - healthcare-team
+      - medical-research
+
+  # Key pattern attachment
+  - policy: internal-dev
+    keys:
+      - "dev-key-*"
+      - "test-key-*"
+
+  # Model-specific attachment
+  - policy: conditional-safety
+    models:
+      - "gpt-4"
+      - "gpt-4-turbo"
+      - "bedrock/*"

--- a/proxy_config.yaml
+++ b/proxy_config.yaml
@@ -20,9 +20,10 @@ general_settings:
 #
 # Policies define guardrails with:
 # - inherit: Inherit guardrails from another policy
+# - description: Human-readable description
 # - guardrails.add: Add guardrails (on top of inherited)
 # - guardrails.remove: Remove guardrails (from inherited)
-# - statements: Conditional guardrails with AWS IAM-style conditions
+# - condition.model: Model pattern (exact or regex) for when guardrails apply
 #
 policies:
   # Global baseline policy
@@ -50,25 +51,23 @@ policies:
       remove:
         - pii_blocker
 
-  # Policy with conditional statements
-  conditional-safety:
-    description: "Model-specific guardrails using conditions"
+  # Policy with model condition (regex pattern)
+  gpt4-safety:
+    description: "Extra safety for GPT-4 models"
     guardrails:
       add:
-        - base_safety
-    statements:
-      - sid: "GPT4ToxicityFilter"
-        guardrails:
-          - toxicity_filter
-        condition:
-          model:
-            in: ["gpt-4", "gpt-4-turbo", "gpt-4o"]
-      - sid: "BedrockPIICheck"
-        guardrails:
-          - strict_pii_blocker
-        condition:
-          model:
-            prefix: "bedrock/"
+        - toxicity_filter
+    condition:
+      model: "gpt-4.*"  # regex: matches gpt-4, gpt-4-turbo, gpt-4o, etc.
+
+  # Policy with model condition (exact match list)
+  bedrock-compliance:
+    description: "Compliance for Bedrock models"
+    guardrails:
+      add:
+        - strict_pii_blocker
+    condition:
+      model: ["bedrock/claude-3", "bedrock/claude-2"]  # exact matches
 
 # ───────────────────────────────────────────────
 # POLICY ATTACHMENTS - Define WHERE policies apply
@@ -94,9 +93,9 @@ policy_attachments:
       - "dev-key-*"
       - "test-key-*"
 
-  # Model-specific attachment
-  - policy: conditional-safety
-    models:
-      - "gpt-4"
-      - "gpt-4-turbo"
-      - "bedrock/*"
+  # Model-specific policies (attached globally, condition filters by model)
+  - policy: gpt4-safety
+    scope: "*"
+
+  - policy: bedrock-compliance
+    scope: "*"

--- a/tests/code_coverage_tests/recursive_detector.py
+++ b/tests/code_coverage_tests/recursive_detector.py
@@ -39,6 +39,7 @@ IGNORE_FUNCTIONS = [
     "_delete_nested_value_custom",  # max depth set (bounded by number of path segments).
     "filter_exceptions_from_params",  # max depth set (default 20) to prevent infinite recursion.
     "__getattr__",  # lazy loading pattern in litellm/__init__.py with proper caching to prevent infinite recursion.
+    "_validate_inheritance_chain",  # max depth set (default 100) to prevent infinite recursion in policy inheritance validation.
 ]
 
 

--- a/tests/test_litellm/proxy/policy_engine/test_attachment_registry.py
+++ b/tests/test_litellm/proxy/policy_engine/test_attachment_registry.py
@@ -1,0 +1,289 @@
+"""
+Unit tests for AttachmentRegistry - tests policy attachment management.
+
+Tests:
+- Loading attachments from config
+- Getting attached policies for a context
+- Global scope attachments
+- Team/key/model specific attachments
+"""
+
+import pytest
+
+from litellm.proxy.policy_engine.attachment_registry import (
+    AttachmentRegistry,
+    get_attachment_registry,
+)
+from litellm.types.proxy.policy_engine import (
+    PolicyAttachment,
+    PolicyMatchContext,
+)
+
+
+class TestAttachmentRegistryLoading:
+    """Test loading attachments from configuration."""
+
+    def test_load_attachments_simple(self):
+        """Test loading simple attachments."""
+        registry = AttachmentRegistry()
+        config = [
+            {"policy": "global-baseline", "scope": "*"},
+            {"policy": "healthcare-policy", "teams": ["healthcare-team"]},
+        ]
+        registry.load_attachments(config)
+
+        assert registry.is_initialized()
+        assert len(registry.get_all_attachments()) == 2
+
+    def test_load_attachments_with_multiple_scopes(self):
+        """Test loading attachments with multiple scope types."""
+        registry = AttachmentRegistry()
+        config = [
+            {"policy": "global-baseline", "scope": "*"},
+            {"policy": "team-policy", "teams": ["team-a", "team-b"]},
+            {"policy": "key-policy", "keys": ["dev-key-*"]},
+            {"policy": "model-policy", "models": ["gpt-4", "gpt-4-turbo"]},
+        ]
+        registry.load_attachments(config)
+
+        assert len(registry.get_all_attachments()) == 4
+
+    def test_load_attachments_empty_list(self):
+        """Test loading empty attachments list."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([])
+
+        assert registry.is_initialized()
+        assert len(registry.get_all_attachments()) == 0
+
+    def test_clear_attachments(self):
+        """Test clearing attachments."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([{"policy": "test", "scope": "*"}])
+        assert registry.is_initialized()
+
+        registry.clear()
+        assert not registry.is_initialized()
+        assert len(registry.get_all_attachments()) == 0
+
+
+class TestGetAttachedPolicies:
+    """Test getting attached policies for a context."""
+
+    def test_global_scope_matches_all(self):
+        """Test global scope (*) matches all contexts."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "global-baseline", "scope": "*"},
+        ])
+
+        context = PolicyMatchContext(
+            team_alias="any-team", key_alias="any-key", model="any-model"
+        )
+        attached = registry.get_attached_policies(context)
+        assert "global-baseline" in attached
+
+    def test_team_specific_attachment(self):
+        """Test team-specific attachment matches only that team."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "healthcare-policy", "teams": ["healthcare-team"]},
+        ])
+
+        # Match
+        context = PolicyMatchContext(
+            team_alias="healthcare-team", key_alias="key", model="gpt-4"
+        )
+        attached = registry.get_attached_policies(context)
+        assert "healthcare-policy" in attached
+
+        # No match
+        context_other = PolicyMatchContext(
+            team_alias="finance-team", key_alias="key", model="gpt-4"
+        )
+        attached_other = registry.get_attached_policies(context_other)
+        assert "healthcare-policy" not in attached_other
+
+    def test_key_pattern_attachment(self):
+        """Test key pattern attachment matches wildcard."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "dev-policy", "keys": ["dev-key-*"]},
+        ])
+
+        # Match
+        context = PolicyMatchContext(
+            team_alias="team", key_alias="dev-key-123", model="gpt-4"
+        )
+        attached = registry.get_attached_policies(context)
+        assert "dev-policy" in attached
+
+        # No match
+        context_prod = PolicyMatchContext(
+            team_alias="team", key_alias="prod-key-123", model="gpt-4"
+        )
+        attached_prod = registry.get_attached_policies(context_prod)
+        assert "dev-policy" not in attached_prod
+
+    def test_model_specific_attachment(self):
+        """Test model-specific attachment."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "gpt4-policy", "models": ["gpt-4", "gpt-4-turbo"]},
+        ])
+
+        # Match
+        context = PolicyMatchContext(
+            team_alias="team", key_alias="key", model="gpt-4"
+        )
+        attached = registry.get_attached_policies(context)
+        assert "gpt4-policy" in attached
+
+        # No match
+        context_other = PolicyMatchContext(
+            team_alias="team", key_alias="key", model="gpt-3.5"
+        )
+        attached_other = registry.get_attached_policies(context_other)
+        assert "gpt4-policy" not in attached_other
+
+    def test_multiple_attachments_match(self):
+        """Test multiple attachments can match same context."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "global-baseline", "scope": "*"},
+            {"policy": "healthcare-policy", "teams": ["healthcare-team"]},
+            {"policy": "gpt4-policy", "models": ["gpt-4"]},
+        ])
+
+        context = PolicyMatchContext(
+            team_alias="healthcare-team", key_alias="key", model="gpt-4"
+        )
+        attached = registry.get_attached_policies(context)
+
+        assert "global-baseline" in attached
+        assert "healthcare-policy" in attached
+        assert "gpt4-policy" in attached
+        assert len(attached) == 3
+
+    def test_no_duplicate_policies(self):
+        """Test same policy attached multiple ways doesn't duplicate."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "multi-policy", "scope": "*"},
+            {"policy": "multi-policy", "teams": ["healthcare-team"]},
+        ])
+
+        context = PolicyMatchContext(
+            team_alias="healthcare-team", key_alias="key", model="gpt-4"
+        )
+        attached = registry.get_attached_policies(context)
+
+        # Should only appear once
+        assert attached.count("multi-policy") == 1
+
+
+class TestIsPolicyAttached:
+    """Test is_policy_attached method."""
+
+    def test_policy_is_attached(self):
+        """Test checking if a specific policy is attached."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "global-baseline", "scope": "*"},
+        ])
+
+        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
+        assert registry.is_policy_attached("global-baseline", context) is True
+        assert registry.is_policy_attached("other-policy", context) is False
+
+
+class TestGetAttachmentsForPolicy:
+    """Test getting attachments for a specific policy."""
+
+    def test_get_attachments_for_policy(self):
+        """Test getting all attachments for a policy."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "multi-policy", "scope": "*"},
+            {"policy": "multi-policy", "teams": ["team-a"]},
+            {"policy": "other-policy", "teams": ["team-b"]},
+        ])
+
+        attachments = registry.get_attachments_for_policy("multi-policy")
+        assert len(attachments) == 2
+
+        attachments_other = registry.get_attachments_for_policy("other-policy")
+        assert len(attachments_other) == 1
+
+
+class TestAddAndRemoveAttachments:
+    """Test adding and removing individual attachments."""
+
+    def test_add_attachment(self):
+        """Test adding a single attachment."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([])
+
+        attachment = PolicyAttachment(policy="new-policy", scope="*")
+        registry.add_attachment(attachment)
+
+        assert len(registry.get_all_attachments()) == 1
+
+    def test_remove_attachments_for_policy(self):
+        """Test removing all attachments for a policy."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "policy-a", "scope": "*"},
+            {"policy": "policy-a", "teams": ["team-a"]},
+            {"policy": "policy-b", "teams": ["team-b"]},
+        ])
+
+        removed = registry.remove_attachments_for_policy("policy-a")
+        assert removed == 2
+        assert len(registry.get_all_attachments()) == 1
+        assert len(registry.get_attachments_for_policy("policy-a")) == 0
+
+
+class TestPolicyAttachmentModel:
+    """Test PolicyAttachment model methods."""
+
+    def test_is_global(self):
+        """Test is_global method."""
+        global_attachment = PolicyAttachment(policy="test", scope="*")
+        assert global_attachment.is_global() is True
+
+        team_attachment = PolicyAttachment(policy="test", teams=["team-a"])
+        assert team_attachment.is_global() is False
+
+    def test_to_policy_scope_global(self):
+        """Test converting global attachment to PolicyScope."""
+        attachment = PolicyAttachment(policy="test", scope="*")
+        scope = attachment.to_policy_scope()
+
+        assert scope.get_teams() == ["*"]
+        assert scope.get_keys() == ["*"]
+        assert scope.get_models() == ["*"]
+
+    def test_to_policy_scope_specific(self):
+        """Test converting specific attachment to PolicyScope."""
+        attachment = PolicyAttachment(
+            policy="test",
+            teams=["team-a", "team-b"],
+            keys=["key-*"],
+            models=["gpt-4"],
+        )
+        scope = attachment.to_policy_scope()
+
+        assert scope.teams == ["team-a", "team-b"]
+        assert scope.keys == ["key-*"]
+        assert scope.models == ["gpt-4"]
+
+
+class TestGlobalSingleton:
+    """Test global singleton behavior."""
+
+    def test_get_attachment_registry_singleton(self):
+        """Test get_attachment_registry returns same instance."""
+        registry1 = get_attachment_registry()
+        registry2 = get_attachment_registry()
+        assert registry1 is registry2

--- a/tests/test_litellm/proxy/policy_engine/test_attachment_registry.py
+++ b/tests/test_litellm/proxy/policy_engine/test_attachment_registry.py
@@ -1,11 +1,7 @@
 """
-Unit tests for AttachmentRegistry - tests policy attachment management.
+Unit tests for AttachmentRegistry - tests policy attachment matching.
 
-Tests:
-- Loading attachments from config
-- Getting attached policies for a context
-- Global scope attachments
-- Team/key/model specific attachments
+Tests the main entry point: get_attached_policies()
 """
 
 import pytest
@@ -14,69 +10,20 @@ from litellm.proxy.policy_engine.attachment_registry import (
     AttachmentRegistry,
     get_attachment_registry,
 )
-from litellm.types.proxy.policy_engine import (
-    PolicyAttachment,
-    PolicyMatchContext,
-)
-
-
-class TestAttachmentRegistryLoading:
-    """Test loading attachments from configuration."""
-
-    def test_load_attachments_simple(self):
-        """Test loading simple attachments."""
-        registry = AttachmentRegistry()
-        config = [
-            {"policy": "global-baseline", "scope": "*"},
-            {"policy": "healthcare-policy", "teams": ["healthcare-team"]},
-        ]
-        registry.load_attachments(config)
-
-        assert registry.is_initialized()
-        assert len(registry.get_all_attachments()) == 2
-
-    def test_load_attachments_with_multiple_scopes(self):
-        """Test loading attachments with multiple scope types."""
-        registry = AttachmentRegistry()
-        config = [
-            {"policy": "global-baseline", "scope": "*"},
-            {"policy": "team-policy", "teams": ["team-a", "team-b"]},
-            {"policy": "key-policy", "keys": ["dev-key-*"]},
-            {"policy": "model-policy", "models": ["gpt-4", "gpt-4-turbo"]},
-        ]
-        registry.load_attachments(config)
-
-        assert len(registry.get_all_attachments()) == 4
-
-    def test_load_attachments_empty_list(self):
-        """Test loading empty attachments list."""
-        registry = AttachmentRegistry()
-        registry.load_attachments([])
-
-        assert registry.is_initialized()
-        assert len(registry.get_all_attachments()) == 0
-
-    def test_clear_attachments(self):
-        """Test clearing attachments."""
-        registry = AttachmentRegistry()
-        registry.load_attachments([{"policy": "test", "scope": "*"}])
-        assert registry.is_initialized()
-
-        registry.clear()
-        assert not registry.is_initialized()
-        assert len(registry.get_all_attachments()) == 0
+from litellm.types.proxy.policy_engine import PolicyMatchContext
 
 
 class TestGetAttachedPolicies:
-    """Test getting attached policies for a context."""
+    """Test get_attached_policies - the main entry point."""
 
-    def test_global_scope_matches_all(self):
-        """Test global scope (*) matches all contexts."""
+    def test_global_scope_matches_all_requests(self):
+        """Test global scope (*) matches any request context."""
         registry = AttachmentRegistry()
         registry.load_attachments([
             {"policy": "global-baseline", "scope": "*"},
         ])
 
+        # Should match any context
         context = PolicyMatchContext(
             team_alias="any-team", key_alias="any-key", model="any-model"
         )
@@ -94,36 +41,32 @@ class TestGetAttachedPolicies:
         context = PolicyMatchContext(
             team_alias="healthcare-team", key_alias="key", model="gpt-4"
         )
-        attached = registry.get_attached_policies(context)
-        assert "healthcare-policy" in attached
+        assert "healthcare-policy" in registry.get_attached_policies(context)
 
-        # No match
+        # No match - different team
         context_other = PolicyMatchContext(
             team_alias="finance-team", key_alias="key", model="gpt-4"
         )
-        attached_other = registry.get_attached_policies(context_other)
-        assert "healthcare-policy" not in attached_other
+        assert "healthcare-policy" not in registry.get_attached_policies(context_other)
 
-    def test_key_pattern_attachment(self):
-        """Test key pattern attachment matches wildcard."""
+    def test_key_wildcard_pattern_attachment(self):
+        """Test key pattern attachment with wildcard."""
         registry = AttachmentRegistry()
         registry.load_attachments([
             {"policy": "dev-policy", "keys": ["dev-key-*"]},
         ])
 
-        # Match
+        # Match - key starts with dev-key-
         context = PolicyMatchContext(
             team_alias="team", key_alias="dev-key-123", model="gpt-4"
         )
-        attached = registry.get_attached_policies(context)
-        assert "dev-policy" in attached
+        assert "dev-policy" in registry.get_attached_policies(context)
 
-        # No match
+        # No match - different prefix
         context_prod = PolicyMatchContext(
             team_alias="team", key_alias="prod-key-123", model="gpt-4"
         )
-        attached_prod = registry.get_attached_policies(context_prod)
-        assert "dev-policy" not in attached_prod
+        assert "dev-policy" not in registry.get_attached_policies(context_prod)
 
     def test_model_specific_attachment(self):
         """Test model-specific attachment."""
@@ -136,18 +79,35 @@ class TestGetAttachedPolicies:
         context = PolicyMatchContext(
             team_alias="team", key_alias="key", model="gpt-4"
         )
-        attached = registry.get_attached_policies(context)
-        assert "gpt4-policy" in attached
+        assert "gpt4-policy" in registry.get_attached_policies(context)
 
         # No match
         context_other = PolicyMatchContext(
             team_alias="team", key_alias="key", model="gpt-3.5"
         )
-        attached_other = registry.get_attached_policies(context_other)
-        assert "gpt4-policy" not in attached_other
+        assert "gpt4-policy" not in registry.get_attached_policies(context_other)
 
-    def test_multiple_attachments_match(self):
-        """Test multiple attachments can match same context."""
+    def test_model_wildcard_pattern(self):
+        """Test model wildcard pattern like bedrock/*."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "bedrock-policy", "models": ["bedrock/*"]},
+        ])
+
+        # Match
+        context = PolicyMatchContext(
+            team_alias="team", key_alias="key", model="bedrock/claude-3"
+        )
+        assert "bedrock-policy" in registry.get_attached_policies(context)
+
+        # No match
+        context_other = PolicyMatchContext(
+            team_alias="team", key_alias="key", model="openai/gpt-4"
+        )
+        assert "bedrock-policy" not in registry.get_attached_policies(context_other)
+
+    def test_multiple_attachments_match_same_context(self):
+        """Test multiple attachments can match the same context."""
         registry = AttachmentRegistry()
         registry.load_attachments([
             {"policy": "global-baseline", "scope": "*"},
@@ -160,12 +120,13 @@ class TestGetAttachedPolicies:
         )
         attached = registry.get_attached_policies(context)
 
+        # All three should match
         assert "global-baseline" in attached
         assert "healthcare-policy" in attached
         assert "gpt4-policy" in attached
         assert len(attached) == 3
 
-    def test_no_duplicate_policies(self):
+    def test_same_policy_multiple_attachments_no_duplicates(self):
         """Test same policy attached multiple ways doesn't duplicate."""
         registry = AttachmentRegistry()
         registry.load_attachments([
@@ -181,108 +142,60 @@ class TestGetAttachedPolicies:
         # Should only appear once
         assert attached.count("multi-policy") == 1
 
-
-class TestIsPolicyAttached:
-    """Test is_policy_attached method."""
-
-    def test_policy_is_attached(self):
-        """Test checking if a specific policy is attached."""
-        registry = AttachmentRegistry()
-        registry.load_attachments([
-            {"policy": "global-baseline", "scope": "*"},
-        ])
-
-        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
-        assert registry.is_policy_attached("global-baseline", context) is True
-        assert registry.is_policy_attached("other-policy", context) is False
-
-
-class TestGetAttachmentsForPolicy:
-    """Test getting attachments for a specific policy."""
-
-    def test_get_attachments_for_policy(self):
-        """Test getting all attachments for a policy."""
-        registry = AttachmentRegistry()
-        registry.load_attachments([
-            {"policy": "multi-policy", "scope": "*"},
-            {"policy": "multi-policy", "teams": ["team-a"]},
-            {"policy": "other-policy", "teams": ["team-b"]},
-        ])
-
-        attachments = registry.get_attachments_for_policy("multi-policy")
-        assert len(attachments) == 2
-
-        attachments_other = registry.get_attachments_for_policy("other-policy")
-        assert len(attachments_other) == 1
-
-
-class TestAddAndRemoveAttachments:
-    """Test adding and removing individual attachments."""
-
-    def test_add_attachment(self):
-        """Test adding a single attachment."""
+    def test_no_attachments_returns_empty(self):
+        """Test empty attachments returns empty list."""
         registry = AttachmentRegistry()
         registry.load_attachments([])
 
-        attachment = PolicyAttachment(policy="new-policy", scope="*")
-        registry.add_attachment(attachment)
+        context = PolicyMatchContext(
+            team_alias="team", key_alias="key", model="gpt-4"
+        )
+        attached = registry.get_attached_policies(context)
+        assert attached == []
 
-        assert len(registry.get_all_attachments()) == 1
-
-    def test_remove_attachments_for_policy(self):
-        """Test removing all attachments for a policy."""
+    def test_no_matching_attachments_returns_empty(self):
+        """Test no matching attachments returns empty list."""
         registry = AttachmentRegistry()
         registry.load_attachments([
-            {"policy": "policy-a", "scope": "*"},
-            {"policy": "policy-a", "teams": ["team-a"]},
-            {"policy": "policy-b", "teams": ["team-b"]},
+            {"policy": "healthcare-policy", "teams": ["healthcare-team"]},
         ])
 
-        removed = registry.remove_attachments_for_policy("policy-a")
-        assert removed == 2
-        assert len(registry.get_all_attachments()) == 1
-        assert len(registry.get_attachments_for_policy("policy-a")) == 0
-
-
-class TestPolicyAttachmentModel:
-    """Test PolicyAttachment model methods."""
-
-    def test_is_global(self):
-        """Test is_global method."""
-        global_attachment = PolicyAttachment(policy="test", scope="*")
-        assert global_attachment.is_global() is True
-
-        team_attachment = PolicyAttachment(policy="test", teams=["team-a"])
-        assert team_attachment.is_global() is False
-
-    def test_to_policy_scope_global(self):
-        """Test converting global attachment to PolicyScope."""
-        attachment = PolicyAttachment(policy="test", scope="*")
-        scope = attachment.to_policy_scope()
-
-        assert scope.get_teams() == ["*"]
-        assert scope.get_keys() == ["*"]
-        assert scope.get_models() == ["*"]
-
-    def test_to_policy_scope_specific(self):
-        """Test converting specific attachment to PolicyScope."""
-        attachment = PolicyAttachment(
-            policy="test",
-            teams=["team-a", "team-b"],
-            keys=["key-*"],
-            models=["gpt-4"],
+        context = PolicyMatchContext(
+            team_alias="finance-team", key_alias="key", model="gpt-4"
         )
-        scope = attachment.to_policy_scope()
+        attached = registry.get_attached_policies(context)
+        assert attached == []
 
-        assert scope.teams == ["team-a", "team-b"]
-        assert scope.keys == ["key-*"]
-        assert scope.models == ["gpt-4"]
+    def test_combined_team_and_model_attachment(self):
+        """Test attachment with both team and model constraints."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "strict-policy", "teams": ["healthcare-team"], "models": ["gpt-4"]},
+        ])
+
+        # Match - both team and model match
+        context = PolicyMatchContext(
+            team_alias="healthcare-team", key_alias="key", model="gpt-4"
+        )
+        assert "strict-policy" in registry.get_attached_policies(context)
+
+        # No match - team matches but model doesn't
+        context_wrong_model = PolicyMatchContext(
+            team_alias="healthcare-team", key_alias="key", model="gpt-3.5"
+        )
+        assert "strict-policy" not in registry.get_attached_policies(context_wrong_model)
+
+        # No match - model matches but team doesn't
+        context_wrong_team = PolicyMatchContext(
+            team_alias="finance-team", key_alias="key", model="gpt-4"
+        )
+        assert "strict-policy" not in registry.get_attached_policies(context_wrong_team)
 
 
-class TestGlobalSingleton:
+class TestAttachmentRegistrySingleton:
     """Test global singleton behavior."""
 
-    def test_get_attachment_registry_singleton(self):
+    def test_get_attachment_registry_returns_same_instance(self):
         """Test get_attachment_registry returns same instance."""
         registry1 = get_attachment_registry()
         registry2 = get_attachment_registry()

--- a/tests/test_litellm/proxy/policy_engine/test_condition_evaluator.py
+++ b/tests/test_litellm/proxy/policy_engine/test_condition_evaluator.py
@@ -1,0 +1,289 @@
+"""
+Unit tests for ConditionEvaluator - tests AWS IAM-style condition evaluation.
+
+Tests:
+- Condition operators (equals, in, prefix, not_equals, not_in)
+- PolicyCondition evaluation against request context
+- Metadata condition evaluation
+"""
+
+import pytest
+
+from litellm.proxy.policy_engine.condition_evaluator import ConditionEvaluator
+from litellm.types.proxy.policy_engine import (
+    ConditionOperator,
+    PolicyCondition,
+    PolicyMatchContext,
+)
+
+
+class TestConditionOperatorEvaluation:
+    """Test individual condition operator evaluation."""
+
+    def test_equals_operator_match(self):
+        """Test equals operator matches exact value."""
+        operator = ConditionOperator(equals="gpt-4")
+        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is True
+
+    def test_equals_operator_no_match(self):
+        """Test equals operator does not match different value."""
+        operator = ConditionOperator(equals="gpt-4")
+        assert ConditionEvaluator.evaluate_operator(operator, "gpt-3.5") is False
+
+    def test_in_operator_match(self):
+        """Test in operator matches value in list."""
+        operator = ConditionOperator(in_=["gpt-4", "gpt-4-turbo", "gpt-4o"])
+        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is True
+        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4-turbo") is True
+
+    def test_in_operator_no_match(self):
+        """Test in operator does not match value not in list."""
+        operator = ConditionOperator(in_=["gpt-4", "gpt-4-turbo"])
+        assert ConditionEvaluator.evaluate_operator(operator, "gpt-3.5") is False
+
+    def test_prefix_operator_match(self):
+        """Test prefix operator matches value starting with prefix."""
+        operator = ConditionOperator(prefix="bedrock/")
+        assert ConditionEvaluator.evaluate_operator(operator, "bedrock/claude-3") is True
+        assert ConditionEvaluator.evaluate_operator(operator, "bedrock/llama") is True
+
+    def test_prefix_operator_no_match(self):
+        """Test prefix operator does not match value not starting with prefix."""
+        operator = ConditionOperator(prefix="bedrock/")
+        assert ConditionEvaluator.evaluate_operator(operator, "openai/gpt-4") is False
+
+    def test_not_equals_operator_match(self):
+        """Test not_equals operator matches when value is different."""
+        operator = ConditionOperator(not_equals="gpt-3.5")
+        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is True
+
+    def test_not_equals_operator_no_match(self):
+        """Test not_equals operator does not match when value is same."""
+        operator = ConditionOperator(not_equals="gpt-4")
+        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is False
+
+    def test_not_in_operator_match(self):
+        """Test not_in operator matches when value not in list."""
+        operator = ConditionOperator(not_in=["gpt-3.5", "gpt-3.5-turbo"])
+        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is True
+
+    def test_not_in_operator_no_match(self):
+        """Test not_in operator does not match when value in list."""
+        operator = ConditionOperator(not_in=["gpt-4", "gpt-4-turbo"])
+        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is False
+
+    def test_none_value_with_positive_operators(self):
+        """Test None value does not match positive operators."""
+        assert ConditionEvaluator.evaluate_operator(
+            ConditionOperator(equals="gpt-4"), None
+        ) is False
+        assert ConditionEvaluator.evaluate_operator(
+            ConditionOperator(in_=["gpt-4"]), None
+        ) is False
+        assert ConditionEvaluator.evaluate_operator(
+            ConditionOperator(prefix="gpt"), None
+        ) is False
+
+    def test_none_value_with_negative_operators(self):
+        """Test None value matches negative operators (None is not equal to anything)."""
+        assert ConditionEvaluator.evaluate_operator(
+            ConditionOperator(not_equals="gpt-4"), None
+        ) is True
+        assert ConditionEvaluator.evaluate_operator(
+            ConditionOperator(not_in=["gpt-4"]), None
+        ) is True
+
+    def test_empty_operator_matches_any(self):
+        """Test empty operator (no conditions) matches any value."""
+        operator = ConditionOperator()
+        assert ConditionEvaluator.evaluate_operator(operator, "anything") is True
+        assert ConditionEvaluator.evaluate_operator(operator, None) is True
+
+
+class TestPolicyConditionEvaluation:
+    """Test PolicyCondition evaluation against request context."""
+
+    def test_model_condition_match(self):
+        """Test model condition matches."""
+        condition = PolicyCondition(
+            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"])
+        )
+        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
+        assert ConditionEvaluator.evaluate(condition, context) is True
+
+    def test_model_condition_no_match(self):
+        """Test model condition does not match."""
+        condition = PolicyCondition(
+            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"])
+        )
+        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-3.5")
+        assert ConditionEvaluator.evaluate(condition, context) is False
+
+    def test_team_condition_match(self):
+        """Test team condition matches."""
+        condition = PolicyCondition(
+            team=ConditionOperator(prefix="healthcare-")
+        )
+        context = PolicyMatchContext(
+            team_alias="healthcare-research", key_alias="key", model="gpt-4"
+        )
+        assert ConditionEvaluator.evaluate(condition, context) is True
+
+    def test_team_condition_no_match(self):
+        """Test team condition does not match."""
+        condition = PolicyCondition(
+            team=ConditionOperator(prefix="healthcare-")
+        )
+        context = PolicyMatchContext(
+            team_alias="finance-team", key_alias="key", model="gpt-4"
+        )
+        assert ConditionEvaluator.evaluate(condition, context) is False
+
+    def test_key_condition_match(self):
+        """Test key condition matches."""
+        condition = PolicyCondition(
+            key=ConditionOperator(equals="production-key")
+        )
+        context = PolicyMatchContext(
+            team_alias="team", key_alias="production-key", model="gpt-4"
+        )
+        assert ConditionEvaluator.evaluate(condition, context) is True
+
+    def test_multiple_conditions_all_match(self):
+        """Test multiple conditions all must match (AND logic)."""
+        condition = PolicyCondition(
+            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"]),
+            team=ConditionOperator(prefix="healthcare-"),
+        )
+        context = PolicyMatchContext(
+            team_alias="healthcare-research", key_alias="key", model="gpt-4"
+        )
+        assert ConditionEvaluator.evaluate(condition, context) is True
+
+    def test_multiple_conditions_one_fails(self):
+        """Test multiple conditions - if one fails, all fails."""
+        condition = PolicyCondition(
+            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"]),
+            team=ConditionOperator(prefix="healthcare-"),
+        )
+        # Model matches but team doesn't
+        context = PolicyMatchContext(
+            team_alias="finance-team", key_alias="key", model="gpt-4"
+        )
+        assert ConditionEvaluator.evaluate(condition, context) is False
+
+    def test_none_condition_always_matches(self):
+        """Test None condition always matches."""
+        context = PolicyMatchContext(team_alias="any", key_alias="any", model="any")
+        assert ConditionEvaluator.evaluate(None, context) is True
+
+
+class TestMetadataConditionEvaluation:
+    """Test metadata condition evaluation."""
+
+    def test_metadata_condition_match(self):
+        """Test metadata condition matches."""
+        condition = PolicyCondition(
+            metadata={
+                "environment": ConditionOperator(equals="production"),
+            }
+        )
+        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
+        metadata = {"environment": "production"}
+        assert ConditionEvaluator.evaluate(condition, context, metadata) is True
+
+    def test_metadata_condition_no_match(self):
+        """Test metadata condition does not match."""
+        condition = PolicyCondition(
+            metadata={
+                "environment": ConditionOperator(equals="production"),
+            }
+        )
+        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
+        metadata = {"environment": "staging"}
+        assert ConditionEvaluator.evaluate(condition, context, metadata) is False
+
+    def test_metadata_condition_missing_field(self):
+        """Test metadata condition with missing field does not match."""
+        condition = PolicyCondition(
+            metadata={
+                "environment": ConditionOperator(equals="production"),
+            }
+        )
+        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
+        metadata = {"other_field": "value"}
+        assert ConditionEvaluator.evaluate(condition, context, metadata) is False
+
+    def test_metadata_condition_with_model_condition(self):
+        """Test combining metadata and model conditions."""
+        condition = PolicyCondition(
+            model=ConditionOperator(in_=["gpt-4"]),
+            metadata={
+                "environment": ConditionOperator(equals="production"),
+            },
+        )
+        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
+        metadata = {"environment": "production"}
+        assert ConditionEvaluator.evaluate(condition, context, metadata) is True
+
+        # Model matches but metadata doesn't
+        metadata_staging = {"environment": "staging"}
+        assert ConditionEvaluator.evaluate(condition, context, metadata_staging) is False
+
+
+class TestEvaluateAllConditions:
+    """Test evaluate_all_conditions helper."""
+
+    def test_all_conditions_match(self):
+        """Test all conditions match returns True."""
+        conditions = [
+            PolicyCondition(model=ConditionOperator(equals="gpt-4")),
+            PolicyCondition(team=ConditionOperator(prefix="healthcare-")),
+        ]
+        context = PolicyMatchContext(
+            team_alias="healthcare-team", key_alias="key", model="gpt-4"
+        )
+        assert ConditionEvaluator.evaluate_all_conditions(conditions, context) is True
+
+    def test_one_condition_fails(self):
+        """Test one condition fails returns False."""
+        conditions = [
+            PolicyCondition(model=ConditionOperator(equals="gpt-4")),
+            PolicyCondition(team=ConditionOperator(prefix="healthcare-")),
+        ]
+        context = PolicyMatchContext(
+            team_alias="finance-team", key_alias="key", model="gpt-4"
+        )
+        assert ConditionEvaluator.evaluate_all_conditions(conditions, context) is False
+
+    def test_empty_conditions_returns_true(self):
+        """Test empty conditions list returns True."""
+        context = PolicyMatchContext(team_alias="any", key_alias="any", model="any")
+        assert ConditionEvaluator.evaluate_all_conditions([], context) is True
+
+
+class TestEvaluateAnyCondition:
+    """Test evaluate_any_condition helper."""
+
+    def test_any_condition_matches(self):
+        """Test any condition matches returns True."""
+        conditions = [
+            PolicyCondition(model=ConditionOperator(equals="gpt-4")),
+            PolicyCondition(model=ConditionOperator(equals="gpt-3.5")),
+        ]
+        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
+        assert ConditionEvaluator.evaluate_any_condition(conditions, context) is True
+
+    def test_no_condition_matches(self):
+        """Test no condition matches returns False."""
+        conditions = [
+            PolicyCondition(model=ConditionOperator(equals="gpt-4")),
+            PolicyCondition(model=ConditionOperator(equals="gpt-3.5")),
+        ]
+        context = PolicyMatchContext(team_alias="team", key_alias="key", model="claude-3")
+        assert ConditionEvaluator.evaluate_any_condition(conditions, context) is False
+
+    def test_empty_conditions_returns_true(self):
+        """Test empty conditions list returns True."""
+        context = PolicyMatchContext(team_alias="any", key_alias="any", model="any")
+        assert ConditionEvaluator.evaluate_any_condition([], context) is True

--- a/tests/test_litellm/proxy/policy_engine/test_condition_evaluator.py
+++ b/tests/test_litellm/proxy/policy_engine/test_condition_evaluator.py
@@ -1,289 +1,113 @@
 """
-Unit tests for ConditionEvaluator - tests AWS IAM-style condition evaluation.
+Unit tests for ConditionEvaluator - tests model condition evaluation.
 
 Tests:
-- Condition operators (equals, in, prefix, not_equals, not_in)
-- PolicyCondition evaluation against request context
-- Metadata condition evaluation
+- Exact model match
+- Regex pattern match
+- List of models
 """
 
 import pytest
 
 from litellm.proxy.policy_engine.condition_evaluator import ConditionEvaluator
 from litellm.types.proxy.policy_engine import (
-    ConditionOperator,
     PolicyCondition,
     PolicyMatchContext,
 )
 
 
-class TestConditionOperatorEvaluation:
-    """Test individual condition operator evaluation."""
+class TestConditionEvaluator:
+    """Test condition evaluation."""
 
-    def test_equals_operator_match(self):
-        """Test equals operator matches exact value."""
-        operator = ConditionOperator(equals="gpt-4")
-        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is True
-
-    def test_equals_operator_no_match(self):
-        """Test equals operator does not match different value."""
-        operator = ConditionOperator(equals="gpt-4")
-        assert ConditionEvaluator.evaluate_operator(operator, "gpt-3.5") is False
-
-    def test_in_operator_match(self):
-        """Test in operator matches value in list."""
-        operator = ConditionOperator(in_=["gpt-4", "gpt-4-turbo", "gpt-4o"])
-        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is True
-        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4-turbo") is True
-
-    def test_in_operator_no_match(self):
-        """Test in operator does not match value not in list."""
-        operator = ConditionOperator(in_=["gpt-4", "gpt-4-turbo"])
-        assert ConditionEvaluator.evaluate_operator(operator, "gpt-3.5") is False
-
-    def test_prefix_operator_match(self):
-        """Test prefix operator matches value starting with prefix."""
-        operator = ConditionOperator(prefix="bedrock/")
-        assert ConditionEvaluator.evaluate_operator(operator, "bedrock/claude-3") is True
-        assert ConditionEvaluator.evaluate_operator(operator, "bedrock/llama") is True
-
-    def test_prefix_operator_no_match(self):
-        """Test prefix operator does not match value not starting with prefix."""
-        operator = ConditionOperator(prefix="bedrock/")
-        assert ConditionEvaluator.evaluate_operator(operator, "openai/gpt-4") is False
-
-    def test_not_equals_operator_match(self):
-        """Test not_equals operator matches when value is different."""
-        operator = ConditionOperator(not_equals="gpt-3.5")
-        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is True
-
-    def test_not_equals_operator_no_match(self):
-        """Test not_equals operator does not match when value is same."""
-        operator = ConditionOperator(not_equals="gpt-4")
-        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is False
-
-    def test_not_in_operator_match(self):
-        """Test not_in operator matches when value not in list."""
-        operator = ConditionOperator(not_in=["gpt-3.5", "gpt-3.5-turbo"])
-        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is True
-
-    def test_not_in_operator_no_match(self):
-        """Test not_in operator does not match when value in list."""
-        operator = ConditionOperator(not_in=["gpt-4", "gpt-4-turbo"])
-        assert ConditionEvaluator.evaluate_operator(operator, "gpt-4") is False
-
-    def test_none_value_with_positive_operators(self):
-        """Test None value does not match positive operators."""
-        assert ConditionEvaluator.evaluate_operator(
-            ConditionOperator(equals="gpt-4"), None
-        ) is False
-        assert ConditionEvaluator.evaluate_operator(
-            ConditionOperator(in_=["gpt-4"]), None
-        ) is False
-        assert ConditionEvaluator.evaluate_operator(
-            ConditionOperator(prefix="gpt"), None
-        ) is False
-
-    def test_none_value_with_negative_operators(self):
-        """Test None value matches negative operators (None is not equal to anything)."""
-        assert ConditionEvaluator.evaluate_operator(
-            ConditionOperator(not_equals="gpt-4"), None
-        ) is True
-        assert ConditionEvaluator.evaluate_operator(
-            ConditionOperator(not_in=["gpt-4"]), None
-        ) is True
-
-    def test_empty_operator_matches_any(self):
-        """Test empty operator (no conditions) matches any value."""
-        operator = ConditionOperator()
-        assert ConditionEvaluator.evaluate_operator(operator, "anything") is True
-        assert ConditionEvaluator.evaluate_operator(operator, None) is True
-
-
-class TestPolicyConditionEvaluation:
-    """Test PolicyCondition evaluation against request context."""
-
-    def test_model_condition_match(self):
-        """Test model condition matches."""
-        condition = PolicyCondition(
-            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"])
-        )
+    def test_no_condition_always_matches(self):
+        """Test that None condition always matches."""
         context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
-        assert ConditionEvaluator.evaluate(condition, context) is True
-
-    def test_model_condition_no_match(self):
-        """Test model condition does not match."""
-        condition = PolicyCondition(
-            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"])
-        )
-        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-3.5")
-        assert ConditionEvaluator.evaluate(condition, context) is False
-
-    def test_team_condition_match(self):
-        """Test team condition matches."""
-        condition = PolicyCondition(
-            team=ConditionOperator(prefix="healthcare-")
-        )
-        context = PolicyMatchContext(
-            team_alias="healthcare-research", key_alias="key", model="gpt-4"
-        )
-        assert ConditionEvaluator.evaluate(condition, context) is True
-
-    def test_team_condition_no_match(self):
-        """Test team condition does not match."""
-        condition = PolicyCondition(
-            team=ConditionOperator(prefix="healthcare-")
-        )
-        context = PolicyMatchContext(
-            team_alias="finance-team", key_alias="key", model="gpt-4"
-        )
-        assert ConditionEvaluator.evaluate(condition, context) is False
-
-    def test_key_condition_match(self):
-        """Test key condition matches."""
-        condition = PolicyCondition(
-            key=ConditionOperator(equals="production-key")
-        )
-        context = PolicyMatchContext(
-            team_alias="team", key_alias="production-key", model="gpt-4"
-        )
-        assert ConditionEvaluator.evaluate(condition, context) is True
-
-    def test_multiple_conditions_all_match(self):
-        """Test multiple conditions all must match (AND logic)."""
-        condition = PolicyCondition(
-            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"]),
-            team=ConditionOperator(prefix="healthcare-"),
-        )
-        context = PolicyMatchContext(
-            team_alias="healthcare-research", key_alias="key", model="gpt-4"
-        )
-        assert ConditionEvaluator.evaluate(condition, context) is True
-
-    def test_multiple_conditions_one_fails(self):
-        """Test multiple conditions - if one fails, all fails."""
-        condition = PolicyCondition(
-            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"]),
-            team=ConditionOperator(prefix="healthcare-"),
-        )
-        # Model matches but team doesn't
-        context = PolicyMatchContext(
-            team_alias="finance-team", key_alias="key", model="gpt-4"
-        )
-        assert ConditionEvaluator.evaluate(condition, context) is False
-
-    def test_none_condition_always_matches(self):
-        """Test None condition always matches."""
-        context = PolicyMatchContext(team_alias="any", key_alias="any", model="any")
         assert ConditionEvaluator.evaluate(None, context) is True
 
-
-class TestMetadataConditionEvaluation:
-    """Test metadata condition evaluation."""
-
-    def test_metadata_condition_match(self):
-        """Test metadata condition matches."""
-        condition = PolicyCondition(
-            metadata={
-                "environment": ConditionOperator(equals="production"),
-            }
-        )
+    def test_exact_model_match(self):
+        """Test exact model string match."""
+        condition = PolicyCondition(model="gpt-4")
+        
+        # Match
         context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
-        metadata = {"environment": "production"}
-        assert ConditionEvaluator.evaluate(condition, context, metadata) is True
+        assert ConditionEvaluator.evaluate(condition, context) is True
+        
+        # No match
+        context_other = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-3.5")
+        assert ConditionEvaluator.evaluate(condition, context_other) is False
 
-    def test_metadata_condition_no_match(self):
-        """Test metadata condition does not match."""
-        condition = PolicyCondition(
-            metadata={
-                "environment": ConditionOperator(equals="production"),
-            }
-        )
-        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
-        metadata = {"environment": "staging"}
-        assert ConditionEvaluator.evaluate(condition, context, metadata) is False
+    def test_regex_pattern_match(self):
+        """Test regex pattern matching."""
+        condition = PolicyCondition(model="gpt-4.*")
+        
+        # Matches
+        assert ConditionEvaluator.evaluate(
+            condition,
+            PolicyMatchContext(team_alias="t", key_alias="k", model="gpt-4")
+        ) is True
+        assert ConditionEvaluator.evaluate(
+            condition,
+            PolicyMatchContext(team_alias="t", key_alias="k", model="gpt-4-turbo")
+        ) is True
+        assert ConditionEvaluator.evaluate(
+            condition,
+            PolicyMatchContext(team_alias="t", key_alias="k", model="gpt-4o")
+        ) is True
+        
+        # No match
+        assert ConditionEvaluator.evaluate(
+            condition,
+            PolicyMatchContext(team_alias="t", key_alias="k", model="gpt-3.5")
+        ) is False
 
-    def test_metadata_condition_missing_field(self):
-        """Test metadata condition with missing field does not match."""
-        condition = PolicyCondition(
-            metadata={
-                "environment": ConditionOperator(equals="production"),
-            }
-        )
-        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
-        metadata = {"other_field": "value"}
-        assert ConditionEvaluator.evaluate(condition, context, metadata) is False
+    def test_list_of_models_match(self):
+        """Test list of model values."""
+        condition = PolicyCondition(model=["gpt-4", "gpt-4-turbo", "claude-3"])
+        
+        # Matches
+        assert ConditionEvaluator.evaluate(
+            condition,
+            PolicyMatchContext(team_alias="t", key_alias="k", model="gpt-4")
+        ) is True
+        assert ConditionEvaluator.evaluate(
+            condition,
+            PolicyMatchContext(team_alias="t", key_alias="k", model="claude-3")
+        ) is True
+        
+        # No match
+        assert ConditionEvaluator.evaluate(
+            condition,
+            PolicyMatchContext(team_alias="t", key_alias="k", model="gpt-3.5")
+        ) is False
 
-    def test_metadata_condition_with_model_condition(self):
-        """Test combining metadata and model conditions."""
-        condition = PolicyCondition(
-            model=ConditionOperator(in_=["gpt-4"]),
-            metadata={
-                "environment": ConditionOperator(equals="production"),
-            },
-        )
-        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
-        metadata = {"environment": "production"}
-        assert ConditionEvaluator.evaluate(condition, context, metadata) is True
+    def test_list_with_regex_patterns(self):
+        """Test list can contain regex patterns."""
+        condition = PolicyCondition(model=["gpt-4.*", "claude-.*"])
+        
+        # Matches
+        assert ConditionEvaluator.evaluate(
+            condition,
+            PolicyMatchContext(team_alias="t", key_alias="k", model="gpt-4-turbo")
+        ) is True
+        assert ConditionEvaluator.evaluate(
+            condition,
+            PolicyMatchContext(team_alias="t", key_alias="k", model="claude-3")
+        ) is True
+        
+        # No match
+        assert ConditionEvaluator.evaluate(
+            condition,
+            PolicyMatchContext(team_alias="t", key_alias="k", model="llama-2")
+        ) is False
 
-        # Model matches but metadata doesn't
-        metadata_staging = {"environment": "staging"}
-        assert ConditionEvaluator.evaluate(condition, context, metadata_staging) is False
+    def test_none_model_does_not_match(self):
+        """Test that None model value doesn't match conditions."""
+        condition = PolicyCondition(model="gpt-4")
+        context = PolicyMatchContext(team_alias="t", key_alias="k", model=None)
+        assert ConditionEvaluator.evaluate(condition, context) is False
 
-
-class TestEvaluateAllConditions:
-    """Test evaluate_all_conditions helper."""
-
-    def test_all_conditions_match(self):
-        """Test all conditions match returns True."""
-        conditions = [
-            PolicyCondition(model=ConditionOperator(equals="gpt-4")),
-            PolicyCondition(team=ConditionOperator(prefix="healthcare-")),
-        ]
-        context = PolicyMatchContext(
-            team_alias="healthcare-team", key_alias="key", model="gpt-4"
-        )
-        assert ConditionEvaluator.evaluate_all_conditions(conditions, context) is True
-
-    def test_one_condition_fails(self):
-        """Test one condition fails returns False."""
-        conditions = [
-            PolicyCondition(model=ConditionOperator(equals="gpt-4")),
-            PolicyCondition(team=ConditionOperator(prefix="healthcare-")),
-        ]
-        context = PolicyMatchContext(
-            team_alias="finance-team", key_alias="key", model="gpt-4"
-        )
-        assert ConditionEvaluator.evaluate_all_conditions(conditions, context) is False
-
-    def test_empty_conditions_returns_true(self):
-        """Test empty conditions list returns True."""
-        context = PolicyMatchContext(team_alias="any", key_alias="any", model="any")
-        assert ConditionEvaluator.evaluate_all_conditions([], context) is True
-
-
-class TestEvaluateAnyCondition:
-    """Test evaluate_any_condition helper."""
-
-    def test_any_condition_matches(self):
-        """Test any condition matches returns True."""
-        conditions = [
-            PolicyCondition(model=ConditionOperator(equals="gpt-4")),
-            PolicyCondition(model=ConditionOperator(equals="gpt-3.5")),
-        ]
-        context = PolicyMatchContext(team_alias="team", key_alias="key", model="gpt-4")
-        assert ConditionEvaluator.evaluate_any_condition(conditions, context) is True
-
-    def test_no_condition_matches(self):
-        """Test no condition matches returns False."""
-        conditions = [
-            PolicyCondition(model=ConditionOperator(equals="gpt-4")),
-            PolicyCondition(model=ConditionOperator(equals="gpt-3.5")),
-        ]
-        context = PolicyMatchContext(team_alias="team", key_alias="key", model="claude-3")
-        assert ConditionEvaluator.evaluate_any_condition(conditions, context) is False
-
-    def test_empty_conditions_returns_true(self):
-        """Test empty conditions list returns True."""
-        context = PolicyMatchContext(team_alias="any", key_alias="any", model="any")
-        assert ConditionEvaluator.evaluate_any_condition([], context) is True
+    def test_empty_condition_always_matches(self):
+        """Test condition with no model field always matches."""
+        condition = PolicyCondition()  # No model specified
+        context = PolicyMatchContext(team_alias="t", key_alias="k", model="any-model")
+        assert ConditionEvaluator.evaluate(condition, context) is True

--- a/tests/test_litellm/proxy/policy_engine/test_policy_matcher.py
+++ b/tests/test_litellm/proxy/policy_engine/test_policy_matcher.py
@@ -1,0 +1,84 @@
+"""
+Unit tests for PolicyMatcher - tests wildcard pattern matching for policies.
+
+Tests:
+- Wildcard matching (*, prefix-*)
+- Scope matching (teams, keys, models)
+"""
+
+import pytest
+
+from litellm.proxy.policy_engine.policy_matcher import PolicyMatcher
+from litellm.types.proxy.policy_engine import (
+    Policy,
+    PolicyGuardrails,
+    PolicyMatchContext,
+    PolicyScope,
+)
+
+
+class TestPolicyMatcherGetMatchingPolicies:
+    """Test getting matching policies from a set of policies."""
+
+    def test_get_matching_policies_by_team(self):
+        """Test matching policies by team alias."""
+        policies = {
+            "healthcare": Policy(
+                guardrails=PolicyGuardrails(add=["hipaa_audit"]),
+                scope=PolicyScope(teams=["healthcare-team"]),
+            ),
+        }
+
+        # Match
+        context = PolicyMatchContext(team_alias="healthcare-team", key_alias="k", model="gpt-4")
+        assert "healthcare" in PolicyMatcher.get_matching_policies(policies=policies, context=context)
+
+        # No match
+        context = PolicyMatchContext(team_alias="finance-team", key_alias="k", model="gpt-4")
+        assert len(PolicyMatcher.get_matching_policies(policies=policies, context=context)) == 0
+
+    def test_get_matching_policies_by_model_wildcard(self):
+        """Test matching policies by model with wildcard pattern."""
+        policies = {
+            "bedrock-only": Policy(
+                guardrails=PolicyGuardrails(add=["pii_blocker"]),
+                scope=PolicyScope(models=["bedrock/*"]),
+            ),
+        }
+
+        # Match - bedrock model
+        context = PolicyMatchContext(team_alias="t", key_alias="k", model="bedrock/claude-3")
+        assert "bedrock-only" in PolicyMatcher.get_matching_policies(policies=policies, context=context)
+
+        # No match - different provider
+        context = PolicyMatchContext(team_alias="t", key_alias="k", model="openai/gpt-4")
+        assert len(PolicyMatcher.get_matching_policies(policies=policies, context=context)) == 0
+
+    def test_get_matching_policies_by_key_pattern(self):
+        """Test matching policies by key alias pattern."""
+        policies = {
+            "dev-keys": Policy(
+                guardrails=PolicyGuardrails(add=["toxicity_filter"]),
+                scope=PolicyScope(keys=["dev-key-*"]),
+            ),
+        }
+
+        # Match
+        context = PolicyMatchContext(team_alias="t", key_alias="dev-key-123", model="gpt-4")
+        assert "dev-keys" in PolicyMatcher.get_matching_policies(policies=policies, context=context)
+
+        # No match
+        context = PolicyMatchContext(team_alias="t", key_alias="prod-key-123", model="gpt-4")
+        assert len(PolicyMatcher.get_matching_policies(policies=policies, context=context)) == 0
+
+    def test_get_matching_policies_global_wildcard(self):
+        """Test global policy with '*' matches everything."""
+        policies = {
+            "global": Policy(
+                guardrails=PolicyGuardrails(add=["pii_blocker"]),
+                scope=PolicyScope(teams=["*"], keys=["*"], models=["*"]),
+            ),
+        }
+
+        context = PolicyMatchContext(team_alias="any-team", key_alias="any-key", model="any-model")
+        assert "global" in PolicyMatcher.get_matching_policies(policies=policies, context=context)

--- a/tests/test_litellm/proxy/policy_engine/test_policy_matcher.py
+++ b/tests/test_litellm/proxy/policy_engine/test_policy_matcher.py
@@ -1,84 +1,96 @@
 """
-Unit tests for PolicyMatcher - tests wildcard pattern matching for policies.
+Unit tests for PolicyMatcher - tests wildcard pattern matching via attachments.
 
 Tests:
 - Wildcard matching (*, prefix-*)
-- Scope matching (teams, keys, models)
+- Scope matching via attachments (teams, keys, models)
 """
 
 import pytest
 
+from litellm.proxy.policy_engine.attachment_registry import AttachmentRegistry
 from litellm.proxy.policy_engine.policy_matcher import PolicyMatcher
 from litellm.types.proxy.policy_engine import (
-    Policy,
-    PolicyGuardrails,
     PolicyMatchContext,
     PolicyScope,
 )
 
 
-class TestPolicyMatcherGetMatchingPolicies:
-    """Test getting matching policies from a set of policies."""
+class TestPolicyMatcherPatternMatching:
+    """Test pattern matching utilities."""
 
-    def test_get_matching_policies_by_team(self):
-        """Test matching policies by team alias."""
-        policies = {
-            "healthcare": Policy(
-                guardrails=PolicyGuardrails(add=["hipaa_audit"]),
-                scope=PolicyScope(teams=["healthcare-team"]),
-            ),
-        }
+    def test_matches_pattern_exact(self):
+        """Test exact pattern matching."""
+        assert PolicyMatcher.matches_pattern("healthcare-team", ["healthcare-team"]) is True
+        assert PolicyMatcher.matches_pattern("finance-team", ["healthcare-team"]) is False
 
-        # Match
-        context = PolicyMatchContext(team_alias="healthcare-team", key_alias="k", model="gpt-4")
-        assert "healthcare" in PolicyMatcher.get_matching_policies(policies=policies, context=context)
+    def test_matches_pattern_wildcard(self):
+        """Test wildcard pattern matching."""
+        assert PolicyMatcher.matches_pattern("any-team", ["*"]) is True
+        assert PolicyMatcher.matches_pattern("dev-key-123", ["dev-key-*"]) is True
+        assert PolicyMatcher.matches_pattern("prod-key-123", ["dev-key-*"]) is False
 
-        # No match
-        context = PolicyMatchContext(team_alias="finance-team", key_alias="k", model="gpt-4")
-        assert len(PolicyMatcher.get_matching_policies(policies=policies, context=context)) == 0
+    def test_matches_pattern_none_value(self):
+        """Test None value only matches '*'."""
+        assert PolicyMatcher.matches_pattern(None, ["*"]) is True
+        assert PolicyMatcher.matches_pattern(None, ["specific"]) is False
 
-    def test_get_matching_policies_by_model_wildcard(self):
-        """Test matching policies by model with wildcard pattern."""
-        policies = {
-            "bedrock-only": Policy(
-                guardrails=PolicyGuardrails(add=["pii_blocker"]),
-                scope=PolicyScope(models=["bedrock/*"]),
-            ),
-        }
 
-        # Match - bedrock model
-        context = PolicyMatchContext(team_alias="t", key_alias="k", model="bedrock/claude-3")
-        assert "bedrock-only" in PolicyMatcher.get_matching_policies(policies=policies, context=context)
+class TestPolicyMatcherScopeMatching:
+    """Test scope matching against context."""
 
-        # No match - different provider
-        context = PolicyMatchContext(team_alias="t", key_alias="k", model="openai/gpt-4")
-        assert len(PolicyMatcher.get_matching_policies(policies=policies, context=context)) == 0
+    def test_scope_matches_all_fields(self):
+        """Test scope matches when all fields match."""
+        scope = PolicyScope(teams=["healthcare-team"], keys=["*"], models=["gpt-4"])
+        context = PolicyMatchContext(team_alias="healthcare-team", key_alias="any-key", model="gpt-4")
+        assert PolicyMatcher.scope_matches(scope, context) is True
 
-    def test_get_matching_policies_by_key_pattern(self):
-        """Test matching policies by key alias pattern."""
-        policies = {
-            "dev-keys": Policy(
-                guardrails=PolicyGuardrails(add=["toxicity_filter"]),
-                scope=PolicyScope(keys=["dev-key-*"]),
-            ),
-        }
+    def test_scope_does_not_match_team(self):
+        """Test scope doesn't match when team doesn't match."""
+        scope = PolicyScope(teams=["healthcare-team"], keys=["*"], models=["*"])
+        context = PolicyMatchContext(team_alias="finance-team", key_alias="any-key", model="gpt-4")
+        assert PolicyMatcher.scope_matches(scope, context) is False
 
-        # Match
-        context = PolicyMatchContext(team_alias="t", key_alias="dev-key-123", model="gpt-4")
-        assert "dev-keys" in PolicyMatcher.get_matching_policies(policies=policies, context=context)
+    def test_scope_matches_with_wildcard_patterns(self):
+        """Test scope matches with wildcard patterns."""
+        scope = PolicyScope(teams=["*"], keys=["dev-key-*"], models=["bedrock/*"])
+        context = PolicyMatchContext(team_alias="any-team", key_alias="dev-key-123", model="bedrock/claude-3")
+        assert PolicyMatcher.scope_matches(scope, context) is True
 
-        # No match
-        context = PolicyMatchContext(team_alias="t", key_alias="prod-key-123", model="gpt-4")
-        assert len(PolicyMatcher.get_matching_policies(policies=policies, context=context)) == 0
-
-    def test_get_matching_policies_global_wildcard(self):
-        """Test global policy with '*' matches everything."""
-        policies = {
-            "global": Policy(
-                guardrails=PolicyGuardrails(add=["pii_blocker"]),
-                scope=PolicyScope(teams=["*"], keys=["*"], models=["*"]),
-            ),
-        }
-
+    def test_scope_global_wildcard(self):
+        """Test global scope with all wildcards."""
+        scope = PolicyScope(teams=["*"], keys=["*"], models=["*"])
         context = PolicyMatchContext(team_alias="any-team", key_alias="any-key", model="any-model")
-        assert "global" in PolicyMatcher.get_matching_policies(policies=policies, context=context)
+        assert PolicyMatcher.scope_matches(scope, context) is True
+
+
+class TestPolicyMatcherWithAttachments:
+    """Test getting matching policies via attachments."""
+
+    def test_get_matching_policies_via_attachments(self):
+        """Test matching policies through attachment registry."""
+        # Create and configure attachment registry
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "healthcare-policy", "teams": ["healthcare-team"]},
+            {"policy": "global-policy", "scope": "*"},
+        ])
+
+        # Test matching via the registry directly
+        context = PolicyMatchContext(team_alias="healthcare-team", key_alias="k", model="gpt-4")
+        attached = registry.get_attached_policies(context)
+
+        assert "healthcare-policy" in attached
+        assert "global-policy" in attached
+
+    def test_get_matching_policies_no_match(self):
+        """Test no policies match when attachments don't match context."""
+        registry = AttachmentRegistry()
+        registry.load_attachments([
+            {"policy": "healthcare-policy", "teams": ["healthcare-team"]},
+        ])
+
+        context = PolicyMatchContext(team_alias="finance-team", key_alias="k", model="gpt-4")
+        attached = registry.get_attached_policies(context)
+
+        assert "healthcare-policy" not in attached

--- a/tests/test_litellm/proxy/policy_engine/test_policy_resolver.py
+++ b/tests/test_litellm/proxy/policy_engine/test_policy_resolver.py
@@ -1,0 +1,96 @@
+"""
+Unit tests for PolicyResolver - tests guardrail resolution for request contexts.
+"""
+
+import pytest
+
+from litellm.proxy.policy_engine.policy_resolver import PolicyResolver
+from litellm.types.proxy.policy_engine import (
+    Policy,
+    PolicyGuardrails,
+    PolicyMatchContext,
+    PolicyScope,
+)
+
+
+class TestPolicyMatcherGetMatchingPolicies:
+    """Test resolve_guardrails_for_context - the main entry point."""
+
+    def test_resolve_guardrails_simple_match(self):
+        """Test resolving guardrails for a simple matching policy."""
+        policies = {
+            "global": Policy(
+                guardrails=PolicyGuardrails(add=["pii_blocker", "toxicity_filter"]),
+                scope=PolicyScope(teams=["*"]),
+            ),
+        }
+
+        context = PolicyMatchContext(team_alias="any-team", key_alias="k", model="gpt-4")
+        guardrails = PolicyResolver.resolve_guardrails_for_context(
+            context=context, policies=policies
+        )
+
+        assert set(guardrails) == {"pii_blocker", "toxicity_filter"}
+
+    def test_resolve_guardrails_with_inheritance(self):
+        """Test child policy inherits and adds guardrails from parent."""
+        policies = {
+            "base": Policy(
+                guardrails=PolicyGuardrails(add=["pii_blocker"]),
+                scope=PolicyScope(teams=["*"]),
+            ),
+            "healthcare": Policy(
+                inherit="base",
+                guardrails=PolicyGuardrails(add=["hipaa_audit"]),
+                scope=PolicyScope(teams=["healthcare-team"]),
+            ),
+        }
+
+        context = PolicyMatchContext(team_alias="healthcare-team", key_alias="k", model="gpt-4")
+        guardrails = PolicyResolver.resolve_guardrails_for_context(
+            context=context, policies=policies
+        )
+
+        # Both base and healthcare match, healthcare inherits from base
+        assert set(guardrails) == {"pii_blocker", "hipaa_audit"}
+
+    def test_resolve_guardrails_with_remove(self):
+        """Test child policy can remove guardrails from parent in its inheritance chain."""
+        policies = {
+            "base": Policy(
+                guardrails=PolicyGuardrails(add=["pii_blocker", "phi_blocker"]),
+                scope=PolicyScope(teams=["internal-only"]),  # Does NOT match dev-team
+            ),
+            "dev": Policy(
+                inherit="base",
+                guardrails=PolicyGuardrails(add=["toxicity_filter"], remove=["phi_blocker"]),
+                scope=PolicyScope(teams=["dev-team"]),  # Only this matches
+            ),
+        }
+
+        # Only dev policy matches (base scope doesn't match)
+        context = PolicyMatchContext(team_alias="dev-team", key_alias="k", model="gpt-4")
+        guardrails = PolicyResolver.resolve_guardrails_for_context(
+            context=context, policies=policies
+        )
+
+        # dev inherits pii_blocker from base, adds toxicity_filter, removes phi_blocker
+        assert "pii_blocker" in guardrails
+        assert "toxicity_filter" in guardrails
+        assert "phi_blocker" not in guardrails
+
+    def test_resolve_guardrails_no_match(self):
+        """Test returns empty list when no policies match."""
+        policies = {
+            "healthcare": Policy(
+                guardrails=PolicyGuardrails(add=["hipaa_audit"]),
+                scope=PolicyScope(teams=["healthcare-team"]),
+            ),
+        }
+
+        context = PolicyMatchContext(team_alias="finance-team", key_alias="k", model="gpt-4")
+        guardrails = PolicyResolver.resolve_guardrails_for_context(
+            context=context, policies=policies
+        )
+
+        assert guardrails == []

--- a/tests/test_litellm/proxy/policy_engine/test_policy_resolver.py
+++ b/tests/test_litellm/proxy/policy_engine/test_policy_resolver.py
@@ -4,19 +4,17 @@ Unit tests for PolicyResolver - tests guardrail resolution.
 Tests:
 - Inheritance chain resolution
 - Inheritance with add/remove
-- Conditional statements
+- Model conditions
 """
 
 import pytest
 
 from litellm.proxy.policy_engine.policy_resolver import PolicyResolver
 from litellm.types.proxy.policy_engine import (
-    ConditionOperator,
     Policy,
     PolicyCondition,
     PolicyGuardrails,
     PolicyMatchContext,
-    PolicyStatement,
 )
 
 
@@ -103,144 +101,66 @@ class TestPolicyResolverInheritance:
         assert resolved.inheritance_chain == ["root", "middle", "leaf"]
 
 
-class TestPolicyResolverWithStatements:
-    """Test resolve_policy_guardrails with conditional statements."""
+class TestPolicyResolverWithConditions:
+    """Test resolve_policy_guardrails with model conditions."""
 
-    def test_statement_condition_matches(self):
-        """Test statement guardrails are added when condition matches."""
+    def test_condition_matches(self):
+        """Test guardrails are added when condition matches."""
         policies = {
-            "conditional-policy": Policy(
-                guardrails=PolicyGuardrails(add=["base_guardrail"]),
-                statements=[
-                    PolicyStatement(
-                        sid="GPT4Safety",
-                        guardrails=["toxicity_filter"],
-                        condition=PolicyCondition(
-                            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"])
-                        ),
-                    ),
-                ],
+            "gpt4-policy": Policy(
+                guardrails=PolicyGuardrails(add=["toxicity_filter"]),
+                condition=PolicyCondition(model="gpt-4.*"),
             ),
         }
 
-        # GPT-4 should get both base and statement guardrails
+        # GPT-4 should get guardrails
         context = PolicyMatchContext(team_alias="team", key_alias="k", model="gpt-4")
         resolved = PolicyResolver.resolve_policy_guardrails(
-            policy_name="conditional-policy",
+            policy_name="gpt4-policy",
             policies=policies,
             context=context,
         )
 
-        assert "base_guardrail" in resolved.guardrails
         assert "toxicity_filter" in resolved.guardrails
 
-    def test_statement_condition_does_not_match(self):
-        """Test statement guardrails are NOT added when condition doesn't match."""
+    def test_condition_does_not_match(self):
+        """Test guardrails are NOT added when condition doesn't match."""
         policies = {
-            "conditional-policy": Policy(
-                guardrails=PolicyGuardrails(add=["base_guardrail"]),
-                statements=[
-                    PolicyStatement(
-                        sid="GPT4Safety",
-                        guardrails=["toxicity_filter"],
-                        condition=PolicyCondition(
-                            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"])
-                        ),
-                    ),
-                ],
+            "gpt4-policy": Policy(
+                guardrails=PolicyGuardrails(add=["toxicity_filter"]),
+                condition=PolicyCondition(model="gpt-4.*"),
             ),
         }
 
-        # GPT-3.5 should only get base guardrails, not statement guardrails
+        # GPT-3.5 should NOT get guardrails
         context = PolicyMatchContext(team_alias="team", key_alias="k", model="gpt-3.5")
         resolved = PolicyResolver.resolve_policy_guardrails(
-            policy_name="conditional-policy",
+            policy_name="gpt4-policy",
             policies=policies,
             context=context,
         )
 
-        assert "base_guardrail" in resolved.guardrails
         assert "toxicity_filter" not in resolved.guardrails
 
-    def test_multiple_statements_some_match(self):
-        """Test multiple statements where only some match."""
+    def test_no_condition_always_applies(self):
+        """Test policy without condition always applies."""
         policies = {
-            "multi-statement": Policy(
-                guardrails=PolicyGuardrails(add=["base"]),
-                statements=[
-                    PolicyStatement(
-                        sid="GPT4Only",
-                        guardrails=["gpt4_guardrail"],
-                        condition=PolicyCondition(
-                            model=ConditionOperator(equals="gpt-4")
-                        ),
-                    ),
-                    PolicyStatement(
-                        sid="HealthcareOnly",
-                        guardrails=["hipaa_audit"],
-                        condition=PolicyCondition(
-                            team=ConditionOperator(prefix="healthcare-")
-                        ),
-                    ),
-                ],
-            ),
-        }
-
-        # Healthcare team with GPT-4 should get all guardrails
-        context = PolicyMatchContext(
-            team_alias="healthcare-team", key_alias="k", model="gpt-4"
-        )
-        resolved = PolicyResolver.resolve_policy_guardrails(
-            policy_name="multi-statement",
-            policies=policies,
-            context=context,
-        )
-
-        assert "base" in resolved.guardrails
-        assert "gpt4_guardrail" in resolved.guardrails
-        assert "hipaa_audit" in resolved.guardrails
-
-        # Finance team with GPT-4 should only get base + gpt4_guardrail
-        context_finance = PolicyMatchContext(
-            team_alias="finance-team", key_alias="k", model="gpt-4"
-        )
-        resolved_finance = PolicyResolver.resolve_policy_guardrails(
-            policy_name="multi-statement",
-            policies=policies,
-            context=context_finance,
-        )
-
-        assert "base" in resolved_finance.guardrails
-        assert "gpt4_guardrail" in resolved_finance.guardrails
-        assert "hipaa_audit" not in resolved_finance.guardrails
-
-    def test_statement_with_no_condition_always_applies(self):
-        """Test statement with no condition always applies."""
-        policies = {
-            "always-policy": Policy(
-                guardrails=PolicyGuardrails(add=["base"]),
-                statements=[
-                    PolicyStatement(
-                        sid="AlwaysApply",
-                        guardrails=["always_guardrail"],
-                        condition=None,  # No condition = always applies
-                    ),
-                ],
+            "global": Policy(
+                guardrails=PolicyGuardrails(add=["pii_blocker"]),
             ),
         }
 
         context = PolicyMatchContext(team_alias="any", key_alias="any", model="any")
         resolved = PolicyResolver.resolve_policy_guardrails(
-            policy_name="always-policy",
+            policy_name="global",
             policies=policies,
             context=context,
         )
 
-        assert "base" in resolved.guardrails
-        assert "always_guardrail" in resolved.guardrails
+        assert "pii_blocker" in resolved.guardrails
 
-    def test_inheritance_with_statements(self):
-        """Test inheritance works with statements."""
+    def test_inheritance_with_condition(self):
+        """Test inheritance works with conditions."""
         policies = {
             "base": Policy(
                 guardrails=PolicyGuardrails(add=["pii_blocker"]),
@@ -248,62 +168,26 @@ class TestPolicyResolverWithStatements:
             "child": Policy(
                 inherit="base",
                 guardrails=PolicyGuardrails(add=["child_guardrail"]),
-                statements=[
-                    PolicyStatement(
-                        sid="ConditionalStatement",
-                        guardrails=["conditional_guardrail"],
-                        condition=PolicyCondition(
-                            model=ConditionOperator(equals="gpt-4")
-                        ),
-                    ),
-                ],
+                condition=PolicyCondition(model="gpt-4"),
             ),
         }
 
-        context = PolicyMatchContext(team_alias="any-team", key_alias="k", model="gpt-4")
-        resolved = PolicyResolver.resolve_policy_guardrails(
+        # GPT-4 should get both base and child guardrails
+        context_gpt4 = PolicyMatchContext(team_alias="t", key_alias="k", model="gpt-4")
+        resolved_gpt4 = PolicyResolver.resolve_policy_guardrails(
             policy_name="child",
             policies=policies,
-            context=context,
+            context=context_gpt4,
         )
+        assert "pii_blocker" in resolved_gpt4.guardrails
+        assert "child_guardrail" in resolved_gpt4.guardrails
 
-        # Should have: inherited pii_blocker, child's child_guardrail, and conditional_guardrail
-        assert "pii_blocker" in resolved.guardrails
-        assert "child_guardrail" in resolved.guardrails
-        assert "conditional_guardrail" in resolved.guardrails
-
-    def test_inheritance_with_remove_and_statements(self):
-        """Test inheritance with remove still works alongside statements."""
-        policies = {
-            "base": Policy(
-                guardrails=PolicyGuardrails(add=["pii_blocker", "phi_blocker"]),
-            ),
-            "child": Policy(
-                inherit="base",
-                guardrails=PolicyGuardrails(
-                    add=["child_guardrail"],
-                    remove=["phi_blocker"],  # Remove phi_blocker from parent
-                ),
-                statements=[
-                    PolicyStatement(
-                        sid="Conditional",
-                        guardrails=["conditional_guardrail"],
-                        condition=PolicyCondition(
-                            model=ConditionOperator(equals="gpt-4")
-                        ),
-                    ),
-                ],
-            ),
-        }
-
-        context = PolicyMatchContext(team_alias="any-team", key_alias="k", model="gpt-4")
-        resolved = PolicyResolver.resolve_policy_guardrails(
+        # GPT-3.5 should only get base guardrails (child condition doesn't match)
+        context_gpt35 = PolicyMatchContext(team_alias="t", key_alias="k", model="gpt-3.5")
+        resolved_gpt35 = PolicyResolver.resolve_policy_guardrails(
             policy_name="child",
             policies=policies,
-            context=context,
+            context=context_gpt35,
         )
-
-        assert "pii_blocker" in resolved.guardrails  # Inherited
-        assert "phi_blocker" not in resolved.guardrails  # Removed
-        assert "child_guardrail" in resolved.guardrails  # Added by child
-        assert "conditional_guardrail" in resolved.guardrails  # From statement
+        assert "pii_blocker" in resolved_gpt35.guardrails
+        assert "child_guardrail" not in resolved_gpt35.guardrails

--- a/tests/test_litellm/proxy/policy_engine/test_policy_resolver.py
+++ b/tests/test_litellm/proxy/policy_engine/test_policy_resolver.py
@@ -1,96 +1,309 @@
 """
-Unit tests for PolicyResolver - tests guardrail resolution for request contexts.
+Unit tests for PolicyResolver - tests guardrail resolution.
+
+Tests:
+- Inheritance chain resolution
+- Inheritance with add/remove
+- Conditional statements
 """
 
 import pytest
 
 from litellm.proxy.policy_engine.policy_resolver import PolicyResolver
 from litellm.types.proxy.policy_engine import (
+    ConditionOperator,
     Policy,
+    PolicyCondition,
     PolicyGuardrails,
     PolicyMatchContext,
-    PolicyScope,
+    PolicyStatement,
 )
 
 
-class TestPolicyMatcherGetMatchingPolicies:
-    """Test resolve_guardrails_for_context - the main entry point."""
+class TestPolicyResolverInheritance:
+    """Test resolve_policy_guardrails - inheritance and add/remove."""
 
-    def test_resolve_guardrails_simple_match(self):
-        """Test resolving guardrails for a simple matching policy."""
+    def test_resolve_simple_policy(self):
+        """Test resolving guardrails for a simple policy."""
         policies = {
             "global": Policy(
                 guardrails=PolicyGuardrails(add=["pii_blocker", "toxicity_filter"]),
-                scope=PolicyScope(teams=["*"]),
             ),
         }
 
-        context = PolicyMatchContext(team_alias="any-team", key_alias="k", model="gpt-4")
-        guardrails = PolicyResolver.resolve_guardrails_for_context(
-            context=context, policies=policies
+        resolved = PolicyResolver.resolve_policy_guardrails(
+            policy_name="global", policies=policies
         )
 
-        assert set(guardrails) == {"pii_blocker", "toxicity_filter"}
+        assert set(resolved.guardrails) == {"pii_blocker", "toxicity_filter"}
+        assert resolved.inheritance_chain == ["global"]
 
-    def test_resolve_guardrails_with_inheritance(self):
+    def test_resolve_with_inheritance(self):
         """Test child policy inherits and adds guardrails from parent."""
         policies = {
             "base": Policy(
                 guardrails=PolicyGuardrails(add=["pii_blocker"]),
-                scope=PolicyScope(teams=["*"]),
             ),
             "healthcare": Policy(
                 inherit="base",
                 guardrails=PolicyGuardrails(add=["hipaa_audit"]),
-                scope=PolicyScope(teams=["healthcare-team"]),
             ),
         }
 
-        context = PolicyMatchContext(team_alias="healthcare-team", key_alias="k", model="gpt-4")
-        guardrails = PolicyResolver.resolve_guardrails_for_context(
-            context=context, policies=policies
+        resolved = PolicyResolver.resolve_policy_guardrails(
+            policy_name="healthcare", policies=policies
         )
 
-        # Both base and healthcare match, healthcare inherits from base
-        assert set(guardrails) == {"pii_blocker", "hipaa_audit"}
+        # Healthcare inherits pii_blocker from base and adds hipaa_audit
+        assert set(resolved.guardrails) == {"pii_blocker", "hipaa_audit"}
+        assert resolved.inheritance_chain == ["base", "healthcare"]
 
-    def test_resolve_guardrails_with_remove(self):
-        """Test child policy can remove guardrails from parent in its inheritance chain."""
+    def test_resolve_with_remove(self):
+        """Test child policy can remove guardrails from parent."""
         policies = {
             "base": Policy(
                 guardrails=PolicyGuardrails(add=["pii_blocker", "phi_blocker"]),
-                scope=PolicyScope(teams=["internal-only"]),  # Does NOT match dev-team
             ),
             "dev": Policy(
                 inherit="base",
                 guardrails=PolicyGuardrails(add=["toxicity_filter"], remove=["phi_blocker"]),
-                scope=PolicyScope(teams=["dev-team"]),  # Only this matches
             ),
         }
 
-        # Only dev policy matches (base scope doesn't match)
-        context = PolicyMatchContext(team_alias="dev-team", key_alias="k", model="gpt-4")
-        guardrails = PolicyResolver.resolve_guardrails_for_context(
-            context=context, policies=policies
+        resolved = PolicyResolver.resolve_policy_guardrails(
+            policy_name="dev", policies=policies
         )
 
         # dev inherits pii_blocker from base, adds toxicity_filter, removes phi_blocker
-        assert "pii_blocker" in guardrails
-        assert "toxicity_filter" in guardrails
-        assert "phi_blocker" not in guardrails
+        assert "pii_blocker" in resolved.guardrails
+        assert "toxicity_filter" in resolved.guardrails
+        assert "phi_blocker" not in resolved.guardrails
 
-    def test_resolve_guardrails_no_match(self):
-        """Test returns empty list when no policies match."""
+    def test_resolve_deep_inheritance_chain(self):
+        """Test multi-level inheritance chain."""
         policies = {
-            "healthcare": Policy(
-                guardrails=PolicyGuardrails(add=["hipaa_audit"]),
-                scope=PolicyScope(teams=["healthcare-team"]),
+            "root": Policy(
+                guardrails=PolicyGuardrails(add=["root_guardrail"]),
+            ),
+            "middle": Policy(
+                inherit="root",
+                guardrails=PolicyGuardrails(add=["middle_guardrail"]),
+            ),
+            "leaf": Policy(
+                inherit="middle",
+                guardrails=PolicyGuardrails(add=["leaf_guardrail"]),
             ),
         }
 
-        context = PolicyMatchContext(team_alias="finance-team", key_alias="k", model="gpt-4")
-        guardrails = PolicyResolver.resolve_guardrails_for_context(
-            context=context, policies=policies
+        resolved = PolicyResolver.resolve_policy_guardrails(
+            policy_name="leaf", policies=policies
         )
 
-        assert guardrails == []
+        assert set(resolved.guardrails) == {"root_guardrail", "middle_guardrail", "leaf_guardrail"}
+        assert resolved.inheritance_chain == ["root", "middle", "leaf"]
+
+
+class TestPolicyResolverWithStatements:
+    """Test resolve_policy_guardrails with conditional statements."""
+
+    def test_statement_condition_matches(self):
+        """Test statement guardrails are added when condition matches."""
+        policies = {
+            "conditional-policy": Policy(
+                guardrails=PolicyGuardrails(add=["base_guardrail"]),
+                statements=[
+                    PolicyStatement(
+                        sid="GPT4Safety",
+                        guardrails=["toxicity_filter"],
+                        condition=PolicyCondition(
+                            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"])
+                        ),
+                    ),
+                ],
+            ),
+        }
+
+        # GPT-4 should get both base and statement guardrails
+        context = PolicyMatchContext(team_alias="team", key_alias="k", model="gpt-4")
+        resolved = PolicyResolver.resolve_policy_guardrails(
+            policy_name="conditional-policy",
+            policies=policies,
+            context=context,
+        )
+
+        assert "base_guardrail" in resolved.guardrails
+        assert "toxicity_filter" in resolved.guardrails
+
+    def test_statement_condition_does_not_match(self):
+        """Test statement guardrails are NOT added when condition doesn't match."""
+        policies = {
+            "conditional-policy": Policy(
+                guardrails=PolicyGuardrails(add=["base_guardrail"]),
+                statements=[
+                    PolicyStatement(
+                        sid="GPT4Safety",
+                        guardrails=["toxicity_filter"],
+                        condition=PolicyCondition(
+                            model=ConditionOperator(in_=["gpt-4", "gpt-4-turbo"])
+                        ),
+                    ),
+                ],
+            ),
+        }
+
+        # GPT-3.5 should only get base guardrails, not statement guardrails
+        context = PolicyMatchContext(team_alias="team", key_alias="k", model="gpt-3.5")
+        resolved = PolicyResolver.resolve_policy_guardrails(
+            policy_name="conditional-policy",
+            policies=policies,
+            context=context,
+        )
+
+        assert "base_guardrail" in resolved.guardrails
+        assert "toxicity_filter" not in resolved.guardrails
+
+    def test_multiple_statements_some_match(self):
+        """Test multiple statements where only some match."""
+        policies = {
+            "multi-statement": Policy(
+                guardrails=PolicyGuardrails(add=["base"]),
+                statements=[
+                    PolicyStatement(
+                        sid="GPT4Only",
+                        guardrails=["gpt4_guardrail"],
+                        condition=PolicyCondition(
+                            model=ConditionOperator(equals="gpt-4")
+                        ),
+                    ),
+                    PolicyStatement(
+                        sid="HealthcareOnly",
+                        guardrails=["hipaa_audit"],
+                        condition=PolicyCondition(
+                            team=ConditionOperator(prefix="healthcare-")
+                        ),
+                    ),
+                ],
+            ),
+        }
+
+        # Healthcare team with GPT-4 should get all guardrails
+        context = PolicyMatchContext(
+            team_alias="healthcare-team", key_alias="k", model="gpt-4"
+        )
+        resolved = PolicyResolver.resolve_policy_guardrails(
+            policy_name="multi-statement",
+            policies=policies,
+            context=context,
+        )
+
+        assert "base" in resolved.guardrails
+        assert "gpt4_guardrail" in resolved.guardrails
+        assert "hipaa_audit" in resolved.guardrails
+
+        # Finance team with GPT-4 should only get base + gpt4_guardrail
+        context_finance = PolicyMatchContext(
+            team_alias="finance-team", key_alias="k", model="gpt-4"
+        )
+        resolved_finance = PolicyResolver.resolve_policy_guardrails(
+            policy_name="multi-statement",
+            policies=policies,
+            context=context_finance,
+        )
+
+        assert "base" in resolved_finance.guardrails
+        assert "gpt4_guardrail" in resolved_finance.guardrails
+        assert "hipaa_audit" not in resolved_finance.guardrails
+
+    def test_statement_with_no_condition_always_applies(self):
+        """Test statement with no condition always applies."""
+        policies = {
+            "always-policy": Policy(
+                guardrails=PolicyGuardrails(add=["base"]),
+                statements=[
+                    PolicyStatement(
+                        sid="AlwaysApply",
+                        guardrails=["always_guardrail"],
+                        condition=None,  # No condition = always applies
+                    ),
+                ],
+            ),
+        }
+
+        context = PolicyMatchContext(team_alias="any", key_alias="any", model="any")
+        resolved = PolicyResolver.resolve_policy_guardrails(
+            policy_name="always-policy",
+            policies=policies,
+            context=context,
+        )
+
+        assert "base" in resolved.guardrails
+        assert "always_guardrail" in resolved.guardrails
+
+    def test_inheritance_with_statements(self):
+        """Test inheritance works with statements."""
+        policies = {
+            "base": Policy(
+                guardrails=PolicyGuardrails(add=["pii_blocker"]),
+            ),
+            "child": Policy(
+                inherit="base",
+                guardrails=PolicyGuardrails(add=["child_guardrail"]),
+                statements=[
+                    PolicyStatement(
+                        sid="ConditionalStatement",
+                        guardrails=["conditional_guardrail"],
+                        condition=PolicyCondition(
+                            model=ConditionOperator(equals="gpt-4")
+                        ),
+                    ),
+                ],
+            ),
+        }
+
+        context = PolicyMatchContext(team_alias="any-team", key_alias="k", model="gpt-4")
+        resolved = PolicyResolver.resolve_policy_guardrails(
+            policy_name="child",
+            policies=policies,
+            context=context,
+        )
+
+        # Should have: inherited pii_blocker, child's child_guardrail, and conditional_guardrail
+        assert "pii_blocker" in resolved.guardrails
+        assert "child_guardrail" in resolved.guardrails
+        assert "conditional_guardrail" in resolved.guardrails
+
+    def test_inheritance_with_remove_and_statements(self):
+        """Test inheritance with remove still works alongside statements."""
+        policies = {
+            "base": Policy(
+                guardrails=PolicyGuardrails(add=["pii_blocker", "phi_blocker"]),
+            ),
+            "child": Policy(
+                inherit="base",
+                guardrails=PolicyGuardrails(
+                    add=["child_guardrail"],
+                    remove=["phi_blocker"],  # Remove phi_blocker from parent
+                ),
+                statements=[
+                    PolicyStatement(
+                        sid="Conditional",
+                        guardrails=["conditional_guardrail"],
+                        condition=PolicyCondition(
+                            model=ConditionOperator(equals="gpt-4")
+                        ),
+                    ),
+                ],
+            ),
+        }
+
+        context = PolicyMatchContext(team_alias="any-team", key_alias="k", model="gpt-4")
+        resolved = PolicyResolver.resolve_policy_guardrails(
+            policy_name="child",
+            policies=policies,
+            context=context,
+        )
+
+        assert "pii_blocker" in resolved.guardrails  # Inherited
+        assert "phi_blocker" not in resolved.guardrails  # Removed
+        assert "child_guardrail" in resolved.guardrails  # Added by child
+        assert "conditional_guardrail" in resolved.guardrails  # From statement

--- a/tests/test_litellm/proxy/policy_engine/test_policy_validator.py
+++ b/tests/test_litellm/proxy/policy_engine/test_policy_validator.py
@@ -1,0 +1,94 @@
+"""
+Unit tests for PolicyValidator - tests policy configuration validation.
+
+Tests validation of:
+- Inheritance chains (parent exists, no circular deps)
+- Guardrail names exist in registry
+- Model names exist in router
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from litellm.proxy.policy_engine.policy_validator import PolicyValidator
+from litellm.types.proxy.policy_engine import (
+    Policy,
+    PolicyGuardrails,
+    PolicyScope,
+    PolicyValidationErrorType,
+)
+
+
+class TestPolicyValidator:
+    """Test policy validation logic."""
+
+    @pytest.mark.asyncio
+    async def test_validate_missing_parent_policy(self):
+        """Test that referencing non-existent parent policy fails."""
+        policies = {
+            "child": Policy(
+                inherit="nonexistent-parent",
+                guardrails=PolicyGuardrails(add=["hipaa_audit"]),
+                scope=PolicyScope(teams=["healthcare-team"]),
+            ),
+        }
+
+        validator = PolicyValidator(prisma_client=None)
+        result = await validator.validate_policies(policies=policies, validate_db=False)
+
+        assert result.valid is False
+        assert any(
+            e.error_type == PolicyValidationErrorType.INVALID_INHERITANCE
+            for e in result.errors
+        )
+
+    @pytest.mark.asyncio
+    async def test_validate_invalid_guardrail(self):
+        """Test that referencing non-existent guardrail fails."""
+        policies = {
+            "test-policy": Policy(
+                guardrails=PolicyGuardrails(add=["nonexistent_guardrail"]),
+                scope=PolicyScope(teams=["*"]),
+            ),
+        }
+
+        validator = PolicyValidator(prisma_client=None)
+        with patch.object(
+            validator, "get_available_guardrails", return_value={"pii_blocker", "toxicity_filter"}
+        ):
+            result = await validator.validate_policies(policies=policies, validate_db=False)
+
+        assert result.valid is False
+        assert any(
+            e.error_type == PolicyValidationErrorType.INVALID_GUARDRAIL
+            and e.value == "nonexistent_guardrail"
+            for e in result.errors
+        )
+
+    @pytest.mark.asyncio
+    async def test_validate_invalid_model(self):
+        """Test that referencing non-existent model warns."""
+        policies = {
+            "test-policy": Policy(
+                guardrails=PolicyGuardrails(add=["pii_blocker"]),
+                scope=PolicyScope(models=["nonexistent-model"]),
+            ),
+        }
+
+        # Mock the router with known model names
+        mock_router = MagicMock()
+        mock_router.model_names = {"gpt-4", "gpt-3.5-turbo"}
+        # Mock pattern_router to return empty list (no pattern matches)
+        mock_router.pattern_router.get_deployments_by_pattern.return_value = []
+
+        validator = PolicyValidator(prisma_client=None, llm_router=mock_router)
+        with patch.object(validator, "get_available_guardrails", return_value={"pii_blocker"}):
+            result = await validator.validate_policies(policies=policies, validate_db=False)
+
+        # Model validation is a warning, not an error
+        assert any(
+            w.error_type == PolicyValidationErrorType.INVALID_MODEL
+            and w.value == "nonexistent-model"
+            for w in result.warnings
+        )

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -16,6 +16,7 @@ from litellm.proxy.litellm_pre_call_utils import (
     _get_dynamic_logging_metadata,
     _get_enforced_params,
     _update_model_if_key_alias_exists,
+    add_guardrails_from_policy_engine,
     add_litellm_data_to_request,
     check_if_token_is_service_account,
 )
@@ -1477,3 +1478,60 @@ async def test_embedding_header_forwarding_without_model_group_config():
     finally:
         # Restore original model_group_settings
         litellm.model_group_settings = original_model_group_settings
+
+
+def test_add_guardrails_from_policy_engine():
+    """
+    Test that add_guardrails_from_policy_engine adds guardrails from matching policies
+    and tracks applied policies in metadata.
+    """
+    from litellm.proxy.policy_engine.policy_registry import get_policy_registry
+    from litellm.types.proxy.policy_engine import Policy, PolicyGuardrails, PolicyScope
+
+    # Setup test data
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "metadata": {},
+    }
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        team_alias="healthcare-team",
+        key_alias="my-key",
+    )
+
+    # Setup mock policies in the registry (directly set parsed Policy objects)
+    registry = get_policy_registry()
+    registry._policies = {
+        "global-baseline": Policy(
+            guardrails=PolicyGuardrails(add=["pii_blocker"]),
+            scope=PolicyScope(teams=["*"]),
+        ),
+        "healthcare": Policy(
+            guardrails=PolicyGuardrails(add=["hipaa_audit"]),
+            scope=PolicyScope(teams=["healthcare-team"]),
+        ),
+    }
+    registry._initialized = True
+
+    # Call the function
+    add_guardrails_from_policy_engine(
+        data=data,
+        metadata_variable_name="metadata",
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    # Verify guardrails were added
+    assert "guardrails" in data["metadata"]
+    assert "pii_blocker" in data["metadata"]["guardrails"]
+    assert "hipaa_audit" in data["metadata"]["guardrails"]
+
+    # Verify applied policies were tracked
+    assert "applied_policies" in data["metadata"]
+    assert "global-baseline" in data["metadata"]["applied_policies"]
+    assert "healthcare" in data["metadata"]["applied_policies"]
+
+    # Clean up registry
+    registry._policies = {}
+    registry._initialized = False


### PR DESCRIPTION
## [Feat] New LiteLLM Policy engine - create policies to manage guardrails, conditions - permissions per Key, Team 

This PR introduces a new Policy Engine for LiteLLM Proxy that allows administrators to define and manage guardrail policies through YAML configuration. The policy engine provides a flexible way to apply guardrails based on teams, API keys, and models.


Use policies to group guardrails and control which ones run for specific teams, keys, or models.

## Why use policies?

- Enable/disable specific guardrails for teams, keys, or models
- Group guardrails into a single policy
- Inherit from existing policies and override what you need

## Quick Start

```yaml showLineNumbers title="config.yaml"
model_list:
  - model_name: gpt-4
    litellm_params:
      model: openai/gpt-4

# 1. Define your guardrails
guardrails:
  - guardrail_name: pii_masking
    litellm_params:
      guardrail: presidio
      mode: pre_call

  - guardrail_name: prompt_injection
    litellm_params:
      guardrail: lakera
      mode: pre_call
      api_key: os.environ/LAKERA_API_KEY

# 2. Create a policy
policies:
  my-policy:
    guardrails:
      add:
        - pii_masking
        - prompt_injection

# 3. Attach the policy
policy_attachments:
  - policy: my-policy
    scope: "*"  # apply to all requests
```

Response headers show what ran:

```
x-litellm-applied-policies: my-policy
x-litellm-applied-guardrails: pii_masking,prompt_injection
```

## Add guardrails for a specific team

:::info
✨ Enterprise only feature for team/key-based policy attachments. [Get a free trial](https://www.litellm.ai/enterprise#trial)
:::

You have a global baseline, but want to add extra guardrails for a specific team.

```yaml showLineNumbers title="config.yaml"
policies:
  global-baseline:
    guardrails:
      add:
        - pii_masking

  finance-team-policy:
    inherit: global-baseline
    guardrails:
      add:
        - strict_compliance_check
        - audit_logger

policy_attachments:
  - policy: global-baseline
    scope: "*"

  - policy: finance-team-policy
    teams:
      - finance  # team alias from /team/new
```

Now the `finance` team gets `pii_masking` + `strict_compliance_check` + `audit_logger`, while everyone else just gets `pii_masking`.

## Remove guardrails for a specific team

:::info
✨ Enterprise only feature for team/key-based policy attachments. [Get a free trial](https://www.litellm.ai/enterprise#trial)
:::

You have guardrails running globally, but want to disable some for a specific team (e.g., internal testing).

```yaml showLineNumbers title="config.yaml"
policies:
  global-baseline:
    guardrails:
      add:
        - pii_masking
        - prompt_injection

  internal-team-policy:
    inherit: global-baseline
    guardrails:
      remove:
        - pii_masking  # don't need PII masking for internal testing

policy_attachments:
  - policy: global-baseline
    scope: "*"

  - policy: internal-team-policy
    teams:
      - internal-testing  # team alias from /team/new
```

Now the `internal-testing` team only gets `prompt_injection`, while everyone else gets both guardrails.


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
