### PR TITLE
feat(helm): Enable PreStop hook configuration in values.yaml

### DIFF
--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -200,6 +200,14 @@ db:
   #  instance.  See the "postgresql" top level key for additional configuration.
   deployStandalone: true
 
+# Lifecycle hooks for the LiteLLM container
+# Example:
+# lifecycle:
+#   preStop:
+#     exec:
+#       command: ["/bin/sh", "-c", "sleep 10"]
+lifecycle: {}
+
 # Settings for Bitnami postgresql chart (if db.deployStandalone is true, ignored
 #  otherwise)
 postgresql:


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/16933

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - *Note: This is a Helm chart change. Verified via `helm template` dry-run.*
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🚄 Infrastructure

## Changes

- Updated `litellm-helm/values.yaml` to include the `lifecycle` configuration block.
- This enables users to configure `preStop` and `postStart` hooks.
- `terminationGracePeriodSeconds` was already supported in the chart.

This change allows users to ensure logs are flushed or other cleanup tasks are performed before the pod terminates, addressing the requirement to "allow setting terminationGracePeriodSeconds and PreStop hook".
