### PR TITLE
[Feature] UI - Models Page: Model Search

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7706,6 +7706,154 @@ def _enrich_model_info_with_litellm_data(
     return model
 
 
+async def _apply_search_filter_to_models(
+    all_models: List[Dict[str, Any]],
+    search: str,
+    page: int,
+    size: int,
+    prisma_client: Optional[Any],
+    proxy_config: Any,
+) -> Tuple[List[Dict[str, Any]], Optional[int]]:
+    """
+    Apply search filter to models, querying database for additional matching models.
+    
+    Args:
+        all_models: List of models to filter
+        search: Search term (case-insensitive)
+        page: Current page number
+        size: Page size
+        prisma_client: Prisma client for database queries
+        proxy_config: Proxy config for decrypting models
+        
+    Returns:
+        Tuple of (filtered_models, total_count). total_count is None if not searching.
+    """
+    if not search or not search.strip():
+        return all_models, None
+    
+    search_lower = search.lower().strip()
+    
+    # Filter models in router by search term
+    filtered_router_models = [
+        m for m in all_models
+        if search_lower in m.get("model_name", "").lower()
+    ]
+    
+    # Separate filtered models into config vs db models, and track db model IDs
+    filtered_config_models = []
+    db_model_ids_in_router = set()
+    
+    for m in filtered_router_models:
+        model_info = m.get("model_info", {})
+        is_db_model = model_info.get("db_model", False)
+        model_id = model_info.get("id")
+        
+        if is_db_model and model_id:
+            db_model_ids_in_router.add(model_id)
+        else:
+            filtered_config_models.append(m)
+    
+    config_models_count = len(filtered_config_models)
+    db_models_in_router_count = len(db_model_ids_in_router)
+    router_models_count = config_models_count + db_models_in_router_count
+    
+    # Query database for additional models with search term
+    db_models = []
+    db_models_total_count = 0
+    models_needed_for_page = size * page
+    
+    try:
+        # Build where condition for database query
+        db_where_condition: Dict[str, Any] = {
+            "model_name": {
+                "contains": search_lower,
+                "mode": "insensitive",
+            }
+        }
+        # Exclude models already in router if we have any
+        if db_model_ids_in_router:
+            db_where_condition["model_id"] = {
+                "not": {"in": list(db_model_ids_in_router)}
+            }
+        
+        # Get total count of matching database models
+        db_models_total_count = await prisma_client.db.litellm_proxymodeltable.count(
+            where=db_where_condition
+        )
+        
+        # Calculate total count for search results
+        search_total_count = router_models_count + db_models_total_count
+        
+        # Fetch database models if we need more for the current page
+        if router_models_count < models_needed_for_page:
+            models_to_fetch = min(
+                models_needed_for_page - router_models_count,
+                db_models_total_count
+            )
+            
+            if models_to_fetch > 0:
+                db_models_raw = await prisma_client.db.litellm_proxymodeltable.find_many(
+                    where=db_where_condition,
+                    take=models_to_fetch,
+                )
+                
+                # Convert database models to router format
+                for db_model in db_models_raw:
+                    decrypted_models = proxy_config.decrypt_model_list_from_db([db_model])
+                    if decrypted_models:
+                        db_models.extend(decrypted_models)
+    except Exception as e:
+        verbose_proxy_logger.exception(
+            f"Error querying database models with search: {str(e)}"
+        )
+        # If error, use router models count as fallback
+        search_total_count = router_models_count
+    
+    # Combine all models
+    filtered_models = filtered_router_models + db_models
+    return filtered_models, search_total_count
+
+
+def _paginate_models_response(
+    all_models: List[Dict[str, Any]],
+    page: int,
+    size: int,
+    total_count: Optional[int],
+    search: Optional[str],
+) -> Dict[str, Any]:
+    """
+    Paginate models and return response dictionary.
+    
+    Args:
+        all_models: List of all models
+        page: Current page number
+        size: Page size
+        total_count: Total count (if None, uses len(all_models))
+        search: Search term (for logging)
+        
+    Returns:
+        Paginated response dictionary
+    """
+    if total_count is None:
+        total_count = len(all_models)
+    
+    skip = (page - 1) * size
+    total_pages = -(-total_count // size) if total_count > 0 else 0
+    paginated_models = all_models[skip : skip + size]
+    
+    verbose_proxy_logger.debug(
+        f"Pagination: skip={skip}, take={size}, total_count={total_count}, total_pages={total_pages}, search={search}"
+    )
+    
+    return {
+        "data": paginated_models,
+        "total_count": total_count,
+        "current_page": page,
+        "total_pages": total_pages,
+        "size": size,
+    }
+
+
 @router.get(
     "/v2/model/info",
     description="v2 - returns models available to the user based on their API key permissions. Shows model info from config.yaml (except api key and api base). Filter to just user-added models with ?user_models_only=true",
@@ -7763,94 +7911,15 @@ async def model_info_v2(
     if model is not None:
         all_models = [m for m in all_models if m["model_name"] == model]
 
-    # Track total count for search (will be calculated if searching)
-    search_total_count = None
-    
     # Apply search filter if provided
-    if search is not None and search.strip():
-        search_lower = search.lower().strip()
-        
-        # First, filter ALL models in router by search term (both config and db models)
-        filtered_router_models = [
-            m for m in all_models
-            if search_lower in m.get("model_name", "").lower()
-        ]
-        
-        # Separate filtered models into config vs db models, and track db model IDs
-        filtered_config_models = []
-        db_model_ids_in_router = set()
-        
-        for m in filtered_router_models:
-            model_info = m.get("model_info", {})
-            is_db_model = model_info.get("db_model", False)
-            model_id = model_info.get("id")
-            
-            if is_db_model and model_id:
-                db_model_ids_in_router.add(model_id)
-            else:
-                filtered_config_models.append(m)
-        
-        config_models_count = len(filtered_config_models)
-        db_models_in_router_count = len(db_model_ids_in_router)
-        router_models_count = config_models_count + db_models_in_router_count
-        
-        # Query database for additional models with search term (not already in router)
-        # We need enough models to fill the current page (size * page total models)
-        db_models = []
-        db_models_total_count = 0
-        models_needed_for_page = size * page  # Total models needed up to current page
-        
-        try:
-            # Build where condition for database query
-            db_where_condition: Dict[str, Any] = {
-                "model_name": {
-                    "contains": search_lower,
-                    "mode": "insensitive",
-                }
-            }
-            # Exclude models already in router if we have any
-            if db_model_ids_in_router:
-                db_where_condition["model_id"] = {
-                    "not": {"in": list(db_model_ids_in_router)}
-                }
-            
-            # Get total count of matching database models (excluding those already in router)
-            db_models_total_count = await prisma_client.db.litellm_proxymodeltable.count(
-                where=db_where_condition
-            )
-            
-            # Calculate total count for search results
-            search_total_count = router_models_count + db_models_total_count
-            
-            # Fetch database models if we need more for the current page
-            if router_models_count < models_needed_for_page:
-                models_to_fetch = min(
-                    models_needed_for_page - router_models_count,
-                    db_models_total_count
-                )
-                
-                if models_to_fetch > 0:
-                    db_models_raw = await prisma_client.db.litellm_proxymodeltable.find_many(
-                        where=db_where_condition,
-                        take=models_to_fetch,
-                    )
-                    
-                    # Convert database models to router format
-                    for db_model in db_models_raw:
-                        decrypted_models = proxy_config.decrypt_model_list_from_db([db_model])
-                        if decrypted_models:
-                            db_models.extend(decrypted_models)
-        except Exception as e:
-            verbose_proxy_logger.exception(
-                f"Error querying database models with search: {str(e)}"
-            )
-            # If error, use router models count as fallback
-            search_total_count = router_models_count
-        
-        # Combine all models: config models first, then db models from router, then db models from database
-        # filtered_router_models already contains both config and db models from router, so we can use it directly
-        all_models = filtered_router_models + db_models
-    # else: No search - models are already in all_models from llm_router.model_list
+    all_models, search_total_count = await _apply_search_filter_to_models(
+        all_models=all_models,
+        search=search or "",
+        page=page,
+        size=size,
+        prisma_client=prisma_client,
+        proxy_config=proxy_config,
+    )
 
     if user_models_only:
         all_models = await non_admin_all_models(
@@ -7867,7 +7936,8 @@ async def model_info_v2(
             llm_router=llm_router,
             all_models=all_models,
         )
-    # fill in model info based on config.yaml and litellm model_prices_and_context_window.json
+    
+    # Fill in model info based on config.yaml and litellm model_prices_and_context_window.json
     for i, _model in enumerate(all_models):
         all_models[i] = _enrich_model_info_with_litellm_data(
             model=_model, debug=debug if debug is not None else False, llm_router=llm_router
@@ -7875,26 +7945,13 @@ async def model_info_v2(
 
     verbose_proxy_logger.debug("all_models: %s", all_models)
     
-    # Use search_total_count if searching, otherwise use len(all_models)
-    total_count = search_total_count if search_total_count is not None else len(all_models)
-    
-    skip = (page - 1) * size
-    
-    total_pages = -(-total_count // size) if total_count > 0 else 0
-    
-    paginated_models = all_models[skip : skip + size]
-    
-    verbose_proxy_logger.debug(
-        f"Pagination: skip={skip}, take={size}, total_count={total_count}, total_pages={total_pages}, search={search}"
+    return _paginate_models_response(
+        all_models=all_models,
+        page=page,
+        size=size,
+        total_count=search_total_count,
+        search=search,
     )
-    
-    return {
-        "data": paginated_models,
-        "total_count": total_count,
-        "current_page": page,
-        "total_pages": total_pages,
-        "size": size,
-    }
 
 
 @router.get(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7727,6 +7727,9 @@ async def model_info_v2(
     debug: Optional[bool] = False,
     page: int = Query(1, description="Page number", ge=1),
     size: int = Query(50, description="Page size", ge=1),
+    search: Optional[str] = fastapi.Query(
+        None, description="Search model names (case-insensitive partial match)"
+    ),
 ):
     """
     BETA ENDPOINT. Might change unexpectedly. Use `/v1/model/info` for now.
@@ -7760,6 +7763,95 @@ async def model_info_v2(
     if model is not None:
         all_models = [m for m in all_models if m["model_name"] == model]
 
+    # Track total count for search (will be calculated if searching)
+    search_total_count = None
+    
+    # Apply search filter if provided
+    if search is not None and search.strip():
+        search_lower = search.lower().strip()
+        
+        # First, filter ALL models in router by search term (both config and db models)
+        filtered_router_models = [
+            m for m in all_models
+            if search_lower in m.get("model_name", "").lower()
+        ]
+        
+        # Separate filtered models into config vs db models, and track db model IDs
+        filtered_config_models = []
+        db_model_ids_in_router = set()
+        
+        for m in filtered_router_models:
+            model_info = m.get("model_info", {})
+            is_db_model = model_info.get("db_model", False)
+            model_id = model_info.get("id")
+            
+            if is_db_model and model_id:
+                db_model_ids_in_router.add(model_id)
+            else:
+                filtered_config_models.append(m)
+        
+        config_models_count = len(filtered_config_models)
+        db_models_in_router_count = len(db_model_ids_in_router)
+        router_models_count = config_models_count + db_models_in_router_count
+        
+        # Query database for additional models with search term (not already in router)
+        # We need enough models to fill the current page (size * page total models)
+        db_models = []
+        db_models_total_count = 0
+        models_needed_for_page = size * page  # Total models needed up to current page
+        
+        try:
+            # Build where condition for database query
+            db_where_condition: Dict[str, Any] = {
+                "model_name": {
+                    "contains": search_lower,
+                    "mode": "insensitive",
+                }
+            }
+            # Exclude models already in router if we have any
+            if db_model_ids_in_router:
+                db_where_condition["model_id"] = {
+                    "not": {"in": list(db_model_ids_in_router)}
+                }
+            
+            # Get total count of matching database models (excluding those already in router)
+            db_models_total_count = await prisma_client.db.litellm_proxymodeltable.count(
+                where=db_where_condition
+            )
+            
+            # Calculate total count for search results
+            search_total_count = router_models_count + db_models_total_count
+            
+            # Fetch database models if we need more for the current page
+            if router_models_count < models_needed_for_page:
+                models_to_fetch = min(
+                    models_needed_for_page - router_models_count,
+                    db_models_total_count
+                )
+                
+                if models_to_fetch > 0:
+                    db_models_raw = await prisma_client.db.litellm_proxymodeltable.find_many(
+                        where=db_where_condition,
+                        take=models_to_fetch,
+                    )
+                    
+                    # Convert database models to router format
+                    for db_model in db_models_raw:
+                        decrypted_models = proxy_config.decrypt_model_list_from_db([db_model])
+                        if decrypted_models:
+                            db_models.extend(decrypted_models)
+        except Exception as e:
+            verbose_proxy_logger.exception(
+                f"Error querying database models with search: {str(e)}"
+            )
+            # If error, use router models count as fallback
+            search_total_count = router_models_count
+        
+        # Combine all models: config models first, then db models from router, then db models from database
+        # filtered_router_models already contains both config and db models from router, so we can use it directly
+        all_models = filtered_router_models + db_models
+    # else: No search - models are already in all_models from llm_router.model_list
+
     if user_models_only:
         all_models = await non_admin_all_models(
             all_models=all_models,
@@ -7783,7 +7875,8 @@ async def model_info_v2(
 
     verbose_proxy_logger.debug("all_models: %s", all_models)
     
-    total_count = len(all_models)
+    # Use search_total_count if searching, otherwise use len(all_models)
+    total_count = search_total_count if search_total_count is not None else len(all_models)
     
     skip = (page - 1) * size
     
@@ -7792,7 +7885,7 @@ async def model_info_v2(
     paginated_models = all_models[skip : skip + size]
     
     verbose_proxy_logger.debug(
-        f"Pagination: skip={skip}, take={size}, total_count={total_count}, total_pages={total_pages}"
+        f"Pagination: skip={skip}, take={size}, total_count={total_count}, total_pages={total_pages}, search={search}"
     )
     
     return {

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
@@ -101,7 +101,8 @@ describe("useModelsInfo", () => {
       "test-user-id",
       "Admin",
       1,
-      50
+      50,
+      undefined
     );
     expect(modelInfoCall).toHaveBeenCalledTimes(1);
   });
@@ -120,7 +121,8 @@ describe("useModelsInfo", () => {
       "test-user-id",
       "Admin",
       2,
-      25
+      25,
+      undefined
     );
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -27,7 +27,7 @@ const modelHubKeys = createQueryKeys("modelHub");
 const allProxyModelsKeys = createQueryKeys("allProxyModels");
 const selectedTeamModelsKeys = createQueryKeys("selectedTeamModels");
 
-export const useModelsInfo = (page: number = 1, size: number = 50) => {
+export const useModelsInfo = (page: number = 1, size: number = 50, search?: string) => {
   const { accessToken, userId, userRole } = useAuthorized();
   return useQuery<PaginatedModelInfoResponse>({
     queryKey: modelKeys.list({
@@ -36,9 +36,10 @@ export const useModelsInfo = (page: number = 1, size: number = 50) => {
         ...(userRole && { userRole }),
         page,
         size,
+        ...(search && { search }),
       },
     }),
-    queryFn: async () => await modelInfoCall(accessToken!, userId!, userRole!, page, size),
+    queryFn: async () => await modelInfoCall(accessToken!, userId!, userRole!, page, size, search),
     enabled: Boolean(accessToken && userId && userRole),
   });
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
@@ -11,7 +11,7 @@ const mockUseModelsInfo = vi.fn(() => ({
 })) as any;
 
 vi.mock("../../hooks/models/useModels", () => ({
-  useModelsInfo: (page?: number, size?: number) => mockUseModelsInfo(page, size),
+  useModelsInfo: (page?: number, size?: number, search?: string) => mockUseModelsInfo(page, size, search),
 }));
 
 // Mock the useModelCostMap hook
@@ -74,7 +74,6 @@ describe("AllModelsTab", () => {
   const mockSetSelectedModelGroup = vi.fn();
   const mockSetSelectedModelId = vi.fn();
   const mockSetSelectedTeamId = vi.fn();
-  const mockSetEditModel = vi.fn();
 
   const defaultProps = {
     selectedModelGroup: "all",
@@ -83,7 +82,6 @@ describe("AllModelsTab", () => {
     availableModelAccessGroups: ["sales-team", "engineering-team"],
     setSelectedModelId: mockSetSelectedModelId,
     setSelectedTeamId: mockSetSelectedTeamId,
-    setEditModel: mockSetEditModel,
   };
 
   const mockUseAuthorized = {
@@ -176,8 +174,10 @@ describe("AllModelsTab", () => {
 
     render(<AllModelsTab {...defaultProps} />);
 
+    // Component shows API total_count (2), not filtered count
+    // Since default is "personal" team and models don't have direct_access, they're filtered out
     await waitFor(() => {
-      expect(screen.getByText("Showing 0 results")).toBeInTheDocument();
+      expect(screen.getByText("Showing 1 - 2 of 2 results")).toBeInTheDocument();
     });
   });
 
@@ -235,8 +235,10 @@ describe("AllModelsTab", () => {
 
     render(<AllModelsTab {...defaultProps} />);
 
+    // Component shows API total_count (2), not filtered count
+    // Since default is "personal" team and models don't have direct_access, they're filtered out
     await waitFor(() => {
-      expect(screen.getByText("Showing 0 results")).toBeInTheDocument();
+      expect(screen.getByText("Showing 1 - 2 of 2 results")).toBeInTheDocument();
     });
   });
 
@@ -280,8 +282,9 @@ describe("AllModelsTab", () => {
 
     render(<AllModelsTab {...defaultProps} />);
 
+    // Component shows API total_count (2), but only 1 model has direct_access
     await waitFor(() => {
-      expect(screen.getByText("Showing 1 - 1 of 1 results")).toBeInTheDocument();
+      expect(screen.getByText("Showing 1 - 2 of 2 results")).toBeInTheDocument();
     });
   });
 
@@ -419,14 +422,15 @@ describe("AllModelsTab", () => {
     );
 
     // Set up mock to return page1Data for page 1
-    mockUseModelsInfo.mockImplementation((page: number = 1) => {
+    mockUseModelsInfo.mockImplementation((page: number = 1, size?: number, search?: string) => {
       return { data: page1Data, isLoading: false, error: null };
     });
 
     render(<AllModelsTab {...defaultProps} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Showing 1 - 1 of 1 results")).toBeInTheDocument();
+      // Component calculates: ((1-1)*50)+1 = 1, Math.min(1*50, 2) = 2
+      expect(screen.getByText("Showing 1 - 2 of 2 results")).toBeInTheDocument();
     });
 
     // Check that Previous button is disabled on first page
@@ -471,7 +475,7 @@ describe("AllModelsTab", () => {
       50, // size
     );
 
-    mockUseModelsInfo.mockImplementation(() => {
+    mockUseModelsInfo.mockImplementation((page?: number, size?: number, search?: string) => {
       return { data: singlePageData, isLoading: false, error: null };
     });
 

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2007,17 +2007,20 @@ export const regenerateKeyCall = async (accessToken: string, keyToRegenerate: st
 let ModelListerrorShown = false;
 let errorTimer: NodeJS.Timeout | null = null;
 
-export const modelInfoCall = async (accessToken: string, userID: string, userRole: string, page: number = 1, size: number = 50) => {
+export const modelInfoCall = async (accessToken: string, userID: string, userRole: string, page: number = 1, size: number = 50, search?: string) => {
   /**
    * Get all models on proxy
    */
   try {
-    console.log("modelInfoCall:", accessToken, userID, userRole, page, size);
+    console.log("modelInfoCall:", accessToken, userID, userRole, page, size, search);
     let url = proxyBaseUrl ? `${proxyBaseUrl}/v2/model/info` : `/v2/model/info`;
     const params = new URLSearchParams();
     params.append("include_team_models", "true");
     params.append("page", page.toString());
     params.append("size", size.toString());
+    if (search && search.trim()) {
+      params.append("search", search.trim());
+    }
     if (params.toString()) {
       url += `?${params.toString()}`;
     }


### PR DESCRIPTION
## Relevant issues
This PR implements the Model Search in the backend endpoint /v2/model/info. Previously this endpoint was not paginated and returns the entire list, so client side filtering worked. Now the list is paginated, and the endpoint needs to search the backend instead.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="695" height="168" alt="image" src="https://github.com/user-attachments/assets/6f8cb0c8-8168-48d9-9a2b-79b498aba3ca" />
<img width="954" height="661" alt="image" src="https://github.com/user-attachments/assets/644b969a-65fc-4be1-9701-f663638ce3d1" />
<img width="729" height="154" alt="image" src="https://github.com/user-attachments/assets/c81a6a11-4420-457e-8787-97d77e333226" />
