### PR TITLE
fix: propagate JWT auth metadata to OTEL spans

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -896,7 +896,7 @@ def get_openapi_schema():
     from litellm.proxy.common_utils.custom_openapi_spec import CustomOpenAPISpec
 
     openapi_schema = CustomOpenAPISpec.add_llm_api_request_schema_body(openapi_schema)
-    
+
     # Fix Swagger UI execute path error when server_root_path is set
     if server_root_path:
         openapi_schema["servers"] = [{"url": "/" + server_root_path.strip("/")}]
@@ -922,7 +922,7 @@ def custom_openapi():
     from litellm.proxy.common_utils.custom_openapi_spec import CustomOpenAPISpec
 
     openapi_schema = CustomOpenAPISpec.add_llm_api_request_schema_body(openapi_schema)
-    
+
     # Fix Swagger UI execute path error when server_root_path is set
     if server_root_path:
         openapi_schema["servers"] = [{"url": "/" + server_root_path.strip("/")}]
@@ -5242,6 +5242,24 @@ async def chat_completion(  # noqa: PLR0915
     global general_settings, user_debug, proxy_logging_obj, llm_model_list
     global user_temperature, user_request_timeout, user_max_tokens, user_api_base
     data = await _read_request_body(request=request)
+    if user_api_key_dict is not None:
+        if data.get("metadata") is None:
+            data["metadata"] = {}
+        if (
+            hasattr(user_api_key_dict, "user_id")
+            and user_api_key_dict.user_id is not None
+        ):
+            data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+        if (
+            hasattr(user_api_key_dict, "team_id")
+            and user_api_key_dict.team_id is not None
+        ):
+            data["metadata"]["user_api_key_team_id"] = user_api_key_dict.team_id
+        if (
+            hasattr(user_api_key_dict, "org_id")
+            and user_api_key_dict.org_id is not None
+        ):
+            data["metadata"]["user_api_key_org_id"] = user_api_key_dict.org_id
     base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)
     try:
         result = await base_llm_response_processor.base_process_llm_request(
@@ -5393,6 +5411,24 @@ async def completion(  # noqa: PLR0915
     data = {}
     try:
         data = await _read_request_body(request=request)
+        if user_api_key_dict is not None:
+            if data.get("metadata") is None:
+                data["metadata"] = {}
+            if (
+                hasattr(user_api_key_dict, "user_id")
+                and user_api_key_dict.user_id is not None
+            ):
+                data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+            if (
+                hasattr(user_api_key_dict, "team_id")
+                and user_api_key_dict.team_id is not None
+            ):
+                data["metadata"]["user_api_key_team_id"] = user_api_key_dict.team_id
+            if (
+                hasattr(user_api_key_dict, "org_id")
+                and user_api_key_dict.org_id is not None
+            ):
+                data["metadata"]["user_api_key_org_id"] = user_api_key_dict.org_id
         base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)
         return await base_llm_response_processor.base_process_llm_request(
             request=request,
@@ -5611,6 +5647,25 @@ async def embeddings(  # noqa: PLR0915
                                 litellm.decode(model="gpt-3.5-turbo", tokens=i)
                             )
                         data["input"] = input_list
+
+        if user_api_key_dict is not None:
+            if data.get("metadata") is None:
+                data["metadata"] = {}
+            if (
+                hasattr(user_api_key_dict, "user_id")
+                and user_api_key_dict.user_id is not None
+            ):
+                data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+            if (
+                hasattr(user_api_key_dict, "team_id")
+                and user_api_key_dict.team_id is not None
+            ):
+                data["metadata"]["user_api_key_team_id"] = user_api_key_dict.team_id
+            if (
+                hasattr(user_api_key_dict, "org_id")
+                and user_api_key_dict.org_id is not None
+            ):
+                data["metadata"]["user_api_key_org_id"] = user_api_key_dict.org_id
 
         # Use unified request processor (same as chat/completions and responses)
         base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)

--- a/tests/test_litellm/proxy/test_chat_completion_metadata.py
+++ b/tests/test_litellm/proxy/test_chat_completion_metadata.py
@@ -1,0 +1,154 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from litellm.proxy.proxy_server import chat_completion, completion, embeddings
+from litellm.proxy._types import UserAPIKeyAuth
+from fastapi import Request, Response
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_metadata_population():
+    # Setup
+    request = MagicMock(spec=Request)
+    # Mock _read_request_body to return a dict
+    with patch(
+        "litellm.proxy.proxy_server._read_request_body", new_callable=AsyncMock
+    ) as mock_read_body:
+        mock_read_body.return_value = {"model": "gpt-3.5-turbo", "messages": []}
+
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="test_user_id", team_id="test_team_id", org_id="test_org_id"
+        )
+
+        fastapi_response = MagicMock(spec=Response)
+
+        # Mock ProxyBaseLLMRequestProcessing
+        with patch(
+            "litellm.proxy.proxy_server.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            mock_instance = MockProcessor.return_value
+            mock_instance.base_process_llm_request = AsyncMock(
+                return_value={"choices": []}
+            )
+
+            # Execute
+            await chat_completion(
+                request=request,
+                fastapi_response=fastapi_response,
+                user_api_key_dict=user_api_key_dict,
+            )
+
+            # Verify
+            # Check if ProxyBaseLLMRequestProcessing was initialized with data containing metadata
+            call_args = MockProcessor.call_args
+            assert call_args is not None
+            data_arg = call_args.kwargs.get("data")
+            assert data_arg is not None
+
+            assert "metadata" in data_arg
+            assert data_arg["metadata"]["user_api_key_user_id"] == "test_user_id"
+            assert data_arg["metadata"]["user_api_key_team_id"] == "test_team_id"
+            assert data_arg["metadata"]["user_api_key_org_id"] == "test_org_id"
+
+
+@pytest.mark.asyncio
+async def test_embedding_metadata_population():
+    """
+    Test that the embedding endpoint correctly populates metadata
+    from UserAPIKeyAuth.
+    """
+    # Setup
+    with patch(
+        "litellm.proxy.proxy_server.ProxyBaseLLMRequestProcessing.base_process_llm_request"
+    ):
+        with patch(
+            "litellm.proxy.proxy_server.ProxyBaseLLMRequestProcessing.__init__",
+            return_value=None,
+        ) as mock_base_process_init:
+            # Create a mock UserAPIKeyAuth object
+            mock_user_auth = MagicMock(spec=UserAPIKeyAuth)
+            mock_user_auth.user_id = "test_user_id_emb"
+            mock_user_auth.team_id = "test_team_id_emb"
+            mock_user_auth.org_id = "test_org_id_emb"
+
+            # Create a mock Request object
+            mock_request = MagicMock(spec=Request)
+            mock_request.json = AsyncMock(
+                return_value={"model": "gpt-3.5-turbo", "input": "hello"}
+            )
+            # Mock _read_request_body to return our data
+            with patch(
+                "litellm.proxy.proxy_server._read_request_body",
+                new=AsyncMock(
+                    return_value={"model": "gpt-3.5-turbo", "input": "hello"}
+                ),
+            ):
+                # Call the endpoint function directly
+                await embeddings(
+                    request=mock_request,
+                    fastapi_response=MagicMock(spec=Response),
+                    user_api_key_dict=mock_user_auth,
+                )
+
+                # Check if ProxyBaseLLMRequestProcessing was initialized with the correct metadata
+                mock_base_process_init.assert_called_once()
+                call_args = mock_base_process_init.call_args
+                # handle both positional and keyword args for data
+                if "data" in call_args.kwargs:
+                    data_arg = call_args.kwargs["data"]
+                else:
+                    data_arg = call_args.args[0]
+
+                assert (
+                    data_arg["metadata"]["user_api_key_user_id"] == "test_user_id_emb"
+                )
+                assert (
+                    data_arg["metadata"]["user_api_key_team_id"] == "test_team_id_emb"
+                )
+                assert data_arg["metadata"]["user_api_key_org_id"] == "test_org_id_emb"
+
+
+@pytest.mark.asyncio
+async def test_completion_metadata_population():
+    # Setup
+    request = MagicMock(spec=Request)
+    # Mock _read_request_body to return a dict
+    with patch(
+        "litellm.proxy.proxy_server._read_request_body", new_callable=AsyncMock
+    ) as mock_read_body:
+        mock_read_body.return_value = {
+            "model": "gpt-3.5-turbo-instruct",
+            "prompt": "test",
+        }
+
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="test_user_id_2", team_id="test_team_id_2", org_id="test_org_id_2"
+        )
+
+        fastapi_response = MagicMock(spec=Response)
+
+        # Mock ProxyBaseLLMRequestProcessing
+        with patch(
+            "litellm.proxy.proxy_server.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            mock_instance = MockProcessor.return_value
+            mock_instance.base_process_llm_request = AsyncMock(
+                return_value={"choices": []}
+            )
+
+            # Execute
+            await completion(
+                request=request,
+                fastapi_response=fastapi_response,
+                user_api_key_dict=user_api_key_dict,
+            )
+
+            # Verify
+            call_args = MockProcessor.call_args
+            assert call_args is not None
+            data_arg = call_args.kwargs.get("data")
+            assert data_arg is not None
+
+            assert "metadata" in data_arg
+            assert data_arg["metadata"]["user_api_key_user_id"] == "test_user_id_2"
+            assert data_arg["metadata"]["user_api_key_team_id"] == "test_team_id_2"
+            assert data_arg["metadata"]["user_api_key_org_id"] == "test_org_id_2"


### PR DESCRIPTION
## Relevant issues

fixes https://github.com/BerriAI/litellm/issues/19597 missing [user_id](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/handle_jwt.py:282:4-294:22), [team_id](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/handle_jwt.py:221:4-245:22), and [org_id](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/handle_jwt.py:401:4-413:21) in logs when using JWT Authentication.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:
- [ ] **CI run for the last commit**  
       Link:
- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

- **Core Logic**: Updated [litellm/proxy/proxy_server.py](cci:7://file:///d:/OSS/litellm/litellm/proxy/proxy_server.py:0:0-0:0) to propagate [user_id](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/handle_jwt.py:282:4-294:22), [team_id](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/handle_jwt.py:221:4-245:22), and [org_id](cci:1://file:///d:/OSS/litellm/litellm/proxy/auth/handle_jwt.py:401:4-413:21) from the authenticated `user_api_key_dict` (e.g., from JWT Auth) into the request [metadata](cci:1://file:///d:/OSS/litellm/tests/test_litellm/proxy/test_chat_completion_metadata.py:52:0-106:87). This ensures these critical fields are correctly exported to OpenTelemetry/Logs.
- **Testing**: Added [tests/test_litellm/proxy/test_chat_completion_metadata.py](cci:7://file:///d:/OSS/litellm/tests/test_litellm/proxy/test_chat_completion_metadata.py:0:0-0:0) with comprehensive unit tests verifying metadata population for:
  - `/v1/chat/completions`
  - `/v1/completions`
  - `/v1/embeddings`

<p align="right">verified via mock testing</p>