### PR TITLE
fix(docker): use correct schema path for prisma generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,8 @@ RUN find /usr/lib -type f -path "*/tornado/test/*" -delete && \
 # Convert Windows line endings to Unix and make executable
 RUN sed -i 's/\r$//' docker/install_auto_router.sh && chmod +x docker/install_auto_router.sh && ./docker/install_auto_router.sh
 
-# Generate prisma client
-RUN prisma generate
+# Generate prisma client using the correct schema
+RUN prisma generate --schema=./litellm/proxy/schema.prisma
 # Convert Windows line endings to Unix for entrypoint scripts
 RUN sed -i 's/\r$//' docker/entrypoint.sh && chmod +x docker/entrypoint.sh
 RUN sed -i 's/\r$//' docker/prod_entrypoint.sh && chmod +x docker/prod_entrypoint.sh


### PR DESCRIPTION
## Relevant issues

fixes https://github.com/BerriAI/litellm/issues/19588 crash when using Claude Code Marketplace features due to missing Prisma client attributes (re: `LiteLLM_ClaudeCodePluginTable`).

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - *(Note: This is an Infrastructure/Docker fix, so unit tests are not applicable, but I verified the fix locally by building the image)*
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: (Leave blank until CI runs)

- [ ] **CI run for the last commit**  
       Link: (Leave blank until CI runs)

- [ ] **Merge / cherry-pick CI run**  
       Links: (Leave blank)

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🚄 Infrastructure

## Changes

- Updated [litellm/Dockerfile](cci:7://file:///d:/OSS/speedup-litellm-2/litellm/Dockerfile:0:0-0:0) to explicitly point to [./litellm/proxy/schema.prisma](cci:7://file:///d:/OSS/speedup-litellm-2/litellm/litellm/proxy/schema.prisma:0:0-0:0) during `prisma generate`.
- This ensures the Docker image builds with the correct, up-to-date Prisma client that includes newer tables (like `LiteLLM_ClaudeCodePluginTable`) instead of the outdated default schema.