### PR TITLE
fix: enhance model cost checks for custom models in utility functions

### DIFF
--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -28,6 +28,13 @@ def get_supported_openai_params(  # noqa: PLR0915
         try:
             custom_llm_provider = litellm.get_llm_provider(model=model)[1]
         except BadRequestError:
+            # Provider not found - check if model is in model_cost before returning None
+            if model in litellm.model_cost:
+                model_info = litellm.model_cost[model]
+                if isinstance(model_info, dict):
+                    supported_params = model_info.get("supported_openai_params")
+                    if supported_params is not None:
+                        return supported_params
             return None
 
     if custom_llm_provider in LlmProvidersSet:
@@ -300,5 +307,13 @@ def get_supported_openai_params(  # noqa: PLR0915
             return None
         elif request_type == "transcription":
             return None
+
+    # Fallback: Check model_cost for custom models 
+    if model in litellm.model_cost:
+        model_info = litellm.model_cost[model]
+        if isinstance(model_info, dict):
+            supported_params = model_info.get("supported_openai_params")
+            if supported_params is not None:
+                return supported_params
 
     return None

--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -33,7 +33,7 @@ def get_supported_openai_params(  # noqa: PLR0915
                 model_info = litellm.model_cost[model]
                 if isinstance(model_info, dict):
                     supported_params = model_info.get("supported_openai_params")
-                    if supported_params is not None:
+                    if supported_params is not None and isinstance(supported_params, list):
                         return supported_params
             return None
 
@@ -313,7 +313,7 @@ def get_supported_openai_params(  # noqa: PLR0915
         model_info = litellm.model_cost[model]
         if isinstance(model_info, dict):
             supported_params = model_info.get("supported_openai_params")
-            if supported_params is not None:
+            if supported_params is not None and isinstance(supported_params, list):
                 return supported_params
 
     return None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2518,6 +2518,14 @@ def _supports_factory(model: str, custom_llm_provider: Optional[str], key: str) 
             f"Model not found or error in checking {key} support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {str(e)}"
         )
 
+        # Check model_cost for custom models
+        if model in litellm.model_cost:
+            model_info = litellm.model_cost[model]
+            if isinstance(model_info, dict):
+                value = model_info.get(key)
+                if value is True:
+                    return True
+
         supported_by_provider = _supports_provider_info_factory(
             model, custom_llm_provider, key
         )

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -550,6 +550,44 @@ def test_supports_web_search(model, expected_bool):
         pytest.fail(f"Error occurred: {e}")
 
 
+def test_supports_function_calling_custom_model():
+    """
+    Custom models added to litellm.model_cost should properly report function calling support,
+    enabling llama-index and other frameworks to detect capabilities.
+    """
+    import litellm
+
+    custom_model = "test-custom-fc-model"
+    litellm.model_cost[custom_model] = {
+        "max_tokens": 8192,
+        "supports_function_calling": True,
+        "supported_openai_params": ["tools", "tool_choice", "functions"],
+    }
+
+    try:
+        result = litellm.supports_function_calling(custom_model)
+        assert result is True, "Custom model with supports_function_calling=True should return True"
+    finally:
+        del litellm.model_cost[custom_model]
+
+
+def test_supports_function_calling_custom_model_disabled():
+    """Test that custom model with supports_function_calling=False returns False."""
+    import litellm
+
+    custom_model = "test-custom-no-fc"
+    litellm.model_cost[custom_model] = {
+        "max_tokens": 2048,
+        "supports_function_calling": False,
+    }
+
+    try:
+        result = litellm.supports_function_calling(custom_model)
+        assert result is False, "Custom model with supports_function_calling=False should return False"
+    finally:
+        del litellm.model_cost[custom_model]
+
+
 @pytest.mark.parametrize(
     "model, expected_bool",
     [
@@ -589,6 +627,52 @@ def test_get_supported_openai_params() -> None:
 
     # Unmapped provider
     assert get_supported_openai_params("nonexistent") is None
+
+
+def test_get_supported_openai_params_custom_model():
+    """
+    Test for Issue #14067: get_supported_openai_params should check model_cost for custom models.
+
+    Custom models added to litellm.model_cost should expose their supported_openai_params,
+    enabling llama-index and other frameworks to detect function calling support.
+    """
+    import litellm
+
+    # Add a custom model with function calling support
+    custom_model = "test-custom-model-14067"
+    litellm.model_cost[custom_model] = {
+        "max_tokens": 4096,
+        "supports_function_calling": True,
+        "supported_openai_params": ["tools", "tool_choice", "functions", "temperature"],
+    }
+
+    try:
+        # Should return the configured params (not None)
+        result = get_supported_openai_params(custom_model)
+        assert result is not None, "Should return params for custom model in model_cost"
+        assert isinstance(result, list), "Should return a list"
+        assert "tools" in result, "Should include 'tools' param"
+        assert "tool_choice" in result, "Should include 'tool_choice' param"
+    finally:
+        # Cleanup
+        del litellm.model_cost[custom_model]
+
+
+def test_get_supported_openai_params_custom_model_without_params():
+    """Test that custom model without supported_openai_params returns None."""
+    import litellm
+
+    custom_model = "test-custom-no-params"
+    litellm.model_cost[custom_model] = {
+        "max_tokens": 2048,
+        "supports_function_calling": False,
+    }
+
+    try:
+        result = get_supported_openai_params(custom_model)
+        assert result is None, "Should return None when supported_openai_params not defined"
+    finally:
+        del litellm.model_cost[custom_model]
 
 
 def test_get_chat_completion_prompt():
@@ -1461,10 +1545,10 @@ def test_get_end_user_id_for_cost_tracking_metadata_handling(
     fields using the get_litellm_metadata_from_kwargs helper function.
     """
     from litellm.utils import get_end_user_id_for_cost_tracking
-    
+
     # Ensure cost tracking is enabled for this test
     litellm.disable_end_user_cost_tracking = False
-    
+
     result = get_end_user_id_for_cost_tracking(litellm_params=litellm_params)
     assert result == expected_end_user_id
 

--- a/tests/local_testing/test_get_model_info.py
+++ b/tests/local_testing/test_get_model_info.py
@@ -455,3 +455,49 @@ def test_get_model_info_case_insensitive_supports_function_calling(monkeypatch):
         supports_function_calling("testmodel-abc", custom_llm_provider="test_provider")
         is True
     )
+
+
+def test_custom_model_function_calling_via_model_cost():
+    """
+    Test the custom models added to model_cost should expose function calling support.
+
+    This test verifies that when users add custom models via litellm.model_cost,
+    the function calling support is properly detected by external frameworks like llama-index.
+    """
+    import litellm
+    from litellm.litellm_core_utils.get_supported_openai_params import (
+        get_supported_openai_params,
+    )
+
+    custom_model = "my-company/custom-gpt-model"
+    litellm.model_cost[custom_model] = {
+        "max_tokens": 8192,
+        "input_cost_per_token": 0.0001,
+        "output_cost_per_token": 0.0002,
+        "supports_function_calling": True,
+        "supports_system_messages": True,
+        "supported_openai_params": [
+            "tools",
+            "tool_choice",
+            "functions",
+            "function_call",
+            "temperature",
+            "max_tokens",
+            "stream",
+        ],
+    }
+
+    try:
+        supported_params = get_supported_openai_params(custom_model)
+        assert supported_params is not None, "Should return params for custom model"
+        assert "tools" in supported_params, "Should include tools param"
+        assert "tool_choice" in supported_params, "Should include tool_choice param"
+        assert litellm.supports_function_calling(custom_model) is True, \
+            "Custom model with supports_function_calling=True should return True"
+        model_info = litellm.get_model_info(custom_model)
+        assert model_info["supports_function_calling"] is True, \
+            "Model info should include supports_function_calling flag"
+
+    finally:
+        # Cleanup
+        del litellm.model_cost[custom_model]


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #14067 

**Summary**

Custom models added to `litellm.model_cost` now properly expose function calling support to external frameworks like llama-index.

**Problem**: When users add custom OpenAI-compatible models via `litellm.model_cost` with `supports_function_calling: true`, llama-index and other frameworks fail to detect this capability, showing `is_function_calling_model = False`. This breaks agentic workflows that rely on function/tool calling.

**Solution**: Added fallback logic to check `litellm.model_cost` when provider detection fails, enabling custom models to properly expose their `supported_openai_params` and function calling capabilities.

**Changes**
Production Code
1.`litellm/litellm_core_utils/get_supported_openai_params.py`
2.`litellm/utils.py`

**Test Files**
3. tests/litellm_utils_tests/test_utils.py
Added `test_get_supported_openai_params_custom_model()` - verifies custom models return params
Added `test_get_supported_openai_params_custom_model_without_params()` - verifies None handling
Added `test_supports_function_calling_custom_model()` - verifies function calling detection
Added `test_supports_function_calling_custom_model_disabled()` - verifies disabled flag works
4. tests/local_testing/test_get_model_info.py
Added`test_custom_model_function_calling_via_model_cost()` - comprehensive integration test



