### PR TITLE
Fix: Responses API logging error for StopIteration

### DIFF
--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -379,6 +379,9 @@ class ResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
                     return result
                 # If result is None, continue the loop to get the next chunk
 
+        except StopAsyncIteration:
+            # Normal end of stream - don't log as failure
+            raise
         except httpx.HTTPError as e:
             # Handle HTTP errors
             self.finished = True
@@ -474,6 +477,9 @@ class SyncResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
                     return result
                 # If result is None, continue the loop to get the next chunk
 
+        except StopIteration:
+            # Normal end of stream - don't log as failure
+            raise
         except httpx.HTTPError as e:
             # Handle HTTP errors
             self.finished = True

--- a/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
+++ b/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
@@ -309,3 +309,123 @@ class TestBaseResponsesAPIStreamingIterator:
                     pytest.fail(f"_handle_logging_completed_response failed with pickle error: {e}")
                 raise
 
+    @pytest.mark.asyncio
+    async def test_stop_async_iteration_not_logged_as_failure(self):
+        """
+        Test that StopAsyncIteration is NOT logged as a failure.
+        
+        This test verifies that when streaming completes normally with StopAsyncIteration,
+        the _handle_failure method is NOT called, preventing false error logs in Langfuse
+        and other logging integrations.
+        
+        """
+        from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+        
+        # Mock dependencies
+        mock_response = Mock()
+        mock_response.headers = {}
+        
+        # Create an async iterator that raises StopAsyncIteration after yielding one chunk
+        async def mock_aiter_lines():
+            yield 'data: {"type": "response.output_text.delta", "delta": "test"}'
+            # Normal end of stream - raise StopAsyncIteration
+        
+        mock_response.aiter_lines = mock_aiter_lines
+        
+        mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+        mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.async_failure_handler = Mock()
+        mock_logging_obj.failure_handler = Mock()
+        
+        mock_config = Mock(spec=BaseResponsesAPIConfig)
+        mock_delta_event = Mock()
+        mock_delta_event.type = ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA
+        mock_delta_event.delta = "test"
+        mock_config.transform_streaming_response.return_value = mock_delta_event
+        
+        # Create the iterator instance
+        iterator = ResponsesAPIStreamingIterator(
+            response=mock_response,
+            model="gpt-4",
+            responses_api_provider_config=mock_config,
+            logging_obj=mock_logging_obj,
+            litellm_metadata={"model_info": {"id": "model_123"}},
+            custom_llm_provider="openai"
+        )
+        
+        # Consume the iterator until StopAsyncIteration
+        chunks_received = []
+        try:
+            async for chunk in iterator:
+                chunks_received.append(chunk)
+        except StopAsyncIteration:
+            pass  # This is expected
+        
+        # Verify we got the chunk
+        assert len(chunks_received) == 1
+        
+        # CRITICAL: Verify that failure handlers were NOT called
+        # StopAsyncIteration is a normal end of stream, not a failure
+        mock_logging_obj.async_failure_handler.assert_not_called()
+        mock_logging_obj.failure_handler.assert_not_called()
+
+    def test_stop_iteration_not_logged_as_failure(self):
+        """
+        Test that StopIteration is NOT logged as a failure in sync iterator.
+        
+        This test verifies that when streaming completes normally with StopIteration,
+        the _handle_failure method is NOT called, preventing false error logs in Langfuse
+        and other logging integrations.
+        
+        Regression test for: https://github.com/BerriAI/litellm/issues/XXXXX
+        """
+        from litellm.responses.streaming_iterator import SyncResponsesAPIStreamingIterator
+        
+        # Mock dependencies
+        mock_response = Mock()
+        mock_response.headers = {}
+        
+        # Create a sync iterator that raises StopIteration after yielding one chunk
+        def mock_iter_lines():
+            yield 'data: {"type": "response.output_text.delta", "delta": "test"}'
+            # Normal end of stream - raise StopIteration
+        
+        mock_response.iter_lines = mock_iter_lines
+        
+        mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+        mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.async_failure_handler = Mock()
+        mock_logging_obj.failure_handler = Mock()
+        
+        mock_config = Mock(spec=BaseResponsesAPIConfig)
+        mock_delta_event = Mock()
+        mock_delta_event.type = ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA
+        mock_delta_event.delta = "test"
+        mock_config.transform_streaming_response.return_value = mock_delta_event
+        
+        # Create the iterator instance
+        iterator = SyncResponsesAPIStreamingIterator(
+            response=mock_response,
+            model="gpt-4",
+            responses_api_provider_config=mock_config,
+            logging_obj=mock_logging_obj,
+            litellm_metadata={"model_info": {"id": "model_123"}},
+            custom_llm_provider="openai"
+        )
+        
+        # Consume the iterator until StopIteration
+        chunks_received = []
+        try:
+            for chunk in iterator:
+                chunks_received.append(chunk)
+        except StopIteration:
+            pass  # This is expected
+        
+        # Verify we got the chunk
+        assert len(chunks_received) == 1
+        
+        # CRITICAL: Verify that failure handlers were NOT called
+        # StopIteration is a normal end of stream, not a failure
+        mock_logging_obj.async_failure_handler.assert_not_called()
+        mock_logging_obj.failure_handler.assert_not_called()
+


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
**Before**
<img width="1784" height="1174" alt="image" src="https://github.com/user-attachments/assets/c11ae3fa-bb0c-4a5c-b752-38ed2db18438" />


**After**
<img width="1784" height="1174" alt="image" src="https://github.com/user-attachments/assets/c1c2d18b-9877-4a6b-8844-268b68fe597b" />
