### PR TITLE
fix(oci): serialize imageUrl as object for OCI GenAI API

### DIFF
--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -32,6 +32,7 @@ from litellm.types.llms.oci import (
     OCICompletionResponse,
     OCIContentPartUnion,
     OCIImageContentPart,
+    OCIImageUrl,
     OCIMessage,
     OCIRoles,
     OCIServingMode,
@@ -1129,7 +1130,7 @@ def adapt_messages_to_generic_oci_standard_content_message(
                 image_url = image_url.get("url")
             if not isinstance(image_url, str):
                 raise Exception("Prop `image_url` must be a string or an object with a `url` property")
-            new_content.append(OCIImageContentPart(imageUrl=image_url))
+            new_content.append(OCIImageContentPart(imageUrl=OCIImageUrl(url=image_url)))
 
     return OCIMessage(
         role=open_ai_to_generic_oci_role_map[role],

--- a/litellm/types/llms/oci.py
+++ b/litellm/types/llms/oci.py
@@ -35,11 +35,18 @@ class OCITextContentPart(OCIContentPart):
     text: str
 
 
+class OCIImageUrl(BaseModel):
+    """ImageUrl object for OCI API. See: https://docs.oracle.com/en-us/iaas/tools/python/latest/api/generative_ai_inference/models/oci.generative_ai_inference.models.ImageUrl.html"""
+
+    url: str
+    detail: Optional[Literal["AUTO", "HIGH", "LOW"]] = None
+
+
 class OCIImageContentPart(OCIContentPart):
     """Image content part for the OCI API."""
 
     type: Literal["IMAGE"] = "IMAGE"
-    imageUrl: str
+    imageUrl: OCIImageUrl
 
 
 OCIContentPartUnion = Union[OCITextContentPart, OCIImageContentPart]


### PR DESCRIPTION
## Relevant issues

Fixes #19589

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

OCI GenAI API expects `imageUrl` to be an object with a `url` property, not a plain string.

**Before (incorrect):**
```json
"imageUrl": "data:image/png;base64,..."
```

**After (correct):**
```json
"imageUrl": { "url": "data:image/png;base64,..." }
```

### Changes made:
1. Added `OCIImageUrl` model in `litellm/types/llms/oci.py` with `url` (required) and `detail` (optional) properties
2. Updated `OCIImageContentPart.imageUrl` type from `str` to `OCIImageUrl`
3. Updated `adapt_messages_to_generic_oci_standard_content_message` in `transformation.py` to wrap the URL in `OCIImageUrl`
4. Updated tests to verify the correct serialization format

### Reference:
- [OCI ImageUrl API Documentation](https://docs.oracle.com/en-us/iaas/tools/python/latest/api/generative_ai_inference/models/oci.generative_ai_inference.models.ImageUrl.html)