### PR TITLE
perf: skip pattern_router.route() for non-wildcard models

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6355,19 +6355,20 @@ class Router:
         elif custom_llm_provider != "azure":
             model = _model
 
-            potential_models = self.pattern_router.route(received_model_name)
-            if "*" in model and potential_models is not None:  # if wildcard route
-                for potential_model in potential_models:
-                    try:
-                        if potential_model.get("model_info", {}).get(
-                            "id"
-                        ) == deployment.get("model_info", {}).get("id"):
-                            model = potential_model.get("litellm_params", {}).get(
-                                "model"
-                            )
-                            break
-                    except Exception:
-                        pass
+            if "*" in model:  # only call pattern_router for wildcard models
+                potential_models = self.pattern_router.route(received_model_name)
+                if potential_models is not None:
+                    for potential_model in potential_models:
+                        try:
+                            if potential_model.get("model_info", {}).get(
+                                "id"
+                            ) == deployment.get("model_info", {}).get("id"):
+                                model = potential_model.get("litellm_params", {}).get(
+                                    "model"
+                                )
+                                break
+                        except Exception:
+                            pass
 
         ## GET LITELLM MODEL INFO - raises exception, if model is not mapped
         if model is None:


### PR DESCRIPTION
Check "*" in model before calling pattern_router.route() to avoid unnecessary pattern matching for non-wildcard model configurations.

Before: 

<img width="932" height="124" alt="Screenshot 2026-01-23 at 11 33 36 AM" src="https://github.com/user-attachments/assets/40333043-be5d-4512-b686-77a591e5e8b5" />

After: 

<img width="1063" height="117" alt="Screenshot 2026-01-23 at 11 33 20 AM" src="https://github.com/user-attachments/assets/d0690271-6da5-4c03-9a03-4641b2a133b5" />

6% standalone improvement, 22.5% when combined with #19606

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring
Performance

## Changes
