### PR TITLE
Add Langfuse mock mode for testing without API calls

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -697,6 +697,7 @@ router_settings:
 | LANGFUSE_FLUSH_INTERVAL | Interval for flushing Langfuse logs
 | LANGFUSE_TRACING_ENVIRONMENT | Environment for Langfuse tracing
 | LANGFUSE_HOST | Host URL for Langfuse service
+| LANGFUSE_MOCK | Enable mock mode for Langfuse integration testing. When set to true, intercepts Langfuse API calls and returns mock responses without making actual network calls. Default is false
 | LANGFUSE_PUBLIC_KEY | Public key for Langfuse authentication
 | LANGFUSE_RELEASE | Release version of Langfuse integration
 | LANGFUSE_SECRET_KEY | Secret key for Langfuse authentication

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -25,6 +25,10 @@ from litellm.litellm_core_utils.core_helpers import (
     reconstruct_model_name,
 )
 from litellm.litellm_core_utils.redact_messages import redact_user_api_key_info
+from litellm.integrations.langfuse.langfuse_mock_client import (
+    create_mock_langfuse_client,
+    should_use_langfuse_mock,
+)
 from litellm.llms.custom_httpx.http_handler import _get_httpx_client
 from litellm.secret_managers.main import str_to_bool
 from litellm.types.integrations.langfuse import *
@@ -119,8 +123,17 @@ class LangFuseLogger:
         self.langfuse_flush_interval = LangFuseLogger._get_langfuse_flush_interval(
             flush_interval
         )
-        http_client = _get_httpx_client()
-        self.langfuse_client = http_client.client
+        
+        # Check if we should use mock mode
+        if should_use_langfuse_mock():
+            # Use mock client - exercises all code without network calls
+            self.langfuse_client = create_mock_langfuse_client()
+            self.is_mock_mode = True
+        else:
+            # Use real httpx client
+            http_client = _get_httpx_client()
+            self.langfuse_client = http_client.client
+            self.is_mock_mode = False
 
         parameters = {
             "public_key": self.public_key,
@@ -139,11 +152,16 @@ class LangFuseLogger:
 
         # set the current langfuse project id in the environ
         # this is used by Alerting to link to the correct project
-        try:
-            project_id = self.Langfuse.client.projects.get().data[0].id
-            os.environ["LANGFUSE_PROJECT_ID"] = project_id
-        except Exception:
-            project_id = None
+        if self.is_mock_mode:
+            # In mock mode, use a fake project ID
+            os.environ["LANGFUSE_PROJECT_ID"] = "mock-project-id"
+            verbose_logger.debug("Langfuse Mock: Using mock project ID")
+        else:
+            try:
+                project_id = self.Langfuse.client.projects.get().data[0].id
+                os.environ["LANGFUSE_PROJECT_ID"] = project_id
+            except Exception:
+                project_id = None
 
         if os.getenv("UPSTREAM_LANGFUSE_SECRET_KEY") is not None:
             upstream_langfuse_debug = (

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -124,13 +124,10 @@ class LangFuseLogger:
             flush_interval
         )
         
-        # Check if we should use mock mode
         if should_use_langfuse_mock():
-            # Use mock client - exercises all code without network calls
             self.langfuse_client = create_mock_langfuse_client()
             self.is_mock_mode = True
         else:
-            # Use real httpx client
             http_client = _get_httpx_client()
             self.langfuse_client = http_client.client
             self.is_mock_mode = False
@@ -153,7 +150,6 @@ class LangFuseLogger:
         # set the current langfuse project id in the environ
         # this is used by Alerting to link to the correct project
         if self.is_mock_mode:
-            # In mock mode, use a fake project ID
             os.environ["LANGFUSE_PROJECT_ID"] = "mock-project-id"
             verbose_logger.debug("Langfuse Mock: Using mock project ID")
         else:

--- a/litellm/integrations/langfuse/langfuse_mock_client.py
+++ b/litellm/integrations/langfuse/langfuse_mock_client.py
@@ -1,0 +1,113 @@
+"""
+Mock httpx client for Langfuse integration testing.
+
+This module intercepts Langfuse API calls and returns successful mock responses,
+allowing full code execution without making actual network calls.
+
+Usage:
+    Set LANGFUSE_MOCK=true in environment variables or config to enable mock mode.
+"""
+
+import httpx
+import json
+from typing import Dict, Optional
+
+from litellm._logging import verbose_logger
+
+# Store original post method for restoration
+_original_httpx_post = None
+
+
+class MockLangfuseResponse:
+    """Mock httpx.Response that satisfies Langfuse SDK requirements."""
+    
+    def __init__(self, status_code: int = 200, json_data: Optional[Dict] = None, url: Optional[str] = None):
+        self.status_code = status_code
+        self._json_data = json_data or {"status": "success"}
+        self.headers = httpx.Headers({})
+        self.is_success = status_code < 400
+        self.is_error = status_code >= 400
+        self.is_redirect = 300 <= status_code < 400
+        self.url = httpx.URL(url) if url else httpx.URL("")
+        self.elapsed = httpx.Timeout(0.0)
+        self._text = json.dumps(self._json_data)
+        self._content = self._text.encode("utf-8")
+    
+    @property
+    def text(self) -> str:
+        """Return response text."""
+        return self._text
+    
+    @property
+    def content(self) -> bytes:
+        """Return response content."""
+        return self._content
+    
+    def json(self) -> Dict:
+        """Return JSON response data."""
+        return self._json_data
+    
+    def read(self) -> bytes:
+        """Read response content."""
+        return self._content
+    
+    def raise_for_status(self):
+        """Raise exception for error status codes."""
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+
+def _mock_httpx_post(self, url, **kwargs):
+    """Monkey-patched httpx.Client.post that intercepts Langfuse calls."""
+    # Only mock Langfuse API calls
+    if isinstance(url, str) and ("langfuse.com" in url or "langfuse" in url.lower()):
+        print(f"[LANGFUSE MOCK] POST to {url}")
+        return MockLangfuseResponse(status_code=200, json_data={"status": "success"}, url=url)
+    # For non-Langfuse calls, use original method
+    if _original_httpx_post is not None:
+        return _original_httpx_post(self, url, **kwargs)
+    # Fallback: if original not set, create a temporary client for this call
+    import httpx
+    with httpx.Client() as client:
+        return client.post(url, **kwargs)
+
+
+def create_mock_langfuse_client():
+    """
+    Monkey-patch httpx.Client.post to intercept Langfuse calls.
+    
+    Returns a real httpx.Client instance - the monkey-patch intercepts all calls.
+    """
+    global _original_httpx_post
+    
+    if _original_httpx_post is None:
+        _original_httpx_post = httpx.Client.post
+        httpx.Client.post = _mock_httpx_post  # type: ignore
+        print("[LANGFUSE MOCK] Patched httpx.Client.post")
+    
+    # Return real client - monkey-patch handles interception
+    return httpx.Client()
+
+
+def should_use_langfuse_mock() -> bool:
+    """
+    Determine if Langfuse should run in mock mode.
+    
+    Checks the LANGFUSE_MOCK environment variable.
+    
+    Returns:
+        bool: True if mock mode should be enabled
+    """
+    import os
+    from litellm.secret_managers.main import str_to_bool
+    
+    mock_mode = os.getenv("LANGFUSE_MOCK", "false")
+    result = str_to_bool(mock_mode)
+    
+    # Ensure we return a bool, not None
+    result = bool(result) if result is not None else False
+    
+    if result:
+        verbose_logger.info("Langfuse Mock Mode: ENABLED - API calls will be mocked")
+    
+    return result

--- a/litellm/integrations/langfuse/langfuse_mock_client.py
+++ b/litellm/integrations/langfuse/langfuse_mock_client.py
@@ -54,7 +54,7 @@ class MockLangfuseResponse:
 def _mock_httpx_post(self, url, **kwargs):
     """Monkey-patched httpx.Client.post that intercepts Langfuse calls."""
     if isinstance(url, str) and ("langfuse.com" in url or "langfuse" in url.lower()):
-        print(f"[LANGFUSE MOCK] POST to {url}")
+        verbose_logger.debug(f"[LANGFUSE MOCK] POST to {url}")
         return MockLangfuseResponse(status_code=200, json_data={"status": "success"}, url=url)
     if _original_httpx_post is not None:
         return _original_httpx_post(self, url, **kwargs)
@@ -74,7 +74,7 @@ def create_mock_langfuse_client():
     if _original_httpx_post is None:
         _original_httpx_post = httpx.Client.post
         httpx.Client.post = _mock_httpx_post  # type: ignore
-        print("[LANGFUSE MOCK] Patched httpx.Client.post")
+        verbose_logger.debug("[LANGFUSE MOCK] Patched httpx.Client.post")
     
     return httpx.Client()
 


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/55569/workflows/98ffdd42-78c4-4c01-b053-56a9cf06bf9f

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/55577/workflows/19168ddd-70e8-42eb-bd58-915ac03a45b7

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🧹 Refactoring


## Changes

- Added a mock mode to allow the full integration code to be exercised without real credentials during performance tests.

## Example

<img width="2248" height="1217" alt="Screenshot 2026-01-23 144701" src="https://github.com/user-attachments/assets/1cf938fa-c763-4893-9636-a714a6731ede" />

<img width="2082" height="260" alt="Screenshot 2026-01-23 144805" src="https://github.com/user-attachments/assets/6835444e-2071-4702-877f-1ef7dce31a8e" />

<img width="739" height="134" alt="Screenshot 2026-01-23 144831" src="https://github.com/user-attachments/assets/42dc5ab4-a7b4-4fae-bedf-3c4f5b56c795" />


