### PR TITLE
perf: Optimize use_custom_pricing_for_model with set intersection

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4254,7 +4254,7 @@ def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
     # Check litellm_params using set intersection (only check keys that exist in both)
     matching_keys = _CUSTOM_PRICING_KEYS & litellm_params.keys()
     for key in matching_keys:
-        if litellm_params[key] is not None:
+        if litellm_params.get(key) is not None:
             return True
 
     # Check model_info
@@ -4264,7 +4264,7 @@ def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
     if model_info:
         matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
         for key in matching_keys:
-            if model_info[key] is not None:
+            if model_info.get(key) is not None:
                 return True
 
     return False

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -205,6 +205,11 @@ _in_memory_loggers: List[Any] = []
 
 ### GLOBAL VARIABLES ###
 
+# Cache custom pricing keys as frozenset for O(1) lookups instead of looping through 49 keys
+_CUSTOM_PRICING_KEYS: frozenset = frozenset(
+    CustomPricingLiteLLMParams.model_fields.keys()
+)
+
 sentry_sdk_instance = None
 capture_exception = None
 add_breadcrumb = None
@@ -539,10 +544,8 @@ class Logging(LiteLLMLoggingBaseClass):
         if "stream_options" in additional_params:
             self.stream_options = additional_params["stream_options"]
         ## check if custom pricing set ##
-        custom_pricing_keys = CustomPricingLiteLLMParams.model_fields.keys()
-        for key in custom_pricing_keys:
-            if litellm_params.get(key) is not None:
-                self.custom_pricing = True
+        if any(litellm_params.get(key) is not None for key in _CUSTOM_PRICING_KEYS & litellm_params.keys()):
+            self.custom_pricing = True
 
         if "custom_llm_provider" in self.model_call_details:
             self.custom_llm_provider = self.model_call_details["custom_llm_provider"]
@@ -4248,15 +4251,21 @@ def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
     if litellm_params is None:
         return False
 
+    # Check litellm_params using set intersection (only check keys that exist in both)
+    matching_keys = _CUSTOM_PRICING_KEYS & litellm_params.keys()
+    for key in matching_keys:
+        if litellm_params[key] is not None:
+            return True
+
+    # Check model_info
     metadata: dict = litellm_params.get("metadata", {}) or {}
     model_info: dict = metadata.get("model_info", {}) or {}
 
-    custom_pricing_keys = CustomPricingLiteLLMParams.model_fields.keys()
-    for key in custom_pricing_keys:
-        if litellm_params.get(key, None) is not None:
-            return True
-        elif model_info.get(key, None) is not None:
-            return True
+    if model_info:
+        matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
+        for key in matching_keys:
+            if model_info[key] is not None:
+                return True
 
     return False
 


### PR DESCRIPTION
Cache CustomPricingLiteLLMParams.model_fields.keys() at module level and use set intersection to reduce loop iterations from 882k to 90k (only iterating over keys that exist in both sets)

Performance improvement: 84% faster (6.3x speedup)
- Before: 1.17s total, 65µs per call
- After: 0.19s total, 10µs per call

Before

<img width="971" height="119" alt="Screenshot 2026-01-23 at 3 08 40 PM" src="https://github.com/user-attachments/assets/6674a087-63f2-4090-bdd4-db5fe07ac2a5" />


After 

<img width="1103" height="125" alt="Screenshot 2026-01-23 at 3 07 52 PM" src="https://github.com/user-attachments/assets/9626d6b7-c65a-4337-9dd5-1079ec63af5d" />

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring
Performance

## Changes
