### PR TITLE
perf: Optimize strip_trailing_slash with O(1) index check

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4651,8 +4651,11 @@ class StandardLoggingPayloadSetup:
 
     @staticmethod
     def strip_trailing_slash(api_base: Optional[str]) -> Optional[str]:
-        if api_base and api_base[-1] == "/":
-            return api_base[:-1]
+        if api_base:
+            if api_base.endswith("//"):
+                return api_base.rstrip("/")
+            if api_base[-1] == "/":
+                return api_base[:-1]
         return api_base
 
     @staticmethod

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4651,8 +4651,8 @@ class StandardLoggingPayloadSetup:
 
     @staticmethod
     def strip_trailing_slash(api_base: Optional[str]) -> Optional[str]:
-        if api_base:
-            return api_base.rstrip("/")
+        if api_base and api_base[-1] == "/":
+            return api_base[:-1]
         return api_base
 
     @staticmethod


### PR DESCRIPTION
Replace rstrip("/") with direct index check for O(1) performance instead of O(n) string scanning

Results:
- strip_trailing_slash: 311ms → 13ms (96% faster)
- get_standard_logging_object_payload: 6.11s → 5.80s (5% faster)

Before: 

<img width="679" height="128" alt="Screenshot 2026-01-23 at 4 01 19 PM" src="https://github.com/user-attachments/assets/5dfc871f-727e-4fdd-8435-be779c9efbc9" />

After: 

<img width="688" height="114" alt="Screenshot 2026-01-23 at 4 01 40 PM" src="https://github.com/user-attachments/assets/a8a2d9e3-f4f0-47d2-a558-30d54c28ea91" />

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring
Performance

## Changes
