### PR TITLE
[Fix] UI - Redirect to ui/login on expired JWT

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
@@ -2,6 +2,7 @@
 
 import { getProxyBaseUrl } from "@/components/networking";
 import { clearTokenCookies, getCookie } from "@/utils/cookieUtils";
+import { isJwtExpired } from "@/utils/jwtUtils";
 import { jwtDecode } from "jwt-decode";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo } from "react";
@@ -42,15 +43,24 @@ const useAuthorized = () => {
 
   const token = typeof document !== "undefined" ? getCookie("token") : null;
 
-  // Redirect after mount if missing/invalid token
+  // Step 1: Check for missing token or expired JWT - kick out immediately (even if UI Config is loading)
+  useEffect(() => {
+    if (!token || (token && isJwtExpired(token))) {
+      if (token) {
+        clearTokenCookies();
+      }
+      router.replace(`${getProxyBaseUrl()}/ui/login`);
+    }
+  }, [token, router]);
+
   useEffect(() => {
     if (isUIConfigLoading) {
       return;
     }
-    if (!token || uiConfig?.admin_ui_disabled) {
+    if (uiConfig?.admin_ui_disabled) {
       router.replace(`${getProxyBaseUrl()}/ui/login`);
     }
-  }, [token, router, isUIConfigLoading, uiConfig]);
+  }, [router, isUIConfigLoading, uiConfig]);
 
   // Decode safely
   const decoded = useMemo(() => {


### PR DESCRIPTION
## Relevant issues
This PR implements checking for expired JWT when the user reaches the UI. Previously expiry was not checked, and it allowed expired sessions to stay inside authenticated routes until the user clicked logout
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="1291" height="329" alt="image" src="https://github.com/user-attachments/assets/60875781-dfeb-4533-8e9b-a4c1316a675d" />
