### PR TITLE
Feat/team level guardrails access #19630

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -763,6 +763,7 @@ model LiteLLM_GuardrailsTable {
   guardrail_name String @unique
   litellm_params Json
   guardrail_info Json?
+  team_id String?
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
 }

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -763,6 +763,7 @@ model LiteLLM_GuardrailsTable {
   guardrail_name String @unique
   litellm_params Json
   guardrail_info Json?
+  team_id String?
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
 }

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -716,6 +716,7 @@ class Guardrail(TypedDict, total=False):
     guardrail_name: Required[str]
     litellm_params: Required[LitellmParams]
     guardrail_info: Optional[Dict]
+    team_id: Optional[str]
     created_at: Optional[datetime]
     updated_at: Optional[datetime]
 
@@ -747,6 +748,7 @@ class GuardrailInfoResponse(BaseModel):
     guardrail_name: str
     litellm_params: Optional[BaseLitellmParams] = None
     guardrail_info: Optional[Dict] = None
+    team_id: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = (

--- a/schema.prisma
+++ b/schema.prisma
@@ -763,6 +763,7 @@ model LiteLLM_GuardrailsTable {
   guardrail_name String @unique
   litellm_params Json
   guardrail_info Json?
+  team_id String?
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
 }

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -159,7 +159,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
   const [userSearchLoading, setUserSearchLoading] = useState<boolean>(false);
   const [mcpAccessGroups, setMcpAccessGroups] = useState<string[]>([]);
   const [disabledCallbacks, setDisabledCallbacks] = useState<string[]>([]);
-  const [keyType, setKeyType] = useState<string>("default");
+  const [keyType, setKeyType] = useState<string>("llm_api");
   const [modelAliases, setModelAliases] = useState<{ [key: string]: string }>({});
   const [autoRotationEnabled, setAutoRotationEnabled] = useState<boolean>(false);
   const [rotationInterval, setRotationInterval] = useState<string>("30d");
@@ -168,7 +168,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
     form.resetFields();
     setLoggingSettings([]);
     setDisabledCallbacks([]);
-    setKeyType("default");
+    setKeyType("llm_api");
     setModelAliases({});
     setAutoRotationEnabled(false);
     setRotationInterval("30d");
@@ -181,7 +181,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
     form.resetFields();
     setLoggingSettings([]);
     setDisabledCallbacks([]);
-    setKeyType("default");
+    setKeyType("llm_api");
     setModelAliases({});
     setAutoRotationEnabled(false);
     setRotationInterval("30d");
@@ -676,11 +676,11 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
                   </span>
                 }
                 name="key_type"
-                initialValue="default"
+                initialValue="llm_api"
                 className="mt-4"
               >
                 <Select
-                  defaultValue="default"
+                  defaultValue="llm_api"
                   placeholder="Select key type"
                   style={{ width: "100%" }}
                   optionLabelProp="label"


### PR DESCRIPTION

#19630 fixes

Allows teams to manage their own guardrails using JWT tokens (reduces admin load)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

* [ ] I have Added testing in the [`[tests/litellm/](https://github.com/BerriAI/litellm/tree/main/tests/litellm)`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [[see details](https://docs.litellm.ai/docs/extras/contributing_code)](https://docs.litellm.ai/docs/extras/contributing_code)
* [ ] My PR passes all unit tests on [`[make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)`](https://docs.litellm.ai/docs/extras/contributing_code)
* [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> * 50-55 passing tests: main is stable with minor issues.
> * 45-49 passing tests: acceptable but needs attention
> * <= 40 passing tests: unstable; be careful with your merges and assess the risk.

* [ ] **Branch creation CI run**
  Link:
* [ ] **CI run for the last commit**
  Link:
* [ ] **Merge / cherry-pick CI run**
  Links:

## Type

🆕 New Feature

## Changes

### Summary

Adds team-level access control for guardrails using JWT tokens.
Teams can manage their own guardrails, admins retain full access.

### Modified Files

* **Schema**: Add `team_id` to `LiteLLM_GuardrailsTable`
* **Types**: Add `team_id` to `Guardrail`, `GuardrailInfoResponse`
* **Endpoints**: Auth checks added to all guardrail CRUD APIs
* **Registry**: DB queries updated to filter by team
