### PR TITLE
fix: resolve aiohttp connection starvation under high load (#19549)

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -110,8 +110,8 @@ _DEFAULT_TTL_FOR_HTTPX_CLIENTS = 3600  # 1 hour, re-use the same httpx client fo
 
 # Aiohttp connection pooling - prevents memory leaks from unbounded connection growth
 # Set to 0 for unlimited (not recommended for production)
-AIOHTTP_CONNECTOR_LIMIT = int(os.getenv("AIOHTTP_CONNECTOR_LIMIT", 300))
-AIOHTTP_CONNECTOR_LIMIT_PER_HOST = int(os.getenv("AIOHTTP_CONNECTOR_LIMIT_PER_HOST", 50))
+AIOHTTP_CONNECTOR_LIMIT = int(os.getenv("AIOHTTP_CONNECTOR_LIMIT", 1000))
+AIOHTTP_CONNECTOR_LIMIT_PER_HOST = int(os.getenv("AIOHTTP_CONNECTOR_LIMIT_PER_HOST", 200))
 AIOHTTP_KEEPALIVE_TIMEOUT = int(os.getenv("AIOHTTP_KEEPALIVE_TIMEOUT", 120))
 AIOHTTP_TTL_DNS_CACHE = int(os.getenv("AIOHTTP_TTL_DNS_CACHE", 300))
 # enable_cleanup_closed is only needed for Python versions with the SSL leak bug

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -848,8 +848,10 @@ class AsyncHTTPHandler:
             "keepalive_timeout": AIOHTTP_KEEPALIVE_TIMEOUT,
             "ttl_dns_cache": AIOHTTP_TTL_DNS_CACHE,
             "enable_cleanup_closed": True,
+            "force_close": False,  # Critical: allows connection reuse and prevents starvation
             **connector_kwargs,
         }
+        # Allow 0 for unlimited connections (previous behavior before v1.80.8)
         if AIOHTTP_CONNECTOR_LIMIT > 0:
             transport_connector_kwargs["limit"] = AIOHTTP_CONNECTOR_LIMIT
         if AIOHTTP_CONNECTOR_LIMIT_PER_HOST > 0:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -653,7 +653,9 @@ async def _initialize_shared_aiohttp_session():
             "keepalive_timeout": AIOHTTP_KEEPALIVE_TIMEOUT,
             "ttl_dns_cache": AIOHTTP_TTL_DNS_CACHE,
             "enable_cleanup_closed": True,
+            "force_close": False,  # Critical: allows connection reuse and prevents starvation
         }
+        # Allow 0 for unlimited connections (previous behavior before v1.80.8)
         if AIOHTTP_CONNECTOR_LIMIT > 0:
             connector_kwargs["limit"] = AIOHTTP_CONNECTOR_LIMIT
         if AIOHTTP_CONNECTOR_LIMIT_PER_HOST > 0:
@@ -664,7 +666,8 @@ async def _initialize_shared_aiohttp_session():
 
         verbose_proxy_logger.info(
             f"SESSION REUSE: Created shared aiohttp session for connection pooling (ID: {id(session)}, "
-            f"limit={AIOHTTP_CONNECTOR_LIMIT}, limit_per_host={AIOHTTP_CONNECTOR_LIMIT_PER_HOST})"
+            f"limit={AIOHTTP_CONNECTOR_LIMIT if AIOHTTP_CONNECTOR_LIMIT > 0 else 'unlimited'}, "
+            f"limit_per_host={AIOHTTP_CONNECTOR_LIMIT_PER_HOST if AIOHTTP_CONNECTOR_LIMIT_PER_HOST > 0 else 'unlimited'})"
         )
         return session
     except Exception as e:


### PR DESCRIPTION
## Summary

Fixes #19549 - TCP connection timeouts under high load (500+ concurrent requests).

## What Was Wrong

1. Default connection limits (300 total, 50 per host) were too low for production
2. `force_close=True` (the default) was closing connections immediately instead of reusing them, causing timeouts when the pool filled up

## What Changed

**litellm/constants.py**
- Raised `AIOHTTP_CONNECTOR_LIMIT` from 300 to 1000
- Raised `AIOHTTP_CONNECTOR_LIMIT_PER_HOST` from 50 to 200

**litellm/proxy/proxy_server.py & litellm/llms/custom_httpx/http_handler.py**
- Added `force_close=False` to enable connection reuse
- This lets requests queue properly instead of timing out