### PR TITLE
[Feature] UI - Model Page: Filter by Model ID and Team ID

### DIFF
--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
+    "test:dot": "vitest --reporter=dot",
     "test:watch": "vitest -w",
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write .",

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
@@ -102,6 +102,8 @@ describe("useModelsInfo", () => {
       "Admin",
       1,
       50,
+      undefined,
+      undefined,
       undefined
     );
     expect(modelInfoCall).toHaveBeenCalledTimes(1);
@@ -122,6 +124,8 @@ describe("useModelsInfo", () => {
       "Admin",
       2,
       25,
+      undefined,
+      undefined,
       undefined
     );
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -27,7 +27,7 @@ const modelHubKeys = createQueryKeys("modelHub");
 const allProxyModelsKeys = createQueryKeys("allProxyModels");
 const selectedTeamModelsKeys = createQueryKeys("selectedTeamModels");
 
-export const useModelsInfo = (page: number = 1, size: number = 50, search?: string) => {
+export const useModelsInfo = (page: number = 1, size: number = 50, search?: string, modelId?: string, teamId?: string) => {
   const { accessToken, userId, userRole } = useAuthorized();
   return useQuery<PaginatedModelInfoResponse>({
     queryKey: modelKeys.list({
@@ -37,9 +37,11 @@ export const useModelsInfo = (page: number = 1, size: number = 50, search?: stri
         page,
         size,
         ...(search && { search }),
+        ...(modelId && { modelId }),
+        ...(teamId && { teamId }),
       },
     }),
-    queryFn: async () => await modelInfoCall(accessToken!, userId!, userRole!, page, size, search),
+    queryFn: async () => await modelInfoCall(accessToken!, userId!, userRole!, page, size, search, modelId, teamId),
     enabled: Boolean(accessToken && userId && userRole),
   });
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
@@ -318,7 +318,6 @@ const ModelsAndEndpointsView: React.FC<ModelDashboardProps> = ({ premiumUser, te
               onClose={() => {
                 setSelectedModelId(null);
               }}
-              modelData={processedModelData.data.find((model: any) => model.model_info.id === selectedModelId)}
               accessToken={accessToken}
               userID={userID}
               userRole={userRole}

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
@@ -8,7 +8,7 @@ import { getDisplayModelName } from "@/components/view_model/model_name_display"
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { PaginationState } from "@tanstack/react-table";
 import { Grid, Select, SelectItem, TabPanel, Text } from "@tremor/react";
-import { Skeleton } from "antd";
+import { Skeleton, Spin } from "antd";
 import debounce from "lodash/debounce";
 import { useEffect, useMemo, useState } from "react";
 import { useModelsInfo } from "../../hooks/models/useModels";
@@ -34,7 +34,7 @@ const AllModelsTab = ({
 }: AllModelsTabProps) => {
   const { data: modelCostMapData, isLoading: isLoadingModelCostMap } = useModelCostMap();
   const { userId, userRole, premiumUser } = useAuthorized();
-  const { data: teams } = useTeams();
+  const { data: teams, isLoading: isLoadingTeams } = useTeams();
 
   const [modelNameSearch, setModelNameSearch] = useState<string>("");
   const [debouncedSearch, setDebouncedSearch] = useState<string>("");
@@ -69,7 +69,16 @@ const AllModelsTab = ({
     };
   }, [modelNameSearch, debouncedUpdateSearch]);
 
-  const { data: rawModelData, isLoading: isLoadingModelsInfo } = useModelsInfo(currentPage, pageSize, debouncedSearch || undefined);
+  // Determine teamId to pass to the query - only pass if not "personal"
+  const teamIdForQuery = currentTeam === "personal" ? undefined : currentTeam.team_id;
+
+  const { data: rawModelData, isLoading: isLoadingModelsInfo } = useModelsInfo(
+    currentPage,
+    pageSize,
+    debouncedSearch || undefined,
+    undefined,
+    teamIdForQuery
+  );
   const isLoading = isLoadingModelsInfo || isLoadingModelCostMap;
 
   const getProviderFromModel = (model: string) => {
@@ -122,30 +131,21 @@ const AllModelsTab = ({
         model.model_info["access_groups"]?.includes(selectedModelAccessGroupFilter) ||
         !selectedModelAccessGroupFilter;
 
-      let teamAccessMatch = true;
-      if (modelViewMode === "current_team") {
-        if (currentTeam === "personal") {
-          teamAccessMatch = model.model_info?.direct_access === true;
-        } else {
-          // Check if model is directly associated with the team via team_ids
-          const directTeamAccess = model.model_info?.access_via_team_ids?.includes(currentTeam.team_id) === true;
-
-          // Check if any of the team's models match the model's access groups
-          const accessGroupMatch =
-            currentTeam.models?.some((teamModel: string) => model.model_info?.access_groups?.includes(teamModel)) ===
-            true;
-
-          teamAccessMatch = directTeamAccess || accessGroupMatch;
-        }
-      }
-
-      return modelNameMatch && accessGroupMatch && teamAccessMatch;
+      // Team filtering is now handled server-side via teamId query parameter
+      // Only apply client-side filtering for model groups and access groups
+      return modelNameMatch && accessGroupMatch;
     });
-  }, [modelData, selectedModelGroup, selectedModelAccessGroupFilter, currentTeam, modelViewMode]);
+  }, [modelData, selectedModelGroup, selectedModelAccessGroupFilter]);
 
   useEffect(() => {
     setPagination((prev: PaginationState) => ({ ...prev, pageIndex: 0 }));
-  }, [selectedModelGroup, selectedModelAccessGroupFilter, currentTeam, modelViewMode]);
+  }, [selectedModelGroup, selectedModelAccessGroupFilter]);
+
+  // Reset pagination when team changes
+  useEffect(() => {
+    setCurrentPage(1);
+    setPagination((prev: PaginationState) => ({ ...prev, pageIndex: 0 }));
+  }, [teamIdForQuery]);
 
   const resetFilters = () => {
     setModelNameSearch("");
@@ -177,9 +177,17 @@ const AllModelsTab = ({
                       onValueChange={(value) => {
                         if (value === "personal") {
                           setCurrentTeam("personal");
+                          // Reset to page 1 when team changes
+                          setCurrentPage(1);
+                          setPagination((prev: PaginationState) => ({ ...prev, pageIndex: 0 }));
                         } else {
                           const team = teams?.find((t) => t.team_id === value);
-                          if (team) setCurrentTeam(team);
+                          if (team) {
+                            setCurrentTeam(team);
+                            // Reset to page 1 when team changes
+                            setCurrentPage(1);
+                            setPagination((prev: PaginationState) => ({ ...prev, pageIndex: 0 }));
+                          }
                         }
                       }}
                     >
@@ -189,20 +197,29 @@ const AllModelsTab = ({
                           <span className="font-medium">Personal</span>
                         </div>
                       </SelectItem>
-                      {teams
-                        ?.filter((team) => team.team_id)
-                        .map((team) => (
-                          <SelectItem key={team.team_id} value={team.team_id}>
-                            <div className="flex items-center gap-2">
-                              <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-                              <span className="font-medium">
-                                {team.team_alias
-                                  ? `${team.team_alias.slice(0, 30)}...`
-                                  : `Team ${team.team_id.slice(0, 30)}...`}
-                              </span>
-                            </div>
-                          </SelectItem>
-                        ))}
+                      {isLoadingTeams ? (
+                        <SelectItem value="loading">
+                          <div className="flex items-center gap-2">
+                            <Spin size="small" />
+                            <span className="font-medium text-gray-500">Loading teams...</span>
+                          </div>
+                        </SelectItem>
+                      ) : (
+                        teams
+                          ?.filter((team) => team.team_id)
+                          .map((team) => (
+                            <SelectItem key={team.team_id} value={team.team_id}>
+                              <div className="flex items-center gap-2">
+                                <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                                <span className="font-medium">
+                                  {team.team_alias
+                                    ? `${team.team_alias.slice(0, 30)}...`
+                                    : `Team ${team.team_id.slice(0, 30)}...`}
+                                </span>
+                              </div>
+                            </SelectItem>
+                          ))
+                      )}
                     </Select>
                   )}
                 </div>

--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -1,112 +1,38 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import React, { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import ModelInfoView from "./model_info_view";
 
 vi.mock("../../utils/dataUtils", () => ({
-  copyToClipboard: vi.fn(),
+  copyToClipboard: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock("./networking", () => ({
   modelInfoV1Call: vi.fn().mockResolvedValue({
     data: [
       {
-        model_name: "aws/anthropic/bedrock-claude-3-5-sonnet-v1",
+        model_name: "GPT-4",
         litellm_params: {
-          aws_region_name: "us-east-1",
-          custom_llm_provider: "bedrock",
-          use_in_pass_through: false,
-          use_litellm_proxy: false,
-          merge_reasoning_content_in_choices: false,
-          model: "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+          model: "gpt-4",
+          api_base: "https://api.openai.com/v1",
+          custom_llm_provider: "openai",
         },
         model_info: {
-          id: "70b94bbd2af4a75215f7e3e465b5b199529dc15deb5d395d0668a4aabc496c84",
-          db_model: false,
-          access_via_team_ids: [
-            "4fe3cfea-c907-412a-a645-60915b618d11",
-            "9a4b2d15-4198-47e4-971b-7329b77f40e4",
-            "14d55eef-b8d4-4cb8-b080-d973269dae54",
-            "693ce1d2-9fae-4605-a5c9-1c9829415e1a",
-            "fe29d910-4968-45bc-9fe0-6716e89c6270",
-          ],
-          direct_access: true,
-          key: "anthropic.claude-3-5-sonnet-20240620-v1:0",
-          max_tokens: 4096,
-          max_input_tokens: 200000,
-          max_output_tokens: 4096,
-          input_cost_per_token: 0.000003,
-          input_cost_per_token_flex: null,
-          input_cost_per_token_priority: null,
-          cache_creation_input_token_cost: null,
-          cache_read_input_token_cost: null,
-          cache_read_input_token_cost_flex: null,
-          cache_read_input_token_cost_priority: null,
-          cache_creation_input_token_cost_above_1hr: null,
-          input_cost_per_character: null,
-          input_cost_per_token_above_128k_tokens: null,
-          input_cost_per_token_above_200k_tokens: null,
-          input_cost_per_query: null,
-          input_cost_per_second: null,
-          input_cost_per_audio_token: null,
-          input_cost_per_token_batches: null,
-          output_cost_per_token_batches: null,
-          output_cost_per_token: 0.000015,
-          output_cost_per_token_flex: null,
-          output_cost_per_token_priority: null,
-          output_cost_per_audio_token: null,
-          output_cost_per_character: null,
-          output_cost_per_reasoning_token: null,
-          output_cost_per_token_above_128k_tokens: null,
-          output_cost_per_character_above_128k_tokens: null,
-          output_cost_per_token_above_200k_tokens: null,
-          output_cost_per_second: null,
-          output_cost_per_video_per_second: null,
-          output_cost_per_image: null,
-          output_vector_size: null,
-          citation_cost_per_token: null,
-          tiered_pricing: null,
-          litellm_provider: "bedrock",
-          mode: "chat",
-          supports_system_messages: null,
-          supports_response_schema: true,
-          supports_vision: true,
-          supports_function_calling: true,
-          supports_tool_choice: true,
-          supports_assistant_prefill: null,
-          supports_prompt_caching: null,
-          supports_audio_input: null,
-          supports_audio_output: null,
-          supports_pdf_input: true,
-          supports_embedding_image_input: null,
-          supports_native_streaming: null,
-          supports_web_search: null,
-          supports_url_context: null,
-          supports_reasoning: null,
-          supports_computer_use: null,
-          search_context_cost_per_query: null,
-          tpm: null,
-          rpm: null,
-          ocr_cost_per_page: null,
-          annotation_cost_per_page: null,
-          supported_openai_params: [
-            "max_tokens",
-            "max_completion_tokens",
-            "stream",
-            "stream_options",
-            "stop",
-            "temperature",
-            "top_p",
-            "extra_headers",
-            "response_format",
-            "requestMetadata",
-            "tools",
-            "tool_choice",
-          ],
+          id: "123",
+          created_by: "123",
+          db_model: true,
+          input_cost_per_token: 0.00003,
+          output_cost_per_token: 0.00006,
         },
       },
     ],
   }),
-  credentialGetCall: vi.fn().mockResolvedValue({}),
+  credentialGetCall: vi.fn().mockResolvedValue({
+    credential_name: "test-credential",
+    credential_values: {},
+    credential_info: {},
+  }),
   getGuardrailsList: vi.fn().mockResolvedValue({
     guardrails: [{ guardrail_name: "content_filter" }, { guardrail_name: "toxicity_filter" }],
   }),
@@ -120,99 +46,135 @@ vi.mock("./networking", () => ({
       description: "Production ready models",
     },
   }),
+  testConnectionRequest: vi.fn().mockResolvedValue({
+    status: "success",
+  }),
+  modelPatchUpdateCall: vi.fn().mockResolvedValue({}),
+  modelDeleteCall: vi.fn().mockResolvedValue({}),
 }));
 
 // Mock the useModelsInfo hook since it uses React Query
+const mockUseModelsInfo = vi.fn();
+const mockUseModelHub = vi.fn();
+
 vi.mock("@/app/(dashboard)/hooks/models/useModels", () => ({
-  useModelsInfo: vi.fn().mockReturnValue({
-    data: {
-      data: [
-        {
-          model_name: "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
-          provider: "bedrock",
-          litellm_model_name: "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
-        },
-        {
-          model_name: "openai/gpt-4",
-          provider: "openai",
-          litellm_model_name: "gpt-4",
-        },
-      ],
-    },
-    isLoading: false,
-    error: null,
-  }),
+  useModelsInfo: (...args: any[]) => mockUseModelsInfo(...args),
+  useModelHub: (...args: any[]) => mockUseModelHub(...args),
+}));
+
+// Mock the useModelCostMap hook
+const mockUseModelCostMap = vi.fn();
+vi.mock("@/app/(dashboard)/hooks/models/useModelCostMap", () => ({
+  useModelCostMap: (...args: any[]) => mockUseModelCostMap(...args),
 }));
 
 describe("ModelInfoView", () => {
-  const modelData = {
-    model_info: {
-      id: "123",
-      created_by: "123",
-      db_model: true,
-    },
+  let queryClient: QueryClient;
+
+  const defaultModelData = {
+    model_name: "GPT-4",
     litellm_params: {
+      model: "gpt-4",
       api_base: "https://api.openai.com/v1",
       custom_llm_provider: "openai",
     },
-    litellm_model_name: "gpt-4",
-    model_name: "GPT-4",
-    litellm_provider: "openai",
-    mode: "chat",
-    supported_openai_params: ["temperature", "max_tokens", "top_p", "frequency_penalty", "presence_penalty"],
+    model_info: {
+      id: "123",
+      created_by: "123",
+      created_at: "2024-01-01T00:00:00Z",
+      db_model: true,
+      input_cost_per_token: 0.00003,
+      output_cost_per_token: 0.00006,
+    },
   };
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    vi.clearAllMocks();
+
+    // Set up default mocks
+    mockUseModelsInfo.mockReturnValue({
+      data: {
+        data: [defaultModelData],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    mockUseModelHub.mockReturnValue({
+      data: {
+        data: [],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    mockUseModelCostMap.mockReturnValue({
+      data: {},
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
 
   const DEFAULT_ADMIN_PROPS = {
     modelId: "123",
     onClose: () => {},
-    modelData: modelData,
     accessToken: "123",
     userID: "123",
     userRole: "Admin",
-    editModel: false,
-    setEditModalVisible: () => {},
-    setSelectedModel: () => {},
     onModelUpdate: () => {},
     modelAccessGroups: [],
   };
 
   describe("Edit Model", () => {
     it("should render the model info view", async () => {
-      const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />);
+      const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
       await waitFor(() => {
         expect(getByText("Model Settings")).toBeInTheDocument();
       });
     });
 
-    it("should not render an edit model button if the model is not a DB model", async () => {
+    it("should not render an edit settings button if the model is not a DB model", async () => {
       const nonDbModelData = {
-        ...modelData,
+        ...defaultModelData,
         model_info: {
-          ...modelData.model_info,
+          ...defaultModelData.model_info,
           db_model: false,
         },
       };
 
-      const NON_DB_ADMIN_PROPS = {
-        ...DEFAULT_ADMIN_PROPS,
-        modelData: nonDbModelData,
-      };
+      mockUseModelsInfo.mockReturnValue({
+        data: {
+          data: [nonDbModelData],
+        },
+        isLoading: false,
+        error: null,
+      });
 
-      const { queryByText } = render(<ModelInfoView {...NON_DB_ADMIN_PROPS} />);
+      const { queryByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
       await waitFor(() => {
-        expect(queryByText("Edit Model")).not.toBeInTheDocument();
+        expect(queryByText("Edit Settings")).not.toBeInTheDocument();
       });
     });
 
     it("should render tags in the edit model", async () => {
-      const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />);
+      const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
       await waitFor(() => {
         expect(getByText("Tags")).toBeInTheDocument();
       });
     });
 
     it("should render the litellm params in the edit model", async () => {
-      const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />);
+      const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
       await waitFor(() => {
         expect(getByText("LiteLLM Params")).toBeInTheDocument();
       });
@@ -220,21 +182,21 @@ describe("ModelInfoView", () => {
   });
 
   it("should render a test connection button", async () => {
-    const { getByTestId } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />);
+    const { getByTestId } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
     await waitFor(() => {
       expect(getByTestId("test-connection-button")).toBeInTheDocument();
     });
   });
 
   it("should render a reuse credentials button", async () => {
-    const { getByTestId } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />);
+    const { getByTestId } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
     await waitFor(() => {
       expect(getByTestId("reuse-credentials-button")).toBeInTheDocument();
     });
   });
 
   it("should render a delete model button", async () => {
-    const { getByTestId } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />);
+    const { getByTestId } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
     await waitFor(() => {
       expect(getByTestId("delete-model-button")).toBeInTheDocument();
     });
@@ -242,17 +204,22 @@ describe("ModelInfoView", () => {
 
   it("should render a disabled delete model button if the model is not a DB model", async () => {
     const nonDbModelData = {
-      ...modelData,
+      ...defaultModelData,
       model_info: {
-        ...modelData.model_info,
+        ...defaultModelData.model_info,
         db_model: false,
       },
     };
-    const NON_DB_ADMIN_PROPS = {
-      ...DEFAULT_ADMIN_PROPS,
-      modelData: nonDbModelData,
-    };
-    const { getByTestId } = render(<ModelInfoView {...NON_DB_ADMIN_PROPS} />);
+
+    mockUseModelsInfo.mockReturnValue({
+      data: {
+        data: [nonDbModelData],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { getByTestId } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
     await waitFor(() => {
       expect(getByTestId("delete-model-button")).toBeDisabled();
     });
@@ -260,18 +227,27 @@ describe("ModelInfoView", () => {
 
   it("should render a disabled delete model button if the user is not an admin and model is not created by the user", async () => {
     const nonCreatedByUserModelData = {
-      ...modelData,
+      ...defaultModelData,
       model_info: {
-        ...modelData.model_info,
+        ...defaultModelData.model_info,
         created_by: "456",
       },
     };
+
+    mockUseModelsInfo.mockReturnValue({
+      data: {
+        data: [nonCreatedByUserModelData],
+      },
+      isLoading: false,
+      error: null,
+    });
+
     const NON_CREATED_BY_USER_ADMIN_PROPS = {
       ...DEFAULT_ADMIN_PROPS,
-      modelData: nonCreatedByUserModelData,
       userRole: "User",
     };
-    const { getByTestId } = render(<ModelInfoView {...NON_CREATED_BY_USER_ADMIN_PROPS} />);
+
+    const { getByTestId } = render(<ModelInfoView {...NON_CREATED_BY_USER_ADMIN_PROPS} />, { wrapper });
     await waitFor(() => {
       expect(getByTestId("delete-model-button")).toBeDisabled();
     });
@@ -279,16 +255,22 @@ describe("ModelInfoView", () => {
 
   it("should render health check model field for wildcard routes", async () => {
     const wildcardModelData = {
-      ...modelData,
-      litellm_model_name: "openai/gpt-4*",
+      ...defaultModelData,
+      litellm_params: {
+        ...defaultModelData.litellm_params,
+        model: "openai/gpt-4*",
+      },
     };
 
-    const WILDCARD_ADMIN_PROPS = {
-      ...DEFAULT_ADMIN_PROPS,
-      modelData: wildcardModelData,
-    };
+    mockUseModelsInfo.mockReturnValue({
+      data: {
+        data: [wildcardModelData],
+      },
+      isLoading: false,
+      error: null,
+    });
 
-    const { getByText } = render(<ModelInfoView {...WILDCARD_ADMIN_PROPS} />);
+    const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
     await waitFor(() => {
       expect(getByText("Model Settings")).toBeInTheDocument();
     });
@@ -298,7 +280,7 @@ describe("ModelInfoView", () => {
   });
 
   it("should not render health check model field for non-wildcard routes", async () => {
-    const { queryByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />);
+    const { queryByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
     await waitFor(() => {
       expect(queryByText("Model Settings")).toBeInTheDocument();
     });
@@ -309,14 +291,14 @@ describe("ModelInfoView", () => {
 
   describe("View Model", () => {
     it("should render the model info view", async () => {
-      const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />);
+      const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
       await waitFor(() => {
         expect(getByText("Model Settings")).toBeInTheDocument();
       });
     });
 
     it("should render tags in the view model", async () => {
-      const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />);
+      const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
       await waitFor(() => {
         expect(getByText("Tags")).toBeInTheDocument();
       });

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2007,12 +2007,12 @@ export const regenerateKeyCall = async (accessToken: string, keyToRegenerate: st
 let ModelListerrorShown = false;
 let errorTimer: NodeJS.Timeout | null = null;
 
-export const modelInfoCall = async (accessToken: string, userID: string, userRole: string, page: number = 1, size: number = 50, search?: string) => {
+export const modelInfoCall = async (accessToken: string, userID: string, userRole: string, page: number = 1, size: number = 50, search?: string, modelId?: string, teamId?: string) => {
   /**
    * Get all models on proxy
    */
   try {
-    console.log("modelInfoCall:", accessToken, userID, userRole, page, size, search);
+    console.log("modelInfoCall:", accessToken, userID, userRole, page, size, search, modelId, teamId);
     let url = proxyBaseUrl ? `${proxyBaseUrl}/v2/model/info` : `/v2/model/info`;
     const params = new URLSearchParams();
     params.append("include_team_models", "true");
@@ -2020,6 +2020,12 @@ export const modelInfoCall = async (accessToken: string, userID: string, userRol
     params.append("size", size.toString());
     if (search && search.trim()) {
       params.append("search", search.trim());
+    }
+    if (modelId && modelId.trim()) {
+      params.append("modelId", modelId.trim());
+    }
+    if (teamId && teamId.trim()) {
+      params.append("teamId", teamId.trim());
     }
     if (params.toString()) {
       url += `?${params.toString()}`;

--- a/ui/litellm-dashboard/src/components/templates/model_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/templates/model_dashboard.tsx
@@ -1025,7 +1025,6 @@ const OldModelDashboard: React.FC<ModelDashboardProps> = ({
                 setSelectedModelId(null);
                 setEditModel(false);
               }}
-              modelData={modelData.data.find((model: any) => model.model_info.id === selectedModelId)}
               accessToken={accessToken}
               userID={userID}
               userRole={userRole}
@@ -1270,9 +1269,9 @@ const OldModelDashboard: React.FC<ModelDashboardProps> = ({
                               <span className="text-sm text-gray-700">
                                 {filteredData.length > 0
                                   ? `Showing ${pagination.pageIndex * pagination.pageSize + 1} - ${Math.min(
-                                      (pagination.pageIndex + 1) * pagination.pageSize,
-                                      filteredData.length,
-                                    )} of ${filteredData.length} results`
+                                    (pagination.pageIndex + 1) * pagination.pageSize,
+                                    filteredData.length,
+                                  )} of ${filteredData.length} results`
                                   : "Showing 0 results"}
                               </span>
 
@@ -1284,11 +1283,10 @@ const OldModelDashboard: React.FC<ModelDashboardProps> = ({
                                       setPagination((prev) => ({ ...prev, pageIndex: prev.pageIndex - 1 }))
                                     }
                                     disabled={pagination.pageIndex === 0}
-                                    className={`px-3 py-1 text-sm border rounded-md ${
-                                      pagination.pageIndex === 0
-                                        ? "bg-gray-100 text-gray-400 cursor-not-allowed"
-                                        : "hover:bg-gray-50"
-                                    }`}
+                                    className={`px-3 py-1 text-sm border rounded-md ${pagination.pageIndex === 0
+                                      ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                                      : "hover:bg-gray-50"
+                                      }`}
                                   >
                                     Previous
                                   </button>
@@ -1300,11 +1298,10 @@ const OldModelDashboard: React.FC<ModelDashboardProps> = ({
                                     disabled={
                                       pagination.pageIndex >= Math.ceil(filteredData.length / pagination.pageSize) - 1
                                     }
-                                    className={`px-3 py-1 text-sm border rounded-md ${
-                                      pagination.pageIndex >= Math.ceil(filteredData.length / pagination.pageSize) - 1
-                                        ? "bg-gray-100 text-gray-400 cursor-not-allowed"
-                                        : "hover:bg-gray-50"
-                                    }`}
+                                    className={`px-3 py-1 text-sm border rounded-md ${pagination.pageIndex >= Math.ceil(filteredData.length / pagination.pageSize) - 1
+                                      ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                                      : "hover:bg-gray-50"
+                                      }`}
                                   >
                                     Next
                                   </button>


### PR DESCRIPTION
## Relevant issues
This is in support of moving all the client filtering logic to the backend. The endpoint is now paginated, so I had to modify the /v2/model/info endpoint to support these params for the UI.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="1632" height="1005" alt="image" src="https://github.com/user-attachments/assets/330ee3fa-2219-4e97-b275-e18f16349d07" />
<img width="846" height="125" alt="image" src="https://github.com/user-attachments/assets/e9f59f99-6c6a-41c1-a774-56bb2014960c" />
<img width="837" height="222" alt="image" src="https://github.com/user-attachments/assets/1adf5058-140c-4bb5-afcf-bc6aad22525f" />
