### PR TITLE
feat: pass prior OpenAI reasoning via chat completions

### DIFF
--- a/docs/my-website/docs/reasoning_content.md
+++ b/docs/my-website/docs/reasoning_content.md
@@ -29,11 +29,14 @@ LiteLLM will standardize the `reasoning_content` in the response and `thinking_b
 "message": {
     ...
     "reasoning_content": "The capital of France is Paris.",
-    "thinking_blocks": [ # returned for Anthropic and OpenAI models
+    "thinking_blocks": [ # shape varies by provider
         {
             "type": "thinking",
+            # Anthropic
             "thinking": "The capital of France is Paris.",
-            "signature": "EqoBCkgIARABGAIiQL2UoU0b1OHYi+..."
+            "signature": "EqoBCkgIARABGAIiQL2UoU0b1OHYi+...",
+            # OpenAI (Responses API bridge)
+            "encrypted_content": "encrypted-blob-abc123",
         }
     ]
 }

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -62,6 +62,59 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
     def __init__(self):
         pass
 
+    @staticmethod
+    def _extract_openai_reasoning_item_from_chat_message(
+        msg: Dict[str, Any],
+        custom_llm_provider: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Support round-tripping OpenAI Responses reasoning blobs through chat messages.
+
+        We store it on the assistant message as:
+          message.provider_specific_fields["reasoning"] = { ... encrypted_content ... }
+        and reconstruct a Responses API input item:
+          {"type": "reasoning", ...}
+        """
+        if custom_llm_provider != "openai":
+            return None
+
+        provider_fields = msg.get("provider_specific_fields")
+        if isinstance(provider_fields, dict):
+            reasoning = provider_fields.get("reasoning")
+            if isinstance(reasoning, dict):
+                encrypted_content = reasoning.get("encrypted_content")
+                if isinstance(encrypted_content, str) and encrypted_content:
+                    item = dict(reasoning)
+                    item.setdefault("type", "reasoning")
+                    if "summary" not in item:
+                        item["summary"] = [{"type": "summary_text", "text": ""}]
+                    return item
+
+            encrypted_content = provider_fields.get("reasoning_encrypted_content") or provider_fields.get(
+                "encrypted_content"
+            )
+            if isinstance(encrypted_content, str) and encrypted_content:
+                return {
+                    "type": "reasoning",
+                    "encrypted_content": encrypted_content,
+                    "summary": [{"type": "summary_text", "text": ""}],
+                }
+
+        thinking_blocks = msg.get("thinking_blocks")
+        if isinstance(thinking_blocks, list):
+            for block in thinking_blocks:
+                if not isinstance(block, dict):
+                    continue
+                encrypted_content = block.get("encrypted_content")
+                if isinstance(encrypted_content, str) and encrypted_content:
+                    return {
+                        "type": "reasoning",
+                        "encrypted_content": encrypted_content,
+                        "summary": [{"type": "summary_text", "text": ""}],
+                    }
+
+        return None
+
     def _handle_raw_dict_response_item(
         self, item: Dict[str, Any], index: int
     ) -> Tuple[Optional[Any], int]:
@@ -144,7 +197,9 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         return None, index
 
     def convert_chat_completion_messages_to_responses_api(
-        self, messages: List["AllMessageValues"]
+        self,
+        messages: List["AllMessageValues"],
+        custom_llm_provider: Optional[str] = None,
     ) -> Tuple[List[Any], Optional[str]]:
         input_items: List[Any] = []
         instructions: Optional[str] = None
@@ -154,6 +209,16 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             content = msg.get("content", "")
             tool_calls = msg.get("tool_calls")
             tool_call_id = msg.get("tool_call_id")
+
+            if role == "assistant":
+                reasoning_item = (
+                    LiteLLMResponsesTransformationHandler._extract_openai_reasoning_item_from_chat_message(
+                        msg=cast(Dict[str, Any], msg),
+                        custom_llm_provider=custom_llm_provider,
+                    )
+                )
+                if reasoning_item is not None:
+                    input_items.append(reasoning_item)
 
             if role == "system":
                 # Extract system message as instructions
@@ -237,10 +302,13 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         litellm_logging_obj: "LiteLLMLoggingObj",
         client: Optional[Any] = None,
     ) -> dict:
+        custom_llm_provider = cast(Optional[str], litellm_params.get("custom_llm_provider"))
         (
             input_items,
             instructions,
-        ) = self.convert_chat_completion_messages_to_responses_api(messages)
+        ) = self.convert_chat_completion_messages_to_responses_api(
+            messages, custom_llm_provider=custom_llm_provider
+        )
 
         optional_params = self._extract_extra_body_params(optional_params)
 
@@ -281,6 +349,20 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         # Get stream parameter from litellm_params if not in optional_params
         stream = optional_params.get("stream") or litellm_params.get("stream", False)
         verbose_logger.debug(f"Chat provider: Stream parameter: {stream}")
+
+        if custom_llm_provider == "openai":
+            has_prior_reasoning = any(
+                isinstance(item, dict)
+                and item.get("type") == "reasoning"
+                and isinstance(item.get("encrypted_content"), str)
+                and item.get("encrypted_content")
+                for item in input_items
+            )
+            if responses_api_request.get("reasoning") is not None or has_prior_reasoning:
+                include = list(responses_api_request.get("include") or [])
+                if "reasoning.encrypted_content" not in include:
+                    include.append("reasoning.encrypted_content")
+                responses_api_request["include"] = include
 
         # Ensure stream is properly set in the request
         if stream:
@@ -355,6 +437,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         choices: List[Choices] = []
         index = 0
         reasoning_content: Optional[str] = None
+        pending_reasoning_item: Optional[Dict[str, Any]] = None
 
         # Collect all tool calls to put them in a single choice
         # (Chat Completions API expects all tool calls in one message)
@@ -367,6 +450,19 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     response_text = getattr(summary_item, "text", "")
                     reasoning_content = response_text if response_text else ""
 
+                encrypted_content = getattr(item, "encrypted_content", None)
+                if isinstance(encrypted_content, str) and encrypted_content:
+                    try:
+                        if hasattr(item, "model_dump"):
+                            pending_reasoning_item = item.model_dump(exclude_none=True)
+                        else:
+                            pending_reasoning_item = item.dict(exclude_none=True)  # type: ignore[attr-defined]
+                    except Exception:
+                        pending_reasoning_item = {
+                            "type": "reasoning",
+                            "encrypted_content": encrypted_content,
+                        }
+
             elif isinstance(item, ResponseOutputMessage):
                 for content in item.content:
                     response_text = getattr(content, "text", "")
@@ -375,11 +471,17 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     annotations = LiteLLMResponsesTransformationHandler._convert_annotations_to_chat_format(
                         raw_annotations
                     )
+                    provider_specific_fields = (
+                        {"reasoning": pending_reasoning_item}
+                        if pending_reasoning_item is not None
+                        else None
+                    )
                     msg = Message(
                         role=item.role,
                         content=response_text if response_text else "",
                         reasoning_content=reasoning_content,
                         annotations=annotations,
+                        provider_specific_fields=provider_specific_fields,
                     )
 
                     choices.append(
@@ -391,6 +493,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     )
 
                     reasoning_content = None  # flush reasoning content
+                    pending_reasoning_item = None
                     index += 1
 
             elif isinstance(item, ResponseFunctionToolCall):
@@ -413,17 +516,39 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             else:
                 pass  # don't fail request if item in list is not supported
 
+        # If reasoning appears after an output message, attach it to the last choice.
+        if pending_reasoning_item is not None and not accumulated_tool_calls and choices:
+            try:
+                last_message = choices[-1].message
+                existing_fields = getattr(last_message, "provider_specific_fields", None)
+                if isinstance(existing_fields, dict):
+                    merged_fields = dict(existing_fields)
+                else:
+                    merged_fields = {}
+                merged_fields["reasoning"] = pending_reasoning_item
+                setattr(last_message, "provider_specific_fields", merged_fields)
+                pending_reasoning_item = None
+            except Exception:
+                pass
+
         # If we accumulated tool calls, create a single choice with all of them
         if accumulated_tool_calls:
+            provider_specific_fields = (
+                {"reasoning": pending_reasoning_item}
+                if pending_reasoning_item is not None
+                else None
+            )
             msg = Message(
                 content=None,
                 tool_calls=accumulated_tool_calls,
                 reasoning_content=reasoning_content,
+                provider_specific_fields=provider_specific_fields,
             )
             choices.append(
                 Choices(message=msg, finish_reason="tool_calls", index=index)
             )
             reasoning_content = None
+            pending_reasoning_item = None
 
         return choices
 
@@ -1062,11 +1187,39 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
         elif event_type == "response.completed":
             # Response is fully complete - now we can signal is_finished=True
             # This ensures we don't prematurely end the stream before tool_calls arrive
+            provider_specific_fields = None
+            try:
+                response_obj = parsed_chunk.get("response")
+                if isinstance(response_obj, dict):
+                    output = response_obj.get("output")
+                    if isinstance(output, list):
+                        for out_item in output:
+                            if (
+                                isinstance(out_item, dict)
+                                and out_item.get("type") == "reasoning"
+                                and isinstance(out_item.get("encrypted_content"), str)
+                                and out_item.get("encrypted_content")
+                            ):
+                                provider_specific_fields = {
+                                    "reasoning": {
+                                        k: v
+                                        for k, v in out_item.items()
+                                        if v is not None
+                                    }
+                                }
+                                break
+            except Exception:
+                provider_specific_fields = None
             return ModelResponseStream(
                 choices=[
                     StreamingChoices(
                         index=0,
-                        delta=Delta(content=""),
+                        delta=Delta(
+                            content="",
+                            provider_specific_fields=provider_specific_fields,
+                        )
+                        if provider_specific_fields is not None
+                        else Delta(content=""),
                         finish_reason="stop",
                     )
                 ]

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -506,6 +506,185 @@ and I learn to carry this small calm home."""
     print("✓ transform_response correctly handled reasoning items and output messages")
 
 
+def test_transform_response_preserves_reasoning_encrypted_content_in_provider_specific_fields():
+    """If Responses API returns reasoning.encrypted_content, preserve it for multi-turn chat."""
+    from unittest.mock import Mock
+
+    from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+    from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
+
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+    from litellm.types.llms.openai import (
+        InputTokensDetails,
+        OutputTokensDetails,
+        ResponseAPIUsage,
+        ResponsesAPIResponse,
+    )
+    from litellm.types.utils import ModelResponse, Usage
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    reasoning_item = ResponseReasoningItem(
+        id="rs_123",
+        summary=[Summary(text="ok", type="summary_text")],
+        type="reasoning",
+        encrypted_content="encrypted-blob-abc123",
+        content=None,
+        status=None,
+    )
+
+    output_message = ResponseOutputMessage(
+        id="msg_123",
+        content=[ResponseOutputText(annotations=[], text="Hello", type="output_text", logprobs=[])],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+
+    raw_response = ResponsesAPIResponse(
+        id="resp_test",
+        created_at=1234567890,
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata={},
+        model="gpt-5.1",
+        object="response",
+        output=[reasoning_item, output_message],
+        parallel_tool_calls=True,
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning={"effort": "low", "summary": "detailed"},
+        status="completed",
+        text={"format": {"type": "text"}, "verbosity": "medium"},
+        truncation="disabled",
+        usage=ResponseAPIUsage(
+            input_tokens=1,
+            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            output_tokens=1,
+            output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+            total_tokens=2,
+        ),
+        user=None,
+        store=True,
+        background=False,
+    )
+
+    model_response = ModelResponse(
+        id="chatcmpl-test",
+        created=1234567890,
+        model=None,
+        object="chat.completion",
+        choices=[],
+        usage=Usage(completion_tokens=0, prompt_tokens=0, total_tokens=0),
+    )
+
+    result = handler.transform_response(
+        model="gpt-5.1",
+        raw_response=raw_response,
+        model_response=model_response,
+        logging_obj=Mock(),
+        request_data={"model": "gpt-5.1"},
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"reasoning_effort": "low"},
+        litellm_params={"custom_llm_provider": "openai"},
+        encoding=Mock(),
+    )
+
+    provider_fields = result.choices[0].message.provider_specific_fields
+    assert provider_fields is not None
+    assert provider_fields["reasoning"]["encrypted_content"] == "encrypted-blob-abc123"
+
+
+def test_convert_chat_completion_messages_to_responses_api_includes_reasoning_item_from_provider_specific_fields():
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": "hello",
+            "provider_specific_fields": {
+                "reasoning": {
+                    "type": "reasoning",
+                    "id": "rs_123",
+                    "summary": [{"text": "ok", "type": "summary_text"}],
+                    "encrypted_content": "encrypted-blob-abc123",
+                }
+            },
+        },
+        {"role": "user", "content": "continue"},
+    ]
+
+    input_items, _ = handler.convert_chat_completion_messages_to_responses_api(
+        messages, custom_llm_provider="openai"
+    )
+
+    assert input_items[0]["type"] == "reasoning"
+    assert input_items[0]["encrypted_content"] == "encrypted-blob-abc123"
+    assert input_items[1]["type"] == "message"
+    assert input_items[1]["role"] == "assistant"
+
+
+def test_transform_request_adds_reasoning_encrypted_content_include_for_openai():
+    from unittest.mock import Mock
+
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    request = handler.transform_request(
+        model="gpt-5.1",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"reasoning_effort": "low"},
+        litellm_params={"custom_llm_provider": "openai"},
+        headers={},
+        litellm_logging_obj=Mock(),
+    )
+
+    assert "reasoning.encrypted_content" in (request.get("include") or [])
+
+
+def test_streaming_response_completed_emits_reasoning_provider_specific_fields():
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=None, sync_stream=True
+    )
+
+    chunk = {
+        "type": "response.completed",
+        "response": {
+            "output": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_123",
+                    "summary": [{"text": "ok", "type": "summary_text"}],
+                    "encrypted_content": "encrypted-blob-abc123",
+                }
+            ]
+        },
+    }
+
+    result = iterator.chunk_parser(chunk)
+    provider_fields = getattr(result.choices[0].delta, "provider_specific_fields", None)
+    assert provider_fields is not None
+    assert provider_fields["reasoning"]["encrypted_content"] == "encrypted-blob-abc123"
+
+
 def test_convert_tools_to_responses_format():
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         LiteLLMResponsesTransformationHandler,


### PR DESCRIPTION
## Summary
- Allow passing prior OpenAI encrypted reasoning into Chat Completions via `message.provider_specific_fields.reasoning.encrypted_content` (or `message.thinking_blocks[*].encrypted_content`).
- Forward it through the Responses bridge as a `type=reasoning` input item and request `reasoning.encrypted_content` when relevant.
- Preserve returned encrypted reasoning on the assistant message (`provider_specific_fields.reasoning`), including on the final streaming chunk.

## Test plan
- `python3 -m pytest -q tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py`