### PR TITLE
[fix] MCP server prefix detection for hyphenated tool names

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -95,6 +95,7 @@ if MCP_AVAILABLE:
         global_mcp_tool_registry,
     )
     from litellm.proxy._experimental.mcp_server.utils import (
+        get_possible_server_name_prefixes,
         split_server_prefix_from_name,
     )
 
@@ -608,9 +609,14 @@ if MCP_AVAILABLE:
         if filtered_server:
             return list(filtered_server.values())
 
+        if mcp_servers is not None:
+            return []
+
         return allowed_mcp_servers
 
-    def _tool_name_matches(tool_name: str, filter_list: List[str]) -> bool:
+    def _tool_name_matches(
+        tool_name: str, filter_list: List[str], server: MCPServer
+    ) -> bool:
         """
         Check if a tool name matches any name in the filter list.
 
@@ -625,6 +631,7 @@ if MCP_AVAILABLE:
             True if the tool name (prefixed or unprefixed) is in the filter list
         """
         from litellm.proxy._experimental.mcp_server.utils import (
+            get_possible_server_name_prefixes,
             split_server_prefix_from_name,
         )
 
@@ -633,7 +640,10 @@ if MCP_AVAILABLE:
             return True
 
         # Check if the unprefixed name is in the list
-        unprefixed_name, _ = split_server_prefix_from_name(tool_name)
+        unprefixed_name, _ = split_server_prefix_from_name(
+            tool_name,
+            known_server_prefixes=get_possible_server_name_prefixes(server),
+        )
         return unprefixed_name in filter_list
 
     def filter_tools_by_allowed_tools(
@@ -661,7 +671,7 @@ if MCP_AVAILABLE:
             tools_to_return = [
                 tool
                 for tool in tools
-                if _tool_name_matches(tool.name, mcp_server.allowed_tools)
+                if _tool_name_matches(tool.name, mcp_server.allowed_tools, mcp_server)
             ]
 
         # Filter by disallowed_tools (blacklist)
@@ -669,7 +679,9 @@ if MCP_AVAILABLE:
             tools_to_return = [
                 tool
                 for tool in tools_to_return
-                if not _tool_name_matches(tool.name, mcp_server.disallowed_tools)
+                if not _tool_name_matches(
+                    tool.name, mcp_server.disallowed_tools, mcp_server
+                )
             ]
 
         return tools_to_return
@@ -1156,13 +1168,21 @@ if MCP_AVAILABLE:
             server_id=server_id,
             user_api_key_auth=user_api_key_auth,
         )
+        server_prefixes: Optional[List[str]] = None
+        if server_id:
+            server = global_mcp_server_manager.get_mcp_server_by_id(server_id)
+            if server:
+                server_prefixes = get_possible_server_name_prefixes(server)
         if allowed_tool_names is not None:
             # Strip prefix from tool names before comparing
             # Tools are stored in DB without prefix, but come from MCP server with prefix
             filtered_tools = []
             for t in tools:
                 # Get tool name without server prefix
-                unprefixed_tool_name, _ = split_server_prefix_from_name(t.name)
+                unprefixed_tool_name, _ = split_server_prefix_from_name(
+                    t.name,
+                    known_server_prefixes=server_prefixes,
+                )
                 if unprefixed_tool_name in allowed_tool_names:
                     filtered_tools.append(t)
         else:
@@ -1367,7 +1387,17 @@ if MCP_AVAILABLE:
         mcp_server: Optional[MCPServer] = None
 
         # Remove prefix from tool name for logging and processing
-        original_tool_name, server_name = split_server_prefix_from_name(name)
+        allowed_prefixes: List[str] = []
+        for server in allowed_mcp_servers:
+            allowed_prefixes.extend(get_possible_server_name_prefixes(server))
+        split_kwargs = (
+            {"known_server_prefixes": allowed_prefixes}
+            if allowed_prefixes
+            else {}
+        )
+        original_tool_name, server_name = split_server_prefix_from_name(
+            name, **split_kwargs
+        )
 
         # If tool name is unprefixed, resolve its server so we can enforce permissions
         if not server_name:
@@ -1574,8 +1604,15 @@ if MCP_AVAILABLE:
         # Decide whether to add prefix based on number of allowed servers
         add_prefix = not (len(allowed_mcp_servers) == 1)
 
+        allowed_prefixes: List[str] = []
+        for server in allowed_mcp_servers:
+            allowed_prefixes.extend(get_possible_server_name_prefixes(server))
+
         if add_prefix:
-            original_prompt_name, server_name = split_server_prefix_from_name(name)
+            original_prompt_name, server_name = split_server_prefix_from_name(
+                name,
+                known_server_prefixes=allowed_prefixes,
+            )
         else:
             original_prompt_name = name
             server_name = allowed_mcp_servers[0].name

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -194,14 +194,17 @@ class LiteLLM_Proxy_MCP_Handler:
                     tool_server_map[tool_name] = allowed_mcp_servers[0]
                 else:
                     _, tool_server_map[tool_name] = split_server_prefix_from_name(
-                        tool_name
+                        tool_name,
+                        known_server_prefixes=allowed_mcp_servers,
                     )
 
         return deduplicated_tools, tool_server_map
 
     @staticmethod
     def _filter_mcp_tools_by_allowed_tools(
-        mcp_tools: List[MCPTool], mcp_tools_with_litellm_proxy: List[ToolParam]
+        mcp_tools: List[MCPTool],
+        mcp_tools_with_litellm_proxy: List[ToolParam],
+        allowed_server_names: Optional[List[str]] = None,
     ) -> List[MCPTool]:
         """Filter MCP tools based on allowed_tools parameter from the original tool configs."""
         # Collect all allowed tool names from all MCP tool configs
@@ -231,7 +234,10 @@ class LiteLLM_Proxy_MCP_Handler:
                 filtered_tools.append(mcp_tool)
                 continue
 
-            unprefixed_name, _ = split_server_prefix_from_name(tool_name)
+            unprefixed_name, _ = split_server_prefix_from_name(
+                tool_name,
+                known_server_prefixes=allowed_server_names,
+            )
             if unprefixed_name in allowed_tool_names:
                 filtered_tools.append(mcp_tool)
 
@@ -298,6 +304,7 @@ class LiteLLM_Proxy_MCP_Handler:
             LiteLLM_Proxy_MCP_Handler._filter_mcp_tools_by_allowed_tools(
                 mcp_tools=mcp_tools_fetched,
                 mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy,
+                allowed_server_names=allowed_mcp_servers,
             )
         )
 
@@ -532,7 +539,8 @@ class LiteLLM_Proxy_MCP_Handler:
                 # Remove the server name prefix if the tool name includes it.
                 sanitized_tool_name = tool_name
                 unprefixed_name, prefixed_server_name = split_server_prefix_from_name(
-                    tool_name
+                    tool_name,
+                    known_server_prefixes=[server_name],
                 )
                 if (
                     prefixed_server_name

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1257,6 +1257,7 @@ async def test_call_mcp_tool_user_unauthorized_access():
                 },
                 user_api_key_auth=mock_user_auth,
                 mcp_auth_header="Bearer test_token",
+                mcp_servers=["restricted_server"],
             )
 
         # Verify the exception details
@@ -1604,24 +1605,24 @@ async def test_list_tools_strips_prefix_when_matching_permissions():
     ):
         # Return tools WITH prefix (as they come from MCP server)
         tool1 = MagicMock()
-        tool1.name = "GITMCP-fetch_litellm_documentation"  # Prefixed
+        tool1.name = "fetch_litellm_documentation"  # Prefixed
         tool1.description = "Fetch docs"
         tool1.inputSchema = {}
 
         tool2 = MagicMock()
         tool2.name = (
-            "GITMCP-search_litellm_documentation"  # Prefixed, not in allowed list
+            "search_litellm_documentation"  # Prefixed, not in allowed list
         )
         tool2.description = "Search docs"
         tool2.inputSchema = {}
 
         tool3 = MagicMock()
-        tool3.name = "GITMCP-search_litellm_code"  # Prefixed
+        tool3.name = "search_litellm_code"  # Prefixed
         tool3.description = "Search code"
         tool3.inputSchema = {}
 
         tool4 = MagicMock()
-        tool4.name = "GITMCP-fetch_generic_url_content"  # Prefixed, not in allowed list
+        tool4.name = "fetch_generic_url_content"  # Prefixed, not in allowed list
         tool4.description = "Fetch URL"
         tool4.inputSchema = {}
 
@@ -1645,8 +1646,8 @@ async def test_list_tools_strips_prefix_when_matching_permissions():
     tool_names = sorted([t.name for t in tools])
     # Tools still have prefixes in the output, but were filtered correctly
     assert tool_names == [
-        "GITMCP-fetch_litellm_documentation",
-        "GITMCP-search_litellm_code",
+        "fetch_litellm_documentation",
+        "search_litellm_code",
     ]
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_utils.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from litellm.proxy._experimental.mcp_server.utils import (
+    get_possible_server_name_prefixes,
+    split_server_prefix_from_name,
+)
+
+
+def test_split_server_prefix_respects_known_prefixes():
+    prefixed = "deepwiki-read_wiki_structure"
+
+    unprefixed, server = split_server_prefix_from_name(
+        prefixed, known_server_prefixes=["deepwiki", "zapier"]
+    )
+
+    assert unprefixed == "read_wiki_structure"
+    assert server == "deepwiki"
+
+
+def test_split_server_prefix_ignores_unknown_prefixes():
+    prefixed = "unknown-read_wiki_structure"
+
+    unprefixed, server = split_server_prefix_from_name(
+        prefixed, known_server_prefixes=["deepwiki"]
+    )
+
+    assert unprefixed == prefixed
+    assert server == ""
+
+
+def test_get_possible_server_name_prefixes_returns_alias_server_name_and_id():
+    server = SimpleNamespace(
+        alias="alias-name", server_name="server-name", server_id="server-id"
+    )
+
+    prefixes = get_possible_server_name_prefixes(server)
+
+    assert prefixes == ["alias-name", "server-name", "server-id"]

--- a/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
+++ b/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
@@ -75,6 +75,32 @@ def test_deduplicate_mcp_tools_prefixed_names(tool_name, expected_server):
     assert server_map[tool_name] == expected_server
 
 
+def test_filter_mcp_tools_matches_known_server_prefix():
+    tools = [{"name": "deepwiki-read_wiki_structure"}]
+    tool_configs = [{"allowed_tools": ["read_wiki_structure"]}]
+
+    filtered = LiteLLM_Proxy_MCP_Handler._filter_mcp_tools_by_allowed_tools(
+        mcp_tools=tools,
+        mcp_tools_with_litellm_proxy=tool_configs,
+        allowed_server_names=["deepwiki"],
+    )
+
+    assert filtered == tools
+
+
+def test_filter_mcp_tools_ignores_unknown_server_prefix():
+    tools = [{"name": "unknown-read_wiki_structure"}]
+    tool_configs = [{"allowed_tools": ["read_wiki_structure"]}]
+
+    filtered = LiteLLM_Proxy_MCP_Handler._filter_mcp_tools_by_allowed_tools(
+        mcp_tools=tools,
+        mcp_tools_with_litellm_proxy=tool_configs,
+        allowed_server_names=["deepwiki"],
+    )
+
+    assert filtered == []
+
+
 def test_extract_tool_calls_from_chat_response_handles_tool_calls():
     response = ModelResponse(
         id="resp-1",


### PR DESCRIPTION
## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

Note: I currently do not have access to CI results.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

<img width="1520" height="870" alt="image" src="https://github.com/user-attachments/assets/851351a0-510e-4229-9696-d6a34bb047fd" />

This PR addresses an issue where MCP tool calls fail when a tool name contains a hyphen (`-`).

The parsing logic has been updated to:
- Match the server name by prefix
- Derive the tool name from the remaining portion

This avoids ambiguous splitting and allows tool names containing `-` to be handled correctly.
