### PR TITLE
fix: add User-Agent header to image fetch requests

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/image_handling.py
+++ b/litellm/litellm_core_utils/prompt_templates/image_handling.py
@@ -11,7 +11,17 @@ from litellm import verbose_logger
 from litellm.caching.caching import InMemoryCache
 from litellm.constants import MAX_IMAGE_URL_DOWNLOAD_SIZE_MB
 
+try:
+    from litellm._version import version
+except Exception:
+    version = "0.0.0"
+
 MAX_IMGS_IN_MEMORY = 10
+
+# Headers for image fetch requests - some CDNs (e.g., Wikimedia) require a User-Agent
+IMAGE_FETCH_HEADERS = {
+    "User-Agent": f"litellm/{version}",
+}
 
 in_memory_cache = InMemoryCache(max_size_in_memory=MAX_IMGS_IN_MEMORY)
 
@@ -80,7 +90,7 @@ async def async_convert_url_to_base64(url: str) -> str:
     client = litellm.module_level_aclient
     for _ in range(3):
         try:
-            response = await client.get(url, follow_redirects=True)
+            response = await client.get(url, headers=IMAGE_FETCH_HEADERS, follow_redirects=True)
             return _process_image_response(response, url)
         except litellm.ImageFetchError:
             raise
@@ -105,7 +115,7 @@ def convert_url_to_base64(url: str) -> str:
     client = litellm.module_level_client
     for _ in range(3):
         try:
-            response = client.get(url, follow_redirects=True)
+            response = client.get(url, headers=IMAGE_FETCH_HEADERS, follow_redirects=True)
             return _process_image_response(response, url)
         except litellm.ImageFetchError:
             raise


### PR DESCRIPTION
  Relevant issues

  Fixes image fetching 403/429 errors from CDNs like Wikimedia that require User-Agent headers.

  Pre-Submission checklist

  Please complete all items before asking a LiteLLM maintainer to review your PR

  - I have Added testing in the https://github.com/BerriAI/litellm/tree/main/tests/litellm directory,
  Adding at least 1 test is a hard requirement - https://docs.litellm.ai/docs/extras/contributing_code
  - My PR passes all unit tests on https://docs.litellm.ai/docs/extras/contributing_code
  - My PR's scope is as isolated as possible, it only solves 1 specific problem

  CI (LiteLLM team)

  CI status guideline:

  - 50-55 passing tests: main is stable with minor issues.
  - 45-49 passing tests: acceptable but needs attention
  - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

  - Branch creation CI run
  Link:
  - CI run for the last commit
  Link:
  - Merge / cherry-pick CI run
  Links:

  Type

  🐛 Bug Fix

  Changes

  Problem

  Image fetching from CDNs like Wikimedia fails with 403/429 errors because these servers require a
  proper User-Agent header. This particularly affects Vertex AI Claude, which requires images to be
  converted to base64 (unlike direct Anthropic Claude which can handle image URLs directly).

  Solution

  Added explicit User-Agent header (litellm/{version}) to image fetch requests in image_handling.py:

  - async_convert_url_to_base64() - async image fetching
  - convert_url_to_base64() - sync image fetching

  Files Changed

  - litellm/litellm_core_utils/prompt_templates/image_handling.py - Added version import and
  IMAGE_FETCH_HEADERS constant, updated both sync/async functions to pass headers
  - tests/test_litellm/litellm_core_utils/test_image_handling.py - Added test_user_agent_header_is_sent
   test, updated mock clients to accept headers parameter, cleaned up unused imports
