### PR TITLE
fix(azure): use generic cost calculator for audio token pricing

### DIFF
--- a/litellm/llms/azure/cost_calculation.py
+++ b/litellm/llms/azure/cost_calculation.py
@@ -1,11 +1,12 @@
 """
 Helper util for handling azure openai-specific cost calculation
-- e.g.: prompt caching
+- e.g.: prompt caching, audio tokens
 """
 
 from typing import Optional, Tuple
 
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.types.utils import Usage
 from litellm.utils import get_model_info
 
@@ -18,34 +19,15 @@ def cost_per_token(
 
     Input:
         - model: str, the model name without provider prefix
-        - usage: LiteLLM Usage block, containing anthropic caching information
+        - usage: LiteLLM Usage block, containing caching and audio token information
 
     Returns:
         Tuple[float, float] - prompt_cost_in_usd, completion_cost_in_usd
     """
     ## GET MODEL INFO
     model_info = get_model_info(model=model, custom_llm_provider="azure")
-    cached_tokens: Optional[int] = None
-    ## CALCULATE INPUT COST
-    non_cached_text_tokens = usage.prompt_tokens
-    if usage.prompt_tokens_details and usage.prompt_tokens_details.cached_tokens:
-        cached_tokens = usage.prompt_tokens_details.cached_tokens
-        non_cached_text_tokens = non_cached_text_tokens - cached_tokens
-    prompt_cost: float = non_cached_text_tokens * model_info["input_cost_per_token"]
 
-    ## CALCULATE OUTPUT COST
-    completion_cost: float = (
-        usage["completion_tokens"] * model_info["output_cost_per_token"]
-    )
-
-    ## Prompt Caching cost calculation
-    if model_info.get("cache_read_input_token_cost") is not None and cached_tokens:
-        # Note: We read ._cache_read_input_tokens from the Usage - since cost_calculator.py standardizes the cache read tokens on usage._cache_read_input_tokens
-        prompt_cost += cached_tokens * (
-            model_info.get("cache_read_input_token_cost", 0) or 0
-        )
-
-    ## Speech / Audio cost calculation
+    ## Speech / Audio cost calculation (cost per second for TTS models)
     if (
         "output_cost_per_second" in model_info
         and model_info["output_cost_per_second"] is not None
@@ -55,7 +37,14 @@ def cost_per_token(
             f"For model={model} - output_cost_per_second: {model_info.get('output_cost_per_second')}; response time: {response_time_ms}"
         )
         ## COST PER SECOND ##
-        prompt_cost = 0
+        prompt_cost = 0.0
         completion_cost = model_info["output_cost_per_second"] * response_time_ms / 1000
+        return prompt_cost, completion_cost
 
-    return prompt_cost, completion_cost
+    ## Use generic cost calculator for all other cases
+    ## This properly handles: text tokens, audio tokens, cached tokens, reasoning tokens, etc.
+    return generic_cost_per_token(
+        model=model,
+        usage=usage,
+        custom_llm_provider="azure",
+    )


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/19764

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Azure audio models were missing audio token cost calculation.

**Request:**
```bash
POST /v1/chat/completions

{
    "model": "gpt-audio",
    "modalities": ["text", "audio"],
    "audio": {
        "voice": "alloy",
        "format": "wav"
    },
    "messages": [
        {
            "role": "user",
            "content": "What is the capital of France?"
        }
    ]
}
```

**Response usage:**
```json
{
    "prompt_tokens": 17,
    "completion_tokens": 592,
    "prompt_tokens_details": {
        "text_tokens": 17,
        "audio_tokens": 0
    },
    "completion_tokens_details": {
        "text_tokens": 110,
        "audio_tokens": 482
    }
}
```

- Expected output cost: `(110 × $0.00001) + (482 × $0.00008) = $0.03966`
- Actual output cost: `(110 + 482) × $0.00001 = $0.00592`
- Audio tokens were charged at text rate instead of `output_cost_per_audio_token`

**Fix:** Use `generic_cost_per_token()` which properly handles audio token pricing.

**Test added:** `test_azure_audio_output_cost_calculation` in `tests/test_litellm/test_cost_calculator.py`