### PR TITLE
fix(xai): correct cached token cost calculation for xAI models

### DIFF
--- a/litellm/llms/azure/cost_calculation.py
+++ b/litellm/llms/azure/cost_calculation.py
@@ -1,11 +1,12 @@
 """
 Helper util for handling azure openai-specific cost calculation
-- e.g.: prompt caching
+- e.g.: prompt caching, audio tokens
 """
 
 from typing import Optional, Tuple
 
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.types.utils import Usage
 from litellm.utils import get_model_info
 
@@ -18,34 +19,15 @@ def cost_per_token(
 
     Input:
         - model: str, the model name without provider prefix
-        - usage: LiteLLM Usage block, containing anthropic caching information
+        - usage: LiteLLM Usage block, containing caching and audio token information
 
     Returns:
         Tuple[float, float] - prompt_cost_in_usd, completion_cost_in_usd
     """
     ## GET MODEL INFO
     model_info = get_model_info(model=model, custom_llm_provider="azure")
-    cached_tokens: Optional[int] = None
-    ## CALCULATE INPUT COST
-    non_cached_text_tokens = usage.prompt_tokens
-    if usage.prompt_tokens_details and usage.prompt_tokens_details.cached_tokens:
-        cached_tokens = usage.prompt_tokens_details.cached_tokens
-        non_cached_text_tokens = non_cached_text_tokens - cached_tokens
-    prompt_cost: float = non_cached_text_tokens * model_info["input_cost_per_token"]
 
-    ## CALCULATE OUTPUT COST
-    completion_cost: float = (
-        usage["completion_tokens"] * model_info["output_cost_per_token"]
-    )
-
-    ## Prompt Caching cost calculation
-    if model_info.get("cache_read_input_token_cost") is not None and cached_tokens:
-        # Note: We read ._cache_read_input_tokens from the Usage - since cost_calculator.py standardizes the cache read tokens on usage._cache_read_input_tokens
-        prompt_cost += cached_tokens * (
-            model_info.get("cache_read_input_token_cost", 0) or 0
-        )
-
-    ## Speech / Audio cost calculation
+    ## Speech / Audio cost calculation (cost per second for TTS models)
     if (
         "output_cost_per_second" in model_info
         and model_info["output_cost_per_second"] is not None
@@ -55,7 +37,14 @@ def cost_per_token(
             f"For model={model} - output_cost_per_second: {model_info.get('output_cost_per_second')}; response time: {response_time_ms}"
         )
         ## COST PER SECOND ##
-        prompt_cost = 0
+        prompt_cost = 0.0
         completion_cost = model_info["output_cost_per_second"] * response_time_ms / 1000
+        return prompt_cost, completion_cost
 
-    return prompt_cost, completion_cost
+    ## Use generic cost calculator for all other cases
+    ## This properly handles: text tokens, audio tokens, cached tokens, reasoning tokens, etc.
+    return generic_cost_per_token(
+        model=model,
+        usage=usage,
+        custom_llm_provider="azure",
+    )

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -30006,6 +30006,7 @@
         "supports_web_search": true
     },
     "xai/grok-3": {
+        "cache_read_input_token_cost": 7.5e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30020,6 +30021,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-beta": {
+        "cache_read_input_token_cost": 7.5e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30034,6 +30036,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-fast-beta": {
+        "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30048,6 +30051,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-fast-latest": {
+        "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30062,6 +30066,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-latest": {
+        "cache_read_input_token_cost": 7.5e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30076,6 +30081,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini": {
+        "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30091,6 +30097,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-beta": {
+        "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30106,6 +30113,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-fast": {
+        "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30121,6 +30129,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-fast-beta": {
+        "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30136,6 +30145,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-fast-latest": {
+        "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30151,6 +30161,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-latest": {
+        "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -30006,6 +30006,7 @@
         "supports_web_search": true
     },
     "xai/grok-3": {
+        "cache_read_input_token_cost": 7.5e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30020,6 +30021,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-beta": {
+        "cache_read_input_token_cost": 7.5e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30034,6 +30036,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-fast-beta": {
+        "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30048,6 +30051,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-fast-latest": {
+        "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30062,6 +30066,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-latest": {
+        "cache_read_input_token_cost": 7.5e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30076,6 +30081,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini": {
+        "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30091,6 +30097,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-beta": {
+        "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30106,6 +30113,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-fast": {
+        "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30121,6 +30129,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-fast-beta": {
+        "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30136,6 +30145,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-fast-latest": {
+        "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -30151,6 +30161,7 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-latest": {
+        "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
      Link:

- [ ] **CI run for the last commit**  
      Link:

- [ ] **Merge / cherry-pick CI run**  
      Links:

## Type

🐛 Bug Fix

## Changes

### Summary

Fix xAI cached token cost calculation (not addressed by #19696 or #19704).
xAI includes `cached_tokens` inside `text_tokens`, causing double-counting:

```json
{
  "prompt_tokens": 616,
  "prompt_tokens_details": {
    "text_tokens": 616,      // Includes cached tokens.
    "cached_tokens": 615,
    "audio_tokens": 0,
    "image_tokens": 0
  }
}
```

LiteLLM calculates:
```
prompt_cost = text_tokens × input_price + cached_tokens × cache_price
prompt_cost = 616 × $0.30/M + 615 × $0.075/M
```

This charges **1231 tokens** when only **616** were used.

### Solution

#### Fix double-counting in `utils.py`

Detect when `text_tokens + cached_tokens + image_tokens + audio_tokens > prompt_tokens`:

```python
total_details = text_tokens + cache_hit + audio_tokens + cache_creation + image_tokens
has_double_counting = cache_hit > 0 and total_details > usage.prompt_tokens

if text_tokens == 0 or has_double_counting:
    text_tokens = prompt_tokens - cache_hit - audio_tokens - cache_creation - image_tokens
```

#### Add `cache_read_input_token_cost` to xAI models

Per [xAI pricing](https://docs.x.ai/docs/models), cached = 25% of input:

| Model | Input | Cached |
|-------|-------|--------|
| grok-3 variants | $3.00/M | $0.75/M |
| grok-3-mini variants | $0.30/M | $0.075/M |

### Tests

**Before:** 432% overcharge → **After**: 0%