### PR TITLE
fix(main): use local tiktoken cache in lazy loading

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7268,8 +7268,11 @@ def _get_encoding():
 def __getattr__(name: str) -> Any:
     """Lazy import handler for main module"""
     if name == "encoding":
-        # Lazy load encoding to avoid heavy tiktoken import at module load time
-        _encoding = tiktoken.get_encoding("cl100k_base")
+        # Use _get_default_encoding which properly sets TIKTOKEN_CACHE_DIR
+        # before loading tiktoken, ensuring the local cache is used
+        # instead of downloading from the internet
+        from litellm._lazy_imports import _get_default_encoding
+        _encoding = _get_default_encoding()
         # Cache it in the module's __dict__ for subsequent accesses
         import sys
         sys.modules[__name__].__dict__["encoding"] = _encoding

--- a/tests/test_litellm/test_eager_tiktoken_load.py
+++ b/tests/test_litellm/test_eager_tiktoken_load.py
@@ -78,6 +78,35 @@ def test_lazy_loading_default():
     assert len(tokens) > 0, "Encoding should work"
 
 
+def test_tiktoken_cache_dir_set_on_lazy_load():
+    """Test that TIKTOKEN_CACHE_DIR is set when encoding is lazy loaded.
+
+    This ensures the local tiktoken cache is used instead of downloading
+    from the internet. Regression test for issue #19768.
+    """
+    # Remove environment variables to ensure clean state
+    if "LITELLM_DISABLE_LAZY_LOADING" in os.environ:
+        del os.environ["LITELLM_DISABLE_LAZY_LOADING"]
+    if "TIKTOKEN_CACHE_DIR" in os.environ:
+        del os.environ["TIKTOKEN_CACHE_DIR"]
+
+    # Clear any cached modules
+    modules_to_clear = [k for k in sys.modules.keys() if k.startswith("litellm")]
+    for module in modules_to_clear:
+        del sys.modules[module]
+
+    # Import litellm fresh
+    import litellm
+
+    # Access encoding (triggers lazy load)
+    _ = litellm.encoding
+
+    # Verify TIKTOKEN_CACHE_DIR is now set and points to local tokenizers
+    assert "TIKTOKEN_CACHE_DIR" in os.environ, "TIKTOKEN_CACHE_DIR should be set after lazy loading encoding"
+    cache_dir = os.environ["TIKTOKEN_CACHE_DIR"]
+    assert "tokenizers" in cache_dir, f"TIKTOKEN_CACHE_DIR should point to tokenizers directory, got: {cache_dir}"
+
+
 @pytest.fixture(autouse=True)
 def cleanup_env():
     """Clean up environment variable after each test"""


### PR DESCRIPTION
## Relevant issues

Fixes #19768

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Context

LiteLLM uses tiktoken for token counting when:
- Providers don't return `usage` info
- Calculating costs with `completion_cost()`
- Using token counting functions like `token_counter()`

Tiktoken needs a vocabulary file to work. This file is already bundled with LiteLLM at:
```
litellm/litellm_core_utils/tokenizers/9b5ad71b2ce5302211f9c61530b329a4922fc6a4
```

The file contains ~100k token-to-ID mappings (the vocabulary). Example entries:

| Token | ID |
|-------|-----|
| `!` | 0 |
| `hello` | 15339 |
| `world` | 14957 |

## Summary

PR #18070 introduced lazy loading for faster imports, but forgot to configure `TIKTOKEN_CACHE_DIR` before calling tiktoken. This caused tiktoken to download the file from the internet instead of using the local copy:

```
https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken
```

Users without internet access or behind firewalls saw this error:
```
HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443): 
Max retries exceeded... Connection timed out
```

## Solution

Use `_get_default_encoding()` from `_lazy_imports.py` which already exists and properly sets `TIKTOKEN_CACHE_DIR` before loading tiktoken:

```python
# Before (downloads from internet)
_encoding = tiktoken.get_encoding("cl100k_base")

# After (uses local file)
from litellm._lazy_imports import _get_default_encoding
_encoding = _get_default_encoding()
```

## Test

Added `test_tiktoken_cache_dir_set_on_lazy_load` to verify `TIKTOKEN_CACHE_DIR` is configured when encoding is lazy loaded.