### PR TITLE
fix(docker): add libsndfile to main Dockerfile for ARM64 audio processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 # Ensure runtime stage runs as root
 USER root
 
-# Install runtime dependencies
-RUN apk add --no-cache bash openssl tzdata nodejs npm python3 py3-pip
+# Install runtime dependencies (libsndfile needed for audio processing on ARM64)
+RUN apk add --no-cache bash openssl tzdata nodejs npm python3 py3-pip libsndfile
 
 WORKDIR /app
 # Copy the current directory contents into the container at /app


### PR DESCRIPTION
## Relevant issues

Fixes #16920 (for stable release users)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - N/A (Dockerfile change, not testable with unit tests)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Adds `libsndfile` to the main `Dockerfile` (Wolfi-based) for ARM64 audio processing support.

### Context

The previous fix (PR #18092) added `libsndfile` to `docker/Dockerfile.alpine`, but stable releases (`v1.81.0-stable`, etc.) are built from the main `Dockerfile` which uses Wolfi, not Alpine.

Users downloading the stable ARM64 image still experience:
```
cannot load library 'libsndfile.so': libsndfile.so: cannot open shared object file
```

This PR adds `libsndfile` to the correct Dockerfile to fix the issue for stable release users.