### PR TITLE
feat(providers): add Latitude AI as OpenAI-compatible provider

### DIFF
--- a/docs/my-website/docs/providers/latitude.md
+++ b/docs/my-website/docs/providers/latitude.md
@@ -1,0 +1,126 @@
+# Latitude AI
+
+[Latitude](https://latitude.sh) is a GPU cloud provider offering OpenAI-compatible inference APIs for open-source LLMs.
+
+## API Keys
+
+```python
+import os
+os.environ["LATITUDE_API_KEY"] = "lat_..."
+```
+
+Get your API key from [Latitude AI Dashboard](https://ai.latitude.sh).
+
+## Usage
+
+```python
+from litellm import completion
+
+response = completion(
+    model="latitude/qwen-2.5-7b",
+    messages=[{"role": "user", "content": "Hello, how are you?"}]
+)
+print(response.choices[0].message.content)
+```
+
+## Streaming
+
+```python
+from litellm import completion
+
+response = completion(
+    model="latitude/llama-3.1-8b",
+    messages=[{"role": "user", "content": "Write a poem about AI"}],
+    stream=True
+)
+
+for chunk in response:
+    print(chunk.choices[0].delta.content or "", end="")
+```
+
+## Supported Models
+
+| Model | Context | Max Output | Features |
+|-------|---------|------------|----------|
+| `latitude/qwen-2.5-7b` | 131K | 8K | Tools, JSON mode |
+| `latitude/llama-3.1-8b` | 128K | 8K | Tools, JSON mode |
+| `latitude/qwen3-32b` | 131K | 8K | Tools, JSON mode |
+| `latitude/gemma-2-27b` | 8K | 8K | Tools, JSON mode |
+| `latitude/deepseek-r1-distill-14b` | 64K | 8K | Tools, JSON mode, Reasoning |
+| `latitude/qwen2.5-coder-32b` | 131K | 8K | Tools, JSON mode |
+| `latitude/qwen-2.5-vl-7b` | 32K | 8K | Tools, JSON mode, Vision |
+
+## Tool Calling
+
+```python
+from litellm import completion
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather in a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"}
+                },
+                "required": ["location"]
+            }
+        }
+    }
+]
+
+response = completion(
+    model="latitude/qwen-2.5-7b",
+    messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
+    tools=tools
+)
+```
+
+## JSON Mode
+
+```python
+from litellm import completion
+
+response = completion(
+    model="latitude/qwen-2.5-7b",
+    messages=[{"role": "user", "content": "List 3 colors as JSON"}],
+    response_format={"type": "json_object"}
+)
+```
+
+## Vision (qwen-2.5-vl-7b)
+
+```python
+from litellm import completion
+
+response = completion(
+    model="latitude/qwen-2.5-vl-7b",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+            ]
+        }
+    ]
+)
+```
+
+## Supported Parameters
+
+| Parameter | Supported |
+|-----------|-----------|
+| `temperature` | ✅ |
+| `max_tokens` | ✅ |
+| `top_p` | ✅ |
+| `stop` | ✅ |
+| `presence_penalty` | ✅ |
+| `frequency_penalty` | ✅ |
+| `seed` | ✅ |
+| `tools` | ✅ |
+| `response_format` | ✅ |
+| `stream` | ✅ |

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -15,6 +15,11 @@
     "base_url": "https://ai-gateway.helicone.ai/",
     "api_key_env": "HELICONE_API_KEY"
   },
+  "latitude": {
+    "base_url": "https://api.lsh.ai/v1",
+    "api_key_env": "LATITUDE_API_KEY",
+    "api_base_env": "LATITUDE_API_BASE"
+  },
   "veniceai": {
     "base_url": "https://api.venice.ai/api/v1",
     "api_key_env": "VENICE_AI_API_KEY"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -19633,6 +19633,84 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "latitude/deepseek-r1-distill-14b": {
+        "input_cost_per_token": 1.44e-06,
+        "litellm_provider": "latitude",
+        "max_input_tokens": 64000,
+        "max_output_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.44e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "latitude/gemma-2-27b": {
+        "input_cost_per_token": 4.5e-07,
+        "litellm_provider": "latitude",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "latitude/llama-3.1-8b": {
+        "input_cost_per_token": 1.6e-07,
+        "litellm_provider": "latitude",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.6e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "latitude/qwen-2.5-7b": {
+        "input_cost_per_token": 2.7e-07,
+        "litellm_provider": "latitude",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.7e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "latitude/qwen-2.5-vl-7b": {
+        "input_cost_per_token": 3.6e-07,
+        "litellm_provider": "latitude",
+        "max_input_tokens": 32768,
+        "max_output_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 3.6e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "latitude/qwen2.5-coder-32b": {
+        "input_cost_per_token": 7.2e-07,
+        "litellm_provider": "latitude",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 7.2e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "latitude/qwen3-32b": {
+        "input_cost_per_token": 4.5e-07,
+        "litellm_provider": "latitude",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 9e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "j2-light": {
         "input_cost_per_token": 3e-06,
         "litellm_provider": "ai21",


### PR DESCRIPTION
## Summary
Adds [Latitude AI](https://latitude.sh) as a new OpenAI-compatible inference provider.

Latitude is a GPU cloud provider offering inference APIs for open-source LLMs with competitive pricing.

## Changes
- Add Latitude to `litellm/llms/openai_like/providers.json`
- Add model pricing for 7 models in `model_prices_and_context_window.json`
- Add documentation in `docs/my-website/docs/providers/latitude.md`

## Models Added
| Model | Context | Max Output | Price (input/output per 1M) |
|-------|---------|------------|----------------------------|
| `latitude/qwen-2.5-7b` | 131K | 8K | $0.27 / $0.27 |
| `latitude/llama-3.1-8b` | 128K | 8K | $0.16 / $0.16 |
| `latitude/qwen3-32b` | 131K | 8K | $0.45 / $0.90 |
| `latitude/gemma-2-27b` | 8K | 8K | $0.45 / $0.45 |
| `latitude/deepseek-r1-distill-14b` | 64K | 8K | $1.44 / $1.44 |
| `latitude/qwen2.5-coder-32b` | 131K | 8K | $0.72 / $0.72 |
| `latitude/qwen-2.5-vl-7b` | 32K | 8K | $0.36 / $0.36 |

## Features Supported
- ✅ Streaming
- ✅ Tool/function calling
- ✅ JSON mode / structured output
- ✅ Vision (qwen-2.5-vl-7b)

## API Details
- **Base URL:** `https://api.lsh.ai/v1`
- **Auth:** Bearer token via `LATITUDE_API_KEY`
- **Docs:** https://latitude.sh

## Usage Example
\`\`\`python
import litellm
import os

os.environ["LATITUDE_API_KEY"] = "lat_..."

response = litellm.completion(
    model="latitude/qwen-2.5-7b",
    messages=[{"role": "user", "content": "Hello!"}]
)
\`\`\`

## Testing
Tested against the live API endpoint.