### PR TITLE
fix(containers): Fix Python 3.10 compatibility for OpenAIContainerConfig

### DIFF
--- a/litellm/llms/openai/containers/transformation.py
+++ b/litellm/llms/openai/containers/transformation.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     BaseLLMException = _BaseLLMException
 else:
     LiteLLMLoggingObj = Any
-    BaseContainerConfig = Any
+    from ...base_llm.containers.transformation import BaseContainerConfig
     BaseLLMException = Any
 
 

--- a/litellm/llms/openai/containers/transformation.py
+++ b/litellm/llms/openai/containers/transformation.py
@@ -16,20 +16,17 @@ from litellm.types.containers.main import (
 )
 from litellm.types.router import GenericLiteLLMParams
 
+from ...base_llm.containers.transformation import BaseContainerConfig
+
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
 
     from ...base_llm.chat.transformation import BaseLLMException as _BaseLLMException
-    from ...base_llm.containers.transformation import (
-        BaseContainerConfig as _BaseContainerConfig,
-    )
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
-    BaseContainerConfig = _BaseContainerConfig
     BaseLLMException = _BaseLLMException
 else:
     LiteLLMLoggingObj = Any
-    from ...base_llm.containers.transformation import BaseContainerConfig
     BaseLLMException = Any
 
 


### PR DESCRIPTION
## Relevant issues

Fixes #19727

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - Existing tests in `tests/test_litellm/containers/test_container_api.py` cover this - they import `OpenAIContainerConfig` and fail on Python 3.10 without this fix
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Summary

LiteLLM's `pyproject.toml` specifies `python = ">=3.9,<4.0"`, supporting Python 3.9+. However, running `make test-unit` on Python 3.10 fails with:

```
TypeError: Cannot subclass typing.Any
```

`typing.Any` is a special type that tells type checkers "don't verify types here". According to the [Python docs](https://docs.python.org/3.11/library/typing.html#typing.Any):

> **Changed in version 3.11:** `Any` can now be used as a base class. This can be useful for avoiding type checker errors with classes that can duck type anywhere or are highly dynamic.

### Solution

Import the actual `BaseContainerConfig` class at runtime instead of using `Any` as a placeholder:

```python
else:
    LiteLLMLoggingObj = Any
    from ...base_llm.containers.transformation import BaseContainerConfig  # Import real class
    BaseLLMException = Any
```

### Verification

Tested on Python 3.10:

12 container tests pass after the fix.