### PR TITLE
fix(register_model): handle openrouter models without '/' in name

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2780,7 +2780,7 @@ def register_model(model_cost: Union[str, dict]):  # noqa: PLR0915
         elif value.get("litellm_provider") == "openrouter":
             split_string = key.split("/", 1)
             if key not in litellm.openrouter_models:
-                litellm.openrouter_models.add(split_string[1])
+                litellm.openrouter_models.add(split_string[-1])
         elif value.get("litellm_provider") == "vercel_ai_gateway":
             if key not in litellm.vercel_ai_gateway_models:
                 litellm.vercel_ai_gateway_models.add(key)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2779,7 +2779,7 @@ def register_model(model_cost: Union[str, dict]):  # noqa: PLR0915
                 litellm.anthropic_models.add(key)
         elif value.get("litellm_provider") == "openrouter":
             split_string = key.split("/", 1)
-            if key not in litellm.openrouter_models:
+            if split_string[-1] not in litellm.openrouter_models:
                 litellm.openrouter_models.add(split_string[-1])
         elif value.get("litellm_provider") == "vercel_ai_gateway":
             if key not in litellm.vercel_ai_gateway_models:


### PR DESCRIPTION
## Relevant issues

Fixes #18936

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

The code required model names always have format `openrouter/model-name`:

For example:
- `"openrouter/gpt-4".split("/", 1)` → `["openrouter", "gpt-4"]` → `[1]` works ✅
- `"my-custom-alias".split("/", 1)` → `["my-custom-alias"]` → `[1]` do not work 

### Fix

Changed `split_string[1]` to `split_string[-1]` which returns the last element:

- `["openrouter", "gpt-4"][-1]` → `"gpt-4"` ✅
- `["my-custom-alias"][-1]` → `"my-custom-alias"` ✅

This maintains backward compatibility for models with `/` while fixing for models without it.

### Test

Added `test_register_model_openrouter_without_slash` covering:
1. Model name without `/` (the bug case)
2. Model name with single `/` (`openrouter/model`)
3. Model name with double `/` (`openrouter/provider/model`)