### PR TITLE
Make test_get_users_key_count deterministic by creating dedicated test user

### DIFF
--- a/tests/proxy_admin_ui_tests/test_key_management.py
+++ b/tests/proxy_admin_ui_tests/test_key_management.py
@@ -473,18 +473,41 @@ async def test_get_users_key_count(prisma_client):
     setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
     await litellm.proxy.proxy_server.prisma_client.connect()
 
-    # Get initial user list and select the first user
-    initial_users = await get_users(role=None, page=1, page_size=20)
+    # Create a test user with no initial keys to ensure deterministic behavior
+    test_user_id = f"test_user_key_count-{uuid.uuid4()}"
+    test_user_request = NewUserRequest(
+        user_id=test_user_id,
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        auto_create_key=False,  # Ensure we start with 0 keys
+    )
+
+    await new_user(
+        test_user_request,
+        UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+            api_key="sk-1234",
+            user_id="admin",
+        ),
+    )
+
+    # Get initial key count for the test user
+    initial_users = await get_users(
+        user_ids=test_user_id,
+        role=None,
+        page=1,
+        page_size=20,
+    )
     print("initial_users", initial_users)
-    assert len(initial_users["users"]) > 0, "No users found to test with"
-
+    assert len(initial_users["users"]) == 1, "Test user should be found"
     test_user = initial_users["users"][0]
+    assert test_user.user_id == test_user_id
     initial_key_count = test_user.key_count
+    assert initial_key_count == 0, f"Expected initial key count to be 0, but got {initial_key_count}"
 
-    # Create a new key for the selected user
+    # Create a new key for the test user
     new_key = await generate_key_fn(
         data=GenerateKeyRequest(
-            user_id=test_user.user_id,
+            user_id=test_user_id,
             key_alias=f"test_key_{uuid.uuid4()}",
             models=["fake-model"],
         ),
@@ -496,18 +519,25 @@ async def test_get_users_key_count(prisma_client):
     )
 
     # Get updated user list and check key count
-    updated_users = await get_users(role=None, page=1, page_size=20)
+    updated_users = await get_users(
+        user_ids=test_user_id,
+        role=None,
+        page=1,
+        page_size=20,
+    )
     print("updated_users", updated_users)
-    updated_key_count = None
-    for user in updated_users["users"]:
-        if user.user_id == test_user.user_id:
-            updated_key_count = user.key_count
-            break
+    assert len(updated_users["users"]) == 1, "Test user should still be found"
+    updated_user = updated_users["users"][0]
+    updated_key_count = updated_user.key_count
 
-    assert updated_key_count is not None, "Test user not found in updated users list"
     assert (
         updated_key_count == initial_key_count + 1
     ), f"Expected key count to increase by 1, but got {updated_key_count} (was {initial_key_count})"
+
+    # Clean up test user and keys
+    await prisma_client.db.litellm_usertable.delete(
+        where={"user_id": test_user_id}
+    )
 
 
 async def cleanup_existing_teams(prisma_client):


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

✅ Test

## Changes

- Create a test user with auto_create_key=False to ensure known starting state
- Filter get_users by user_ids to target only the test user
- Verify initial key count is 0 before creating a key
- Clean up test user after test completes
- This ensures consistent behavior across CI and local environments

