### PR TITLE
Fix(#19781): Unable to reset user max budget to unlimited 

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -851,6 +851,13 @@ class GenerateRequestBase(LiteLLMPydanticObjectBase):
     aliases: Optional[dict] = {}
     object_permission: Optional[LiteLLM_ObjectPermissionBase] = None
 
+    @field_validator("max_budget", mode="before")
+    @classmethod
+    def check_max_budget(cls, v):
+        if v == "":
+            return None
+        return v
+
 
 class AllowedVectorStoreIndexItem(LiteLLMPydanticObjectBase):
     index_name: str

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -814,7 +814,9 @@ def _update_internal_user_params(
 ) -> dict:
     non_default_values = {}
     for k, v in data_json.items():
-        if (
+        if k == "max_budget":
+            non_default_values[k] = v
+        elif (
             v is not None
             and v
             not in (


### PR DESCRIPTION
## Relevant issues

Fixes #19781 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Issue 

Previously, attempting to clear the `max_budget` field (sending an empty string `""` from the frontend) resulted in two errors:

1. **Validation Error:** The API would return a `float_parsing` error because Pydantic could not coerce `""` to a float.
2. **Logic Error:** Even if `null` was sent, the backend update logic explicitly ignored `None` values, making it impossible to unset the budget in the database.

## Changes

* **Input Sanitization:** Added a `field_validator` to the `GenerateRequestBase` model. This validator intercepts empty strings `""` for `max_budget` and converts them to `None` before Pydantic attempts to parse them as floats.
* **Update Logic:** Modified `_update_internal_user_params` in `litellm/proxy/management_endpoints/internal_user_endpoints.py`. The function now explicitly checks for `max_budget` in the request keys and allows `None` values to pass through to the database update, ensuring the budget is correctly reset to `NULL`.

<img width="1728" height="1117" alt="SCR-20260126-ujim" src="https://github.com/user-attachments/assets/80f900b5-fbfc-4dd0-a43c-6a20647f0ae6" />
<img width="1728" height="1117" alt="SCR-20260126-ukdb" src="https://github.com/user-attachments/assets/dff68b90-ad60-49f7-ab8d-b79d6078a89e" />

## Testcases

I have added new unit tests to `tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py` covering the following scenarios:

- **Validator Test:** Verifies that `GenerateRequestBase` correctly converts `""` to `None`.
- **Logic Test:** Verifies that `_update_internal_user_params` correctly includes `max_budget: None` in the update payload when explicitly requested.
- **Regression Test:** Verifies that other fields with `None` values (like `user_alias`) are still correctly ignored by the filter.
