### PR TITLE
Add test for Router.get_valid_args, fix router code coverage encoding

### DIFF
--- a/tests/code_coverage_tests/router_code_coverage.py
+++ b/tests/code_coverage_tests/router_code_coverage.py
@@ -6,7 +6,7 @@ def get_function_names_from_file(file_path):
     """
     Extracts all function names from a given Python file.
     """
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         tree = ast.parse(file.read())
 
     function_names = []
@@ -45,7 +45,7 @@ def get_all_functions_called_in_tests(base_dir):
                 if file.endswith(".py") and "router" in file.lower():
                     print("file: ", file)
                     file_path = os.path.join(root, file)
-                    with open(file_path, "r") as f:
+                    with open(file_path, "r", encoding="utf-8") as f:
                         try:
                             tree = ast.parse(f.read())
                         except SyntaxError:

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -2169,3 +2169,32 @@ def test_resolve_model_name_from_model_id():
 
     result = router.resolve_model_name_from_model_id("gpt-3.5-turbo")
     assert result == "gpt-3.5-turbo"
+
+
+def test_get_valid_args():
+    """Test get_valid_args static method returns valid Router.__init__ arguments"""
+    # Call the static method
+    valid_args = Router.get_valid_args()
+    
+    # Verify it returns a list
+    assert isinstance(valid_args, list)
+    assert len(valid_args) > 0
+    
+    # Verify it contains expected Router.__init__ arguments
+    expected_args = [
+        "model_list",
+        "routing_strategy",
+        "cache_responses",
+        "num_retries",
+        "timeout",
+        "fallbacks",
+    ]
+    for arg in expected_args:
+        assert arg in valid_args, f"Expected argument '{arg}' not found in valid_args"
+    
+    # Verify "self" is not in the list (since it's removed)
+    assert "self" not in valid_args
+    
+    # Verify it contains keyword-only arguments too
+    # These are common Router.__init__ parameters
+    assert "assistants_config" in valid_args or "search_tools" in valid_args


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

✅ Test

## Changes

- Add test_get_valid_args in test_router_helper_utils.py to cover get_valid_args
- Use encoding='utf-8' in router_code_coverage.py for cross-platform file reads

