### PR TITLE
fix(responses): fix custom_llm_provider for provider-specific params

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -434,6 +434,8 @@ async def aresponses(
             _, custom_llm_provider, _, _ = litellm.get_llm_provider(
                 model=model, api_base=local_vars.get("base_url", None)
             )
+            # Update local_vars with detected provider (fixes #19782)
+            local_vars["custom_llm_provider"] = custom_llm_provider
 
         func = partial(
             responses,
@@ -582,6 +584,9 @@ def responses(
             api_base=litellm_params.api_base,
             api_key=litellm_params.api_key,
         )
+
+        # Update local_vars with detected provider (fixes #19782)
+        local_vars["custom_llm_provider"] = custom_llm_provider
 
         # Use dynamic credentials from get_llm_provider (e.g., when use_litellm_proxy=True)
         if dynamic_api_key is not None:
@@ -1411,6 +1416,8 @@ async def acompact_responses(
             _, custom_llm_provider, _, _ = litellm.get_llm_provider(
                 model=model, api_base=local_vars.get("base_url", None)
             )
+            # Update local_vars with detected provider (fixes #19782)
+            local_vars["custom_llm_provider"] = custom_llm_provider
 
         func = partial(
             compact_responses,
@@ -1497,6 +1504,9 @@ def compact_responses(
             api_base=litellm_params.api_base,
             api_key=litellm_params.api_key,
         )
+
+        # Update local_vars with detected provider (fixes #19782)
+        local_vars["custom_llm_provider"] = custom_llm_provider
 
         # Use dynamic credentials from get_llm_provider (e.g., when use_litellm_proxy=True)
         if dynamic_api_key is not None:

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -309,3 +309,46 @@ class TestResponseAPILoggingUtils:
         assert result.completion_tokens_details.reasoning_tokens == 30
         assert result.completion_tokens_details.image_tokens == 100
         assert result.completion_tokens_details.text_tokens == 70
+
+
+class TestResponsesAPIProviderSpecificParams:
+    """
+    Tests for fix #19782: provider-specific params (aws_*, vertex_*) should work
+    without explicitly passing custom_llm_provider.
+    """
+
+    def test_provider_specific_params_no_crash_with_bedrock(self):
+        """Test that processing aws_* params with bedrock provider doesn't crash."""
+        params = {
+            "temperature": 0.7,
+            "custom_llm_provider": "bedrock",
+            "kwargs": {"aws_region_name": "eu-central-1"},
+        }
+
+        # Should not raise any exception
+        result = ResponsesAPIRequestUtils.get_requested_response_api_optional_param(params)
+        assert "temperature" in result
+
+    def test_provider_specific_params_no_crash_with_openai(self):
+        """Test that processing aws_* params with openai provider doesn't crash."""
+        params = {
+            "temperature": 0.7,
+            "custom_llm_provider": "openai",
+            "kwargs": {"aws_region_name": "eu-central-1"},
+        }
+
+        # Should not raise any exception
+        result = ResponsesAPIRequestUtils.get_requested_response_api_optional_param(params)
+        assert "temperature" in result
+
+    def test_provider_specific_params_no_crash_with_vertex_ai(self):
+        """Test that processing vertex_* params with vertex_ai provider doesn't crash."""
+        params = {
+            "temperature": 0.7,
+            "custom_llm_provider": "vertex_ai",
+            "kwargs": {"vertex_project": "my-project"},
+        }
+
+        # Should not raise any exception
+        result = ResponsesAPIRequestUtils.get_requested_response_api_optional_param(params)
+        assert "temperature" in result


### PR DESCRIPTION
## Relevant issues

Fixes #19782

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

When using the responses API with provider-specific params (`aws_*`, `vertex_*`) without explicitly passing `custom_llm_provider`, the code crashed:

```python
import litellm

# AttributeError: 'NoneType' object has no attribute 'startswith'
litellm.responses(
    model="bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0",
    input=[{"content": "Hello", "role": "user"}],
    aws_region_name="eu-central-1"  # provider-specific param
)
```

`local_vars = locals()` was captured **before** `get_llm_provider()` detected the provider from the model string. So even though `get_llm_provider()` correctly extracted `"bedrock"` from `"bedrock/..."`, `local_vars["custom_llm_provider"]` remained `None`.

### Fix

Update `local_vars["custom_llm_provider"]` after `get_llm_provider()` extracts the provider:

```python
custom_llm_provider = litellm.get_llm_provider(model=model, ...)

# Fix: update local_vars with detected provider
local_vars["custom_llm_provider"] = custom_llm_provider
```

### Affected Provider-Specific Params

| Provider | Params |
|----------|--------|
| Bedrock/SageMaker | `aws_region_name`, `aws_access_key_id`, `aws_secret_access_key`, etc. |
| Vertex AI | `vertex_project`, `vertex_location`, etc. |

### Tests Added

- `tests/test_litellm/responses/test_responses_utils.py::TestResponsesAPIProviderSpecificParams`
  - `test_provider_specific_params_no_crash_with_bedrock`
  - `test_provider_specific_params_no_crash_with_openai`
  - `test_provider_specific_params_no_crash_with_vertex_ai`