### PR TITLE
[Fix] SSO Email Case Sensitivity

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1014,8 +1014,10 @@ async def _get_fuzzy_user_object(
         )
 
     if response is None and user_email is not None:
+        # Use case-insensitive query to handle emails with different casing
+        # This matches the pattern used in _check_duplicate_user_email
         response = await prisma_client.db.litellm_usertable.find_first(
-            where={"user_email": user_email},
+            where={"user_email": {"equals": user_email, "mode": "insensitive"}},
             include={"organization_memberships": True},
         )
 

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -93,6 +93,26 @@ else:
 router = APIRouter()
 
 
+def normalize_email(email: Optional[str]) -> Optional[str]:
+    """
+    Normalize email address to lowercase for consistent storage and comparison.
+    
+    Email addresses should be treated as case-insensitive for SSO purposes,
+    even though RFC 5321 technically allows case-sensitive local parts.
+    This prevents issues where SSO providers return emails with different casing
+    than what's stored in the database.
+    
+    Args:
+        email: Email address to normalize, can be None
+        
+    Returns:
+        Lowercased email address, or None if input is None
+    """
+    if email is None:
+        return None
+    return email.lower() if isinstance(email, str) else email
+
+
 def determine_role_from_groups(
     user_groups: List[str],
     role_mappings: "RoleMappings",
@@ -390,7 +410,7 @@ def generic_response_convertor(
         display_name=get_nested_value(
             response, generic_user_display_name_attribute_name
         ),
-        email=get_nested_value(response, generic_user_email_attribute_name),
+        email=normalize_email(get_nested_value(response, generic_user_email_attribute_name)),
         first_name=get_nested_value(response, generic_user_first_name_attribute_name),
         last_name=get_nested_value(response, generic_user_last_name_attribute_name),
         provider=get_nested_value(response, generic_provider_attribute_name),
@@ -688,7 +708,7 @@ async def get_user_info_from_db(
             if _id is not None and isinstance(_id, str):
                 potential_user_ids.append(_id)
 
-        user_email = (
+        user_email = normalize_email(
             getattr(result, "email", None)
             if not isinstance(result, dict)
             else result.get("email", None)
@@ -763,8 +783,8 @@ def _build_sso_user_update_data(
 
     Returns:
         dict: Update data containing user_email and optionally user_role if valid
-    """
-    update_data: dict = {"user_email": user_email}
+        """
+    update_data: dict = {"user_email": normalize_email(user_email)}
 
     # Get SSO role from result and include if valid
     sso_role = getattr(result, "user_role", None)
@@ -1266,7 +1286,7 @@ async def insert_sso_user(
 
     new_user_request = NewUserRequest(
         user_id=user_defined_values["user_id"],
-        user_email=user_defined_values["user_email"],
+        user_email=normalize_email(user_defined_values["user_email"]),
         user_role=user_defined_values["user_role"],  # type: ignore
         max_budget=user_defined_values["max_budget"],
         budget_duration=user_defined_values["budget_duration"],
@@ -1931,7 +1951,7 @@ class SSOAuthenticationHandler:
         """
         Gets the user email and id from the OpenID result after validating the email domain
         """
-        user_email: Optional[str] = getattr(result, "email", None)
+        user_email: Optional[str] = normalize_email(getattr(result, "email", None))
         user_id: Optional[str] = (
             getattr(result, "id", None) if result is not None else None
         )
@@ -1970,7 +1990,7 @@ class SSOAuthenticationHandler:
                 "GENERIC_USER_ROLE_ATTRIBUTE", "role"
             )
             user_id = getattr(result, "id", None)
-            user_email = getattr(result, "email", None)
+            user_email = normalize_email(getattr(result, "email", None))
             if user_role is None:
                 _role_from_attr = getattr(result, generic_user_role_attribute_name, None)  # type: ignore
                 if _role_from_attr is not None:
@@ -2363,7 +2383,7 @@ class MicrosoftSSOHandler:
         response = response or {}
         verbose_proxy_logger.debug(f"Microsoft SSO Callback Response: {response}")
         openid_response = CustomOpenID(
-            email=response.get(MICROSOFT_USER_EMAIL_ATTRIBUTE) or response.get("mail"),
+            email=normalize_email(response.get(MICROSOFT_USER_EMAIL_ATTRIBUTE) or response.get("mail")),
             display_name=response.get(MICROSOFT_USER_DISPLAY_NAME_ATTRIBUTE),
             provider="microsoft",
             id=response.get(MICROSOFT_USER_ID_ATTRIBUTE),

--- a/tests/proxy_unit_tests/test_auth_checks.py
+++ b/tests/proxy_unit_tests/test_auth_checks.py
@@ -584,7 +584,7 @@ async def test_get_fuzzy_user_object():
     )
     assert result == test_user
     mock_prisma.db.litellm_usertable.find_first.assert_called_with(
-        where={"user_email": "test@example.com"},
+        where={"user_email": {"equals": "test@example.com", "mode": "insensitive"}},
         include={"organization_memberships": True},
     )
 
@@ -612,7 +612,7 @@ async def test_get_fuzzy_user_object():
     )
     assert result == test_user
     mock_prisma.db.litellm_usertable.find_first.assert_called_with(
-        where={"user_email": "test@example.com"},
+        where={"user_email": {"equals": "test@example.com", "mode": "insensitive"}},
         include={"organization_memberships": True},
     )
 

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -28,6 +28,7 @@ from litellm.proxy._types import (
 from litellm.proxy.auth.auth_checks import (
     ExperimentalUIJWTToken,
     _can_object_call_vector_stores,
+    _get_fuzzy_user_object,
     _get_team_db_check,
     _virtual_key_max_budget_alert_check,
     _virtual_key_soft_budget_check,
@@ -1277,3 +1278,42 @@ async def test_virtual_key_max_budget_alert_check_scenarios(
     assert (
         alert_triggered == expect_alert
     ), f"Expected alert_triggered to be {expect_alert} for spend={spend}, max_budget={max_budget}"
+
+
+@pytest.mark.asyncio
+async def test_get_fuzzy_user_object_case_insensitive_email():
+    """Test that _get_fuzzy_user_object uses case-insensitive email lookup"""
+    # Setup mock Prisma client
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_usertable = MagicMock()
+
+    # Mock user data with mixed case email
+    test_user = LiteLLM_UserTable(
+        user_id="test_123",
+        sso_user_id=None,
+        user_email="Test@Example.com",  # Mixed case in DB
+        organization_memberships=[],
+        max_budget=None,
+    )
+
+    # Test: SSO ID not found, find by email with different casing
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=test_user)
+
+    # Search with lowercase email (different from DB)
+    result = await _get_fuzzy_user_object(
+        prisma_client=mock_prisma,
+        sso_user_id=None,
+        user_email="test@example.com",  # Lowercase search
+    )
+
+    # Verify user was found despite case difference
+    assert result == test_user
+
+    # Verify the query used case-insensitive mode
+    mock_prisma.db.litellm_usertable.find_first.assert_called_once()
+    call_args = mock_prisma.db.litellm_usertable.find_first.call_args
+    assert call_args.kwargs["where"]["user_email"]["equals"] == "test@example.com"
+    assert call_args.kwargs["where"]["user_email"]["mode"] == "insensitive"
+    assert call_args.kwargs["include"] == {"organization_memberships": True}


### PR DESCRIPTION
## Relevant issues
This PR fixes the case sensitivity issue experienced with some users signing in via SSO.

The root cause is we are not normalizing emails when users sign in via SSO, but we are enforcing lower cased emails when checking for duplicate user emails. This leads to issues when SSO provides an email such as EXAMPLE@example.com, but the user's email was previously example@example.com (lowercase). The PR fixes this by normalizing (lowercasing emails) in the same way we check for duplicate users
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="1066" height="242" alt="image" src="https://github.com/user-attachments/assets/828ce206-7a44-4cb3-910e-ba006088a437" />
