### PR TITLE
fix(anthropic): properly handle OAuth tokens (sk-ant-oat*) across all…

### DIFF
--- a/litellm/llms/anthropic/batches/transformation.py
+++ b/litellm/llms/anthropic/batches/transformation.py
@@ -42,18 +42,19 @@ class AnthropicBatchesConfig(BaseBatchesConfig):
         api_base: Optional[str] = None,
     ) -> dict:
         """Validate and prepare environment-specific headers and parameters."""
+        from ..common_utils import set_anthropic_headers
+
         # Resolve api_key from environment if not provided
         api_key = api_key or self.anthropic_model_info.get_api_key()
         if api_key is None:
             raise ValueError(
                 "Missing Anthropic API Key - A call is being made to anthropic but no key is set either in the environment variables or via params"
             )
-        _headers = {
+        _headers = set_anthropic_headers(api_key, {
             "accept": "application/json",
             "anthropic-version": "2023-06-01",
             "content-type": "application/json",
-            "x-api-key": api_key,
-        }
+        })
         # Add beta header for message batches
         if "anthropic-beta" not in headers:
             headers["anthropic-beta"] = "message-batches-2024-09-24"

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -57,9 +57,13 @@ def set_anthropic_headers(api_key: str, headers: Optional[dict] = None) -> dict:
     """
     result = dict(headers) if headers else {}
     if is_anthropic_oauth_key(api_key):
-        result["authorization"] = f"Bearer {api_key}"
+        if api_key.lower().startswith("bearer "):
+            result["authorization"] = api_key
+        else:
+            result["authorization"] = f"Bearer {api_key}"
     else:
         result["x-api-key"] = api_key
+        
     return result
 
 

--- a/litellm/llms/anthropic/completion/transformation.py
+++ b/litellm/llms/anthropic/completion/transformation.py
@@ -91,16 +91,17 @@ class AnthropicTextConfig(BaseConfig):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
     ) -> dict:
+        from litellm.llms.anthropic.common_utils import set_anthropic_headers
+
         if api_key is None:
             raise ValueError(
                 "Missing Anthropic API Key - A call is being made to anthropic but no key is set either in the environment variables or via params"
             )
-        _headers = {
+        _headers = set_anthropic_headers(api_key, {
             "accept": "application/json",
             "anthropic-version": "2023-06-01",
             "content-type": "application/json",
-            "x-api-key": api_key,
-        }
+        })
         headers.update(_headers)
         return headers
 

--- a/litellm/llms/anthropic/count_tokens/transformation.py
+++ b/litellm/llms/anthropic/count_tokens/transformation.py
@@ -7,6 +7,7 @@ This module handles the transformation of requests to Anthropic's CountTokens AP
 from typing import Any, Dict, List
 
 from litellm.constants import ANTHROPIC_TOKEN_COUNTING_BETA_VERSION
+from litellm.llms.anthropic.common_utils import set_anthropic_headers
 
 
 class AnthropicCountTokensConfig:
@@ -63,12 +64,11 @@ class AnthropicCountTokensConfig:
         Returns:
             Dictionary of required headers
         """
-        return {
+        return set_anthropic_headers(api_key, {
             "Content-Type": "application/json",
-            "x-api-key": api_key,
             "anthropic-version": "2023-06-01",
             "anthropic-beta": ANTHROPIC_TOKEN_COUNTING_BETA_VERSION,
-        }
+        })
 
     def validate_request(
         self, model: str, messages: List[Dict[str, Any]]

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -21,6 +21,7 @@ from ...common_utils import (
     AnthropicError,
     AnthropicModelInfo,
     optionally_handle_anthropic_oauth,
+    set_anthropic_headers,
 )
 
 DEFAULT_ANTHROPIC_API_BASE = "https://api.anthropic.com"
@@ -78,8 +79,10 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         if api_key is None:
             api_key = os.getenv("ANTHROPIC_API_KEY")
 
-        if "x-api-key" not in headers and api_key:
-            headers["x-api-key"] = api_key
+        # Case-insensitive check for existing auth headers
+        headers_lower = {k.lower(): v for k, v in headers.items()}
+        if "x-api-key" not in headers_lower and "authorization" not in headers_lower and api_key:
+            headers.update(set_anthropic_headers(api_key))
         if "anthropic-version" not in headers:
             headers["anthropic-version"] = DEFAULT_ANTHROPIC_API_VERSION
         if "content-type" not in headers:

--- a/litellm/llms/anthropic/files/handler.py
+++ b/litellm/llms/anthropic/files/handler.py
@@ -22,7 +22,7 @@ from litellm.types.llms.openai import (
 from litellm.types.utils import CallTypes, LlmProviders, ModelResponse
 
 from ..chat.transformation import AnthropicConfig
-from ..common_utils import AnthropicModelInfo
+from ..common_utils import AnthropicModelInfo, set_anthropic_headers
 
 # Map Anthropic error types to HTTP status codes
 ANTHROPIC_ERROR_STATUS_CODE_MAP = {
@@ -94,11 +94,10 @@ class AnthropicFilesHandler:
         results_url = f"{api_base.rstrip('/')}/v1/messages/batches/{batch_id}/results"
 
         # Prepare headers
-        headers = {
+        headers = set_anthropic_headers(api_key, {
             "accept": "application/json",
             "anthropic-version": "2023-06-01",
-            "x-api-key": api_key,
-        }
+        })
 
         # Make the request to Anthropic
         async_client = get_async_httpx_client(llm_provider=LlmProviders.ANTHROPIC)

--- a/litellm/llms/anthropic/skills/transformation.py
+++ b/litellm/llms/anthropic/skills/transformation.py
@@ -33,7 +33,7 @@ class AnthropicSkillsConfig(BaseSkillsAPIConfig):
         self, headers: dict, litellm_params: Optional[GenericLiteLLMParams]
     ) -> dict:
         """Add Anthropic-specific headers"""
-        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo, set_anthropic_headers
 
         # Get API key
         api_key = None
@@ -45,7 +45,7 @@ class AnthropicSkillsConfig(BaseSkillsAPIConfig):
             raise ValueError("ANTHROPIC_API_KEY is required for Skills API")
 
         # Add required headers
-        headers["x-api-key"] = api_key
+        headers.update(set_anthropic_headers(api_key))
         headers["anthropic-version"] = "2023-06-01"
         
         # Add beta header for skills API

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -26,6 +26,7 @@ _SPECIAL_HEADERS_CACHE = frozenset(
 )
 from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.router import Router
+from litellm.llms.anthropic.common_utils import is_anthropic_oauth_key
 from litellm.types.llms.anthropic import ANTHROPIC_API_HEADERS
 from litellm.types.services import ServiceTypes
 from litellm.types.utils import (
@@ -320,6 +321,7 @@ class LiteLLMProxyRequestSetup:
         Looks for any `x-` headers and sends them to the LLM Provider.
 
         [07/09/2025] - Support 'anthropic-beta' header as well.
+        [01/26/2026] - Support 'authorization' header for Anthropic OAuth tokens.
         """
         forwarded_headers = {}
         for header, value in headers.items():
@@ -328,6 +330,9 @@ class LiteLLMProxyRequestSetup:
             ):  # causes openai sdk to fail
                 forwarded_headers[header] = value
             elif header.lower().startswith("anthropic-beta"):
+                forwarded_headers[header] = value
+            elif header.lower() == "authorization" and is_anthropic_oauth_key(value):
+                # Forward Authorization header for Anthropic OAuth tokens (sk-ant-oat*)
                 forwarded_headers[header] = value
 
         return forwarded_headers

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -594,11 +594,30 @@ async def anthropic_proxy_route(
     base_url = httpx.URL(base_target_url)
     updated_url = base_url.copy_with(path=encoded_endpoint)
 
-    # Add or update query parameters
-    anthropic_api_key = passthrough_endpoint_router.get_credentials(
-        custom_llm_provider="anthropic",
-        region_name=None,
+    # Check for OAuth token in incoming request, otherwise use stored credentials
+    from litellm.llms.anthropic.common_utils import (
+        optionally_handle_anthropic_oauth,
+        set_anthropic_headers,
     )
+
+    incoming_headers = dict(request.headers)
+    oauth_headers, oauth_api_key = optionally_handle_anthropic_oauth(
+        headers=incoming_headers, api_key=None
+    )
+
+    if oauth_api_key:
+        # OAuth token found - use Authorization header with OAuth beta headers
+        custom_headers = set_anthropic_headers(oauth_api_key)
+        custom_headers["anthropic-dangerous-direct-browser-access"] = oauth_headers.get(
+            "anthropic-dangerous-direct-browser-access", "true"
+        )
+    else:
+        # No OAuth token - use stored API key with x-api-key
+        anthropic_api_key = passthrough_endpoint_router.get_credentials(
+            custom_llm_provider="anthropic",
+            region_name=None,
+        )
+        custom_headers = {"x-api-key": "{}".format(anthropic_api_key)}
 
     ## check for streaming
     is_streaming_request = await is_streaming_request_fn(request)
@@ -607,7 +626,7 @@ async def anthropic_proxy_route(
     endpoint_func = create_pass_through_route(
         endpoint=endpoint,
         target=str(updated_url),
-        custom_headers={"x-api-key": "{}".format(anthropic_api_key)},
+        custom_headers=custom_headers,
         _forward_headers=True,
         is_streaming_request=is_streaming_request,
     )  # dynamically construct pass-through endpoint based on incoming path

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -5,6 +5,8 @@ Tests for Anthropic OAuth token handling for Claude Code Max integration.
 import os
 import sys
 
+from litellm.llms.anthropic.common_utils import is_anthropic_oauth_key
+
 # Add litellm to path
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
@@ -19,7 +21,7 @@ def test_oauth_detection_in_common_utils():
     headers = {"authorization": f"Bearer {FAKE_OAUTH_TOKEN}"}
     updated_headers, extracted_api_key = optionally_handle_anthropic_oauth(headers, None)
 
-    assert extracted_api_key == FAKE_OAUTH_TOKEN
+    assert is_anthropic_oauth_key(extracted_api_key)
     assert updated_headers["anthropic-beta"] == "oauth-2025-04-20"
     assert updated_headers["anthropic-dangerous-direct-browser-access"] == "true"
 
@@ -41,7 +43,9 @@ def test_oauth_integration_in_validate_environment():
         api_base=None,
     )
 
-    assert updated_headers["x-api-key"] == FAKE_OAUTH_TOKEN
+    # OAuth should use Authorization header, not x-api-key
+    assert "x-api-key" not in updated_headers
+    assert "authorization" in updated_headers
     assert updated_headers["anthropic-dangerous-direct-browser-access"] == "true"
 
 
@@ -64,7 +68,9 @@ def test_oauth_detection_in_messages_transformation():
         api_base=None,
     )
 
-    assert updated_headers["x-api-key"] == FAKE_OAUTH_TOKEN
+    # OAuth should use Authorization header, not x-api-key
+    assert "x-api-key" not in updated_headers
+    assert "authorization" in updated_headers
     assert "oauth-2025-04-20" in updated_headers["anthropic-beta"]
     assert updated_headers["anthropic-dangerous-direct-browser-access"] == "true"
 
@@ -82,3 +88,94 @@ def test_regular_api_keys_still_work():
     assert extracted_api_key == regular_key
     # OAuth headers should NOT be added
     assert "anthropic-dangerous-direct-browser-access" not in updated_headers
+
+
+def test_is_anthropic_oauth_key_formats():
+    """Test 5: is_anthropic_oauth_key handles both raw and Bearer formats"""
+    # Raw token format (after extraction from Authorization header)
+    assert is_anthropic_oauth_key(FAKE_OAUTH_TOKEN) is True
+
+    # Bearer token format (from Authorization header)
+    assert is_anthropic_oauth_key(f"Bearer {FAKE_OAUTH_TOKEN}") is True
+
+    # Case insensitive Bearer
+    assert is_anthropic_oauth_key(f"bearer {FAKE_OAUTH_TOKEN}") is True
+    assert is_anthropic_oauth_key(f"BEARER {FAKE_OAUTH_TOKEN}") is True
+
+    # Regular API keys should return False
+    assert is_anthropic_oauth_key("sk-ant-api03-regular-key-123") is False
+    assert is_anthropic_oauth_key("Bearer sk-ant-api03-regular-key-123") is False
+
+    # Edge cases
+    assert is_anthropic_oauth_key(None) is False
+    assert is_anthropic_oauth_key("") is False
+    assert is_anthropic_oauth_key("Bearer ") is False
+
+
+def test_oauth_with_direct_api_key():
+    """Test 6: OAuth token passed directly as api_key (not via Authorization header)"""
+    from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+    config = AnthropicModelInfo()
+    headers = {}
+
+    updated_headers = config.validate_environment(
+        headers=headers,
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params={},
+        litellm_params={},
+        api_key=FAKE_OAUTH_TOKEN,  # OAuth token passed directly
+        api_base=None,
+    )
+
+    # OAuth should use Authorization header, not x-api-key
+    assert "x-api-key" not in updated_headers
+    assert "authorization" in updated_headers
+    assert updated_headers["authorization"] == f"Bearer {FAKE_OAUTH_TOKEN}"
+    # OAuth beta headers should also be set
+    assert "oauth-2025-04-20" in updated_headers["anthropic-beta"]
+    assert updated_headers["anthropic-dangerous-direct-browser-access"] == "true"
+
+
+def test_proxy_forwards_oauth_authorization_header():
+    """Test 7: Proxy _get_forwardable_headers forwards OAuth Authorization header"""
+    from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
+
+    # OAuth token in Authorization header should be forwarded
+    oauth_headers = {"authorization": f"Bearer {FAKE_OAUTH_TOKEN}"}
+    forwarded = LiteLLMProxyRequestSetup._get_forwardable_headers(oauth_headers)
+    assert "authorization" in forwarded
+    assert forwarded["authorization"] == f"Bearer {FAKE_OAUTH_TOKEN}"
+
+    # Regular API key in Authorization header should NOT be forwarded
+    regular_headers = {"authorization": "Bearer sk-ant-api03-regular-key-123"}
+    forwarded = LiteLLMProxyRequestSetup._get_forwardable_headers(regular_headers)
+    assert "authorization" not in forwarded
+
+    # x-* headers should still be forwarded
+    x_headers = {"x-custom-header": "value", "authorization": "Bearer sk-regular"}
+    forwarded = LiteLLMProxyRequestSetup._get_forwardable_headers(x_headers)
+    assert "x-custom-header" in forwarded
+    assert "authorization" not in forwarded
+
+
+def test_oauth_case_insensitive_authorization_header():
+    """Test 8: OAuth detection works with different Authorization header cases"""
+    from litellm.llms.anthropic.common_utils import optionally_handle_anthropic_oauth
+
+    # Test with capital 'A' (how HTTP headers typically come through)
+    headers_capital = {"Authorization": f"Bearer {FAKE_OAUTH_TOKEN}"}
+    updated_headers, extracted_api_key = optionally_handle_anthropic_oauth(headers_capital, None)
+    assert is_anthropic_oauth_key(extracted_api_key)
+    assert updated_headers["anthropic-beta"] == "oauth-2025-04-20"
+
+    # Test with lowercase (our test default)
+    headers_lower = {"authorization": f"Bearer {FAKE_OAUTH_TOKEN}"}
+    updated_headers, extracted_api_key = optionally_handle_anthropic_oauth(headers_lower, None)
+    assert is_anthropic_oauth_key(extracted_api_key)
+
+    # Test with mixed case
+    headers_mixed = {"AUTHORIZATION": f"Bearer {FAKE_OAUTH_TOKEN}"}
+    updated_headers, extracted_api_key = optionally_handle_anthropic_oauth(headers_mixed, None)
+    assert is_anthropic_oauth_key(extracted_api_key)

--- a/tests/test_litellm/llms/anthropic/test_anthropic_oauth_manual.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_oauth_manual.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Manual integration tests for Anthropic OAuth token handling.
+
+These tests require a real Anthropic OAuth token and make actual API calls.
+They are skipped by default in CI - run manually with:
+
+    ANTHROPIC_OAUTH_TOKEN=sk-ant-oat... poetry run pytest tests/test_litellm/llms/anthropic/test_anthropic_oauth_manual.py -v -s
+
+Or run as a script:
+
+    poetry run python tests/test_litellm/llms/anthropic/test_anthropic_oauth_manual.py sk-ant-oat...
+"""
+
+import json
+import os
+import sys
+from typing import Any, Dict, Optional
+
+import pytest
+
+# Get OAuth token from env or skip
+OAUTH_TOKEN: Optional[str] = os.getenv("ANTHROPIC_OAUTH_TOKEN")
+
+# Skip all tests if no OAuth token is available
+pytestmark = pytest.mark.skipif(
+    OAUTH_TOKEN is None,
+    reason="ANTHROPIC_OAUTH_TOKEN environment variable not set"
+)
+
+
+def _print_headers(headers: Dict[str, Any], title: str = "Headers") -> None:
+    """Helper to print headers in a readable format."""
+    print(f"\n{title}:")
+    print(json.dumps(headers, indent=2))
+
+
+def _print_response(response: Any, title: str = "Response") -> None:
+    """Helper to print response in a readable format."""
+    print(f"\n{title}:")
+    if hasattr(response, "model_dump"):
+        print(json.dumps(response.model_dump(), indent=2, default=str))
+    elif hasattr(response, "json"):
+        print(json.dumps(response.json(), indent=2, default=str))
+    else:
+        print(json.dumps(dict(response), indent=2, default=str))
+
+
+class TestOAuthPassThroughHeaders:
+    """Test OAuth header transformation for pass-through API."""
+
+    def test_pass_through_headers_transformation(self) -> None:
+        """Verify pass-through correctly transforms OAuth headers."""
+        from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+            AnthropicMessagesConfig,
+        )
+
+        assert OAUTH_TOKEN is not None
+        config = AnthropicMessagesConfig()
+        headers = {"authorization": f"Bearer {OAUTH_TOKEN}"}
+
+        updated_headers, _ = config.validate_anthropic_messages_environment(
+            headers=headers,
+            model="claude-3-haiku-20240307",
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={},
+            api_key=None,
+            api_base=None,
+        )
+
+        _print_headers(updated_headers, "Pass-through Transformed Headers")
+
+        # Verify OAuth headers
+        assert "authorization" in updated_headers
+        assert "x-api-key" not in updated_headers
+        assert "oauth-2025-04-20" in updated_headers.get("anthropic-beta", "")
+        assert updated_headers.get("anthropic-dangerous-direct-browser-access") == "true"
+
+
+class TestOAuthDirectApiKey:
+    """Test OAuth header transformation when token passed as api_key."""
+
+    def test_direct_api_key_headers_transformation(self) -> None:
+        """Verify direct api_key correctly transforms OAuth headers."""
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        assert OAUTH_TOKEN is not None
+        config = AnthropicModelInfo()
+        headers: Dict[str, str] = {}
+
+        updated_headers = config.validate_environment(
+            headers=headers,
+            model="claude-3-haiku-20240307",
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={},
+            api_key=OAUTH_TOKEN,
+            api_base=None,
+        )
+
+        _print_headers(updated_headers, "Direct api_key Transformed Headers")
+
+        # Verify OAuth headers
+        assert "authorization" in updated_headers
+        assert "x-api-key" not in updated_headers
+        assert "oauth-2025-04-20" in updated_headers.get("anthropic-beta", "")
+        assert updated_headers.get("anthropic-dangerous-direct-browser-access") == "true"
+
+
+class TestOAuthRealAPICalls:
+    """Test real API calls with OAuth token."""
+
+    def test_litellm_completion(self) -> None:
+        """Test litellm.completion() with OAuth token."""
+        import litellm
+
+        assert OAUTH_TOKEN is not None
+        response = litellm.completion(
+            model="anthropic/claude-3-haiku-20240307",
+            messages=[{"role": "user", "content": "Say 'OAuth test successful' in exactly 3 words"}],
+            api_key=OAUTH_TOKEN,
+            max_tokens=20,
+        )
+
+        _print_response(response, "litellm.completion Response")
+
+        assert response.choices[0].message.content is not None
+
+    def test_pass_through_api_call(self) -> None:
+        """Test direct API call with pass-through transformed headers."""
+        import httpx
+
+        from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+            AnthropicMessagesConfig,
+        )
+
+        assert OAUTH_TOKEN is not None
+        config = AnthropicMessagesConfig()
+        headers = {"authorization": f"Bearer {OAUTH_TOKEN}"}
+
+        updated_headers, _ = config.validate_anthropic_messages_environment(
+            headers=headers,
+            model="claude-3-haiku-20240307",
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={},
+            api_key=None,
+            api_base=None,
+        )
+
+        response = httpx.post(
+            "https://api.anthropic.com/v1/messages",
+            headers=updated_headers,
+            json={
+                "model": "claude-3-haiku-20240307",
+                "max_tokens": 20,
+                "messages": [{"role": "user", "content": "Say 'pass-through works' in 3 words"}],
+            },
+            timeout=30.0,
+        )
+
+        print(f"\nStatus: {response.status_code}")
+        _print_headers(dict(response.headers), "Response Headers")
+        _print_response(response, "Response Body")
+
+        assert response.status_code == 200
+        assert "content" in response.json()
+
+
+# Allow running as a script
+if __name__ == "__main__":
+    # Get token from CLI arg if provided
+    if len(sys.argv) > 1:
+        OAUTH_TOKEN = sys.argv[1]
+
+    if not OAUTH_TOKEN:
+        print("Usage: python test_anthropic_oauth_manual.py <oauth-token>")
+        print("   or: ANTHROPIC_OAUTH_TOKEN=sk-ant-oat... python test_anthropic_oauth_manual.py")
+        sys.exit(1)
+
+    if not OAUTH_TOKEN.startswith("sk-ant-oat"):
+        print(f"Warning: Token doesn't look like an OAuth token (expected sk-ant-oat prefix)")
+
+    print("Anthropic OAuth Token Manual Test Suite")
+    print(f"Token: {OAUTH_TOKEN[:15]}...{OAUTH_TOKEN[-5:]}")
+    print("=" * 60)
+
+    # Run tests manually
+    test_passthrough = TestOAuthPassThroughHeaders()
+    test_passthrough.test_pass_through_headers_transformation()
+
+    test_direct = TestOAuthDirectApiKey()
+    test_direct.test_direct_api_key_headers_transformation()
+
+    test_api = TestOAuthRealAPICalls()
+    test_api.test_litellm_completion()
+    test_api.test_pass_through_api_call()
+
+    print("\n" + "=" * 60)
+    print("All tests passed!")


### PR DESCRIPTION
## Summary

OAuth tokens require `Authorization` header (not `x-api-key`) plus specific beta headers. This change:

- Adds `is_anthropic_oauth_key()` to detect OAuth token prefix (`sk-ant-oat*`)
- Adds `set_anthropic_headers()` to set correct auth header based on key type
- Updates `optionally_handle_anthropic_oauth()` to handle tokens from both Authorization header and direct `api_key` parameter
- Applies OAuth handling consistently across all Anthropic endpoints: batches, completion, count_tokens, files, skills, and pass-through
- Adds unit tests and manual integration test suite

## Relevant issues

Fixes #19618

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

| File | Change |
|------|--------|
| `litellm/llms/anthropic/common_utils.py` | Added `is_anthropic_oauth_key()`, `set_anthropic_headers()`, updated `optionally_handle_anthropic_oauth()` |
| `litellm/llms/anthropic/batches/transformation.py` | Use `set_anthropic_headers()` for auth |
| `litellm/llms/anthropic/completion/transformation.py` | Use `set_anthropic_headers()` for auth |
| `litellm/llms/anthropic/count_tokens/transformation.py` | Use `set_anthropic_headers()` for auth |
| `litellm/llms/anthropic/files/handler.py` | Use `set_anthropic_headers()` for auth |
| `litellm/llms/anthropic/skills/transformation.py` | Use `set_anthropic_headers()` for auth |
| `litellm/llms/anthropic/experimental_pass_through/messages/transformation.py` | Use `set_anthropic_headers()` for auth |
| `tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py` | 6 unit tests for OAuth handling |
| `tests/test_litellm/llms/anthropic/test_anthropic_oauth_manual.py` | Manual integration tests (skipped in CI) |

## Test plan

- [x] Unit tests pass (`poetry run pytest tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py -v`)
- [x] Manual integration tests verified with real OAuth token
