### PR TITLE
fix: make HTTPHandler mockable in OIDC secret manager tests

### DIFF
--- a/tests/test_litellm/containers/test_container_integration.py
+++ b/tests/test_litellm/containers/test_container_integration.py
@@ -385,10 +385,12 @@ class TestContainerIntegration:
             name="Provider Test Container"
         )
         
-        with patch.object(litellm.main.base_llm_http_handler, 'container_create_handler', return_value=mock_response):
+        with patch.object(litellm.main.base_llm_http_handler, 'container_create_handler', return_value=mock_response) as mock_handler:
             response = create_container(
                 name="Provider Test Container",
                 custom_llm_provider=provider
             )
             
             assert response.name == "Provider Test Container"
+            # Verify the mock was actually called (not making real API calls)
+            mock_handler.assert_called_once()

--- a/tests/test_litellm/containers/test_container_integration.py
+++ b/tests/test_litellm/containers/test_container_integration.py
@@ -357,15 +357,15 @@ class TestContainerIntegration:
 
     def test_error_handling_integration(self):
         """Test error handling in the integration flow."""
-        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
-            # Simulate an API error
-            mock_handler.container_create_handler.side_effect = litellm.APIError(
-                status_code=400,
-                message="API Error occurred", 
-                llm_provider="openai",
-                model=""
-            )
-            
+        # Simulate an API error
+        api_error = litellm.APIError(
+            status_code=400,
+            message="API Error occurred", 
+            llm_provider="openai",
+            model=""
+        )
+        
+        with patch.object(litellm.main.base_llm_http_handler, 'container_create_handler', side_effect=api_error):
             with pytest.raises(litellm.APIError):
                 create_container(
                     name="Error Test Container",
@@ -385,9 +385,7 @@ class TestContainerIntegration:
             name="Provider Test Container"
         )
         
-        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
-            mock_handler.container_create_handler.return_value = mock_response
-            
+        with patch.object(litellm.main.base_llm_http_handler, 'container_create_handler', return_value=mock_response):
             response = create_container(
                 name="Provider Test Container",
                 custom_llm_provider=provider

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -477,6 +477,12 @@ async def test_openai_env_base(
     respx_mock: respx.MockRouter, env_base, openai_api_response, monkeypatch
 ):
     "This tests OpenAI env variables are honored, including legacy OPENAI_API_BASE"
+    # Clear cache to ensure no cached clients from previous tests interfere
+    # This prevents cache pollution where a previous test cached a client with
+    # aiohttp transport, which would bypass respx mocks
+    if hasattr(litellm, "in_memory_llm_clients_cache"):
+        litellm.in_memory_llm_clients_cache.flush_cache()
+    
     # Ensure aiohttp transport is disabled to use httpx which respx can mock
     litellm.disable_aiohttp_transport = True
 


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

✅ Test

## Changes

- Add _get_oidc_http_handler() factory function to make HTTPHandler
  easily mockable in tests
- Update test_oidc_github_success to patch factory function instead
  of HTTPHandler directly
- Update Google OIDC tests for consistency
- Fixes test_oidc_github_success failure where mock was bypassed

This change allows tests to properly mock HTTPHandler instances used
for OIDC token requests, fixing the test failure where the mock was
not being used.
