### PR TITLE
perf: add LRU cache to normalize_request_route

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+from functools import lru_cache
 from typing import Any, List, Optional, Tuple
 
 from fastapi import HTTPException, Request, status
@@ -311,10 +312,11 @@ def get_request_route(request: Request) -> str:
         return request.url.path
 
 
+@lru_cache(maxsize=256)
 def normalize_request_route(route: str) -> str:
     """
     Normalize request routes by replacing dynamic path parameters with placeholders.
-    
+
     This prevents high cardinality in Prometheus metrics by collapsing routes like:
     - /v1/responses/1234567890 -> /v1/responses/{response_id}
     - /v1/threads/thread_123 -> /v1/threads/{thread_id}


### PR DESCRIPTION
Add @lru_cache(maxsize=256) to eliminate redundant regex work for repeated routes. Reduces time from 1.04s to ~0s for 6,006 calls. 

All relevant tests and lint checks pass before and after. 

Before 

<img width="1004" height="124" alt="Screenshot 2026-01-26 at 12 59 13 PM" src="https://github.com/user-attachments/assets/b7c8c156-cc1c-470f-85a4-76331e5e2135" />

After 

<img width="1018" height="55" alt="Screenshot 2026-01-26 at 12 59 37 PM" src="https://github.com/user-attachments/assets/8b1e3178-e1cd-4c11-ad55-29ed2639a376" />

This makes sense because for the benchmarking script it will cache the completions route on the first request and from there reduce the overhead for this function to ~0s because it will hit the cache every time after and not repeat the regex work. 

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

Performance

## Changes
