### PR TITLE
fix: allow tool_choice for Azure GPT-5 chat models

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -19,7 +19,9 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
 
     @classmethod
     def is_model_gpt_5_model(cls, model: str) -> bool:
-        return "gpt-5" in model
+        # gpt-5-chat* behaves like a regular chat model (supports temperature, etc.)
+        # Don't route it through GPT-5 reasoning-specific parameter restrictions.
+        return "gpt-5" in model and "gpt-5-chat" not in model
 
     @classmethod
     def is_model_gpt_5_codex_model(cls, model: str) -> bool:

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -3130,7 +3130,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
-        "supports_tool_choice": false,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "azure/gpt-5-chat-latest": {
@@ -3162,7 +3162,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
-        "supports_tool_choice": false,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "azure/gpt-5-codex": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3130,7 +3130,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
-        "supports_tool_choice": false,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "azure/gpt-5-chat-latest": {
@@ -3162,7 +3162,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
-        "supports_tool_choice": false,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "azure/gpt-5-codex": {

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -16,6 +16,17 @@ def test_azure_gpt5_supports_reasoning_effort(config: AzureOpenAIGPT5Config):
     )
 
 
+def test_azure_gpt5_allows_tool_choice_for_deployment_names():
+    supported_params = litellm.get_supported_openai_params(
+        model="gpt-5-chat-2025-08-07", custom_llm_provider="azure"
+    )
+    assert supported_params is not None
+    assert "tool_choice" in supported_params
+    # gpt-5-chat* should not be treated as a GPT-5 reasoning model
+    assert "reasoning_effort" not in supported_params
+    assert "temperature" in supported_params
+
+
 def test_azure_gpt5_maps_max_tokens(config: AzureOpenAIGPT5Config):
     params = config.map_openai_params(
         non_default_params={"max_tokens": 5},

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -20,6 +20,23 @@ def test_gpt5_supports_reasoning_effort(config: OpenAIConfig):
     assert "reasoning_effort" in config.get_supported_openai_params(model="gpt-5-mini")
 
 
+def test_gpt5_chat_does_not_support_reasoning_effort(config: OpenAIConfig):
+    assert (
+        "reasoning_effort"
+        not in config.get_supported_openai_params(model="gpt-5-chat-latest")
+    )
+
+
+def test_gpt5_chat_supports_temperature(config: OpenAIConfig):
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.3},
+        optional_params={},
+        model="gpt-5-chat-latest",
+        drop_params=False,
+    )
+    assert params["temperature"] == 0.3
+
+
 def test_gpt5_maps_max_tokens(config: OpenAIConfig):
     params = config.map_openai_params(
         non_default_params={"max_tokens": 10},


### PR DESCRIPTION
## Summary
- Stop treating `gpt-5-chat*` as GPT-5 reasoning models, so chat params (like `tool_choice` / `temperature`) aren’t blocked.
- Mark Azure `gpt-5-chat` and `gpt-5-chat-latest` as `supports_tool_choice=true`.
- Add regression coverage for `gpt-5-chat-2025-08-07`.

## Test plan
- `python3 -m pytest tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py -q`
- `python3 -m pytest tests/test_litellm/llms/openai/test_gpt5_transformation.py -q`

Fixes #14704.