### PR TITLE
fix: search tools not found when using per-request routers

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -547,9 +547,14 @@ class ProxyBaseLLMRequestProcessing:
                 # Get model_list from current router
                 model_list = llm_router.get_model_list()
                 if model_list is not None:
-                    # Create user_config with model_list and router_settings
+                    # Create user_config with model_list, search_tools, and router_settings
                     # This creates a per-request router with the hierarchical settings
                     user_config = {"model_list": model_list, **router_settings}
+
+                    # Include search_tools from main router so per-request router has them
+                    if hasattr(llm_router, "search_tools") and llm_router.search_tools:
+                        user_config["search_tools"] = llm_router.search_tools
+
                     self.data["user_config"] = user_config
 
         if "messages" in self.data and self.data["messages"]:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3173,17 +3173,18 @@ class ProxyConfig:
                 _model_list: list = self.decrypt_model_list_from_db(
                     new_models=models_list
                 )
-                if len(_model_list) > 0:
-                    verbose_proxy_logger.debug(f"_model_list: {_model_list}")
-                    llm_router = litellm.Router(
-                        model_list=_model_list,
-                        router_general_settings=RouterGeneralSettings(
-                            async_only_mode=True  # only init async clients
-                        ),
-                        search_tools=search_tools,
-                        ignore_invalid_deployments=True,
-                    )
-                    verbose_proxy_logger.debug(f"updated llm_router: {llm_router}")
+                # Create router even with empty model list to support search_tools
+                # Router can function with model_list=[] and only search_tools
+                verbose_proxy_logger.debug(f"_model_list: {_model_list}")
+                llm_router = litellm.Router(
+                    model_list=_model_list,
+                    router_general_settings=RouterGeneralSettings(
+                        async_only_mode=True  # only init async clients
+                    ),
+                    search_tools=search_tools,
+                    ignore_invalid_deployments=True,
+                )
+                verbose_proxy_logger.debug(f"updated llm_router: {llm_router}")
             else:
                 verbose_proxy_logger.debug(f"len new_models: {len(models_list)}")
                 ## DELETE MODEL LOGIC


### PR DESCRIPTION
**Root Cause:**

When API keys or teams have router_settings configured, the proxy creates per-request Router instances from user_config. These new routers were missing search_tools from the main router, causing "search tool not found" errors despite search_tools being configured.

**The Fix:**

1. **common_request_processing.py (lines 554-556):** Pass search_tools from main router to user_config so per-request routers inherit them

2. **proxy_server.py (line 3171):** Remove `if len(_model_list) > 0` check to allow router creation with empty model list (needed for search-tools-only use case)

3. **proxy_server.py (line 746):** Remove redundant search_tools loading code (already handled by _init_search_tools_in_db() called during startup)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
