### PR TITLE
docs(readme): add OpenAI Agents SDK to OSS Adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Support for more providers. Missing a provider or LLM Platform, raise a [feature
     <td><img height="60" alt="Greptile" src="https://github.com/user-attachments/assets/0be4bd8a-7cfa-48d3-9090-f415fe948280" /></td>
     <td><img height="60" alt="OpenHands" src="https://github.com/user-attachments/assets/a6150c4c-149e-4cae-888b-8b92be6e003f" /></td>
     <td><h2>Netflix</h2></td>
+    <td><h2>OpenAI Agents SDK</h2></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Support for more providers. Missing a provider or LLM Platform, raise a [feature
     <td><img height="60" alt="Greptile" src="https://github.com/user-attachments/assets/0be4bd8a-7cfa-48d3-9090-f415fe948280" /></td>
     <td><img height="60" alt="OpenHands" src="https://github.com/user-attachments/assets/a6150c4c-149e-4cae-888b-8b92be6e003f" /></td>
     <td><h2>Netflix</h2></td>
-    <td><h2>OpenAI Agents SDK</h2></td>
+    <td><img height="60" alt="OpenAI Agents SDK" src="https://github.com/user-attachments/assets/c02f7be0-8c2e-4d27-aea7-7c024bfaebc0" /></td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Summary
- Adds OpenAI Agents SDK to the OSS Adopters section in README