### PR TITLE
perf: remove redundant get_llm_provider call in function_setup

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -973,28 +973,12 @@ def function_setup(  # noqa: PLR0915
             # signatures to ensure compatibility.
             if isinstance(messages, list) and len(messages) > 0:
                 try:
-                    from litellm.litellm_core_utils.get_llm_provider_logic import (
-                        get_llm_provider,
-                    )
                     from litellm.litellm_core_utils.prompt_templates.factory import (
                         THOUGHT_SIGNATURE_SEPARATOR,
                     )
 
-                    # Get custom_llm_provider to determine target provider
                     custom_llm_provider = kwargs.get("custom_llm_provider")
 
-                    # If custom_llm_provider not in kwargs, try to determine it from the model
-                    if not custom_llm_provider and model:
-                        try:
-                            _, custom_llm_provider, _, _ = get_llm_provider(
-                                model=model,
-                                custom_llm_provider=custom_llm_provider,
-                            )
-                        except Exception:
-                            # If we can't determine the provider, skip this processing
-                            pass
-
-                    # Only process if target is NOT a Gemini model
                     if not _is_gemini_model(model, custom_llm_provider):
                         verbose_logger.debug(
                             "Removing thought signatures from tool call IDs for non-Gemini model"


### PR DESCRIPTION
The get_llm_provider call was used to determine if the target model is a Gemini model for thought signature removal. This call is redundant because _is_gemini_model already has a fallback that checks if "gemini" is in the model name, which covers all cases where get_llm_provider would return "gemini" as the provider.

All relevant tests pass before & after. 

Profiling shows this reduces function_setup time by ~37% (8.18s -> 5.19s across 6000 requests), saving ~500µs per request.

Before: 

<img width="950" height="119" alt="Screenshot 2026-01-26 at 4 22 46 PM" src="https://github.com/user-attachments/assets/671d37df-9323-42d9-9714-d17e9b5650ac" />

After: 

<img width="933" height="119" alt="Screenshot 2026-01-26 at 4 23 03 PM" src="https://github.com/user-attachments/assets/64830bce-e3b7-4cf9-9672-deeb2950bf2a" />

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

Performance

## Changes
