### PR TITLE
fix: log finish_reason in Langfuse OTEL streaming responses

### DIFF
--- a/litellm/integrations/arize/_utils.py
+++ b/litellm/integrations/arize/_utils.py
@@ -104,6 +104,8 @@ def _set_response_attributes(span: "Span", response_obj):
 
 
 def _set_choice_outputs(span: "Span", response_obj, msg_attrs, span_attrs):
+    # Collect finish_reasons from all choices
+    finish_reasons = []
     for idx, choice in enumerate(response_obj.get("choices", [])):
         response_message = choice.get("message", {})
         safe_set_attribute(
@@ -122,6 +124,14 @@ def _set_choice_outputs(span: "Span", response_obj, msg_attrs, span_attrs):
             f"{prefix}.{msg_attrs.MESSAGE_CONTENT}",
             response_message.get("content", ""),
         )
+        # Extract finish_reason from each choice
+        finish_reason = choice.get("finish_reason")
+        if finish_reason:
+            finish_reasons.append(finish_reason)
+
+    # Set finish_reasons as a span attribute (matches OTEL semantic conventions)
+    if finish_reasons:
+        safe_set_attribute(span, "gen_ai.response.finish_reasons", safe_dumps(finish_reasons))
 
 
 def _set_image_outputs(span: "Span", response_obj, image_attrs, span_attrs):


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes missing `finish_reason` attribute in Langfuse OTEL spans for streaming responses.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

### Problem
`finish_reason` was not being logged as a span attribute (`gen_ai.response.finish_reasons`) in Langfuse OTEL integration for streaming responses.

**Streaming response (missing `finish_reason`):**
```
{
  "id": "09c5e0b1-ee15-4971-9c02-35a79d9c4c26",
  "name": "litellm_request",
  "input": {...},
  "output": {
    "id": "chatcmpl-BKBmruVC7DaQyOdoMWgOjYXTVpvaO",
    "choices": [{"message": {"content": "Hello...", "role": "assistant"}}],
    "model": "gpt-4o-mini-2024-07-18"
  }
  // ❌ No finish_reason attribute
}
```

**Non-streaming response (has finish_reason embedded in raw response):**
```
{
  "name": "raw_gen_ai_request",
  "output": {
    "llm.openai.choices": "[{\"content_filter_results\": {...}, \"finish_reason\": \"stop\", \"index\": 0, ...}]"
  }
  // ✅ finish_reason exists but only in stringified raw response
}
```