### PR TITLE
test(proxy): add regression tests for vertex passthrough model names …

### DIFF
--- a/tests/local_testing/test_auth_utils.py
+++ b/tests/local_testing/test_auth_utils.py
@@ -356,6 +356,25 @@ def test_get_internal_user_header_from_mapping_no_internal_returns_none():
             "/openai/deployments/my-deployment/chat/completions",
             "my-deployment"
         ),
+        # Custom model_name with slashes (e.g., gcp/google/gemini-2.5-flash)
+        # This is the NVIDIA P0 bug fix - regex should capture full model name including slashes
+        (
+            {},
+            "/vertex_ai/v1/projects/my-project/locations/us-central1/publishers/google/models/gcp/google/gemini-2.5-flash:generateContent",
+            "gcp/google/gemini-2.5-flash"
+        ),
+        # Another custom model_name with slashes
+        (
+            {},
+            "/vertex_ai/v1/projects/my-project/locations/global/publishers/google/models/gcp/google/gemini-3-flash-preview:generateContent",
+            "gcp/google/gemini-3-flash-preview"
+        ),
+        # Model name with single slash
+        (
+            {},
+            "/vertex_ai/v1/projects/my-project/locations/us-central1/publishers/google/models/custom/model:generateContent",
+            "custom/model"
+        ),
     ],
 )
 def test_get_model_from_request_vertex_ai_passthrough(request_data, route, expected_model):


### PR DESCRIPTION
## Relevant issues
Adds regression tests for custom model names with slashes in Vertex AI passthrough URLs (e.g., `gcp/google/gemini-2.5-flash`).

Related to fix in #19737.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

✅ Test

## Changes

Added unit tests to ensure model names with slashes are correctly extracted from Vertex AI passthrough URLs.

**Test cases added:**
- `gcp/google/gemini-2.5-flash`
- `gcp/google/gemini-3-flash-preview`
- `custom/model`

**Manual testing performed:**

Config:
- `model_name: gcp/google/gemini-2.5-flash`
- `access_groups: ["default-models"]`
- Team with `models: ["default-models"]`

Result: Auth passes for URL `/vertex_ai/.../models/gcp/google/gemini-2.5-flash:generateContent`

### Screenshot
<img width="1884" height="908" alt="Screenshot 2026-01-27 alle 16 06 15" src="https://github.com/user-attachments/assets/d35dd4a5-89ce-4633-a44e-946b72a2d3b0" />



