### PR TITLE
fix(enterprise): correct error message for DISABLE_ADMIN_ENDPOINTS

### DIFF
--- a/enterprise/litellm_enterprise/proxy/auth/route_checks.py
+++ b/enterprise/litellm_enterprise/proxy/auth/route_checks.py
@@ -36,7 +36,7 @@ class EnterpriseRouteChecks:
             if not premium_user:
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail=f"🚨🚨🚨 DISABLING LLM API ENDPOINTS is an Enterprise feature\n🚨 {CommonProxyErrors.not_premium_user.value}",
+                    detail=f"🚨🚨🚨 DISABLING ADMIN ENDPOINTS is an Enterprise feature\n🚨 {CommonProxyErrors.not_premium_user.value}",
                 )
 
         return get_secret_bool("DISABLE_ADMIN_ENDPOINTS") is True

--- a/tests/enterprise/litellm_enterprise/proxy/auth/test_route_checks.py
+++ b/tests/enterprise/litellm_enterprise/proxy/auth/test_route_checks.py
@@ -180,3 +180,68 @@ class TestEnterpriseRouteChecks:
 
         # Should not raise exception since management routes are enabled
         EnterpriseRouteChecks.should_call_route("/config/update")
+
+
+class TestEnterpriseRouteChecksErrorMessages:
+    """Test that error messages correctly identify which feature requires Enterprise license"""
+
+    @patch("litellm.secret_managers.main.get_secret_bool")
+    @patch("litellm.proxy.proxy_server.premium_user", False)
+    def test_disable_llm_api_endpoints_error_message(self, mock_get_secret_bool):
+        """
+        Test that when DISABLE_LLM_API_ENDPOINTS is set without Enterprise license,
+        the error message correctly mentions 'LLM API ENDPOINTS'
+        """
+        with patch.dict(os.environ, {"DISABLE_LLM_API_ENDPOINTS": "true"}):
+            with pytest.raises(HTTPException) as exc_info:
+                EnterpriseRouteChecks.is_llm_api_route_disabled()
+
+            assert exc_info.value.status_code == 500
+            assert "DISABLING LLM API ENDPOINTS is an Enterprise feature" in str(
+                exc_info.value.detail
+            )
+
+    @patch("litellm.secret_managers.main.get_secret_bool")
+    @patch("litellm.proxy.proxy_server.premium_user", False)
+    def test_disable_admin_endpoints_error_message(self, mock_get_secret_bool):
+        """
+        Test that when DISABLE_ADMIN_ENDPOINTS is set without Enterprise license,
+        the error message correctly mentions 'ADMIN ENDPOINTS' (not 'LLM API ENDPOINTS')
+
+        This is a regression test for a bug where the error message incorrectly said
+        'DISABLING LLM API ENDPOINTS' when the actual issue was DISABLE_ADMIN_ENDPOINTS.
+        """
+        with patch.dict(os.environ, {"DISABLE_ADMIN_ENDPOINTS": "true"}):
+            with pytest.raises(HTTPException) as exc_info:
+                EnterpriseRouteChecks.is_management_routes_disabled()
+
+            assert exc_info.value.status_code == 500
+            assert "DISABLING ADMIN ENDPOINTS is an Enterprise feature" in str(
+                exc_info.value.detail
+            )
+            # Ensure it does NOT mention LLM API ENDPOINTS (the old buggy message)
+            assert "LLM API ENDPOINTS" not in str(exc_info.value.detail)
+
+    @patch("litellm.secret_managers.main.get_secret_bool")
+    @patch("litellm.proxy.proxy_server.premium_user", True)
+    def test_disable_llm_api_endpoints_with_premium_user(self, mock_get_secret_bool):
+        """
+        Test that premium users can use DISABLE_LLM_API_ENDPOINTS without error
+        """
+        mock_get_secret_bool.return_value = True
+        with patch.dict(os.environ, {"DISABLE_LLM_API_ENDPOINTS": "true"}):
+            # Should not raise exception for premium users
+            result = EnterpriseRouteChecks.is_llm_api_route_disabled()
+            assert result is True
+
+    @patch("litellm.secret_managers.main.get_secret_bool")
+    @patch("litellm.proxy.proxy_server.premium_user", True)
+    def test_disable_admin_endpoints_with_premium_user(self, mock_get_secret_bool):
+        """
+        Test that premium users can use DISABLE_ADMIN_ENDPOINTS without error
+        """
+        mock_get_secret_bool.return_value = True
+        with patch.dict(os.environ, {"DISABLE_ADMIN_ENDPOINTS": "true"}):
+            # Should not raise exception for premium users
+            result = EnterpriseRouteChecks.is_management_routes_disabled()
+            assert result is True


### PR DESCRIPTION
The error message for DISABLE_ADMIN_ENDPOINTS incorrectly said "DISABLING LLM API ENDPOINTS is an Enterprise feature" instead of "DISABLING ADMIN ENDPOINTS is an Enterprise feature".

This was a copy-paste bug from the is_llm_api_route_disabled() function.

Added regression tests to verify both error messages are correct.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

- Fixed error message in `enterprise/litellm_enterprise/proxy/auth/route_checks.py:39` to correctly say "DISABLING ADMIN ENDPOINTS" instead of "DISABLING LLM API ENDPOINTS"
- Added 4 regression tests in `tests/enterprise/litellm_enterprise/proxy/auth/test_route_checks.py` to verify error messages are correct for both `DISABLE_LLM_API_ENDPOINTS` and `DISABLE_ADMIN_ENDPOINTS`