### PR TITLE
feat: add retry callback hooks for completion_with_retries

### DIFF
--- a/docs/my-website/docs/observability/custom_callback.md
+++ b/docs/my-website/docs/observability/custom_callback.md
@@ -62,6 +62,7 @@ asyncio.run(completion())
 - `async_log_failure_event` - Log failed API calls  
 - `log_pre_api_call` - Log before API call
 - `log_post_api_call` - Log after API call
+- `log_retry_event` / `async_log_retry_event` - Log retry attempts when using `completion_with_retries()` or `acompletion_with_retries()`
 
 **Proxy-only hooks** (only work with LiteLLM Proxy):
 - `async_post_call_success_hook` - Access user data + modify responses

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -135,6 +135,24 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
     def log_failure_event(self, kwargs, response_obj, start_time, end_time):
         pass
 
+    def log_retry_event(
+        self,
+        kwargs: dict,
+        exception: Optional[BaseException],
+        retry_count: int,
+        max_retries: int,
+    ):
+        """
+        Called when a retry is about to occur.
+
+        Args:
+            kwargs: The original request kwargs being retried
+            exception: The exception that triggered the retry
+            retry_count: Current retry attempt number (1-indexed)
+            max_retries: Maximum number of retries configured
+        """
+        pass
+
     #### ASYNC ####
 
     async def async_log_stream_event(self, kwargs, response_obj, start_time, end_time):
@@ -175,6 +193,24 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         pass
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        pass
+
+    async def async_log_retry_event(
+        self,
+        kwargs: dict,
+        exception: Optional[BaseException],
+        retry_count: int,
+        max_retries: int,
+    ):
+        """
+        Async version of log_retry_event. Called when a retry is about to occur.
+
+        Args:
+            kwargs: The original request kwargs being retried
+            exception: The exception that triggered the retry
+            retry_count: Current retry attempt number (1-indexed)
+            max_retries: Maximum number of retries configured
+        """
         pass
 
     #### PROMPT MANAGEMENT HOOKS ####

--- a/tests/test_litellm/integrations/test_retry_callback_hook.py
+++ b/tests/test_litellm/integrations/test_retry_callback_hook.py
@@ -1,0 +1,211 @@
+"""
+Tests for the retry callback hook functionality.
+
+Tests that log_retry_event and async_log_retry_event methods are called
+on CustomLogger instances when retries occur.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import litellm
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.main import _async_fire_retry_callbacks, _fire_retry_callbacks
+
+
+class RetryCallbackHandler(CustomLogger):
+    """Test logger that tracks retry events."""
+
+    def __init__(self):
+        super().__init__()
+        self.retry_events = []
+        self.async_retry_events = []
+
+    def log_retry_event(
+        self,
+        kwargs: dict,
+        exception: Exception,
+        retry_count: int,
+        max_retries: int,
+    ) -> None:
+        self.retry_events.append(
+            {
+                "kwargs": kwargs,
+                "exception": exception,
+                "retry_count": retry_count,
+                "max_retries": max_retries,
+            }
+        )
+
+    async def async_log_retry_event(
+        self,
+        kwargs: dict,
+        exception: Exception,
+        retry_count: int,
+        max_retries: int,
+    ) -> None:
+        self.async_retry_events.append(
+            {
+                "kwargs": kwargs,
+                "exception": exception,
+                "retry_count": retry_count,
+                "max_retries": max_retries,
+            }
+        )
+
+
+class FailingRetryHandler(CustomLogger):
+    """Handler that raises an exception in log_retry_event."""
+
+    def log_retry_event(
+        self,
+        kwargs: dict,
+        exception: Exception,
+        retry_count: int,
+        max_retries: int,
+    ) -> None:
+        raise RuntimeError("Callback failed")
+
+
+class TestRetryCallbackHook:
+    """Tests for retry callback hook functionality."""
+
+    def test_fire_retry_callbacks_calls_log_retry_event(self):
+        """Test that _fire_retry_callbacks calls log_retry_event on CustomLogger."""
+        test_handler = RetryCallbackHandler()
+        original_callbacks = litellm.callbacks.copy()
+
+        try:
+            litellm.callbacks = [test_handler]
+
+            # Create mock retry_state
+            mock_retry_state = MagicMock()
+            mock_exception = Exception("Test error")
+            mock_retry_state.outcome.exception.return_value = mock_exception
+            mock_retry_state.attempt_number = 2
+
+            test_kwargs = {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "test"}],
+            }
+
+            _fire_retry_callbacks(mock_retry_state, num_retries=3, kwargs=test_kwargs)
+
+            assert len(test_handler.retry_events) == 1
+            event = test_handler.retry_events[0]
+            assert event["exception"] == mock_exception
+            assert event["retry_count"] == 2
+            assert event["max_retries"] == 3
+            assert event["kwargs"] == test_kwargs
+        finally:
+            litellm.callbacks = original_callbacks
+
+    @pytest.mark.asyncio
+    async def test_async_fire_retry_callbacks_calls_async_log_retry_event(self):
+        """Test that _async_fire_retry_callbacks calls async_log_retry_event on CustomLogger."""
+        test_handler = RetryCallbackHandler()
+        original_callbacks = litellm.callbacks.copy()
+
+        try:
+            litellm.callbacks = [test_handler]
+
+            # Create mock retry_state
+            mock_retry_state = MagicMock()
+            mock_exception = Exception("Test async error")
+            mock_retry_state.outcome.exception.return_value = mock_exception
+            mock_retry_state.attempt_number = 1
+
+            test_kwargs = {
+                "model": "claude-3",
+                "messages": [{"role": "user", "content": "async test"}],
+            }
+
+            await _async_fire_retry_callbacks(
+                mock_retry_state, num_retries=5, kwargs=test_kwargs
+            )
+
+            assert len(test_handler.async_retry_events) == 1
+            event = test_handler.async_retry_events[0]
+            assert event["exception"] == mock_exception
+            assert event["retry_count"] == 1
+            assert event["max_retries"] == 5
+            assert event["kwargs"] == test_kwargs
+        finally:
+            litellm.callbacks = original_callbacks
+
+    def test_fire_retry_callbacks_skips_callbacks_without_method(self):
+        """Test that callbacks without log_retry_event are skipped."""
+
+        # Create a callback without log_retry_event method
+        class SimpleCallback:
+            pass
+
+        simple_callback = SimpleCallback()
+        test_handler = RetryCallbackHandler()
+        original_callbacks = litellm.callbacks.copy()
+
+        try:
+            litellm.callbacks = [simple_callback, test_handler]
+
+            mock_retry_state = MagicMock()
+            mock_retry_state.outcome.exception.return_value = Exception("Test")
+            mock_retry_state.attempt_number = 1
+
+            # Should not raise, should skip simple_callback
+            _fire_retry_callbacks(mock_retry_state, num_retries=3, kwargs={})
+
+            # Only test_handler should have received the event
+            assert len(test_handler.retry_events) == 1
+        finally:
+            litellm.callbacks = original_callbacks
+
+    def test_fire_retry_callbacks_handles_callback_exceptions(self):
+        """Test that exceptions in callbacks are caught and logged."""
+        failing_handler = FailingRetryHandler()
+        test_handler = RetryCallbackHandler()
+        original_callbacks = litellm.callbacks.copy()
+
+        try:
+            litellm.callbacks = [failing_handler, test_handler]
+
+            mock_retry_state = MagicMock()
+            mock_retry_state.outcome.exception.return_value = Exception("Test")
+            mock_retry_state.attempt_number = 1
+
+            # Should not raise, should continue to next callback
+            _fire_retry_callbacks(mock_retry_state, num_retries=3, kwargs={})
+
+            # test_handler should still receive the event
+            assert len(test_handler.retry_events) == 1
+        finally:
+            litellm.callbacks = original_callbacks
+
+
+class TestCustomLoggerBaseRetryMethods:
+    """Tests for base CustomLogger retry methods."""
+
+    def test_custom_logger_base_retry_methods_are_no_ops(self):
+        """Test that base CustomLogger retry methods are no-ops."""
+        logger = CustomLogger()
+
+        # Should not raise
+        logger.log_retry_event(
+            kwargs={},
+            exception=Exception("test"),
+            retry_count=1,
+            max_retries=3,
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_logger_async_base_retry_method_is_no_op(self):
+        """Test that base CustomLogger async retry method is a no-op."""
+        logger = CustomLogger()
+
+        # Should not raise
+        await logger.async_log_retry_event(
+            kwargs={},
+            exception=Exception("test"),
+            retry_count=1,
+            max_retries=3,
+        )


### PR DESCRIPTION
Add log_retry_event and async_log_retry_event methods to CustomLogger that fire when retries occur in completion_with_retries() and acompletion_with_retries().

## Relevant issues

Fixes #19806 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


Note: `make test-unit` has some failing tests that appear to be due to google-cloud-aiplatform not being installed, and appear to be unrelated to my changes. 

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

This PR adds retry callback hooks to `CustomLogger`, allowing users to observe retry attempts when using `completion_with_retries()` and `acompletion_with_retries()`.

### New Methods in `CustomLogger`
- `log_retry_event(kwargs, exception, retry_count, max_retries)` - sync version
- `async_log_retry_event(kwargs, exception, retry_count, max_retries)` - async version

### Implementation
- Uses tenacity's `before_sleep` callback to fire events before each retry
- Callbacks receive the original request kwargs, the exception that triggered the retry, current retry count (1-indexed), and max retries configured
- Errors in callbacks are caught and logged to prevent breaking the retry flow