### PR TITLE
fix(bedrock): support tool search header translation for Sonnet 4.5

### DIFF
--- a/tests/test_litellm/llms/bedrock/test_anthropic_beta_support.py
+++ b/tests/test_litellm/llms/bedrock/test_anthropic_beta_support.py
@@ -427,16 +427,18 @@ class TestAnthropicBetaHeaderSupport:
             "tool-examples-2025-10-29 should be added for Opus 4.5"
         )
 
-    def test_messages_advanced_tool_use_filtered_non_opus_4_5(self):
-        """Test that advanced-tool-use header is filtered out for non-Opus 4.5 models.
-        
-        The translation to Bedrock-specific headers should only happen for Opus 4.5.
-        For other models, the advanced-tool-use header should just be removed.
+    def test_messages_advanced_tool_use_translation_sonnet_4_5(self):
+        """Test that advanced-tool-use header is translated to Bedrock-specific headers for Sonnet 4.5.
+
+        Regression test for: Claude Code sends advanced-tool-use-2025-11-20 header which needs
+        to be translated to tool-search-tool-2025-10-19 and tool-examples-2025-10-29 for
+        Bedrock Invoke API on Claude Sonnet 4.5.
+
+        Ref: https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool
         """
         config = AmazonAnthropicClaudeMessagesConfig()
         headers = {"anthropic-beta": "advanced-tool-use-2025-11-20"}
-        
-        # Test with Sonnet 4.5 (not Opus 4.5)
+
         result = config.transform_anthropic_messages_request(
             model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
             messages=[{"role": "user", "content": "Test"}],
@@ -444,12 +446,47 @@ class TestAnthropicBetaHeaderSupport:
             litellm_params={},
             headers=headers
         )
-        
+
+        assert "anthropic_beta" in result
+        beta_headers = result["anthropic_beta"]
+
+        # advanced-tool-use should be removed
+        assert "advanced-tool-use-2025-11-20" not in beta_headers, (
+            "advanced-tool-use-2025-11-20 should be removed for Bedrock Invoke API"
+        )
+
+        # Bedrock-specific headers should be added for Sonnet 4.5
+        assert "tool-search-tool-2025-10-19" in beta_headers, (
+            "tool-search-tool-2025-10-19 should be added for Sonnet 4.5"
+        )
+        assert "tool-examples-2025-10-29" in beta_headers, (
+            "tool-examples-2025-10-29 should be added for Sonnet 4.5"
+        )
+
+    def test_messages_advanced_tool_use_filtered_unsupported_model(self):
+        """Test that advanced-tool-use header is filtered out for models that don't support tool search.
+
+        The translation to Bedrock-specific headers should only happen for models that
+        support tool search on Bedrock (Opus 4.5, Sonnet 4.5).
+        For other models, the advanced-tool-use header should just be removed.
+        """
+        config = AmazonAnthropicClaudeMessagesConfig()
+        headers = {"anthropic-beta": "advanced-tool-use-2025-11-20"}
+
+        # Test with Claude 3.5 Sonnet (does NOT support tool search on Bedrock)
+        result = config.transform_anthropic_messages_request(
+            model="us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+            messages=[{"role": "user", "content": "Test"}],
+            anthropic_messages_optional_request_params={"max_tokens": 100},
+            litellm_params={},
+            headers=headers
+        )
+
         beta_headers = result.get("anthropic_beta", [])
-        
+
         # advanced-tool-use should be removed
         assert "advanced-tool-use-2025-11-20" not in beta_headers
-        
-        # Bedrock-specific headers should NOT be added for non-Opus 4.5
+
+        # Bedrock-specific headers should NOT be added for unsupported models
         assert "tool-search-tool-2025-10-19" not in beta_headers
         assert "tool-examples-2025-10-29" not in beta_headers


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

Relates to #19841

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

Extends the `advanced-tool-use-2025-11-20` header translation to include **Claude Sonnet 4.5** in addition to Opus 4.5 on Bedrock Invoke API.

### Problem

PR #19841 introduced header translation for tool search on Bedrock, but only for Opus 4.5. When Claude Code users send requests with `advanced-tool-use-2025-11-20` header to Bedrock with Sonnet 4.5, they receive:

```
400 {"error":{"message":"tools.18.custom.defer_loading: Extra inputs are not permitted"}}
```

This happens because Bedrock doesn't recognize the `advanced-tool-use` header and requires the Bedrock-specific headers instead.

### Solution

- Added `_supports_tool_search_on_bedrock()` method that checks for both Opus 4.5 and Sonnet 4.5
- Updated `_filter_unsupported_beta_headers_for_bedrock()` to use the new method
- When `advanced-tool-use-2025-11-20` is detected, it's now translated to Bedrock-specific headers for both model families:
  - `tool-search-tool-2025-10-19`
  - `tool-examples-2025-10-29`

### Tests

- Added `test_messages_advanced_tool_use_translation_sonnet_4_5` - verifies Sonnet 4.5 gets the Bedrock headers
- Renamed and fixed `test_messages_advanced_tool_use_filtered_unsupported_model` - now tests with Claude 3.5 Sonnet (a model that doesn't support tool search)

**Ref:** https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool