### PR TITLE
Add OpenRouter Kimi K2.5

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23676,6 +23676,20 @@
         "output_cost_per_token": 6.5e-07,
         "supports_tool_choice": true
     },
+    "openrouter/moonshotai/kimi-k2.5": {
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://openrouter.ai/moonshotai/kimi-k2.5",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "openrouter/nousresearch/nous-hermes-llama2-13b": {
         "input_cost_per_token": 2e-07,
         "litellm_provider": "openrouter",

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -2543,6 +2543,48 @@ def test_model_info_for_vertex_ai_deepseek_model():
     print("vertex deepseek model info", model_info)
 
 
+def test_model_info_for_openrouter_kimi_k2_5():
+    """
+    Test that openrouter/moonshotai/kimi-k2.5 model info is correctly configured
+    in model_prices_and_context_window.json.
+
+    Model properties from OpenRouter API:
+    - context_length: 262144
+    - pricing: prompt=$0.0000006, completion=$0.000003, input_cache_read=$0.0000001
+    - modality: text+image->text (supports vision)
+    - supports: tool_choice, tools (function calling)
+    """
+    import json
+    from pathlib import Path
+
+    # Load directly from the local JSON file
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(json_path) as f:
+        model_cost = json.load(f)
+
+    model_info = model_cost.get("openrouter/moonshotai/kimi-k2.5")
+    assert model_info is not None, "Model not found in model_prices_and_context_window.json"
+    assert model_info["litellm_provider"] == "openrouter"
+    assert model_info["mode"] == "chat"
+
+    # Verify context window
+    assert model_info["max_input_tokens"] == 262144
+    assert model_info["max_output_tokens"] == 262144
+    assert model_info["max_tokens"] == 262144
+
+    # Verify pricing
+    assert model_info["input_cost_per_token"] == 6e-07
+    assert model_info["output_cost_per_token"] == 3e-06
+    assert model_info["cache_read_input_token_cost"] == 1e-07
+
+    # Verify capabilities
+    assert model_info["supports_vision"] is True
+    assert model_info["supports_function_calling"] is True
+    assert model_info["supports_tool_choice"] is True
+
+    print("openrouter kimi-k2.5 model info", model_info)
+
+
 class TestGetValidModelsWithCLI:
     """Test get_valid_models function as used in CLI token usage"""
 


### PR DESCRIPTION
## Title

Add OpenRouter Kimi K2.5 model

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

Added moonshotai/kimi-k2.5 model to model_prices_and_context_window.json:

- openrouter/moonshotai/kimi-k2.5

Added pricing and context window values aligning with provider sources

https://openrouter.ai/moonshotai/kimi-k2.5

Model properties as retrieved from OpenRouter API:
```json
{
  "id": "moonshotai/kimi-k2.5",
  "canonical_slug": "moonshotai/kimi-k2.5-0127",
  "hugging_face_id": "moonshotai/Kimi-K2.5",
  "name": "MoonshotAI: Kimi K2.5",
  "created": 1769487076,
  "description": "Kimi K2.5 is Moonshot AI's native multimodal model, delivering state-of-the-art visual coding capability and a self-directed agent swarm paradigm. Built on Kimi K2 with continued pretraining over approximately 15T mixed visual and text tokens, it delivers strong performance in general reasoning, visual coding, and agentic tool-calling.",
  "context_length": 262144,
  "architecture": {
    "modality": "text+image->text",
    "input_modalities": [
      "text",
      "image"
    ],
    "output_modalities": [
      "text"
    ],
    "tokenizer": "Other",
    "instruct_type": null
  },
  "pricing": {
    "prompt": "0.0000006",
    "completion": "0.000003",
    "input_cache_read": "0.0000001"
  },
  "top_provider": {
    "context_length": 262144,
    "max_completion_tokens": null,
    "is_moderated": false
  },
  "per_request_limits": null,
  "supported_parameters": [
    "frequency_penalty",
    "include_reasoning",
    "max_tokens",
    "presence_penalty",
    "reasoning",
    "response_format",
    "stop",
    "structured_outputs",
    "tool_choice",
    "tools"
  ],
  "default_parameters": {
    "temperature": null,
    "top_p": null,
    "frequency_penalty": null
  },
  "expiration_date": null
}
```

## Test passing locally

```
$ poetry run pytest tests/test_litellm/test_utils.py::test_model_info_for_openrouter_kimi_k2_5 -v
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-7.4.4, pluggy-1.6.0
collected 1 item

tests/test_litellm/test_utils.py::test_model_info_for_openrouter_kimi_k2_5 PASSED [100%]

============================== 1 passed in 0.44s ===============================
```

🤖 Generated with [Claude Code](https://claude.ai/code)