### PR TITLE
fix(vertex_ai): convert image URLs to base64 in tool messages for Anthropic

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_anthropic_image_url_handling.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_anthropic_image_url_handling.py
@@ -4,6 +4,9 @@ Tests for Vertex AI Anthropic image URL handling.
 Issue: https://github.com/BerriAI/litellm/issues/18430
 Vertex AI Anthropic models don't support URL sources for images.
 LiteLLM should convert image URLs to base64 when using Vertex AI Anthropic.
+
+Issue: https://github.com/BerriAI/litellm/issues/19891
+Tool messages with image_url should also be converted to base64 for Vertex AI.
 """
 import os
 import sys
@@ -17,6 +20,7 @@ sys.path.insert(
 
 from litellm.litellm_core_utils.prompt_templates.factory import (
     anthropic_messages_pt,
+    convert_to_anthropic_tool_result,
     create_anthropic_image_param,
 )
 
@@ -177,3 +181,194 @@ class TestCreateAnthropicImageParam:
         mock_convert_url.assert_not_called()
         assert result["source"]["type"] == "url"
         assert result["source"]["url"] == "https://example.com/image.jpg"
+
+
+class TestToolMessageImageURLHandling:
+    """
+    Test that tool messages with image_url are converted to base64 for Vertex AI.
+
+    Issue: https://github.com/BerriAI/litellm/issues/19891
+    """
+
+    @patch("litellm.litellm_core_utils.prompt_templates.factory.convert_url_to_base64")
+    def test_convert_to_anthropic_tool_result_with_force_base64(
+        self, mock_convert_url: MagicMock
+    ):
+        """
+        Test that convert_to_anthropic_tool_result converts image URLs to base64
+        when force_base64=True.
+        """
+        mock_convert_url.return_value = "data:image/jpeg;base64,/9j/4AAQSkZJRg=="
+
+        tool_message = {
+            "role": "tool",
+            "tool_call_id": "call_123",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/tool_result.jpg"},
+                }
+            ],
+        }
+
+        result = convert_to_anthropic_tool_result(tool_message, force_base64=True)
+
+        mock_convert_url.assert_called_once_with(url="https://example.com/tool_result.jpg")
+        assert result["type"] == "tool_result"
+        assert result["tool_use_id"] == "call_123"
+
+        # Check the image content is base64
+        content = result["content"]
+        assert len(content) == 1
+        assert content[0]["type"] == "image"
+        assert content[0]["source"]["type"] == "base64"
+
+    @patch("litellm.litellm_core_utils.prompt_templates.factory.convert_url_to_base64")
+    def test_convert_to_anthropic_tool_result_without_force_base64(
+        self, mock_convert_url: MagicMock
+    ):
+        """
+        Test that convert_to_anthropic_tool_result uses URL type when force_base64=False.
+        """
+        tool_message = {
+            "role": "tool",
+            "tool_call_id": "call_456",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.jpg"},
+                }
+            ],
+        }
+
+        result = convert_to_anthropic_tool_result(tool_message, force_base64=False)
+
+        mock_convert_url.assert_not_called()
+        assert result["type"] == "tool_result"
+
+        # Check the image content uses URL type
+        content = result["content"]
+        assert len(content) == 1
+        assert content[0]["type"] == "image"
+        assert content[0]["source"]["type"] == "url"
+
+    @patch("litellm.litellm_core_utils.prompt_templates.factory.convert_url_to_base64")
+    def test_vertex_ai_tool_message_converts_image_to_base64(
+        self, mock_convert_url: MagicMock
+    ):
+        """
+        Test full conversation with tool result containing image for Vertex AI.
+        The image URL should be converted to base64.
+        """
+        mock_convert_url.return_value = "data:image/jpeg;base64,/9j/4AAQSkZJRg=="
+
+        messages = [
+            {
+                "role": "user",
+                "content": "Get me an image and describe it",
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_789",
+                        "type": "function",
+                        "function": {
+                            "name": "get_image",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_789",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/result.jpg"},
+                    }
+                ],
+            },
+        ]
+
+        result = anthropic_messages_pt(
+            messages=messages,
+            model="claude-sonnet-4",
+            llm_provider="vertex_ai",
+        )
+
+        # Verify convert_url_to_base64 was called for the tool result image
+        mock_convert_url.assert_called_once_with(url="https://example.com/result.jpg")
+
+        # Find the tool_result in the converted messages
+        for msg in result:
+            if msg.get("role") == "user":
+                for content_item in msg.get("content", []):
+                    if isinstance(content_item, dict) and content_item.get("type") == "tool_result":
+                        tool_content = content_item.get("content", [])
+                        for item in tool_content:
+                            if isinstance(item, dict) and item.get("type") == "image":
+                                assert item["source"]["type"] == "base64"
+                                return
+        pytest.fail("Could not find image in tool result")
+
+    @patch("litellm.litellm_core_utils.prompt_templates.factory.convert_url_to_base64")
+    def test_regular_anthropic_tool_message_uses_url(
+        self, mock_convert_url: MagicMock
+    ):
+        """
+        Test that regular Anthropic API uses URL type for tool result images.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": "Get me an image",
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {
+                            "name": "get_image",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_abc",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.jpg"},
+                    }
+                ],
+            },
+        ]
+
+        result = anthropic_messages_pt(
+            messages=messages,
+            model="claude-sonnet-4",
+            llm_provider="anthropic",
+        )
+
+        # convert_url_to_base64 should NOT be called for regular Anthropic
+        mock_convert_url.assert_not_called()
+
+        # Find the tool_result and verify URL type
+        for msg in result:
+            if msg.get("role") == "user":
+                for content_item in msg.get("content", []):
+                    if isinstance(content_item, dict) and content_item.get("type") == "tool_result":
+                        tool_content = content_item.get("content", [])
+                        for item in tool_content:
+                            if isinstance(item, dict) and item.get("type") == "image":
+                                assert item["source"]["type"] == "url"
+                                return
+        pytest.fail("Could not find image in tool result")

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_anthropic_image_url_handling.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_anthropic_image_url_handling.py
@@ -4,9 +4,6 @@ Tests for Vertex AI Anthropic image URL handling.
 Issue: https://github.com/BerriAI/litellm/issues/18430
 Vertex AI Anthropic models don't support URL sources for images.
 LiteLLM should convert image URLs to base64 when using Vertex AI Anthropic.
-
-Issue: https://github.com/BerriAI/litellm/issues/19891
-Tool messages with image_url should also be converted to base64 for Vertex AI.
 """
 import os
 import sys


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/19891

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

When sending images to Anthropic models:

- **Direct Anthropic API**: Accepts image URLs directly. Anthropic's servers download the image.
- **Vertex AI Anthropic**: Does not support image URLs. LiteLLM must download the image and convert it to base64 before sending.

LiteLLM already handled this conversion for **user messages**, but not for **tool messages** (`role='tool'`).

When a tool returns an image URL in its result (common in agents with screenshot/image capabilities), Vertex AI Anthropic fails with:

```
BadRequestError: Vertex_aiException BadRequestError - 
messages.1.content.2.image.source.base64.data: URL sources are not supported
```

### Example payload

```json
{
  "role": "tool",
  "tool_call_id": "call_123",
  "content": [
    {
      "type": "image_url",
      "image_url": {
        "url": "https://example.com/screenshot.png",
        "detail": "high"
      }
    }
  ]
}
```

With this fix, LiteLLM automatically downloads the image and converts it to base64 before sending to the Vertex API.

### Changes:
- Add `force_base64` parameter to `convert_to_anthropic_tool_result()`
- Pass `force_base64` to `create_anthropic_image_param()` for tool message images
- Calculate `force_base64` in `anthropic_messages_pt()` based on `llm_provider`
- Add 4 unit tests for tool message image handling

### Files changed:
- `litellm/litellm_core_utils/prompt_templates/factory.py`
- `tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_anthropic_image_url_handling.py`