### PR TITLE
Add native_background_mode to override polling_via_cache for specific models

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1224,6 +1224,7 @@ redis_usage_cache: Optional[
     RedisCache
 ] = None  # redis cache used for tracking spend, tpm/rpm limits
 polling_via_cache_enabled: Union[Literal["all"], List[str], bool] = False
+native_background_mode: List[str] = []  # Models that should use native provider background mode instead of polling
 polling_cache_ttl: int = 3600  # Default 1 hour TTL for polling cache
 user_custom_auth = None
 user_custom_key_generate = None
@@ -2456,14 +2457,17 @@ class ProxyConfig:
                     pass
                 elif key == "responses":
                     # Initialize global polling via cache settings
-                    global polling_via_cache_enabled, polling_cache_ttl
+                    global polling_via_cache_enabled, native_background_mode, polling_cache_ttl
                     background_mode = value.get("background_mode", {})
                     polling_via_cache_enabled = background_mode.get(
                         "polling_via_cache", False
                     )
+                    native_background_mode = background_mode.get(
+                        "native_background_mode", []
+                    )
                     polling_cache_ttl = background_mode.get("ttl", 3600)
                     verbose_proxy_logger.debug(
-                        f"{blue_color_code} Initialized polling via cache: enabled={polling_via_cache_enabled}, ttl={polling_cache_ttl}{reset_color_code}"
+                        f"{blue_color_code} Initialized polling via cache: enabled={polling_via_cache_enabled}, native_background_mode={native_background_mode}, ttl={polling_cache_ttl}{reset_color_code}"
                     )
                 elif key == "default_team_settings":
                     for idx, team_setting in enumerate(

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -68,6 +68,7 @@ async def responses_api(
         _read_request_body,
         general_settings,
         llm_router,
+        native_background_mode,
         polling_cache_ttl,
         polling_via_cache_enabled,
         proxy_config,
@@ -95,6 +96,7 @@ async def responses_api(
         redis_cache=redis_usage_cache,
         model=data.get("model", ""),
         llm_router=llm_router,
+        native_background_mode=native_background_mode,
     )
     
     # If polling is enabled, use polling mode

--- a/tests/proxy_unit_tests/test_response_polling_handler.py
+++ b/tests/proxy_unit_tests/test_response_polling_handler.py
@@ -1005,6 +1005,142 @@ class TestPollingConditionChecks:
         
         assert result is False
 
+    # ==================== Native Background Mode Tests ====================
+
+    def test_polling_disabled_when_model_in_native_background_mode(self):
+        """Test that polling is disabled when model is in native_background_mode list"""
+        from litellm.proxy.response_polling.polling_handler import should_use_polling_for_request
+        
+        result = should_use_polling_for_request(
+            background_mode=True,
+            polling_via_cache_enabled="all",
+            redis_cache=Mock(),
+            model="o4-mini-deep-research",
+            llm_router=None,
+            native_background_mode=["o4-mini-deep-research", "o3-deep-research"],
+        )
+        
+        assert result is False
+
+    def test_polling_disabled_for_native_background_mode_with_provider_list(self):
+        """Test that native_background_mode takes precedence even when provider matches"""
+        from litellm.proxy.response_polling.polling_handler import should_use_polling_for_request
+        
+        result = should_use_polling_for_request(
+            background_mode=True,
+            polling_via_cache_enabled=["openai"],
+            redis_cache=Mock(),
+            model="openai/o4-mini-deep-research",
+            llm_router=None,
+            native_background_mode=["openai/o4-mini-deep-research"],
+        )
+        
+        assert result is False
+
+    def test_polling_enabled_when_model_not_in_native_background_mode(self):
+        """Test that polling is enabled when model is not in native_background_mode list"""
+        from litellm.proxy.response_polling.polling_handler import should_use_polling_for_request
+        
+        result = should_use_polling_for_request(
+            background_mode=True,
+            polling_via_cache_enabled="all",
+            redis_cache=Mock(),
+            model="gpt-4o",
+            llm_router=None,
+            native_background_mode=["o4-mini-deep-research"],
+        )
+        
+        assert result is True
+
+    def test_polling_enabled_when_native_background_mode_is_none(self):
+        """Test that polling works normally when native_background_mode is None"""
+        from litellm.proxy.response_polling.polling_handler import should_use_polling_for_request
+        
+        result = should_use_polling_for_request(
+            background_mode=True,
+            polling_via_cache_enabled="all",
+            redis_cache=Mock(),
+            model="gpt-4o",
+            llm_router=None,
+            native_background_mode=None,
+        )
+        
+        assert result is True
+
+    def test_polling_enabled_when_native_background_mode_is_empty_list(self):
+        """Test that polling works normally when native_background_mode is empty list"""
+        from litellm.proxy.response_polling.polling_handler import should_use_polling_for_request
+        
+        result = should_use_polling_for_request(
+            background_mode=True,
+            polling_via_cache_enabled="all",
+            redis_cache=Mock(),
+            model="gpt-4o",
+            llm_router=None,
+            native_background_mode=[],
+        )
+        
+        assert result is True
+
+    def test_native_background_mode_exact_match_required(self):
+        """Test that native_background_mode uses exact model name matching"""
+        from litellm.proxy.response_polling.polling_handler import should_use_polling_for_request
+        
+        # "o4-mini" should not match "o4-mini-deep-research"
+        result = should_use_polling_for_request(
+            background_mode=True,
+            polling_via_cache_enabled="all",
+            redis_cache=Mock(),
+            model="o4-mini",
+            llm_router=None,
+            native_background_mode=["o4-mini-deep-research"],
+        )
+        
+        assert result is True
+
+    def test_native_background_mode_with_provider_prefix_in_request(self):
+        """Test native_background_mode matching when request model has provider prefix"""
+        from litellm.proxy.response_polling.polling_handler import should_use_polling_for_request
+        
+        # Model in native_background_mode without provider prefix
+        # Request comes in with provider prefix - should not match
+        result = should_use_polling_for_request(
+            background_mode=True,
+            polling_via_cache_enabled=["openai"],
+            redis_cache=Mock(),
+            model="openai/o4-mini-deep-research",
+            llm_router=None,
+            native_background_mode=["o4-mini-deep-research"],  # Without prefix
+        )
+        
+        # Should return True because "openai/o4-mini-deep-research" != "o4-mini-deep-research"
+        assert result is True
+
+    def test_native_background_mode_with_router_lookup(self):
+        """Test that native_background_mode works with router-resolved models"""
+        from litellm.proxy.response_polling.polling_handler import should_use_polling_for_request
+        
+        mock_router = Mock()
+        mock_router.model_name_to_deployment_indices = {"deep-research": [0]}
+        mock_router.model_list = [
+            {
+                "model_name": "deep-research",
+                "litellm_params": {"model": "openai/o4-mini-deep-research"}
+            }
+        ]
+        
+        # Model alias "deep-research" is in native_background_mode
+        result = should_use_polling_for_request(
+            background_mode=True,
+            polling_via_cache_enabled=["openai"],
+            redis_cache=Mock(),
+            model="deep-research",
+            llm_router=mock_router,
+            native_background_mode=["deep-research"],
+        )
+        
+        assert result is False
+
 
 class TestStreamingEventParsing:
     """


### PR DESCRIPTION
## Relevant issues
This follow-up to PR #16862 allows users to specify models that should use the native provider's background mode instead of polling via cache.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature


## Changes
This follow-up to PR #16862 allows users to specify models that should use the native provider's background mode instead of polling via cache.

Config example:
  litellm_settings:
    responses:
      background_mode:
        polling_via_cache: ["openai"]
        native_background_mode: ["o4-mini-deep-research"]
        ttl: 3600

When a model is in native_background_mode list, should_use_polling_for_request returns False, allowing the request to fall through to native provider handling.
## Testing

Config: 
``` 
litellm_settings:
  cache: true
  cache_params:
    type: "redis"
    ttl: 3600
    host: "127.0.0.1"
    port: 6379
  responses:
    background_mode:
      polling_via_cache: ["openai"]
      native_background_mode: ["o4-mini-deep-research"]
      ttl: 3600
```

polling_via_cache enabled for gpt-5.2:
```curl http://0.0.0.0:4000/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{
    "model": "gpt-5.2",
    "input": "Tell me a three sentence bedtime story about a unicorn.",
    "background": true
  }' \
  | jq
```
Response:
```{
  "id": "litellm_poll_488c5546-7b0c-412d-955e-5792202d2201",
  "created_at": 1769579421,
  "error": null,
  "incomplete_details": null,
  "instructions": null,
  "metadata": {},
  "model": null,
  "object": "response",
  "output": [],
  "parallel_tool_calls": null,
  "temperature": null,
  "tool_choice": null,
  "tools": null,
  "top_p": null,
  "max_output_tokens": null,
  "previous_response_id": null,
  "reasoning": null,
  "status": "queued",
  "text": null,
  "truncation": null,
  "usage": null,
  "user": null,
  "store": null
}
```

Poll the response:
```
  curl http://0.0.0.0:4000/v1/responses/litellm_poll_488c5546-7b0c-412d-955e-5792202d2201 \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  | jq
```

```
{
  "id": "litellm_poll_488c5546-7b0c-412d-955e-5792202d2201",
  "created_at": 1769579421,
  "error": null,
  "incomplete_details": null,
  "instructions": null,
  "metadata": {},
  "model": "gpt-5.2-2025-12-11",
  "object": "response",
  "output": [
    {
      "id": "msg_0846a0de0fb14792006979a39e16188190bdb1f669aa610ea8",
      "content": [
        {
          "annotations": [],
          "text": "A gentle unicorn named Luma trotted through a moonlit meadow, leaving a soft trail of sparkling dew behind her. When she found a lost little bunny shivering under a fern, she warmed it with her glowing horn and guided it safely home. As the stars hummed quietly overhead, Luma curled up in the silver grass and everyone in the meadow drifted into peaceful dreams.",
          "type": "output_text",
          "logprobs": []
        }
      ],
      "role": "assistant",
      "status": "completed",
      "type": "message"
    }
  ],
  "parallel_tool_calls": true,
  "temperature": 1.0,
  "tool_choice": "auto",
  "tools": [],
  "top_p": 0.98,
  "max_output_tokens": null,
  "previous_response_id": null,
  "reasoning": {
    "effort": "none"
  },
  "status": "completed",
  "text": {
    "format": {
      "type": "text"
    },
    "verbosity": "medium"
  },
  "truncation": "disabled",
  "usage": {
    "input_tokens": 17,
    "input_tokens_details": {
      "cached_tokens": 0
    },
    "output_tokens": 81,
    "output_tokens_details": {
      "reasoning_tokens": 0
    },
    "total_tokens": 98
  },
  "user": null,
  "store": true
}

```

When native background enabled, user should get response id starts with `resp`:

Request:
```
curl http://0.0.0.0:4000/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{
    "model": "o4-mini-deep-research",
    "input": "Tell me a three sentence bedtime story about a unicorn.",
    "tools": [
      {"type": "web_search"}
    ],
    "background": true
  }' \
  | jq
```

Response:
```
{
  "id": "resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDpmOGYxOWJiNzQ1NGM1OTlmMzI2NzhiZjQ2NzViZjg4ZDAzZTVjZmY4YzAwNWZlYmI3NmE2NWIzNDVkYWVmMmE5O3Jlc3BvbnNlX2lkOnJlc3BfMDExMWE4NzE5MWI5ZDM4NTAwNjk3OWE3MDk5ZmM0ODE5NmJiZjUxOTkwODMxNzUyZGU=",
  "created_at": 1769580297,
  "error": null,
  "incomplete_details": null,
  "instructions": null,
  "metadata": {},
  "model": "o4-mini-deep-research-2025-06-26",
  "object": "response",
  "output": [],
  "parallel_tool_calls": true,
  "temperature": 1.0,
  "tool_choice": "auto",
  "tools": [
    {
      "type": "web_search_preview",
      "search_context_size": "medium",
      "user_location": null
    }
  ],
  "top_p": 1.0,
  "max_output_tokens": null,
  "previous_response_id": null,
  "reasoning": {
    "effort": "medium",
    "summary": null
  },
  "status": "queued",
  "text": {
    "format": {
      "type": "text"
    },
    "verbosity": "medium"
  },
  "truncation": "disabled",
  "usage": null,
  "user": null,
  "store": true,
  "background": true,
  "completed_at": null,
  "frequency_penalty": 0.0,
  "max_tool_calls": 225,
  "presence_penalty": 0.0,
  "prompt_cache_key": null,
  "prompt_cache_retention": null,
  "safety_identifier": null,
  "service_tier": "auto",
  "top_logprobs": 0
}
```

Get response with response id under native background mode:
Request:
```
curl http://0.0.0.0:4000/v1/responses/resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDpmOGYxOWJiNzQ1NGM1OTlmMzI2NzhiZjQ2NzViZjg4ZDAzZTVjZmY4YzAwNWZlYmI3NmE2NWIzNDVkYWVmMmE5O3Jlc3BvbnNlX2lkOnJlc3BfMDExMWE4NzE5MWI5ZDM4NTAwNjk3OWE3MDk5ZmM0ODE5NmJiZjUxOTkwODMxNzUyZGU\= \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  | jq
```
Partial response:
```
{
  "id": "resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDpmOGYxOWJiNzQ1NGM1OTlmMzI2NzhiZjQ2NzViZjg4ZDAzZTVjZmY4YzAwNWZlYmI3NmE2NWIzNDVkYWVmMmE5O3Jlc3BvbnNlX2lkOnJlc3BfMDExMWE4NzE5MWI5ZDM4NTAwNjk3OWE3MDk5ZmM0ODE5NmJiZjUxOTkwODMxNzUyZGU=",
  "created_at": 1769580297,
  "error": null,
  "incomplete_details": null,
  "instructions": null,
  "metadata": {},
  "model": "o4-mini-deep-research-2025-06-26",
  "object": "response",
  "output": [],
  "parallel_tool_calls": true,
  "temperature": 1.0,
  "tool_choice": "auto",
  "tools": [
    {
      "type": "web_search_preview",
      "search_context_size": "medium",
      "user_location": null
    }
  ],
  "top_p": 1.0,
  "max_output_tokens": null,
  "previous_response_id": null,
  "reasoning": {
    "effort": "medium",
    "summary": null
  },
  "status": "in_progress",
  "text": {
    "format": {
      "type": "text"
    },
    "verbosity": "medium"
  },
  "truncation": "disabled",
  "usage": null,
  "user": null,
  "store": true,
  "background": true,
  "completed_at": null,
  "frequency_penalty": 0.0,
  "max_tool_calls": 225,
  "presence_penalty": 0.0,
  "prompt_cache_key": null,
  "prompt_cache_retention": null,
  "safety_identifier": null,
  "service_tier": "auto",
  "top_logprobs": 0
}

```