### PR TITLE
[Feature] UI - Model Page: Server Sort

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
@@ -104,6 +104,8 @@ describe("useModelsInfo", () => {
       50,
       undefined,
       undefined,
+      undefined,
+      undefined,
       undefined
     );
     expect(modelInfoCall).toHaveBeenCalledTimes(1);
@@ -124,6 +126,8 @@ describe("useModelsInfo", () => {
       "Admin",
       2,
       25,
+      undefined,
+      undefined,
       undefined,
       undefined,
       undefined

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -27,7 +27,7 @@ const modelHubKeys = createQueryKeys("modelHub");
 const allProxyModelsKeys = createQueryKeys("allProxyModels");
 const selectedTeamModelsKeys = createQueryKeys("selectedTeamModels");
 
-export const useModelsInfo = (page: number = 1, size: number = 50, search?: string, modelId?: string, teamId?: string) => {
+export const useModelsInfo = (page: number = 1, size: number = 50, search?: string, modelId?: string, teamId?: string, sortBy?: string, sortOrder?: string) => {
   const { accessToken, userId, userRole } = useAuthorized();
   return useQuery<PaginatedModelInfoResponse>({
     queryKey: modelKeys.list({
@@ -39,9 +39,11 @@ export const useModelsInfo = (page: number = 1, size: number = 50, search?: stri
         ...(search && { search }),
         ...(modelId && { modelId }),
         ...(teamId && { teamId }),
+        ...(sortBy && { sortBy }),
+        ...(sortOrder && { sortOrder }),
       },
     }),
-    queryFn: async () => await modelInfoCall(accessToken!, userId!, userRole!, page, size, search, modelId, teamId),
+    queryFn: async () => await modelInfoCall(accessToken!, userId!, userRole!, page, size, search, modelId, teamId, sortBy, sortOrder),
     enabled: Boolean(accessToken && userId && userRole),
   });
 };

--- a/ui/litellm-dashboard/src/components/model_dashboard/all_models_table.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard/all_models_table.tsx
@@ -1,0 +1,196 @@
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  SortingState,
+  useReactTable,
+  ColumnResizeMode,
+  VisibilityState,
+  PaginationState,
+  OnChangeFn,
+} from "@tanstack/react-table";
+import React from "react";
+import { Table, TableHead, TableHeaderCell, TableBody, TableRow, TableCell } from "@tremor/react";
+import { SwitchVerticalIcon, ChevronUpIcon, ChevronDownIcon } from "@heroicons/react/outline";
+
+// Extend the column meta type to include className
+declare module "@tanstack/react-table" {
+  interface ColumnMeta<TData, TValue> {
+    className?: string;
+  }
+}
+
+interface AllModelsDataTableProps<TData, TValue> {
+  data: TData[];
+  columns: ColumnDef<TData, TValue>[];
+  isLoading?: boolean;
+  sorting?: SortingState;
+  onSortingChange?: OnChangeFn<SortingState>;
+  pagination?: PaginationState;
+  onPaginationChange?: OnChangeFn<PaginationState>;
+  enablePagination?: boolean;
+}
+
+export function AllModelsDataTable<TData, TValue>({
+  data = [],
+  columns,
+  isLoading = false,
+  sorting = [],
+  onSortingChange,
+  pagination,
+  onPaginationChange,
+  enablePagination = false,
+}: AllModelsDataTableProps<TData, TValue>) {
+  const [columnResizeMode] = React.useState<ColumnResizeMode>("onChange");
+  const [columnSizing, setColumnSizing] = React.useState({});
+  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
+
+  const tableInstance = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      columnSizing,
+      columnVisibility,
+      ...(enablePagination && pagination ? { pagination } : {}),
+    },
+    columnResizeMode,
+    onSortingChange: onSortingChange,
+    onColumnSizingChange: setColumnSizing,
+    onColumnVisibilityChange: setColumnVisibility,
+    ...(enablePagination && onPaginationChange ? { onPaginationChange } : {}),
+    getCoreRowModel: getCoreRowModel(),
+    // NO getSortedRowModel - sorting is handled server-side
+    ...(enablePagination ? { getPaginationRowModel: getPaginationRowModel() } : {}),
+    enableSorting: true,
+    enableColumnResizing: true,
+    manualSorting: true, // Enable manual sorting for server-side sorting
+    defaultColumn: {
+      minSize: 40,
+      maxSize: 500,
+    },
+  });
+
+  const getHeaderText = (header: any): string => {
+    if (typeof header === "string") {
+      return header;
+    }
+    if (typeof header === "function") {
+      const headerElement = header();
+      if (headerElement && headerElement.props && headerElement.props.children) {
+        const children = headerElement.props.children;
+        if (typeof children === "string") {
+          return children;
+        }
+        if (children.props && children.props.children) {
+          return children.props.children;
+        }
+      }
+    }
+    return "";
+  };
+
+  return (
+    <div className="rounded-lg custom-border relative">
+      <div className="overflow-x-auto">
+        <div className="relative min-w-full">
+          <Table className="[&_td]:py-2 [&_th]:py-2 w-full">
+            <TableHead>
+              {tableInstance.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <TableHeaderCell
+                      key={header.id}
+                      className={`py-1 h-8 relative ${
+                        header.id === "actions"
+                          ? "sticky right-0 bg-white shadow-[-4px_0_8px_-6px_rgba(0,0,0,0.1)] w-[120px] ml-8"
+                          : ""
+                      } ${header.column.columnDef.meta?.className || ""}`}
+                      style={{
+                        width: header.id === "actions" ? 120 : header.getSize(),
+                        position: header.id === "actions" ? "sticky" : "relative",
+                        right: header.id === "actions" ? 0 : "auto",
+                      }}
+                      onClick={header.column.getCanSort() ? header.column.getToggleSortingHandler() : undefined}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center">
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(header.column.columnDef.header, header.getContext())}
+                        </div>
+                        {header.id !== "actions" && header.column.getCanSort() && (
+                          <div className="w-4">
+                            {header.column.getIsSorted() ? (
+                              {
+                                asc: <ChevronUpIcon className="h-4 w-4 text-blue-500" />,
+                                desc: <ChevronDownIcon className="h-4 w-4 text-blue-500" />,
+                              }[header.column.getIsSorted() as string]
+                            ) : (
+                              <SwitchVerticalIcon className="h-4 w-4 text-gray-400" />
+                            )}
+                          </div>
+                        )}
+                      </div>
+                      {header.column.getCanResize() && (
+                        <div
+                          onMouseDown={header.getResizeHandler()}
+                          onTouchStart={header.getResizeHandler()}
+                          className={`absolute right-0 top-0 h-full w-2 cursor-col-resize select-none touch-none ${
+                            header.column.getIsResizing() ? "bg-blue-500" : "hover:bg-blue-200"
+                          }`}
+                        />
+                      )}
+                    </TableHeaderCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHead>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-8 text-center">
+                    <div className="text-center text-gray-500">
+                      <p>🚅 Loading models...</p>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ) : tableInstance.getRowModel().rows.length > 0 ? (
+                tableInstance.getRowModel().rows.map((row) => (
+                  <TableRow key={row.id}>
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell
+                        key={cell.id}
+                        className={`py-0.5 ${
+                          cell.column.id === "actions"
+                            ? "sticky right-0 bg-white shadow-[-4px_0_8px_-6px_rgba(0,0,0,0.1)] w-[120px] ml-8"
+                            : ""
+                        } ${cell.column.columnDef.meta?.className || ""}`}
+                        style={{
+                          width: cell.column.id === "actions" ? 120 : cell.column.getSize(),
+                          position: cell.column.id === "actions" ? "sticky" : "relative",
+                          right: cell.column.id === "actions" ? 0 : "auto",
+                        }}
+                      >
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-8 text-center">
+                    <div className="text-center text-gray-500">
+                      <p>No models found</p>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2007,12 +2007,12 @@ export const regenerateKeyCall = async (accessToken: string, keyToRegenerate: st
 let ModelListerrorShown = false;
 let errorTimer: NodeJS.Timeout | null = null;
 
-export const modelInfoCall = async (accessToken: string, userID: string, userRole: string, page: number = 1, size: number = 50, search?: string, modelId?: string, teamId?: string) => {
+export const modelInfoCall = async (accessToken: string, userID: string, userRole: string, page: number = 1, size: number = 50, search?: string, modelId?: string, teamId?: string, sortBy?: string, sortOrder?: string) => {
   /**
    * Get all models on proxy
    */
   try {
-    console.log("modelInfoCall:", accessToken, userID, userRole, page, size, search, modelId, teamId);
+    console.log("modelInfoCall:", accessToken, userID, userRole, page, size, search, modelId, teamId, sortBy, sortOrder);
     let url = proxyBaseUrl ? `${proxyBaseUrl}/v2/model/info` : `/v2/model/info`;
     const params = new URLSearchParams();
     params.append("include_team_models", "true");
@@ -2026,6 +2026,12 @@ export const modelInfoCall = async (accessToken: string, userID: string, userRol
     }
     if (teamId && teamId.trim()) {
       params.append("teamId", teamId.trim());
+    }
+    if (sortBy && sortBy.trim()) {
+      params.append("sortBy", sortBy.trim());
+    }
+    if (sortOrder && sortOrder.trim()) {
+      params.append("sortOrder", sortOrder.trim());
     }
     if (params.toString()) {
       url += `?${params.toString()}`;

--- a/ui/litellm-dashboard/src/components/vector_store_management/S3VectorsConfig.tsx
+++ b/ui/litellm-dashboard/src/components/vector_store_management/S3VectorsConfig.tsx
@@ -53,7 +53,7 @@ const S3VectorsConfig: React.FC<S3VectorsConfigProps> = ({
           <div>
             <p>AWS S3 Vectors allows you to store and query vector embeddings directly in S3:</p>
             <ul style={{ marginLeft: "16px", marginTop: "8px" }}>
-              <li>Vector buckets and indexes will be automatically created if they don't exist</li>
+              <li>Vector buckets and indexes will be automatically created if they don&apos;t exist</li>
               <li>Vector dimensions are auto-detected from your selected embedding model</li>
               <li>Ensure your AWS credentials have permissions for S3 Vectors operations</li>
               <li>


### PR DESCRIPTION
## Relevant issues
Currently this table sorts only the page being shown as the /v2/models/info endpoint was recently migrated to be paginated. Taking advantage of a previous PR that implemented sortBy and sortOrder to the /v2/models/info endpoint, this PR changes the All Models Table to use these new fields.

Note:
I needed to decouple this for ModelDataTable as this is a common component that expects client side sorting
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
