### PR TITLE
[Feature] Allow Dynamic Setting of store_prompts_in_spend_logs

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2073,6 +2073,14 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="Controls how non-admin users interact with MCP servers in the dashboard. 'restricted' shows only accessible servers, 'view_all' lists every server in read-only mode.",
     )
+    store_prompts_in_spend_logs: Optional[bool] = Field(
+        None,
+        description="If True, stores request messages and responses in spend logs. Default is False.",
+    )
+    maximum_spend_logs_retention_period: Optional[str] = Field(
+        None,
+        description="Maximum retention period for spend logs (e.g., '7d' for 7 days). Logs older than this will be deleted.",
+    )
 
 
 class ConfigYAML(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -759,10 +759,19 @@ def _should_store_prompts_and_responses_in_spend_logs() -> bool:
     from litellm.proxy.proxy_server import general_settings
     from litellm.secret_managers.main import get_secret_bool
 
-    return (
-        general_settings.get("store_prompts_in_spend_logs") is True
-        or get_secret_bool("STORE_PROMPTS_IN_SPEND_LOGS") is True
-    )
+    # Check general_settings (from DB or proxy_config.yaml)
+    store_prompts_value = general_settings.get("store_prompts_in_spend_logs")
+    
+    # Normalize case: handle True/true/TRUE, False/false/FALSE, None/null
+    if store_prompts_value is True:
+        return True
+    elif isinstance(store_prompts_value, str):
+        # Case-insensitive string comparison
+        if store_prompts_value.lower() == "true":
+            return True
+    
+    # Also check environment variable
+    return get_secret_bool("STORE_PROMPTS_IN_SPEND_LOGS") is True
 
 
 def _get_status_for_spend_log(


### PR DESCRIPTION
## Relevant issues
Currently, store_prompts_in_spend_logs is a setting under general_settings, and it is only set inside of the proxy_config. This creates issues for users deploying LiteLLM in cloud instances, as they may not have easy access to the proxy_config. Furthermore, adjusting the proxy_config requires a restart for the changes to take effect.

This PR solves this issue by allowing store_prompts_in_spend_logs to be stored inside of LiteLLM_Config > general_settings. When it is time to see if we should store the request/response pair inside of the logs, it reads from this value.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="729" height="163" alt="image" src="https://github.com/user-attachments/assets/fc6d965a-64a1-4908-b3d2-759b4e1c3cc0" />
<img width="722" height="309" alt="image" src="https://github.com/user-attachments/assets/7d2e1854-3cae-4d3f-b56f-b2a07cb3c638" />
<img width="512" height="415" alt="image" src="https://github.com/user-attachments/assets/df80418c-2eb3-48b2-b3ee-68d812e77a05" />
Without restart:
<img width="1217" height="787" alt="image" src="https://github.com/user-attachments/assets/0ff4e9db-204a-46bf-b1d5-9487d019618a" />
