### PR TITLE
[Feature] UI - Spend Logs: Settings Modal

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/storeRequestInSpendLogs/useStoreRequestInSpendLogs.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/storeRequestInSpendLogs/useStoreRequestInSpendLogs.ts
@@ -1,0 +1,63 @@
+import { useMutation, UseMutationResult } from "@tanstack/react-query";
+import { getProxyBaseUrl, getGlobalLitellmHeaderName } from "@/components/networking";
+import useAuthorized from "../useAuthorized";
+
+export interface StoreRequestInSpendLogsParams {
+  store_prompts_in_spend_logs: boolean;
+  maximum_spend_logs_retention_period?: string;
+}
+
+export interface StoreRequestInSpendLogsResponse {
+  message: string;
+}
+
+const performStoreRequestInSpendLogs = async (
+  accessToken: string,
+  params: StoreRequestInSpendLogsParams
+): Promise<StoreRequestInSpendLogsResponse> => {
+  const proxyBaseUrl = getProxyBaseUrl();
+  const url = proxyBaseUrl ? `${proxyBaseUrl}/config/update` : `/config/update`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      general_settings: {
+        store_prompts_in_spend_logs: params.store_prompts_in_spend_logs,
+        ...(params.maximum_spend_logs_retention_period && {
+          maximum_spend_logs_retention_period: params.maximum_spend_logs_retention_period,
+        }),
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    const errorMessage =
+      errorData?.error?.message || errorData?.message || errorData?.detail || "Failed to update spend logs settings";
+    throw new Error(errorMessage);
+  }
+
+  const data = await response.json();
+  return data;
+};
+
+export const useStoreRequestInSpendLogs = (): UseMutationResult<
+  StoreRequestInSpendLogsResponse,
+  Error,
+  StoreRequestInSpendLogsParams
+> => {
+  const { accessToken } = useAuthorized();
+
+  return useMutation<StoreRequestInSpendLogsResponse, Error, StoreRequestInSpendLogsParams>({
+    mutationFn: async (params: StoreRequestInSpendLogsParams) => {
+      if (!accessToken) {
+        throw new Error("Access token is required");
+      }
+      return await performStoreRequestInSpendLogs(accessToken, params);
+    },
+  });
+};

--- a/ui/litellm-dashboard/src/components/view_logs/SpendLogsSettingsModal/SpendLogsSettingsModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/SpendLogsSettingsModal/SpendLogsSettingsModal.test.tsx
@@ -1,0 +1,348 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi, Mock } from "vitest";
+import SpendLogsSettingsModal from "./SpendLogsSettingsModal";
+import { useStoreRequestInSpendLogs } from "@/app/(dashboard)/hooks/storeRequestInSpendLogs/useStoreRequestInSpendLogs";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+import { parseErrorMessage } from "@/components/shared/errorUtils";
+import { renderWithProviders } from "../../../../tests/test-utils";
+
+vi.mock("@/app/(dashboard)/hooks/storeRequestInSpendLogs/useStoreRequestInSpendLogs");
+vi.mock("@/components/molecules/notifications_manager", () => ({
+  default: {
+    success: vi.fn(),
+    fromBackend: vi.fn(),
+  },
+}));
+vi.mock("@/components/shared/errorUtils", () => ({
+  parseErrorMessage: vi.fn(),
+}));
+
+const mockUseStoreRequestInSpendLogs = vi.mocked(useStoreRequestInSpendLogs);
+const mockNotificationsManager = vi.mocked(NotificationsManager);
+const mockParseErrorMessage = vi.mocked(parseErrorMessage);
+
+describe("SpendLogsSettingsModal", () => {
+  const mockOnCancel = vi.fn();
+  const mockOnSuccess = vi.fn();
+  const mockMutateAsync = vi.fn();
+
+  const defaultProps = {
+    isVisible: true,
+    onCancel: mockOnCancel,
+    onSuccess: mockOnSuccess,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseStoreRequestInSpendLogs.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as any);
+    mockParseErrorMessage.mockImplementation((error: any) => error?.message || String(error));
+  });
+
+  it("should render the modal", () => {
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Spend Logs Settings")).toBeInTheDocument();
+  });
+
+  it("should render form fields with initial values", () => {
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+    
+    expect(screen.getByText("Store Prompts in Spend Logs")).toBeInTheDocument();
+    expect(screen.getByLabelText("Maximum Spend Logs Retention Period (Optional)")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("e.g., 7d, 30d")).toBeInTheDocument();
+  });
+
+  it("should render cancel and save buttons", () => {
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+    
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save Settings" })).toBeInTheDocument();
+  });
+
+  it("should call onCancel when cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    await user.click(cancelButton);
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onCancel when modal close button is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const closeButton = screen.getByRole("button", { name: /close/i });
+    await user.click(closeButton);
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("should toggle store prompts switch", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const switchElement = screen.getByRole("switch");
+    expect(switchElement).not.toBeChecked();
+
+    await user.click(switchElement);
+
+    await waitFor(() => {
+      expect(switchElement).toBeChecked();
+    });
+  });
+
+  it("should update retention period input", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const retentionInput = screen.getByPlaceholderText("e.g., 7d, 30d");
+    await user.type(retentionInput, "30d");
+
+    expect(retentionInput).toHaveValue("30d");
+  });
+
+  it("should submit form with store prompts enabled and retention period", async () => {
+    const user = userEvent.setup();
+    mockMutateAsync.mockImplementation(async (params, options) => {
+      await Promise.resolve();
+      options?.onSuccess?.();
+      return { message: "Success" };
+    });
+    
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const switchElement = screen.getByRole("switch");
+    await user.click(switchElement);
+
+    const retentionInput = screen.getByPlaceholderText("e.g., 7d, 30d");
+    await user.type(retentionInput, "30d");
+
+    const saveButton = screen.getByRole("button", { name: "Save Settings" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        {
+          store_prompts_in_spend_logs: true,
+          maximum_spend_logs_retention_period: "30d",
+        },
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("should submit form with store prompts disabled and no retention period", async () => {
+    const user = userEvent.setup();
+    mockMutateAsync.mockImplementation(async (params, options) => {
+      await Promise.resolve();
+      options?.onSuccess?.();
+      return { message: "Success" };
+    });
+    
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const saveButton = screen.getByRole("button", { name: "Save Settings" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        {
+          store_prompts_in_spend_logs: false,
+          maximum_spend_logs_retention_period: undefined,
+        },
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("should show success notification and call onSuccess on successful submission", async () => {
+    const user = userEvent.setup();
+    mockMutateAsync.mockImplementation(async (params, options) => {
+      await Promise.resolve();
+      options?.onSuccess?.();
+      return { message: "Success" };
+    });
+    
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const saveButton = screen.getByRole("button", { name: "Save Settings" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockNotificationsManager.success).toHaveBeenCalledWith("Spend logs settings updated successfully");
+      expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("should show error notification when submission fails", async () => {
+    const user = userEvent.setup();
+    const error = new Error("Network error");
+    mockMutateAsync.mockRejectedValue(error);
+    mockParseErrorMessage.mockReturnValue("Network error");
+    
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const saveButton = screen.getByRole("button", { name: "Save Settings" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockNotificationsManager.fromBackend).toHaveBeenCalledWith("Failed to save spend logs settings: Network error");
+    });
+  });
+
+  it("should show error notification from onError callback", async () => {
+    const user = userEvent.setup();
+    const error = new Error("Backend error");
+    mockMutateAsync.mockImplementation((params, options) => {
+      options?.onError?.(error);
+      return Promise.reject(error);
+    });
+    mockParseErrorMessage.mockReturnValue("Backend error");
+    
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const saveButton = screen.getByRole("button", { name: "Save Settings" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockNotificationsManager.fromBackend).toHaveBeenCalledWith("Failed to save spend logs settings: Backend error");
+    });
+  });
+
+  it("should disable cancel button when pending", () => {
+    mockUseStoreRequestInSpendLogs.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: true,
+    } as any);
+
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    expect(cancelButton).toBeDisabled();
+  });
+
+  it("should show loading state on save button when pending", () => {
+    mockUseStoreRequestInSpendLogs.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: true,
+    } as any);
+
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const saveButton = screen.getByRole("button", { name: /Saving/i });
+    expect(saveButton).toBeInTheDocument();
+    expect(saveButton.className).toContain("ant-btn-loading");
+  });
+
+  it("should call onCancel when cancel button is clicked after modifying form", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const switchElement = screen.getByRole("switch");
+    await user.click(switchElement);
+
+    const retentionInput = screen.getByPlaceholderText("e.g., 7d, 30d");
+    await user.type(retentionInput, "30d");
+
+    expect(switchElement).toBeChecked();
+    expect(retentionInput).toHaveValue("30d");
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    await user.click(cancelButton);
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reset form fields after successful submission", async () => {
+    const user = userEvent.setup();
+    mockMutateAsync.mockImplementation(async (params, options) => {
+      await Promise.resolve();
+      options?.onSuccess?.();
+      return { message: "Success" };
+    });
+    
+    const { rerender } = renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const switchElement = screen.getByRole("switch");
+    await user.click(switchElement);
+
+    const retentionInput = screen.getByPlaceholderText("e.g., 7d, 30d");
+    await user.type(retentionInput, "30d");
+
+    expect(switchElement).toBeChecked();
+    expect(retentionInput).toHaveValue("30d");
+
+    const saveButton = screen.getByRole("button", { name: "Save Settings" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockNotificationsManager.success).toHaveBeenCalled();
+    });
+
+    rerender(<SpendLogsSettingsModal {...defaultProps} />);
+    
+    await waitFor(() => {
+      const updatedSwitchElement = screen.getByRole("switch");
+      const updatedRetentionInput = screen.getByPlaceholderText("e.g., 7d, 30d");
+      expect(updatedSwitchElement).not.toBeChecked();
+      expect(updatedRetentionInput).toHaveValue("");
+    });
+  });
+
+  it("should not call onSuccess when it is not provided", async () => {
+    const user = userEvent.setup();
+    mockMutateAsync.mockImplementation(async (params, options) => {
+      await Promise.resolve();
+      options?.onSuccess?.();
+      return { message: "Success" };
+    });
+    
+    renderWithProviders(<SpendLogsSettingsModal isVisible={true} onCancel={mockOnCancel} />);
+
+    const saveButton = screen.getByRole("button", { name: "Save Settings" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockNotificationsManager.success).toHaveBeenCalled();
+    });
+  });
+
+  it("should not render modal when isVisible is false", () => {
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} isVisible={false} />);
+    
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should submit form with only store prompts enabled and no retention period", async () => {
+    const user = userEvent.setup();
+    mockMutateAsync.mockImplementation(async (params, options) => {
+      await Promise.resolve();
+      options?.onSuccess?.();
+      return { message: "Success" };
+    });
+    
+    renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
+
+    const switchElement = screen.getByRole("switch");
+    await user.click(switchElement);
+
+    const saveButton = screen.getByRole("button", { name: "Save Settings" });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        {
+          store_prompts_in_spend_logs: true,
+          maximum_spend_logs_retention_period: undefined,
+        },
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/view_logs/SpendLogsSettingsModal/SpendLogsSettingsModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/SpendLogsSettingsModal/SpendLogsSettingsModal.test.tsx
@@ -1,11 +1,11 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi, Mock } from "vitest";
-import SpendLogsSettingsModal from "./SpendLogsSettingsModal";
 import { useStoreRequestInSpendLogs } from "@/app/(dashboard)/hooks/storeRequestInSpendLogs/useStoreRequestInSpendLogs";
 import NotificationsManager from "@/components/molecules/notifications_manager";
 import { parseErrorMessage } from "@/components/shared/errorUtils";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "../../../../tests/test-utils";
+import SpendLogsSettingsModal from "./SpendLogsSettingsModal";
 
 vi.mock("@/app/(dashboard)/hooks/storeRequestInSpendLogs/useStoreRequestInSpendLogs");
 vi.mock("@/components/molecules/notifications_manager", () => ({
@@ -50,7 +50,7 @@ describe("SpendLogsSettingsModal", () => {
 
   it("should render form fields with initial values", () => {
     renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
-    
+
     expect(screen.getByText("Store Prompts in Spend Logs")).toBeInTheDocument();
     expect(screen.getByLabelText("Maximum Spend Logs Retention Period (Optional)")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("e.g., 7d, 30d")).toBeInTheDocument();
@@ -58,7 +58,7 @@ describe("SpendLogsSettingsModal", () => {
 
   it("should render cancel and save buttons", () => {
     renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
-    
+
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save Settings" })).toBeInTheDocument();
   });
@@ -114,7 +114,7 @@ describe("SpendLogsSettingsModal", () => {
       options?.onSuccess?.();
       return { message: "Success" };
     });
-    
+
     renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
 
     const switchElement = screen.getByRole("switch");
@@ -144,7 +144,7 @@ describe("SpendLogsSettingsModal", () => {
       options?.onSuccess?.();
       return { message: "Success" };
     });
-    
+
     renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
 
     const saveButton = screen.getByRole("button", { name: "Save Settings" });
@@ -168,7 +168,7 @@ describe("SpendLogsSettingsModal", () => {
       options?.onSuccess?.();
       return { message: "Success" };
     });
-    
+
     renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
 
     const saveButton = screen.getByRole("button", { name: "Save Settings" });
@@ -185,7 +185,7 @@ describe("SpendLogsSettingsModal", () => {
     const error = new Error("Network error");
     mockMutateAsync.mockRejectedValue(error);
     mockParseErrorMessage.mockReturnValue("Network error");
-    
+
     renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
 
     const saveButton = screen.getByRole("button", { name: "Save Settings" });
@@ -204,7 +204,7 @@ describe("SpendLogsSettingsModal", () => {
       return Promise.reject(error);
     });
     mockParseErrorMessage.mockReturnValue("Backend error");
-    
+
     renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
 
     const saveButton = screen.getByRole("button", { name: "Save Settings" });
@@ -266,7 +266,7 @@ describe("SpendLogsSettingsModal", () => {
       options?.onSuccess?.();
       return { message: "Success" };
     });
-    
+
     const { rerender } = renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
 
     const switchElement = screen.getByRole("switch");
@@ -286,7 +286,7 @@ describe("SpendLogsSettingsModal", () => {
     });
 
     rerender(<SpendLogsSettingsModal {...defaultProps} />);
-    
+
     await waitFor(() => {
       const updatedSwitchElement = screen.getByRole("switch");
       const updatedRetentionInput = screen.getByPlaceholderText("e.g., 7d, 30d");
@@ -302,7 +302,7 @@ describe("SpendLogsSettingsModal", () => {
       options?.onSuccess?.();
       return { message: "Success" };
     });
-    
+
     renderWithProviders(<SpendLogsSettingsModal isVisible={true} onCancel={mockOnCancel} />);
 
     const saveButton = screen.getByRole("button", { name: "Save Settings" });
@@ -315,7 +315,7 @@ describe("SpendLogsSettingsModal", () => {
 
   it("should not render modal when isVisible is false", () => {
     renderWithProviders(<SpendLogsSettingsModal {...defaultProps} isVisible={false} />);
-    
+
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
@@ -326,7 +326,7 @@ describe("SpendLogsSettingsModal", () => {
       options?.onSuccess?.();
       return { message: "Success" };
     });
-    
+
     renderWithProviders(<SpendLogsSettingsModal {...defaultProps} />);
 
     const switchElement = screen.getByRole("switch");

--- a/ui/litellm-dashboard/src/components/view_logs/SpendLogsSettingsModal/SpendLogsSettingsModal.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/SpendLogsSettingsModal/SpendLogsSettingsModal.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { StoreRequestInSpendLogsParams, useStoreRequestInSpendLogs } from "@/app/(dashboard)/hooks/storeRequestInSpendLogs/useStoreRequestInSpendLogs";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+import { parseErrorMessage } from "@/components/shared/errorUtils";
+import { ClockCircleOutlined } from "@ant-design/icons";
+import { Button, Form, Input, Modal, Space, Switch } from "antd";
+import React from "react";
+
+interface SpendLogsSettingsModalProps {
+  isVisible: boolean;
+  onCancel: () => void;
+  onSuccess?: () => void;
+}
+
+const SpendLogsSettingsModal: React.FC<SpendLogsSettingsModalProps> = ({ isVisible, onCancel, onSuccess }) => {
+  const [form] = Form.useForm();
+  const { mutateAsync, isPending } = useStoreRequestInSpendLogs();
+  const storePromptsValue = Form.useWatch('store_prompts_in_spend_logs', form);
+
+  const handleFormSubmit = async (formValues: StoreRequestInSpendLogsParams) => {
+    try {
+      await mutateAsync(formValues, {
+        onSuccess: () => {
+          NotificationsManager.success("Spend logs settings updated successfully");
+          form.resetFields();
+          onSuccess?.();
+        },
+        onError: (error) => {
+          NotificationsManager.fromBackend("Failed to save spend logs settings: " + parseErrorMessage(error));
+        },
+      });
+    } catch (error) {
+      NotificationsManager.fromBackend("Failed to save spend logs settings: " + parseErrorMessage(error));
+    }
+  };
+
+  const handleCancel = () => {
+    form.resetFields();
+    onCancel();
+  };
+
+  return (
+    <Modal
+      title="Spend Logs Settings"
+      open={isVisible}
+      width={600}
+      footer={
+        <Space>
+          <Button onClick={handleCancel} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button type="primary" loading={isPending} onClick={() => form.submit()}>
+            {isPending ? "Saving..." : "Save Settings"}
+          </Button>
+        </Space>
+      }
+      onCancel={handleCancel}
+    >
+      <Form
+        form={form}
+        layout="horizontal"
+        labelCol={{ flex: "auto", style: { textAlign: "left" } }}
+        wrapperCol={{ flex: "auto", style: { textAlign: "right" } }}
+        onFinish={handleFormSubmit}
+        initialValues={{
+          store_prompts_in_spend_logs: false,
+          maximum_spend_logs_retention_period: undefined,
+        }}
+      >
+        <Form.Item
+          name="store_prompts_in_spend_logs"
+          tooltip="When enabled, prompts will be stored in spend logs for tracking and analysis purposes."
+          valuePropName="checked"
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span>Store Prompts in Spend Logs</span>
+            <Switch checked={storePromptsValue ?? false} onChange={(checked) => form.setFieldValue('store_prompts_in_spend_logs', checked)} />
+          </div>
+        </Form.Item>
+
+
+        <Form.Item
+          label="Maximum Spend Logs Retention Period (Optional)"
+          name="maximum_spend_logs_retention_period"
+          tooltip="Set the maximum retention period for spend logs (e.g., '7d' for 7 days, '30d' for 30 days). Leave empty for no limit."
+          labelCol={{ flex: "auto", style: { textAlign: "left" } }}
+          wrapperCol={{ flex: "0 0 25%", style: { textAlign: "right" } }}
+        >
+          <Input
+            placeholder="e.g., 7d, 30d"
+            prefix={<ClockCircleOutlined />}
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default SpendLogsSettingsModal;

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -12,7 +12,7 @@ import { RequestResponsePanel } from "./RequestResponsePanel";
 import { ErrorViewer } from "./ErrorViewer";
 import { internalUserRoles } from "../../utils/roles";
 import { ConfigInfoMessage } from "./ConfigInfoMessage";
-import { Tooltip } from "antd";
+import { Button, Tooltip } from "antd";
 import { KeyResponse, Team } from "../key_team_helpers/key_list";
 import KeyInfoView from "../templates/key_info_view";
 import { SessionView } from "./SessionView";
@@ -31,6 +31,8 @@ import { truncateString } from "@/utils/textUtils";
 import DeletedKeysPage from "../DeletedKeysPage/DeletedKeysPage";
 import DeletedTeamsPage from "../DeletedTeamsPage/DeletedTeamsPage";
 import NewBadge from "../common_components/NewBadge";
+import SpendLogsSettingsModal from "./SpendLogsSettingsModal/SpendLogsSettingsModal";
+import { SettingOutlined } from "@ant-design/icons";
 
 interface SpendLogsTableProps {
   accessToken: string | null;
@@ -91,6 +93,7 @@ export default function SpendLogsTable({
 
   const [expandedRequestId, setExpandedRequestId] = useState<string | null>(null);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [isSpendLogsSettingsModalVisible, setIsSpendLogsSettingsModalVisible] = useState(false);
 
   const queryClient = useQueryClient();
 
@@ -526,6 +529,13 @@ export default function SpendLogsTable({
                   "Request Logs"
                 )}
               </h1>
+              {!selectedSessionId && (
+                <Button
+                  icon={<SettingOutlined />}
+                  onClick={() => setIsSpendLogsSettingsModalVisible(true)}
+                  title="Spend Logs Settings"
+                />
+              )}
             </div>
             {selectedKeyInfo && selectedKeyIdInfoView && selectedKeyInfo.api_key === selectedKeyIdInfoView ? (
               <KeyInfoView
@@ -551,6 +561,11 @@ export default function SpendLogsTable({
                   options={logFilterOptions}
                   onApplyFilters={handleFilterChange}
                   onResetFilters={handleFilterReset}
+                />
+                <SpendLogsSettingsModal
+                  isVisible={isSpendLogsSettingsModalVisible}
+                  onCancel={() => setIsSpendLogsSettingsModalVisible(false)}
+                  onSuccess={() => setIsSpendLogsSettingsModalVisible(false)}
                 />
                 <div className="bg-white rounded-lg shadow w-full max-w-full box-border">
                   <div className="border-b px-6 py-4 w-full max-w-full box-border">


### PR DESCRIPTION
## Relevant issues
This PR implements the Spend Logs Settings Modal. Currently this only shows the store_prompt_in_spend_logs and the retention period. This is meant to allow UI users to configure spend logs to start storing the request/response pair without restart of the instance
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="693" height="307" alt="image" src="https://github.com/user-attachments/assets/96e22486-343f-493f-9627-0b6979ade149" />
<img width="714" height="271" alt="image" src="https://github.com/user-attachments/assets/f9770383-bd36-4ca5-b005-b0dda25badd2" />
