### PR TITLE
fix(anthropic): remove explicit cache_control null in tool_result content

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1677,13 +1677,16 @@ def convert_to_anthropic_tool_result(
         ] = []
         for content in content_list:
             if content["type"] == "text":
-                anthropic_content_list.append(
-                    AnthropicMessagesToolResultContent(
-                        type="text",
-                        text=content["text"],
-                        cache_control=content.get("cache_control", None),
-                    )
-                )
+                # Only include cache_control if explicitly set and not None
+                # to avoid sending "cache_control": null which breaks some API channels
+                text_content: AnthropicMessagesToolResultContent = {
+                    "type": "text",
+                    "text": content["text"],
+                }
+                cache_control_value = content.get("cache_control")
+                if cache_control_value is not None:
+                    text_content["cache_control"] = cache_control_value
+                anthropic_content_list.append(text_content)
             elif content["type"] == "image_url":
                 format = (
                     content["image_url"].get("format")


### PR DESCRIPTION
## Description                                                                                                  
                                                                                                                  
  Fixes an issue where Anthropic tool_result content blocks include explicit `"cache_control": null` which breaks 
  some Anthropic API channels (such as certain proxy implementations or Vertex AI).                               

###   Related Issues                                                                                                  
 Fix #19916 
## Problem                                                                                                      

  When converting OpenAI-format tool messages to Anthropic format, the code was explicitly adding                 
  `"cache_control": null` even when the original request didn't specify this field. Some API implementations      
  reject requests with explicit null values.                                                                      

  **Root cause**: In `litellm/litellm_core_utils/prompt_templates/factory.py`, the                                
  `convert_to_anthropic_tool_result()` function always included `cache_control` field using `.get("cache_control",
   None)` pattern.                                                                                                

  ## Changes                                                                                                      

  - Modified `convert_to_anthropic_tool_result()` to only include `cache_control` field when explicitly set and   
  not None                                                                                                        
  - Prevents serialization of null values in tool_result text content blocks                                      
  - Maintains backward compatibility with existing cache_control usage                                            

  ### Before                                                                                                      
  ```json                                                                                                         
  {                                                                                                               
    "type": "tool_result",                                                                                        
    "tool_use_id": "call_123",                                                                                    
    "content": [                                                                                                  
      {                                                                                                           
        "type": "text",                                                                                           
        "text": "tool execution result",                                                                          
        "cache_control": null  // ❌ Always present, breaks some channels                                         
      }                                                                                                           
    ]                                                                                                             
  }                                                                                                               
  ```                                                                                                             
  ### After                                                                                                           
  ```                                                                                                               
  {                                                                                                               
    "type": "tool_result",                                                                                        
    "tool_use_id": "call_123",                                                                                    
    "content": [                                                                                                  
      {                                                                                                           
        "type": "text",                                                                                           
        "text": "tool execution result"                                                                           
        // ✅ cache_control only present when explicitly set                                                      
      }                                                                                                           
    ]                                                                                                             
  }                                                                                                               
   ```                                                                                                               
  ## Testing                                                                                                         

  - When cache_control is explicitly set to a value, it's still included in the output (backward compatible)      
  - When cache_control is not set or is None, the field is now omitted from the JSON output                       

 ## Type
 🐛 Bug Fix

