### PR TITLE
fix(langfuse_otel): prevent empty proxy request spans from being sent to Langfuse

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -1,6 +1,7 @@
 import base64
 import json  # <--- NEW
 import os
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from litellm._logging import verbose_logger
@@ -352,6 +353,22 @@ class LangfuseOtelLogger(OpenTelemetry):
             dynamic_headers["Authorization"] = auth_header
 
         return dynamic_headers
+
+    def create_litellm_proxy_request_started_span(
+        self,
+        start_time: datetime,
+        headers: dict,
+    ) -> Optional[Span]:
+        """
+        Override to prevent creating empty proxy request spans.
+
+        Langfuse should only receive spans for actual LLM calls, not for
+        internal proxy operations (auth, postgres, proxy_pre_call, etc.).
+
+        By returning None, we prevent the parent span from being created,
+        which in turn prevents empty traces from being sent to Langfuse.
+        """
+        return None
 
     async def async_service_success_hook(self, *args, **kwargs):
         """

--- a/tests/test_service_logger_otel.py
+++ b/tests/test_service_logger_otel.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import unittest
+from datetime import datetime
 from unittest.mock import patch, AsyncMock, MagicMock
 
 # Add the project root to sys.path
@@ -40,6 +41,33 @@ class TestServiceLoggerOTEL(unittest.IsolatedAsyncioTestCase):
             logger.async_service_failure_hook.__qualname__,
             "LangfuseOtelLogger.async_service_failure_hook",
         )
+
+    @patch("litellm.integrations.opentelemetry.OpenTelemetry._init_tracing")
+    @patch("litellm.integrations.opentelemetry.OpenTelemetry._init_metrics")
+    @patch("litellm.integrations.opentelemetry.OpenTelemetry._init_logs")
+    async def test_langfuse_otel_does_not_create_proxy_request_span(
+        self, mock_logs, mock_metrics, mock_tracing
+    ):
+        """
+        Test that LangfuseOtelLogger returns None for create_litellm_proxy_request_started_span.
+
+        This prevents empty proxy request spans from being sent to Langfuse when
+        requests don't result in actual LLM calls (e.g., auth failures, health checks).
+        """
+        logger = LangfuseOtelLogger()
+
+        # Verify the method is overridden
+        self.assertEqual(
+            logger.create_litellm_proxy_request_started_span.__qualname__,
+            "LangfuseOtelLogger.create_litellm_proxy_request_started_span",
+        )
+
+        # Verify it returns None
+        result = logger.create_litellm_proxy_request_started_span(
+            start_time=datetime.now(),
+            headers={"Authorization": "Bearer test"},
+        )
+        self.assertIsNone(result)
 
     @patch("litellm.integrations.opentelemetry.OpenTelemetry._init_tracing")
     @patch("litellm.integrations.opentelemetry.OpenTelemetry._init_metrics")


### PR DESCRIPTION
## Summary
- Fixes empty traces being sent to Langfuse when using `langfuse_otel` callback
- These empty traces contained only internal proxy operations (auth, postgres, proxy_pre_call) with no LLM data

## Problem
When using `langfuse_otel`, every proxy request created a parent span "Received Proxy Server Request" that was sent to Langfuse, even when no actual LLM call occurred. This resulted in useless empty traces cluttering Langfuse.

## Solution
Override `create_litellm_proxy_request_started_span` in `LangfuseOtelLogger` to return `None`, preventing the creation of empty parent spans. This is consistent with the existing overrides for `async_service_success_hook` and `async_service_failure_hook`.

## Test plan
- [x] Added unit test `test_langfuse_otel_does_not_create_proxy_request_span`
- [x] Manual testing with Langfuse v3 to verify empty traces no longer appear

Closes #14102