### PR TITLE
fix(vertex_ai): support model names with slashes in passthrough URLs

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -849,7 +849,7 @@ def get_vertex_model_id_from_url(url: str) -> Optional[str]:
 
     `https://${LOCATION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${LOCATION}/publishers/google/models/${MODEL_ID}:streamGenerateContent`
     """
-    match = re.search(r"/models/([^/:]+)", url)
+    match = re.search(r"/models/([^:]+)", url)
     return match.group(1) if match else None
 
 

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -812,6 +812,36 @@ def test_get_vertex_model_id_from_url():
     assert model_id is None
 
 
+def test_get_vertex_model_id_from_url_with_slashes():
+    """Test get_vertex_model_id_from_url with model names containing slashes (e.g., gcp/google/gemini-2.5-flash)
+
+    Regression test for NVIDIA issue: custom model names with slashes in passthrough URLs
+    were being truncated (e.g., 'gcp/google/gemini-2.5-flash' -> 'gcp'), causing access_groups
+    checks to fail.
+    """
+    from litellm.llms.vertex_ai.common_utils import get_vertex_model_id_from_url
+
+    # Test with model name containing slashes: gcp/google/gemini-2.5-flash
+    url = "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gcp/google/gemini-2.5-flash:generateContent"
+    model_id = get_vertex_model_id_from_url(url)
+    assert model_id == "gcp/google/gemini-2.5-flash"
+
+    # Test with model name containing slashes: gcp/google/gemini-3-flash-preview
+    url = "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/global/publishers/google/models/gcp/google/gemini-3-flash-preview:streamGenerateContent"
+    model_id = get_vertex_model_id_from_url(url)
+    assert model_id == "gcp/google/gemini-3-flash-preview"
+
+    # Test with custom model path: custom/model
+    url = "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/custom/model:generateContent"
+    model_id = get_vertex_model_id_from_url(url)
+    assert model_id == "custom/model"
+
+    # Test passthrough URL format (without host)
+    url = "v1/projects/my-project/locations/us-central1/publishers/google/models/gcp/google/gemini-2.5-flash:generateContent"
+    model_id = get_vertex_model_id_from_url(url)
+    assert model_id == "gcp/google/gemini-2.5-flash"
+
+
 def test_construct_target_url_with_version_prefix():
     """Test construct_target_url with version prefixes"""
     from litellm.llms.vertex_ai.common_utils import construct_target_url


### PR DESCRIPTION
The regex in `get_vertex_model_id_from_url()` was using `[^/:]+` which stopped at the first slash, truncating model names like `gcp/google/gemini-2.5-flash` to just `gcp`. This caused access_groups checks to fail for custom model names.

Changed the pattern to `[^:]+` to allow slashes in model names, only stopping at the colon before the action (e.g., `:generateContent`).

## Relevant issues

Related to #19737 (similar regex fix in `get_model_from_request()`)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory,
**Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🐛 Bug Fix

## Changes

- Fixed regex pattern in `get_vertex_model_id_from_url()` from `[^/:]+` to `[^:]+` to support model names containing slashes
- Added regression test `test_get_vertex_model_id_from_url_with_slashes()` covering:
  - Model names with multiple slashes (e.g., `gcp/google/gemini-2.5-flash`)
  - Passthrough URL format without host
  - Standard model names (backward compatibility)

## Screenshot
<img width="757" height="344" alt="Screenshot 2026-01-28 alle 18 03 45" src="https://github.com/user-attachments/assets/8b2c5cf1-0939-404f-8cb3-2b03c38e970c" />

