### PR TITLE
fix(proxy): add datadog_llm_observability to /health/services allowed…

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -118,6 +118,7 @@ services = Union[
         "email",
         "braintrust",
         "datadog",
+        "datadog_llm_observability",
         "generic_api",
         "arize",
         "sqs"
@@ -190,6 +191,7 @@ async def health_services_endpoint(  # noqa: PLR0915
             "custom_callback_api",
             "langsmith",
             "datadog",
+            "datadog_llm_observability",
             "generic_api",
             "arize",
             "sqs"

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -312,6 +312,43 @@ async def test_test_model_connection_loads_config_from_router():
         assert "result" in result
 
 
+@pytest.mark.asyncio
+async def test_health_services_endpoint_datadog_llm_observability():
+    """
+    Verify that 'datadog_llm_observability' is accepted as a valid service
+    by the /health/services endpoint and does not raise a 400 error.
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/XXXX
+    The service was missing from the allowed services validation list.
+    """
+    from litellm.proxy.health_endpoints._health_endpoints import (
+        health_services_endpoint,
+    )
+
+    # Mock datadog_llm_observability to be in success_callback so the generic branch handles it
+    with patch("litellm.success_callback", ["datadog_llm_observability"]):
+        result = await health_services_endpoint(
+            service="datadog_llm_observability"
+        )
+
+    # Should not raise HTTPException(400) and should return success
+    assert result["status"] == "success"
+    assert "datadog_llm_observability" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_health_services_endpoint_rejects_unknown_service():
+    """
+    Verify that an unknown service name is rejected with a 400 error.
+    """
+    from litellm.proxy._types import ProxyException
+
+    with pytest.raises(ProxyException):
+        await health_services_endpoint(
+            service="totally_unknown_service_xyz"
+        )
+
+
 @pytest.fixture(scope="function")
 def proxy_client(monkeypatch):
     """


### PR DESCRIPTION
The /health/services endpoint rejected `datadog_llm_observability` as an unknown service, even though it was registered in the core callback registry and `__init__.py`. Added it to both the Literal type hint and the hardcoded validation list in the health endpoint.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Added `datadog_llm_observability` to the `services` Literal type in `_health_endpoints.py`
- Added `datadog_llm_observability` to the hardcoded validation list in `health_services_endpoint()`
- Added unit tests:
  - `test_health_services_endpoint_datadog_llm_observability` — verifies the service is accepted
  - `test_health_services_endpoint_rejects_unknown_service` — verifies unknown services are still rejected

## Screenshots

### Before (error)
<img width="1461" height="187" alt="Screenshot 2026-01-28 alle 22 20 52" src="https://github.com/user-attachments/assets/b41ee38e-6d41-4686-bae3-25abd8d06697" />


### After (fix)
<img width="1109" height="58" alt="Screenshot 2026-01-28 alle 22 21 21" src="https://github.com/user-attachments/assets/6722e422-5f9e-4905-a38d-3ea3d56b73ff" />

