### PR TITLE
fix(streaming): propagate response headers to assembled response

### DIFF
--- a/tests/test_litellm/test_streaming_headers_propagation.py
+++ b/tests/test_litellm/test_streaming_headers_propagation.py
@@ -1,0 +1,126 @@
+"""
+Test that streaming response headers are propagated to the final assembled response.
+Fixes: https://github.com/BerriAI/litellm/issues/19930
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+import litellm
+from litellm import ModelResponse
+from litellm.main import stream_chunk_builder
+from litellm.types.utils import ModelResponseStream, StreamingChoices, Delta
+
+
+class TestStreamingHeadersPropagation:
+    """Tests for streaming headers propagation to final response."""
+
+    def test_stream_chunk_builder_propagates_additional_headers(self):
+        """
+        Test that stream_chunk_builder copies _hidden_params["additional_headers"]
+        from chunks to the final assembled response.
+        """
+        # Create mock streaming chunks with _hidden_params containing headers
+        chunk1 = ModelResponseStream(
+            id="test-id",
+            model="gpt-4",
+            choices=[StreamingChoices(index=0, delta=Delta(content="Hello "))],
+        )
+        chunk1._hidden_params = {
+            "additional_headers": {
+                "llm_provider-x-ms-region": "eastus",
+                "llm_provider-x-ratelimit-remaining-tokens": "10000",
+            },
+            "model_id": "test-model-id",
+            "api_base": "https://api.openai.com",
+            "custom_llm_provider": "azure",
+        }
+
+        chunk2 = ModelResponseStream(
+            id="test-id",
+            model="gpt-4",
+            choices=[
+                StreamingChoices(index=0, delta=Delta(content="World"), finish_reason="stop")
+            ],
+        )
+        chunk2._hidden_params = {}
+
+        chunks = [chunk1, chunk2]
+
+        # Call stream_chunk_builder
+        result = stream_chunk_builder(chunks=chunks, messages=[{"role": "user", "content": "Hi"}])
+
+        # Verify the result has _hidden_params with headers
+        assert result is not None
+        assert hasattr(result, "_hidden_params")
+        assert "additional_headers" in result._hidden_params
+
+        # Check that the specific headers are preserved
+        additional_headers = result._hidden_params["additional_headers"]
+        assert additional_headers.get("llm_provider-x-ms-region") == "eastus"
+        assert additional_headers.get("llm_provider-x-ratelimit-remaining-tokens") == "10000"
+
+        # Check other hidden params are also copied
+        assert result._hidden_params.get("model_id") == "test-model-id"
+        assert result._hidden_params.get("api_base") == "https://api.openai.com"
+        assert result._hidden_params.get("custom_llm_provider") == "azure"
+
+    def test_stream_chunk_builder_handles_missing_hidden_params(self):
+        """
+        Test that stream_chunk_builder works correctly when chunks don't have _hidden_params.
+        """
+        # Create chunks without _hidden_params
+        chunk1 = ModelResponseStream(
+            id="test-id",
+            model="gpt-4",
+            choices=[StreamingChoices(index=0, delta=Delta(content="Hello "))],
+        )
+        # Don't set _hidden_params
+
+        chunk2 = ModelResponseStream(
+            id="test-id",
+            model="gpt-4",
+            choices=[
+                StreamingChoices(index=0, delta=Delta(content="World"), finish_reason="stop")
+            ],
+        )
+
+        chunks = [chunk1, chunk2]
+
+        # Call stream_chunk_builder - should not raise
+        result = stream_chunk_builder(chunks=chunks, messages=[{"role": "user", "content": "Hi"}])
+
+        # Verify result is valid
+        assert result is not None
+
+    def test_stream_chunk_builder_handles_empty_additional_headers(self):
+        """
+        Test that stream_chunk_builder handles empty additional_headers gracefully.
+        """
+        chunk1 = ModelResponseStream(
+            id="test-id",
+            model="gpt-4",
+            choices=[StreamingChoices(index=0, delta=Delta(content="Hello "))],
+        )
+        chunk1._hidden_params = {
+            "model_id": "test-id",
+            # No additional_headers
+        }
+
+        chunk2 = ModelResponseStream(
+            id="test-id",
+            model="gpt-4",
+            choices=[
+                StreamingChoices(index=0, delta=Delta(content="World"), finish_reason="stop")
+            ],
+        )
+
+        chunks = [chunk1, chunk2]
+
+        result = stream_chunk_builder(chunks=chunks, messages=[{"role": "user", "content": "Hi"}])
+
+        assert result is not None
+        assert hasattr(result, "_hidden_params")
+        # additional_headers should not be present if it wasn't in the source
+        assert "additional_headers" not in result._hidden_params or result._hidden_params.get("additional_headers") is None
+


### PR DESCRIPTION
## Summary
Fixes #19930: Missing `llm_provider-x-ms-region` headers in streaming callbacks for Codex models

## Problem
When streaming completes, the `async_log_success_event` callback receives the assembled response. However, `_hidden_params['additional_headers']` (containing headers like `llm_provider-x-ms-region`) from the initial HTTP response were not being copied to the final assembled response.

## Solution
Modified `stream_chunk_builder()` in `litellm/main.py` to copy `additional_headers` and other key hidden params from the first streaming chunk to the final `ModelResponse` object.

## Changes
- **litellm/main.py**: Add header propagation logic in `stream_chunk_builder`
- **tests/test_litellm/test_streaming_headers_propagation.py**: Unit tests for header propagation

## Testing
- Added 3 unit tests that verify:
  1. Headers are correctly propagated from chunks to final response
  2. Missing `_hidden_params` is handled gracefully
  3. Empty `additional_headers` is handled correctly

All tests pass locally.