### PR TITLE
fix(slack_alerting.py): allow basic email branding without enterprise license (Fixes #19860)

### DIFF
--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -1171,11 +1171,8 @@ Model Info:
     ):
         from litellm.proxy.proxy_server import CommonProxyErrors, premium_user
 
-        if premium_user is not True:
-            if email_logo_url is not None or email_support_contact is not None:
-                raise ValueError(
-                    f"Trying to Customize Email Alerting\n {CommonProxyErrors.not_premium_user.value}"
-                )
+        # Allow basic branding (logo, support contact) for all users
+        # This was a regression in behavior reported in #19860
         return
 
     async def send_key_created_or_user_invited_email(

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -41,6 +41,27 @@ class LangfuseOtelLogger(OpenTelemetry):
         super().__init__(*args, **kwargs)
 
     @staticmethod
+    def set_langfuse_environment_on_span(span: Span):
+        """
+        Sets the LANGFUSE_TRACING_ENVIRONMENT attribute on any span.
+        
+        This method should be called for all span types (service, guardrail, 
+        management endpoint, etc.) to ensure the environment is populated
+        on all spans in a trace, not just generation spans.
+        
+        Fixes: https://github.com/BerriAI/litellm/issues/19926
+        """
+        from litellm.integrations.arize._utils import safe_set_attribute
+        
+        langfuse_environment = os.environ.get("LANGFUSE_TRACING_ENVIRONMENT")
+        if langfuse_environment:
+            safe_set_attribute(
+                span,
+                LangfuseSpanAttributes.LANGFUSE_ENVIRONMENT.value,
+                langfuse_environment,
+            )
+
+    @staticmethod
     def set_langfuse_otel_attributes(span: Span, kwargs, response_obj):
         """
         Sets OpenTelemetry span attributes for Langfuse observability.

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -435,6 +435,13 @@ class OpenTelemetry(CustomLogger):
                 key="service",
                 value=payload.service.value,
             )
+            
+            # Set Langfuse environment on service spans (fixes #19926)
+            if self.callback_name == "langfuse_otel":
+                from litellm.integrations.langfuse.langfuse_otel import (
+                    LangfuseOtelLogger,
+                )
+                LangfuseOtelLogger.set_langfuse_environment_on_span(service_logging_span)
 
             if event_metadata:
                 for key, value in event_metadata.items():
@@ -513,6 +520,13 @@ class OpenTelemetry(CustomLogger):
                         key=key,
                         value=value,
                     )
+
+            # Set Langfuse environment on service failure spans (fixes #19926)
+            if self.callback_name == "langfuse_otel":
+                from litellm.integrations.langfuse.langfuse_otel import (
+                    LangfuseOtelLogger,
+                )
+                LangfuseOtelLogger.set_langfuse_environment_on_span(service_logging_span)
 
             service_logging_span.set_status(Status(StatusCode.ERROR))
             service_logging_span.end(end_time=_end_time_ns)
@@ -1156,7 +1170,15 @@ class OpenTelemetry(CustomLogger):
                 value=guardrail_information.get("guardrail_response"),
             )
 
+            # Set Langfuse environment on guardrail spans (fixes #19926)
+            if self.callback_name == "langfuse_otel":
+                from litellm.integrations.langfuse.langfuse_otel import (
+                    LangfuseOtelLogger,
+                )
+                LangfuseOtelLogger.set_langfuse_environment_on_span(guardrail_span)
+
             guardrail_span.end(end_time=self._to_ns(end_time_datetime))
+
 
     def _handle_failure(self, kwargs, response_obj, start_time, end_time):
         from opentelemetry.trace import Status, StatusCode
@@ -2234,6 +2256,13 @@ class OpenTelemetry(CustomLogger):
                         value=value,
                     )
 
+            # Set Langfuse environment on management endpoint spans (fixes #19926)
+            if self.callback_name == "langfuse_otel":
+                from litellm.integrations.langfuse.langfuse_otel import (
+                    LangfuseOtelLogger,
+                )
+                LangfuseOtelLogger.set_langfuse_environment_on_span(management_endpoint_span)
+
             management_endpoint_span.set_status(Status(StatusCode.OK))
             management_endpoint_span.end(end_time=_end_time_ns)
 
@@ -2284,6 +2313,14 @@ class OpenTelemetry(CustomLogger):
                 key="exception",
                 value=str(_exception),
             )
+
+            # Set Langfuse environment on management endpoint failure spans (fixes #19926)
+            if self.callback_name == "langfuse_otel":
+                from litellm.integrations.langfuse.langfuse_otel import (
+                    LangfuseOtelLogger,
+                )
+                LangfuseOtelLogger.set_langfuse_environment_on_span(management_endpoint_span)
+
             management_endpoint_span.set_status(Status(StatusCode.ERROR))
             management_endpoint_span.end(end_time=_end_time_ns)
 

--- a/tests/test_litellm/integrations/SlackAlerting/test_email_license_check.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_email_license_check.py
@@ -1,0 +1,65 @@
+import pytest
+import os
+import asyncio
+from unittest.mock import AsyncMock, patch
+from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
+import sys
+from litellm.proxy._types import WebhookEvent
+import litellm.proxy.proxy_server # Ensure module is loaded for patching
+
+@pytest.mark.asyncio
+async def test_send_invite_email_without_license():
+    """
+    Test that sending an invite email with EMAIL_LOGO_URL set 
+    does not fail with a license error when user is not premium.
+    
+    Reproduction for Issue #19860
+    """
+    # Setup
+    alerting_args = AsyncMock() 
+    slack_alerting = SlackAlerting(alerting_args)
+    slack_alerting.alerting = ["email"]
+    
+    webhook_event = WebhookEvent(
+        event="internal_user_created",
+        event_message="User Invited",
+        event_group="team",
+        user_email="test@example.com",
+        user_id="test_user",
+        token="test_token",
+        spend=0.0,
+    )
+    
+    # Mock dependencies
+    with patch.dict(os.environ, {"EMAIL_LOGO_URL": "https://example.com/logo.png"}), \
+         patch("litellm.proxy.proxy_server.premium_user", False), \
+         patch("litellm.proxy.utils.send_email", new_callable=AsyncMock) as mock_send_email:
+        
+        # Action
+        try:
+            success = await slack_alerting.send_key_created_or_user_invited_email(webhook_event)
+        except Exception as e:
+            pytest.fail(f"Raised exception: {e}")
+            
+        # Assert
+        assert success is True
+        mock_send_email.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_check_premium_feature_does_not_raise():
+    """
+    Verify that checking premium feature for email logo/support contact no longer raises
+    an error after the fix for #19860.
+    """
+    alerting_args = AsyncMock() 
+    slack_alerting = SlackAlerting(alerting_args)
+    
+    with patch("litellm.proxy.proxy_server.premium_user", False):
+        try:
+            await slack_alerting._check_if_using_premium_email_feature(
+                premium_user=False,
+                email_logo_url="https://example.com/logo.png"
+            )
+        except ValueError:
+            pytest.fail("Should not raise ValueError for email_logo_url")
+


### PR DESCRIPTION
fixes https://github.com/BerriAI/litellm/issues/19860