### PR TITLE
fix(ui): display correct callback mode (success/failure) in logging s…

### DIFF
--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -73,6 +73,32 @@ def test_process_callback_with_no_required_env_vars(mock_get_env_vars):
     assert result["variables"] == {}
 
 
+@patch(
+    "litellm.proxy.common_utils.callback_utils.CustomLogger.get_callback_env_vars",
+    return_value=[],
+)
+def test_process_callback_returns_correct_type_for_each_callback_mode(mock_get_env_vars):
+    """
+    Verify that process_callback returns the correct 'type' field for success,
+    failure, and success_and_failure callback modes. The UI relies on this field
+    to display the correct mode badge.
+
+    Regression test: the UI was reading 'mode' instead of 'type', causing all
+    callbacks to display as 'Success'. The frontend was fixed to read 'type'.
+    This test ensures the backend contract is maintained.
+    """
+    for callback_type in ["success", "failure", "success_and_failure"]:
+        result = process_callback(
+            _callback="s3_v2",
+            callback_type=callback_type,
+            environment_variables={},
+        )
+        assert result["type"] == callback_type, (
+            f"Expected type '{callback_type}', got '{result['type']}'"
+        )
+        assert result["name"] == "s3_v2"
+
+
 def test_normalize_callback_names_none_returns_empty_list():
     assert normalize_callback_names(None) == []
     assert normalize_callback_names([]) == []

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.tsx
@@ -57,7 +57,7 @@ export const LoggingCallbacksTable: React.FC<LoggingCallbacksProps> = ({
       title: <span className="font-medium text-gray-700">Mode</span>,
       key: "mode",
       render: (_: unknown, record: CallbackRow) => {
-        const mode = record.mode || "success";
+        const mode = record.type || record.mode || "success";
         const label = CALLBACK_MODES.find((m) => m.value === mode)?.label || mode;
         const badgeClass =
           mode === "success"

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
@@ -1,6 +1,7 @@
 export interface AlertingObject {
   name: string;
   variables: AlertingVariables;
+  type?: "success" | "failure" | "success_and_failure" | string;
 }
 
 export interface AlertingVariables {


### PR DESCRIPTION
The UI was reading a `mode` field from callback data, but the backend returns a `type` field. This caused all callbacks to default to "Success" mode, even those configured as `failure_callback`.
Fixed the frontend to read the `type` field and added it to the `AlertingObject` interface.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Added `type` field to `AlertingObject` interface in `types.ts`
- Changed `LoggingCallbacksTable.tsx` to read `record.type` (backend field) instead of `record.mode`
- Added unit test verifying `process_callback` returns the correct `type` for each callback mode

## Screenshots

### Before
<img width="1232" height="392" alt="Screenshot 2026-01-29 alle 00 53 05" src="https://github.com/user-attachments/assets/f2fba6db-09a2-4abc-b96c-69faa33a23fb" />

### After
<img width="1198" height="385" alt="Screenshot 2026-01-29 alle 01 15 22" src="https://github.com/user-attachments/assets/b6b58f53-48ff-43b8-abbc-157c9d49f6cb" />
