### PR TITLE
[Fix] Sorting for /v2/model/info

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11,7 +11,7 @@ import sys
 import time
 import traceback
 import warnings
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -8042,6 +8042,48 @@ async def _apply_search_filter_to_models(
     return filtered_models, search_total_count
 
 
+def _normalize_datetime_for_sorting(dt: Any) -> Optional[datetime]:
+    """
+    Normalize a datetime value to a timezone-aware UTC datetime for sorting.
+    
+    This function handles:
+    - None values: returns None
+    - String values: parses ISO format strings and converts to UTC-aware datetime
+    - Datetime objects: converts naive datetimes to UTC-aware, and aware datetimes to UTC
+    
+    Args:
+        dt: Datetime value (None, str, or datetime object)
+        
+    Returns:
+        UTC-aware datetime object, or None if input is None or cannot be parsed
+    """
+    if dt is None:
+        return None
+    
+    if isinstance(dt, str):
+        try:
+            # Handle ISO format strings, including 'Z' suffix
+            dt_str = dt.replace("Z", "+00:00") if dt.endswith("Z") else dt
+            parsed_dt = datetime.fromisoformat(dt_str)
+            # Ensure it's UTC-aware
+            if parsed_dt.tzinfo is None:
+                parsed_dt = parsed_dt.replace(tzinfo=timezone.utc)
+            else:
+                parsed_dt = parsed_dt.astimezone(timezone.utc)
+            return parsed_dt
+        except (ValueError, AttributeError):
+            return None
+    
+    if isinstance(dt, datetime):
+        # If naive, assume UTC and make it aware
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        # If aware, convert to UTC
+        return dt.astimezone(timezone.utc)
+    
+    return None
+
+
 def _sort_models(
     all_models: List[Dict[str, Any]],
     sort_by: Optional[str],
@@ -8071,26 +8113,18 @@ def _sort_models(
         
         elif sort_by == "created_at":
             created_at = model_info.get("created_at")
-            if created_at is None:
+            normalized_dt = _normalize_datetime_for_sorting(created_at)
+            if normalized_dt is None:
                 # Put None values at the end for asc, at the start for desc
-                return (datetime.max if not reverse else datetime.min)
-            if isinstance(created_at, str):
-                try:
-                    return datetime.fromisoformat(created_at.replace("Z", "+00:00"))
-                except (ValueError, AttributeError):
-                    return datetime.min if not reverse else datetime.max
-            return created_at
+                return (datetime.max.replace(tzinfo=timezone.utc) if not reverse else datetime.min.replace(tzinfo=timezone.utc))
+            return normalized_dt
         
         elif sort_by == "updated_at":
             updated_at = model_info.get("updated_at")
-            if updated_at is None:
-                return (datetime.max if not reverse else datetime.min)
-            if isinstance(updated_at, str):
-                try:
-                    return datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
-                except (ValueError, AttributeError):
-                    return datetime.min if not reverse else datetime.max
-            return updated_at
+            normalized_dt = _normalize_datetime_for_sorting(updated_at)
+            if normalized_dt is None:
+                return (datetime.max.replace(tzinfo=timezone.utc) if not reverse else datetime.min.replace(tzinfo=timezone.utc))
+            return normalized_dt
         
         elif sort_by == "costs":
             input_cost = model_info.get("input_cost_per_token", 0) or 0


### PR DESCRIPTION
## Relevant issues
This PR fixes an issue with the /v2/model/info endpoint, where when passing in sortBy = created_at or updated_at, it will throw an error about comparing offset-naive and offset-aware timezones. This PR fixes this with normalizing time zones before comparing them.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
<img width="975" height="333" alt="image" src="https://github.com/user-attachments/assets/f4751d72-8831-47e2-b048-c42cc4bacf41" />
