### PR TITLE
fix(openrouter): auto-detect models with ":free" suffix

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -439,6 +439,8 @@ def get_llm_provider(  # noqa: PLR0915
             custom_llm_provider = "amazon_nova"
         elif model.startswith("sap/"):
             custom_llm_provider = "sap"
+        elif model.endswith(":free"):
+            custom_llm_provider = "openrouter"
         if not custom_llm_provider:
             if litellm.suppress_debug_info is False:
                 print()  # noqa

--- a/tests/local_testing/test_get_llm_provider.py
+++ b/tests/local_testing/test_get_llm_provider.py
@@ -420,3 +420,14 @@ def test_get_llm_provider_use_proxy_arg_true_with_direct_args():
     assert provider == "litellm_proxy"
     assert key == arg_api_key  # Should use the argument key
     assert base == arg_api_base # Should use the argument base
+
+
+def test_openrouter_free_model():
+    """
+    Test that models ending in :free are routed to openrouter
+    """
+    model, custom_llm_provider, _, _ = litellm.get_llm_provider(
+        model="google/gemma-3-27b-it:free",
+    )
+    assert custom_llm_provider == "openrouter"
+    assert model == "google/gemma-3-27b-it:free"


### PR DESCRIPTION
This PR fixes an issue where OpenRouter free tier models (e.g., google/gemma-3-27b-it:free) were failing to connect because LiteLLM could not automatically infer the provider without an explicit 
openrouter/
 prefix.

The Logic
Updated get_llm_provider_logic to check if a model name ends with :free. If matched, it now defaults the provider to 
openrouter
, allowing users to pass model IDs like google/gemma-3-27b-it:free directly.

Fixes
Fixes #19934 ("Free Models of Open Router - model: google/gemma-3-27b-it:free")
Verification
Added a regression test 
test_openrouter_free_model
 in 
tests/local_testing/test_get_llm_provider.py
 which affirms that google/gemma-3-27b-it:free is correctly routed to OpenRouter.