### PR TITLE
fix: Allow admin viewer to access customer list and usage

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -646,6 +646,9 @@ class LiteLLMRoutes(enum.Enum):
         "/team/daily/activity",
         "/tag/daily/activity",
         "/tag/list",
+        "/customer/list",
+        "/customer/info",
+        "/customer/daily/activity",
     ] + info_routes
 
     # All routes accesible by an Org Admin


### PR DESCRIPTION
fix: #19990

### Type: Bug fix

- Changes
- Fix: Admin (view only) users can see customer usage again.
- Cause: /customer/list (and related read-only customer routes) were not in the allowed routes for the proxy_admin_viewer role, so the route check returned 403 before the endpoint ran.

- What we did: Added /customer/list, /customer/info, and /customer/daily/activity to admin_viewer_routes in litellm/proxy/_types.py so proxy_admin_viewer can call these read-only customer endpoints.

- Test: Added a test in tests/test_litellm/proxy/auth/test_route_checks.py that proxy_admin_viewer can access these customer routes without getting 403.