### PR TITLE
fix: run prisma generate as nobody user in non-root container

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -170,11 +170,13 @@ RUN sed -i 's/\r$//' docker/entrypoint.sh && \
     [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chmod -R g+w $LITELLM_PROXY_EXTRAS_PATH || true && \
     chmod -R g+rX $PRISMA_PATH && \
     chmod -R g+rX /app/.cache && \
-    mkdir -p /tmp/.npm /nonexistent /.npm && \
-    prisma generate
+    mkdir -p /tmp/.npm /nonexistent /.npm
 
 # Switch to non-root user for runtime
 USER nobody
+
+# Generate Prisma client as nobody user to ensure correct file ownership
+RUN prisma generate
 
 # Prisma runtime knobs for offline containers
 ENV PRISMA_SKIP_POSTINSTALL_GENERATE=1 \


### PR DESCRIPTION
Fixes permission error where prisma generate fails with 'Permission denied' when trying to write schema.prisma in non-root containers.

The issue was that prisma generate was running as root before switching to nobody user, causing generated files to be owned by root:root. Moving prisma generate after USER nobody ensures files are owned by nobody:nobody and can be written to during runtime.

## Relevant issues

Fixes #19859

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
- fix non root prisma permissions