### PR TITLE
[Feature] UI - Spend Logs: Show Current Store and Retention Status

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10616,6 +10616,8 @@ async def get_config_list(
         "max_request_size_mb": {"type": "Integer"},
         "max_response_size_mb": {"type": "Integer"},
         "pass_through_endpoints": {"type": "PydanticModel"},
+        "store_prompts_in_spend_logs": {"type": "Boolean"},
+        "maximum_spend_logs_retention_period": {"type": "String"},
     }
 
     return_val = []

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxyConfig/useProxyConfig.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxyConfig/useProxyConfig.test.ts
@@ -1,0 +1,554 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { ReactNode } from "react";
+import {
+  useProxyConfig,
+  useDeleteProxyConfigField,
+  getProxyConfigCall,
+  deleteProxyConfigFieldCall,
+  ConfigType,
+  GeneralSettingsFieldName,
+  type ProxyConfigResponse,
+  type DeleteProxyConfigFieldRequest,
+  type DeleteProxyConfigFieldResponse,
+} from "./useProxyConfig";
+
+const {
+  mockProxyBaseUrl,
+  mockAccessToken,
+  mockHeaderName,
+  mockProxyConfigResponse,
+  mockDeleteResponse,
+  mockUseAuthorized,
+  mockGetGlobalLitellmHeaderName,
+  mockDeriveErrorMessage,
+  mockHandleError,
+} = vi.hoisted(() => {
+  const mockProxyBaseUrl = "https://proxy.example.com";
+  const mockAccessToken = "test-access-token";
+  const mockHeaderName = "X-LiteLLM-API-Key";
+
+  const mockProxyConfigResponse: ProxyConfigResponse = [
+    {
+      field_name: "maximum_spend_logs_retention_period",
+      field_type: "int",
+      field_description: "Maximum retention period for spend logs",
+      field_value: 30,
+      stored_in_db: true,
+      field_default_value: 7,
+      premium_field: false,
+      nested_fields: null,
+    },
+    {
+      field_name: "another_field",
+      field_type: "string",
+      field_description: "Another config field",
+      field_value: "test-value",
+      stored_in_db: false,
+      field_default_value: "default-value",
+      premium_field: true,
+      nested_fields: [
+        {
+          field_name: "nested_field",
+          field_type: "string",
+          field_description: "Nested field description",
+          field_default_value: "nested-default",
+          stored_in_db: true,
+        },
+      ],
+    },
+  ];
+
+  const mockDeleteResponse: DeleteProxyConfigFieldResponse = {
+    message: "Field deleted successfully",
+  };
+
+  const mockUseAuthorized = vi.fn();
+  const mockGetGlobalLitellmHeaderName = vi.fn(() => mockHeaderName);
+  const mockDeriveErrorMessage = vi.fn((errorData: any) => {
+    if (typeof errorData === "string") return errorData;
+    return errorData?.message || errorData?.error || "An error occurred";
+  });
+  const mockHandleError = vi.fn();
+
+  return {
+    mockProxyBaseUrl,
+    mockAccessToken,
+    mockHeaderName,
+    mockProxyConfigResponse,
+    mockDeleteResponse,
+    mockUseAuthorized,
+    mockGetGlobalLitellmHeaderName,
+    mockDeriveErrorMessage,
+    mockHandleError,
+  };
+});
+
+vi.mock("../useAuthorized", () => ({
+  default: () => mockUseAuthorized(),
+}));
+
+vi.mock("@/components/networking", () => ({
+  proxyBaseUrl: mockProxyBaseUrl,
+  getGlobalLitellmHeaderName: mockGetGlobalLitellmHeaderName,
+  deriveErrorMessage: mockDeriveErrorMessage,
+  handleError: mockHandleError,
+}));
+
+vi.mock("../common/queryKeysFactory", () => ({
+  createQueryKeys: vi.fn((resource: string) => ({
+    all: [resource],
+    lists: () => [resource, "list"],
+    list: (params?: any) => [resource, "list", { params }],
+    details: () => [resource, "detail"],
+    detail: (uid: string) => [resource, "detail", uid],
+  })),
+}));
+
+describe("useProxyConfig", () => {
+  let queryClient: QueryClient;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    vi.clearAllMocks();
+
+    mockUseAuthorized.mockReturnValue({
+      accessToken: mockAccessToken,
+      userId: "test-user-id",
+      userRole: "Admin",
+      token: "test-token",
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+
+    fetchSpy = vi.fn();
+    global.fetch = fetchSpy;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it("should render successfully", () => {
+    (fetchSpy as any).mockResolvedValue({
+      ok: true,
+      json: async () => mockProxyConfigResponse,
+    });
+
+    const { result } = renderHook(() => useProxyConfig(ConfigType.GENERAL_SETTINGS), { wrapper });
+
+    expect(result.current).toBeDefined();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("should return proxy config data when query is successful", async () => {
+    (fetchSpy as any).mockResolvedValue({
+      ok: true,
+      json: async () => mockProxyConfigResponse,
+    });
+
+    const { result } = renderHook(() => useProxyConfig(ConfigType.GENERAL_SETTINGS), { wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockProxyConfigResponse);
+    expect(result.current.error).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${mockProxyBaseUrl}/config/list?config_type=${ConfigType.GENERAL_SETTINGS}`,
+      {
+        method: "GET",
+        headers: {
+          [mockHeaderName]: `Bearer ${mockAccessToken}`,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle error when API call fails", async () => {
+    const errorMessage = "Failed to fetch proxy config";
+    const errorResponse = { message: errorMessage };
+
+    (fetchSpy as any).mockResolvedValue({
+      ok: false,
+      json: async () => errorResponse,
+    });
+
+    const { result } = renderHook(() => useProxyConfig(ConfigType.GENERAL_SETTINGS), { wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should not execute query when accessToken is missing", async () => {
+    mockUseAuthorized.mockReturnValue({
+      accessToken: null,
+      userId: "test-user-id",
+      userRole: "Admin",
+      token: null,
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+
+    const { result } = renderHook(() => useProxyConfig(ConfigType.GENERAL_SETTINGS), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetched).toBe(false);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("should use correct query key with config type filter", async () => {
+    (fetchSpy as any).mockResolvedValue({
+      ok: true,
+      json: async () => mockProxyConfigResponse,
+    });
+
+    const { result } = renderHook(() => useProxyConfig(ConfigType.GENERAL_SETTINGS), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockProxyConfigResponse);
+  });
+
+  it("should handle network errors", async () => {
+    const networkError = new Error("Network error");
+    (fetchSpy as any).mockRejectedValue(networkError);
+
+    const { result } = renderHook(() => useProxyConfig(ConfigType.GENERAL_SETTINGS), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should handle empty config response", async () => {
+    (fetchSpy as any).mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    const { result } = renderHook(() => useProxyConfig(ConfigType.GENERAL_SETTINGS), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual([]);
+  });
+});
+
+describe("useDeleteProxyConfigField", () => {
+  let queryClient: QueryClient;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+        mutations: {
+          retry: false,
+        },
+      },
+    });
+
+    vi.clearAllMocks();
+
+    mockUseAuthorized.mockReturnValue({
+      accessToken: mockAccessToken,
+      userId: "test-user-id",
+      userRole: "Admin",
+      token: "test-token",
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+
+    fetchSpy = vi.fn();
+    global.fetch = fetchSpy;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it("should render successfully", () => {
+    const { result } = renderHook(() => useDeleteProxyConfigField(), { wrapper });
+
+    expect(result.current).toBeDefined();
+    expect(result.current.isIdle).toBe(true);
+  });
+
+  it("should successfully delete a proxy config field", async () => {
+    (fetchSpy as any).mockResolvedValue({
+      ok: true,
+      json: async () => mockDeleteResponse,
+    });
+
+    const { result } = renderHook(() => useDeleteProxyConfigField(), { wrapper });
+
+    const deleteRequest: DeleteProxyConfigFieldRequest = {
+      config_type: ConfigType.GENERAL_SETTINGS,
+      field_name: GeneralSettingsFieldName.MAXIMUM_SPEND_LOGS_RETENTION_PERIOD,
+    };
+
+    result.current.mutate(deleteRequest);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockDeleteResponse);
+    expect(fetchSpy).toHaveBeenCalledWith(`${mockProxyBaseUrl}/config/field/delete`, {
+      method: "POST",
+      headers: {
+        [mockHeaderName]: `Bearer ${mockAccessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(deleteRequest),
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle error when delete request fails", async () => {
+    const errorMessage = "Failed to delete field";
+    const errorResponse = { message: errorMessage };
+
+    (fetchSpy as any).mockResolvedValue({
+      ok: false,
+      json: async () => errorResponse,
+    });
+
+    const { result } = renderHook(() => useDeleteProxyConfigField(), { wrapper });
+
+    const deleteRequest: DeleteProxyConfigFieldRequest = {
+      config_type: ConfigType.GENERAL_SETTINGS,
+      field_name: GeneralSettingsFieldName.MAXIMUM_SPEND_LOGS_RETENTION_PERIOD,
+    };
+
+    result.current.mutate(deleteRequest);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should throw error when accessToken is missing", async () => {
+    mockUseAuthorized.mockReturnValue({
+      accessToken: null,
+      userId: "test-user-id",
+      userRole: "Admin",
+      token: null,
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+
+    const { result } = renderHook(() => useDeleteProxyConfigField(), { wrapper });
+
+    const deleteRequest: DeleteProxyConfigFieldRequest = {
+      config_type: ConfigType.GENERAL_SETTINGS,
+      field_name: GeneralSettingsFieldName.MAXIMUM_SPEND_LOGS_RETENTION_PERIOD,
+    };
+
+    result.current.mutate(deleteRequest);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe("Access token is required");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("should handle network errors during delete", async () => {
+    const networkError = new Error("Network error");
+    (fetchSpy as any).mockRejectedValue(networkError);
+
+    const { result } = renderHook(() => useDeleteProxyConfigField(), { wrapper });
+
+    const deleteRequest: DeleteProxyConfigFieldRequest = {
+      config_type: ConfigType.GENERAL_SETTINGS,
+      field_name: GeneralSettingsFieldName.MAXIMUM_SPEND_LOGS_RETENTION_PERIOD,
+    };
+
+    result.current.mutate(deleteRequest);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+  });
+});
+
+describe("getProxyConfigCall", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    global.fetch = fetchSpy;
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should successfully fetch proxy config", async () => {
+    (fetchSpy as any).mockResolvedValue({
+      ok: true,
+      json: async () => mockProxyConfigResponse,
+    });
+
+    const result = await getProxyConfigCall(mockAccessToken, ConfigType.GENERAL_SETTINGS);
+
+    expect(result).toEqual(mockProxyConfigResponse);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${mockProxyBaseUrl}/config/list?config_type=${ConfigType.GENERAL_SETTINGS}`,
+      {
+        method: "GET",
+        headers: {
+          [mockHeaderName]: `Bearer ${mockAccessToken}`,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+
+  it("should throw error when API returns error response", async () => {
+    const errorMessage = "Failed to fetch config";
+    const errorResponse = { message: errorMessage };
+
+    (fetchSpy as any).mockResolvedValue({
+      ok: false,
+      json: async () => errorResponse,
+    });
+
+    await expect(getProxyConfigCall(mockAccessToken, ConfigType.GENERAL_SETTINGS)).rejects.toThrow(errorMessage);
+  });
+
+  it("should handle network errors", async () => {
+    const networkError = new Error("Network error");
+    (fetchSpy as any).mockRejectedValue(networkError);
+
+    await expect(getProxyConfigCall(mockAccessToken, ConfigType.GENERAL_SETTINGS)).rejects.toThrow("Network error");
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});
+
+describe("deleteProxyConfigFieldCall", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    global.fetch = fetchSpy;
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should successfully delete proxy config field", async () => {
+    (fetchSpy as any).mockResolvedValue({
+      ok: true,
+      json: async () => mockDeleteResponse,
+    });
+
+    const deleteRequest: DeleteProxyConfigFieldRequest = {
+      config_type: ConfigType.GENERAL_SETTINGS,
+      field_name: GeneralSettingsFieldName.MAXIMUM_SPEND_LOGS_RETENTION_PERIOD,
+    };
+
+    const result = await deleteProxyConfigFieldCall(mockAccessToken, deleteRequest);
+
+    expect(result).toEqual(mockDeleteResponse);
+    expect(fetchSpy).toHaveBeenCalledWith(`${mockProxyBaseUrl}/config/field/delete`, {
+      method: "POST",
+      headers: {
+        [mockHeaderName]: `Bearer ${mockAccessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(deleteRequest),
+    });
+  });
+
+  it("should throw error when API returns error response", async () => {
+    const errorMessage = "Failed to delete field";
+    const errorResponse = { message: errorMessage };
+
+    (fetchSpy as any).mockResolvedValue({
+      ok: false,
+      json: async () => errorResponse,
+    });
+
+    const deleteRequest: DeleteProxyConfigFieldRequest = {
+      config_type: ConfigType.GENERAL_SETTINGS,
+      field_name: GeneralSettingsFieldName.MAXIMUM_SPEND_LOGS_RETENTION_PERIOD,
+    };
+
+    await expect(deleteProxyConfigFieldCall(mockAccessToken, deleteRequest)).rejects.toThrow(errorMessage);
+  });
+
+  it("should handle network errors", async () => {
+    const networkError = new Error("Network error");
+    (fetchSpy as any).mockRejectedValue(networkError);
+
+    const deleteRequest: DeleteProxyConfigFieldRequest = {
+      config_type: ConfigType.GENERAL_SETTINGS,
+      field_name: GeneralSettingsFieldName.MAXIMUM_SPEND_LOGS_RETENTION_PERIOD,
+    };
+
+    await expect(deleteProxyConfigFieldCall(mockAccessToken, deleteRequest)).rejects.toThrow("Network error");
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxyConfig/useProxyConfig.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxyConfig/useProxyConfig.ts
@@ -1,0 +1,180 @@
+import { useQuery, useMutation, UseMutationResult } from "@tanstack/react-query";
+import { createQueryKeys } from "../common/queryKeysFactory";
+import useAuthorized from "../useAuthorized";
+import { proxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
+
+/**
+ * Enum for config types that can be fetched from the proxy config endpoint.
+ * Currently supports general_settings, but can be extended as more config types are added.
+ */
+export enum ConfigType {
+  GENERAL_SETTINGS = "general_settings",
+}
+
+/**
+ * Enum for supported field names that can be deleted from general_settings.
+ * This should match the fields available in ConfigGeneralSettings.
+ */
+export enum GeneralSettingsFieldName {
+  MAXIMUM_SPEND_LOGS_RETENTION_PERIOD = "maximum_spend_logs_retention_period",
+  // Add more field names here as needed
+}
+
+/**
+ * Field detail for nested fields within a config field
+ */
+export interface FieldDetail {
+  field_name: string;
+  field_type: string;
+  field_description: string;
+  field_default_value: any;
+  stored_in_db: boolean | null;
+}
+
+/**
+ * Configuration list item returned from /config/list endpoint
+ */
+export interface ConfigListItem {
+  field_name: string;
+  field_type: string;
+  field_description: string;
+  field_value: any;
+  stored_in_db: boolean | null;
+  field_default_value: any;
+  premium_field?: boolean;
+  nested_fields?: FieldDetail[] | null;
+}
+
+/**
+ * Response type for /config/list endpoint
+ */
+export type ProxyConfigResponse = ConfigListItem[];
+
+/**
+ * Request body for /config/field/delete endpoint
+ */
+export interface DeleteProxyConfigFieldRequest {
+  config_type: ConfigType;
+  field_name: string;
+}
+
+/**
+ * Response type for /config/field/delete endpoint
+ */
+export interface DeleteProxyConfigFieldResponse {
+  message?: string;
+  [key: string]: any;
+}
+
+/**
+ * Network call function to fetch proxy config by config type
+ * @param accessToken - The access token for authentication
+ * @param configType - The type of config to fetch (from ConfigType enum)
+ * @returns Promise resolving to the config list response
+ */
+export const getProxyConfigCall = async (accessToken: string, configType: ConfigType): Promise<ProxyConfigResponse> => {
+  try {
+    const url = proxyBaseUrl
+      ? `${proxyBaseUrl}/config/list?config_type=${configType}`
+      : `/config/list?config_type=${configType}`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error(`Failed to get proxy config for ${configType}:`, error);
+    throw error;
+  }
+};
+
+const proxyConfigKeys = createQueryKeys("proxyConfig");
+
+/**
+ * Network call function to delete a proxy config field
+ * @param accessToken - The access token for authentication
+ * @param request - The delete request containing config_type and field_name
+ * @returns Promise resolving to the delete response
+ */
+export const deleteProxyConfigFieldCall = async (
+  accessToken: string,
+  request: DeleteProxyConfigFieldRequest,
+): Promise<DeleteProxyConfigFieldResponse> => {
+  try {
+    const url = proxyBaseUrl ? `${proxyBaseUrl}/config/field/delete` : `/config/field/delete`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error(`Failed to delete proxy config field ${request.field_name}:`, error);
+    throw error;
+  }
+};
+
+/**
+ * React Query hook to fetch proxy config by config type
+ * @param configType - The type of config to fetch (from ConfigType enum)
+ * @returns React Query result with the config list data
+ */
+export const useProxyConfig = (configType: ConfigType) => {
+  const { accessToken } = useAuthorized();
+  return useQuery<ProxyConfigResponse>({
+    queryKey: proxyConfigKeys.list({
+      filters: {
+        configType,
+      },
+    }),
+    queryFn: async () => await getProxyConfigCall(accessToken!, configType),
+    enabled: Boolean(accessToken),
+  });
+};
+
+/**
+ * React Query hook to delete a proxy config field
+ * @returns React Query mutation result for deleting config fields
+ */
+export const useDeleteProxyConfigField = (): UseMutationResult<
+  DeleteProxyConfigFieldResponse,
+  Error,
+  DeleteProxyConfigFieldRequest
+> => {
+  const { accessToken } = useAuthorized();
+
+  return useMutation<DeleteProxyConfigFieldResponse, Error, DeleteProxyConfigFieldRequest>({
+    mutationFn: async (request: DeleteProxyConfigFieldRequest) => {
+      if (!accessToken) {
+        throw new Error("Access token is required");
+      }
+      return await deleteProxyConfigFieldCall(accessToken, request);
+    },
+  });
+};

--- a/ui/litellm-dashboard/src/components/view_logs/ConfigInfoMessage.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/ConfigInfoMessage.tsx
@@ -2,9 +2,10 @@ import React from "react";
 
 interface ConfigInfoMessageProps {
   show: boolean;
+  onOpenSettings?: () => void;
 }
 
-export const ConfigInfoMessage: React.FC<ConfigInfoMessageProps> = ({ show }) => {
+export const ConfigInfoMessage: React.FC<ConfigInfoMessageProps> = ({ show, onOpenSettings }) => {
   if (!show) return null;
 
   return (
@@ -30,7 +31,18 @@ export const ConfigInfoMessage: React.FC<ConfigInfoMessageProps> = ({ show }) =>
         <h4 className="text-sm font-medium text-blue-800">Request/Response Data Not Available</h4>
         <p className="text-sm text-blue-700 mt-1">
           To view request and response details, enable prompt storage in your LiteLLM configuration by adding the
-          following to your <code className="bg-blue-100 px-1 py-0.5 rounded">proxy_config.yaml</code> file:
+          following to your <code className="bg-blue-100 px-1 py-0.5 rounded">proxy_config.yaml</code> file
+          {onOpenSettings && (
+            <> or{" "}
+              <button
+                onClick={onOpenSettings}
+                className="text-blue-600 hover:text-blue-800 underline font-medium"
+              >
+                open the settings
+              </button>
+              {" "}to configure this directly.
+            </>
+          )}
         </p>
         <pre className="mt-2 bg-white p-3 rounded border border-blue-200 text-xs font-mono overflow-auto">
           {`general_settings:

--- a/ui/litellm-dashboard/src/components/view_logs/SpendLogsSettingsModal/SpendLogsSettingsModal.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/SpendLogsSettingsModal/SpendLogsSettingsModal.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { StoreRequestInSpendLogsParams, useStoreRequestInSpendLogs } from "@/app/(dashboard)/hooks/storeRequestInSpendLogs/useStoreRequestInSpendLogs";
+import { ConfigType, useProxyConfig, useDeleteProxyConfigField, GeneralSettingsFieldName } from "@/app/(dashboard)/hooks/proxyConfig/useProxyConfig";
 import NotificationsManager from "@/components/molecules/notifications_manager";
 import { parseErrorMessage } from "@/components/shared/errorUtils";
 import { ClockCircleOutlined } from "@ant-design/icons";
-import { Button, Form, Input, Modal, Space, Switch } from "antd";
-import React from "react";
+import { Button, Form, Input, Modal, Skeleton, Space, Switch } from "antd";
+import React, { useEffect, useMemo } from "react";
 
 interface SpendLogsSettingsModalProps {
   isVisible: boolean;
@@ -16,14 +17,69 @@ interface SpendLogsSettingsModalProps {
 const SpendLogsSettingsModal: React.FC<SpendLogsSettingsModalProps> = ({ isVisible, onCancel, onSuccess }) => {
   const [form] = Form.useForm();
   const { mutateAsync, isPending } = useStoreRequestInSpendLogs();
+  const { mutateAsync: deleteField, isPending: isDeletingField } = useDeleteProxyConfigField();
+  const { data: proxyConfigData, isLoading: isLoadingConfig, refetch } = useProxyConfig(ConfigType.GENERAL_SETTINGS);
   const storePromptsValue = Form.useWatch('store_prompts_in_spend_logs', form);
+
+  // Refetch config when modal opens to ensure we have the latest values
+  useEffect(() => {
+    if (isVisible) {
+      refetch();
+    }
+  }, [isVisible, refetch]);
+
+  // Compute initial values from fetched config data
+  const initialValues = useMemo(() => {
+    if (!proxyConfigData) {
+      return {
+        store_prompts_in_spend_logs: false,
+        maximum_spend_logs_retention_period: undefined,
+      };
+    }
+
+    const storePromptsField = proxyConfigData.find(field => field.field_name === 'store_prompts_in_spend_logs');
+    const retentionPeriodField = proxyConfigData.find(field => field.field_name === 'maximum_spend_logs_retention_period');
+
+    return {
+      store_prompts_in_spend_logs: storePromptsField?.field_value ?? false,
+      maximum_spend_logs_retention_period: retentionPeriodField?.field_value ?? undefined,
+    };
+  }, [proxyConfigData]);
 
   const handleFormSubmit = async (formValues: StoreRequestInSpendLogsParams) => {
     try {
-      await mutateAsync(formValues, {
+      // If maximum_spend_logs_retention_period is empty/null, delete the field first
+      const retentionPeriodValue = formValues.maximum_spend_logs_retention_period;
+      const shouldDeleteRetentionPeriod =
+        !retentionPeriodValue ||
+        (typeof retentionPeriodValue === "string" && retentionPeriodValue.trim() === "");
+
+      if (shouldDeleteRetentionPeriod) {
+        try {
+          await deleteField({
+            config_type: ConfigType.GENERAL_SETTINGS,
+            field_name: GeneralSettingsFieldName.MAXIMUM_SPEND_LOGS_RETENTION_PERIOD,
+          });
+        } catch (deleteError) {
+          // If field doesn't exist, that's okay - continue with update
+          console.warn("Failed to delete retention period field (may not exist):", deleteError);
+        }
+      }
+
+      // Update the settings (excluding maximum_spend_logs_retention_period if it's empty)
+      const updateParams: StoreRequestInSpendLogsParams = {
+        store_prompts_in_spend_logs: formValues.store_prompts_in_spend_logs,
+        ...(retentionPeriodValue &&
+          typeof retentionPeriodValue === "string" &&
+          retentionPeriodValue.trim() !== "" && {
+          maximum_spend_logs_retention_period: retentionPeriodValue,
+        }),
+      };
+
+      await mutateAsync(updateParams, {
         onSuccess: () => {
           NotificationsManager.success("Spend logs settings updated successfully");
-          form.resetFields();
+          refetch(); // Refetch config to get updated values
           onSuccess?.();
         },
         onError: (error) => {
@@ -44,53 +100,53 @@ const SpendLogsSettingsModal: React.FC<SpendLogsSettingsModalProps> = ({ isVisib
     <Modal
       title="Spend Logs Settings"
       open={isVisible}
-      width={600}
       footer={
         <Space>
-          <Button onClick={handleCancel} disabled={isPending}>
+          <Button onClick={handleCancel} disabled={isPending || isDeletingField || isLoadingConfig}>
             Cancel
           </Button>
-          <Button type="primary" loading={isPending} onClick={() => form.submit()}>
-            {isPending ? "Saving..." : "Save Settings"}
+          <Button type="primary" loading={isPending || isDeletingField} disabled={isLoadingConfig} onClick={() => form.submit()}>
+            {isPending || isDeletingField ? "Saving..." : "Save Settings"}
           </Button>
         </Space>
       }
       onCancel={handleCancel}
     >
+
       <Form
+        key={proxyConfigData ? JSON.stringify(initialValues) : 'loading'}
         form={form}
         layout="horizontal"
-        labelCol={{ flex: "auto", style: { textAlign: "left" } }}
-        wrapperCol={{ flex: "auto", style: { textAlign: "right" } }}
         onFinish={handleFormSubmit}
-        initialValues={{
-          store_prompts_in_spend_logs: false,
-          maximum_spend_logs_retention_period: undefined,
-        }}
+        initialValues={initialValues}
       >
         <Form.Item
+          label="Store Prompts in Spend Logs"
           name="store_prompts_in_spend_logs"
-          tooltip="When enabled, prompts will be stored in spend logs for tracking and analysis purposes."
+          tooltip={
+            proxyConfigData?.find(f => f.field_name === 'store_prompts_in_spend_logs')?.field_description ||
+            "When enabled, prompts will be stored in spend logs for tracking and analysis purposes."
+          }
           valuePropName="checked"
         >
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <span>Store Prompts in Spend Logs</span>
-            <Switch checked={storePromptsValue ?? false} onChange={(checked) => form.setFieldValue('store_prompts_in_spend_logs', checked)} />
+          <div>
+
+            {isLoadingConfig ? <Skeleton.Input active block /> : <Switch checked={storePromptsValue ?? false} onChange={(checked) => form.setFieldValue('store_prompts_in_spend_logs', checked)} />}
           </div>
         </Form.Item>
-
 
         <Form.Item
           label="Maximum Spend Logs Retention Period (Optional)"
           name="maximum_spend_logs_retention_period"
-          tooltip="Set the maximum retention period for spend logs (e.g., '7d' for 7 days, '30d' for 30 days). Leave empty for no limit."
-          labelCol={{ flex: "auto", style: { textAlign: "left" } }}
-          wrapperCol={{ flex: "0 0 25%", style: { textAlign: "right" } }}
+          tooltip={
+            proxyConfigData?.find(f => f.field_name === 'maximum_spend_logs_retention_period')?.field_description ||
+            "Set the maximum retention period for spend logs (e.g., '7d' for 7 days, '30d' for 30 days). Leave empty for no limit."
+          }
         >
-          <Input
+          {isLoadingConfig ? <Skeleton.Input active block /> : <Input
             placeholder="e.g., 7d, 30d"
             prefix={<ClockCircleOutlined />}
-          />
+          />}
         </Form.Item>
       </Form>
     </Modal>

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -555,7 +555,7 @@ export default function SpendLogsTable({
                 <DataTable
                   columns={columns}
                   data={sessionData}
-                  renderSubComponent={RequestViewer}
+                  renderSubComponent={({ row }) => <RequestViewer row={row} onOpenSettings={() => setIsSpendLogsSettingsModalVisible(true)} />}
                   getRowCanExpand={() => true}
                 // Optionally: add session-specific row expansion state
                 />
@@ -754,7 +754,7 @@ export default function SpendLogsTable({
                   <DataTable
                     columns={columns}
                     data={filteredData}
-                    renderSubComponent={RequestViewer}
+                    renderSubComponent={({ row }) => <RequestViewer row={row} onOpenSettings={() => setIsSpendLogsSettingsModalVisible(true)} />}
                     getRowCanExpand={() => true}
                   />
                 </div>
@@ -780,7 +780,7 @@ export default function SpendLogsTable({
   );
 }
 
-export function RequestViewer({ row }: { row: Row<LogEntry> }) {
+export function RequestViewer({ row, onOpenSettings }: { row: Row<LogEntry>; onOpenSettings?: () => void }) {
   // Helper function to clean metadata by removing specific fields
   const formatData = (input: any) => {
     if (typeof input === "string") {
@@ -991,7 +991,7 @@ export function RequestViewer({ row }: { row: Row<LogEntry> }) {
       <CostBreakdownViewer costBreakdown={row.original.metadata?.cost_breakdown} totalSpend={row.original.spend || 0} />
 
       {/* Configuration Info Message - Show when data is missing */}
-      <ConfigInfoMessage show={missingData} />
+      <ConfigInfoMessage show={missingData} onOpenSettings={onOpenSettings} />
 
       {/* Request/Response Panel */}
       <div className="w-full max-w-full overflow-hidden">


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
✅ Test

## Changes

Adds functionality to display spend logs settings in the UI and allows deletion of the retention period field. The `SpendLogsSettingsModal` now fetches current proxy config values for `store_prompts_in_spend_logs` and `maximum_spend_logs_retention_period` and displays them. Users can delete the retention period by clearing the field value. Added a new `useProxyConfig` hook for fetching and deleting proxy config fields, with corresponding tests. Updated `proxy_server.py` to include the two spend logs config fields in the config list endpoint.

## Screenshots

<img width="634" height="298" alt="image" src="https://github.com/user-attachments/assets/036d5d03-a18c-4bef-a857-87898e719123" />
<img width="1411" height="209" alt="image" src="https://github.com/user-attachments/assets/ac832312-50d8-45b6-8339-09c09f2f66ed" />
<img width="974" height="292" alt="image" src="https://github.com/user-attachments/assets/207b2c3b-e8d3-49ad-8f42-b81ceef26191" />
