### PR TITLE
fix: Remove wildcard patterns from /v1/models and deduplicate expansions

### DIFF
--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -62,3 +62,105 @@ def test_get_complete_model_list_order(key_models, team_models, proxy_model_list
         infer_model_from_keys=False,
         llm_router=Router(model_list=model_list),
     ) == expected
+
+
+def test_wildcard_patterns_removed_from_model_list_with_router():
+    """
+    Test that wildcard patterns like 'anthropic/*' are removed from the model
+    list when llm_router is present.
+
+    Previously, models_to_remove.add(model) was only called in the
+    llm_router is None branch, causing wildcard patterns to appear as
+    literal model names in the /v1/models response.
+    """
+    from litellm.proxy.auth.model_checks import _get_wildcard_models
+
+    mock_router = MagicMock()
+    mock_router.get_model_list.return_value = [
+        {"litellm_params": {"model": "anthropic/claude-3-haiku-20240307"}}
+    ]
+
+    unique_models = ["anthropic/*", "gpt-4"]
+
+    with patch(
+        "litellm.proxy.auth.model_checks.get_known_models_from_wildcard",
+        return_value=["anthropic/claude-3-haiku-20240307", "anthropic/claude-3-5-sonnet-20241022"],
+    ):
+        result = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=mock_router,
+        )
+
+    # The wildcard pattern should be removed from unique_models
+    assert "anthropic/*" not in unique_models
+    # Explicit models should remain
+    assert "gpt-4" in unique_models
+    # Expanded models should be in the result
+    assert "anthropic/claude-3-haiku-20240307" in result
+    assert "anthropic/claude-3-5-sonnet-20241022" in result
+
+
+def test_wildcard_expansion_deduplicates_across_deployments():
+    """
+    Test that when multiple wildcard deployments exist for the same provider
+    (e.g. several 'anthropic/*' entries with different credentials), the
+    expanded model list does not contain duplicates.
+    """
+    from litellm.proxy.auth.model_checks import _get_wildcard_models
+
+    mock_router = MagicMock()
+    # Simulate two deployments for anthropic/* (e.g. different team credentials)
+    mock_router.get_model_list.return_value = [
+        {"litellm_params": {"model": "anthropic/team1-key"}},
+        {"litellm_params": {"model": "anthropic/team2-key"}},
+    ]
+
+    unique_models = ["anthropic/*"]
+    expanded = ["anthropic/claude-3-haiku-20240307", "anthropic/claude-3-5-sonnet-20241022"]
+
+    with patch(
+        "litellm.proxy.auth.model_checks.get_known_models_from_wildcard",
+        return_value=expanded,
+    ):
+        result = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=mock_router,
+        )
+
+    # Each model should appear exactly once despite two deployments
+    assert result.count("anthropic/claude-3-haiku-20240307") == 1
+    assert result.count("anthropic/claude-3-5-sonnet-20241022") == 1
+
+
+def test_wildcard_expansion_deduplicates_against_explicit_models():
+    """
+    Test that models already present in unique_models (with or without
+    provider prefix) are not duplicated by wildcard expansion.
+    """
+    from litellm.proxy.auth.model_checks import _get_wildcard_models
+
+    mock_router = MagicMock()
+    mock_router.get_model_list.return_value = [
+        {"litellm_params": {"model": "openai/some-key"}}
+    ]
+
+    # gpt-4 is explicitly configured (without prefix)
+    unique_models = ["openai/*", "gpt-4"]
+
+    with patch(
+        "litellm.proxy.auth.model_checks.get_known_models_from_wildcard",
+        return_value=["openai/gpt-4", "openai/gpt-4o", "openai/gpt-3.5-turbo"],
+    ):
+        result = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=mock_router,
+        )
+
+    # openai/gpt-4 should NOT appear since gpt-4 is already in unique_models
+    assert "openai/gpt-4" not in result
+    # Other expanded models should appear
+    assert "openai/gpt-4o" in result
+    assert "openai/gpt-3.5-turbo" in result


### PR DESCRIPTION
## Relevant issues

Fixes wildcard model patterns (e.g. `anthropic/*`) appearing as literal model names in `/v1/models` response, and massive duplication when multiple wildcard deployments exist.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Two bugs in `_get_wildcard_models()` in `litellm/proxy/auth/model_checks.py`:

### Bug 1: Wildcard patterns leak into `/v1/models` response

`models_to_remove.add(model)` was only called in the `llm_router is None` branch. In production, `llm_router` is always present, so wildcard patterns like `anthropic/*`, `openai/*`, `gemini/*` were never removed from `unique_models` and appeared as literal model names in the API response.

**Fix:** Move `models_to_remove.add(model)` to always execute when a wildcard pattern is detected, regardless of whether `llm_router` is present.

### Bug 2: Massive duplication in wildcard expansion

When multiple wildcard deployments exist for the same provider (e.g. several `anthropic/*` entries with different API keys for different teams), each deployment independently expanded to the full set of known provider models. For example, with 4 `gemini/*` deployments, every Gemini model appeared 4 times. Additionally, models that were both explicitly configured and part of a wildcard expansion appeared twice (e.g. `gpt-4` as an explicit model and `openai/gpt-4` from `openai/*` expansion).

**Fix:** Add a deduplication pass after wildcard expansion that:
- Removes duplicate models across multiple wildcard deployments
- Removes models already present in `unique_models` (matching with or without provider prefix)

### Tests added

- `test_wildcard_patterns_removed_from_model_list_with_router` - verifies Bug 1 fix
- `test_wildcard_expansion_deduplicates_across_deployments` - verifies Bug 2 (cross-deployment dedup)
- `test_wildcard_expansion_deduplicates_against_explicit_models` - verifies Bug 2 (explicit model dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)