### PR TITLE
fix: Filter deprecated models from wildcard expansion in /v1/models

### DIFF
--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -62,3 +62,93 @@ def test_get_complete_model_list_order(key_models, team_models, proxy_model_list
         infer_model_from_keys=False,
         llm_router=Router(model_list=model_list),
     ) == expected
+
+
+def test_is_model_deprecated_filters_past_dates():
+    """
+    Test that _is_model_deprecated returns True for models whose
+    deprecation_date is in the past.
+    """
+    from litellm.proxy.auth.model_checks import _is_model_deprecated
+
+    mock_cost = {
+        "claude-3-5-sonnet-20240620": {
+            "deprecation_date": "2025-06-01",
+            "litellm_provider": "anthropic",
+        },
+        "claude-3-5-sonnet-20241022": {
+            "deprecation_date": "2099-12-31",
+            "litellm_provider": "anthropic",
+        },
+        "gpt-4-current": {
+            "litellm_provider": "openai",
+        },
+    }
+
+    with patch("litellm.proxy.auth.model_checks.litellm") as mock_litellm:
+        mock_litellm.model_cost = mock_cost
+
+        # Past deprecation date -> deprecated
+        assert _is_model_deprecated("claude-3-5-sonnet-20240620") is True
+        # Also works with provider prefix (bare name lookup)
+        assert _is_model_deprecated("anthropic/claude-3-5-sonnet-20240620") is True
+
+        # Future deprecation date -> not deprecated
+        assert _is_model_deprecated("claude-3-5-sonnet-20241022") is False
+        assert _is_model_deprecated("anthropic/claude-3-5-sonnet-20241022") is False
+
+        # No deprecation_date field -> not deprecated
+        assert _is_model_deprecated("gpt-4-current") is False
+
+        # Unknown model -> not deprecated
+        assert _is_model_deprecated("nonexistent-model") is False
+
+
+def test_wildcard_expansion_filters_deprecated_models():
+    """
+    Test that _get_wildcard_models excludes models with a past
+    deprecation_date from the expanded wildcard list.
+    """
+    from litellm.proxy.auth.model_checks import _get_wildcard_models
+
+    mock_router = MagicMock()
+    mock_router.get_model_list.return_value = [
+        {"litellm_params": {"model": "anthropic/some-key"}}
+    ]
+
+    unique_models = ["anthropic/*"]
+
+    expanded = [
+        "anthropic/claude-3-haiku-20240307",      # no deprecation_date
+        "anthropic/claude-3-5-sonnet-20240620",    # deprecated (past date)
+        "anthropic/claude-3-5-sonnet-20241022",    # not deprecated (future date)
+    ]
+
+    mock_cost = {
+        "claude-3-5-sonnet-20240620": {
+            "deprecation_date": "2025-06-01",
+            "litellm_provider": "anthropic",
+        },
+        "claude-3-5-sonnet-20241022": {
+            "deprecation_date": "2099-12-31",
+            "litellm_provider": "anthropic",
+        },
+    }
+
+    with patch(
+        "litellm.proxy.auth.model_checks.get_known_models_from_wildcard",
+        return_value=expanded,
+    ), patch("litellm.proxy.auth.model_checks.litellm") as mock_litellm:
+        mock_litellm.model_cost = mock_cost
+
+        result = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=mock_router,
+        )
+
+    # Deprecated model should be filtered out
+    assert "anthropic/claude-3-5-sonnet-20240620" not in result
+    # Non-deprecated models should remain
+    assert "anthropic/claude-3-haiku-20240307" in result
+    assert "anthropic/claude-3-5-sonnet-20241022" in result


### PR DESCRIPTION
## Relevant issues

When wildcard routes like `anthropic/*` are expanded, deprecated models (e.g. `claude-3-5-sonnet-20240620`) appear in the `/v1/models` response. Users who call these models get 404 errors from the provider API since the models have been sunset.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### The Problem

`get_known_models_from_wildcard()` expands wildcard routes (e.g. `anthropic/*`) into all known provider models by reading from `litellm.models_by_provider`, which is populated from `litellm.model_cost`. The `model_cost` data already contains `deprecation_date` fields (YYYY-MM-DD format) on 100+ models, but this information was never used for filtering.

As a result, deprecated models like `claude-3-5-sonnet-20240620` (deprecated 2025-06-01) appear in the `/v1/models` response as valid models. When users try to call them, they get 404 errors from the provider API (not from LiteLLM) because the provider has sunset the model. This is confusing because the model appears in the list but doesn't work.

### The Fix

- Add `_is_model_deprecated()` helper in `model_checks.py` that checks a model name against `litellm.model_cost` for a `deprecation_date` in the past. It handles both provider-prefixed names (`anthropic/claude-...`) and bare names (`claude-...`).
- Filter the wildcard expansion results in `_get_wildcard_models()` before returning, removing any deprecated models.

### Tests added

- `test_is_model_deprecated_filters_past_dates` — tests the helper with past dates, future dates, missing dates, and unknown models; also tests bare vs prefixed name lookup
- `test_wildcard_expansion_filters_deprecated_models` — end-to-end test that deprecated models are excluded from `_get_wildcard_models()` results while non-deprecated models are kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)