### PR TITLE
Add event-driven coordination for global spend query to prevent cache stampede

### DIFF
--- a/litellm/proxy/common_utils/cache_coordinator.py
+++ b/litellm/proxy/common_utils/cache_coordinator.py
@@ -1,0 +1,191 @@
+"""
+Event-driven cache coordinator to prevent cache stampede.
+
+Use this when many requests can miss the same cache key at once (e.g. after
+expiry or restart). Without coordination, they would all run the expensive
+load (DB query, API call) in parallel and overload the backend.
+
+This module ensures only one request performs the load; the rest wait for a
+signal and then read the freshly cached value. Reuse it for any cache-aside
+pattern: global spend, feature flags, config, or other shared read-through data.
+"""
+
+import asyncio
+import time
+from typing import Any, Awaitable, Callable, Optional, Protocol, TypeVar
+
+from litellm._logging import verbose_proxy_logger
+
+T = TypeVar("T")
+
+
+class AsyncCacheProtocol(Protocol):
+    """Protocol for cache backends used by EventDrivenCacheCoordinator."""
+
+    async def async_get_cache(self, key: str, **kwargs: Any) -> Any:
+        ...
+
+    async def async_set_cache(self, key: str, value: Any, **kwargs: Any) -> Any:
+        ...
+
+
+class EventDrivenCacheCoordinator:
+    """
+    Coordinates a single in-flight load per logical resource to prevent cache stampede.
+
+    Pattern:
+    - First request: loads data (e.g. DB query), caches it, then signals waiters.
+    - Other requests: wait for the signal, then read from cache.
+
+    Create one instance per resource (e.g. one for global spend, one for feature flags).
+    """
+
+    def __init__(self, log_prefix: str = "[CACHE]"):
+        self._lock = asyncio.Lock()
+        self._event: Optional[asyncio.Event] = None
+        self._query_in_progress = False
+        self._log_prefix = log_prefix
+
+    async def _get_cached(
+        self, cache_key: str, cache: AsyncCacheProtocol
+    ) -> Optional[T]:
+        """Return value from cache if present, else None."""
+        return await cache.async_get_cache(key=cache_key)
+
+    def _log_cache_hit(self, value: T) -> None:
+        if self._log_prefix:
+            verbose_proxy_logger.debug(
+                "%s Cache hit, value: %s", self._log_prefix, value
+            )
+
+    def _log_cache_miss(self) -> None:
+        if self._log_prefix:
+            verbose_proxy_logger.debug("%s Cache miss", self._log_prefix)
+
+    async def _claim_role(self) -> Optional[asyncio.Event]:
+        """
+        Under lock: return event to wait on if load is in progress, else set us as loader and return None.
+        """
+        async with self._lock:
+            if self._query_in_progress and self._event is not None:
+                if self._log_prefix:
+                    verbose_proxy_logger.debug(
+                        "%s Load in flight, waiting for signal", self._log_prefix
+                    )
+                return self._event
+            self._query_in_progress = True
+            self._event = asyncio.Event()
+            if self._log_prefix:
+                verbose_proxy_logger.debug(
+                    "%s Starting load (will signal others when done)",
+                    self._log_prefix,
+                )
+            return None
+
+    async def _wait_for_signal_and_get(
+        self,
+        event: asyncio.Event,
+        cache_key: str,
+        cache: AsyncCacheProtocol,
+    ) -> Optional[T]:
+        """Wait for loader to finish, then read from cache."""
+        await event.wait()
+        if self._log_prefix:
+            verbose_proxy_logger.debug(
+                "%s Signal received, reading from cache", self._log_prefix
+            )
+        value = await cache.async_get_cache(key=cache_key)
+        if value is not None and self._log_prefix:
+            verbose_proxy_logger.debug(
+                "%s Cache filled by other request, value: %s",
+                self._log_prefix,
+                value,
+            )
+        elif value is None and self._log_prefix:
+            verbose_proxy_logger.debug(
+                "%s Signal received but cache still empty", self._log_prefix
+            )
+        return value
+
+    async def _load_and_cache(
+        self,
+        cache_key: str,
+        cache: AsyncCacheProtocol,
+        load_fn: Callable[[], Awaitable[T]],
+    ) -> Optional[T]:
+        """Double-check cache, run load_fn, set cache, return value. Caller must call _signal_done in finally."""
+        value = await cache.async_get_cache(key=cache_key)
+        if value is not None:
+            if self._log_prefix:
+                verbose_proxy_logger.debug(
+                    "%s Cache filled while acquiring lock, value: %s",
+                    self._log_prefix,
+                    value,
+                )
+            return value
+
+        if self._log_prefix:
+            verbose_proxy_logger.debug("%s Running load", self._log_prefix)
+        start = time.perf_counter()
+        value = await load_fn()
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        if self._log_prefix:
+            verbose_proxy_logger.debug(
+                "%s Load completed in %.2fms, result: %s",
+                self._log_prefix,
+                elapsed_ms,
+                value,
+            )
+
+        await cache.async_set_cache(key=cache_key, value=value)
+        if self._log_prefix:
+            verbose_proxy_logger.debug("%s Result cached", self._log_prefix)
+        return value
+
+    async def _signal_done(self) -> None:
+        """Reset loader state and signal all waiters."""
+        async with self._lock:
+            self._query_in_progress = False
+            if self._event is not None:
+                if self._log_prefix:
+                    verbose_proxy_logger.debug(
+                        "%s Signaling all waiting requests", self._log_prefix
+                    )
+                self._event.set()
+                self._event = None
+
+    async def get_or_load(
+        self,
+        cache_key: str,
+        cache: AsyncCacheProtocol,
+        load_fn: Callable[[], Awaitable[T]],
+    ) -> Optional[T]:
+        """
+        Return cached value or load it once and signal waiters.
+
+        - cache_key: Key to read/write in the cache.
+        - cache: Object with async_get_cache(key) and async_set_cache(key, value).
+        - load_fn: Async callable that performs the load (e.g. DB query). No args.
+                   Return value is cached and returned. If it raises, waiters are
+                   still signaled so they can retry or handle empty cache.
+
+        Returns the value from cache or from load_fn, or None if load failed or
+        cache was still empty after waiting.
+        """
+        value = await self._get_cached(cache_key, cache)
+        if value is not None:
+            self._log_cache_hit(value)
+            return value
+
+        self._log_cache_miss()
+        event_to_wait = await self._claim_role()
+
+        if event_to_wait is not None:
+            return await self._wait_for_signal_and_get(
+                event_to_wait, cache_key, cache
+            )
+
+        try:
+            return await self._load_and_cache(cache_key, cache, load_fn)
+        finally:
+            await self._signal_done()


### PR DESCRIPTION
## Relevant issues

When a global proxy budget is enabled, concurrent requests can trigger a cache miss at the same time, causing all of them to query the database for global spend. This results in a cache stampede.

The global budget query is very expensive, and even a relatively small spike (e.g., ~100 concurrent requests) can overwhelm the database, leading to widespread timeouts and potentially taking both the database and the proxy offline.

## Solution Summary

We use in-flight query detection: if many requests (e.g. 100) hit a cache miss at once, we detect that a query for the same data is already running. Instead of sending all of them to the database, we have the extra requests wait. When the in-flight query finishes, it notifies the waiters so they read the result from cache instead of issuing duplicate queries.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->

🐛 Bug Fix

## Changes

- **Added `EventDrivenCacheCoordinator`** in `litellm/proxy/common_utils/cache_coordinator.py`: reusable helper that avoids cache stampede by letting only one request run the expensive load; others wait on an event and then read from cache.
- **Wired global spend into the coordinator** in `litellm/proxy/auth/user_api_key_auth.py`: `_fetch_global_spend_with_event_coordination` now uses a single shared coordinator instance. On cache miss, one request runs the global spend query, caches the result, and signals waiters; concurrent requests wait for that signal and then read the cached value instead of each hitting the DB.
- Coordinator is generic (cache protocol + load function) so it can be reused for other cache-aside flows (e.g. feature flags, config) if needed.