### PR TITLE
fix(guardrails): populate applied_guardrails when Model Armor blocks content

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
@@ -421,6 +421,13 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                     )
                     else "success"
                 )
+
+            # Add guardrail to applied_guardrails BEFORE potential blocking
+            # This ensures guardrail is recorded even when it blocks the request
+            add_guardrail_to_applied_guardrails_header(
+                request_data=data, guardrail_name=self.guardrail_name
+            )
+
             # Check if content should be blocked
             if self._should_block_content(
                 armor_response, allow_sanitization=self.mask_request_content
@@ -455,11 +462,6 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
             # Depending on configuration, either fail or continue
             if self.optional_params.get("fail_on_error", True):
                 raise
-
-        # Add guardrail to headers
-        add_guardrail_to_applied_guardrails_header(
-            request_data=data, guardrail_name=self.guardrail_name
-        )
 
         return data
 
@@ -517,6 +519,12 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                     else "success"
                 )
 
+            # Add guardrail to applied_guardrails BEFORE potential blocking
+            # This ensures guardrail is recorded even when it blocks the request
+            add_guardrail_to_applied_guardrails_header(
+                request_data=data, guardrail_name=self.guardrail_name
+            )
+
             # Check if content should be blocked
             if self._should_block_content(
                 armor_response, allow_sanitization=self.mask_request_content
@@ -549,11 +557,6 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
             )
             if self.optional_params.get("fail_on_error", True):
                 raise
-
-        # Add guardrail to headers
-        add_guardrail_to_applied_guardrails_header(
-            request_data=data, guardrail_name=self.guardrail_name
-        )
 
         return data
 
@@ -622,6 +625,12 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                     guardrail_response=standard_logging_guardrail_information,
                 )
 
+            # Add guardrail to applied_guardrails BEFORE potential blocking
+            # This ensures guardrail is recorded even when it blocks the request
+            add_guardrail_to_applied_guardrails_header(
+                request_data=data, guardrail_name=self.guardrail_name
+            )
+
             # Check if content should be blocked
             if self._should_block_content(
                 armor_response, allow_sanitization=self.mask_response_content
@@ -653,11 +662,6 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
             )
             if self.optional_params.get("fail_on_error", True):
                 raise
-
-        # Add guardrail to headers
-        add_guardrail_to_applied_guardrails_header(
-            request_data=data, guardrail_name=self.guardrail_name
-        )
 
         return response
 
@@ -702,6 +706,16 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                             if self._should_block_content(armor_response)
                             else "success"
                         )
+
+                    # Add guardrail to applied_guardrails BEFORE potential blocking
+                    # This ensures guardrail is recorded even when it blocks the request
+                    from litellm.proxy.common_utils.callback_utils import (
+                        add_guardrail_to_applied_guardrails_header,
+                    )
+
+                    add_guardrail_to_applied_guardrails_header(
+                        request_data=request_data, guardrail_name=self.guardrail_name
+                    )
 
                     # Check if blocked
                     if self._should_block_content(armor_response):


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes https://github.com/BerriAI/litellm/issues/19982

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Previously, when Model Armor guardrail blocked a request/response, the `applied_guardrails` field was not populated in the logs because `add_guardrail_to_applied_guardrails_header()` was called after the HTTPException was raised.

This fix moves the `add_guardrail_to_applied_guardrails_header()` call to before the blocking check in all hooks:
- async_pre_call_hook (pre_call mode)
- async_moderation_hook (during_call mode)
- async_post_call_success_hook (post_call mode)
- async_post_call_streaming_iterator_hook (streaming)

This ensures that even when a guardrail blocks content, the guardrail name is properly recorded in the logs for observability.

Added regression tests to verify applied_guardrails is populated when content is blocked.

