### PR TITLE
fix(ResponseAPILoggingUtils): extract input tokens details as dict

### DIFF
--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -462,12 +462,17 @@ class ResponseAPILoggingUtils:
         completion_tokens: int = response_api_usage.output_tokens or 0
         prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
         if response_api_usage.input_tokens_details:
-            prompt_tokens_details = PromptTokensDetailsWrapper(
-                cached_tokens=getattr(response_api_usage.input_tokens_details, "cached_tokens", None),
-                audio_tokens=getattr(response_api_usage.input_tokens_details, "audio_tokens", None),
-                text_tokens=getattr(response_api_usage.input_tokens_details, "text_tokens", None),
-                image_tokens=getattr(response_api_usage.input_tokens_details, "image_tokens", None),
-            )
+            if isinstance(response_api_usage.input_tokens_details, dict):
+                prompt_tokens_details = PromptTokensDetailsWrapper(
+                    **response_api_usage.input_tokens_details
+                )
+            else:
+                prompt_tokens_details = PromptTokensDetailsWrapper(
+                    cached_tokens=getattr(response_api_usage.input_tokens_details, "cached_tokens", None),
+                    audio_tokens=getattr(response_api_usage.input_tokens_details, "audio_tokens", None),
+                    text_tokens=getattr(response_api_usage.input_tokens_details, "text_tokens", None),
+                    image_tokens=getattr(response_api_usage.input_tokens_details, "image_tokens", None),
+                )
         completion_tokens_details: Optional[CompletionTokensDetailsWrapper] = None
         output_tokens_details = getattr(response_api_usage, "output_tokens_details", None)
         if output_tokens_details:


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #20043 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix
## Changes
Handle the `input_tokens_details` in case it is in the `dict` type

## After
<img width="1895" height="946" alt="image" src="https://github.com/user-attachments/assets/fb621f13-9b01-4f28-b2c0-a6ee3f33a4f9" />
<img width="628" height="122" alt="image" src="https://github.com/user-attachments/assets/83ae8cca-5e8d-4f71-bbe1-cc7c73e71b27" />




