### PR TITLE
Add async_post_call_response_headers_hook to CustomLogger

### DIFF
--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -371,6 +371,28 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
     ]:  # raise exception if invalid, return a str for the user to receive - if rejected, or return a modified dictionary for passing into litellm
         pass
 
+    async def async_post_call_response_headers_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+        request_headers: Optional[Dict[str, str]] = None,
+    ) -> Optional[Dict[str, str]]:
+        """
+        Called after an LLM API call (success or failure) to allow injecting custom HTTP response headers.
+
+        Args:
+            - data: dict - The request data.
+            - user_api_key_dict: UserAPIKeyAuth - The user API key dictionary.
+            - response: Any - The response object (None for failure cases).
+            - request_headers: Optional[Dict[str, str]] - The original request headers.
+
+        Returns:
+            - Optional[Dict[str, str]]: A dictionary of headers to inject into the HTTP response.
+                                        Return None to not inject any headers.
+        """
+        return None
+
     async def async_post_call_failure_hook(
         self,
         request_data: dict,

--- a/tests/test_litellm/proxy/hooks/test_post_call_response_headers_hook.py
+++ b/tests/test_litellm/proxy/hooks/test_post_call_response_headers_hook.py
@@ -1,0 +1,197 @@
+"""
+Integration tests for async_post_call_response_headers_hook.
+
+Tests verify that CustomLogger callbacks can inject custom HTTP response headers
+into success (streaming and non-streaming) and failure responses.
+"""
+
+import os
+import sys
+import pytest
+from typing import Any, Dict, Optional
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+class HeaderInjectorLogger(CustomLogger):
+    """Logger that injects custom headers into responses."""
+
+    def __init__(self, headers: Optional[Dict[str, str]] = None):
+        self.headers = headers
+        self.called = False
+        self.received_response = None
+        self.received_data = None
+
+    async def async_post_call_response_headers_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+        request_headers: Optional[Dict[str, str]] = None,
+    ) -> Optional[Dict[str, str]]:
+        self.called = True
+        self.received_response = response
+        self.received_data = data
+        return self.headers
+
+
+@pytest.mark.asyncio
+async def test_response_headers_hook_returns_headers():
+    """Test that the hook returns headers from a single callback."""
+    injector = HeaderInjectorLogger(headers={"x-custom-id": "abc123"})
+
+    with patch("litellm.callbacks", [injector]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        result = await proxy_logging.post_call_response_headers_hook(
+            data={"model": "test-model"},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            response={"id": "resp-1"},
+        )
+
+        assert injector.called is True
+        assert result == {"x-custom-id": "abc123"}
+
+
+@pytest.mark.asyncio
+async def test_response_headers_hook_returns_none():
+    """Test that returning None results in empty headers dict."""
+    injector = HeaderInjectorLogger(headers=None)
+
+    with patch("litellm.callbacks", [injector]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        result = await proxy_logging.post_call_response_headers_hook(
+            data={"model": "test-model"},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            response={"id": "resp-1"},
+        )
+
+        assert injector.called is True
+        assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_response_headers_hook_multiple_callbacks_merge():
+    """Test that headers from multiple callbacks are merged."""
+    injector1 = HeaderInjectorLogger(headers={"x-header-a": "value-a"})
+    injector2 = HeaderInjectorLogger(headers={"x-header-b": "value-b"})
+
+    with patch("litellm.callbacks", [injector1, injector2]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        result = await proxy_logging.post_call_response_headers_hook(
+            data={"model": "test-model"},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            response=None,
+        )
+
+        assert injector1.called is True
+        assert injector2.called is True
+        assert result == {"x-header-a": "value-a", "x-header-b": "value-b"}
+
+
+@pytest.mark.asyncio
+async def test_response_headers_hook_later_callback_overrides():
+    """Test that later callbacks override earlier ones for the same header key."""
+    injector1 = HeaderInjectorLogger(headers={"x-request-id": "first"})
+    injector2 = HeaderInjectorLogger(headers={"x-request-id": "second"})
+
+    with patch("litellm.callbacks", [injector1, injector2]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        result = await proxy_logging.post_call_response_headers_hook(
+            data={"model": "test-model"},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            response=None,
+        )
+
+        assert result == {"x-request-id": "second"}
+
+
+@pytest.mark.asyncio
+async def test_response_headers_hook_receives_response_on_success():
+    """Test that the hook receives the response object on success."""
+    injector = HeaderInjectorLogger(headers={"x-ok": "1"})
+    mock_response = {"id": "resp-success", "choices": []}
+
+    with patch("litellm.callbacks", [injector]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        await proxy_logging.post_call_response_headers_hook(
+            data={"model": "test-model"},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            response=mock_response,
+        )
+
+        assert injector.received_response is mock_response
+
+
+@pytest.mark.asyncio
+async def test_response_headers_hook_receives_none_response_on_failure():
+    """Test that the hook receives None response for failure cases."""
+    injector = HeaderInjectorLogger(headers={"x-error-id": "err-1"})
+
+    with patch("litellm.callbacks", [injector]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        await proxy_logging.post_call_response_headers_hook(
+            data={"model": "test-model"},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            response=None,
+        )
+
+        assert injector.received_response is None
+
+
+@pytest.mark.asyncio
+async def test_response_headers_hook_no_callbacks():
+    """Test that no callbacks results in empty headers."""
+    with patch("litellm.callbacks", []):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        result = await proxy_logging.post_call_response_headers_hook(
+            data={"model": "test-model"},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            response=None,
+        )
+
+        assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_default_hook_returns_none():
+    """Test that the base CustomLogger hook returns None by default."""
+    logger = CustomLogger()
+    result = await logger.async_post_call_response_headers_hook(
+        data={},
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        response=None,
+    )
+    assert result is None


### PR DESCRIPTION
Allow CustomLogger callbacks to inject custom HTTP response headers into streaming, non-streaming, and failure responses via a new async_post_call_response_headers_hook method.

## Relevant issues

Adds feature in issue #19646

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🆕 New Feature

## Changes

- Added `async_post_call_response_headers_hook` to `CustomLogger` base class (`litellm/integrations/custom_logger.py`) — returns `Optional[Dict[str, str]]` of headers to inject
- Added `post_call_response_headers_hook` orchestration method to `ProxyLogging` (`litellm/proxy/utils.py`) — iterates all callbacks and merges returned headers
- Wired up the hook in `common_request_processing.py` for three paths:
  - **Non-streaming success**: headers injected into `fastapi_response.headers` after default litellm headers
  - **Streaming success**: headers merged into `custom_headers` dict before `StreamingResponse` creation
  - **Failure**: headers merged into error response headers before `ProxyException` is raised
- Added 8 unit tests in `tests/test_litellm/proxy/hooks/test_post_call_response_headers_hook.py`

## Screenshots
<img width="1920" height="1020" alt="Screenshot 2026-01-30 alle 17 32 36" src="https://github.com/user-attachments/assets/d602c247-2443-4e49-a077-de8812eb615c" />

<img width="1920" height="817" alt="Screenshot 2026-01-30 alle 17 33 02" src="https://github.com/user-attachments/assets/a4a477c2-725b-44b2-bf2a-e4fcc0ea8846" />

<img width="1725" height="370" alt="Screenshot 2026-01-30 alle 17 33 15" src="https://github.com/user-attachments/assets/9637b3dc-d40a-47c7-9a6d-bec2ce5a3099" />
