### PR TITLE
fix: #19985 prevent error when max_fallbacks exceeds available models 

### DIFF
--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -113,8 +113,16 @@ async def run_async_fallback(
         The most recent exception if all fallback model groups fail.
     """
 
-    ### BASE CASE ### MAX FALLBACK DEPTH REACHED
-    if fallback_depth >= max_fallbacks:
+    ### BASE CASE ### MAX FALLBACK DEPTH REACHED 
+    if fallback_depth >= max_fallbacks: 
+        raise original_exception
+
+    ### CHECK IF MODEL GROUP LIST EXHAUSTED
+    if original_model_group in fallback_model_group:
+        fallback_group_length = len(fallback_model_group) - 1
+    else:
+        fallback_group_length = len(fallback_model_group) 
+    if fallback_depth >= fallback_group_length:
         raise original_exception
 
     error_from_fallbacks = original_exception


### PR DESCRIPTION
## Relevant issues

Fixes #19985

Added a boundary check to prevent Error when max_fallbacks is greater than the number of available fallback models. The router now correctly raises the original exception once the fallback list is exhausted.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
