### PR TITLE
Realtime API benchmarks

### DIFF
--- a/docs/my-website/docs/benchmarks.md
+++ b/docs/my-website/docs/benchmarks.md
@@ -50,17 +50,17 @@ In these tests the baseline latency characteristics are measured against a fake-
 
 ## `/realtime` API Benchmarks
 
-LiteLLM's `/realtime` endpoint has been optimized for low-latency WebSocket connections, achieving significant performance improvements through removal of redundant encodings, SSL context reuse, and caching of formatting strings.
+End-to-end latency benchmarks for the `/realtime` endpoint tested against a fake realtime endpoint.
 
 ### Performance Metrics
 
-| Metric          | Before    | After     | Improvement                |
-| --------------- | --------- | --------- | -------------------------- |
-| Median latency  | 2,200 ms  | **59 ms** | **−97% (~37× faster)**     |
-| p95 latency     | 8,500 ms  | **67 ms** | **−99% (~127× faster)**    |
-| p99 latency     | 18,000 ms | **99 ms** | **−99% (~182× faster)**    |
-| Average latency | 3,214 ms  | **63 ms** | **−98% (~51× faster)**     |
-| RPS             | 165       | **1,207** | **+631% (~7.3× increase)** |
+| Metric          | Value      |
+| --------------- | ---------- |
+| Median latency  | 59 ms      |
+| p95 latency     | 67 ms      |
+| p99 latency     | 99 ms      |
+| Average latency | 63 ms      |
+| RPS             | 1,207      |
 
 ### Test Setup
 
@@ -69,12 +69,6 @@ LiteLLM's `/realtime` endpoint has been optimized for low-latency WebSocket conn
 | **Load Testing** | Locust: 1,000 concurrent users, 500 ramp-up |
 | **System** | 4 vCPUs, 8 GB RAM, 4 workers, 4 instances |
 | **Database** | PostgreSQL (Redis unused) |
-
-### Key Optimizations
-
-- Removed redundant encodings on the hot path
-- Reused shared SSL contexts to prevent excessive memory allocation
-- Cached formatting strings that were being regenerated twice per request
 
 ## Machine Spec used for testing
 

--- a/docs/my-website/docs/benchmarks.md
+++ b/docs/my-website/docs/benchmarks.md
@@ -48,6 +48,34 @@ In these tests the baseline latency characteristics are measured against a fake-
 - High-percentile latencies drop significantly: P95 630 ms → 150 ms, P99 1,200 ms → 240 ms.
 - Setting workers equal to CPU count gives optimal performance.
 
+## `/realtime` API Benchmarks
+
+LiteLLM's `/realtime` endpoint has been optimized for low-latency WebSocket connections, achieving significant performance improvements through removal of redundant encodings, SSL context reuse, and caching of formatting strings.
+
+### Performance Metrics
+
+| Metric          | Before    | After     | Improvement                |
+| --------------- | --------- | --------- | -------------------------- |
+| Median latency  | 2,200 ms  | **59 ms** | **−97% (~37× faster)**     |
+| p95 latency     | 8,500 ms  | **67 ms** | **−99% (~127× faster)**    |
+| p99 latency     | 18,000 ms | **99 ms** | **−99% (~182× faster)**    |
+| Average latency | 3,214 ms  | **63 ms** | **−98% (~51× faster)**     |
+| RPS             | 165       | **1,207** | **+631% (~7.3× increase)** |
+
+### Test Setup
+
+| Category | Specification |
+|----------|---------------|
+| **Load Testing** | Locust: 1,000 concurrent users, 500 ramp-up |
+| **System** | 4 vCPUs, 8 GB RAM, 4 workers, 4 instances |
+| **Database** | PostgreSQL (Redis unused) |
+
+### Key Optimizations
+
+- Removed redundant encodings on the hot path
+- Reused shared SSL contexts to prevent excessive memory allocation
+- Cached formatting strings that were being regenerated twice per request
+
 ## Machine Spec used for testing
 
 Each machine deploying LiteLLM had the following specs:


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
📖 Documentation

## Changes

Adds a new section to the `Benchmarks` documentation (`docs/my-website/docs/benchmarks.md`) to include the `/realtime` API performance benchmarks. This centralizes performance data previously mentioned in release notes, making it more accessible. The new section details performance metrics (latency, RPS), test setup, and key optimizations for the `/realtime` endpoint.

---
[Slack Thread](https://berriaillm.slack.com/archives/C09F56F8G31/p1769795297216789?thread_ts=1769795297.216789&cid=C09F56F8G31)

<a href="https://cursor.com/background-agent?bcId=bc-4920d1ac-3c27-413e-8eb9-dae3ab7bb966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4920d1ac-3c27-413e-8eb9-dae3ab7bb966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

