### PR TITLE
perf: cache _get_relevant_args_to_use_for_logging() at module level

### DIFF
--- a/litellm/litellm_core_utils/model_param_helper.py
+++ b/litellm/litellm_core_utils/model_param_helper.py
@@ -17,15 +17,16 @@ from litellm.types.rerank import RerankRequest
 
 
 class ModelParamHelper:
+    # Cached at class level — deterministic set built from static OpenAI type annotations
+    _relevant_logging_args: frozenset = frozenset()
+
     @staticmethod
     def get_standard_logging_model_parameters(
         model_parameters: dict,
     ) -> dict:
         """ """
         standard_logging_model_parameters: dict = {}
-        supported_model_parameters = (
-            ModelParamHelper._get_relevant_args_to_use_for_logging()
-        )
+        supported_model_parameters = ModelParamHelper._relevant_logging_args
 
         for key, value in model_parameters.items():
             if key in supported_model_parameters:
@@ -172,3 +173,8 @@ class ModelParamHelper:
         Get the kwargs to exclude from the cache key
         """
         return set(["metadata"])
+
+
+ModelParamHelper._relevant_logging_args = frozenset(
+    ModelParamHelper._get_relevant_args_to_use_for_logging()
+)

--- a/tests/test_litellm/test_model_param_helper.py
+++ b/tests/test_litellm/test_model_param_helper.py
@@ -1,0 +1,33 @@
+from litellm.litellm_core_utils.model_param_helper import ModelParamHelper
+
+
+def test_cached_relevant_logging_args_matches_dynamic():
+    """Verify the cached frozenset matches the dynamically computed set."""
+    cached = ModelParamHelper._relevant_logging_args
+    dynamic = ModelParamHelper._get_relevant_args_to_use_for_logging()
+    assert cached == dynamic
+    assert isinstance(cached, frozenset)
+
+
+def test_get_standard_logging_model_parameters_filters():
+    """Verify model parameters are filtered to only supported keys."""
+    params = {"temperature": 0.7, "messages": [{"role": "user"}], "max_tokens": 100}
+    result = ModelParamHelper.get_standard_logging_model_parameters(params)
+    assert "temperature" in result
+    assert "max_tokens" in result
+    assert "messages" not in result  # excluded prompt content
+
+
+def test_get_standard_logging_model_parameters_excludes_prompt_content():
+    """Verify all prompt content keys are excluded."""
+    params = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "prompt": "hello",
+        "input": "test",
+        "temperature": 0.5,
+    }
+    result = ModelParamHelper.get_standard_logging_model_parameters(params)
+    assert "messages" not in result
+    assert "prompt" not in result
+    assert "input" not in result
+    assert result == {"temperature": 0.5}


### PR DESCRIPTION
The set of valid LLM API parameter names for logging was being rebuilt on every request from 8 OpenAI SDK type annotations + set operations. Since these are static TypedDict annotations that never change at runtime, compute once at import time and store as a class-level frozenset

Added tests to verify they're cached and param's are filtered correctly

Line profiler: get_standard_logging_model_parameters() dropped from 774ms to 77ms across 12K calls (90% reduction, ~25µs/req saved).

Before 

<img width="706" height="98" alt="Screenshot 2026-01-30 at 10 27 33 AM" src="https://github.com/user-attachments/assets/9c75623c-5176-4a7c-b3d8-1b6d23341d9d" />

After 

<img width="689" height="106" alt="Screenshot 2026-01-30 at 10 27 09 AM" src="https://github.com/user-attachments/assets/c0f389ba-e8ef-4298-b258-ecaed9d5a28c" />


## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring
Performance

## Changes
