### PR TITLE
perf: bypass FastAPI dependency injection for auth via middleware

### DIFF
--- a/litellm/proxy/middleware/auth_middleware.py
+++ b/litellm/proxy/middleware/auth_middleware.py
@@ -1,0 +1,92 @@
+"""
+Auth Middleware
+
+Runs user_api_key_auth before FastAPI's dependency injection and stores
+the result in request.state.user_api_key_dict.
+"""
+
+from fastapi import HTTPException, Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import SpecialHeaders
+from litellm.proxy.auth.auth_utils import (
+    get_end_user_id_from_request_body,
+    get_request_route,
+    normalize_request_route,
+)
+from litellm.proxy.auth.route_checks import RouteChecks
+from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+from litellm.proxy.common_utils.http_parsing_utils import (
+    _read_request_body,
+    _safe_get_request_headers,
+    populate_request_with_path_params,
+)
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        try:
+            api_key = (
+                request.headers.get(SpecialHeaders.openai_authorization.value) or ""
+            )
+            azure_api_key_header = request.headers.get(
+                SpecialHeaders.azure_authorization.value
+            )
+            anthropic_api_key_header = request.headers.get(
+                SpecialHeaders.anthropic_authorization.value
+            )
+            google_ai_studio_api_key_header = request.headers.get(
+                SpecialHeaders.google_ai_studio_authorization.value
+            )
+            azure_apim_header = request.headers.get(
+                SpecialHeaders.azure_apim_authorization.value
+            )
+            custom_litellm_key_header = request.headers.get(
+                SpecialHeaders.custom_litellm_api_key.value
+            )
+
+            request_data = await _read_request_body(request=request)
+            request_data = populate_request_with_path_params(
+                request_data=request_data, request=request
+            )
+            route = get_request_route(request=request)
+
+            user_api_key_auth_obj = await _user_api_key_auth_builder(
+                request=request,
+                api_key=api_key,
+                azure_api_key_header=azure_api_key_header,
+                anthropic_api_key_header=anthropic_api_key_header,
+                google_ai_studio_api_key_header=google_ai_studio_api_key_header,
+                azure_apim_header=azure_apim_header,
+                request_data=request_data,
+                custom_litellm_key_header=custom_litellm_key_header,
+            )
+
+            RouteChecks.should_call_route(
+                route=route, valid_token=user_api_key_auth_obj
+            )
+
+            end_user_id = get_end_user_id_from_request_body(
+                request_data, _safe_get_request_headers(request)
+            )
+            if end_user_id is not None:
+                user_api_key_auth_obj.end_user_id = end_user_id
+
+            user_api_key_auth_obj.request_route = normalize_request_route(route)
+
+            request.state.user_api_key_dict = user_api_key_auth_obj
+
+        except HTTPException:
+            verbose_proxy_logger.debug(
+                "AuthMiddleware: auth rejected for %s", request.url.path
+            )
+        except Exception:
+            verbose_proxy_logger.warning(
+                "AuthMiddleware: unexpected error for %s",
+                request.url.path,
+                exc_info=True,
+            )
+
+        response = await call_next(request)
+        return response


### PR DESCRIPTION
Move auth out of FastAPI's Depends(Security()) into ASGI middleware. AuthMiddleware runs user_api_key_auth before DI and caches the result in request.state, eliminating ~21s of solve_dependencies overhead per 40K requests (the auth check still is about 8s per 40k requests instead of 10s and just moved to be in middleware instead of through fastapi's DI. 

FastAPI's `solve_dependencies` resolves the `Depends(user_api_key_auth)` dependency tree (7 nodes: auth function + 6 `Security(APIKeyHeader)` sub-dependencies) on every request.  Endpoint signatures and dependency_overrides unchanged. 

- **New `litellm/proxy/middleware/auth_middleware.py`** — Runs auth before DI, caches result in `request.state.user_api_key_dict`. Fails silently on auth errors so the endpoint fallback handles 401s.
- **Modified `user_api_key_auth()`** — Checks `request.state` first; falls back to direct header extraction if middleware didn't run. Removed 6 `Security()` params.
- **Modified `proxy_server.py`** — Registers middleware, adds OpenAPI security scheme only to routes that have `Depends(user_api_key_auth)`.

Before:

<img width="715" height="88" alt="Screenshot 2026-01-30 at 5 25 26 PM" src="https://github.com/user-attachments/assets/2a28a47d-be33-4932-acce-23a8dd38c1ce" />

After:

<img width="889" height="116" alt="Screenshot 2026-01-30 at 5 25 50 PM" src="https://github.com/user-attachments/assets/31f48981-ad1c-48e7-8808-cf1f43dd2eef" />

Tests added:
- **`test_auth_middleware_result_matches_depends`** — Middleware path and fallback path return same result
- **`test_auth_middleware_skips_on_failure`** — Auth failure doesn't set `request.state`, `call_next` still called
- **`test_auth_middleware_sets_state_on_success`** — Happy path sets `request.state`
- **`test_openapi_security_scheme`** — Security applied to auth routes, not to public routes
- **`test_security_schemes_present`** — `/openapi.json` has correct `securitySchemes` format
- **`test_authenticated_routes_have_security`** — `/chat/completions` has security annotation
- **`test_unauthenticated_routes_no_security`** — `/health/liveliness` does not


## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

Performance
🧹 Refactoring


## Changes
