### PR TITLE
fixed mcp tools instructions on ui to show comma seprated str instead…

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_connect.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_connect.tsx
@@ -32,7 +32,7 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
   description,
   children,
   serverName,
-  accessGroups = ["dev"],
+  accessGroups = ["dev-group"],
 }) => {
   const [useServerHeader, setUseServerHeader] = useState(false);
 
@@ -42,9 +42,9 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
     };
     if (useServerHeader && serverName) {
       const formattedServerName = serverName.replace(/\s+/g, "_");
-      // Include both server name and access groups in the same header
+      // Include both server name and access groups in the same header (comma-separated string)
       const serverAndGroups = [formattedServerName, ...accessGroups].join(",");
-      headers["x-mcp-servers"] = [serverAndGroups];
+      headers["x-mcp-servers"] = serverAndGroups;
     }
     return headers;
   };
@@ -77,13 +77,13 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
               description={
                 <div>
                   <p>
-                    <strong>Option 1:</strong> Get a specific server: <code>["{serverName.replace(/\s+/g, "_")}"]</code>
+                    <strong>Option 1:</strong> Get a specific server: <code>"{serverName.replace(/\s+/g, "_")}"</code>
                   </p>
                   <p>
-                    <strong>Option 2:</strong> Get a group of MCPs: <code>["dev-group"]</code>
+                    <strong>Option 2:</strong> Get a group of MCPs: <code>"dev-group"</code>
                   </p>
                   <p className="mt-2 text-sm text-gray-600">
-                    You can also mix both: <code>["Server1,dev-group"]</code>
+                    You can also mix both: <code>"Server1,dev-group"</code>
                   </p>
                 </div>
               }
@@ -144,8 +144,8 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
       // Format server names (replace spaces with underscores)
       const formattedServers = serverHeaders[type].map((s) => s.replace(/\s+/g, "_"));
 
-      // Use comma-separated format (can include both servers and access groups)
-      headers["x-mcp-servers"] = [formattedServers.join(",")];
+      // Use comma-separated string (can include both servers and access groups)
+      headers["x-mcp-servers"] = formattedServers.join(",");
     }
 
     return headers;
@@ -244,7 +244,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
           title="Implementation Example"
           description="Complete cURL example for using the LiteLLM Proxy Responses API"
           serverName={currentServer}
-          accessGroups={["dev"]}
+          accessGroups={["dev-group"]}
         >
           <CodeBlock
             code={`curl --location '${proxyBaseUrl}/v1/responses' \\
@@ -260,7 +260,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
             "require_approval": "never",
             "headers": {
                 "x-litellm-api-key": "Bearer YOUR_LITELLM_VIRTUAL_KEY",
-                "x-mcp-servers": ["Zapier_MCP,dev"]
+                "x-mcp-servers": "Zapier_MCP,dev-group"
             }
         }
     ],
@@ -327,7 +327,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
           title="Implementation Example"
           description="Complete cURL example for using the Responses API"
           serverName="Zapier Gmail"
-          accessGroups={["dev"]}
+          accessGroups={["dev-group"]}
         >
           <CodeBlock
             code={`curl --location 'https://api.openai.com/v1/responses' \\
@@ -343,7 +343,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
             "require_approval": "never",
             "headers": {
                 "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
-                "x-mcp-servers": ["Zapier_MCP,dev"]
+                "x-mcp-servers": "Zapier_MCP,dev-group"
             }
         }
     ],
@@ -400,7 +400,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
               title="Configuration"
               description="Cursor MCP configuration"
               serverName="Zapier Gmail"
-              accessGroups={["dev"]}
+              accessGroups={["dev-group"]}
             >
               <CodeBlock
                 code={`{
@@ -409,7 +409,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
       "url": "${proxyBaseUrl}/mcp",
       "headers": {
         "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
-        "x-mcp-servers": ["Zapier_MCP,dev"]
+        "x-mcp-servers": "Zapier_MCP,dev-group"
       }
     }
   }


### PR DESCRIPTION
## Relevant issues
Updates the MCP Connect UI so the x-mcp-servers header is shown and built as a comma-separated string (e.g. "Zapier_MCP,dev") instead of a JSON array (e.g. ["Zapier_MCP,dev"]). The LiteLLM MCP gateway expects a string and splits on commas; an array was incorrect and caused direct MCP clients (e.g. streamable HTTP) to fail when copying the snippet.

Before:
<img width="1049" height="656" alt="Screenshot 2026-01-30 at 7 27 30 PM" src="https://github.com/user-attachments/assets/b82e346c-6d21-436d-811c-dd08e202ccb1" />

After:
<img width="1251" height="725" alt="Screenshot 2026-01-30 at 7 27 58 PM" src="https://github.com/user-attachments/assets/294a3092-c008-4b1d-809d-2770cdf78943" />


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

UI Instructions fix

## Changes
