### PR TITLE
Fix Vertex AI Gemini streaming content_filter handling

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1733,6 +1733,52 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             return "stop"
 
     @staticmethod
+    def _check_prompt_level_content_filter(
+        processed_chunk: GenerateContentResponseBody,
+        response_id: Optional[str],
+    ) -> Optional["ModelResponseStream"]:
+        """
+        Check if prompt is blocked due to content filtering at the prompt level.
+
+        This handles the case where Vertex AI blocks the prompt before generation begins,
+        indicated by promptFeedback.blockReason being present.
+
+        Args:
+            processed_chunk: The parsed response chunk from Vertex AI
+            response_id: The response ID from the chunk
+
+        Returns:
+            ModelResponseStream with content_filter finish_reason if blocked, None otherwise.
+
+        Note:
+            This is consistent with non-streaming _handle_blocked_response() behavior.
+            Candidate-level content filtering (SAFETY, RECITATION, etc.) is handled
+            separately via _process_candidates() → _check_finish_reason().
+        """
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        # Check if prompt is blocked due to content filtering
+        prompt_feedback = processed_chunk.get("promptFeedback")
+        if prompt_feedback and "blockReason" in prompt_feedback:
+            verbose_logger.debug(
+                f"Prompt blocked due to: {prompt_feedback.get('blockReason')} - {prompt_feedback.get('blockReasonMessage')}"
+            )
+
+            # Create a content_filter response (consistent with non-streaming _handle_blocked_response)
+            choice = StreamingChoices(
+                finish_reason="content_filter",
+                index=0,
+                delta=Delta(content=None, role="assistant"),
+                logprobs=None,
+                enhancements=None,
+            )
+
+            model_response = ModelResponseStream(choices=[choice], id=response_id)
+            return model_response
+
+        return None
+
+    @staticmethod
     def _calculate_web_search_requests(grounding_metadata: List[dict]) -> Optional[int]:
         web_search_requests: Optional[int] = None
 
@@ -2813,6 +2859,15 @@ class ModelResponseIterator:
             processed_chunk = GenerateContentResponseBody(**chunk)  # type: ignore
             response_id = processed_chunk.get("responseId")
             model_response = ModelResponseStream(choices=[], id=response_id)
+
+            # Check if prompt is blocked due to content filtering
+            blocked_response = VertexGeminiConfig._check_prompt_level_content_filter(
+                processed_chunk=processed_chunk,
+                response_id=response_id,
+            )
+            if blocked_response is not None:
+                model_response = blocked_response
+
             usage: Optional[Usage] = None
             _candidates: Optional[List[Candidates]] = processed_chunk.get("candidates")
             grounding_metadata: List[dict] = []

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -3218,3 +3218,123 @@ def test_video_metadata_only_for_gemini_3():
     assert file_part_3 is not None
     assert "media_resolution" in file_part_3, "Gemini 3 should have media_resolution"
     assert "video_metadata" in file_part_3, "Gemini 3 should have video_metadata"
+
+
+
+def test_chunk_parser_handles_prompt_feedback_block():
+    """Test chunk_parser correctly handles promptFeedback.blockReason"""
+    from unittest.mock import Mock
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    # Arrange - mock a blocked response
+    blocked_chunk = {
+        "promptFeedback": {
+            "blockReason": "PROHIBITED_CONTENT",
+            "blockReasonMessage": "The prompt is blocked due to prohibited contents"
+        },
+        "responseId": "test_response_id",
+        "modelVersion": "gemini-3-pro-preview"
+    }
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj
+    )
+
+    # Act
+    result = streaming_obj.chunk_parser(blocked_chunk)
+
+    # Assert
+    assert result is not None, "Result should not be None"
+    assert len(result.choices) == 1, "Should have exactly one choice"
+    assert result.choices[0].finish_reason == "content_filter", f"finish_reason should be content_filter, got {result.choices[0].finish_reason}"
+    assert result.choices[0].delta.content is None, "content should be None"
+
+
+def test_chunk_parser_handles_prompt_feedback_safety_block():
+    """Test chunk_parser handles different blockReason types (SAFETY)"""
+    from unittest.mock import Mock
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    # Arrange - mock a SAFETY blocked response
+    blocked_chunk = {
+        "promptFeedback": {
+            "blockReason": "SAFETY",
+            "blockReasonMessage": "The prompt is blocked due to safety concerns"
+        },
+        "responseId": "test_safety_response_id",
+    }
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj
+    )
+
+    # Act
+    result = streaming_obj.chunk_parser(blocked_chunk)
+
+    # Assert
+    assert result is not None
+    assert len(result.choices) == 1
+    assert result.choices[0].finish_reason == "content_filter"
+
+
+def test_chunk_parser_handles_prompt_feedback_block_with_usage():
+    """Test chunk_parser correctly extracts usageMetadata when promptFeedback.blockReason is present"""
+    from unittest.mock import Mock
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    # Arrange - 模拟一个包含 usageMetadata 的 blocked response
+    blocked_chunk = {
+        "promptFeedback": {
+            "blockReason": "PROHIBITED_CONTENT",
+            "blockReasonMessage": "The prompt is blocked due to prohibited contents"
+        },
+        "responseId": "test_response_id_with_usage",
+        "modelVersion": "gemini-3-pro-preview",
+        "usageMetadata": {
+            "promptTokenCount": 8175,
+            "candidatesTokenCount": 0,
+            "totalTokenCount": 8175
+        }
+    }
+
+    logging_obj = Mock()
+    logging_obj.optional_params = {}
+
+    streaming_obj = ModelResponseIterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+        logging_obj=logging_obj
+    )
+
+    # Act
+    result = streaming_obj.chunk_parser(blocked_chunk)
+
+    # Assert - 验证 content_filter 响应和 usage 都被正确处理
+    assert result is not None, "Result should not be None"
+    assert len(result.choices) == 1, "Should have exactly one choice"
+    assert result.choices[0].finish_reason == "content_filter", f"finish_reason should be content_filter, got {result.choices[0].finish_reason}"
+    assert result.choices[0].delta.content is None, "content should be None"
+
+    # 验证 usage 信息被正确提取
+    assert hasattr(result, "usage"), "result should have usage attribute"
+    assert result.usage is not None, "usage should not be None"
+    assert result.usage.prompt_tokens == 8175, f"prompt_tokens should be 8175, got {result.usage.prompt_tokens}"
+    assert result.usage.completion_tokens == 0, f"completion_tokens should be 0, got {result.usage.completion_tokens}"
+    assert result.usage.total_tokens == 8175, f"total_tokens should be 8175, got {result.usage.total_tokens}"
+


### PR DESCRIPTION
## Description

Fixes #20104

This PR fixes the issue where Vertex AI Gemini streaming doesn't return `finish_reason="content_filter"` when prompts are blocked by content filters.


## Problem

When sending a prompt that triggers Vertex AI's safety/content filter via streaming API, the raw response contains proper blocking information:

**Direct Vertex AI Streaming Response:**
```json
[{
  "promptFeedback": {
    "blockReason": "PROHIBITED_CONTENT",
    "blockReasonMessage": "The prompt is blocked due to prohibited contents"
  },
  "usageMetadata": {
    "promptTokenCount": 8175,
    "totalTokenCount": 8175,
    "trafficType": "ON_DEMAND",
    "promptTokensDetails": [
      {
        "modality": "TEXT",
        "tokenCount": 8175
      }
    ]
  },
  "modelVersion": "gemini-3-pro-preview",
  "createTime": "2026-01-31T03:24:42.712931Z",
  "responseId": "-nV9aePBK962odAPgsTH8QQ"
}]
```

**LiteLLM Non-Streaming Response (Correct):**
```json
{
    "id": "chatcmpl-fb556b3a-b6e2-4782-b321-f660528f3e2b",
    "created": 1769830160,
    "model": "gemini-3-pro-preview",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "content_filter",
            "index": 0,
            "message": {
                "content": null,
                "role": "assistant"
            }
        }
    ],
    "usage": {
        "completion_tokens": 0,
        "prompt_tokens": 8175,
        "total_tokens": 8175
    }
}
```

**LiteLLM Streaming Response With `stream_options: {"include_usage": true}` (Before Fix - Incorrect):**
```
data: {"id":"l4R9aanRNda7odAP0drW2AQ","created":1769833624,"model":"gemini-3-pro-preview","object":"chat.completion.chunk","choices":[{"finish_reason":"stop","index":0,"delta":{}}]}

data: {"id":"l4R9aanRNda7odAP0drW2AQ","created":1769833624,"model":"gemini-3-pro-preview","object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}],"usage":{...}}

data: [DONE]
```

**Issue:** Returns `finish_reason="stop"` instead of `"content_filter"` - impossible to detect that the request was blocked.

## Root Cause

The `chunk_parser()` function in streaming mode didn't check for `promptFeedback.blockReason` at the beginning. It only processed `candidates` array, which is empty when the prompt is blocked. This resulted in returning a default `finish_reason="stop"` instead of detecting the block.

## Changes

### 1. Core Fix - `vertex_and_google_ai_studio_gemini.py:2810-2827`

Added `promptFeedback.blockReason` check at the beginning of `chunk_parser()`:

- **Check for blocked prompts**: Detect `promptFeedback.blockReason` before processing candidates
- **Return content_filter**: Create `StreamingChoices` with `finish_reason="content_filter"`
- **Consistency**: Aligns with non-streaming `_handle_blocked_response()` behavior

### 2. Unit Tests - `test_vertex_and_google_ai_studio_gemini.py`

Added 2 test cases:

1. **`test_chunk_parser_handles_prompt_feedback_block`**
   - Tests basic `PROHIBITED_CONTENT` blocking scenario
   - Verifies `content_filter` finish_reason is returned

2. **`test_chunk_parser_handles_prompt_feedback_safety_block`**
   - Tests different blockReason type (`SAFETY`)
   - Ensures all block types are handled correctly

## Behavior Changes

### Before (Streaming)
```python
# Blocked prompt returns incorrect response
for chunk in response:
    print(chunk)
    # {"choices": [{"finish_reason": "stop", ...}]}
    # Wrong finish_reason

# Result: Cannot detect content filtering
```

### After (Streaming)
```python
# Blocked prompt returns proper chunk
for chunk in response:
    print(chunk)
    # ModelResponseStream(
    #   choices=[StreamingChoices(
    #     finish_reason='content_filter',
    #     delta=Delta(content=None, role='assistant')
    #   )]
    # )
```

**`/chat/completions` Endpoint Response (After Fix - Correct):**
```
data: {"id":"XZZ9admZOPbWodAPyMLmwAs","created":1769838174,"model":"gemini-3-pro-preview","object":"chat.completion.chunk","choices":[{"finish_reason":"content_filter","index":0,"delta":{}}]}

data: {"id":"XZZ9admZOPbWodAPyMLmwAs","created":1769838174,"model":"gemini-3-pro-preview","object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}],"usage":{"completion_tokens":0,"prompt_tokens":8175,"total_tokens":8175,"completion_tokens_details":{"reasoning_tokens":0},"prompt_tokens_details":{"text_tokens":8175}}}

data: [DONE]
```

## Testing

### Unit Tests
```bash
poetry run pytest tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py::test_chunk_parser_handles_prompt_feedback_block -v
poetry run pytest tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py::test_chunk_parser_handles_prompt_feedback_safety_block -v
```
<img width="2266" height="1530" alt="image" src="https://github.com/user-attachments/assets/0d2f9848-deb3-4740-9de2-528bff432f2b" />

### Manual Testing
Tested with actual Vertex AI Gemini requests that trigger content filtering:
- ✅ Streaming mode now returns `content_filter` finish_reason
- ✅ `/chat/completions` endpoint correctly outputs `"finish_reason":"content_filter"`
- ✅ Consistent with non-streaming behavior

## Checklist

- [x] Added unit tests in `tests/test_litellm/`
- [x] Verified `make test-unit` passes
- [x] Code follows existing patterns in codebase
- [x] Behavior matches OpenAI API standard for content filtering
- [x] Aligns with non-streaming implementation

## Impact

- Users get clear feedback when content is filtered in streaming mode
- Consistent API behavior across streaming and non-streaming modes
- Better debugging for content policy violations

## References

- Vertex AI Generative AI API: [Streaming responses](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini#streaming)
- OpenAI API: [Content filtering](https://platform.openai.com/docs/guides/moderation/overview)
- Related code: `_handle_blocked_response()` in same file (non-streaming implementation)