### PR TITLE
fix(github_copilot): preserve system prompts and auto-add headers                                                                                      

### DIFF
--- a/docs/my-website/docs/providers/github_copilot.md
+++ b/docs/my-website/docs/providers/github_copilot.md
@@ -35,11 +35,10 @@ from litellm import completion
 
 response = completion(
     model="github_copilot/gpt-4",
-    messages=[{"role": "user", "content": "Write a Python function to calculate fibonacci numbers"}],
-    extra_headers={
-        "editor-version": "vscode/1.85.1",
-        "Copilot-Integration-Id": "vscode-chat"
-    }
+    messages=[
+        {"role": "system", "content": "You are a helpful coding assistant"},
+        {"role": "user", "content": "Write a Python function to calculate fibonacci numbers"}
+    ]
 )
 print(response)
 ```
@@ -50,11 +49,7 @@ from litellm import completion
 stream = completion(
     model="github_copilot/gpt-4",
     messages=[{"role": "user", "content": "Explain async/await in Python"}],
-    stream=True,
-    extra_headers={
-        "editor-version": "vscode/1.85.1",
-        "Copilot-Integration-Id": "vscode-chat"
-    }
+    stream=True
 )
 
 for chunk in stream:
@@ -134,11 +129,7 @@ client = OpenAI(
 # Non-streaming response
 response = client.chat.completions.create(
     model="github_copilot/gpt-4",
-    messages=[{"role": "user", "content": "How do I optimize this SQL query?"}],
-    extra_headers={
-        "editor-version": "vscode/1.85.1",
-        "Copilot-Integration-Id": "vscode-chat"
-    }
+    messages=[{"role": "user", "content": "How do I optimize this SQL query?"}]
 )
 
 print(response.choices[0].message.content)
@@ -156,11 +147,7 @@ response = litellm.completion(
     model="litellm_proxy/github_copilot/gpt-4",
     messages=[{"role": "user", "content": "Review this code for bugs"}],
     api_base="http://localhost:4000",
-    api_key="your-proxy-api-key",
-    extra_headers={
-        "editor-version": "vscode/1.85.1",
-        "Copilot-Integration-Id": "vscode-chat"
-    }
+    api_key="your-proxy-api-key"
 )
 
 print(response.choices[0].message.content)
@@ -174,8 +161,6 @@ print(response.choices[0].message.content)
 curl http://localhost:4000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer your-proxy-api-key" \
-  -H "editor-version: vscode/1.85.1" \
-  -H "Copilot-Integration-Id: vscode-chat" \
   -d '{
     "model": "github_copilot/gpt-4",
     "messages": [{"role": "user", "content": "Explain this error message"}]
@@ -211,9 +196,11 @@ export GITHUB_COPILOT_API_KEY_FILE="api-key.json"
 
 ### Headers
 
-GitHub Copilot supports various editor-specific headers:
+LiteLLM automatically injects the required GitHub Copilot headers (simulating VSCode). You don't need to specify them manually.
 
-```python showLineNumbers title="Common Headers"
+If you want to override the defaults (e.g., to simulate a different editor), you can use `extra_headers`:
+
+```python showLineNumbers title="Custom Headers (Optional)"
 extra_headers = {
     "editor-version": "vscode/1.85.1",           # Editor version
     "editor-plugin-version": "copilot/1.155.0",  # Plugin version

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -94,7 +94,7 @@ litellm_settings:
       # /chat/completions, /completions, /embeddings, /audio/transcriptions
     mode: default_off # if default_off, you need to opt in to caching on a per call basis
     ttl: 600 # ttl for caching
-    disable_copilot_system_to_assistant: False # If false (default), converts all 'system' role messages to 'assistant' for GitHub Copilot compatibility. Set to true to disable this behavior.
+    disable_copilot_system_to_assistant: False # DEPRECATED - GitHub Copilot API supports system prompts.
 
 callback_settings:
   otel:
@@ -197,7 +197,7 @@ router_settings:
 | disable_add_transform_inline_image_block | boolean | For Fireworks AI models - if true, turns off the auto-add of `#transform=inline` to the url of the image_url, if the model is not a vision model. |
 | disable_hf_tokenizer_download | boolean | If true, it defaults to using the openai tokenizer for all models (including huggingface models). |
 | enable_json_schema_validation | boolean | If true, enables json schema validation for all requests. |
-| disable_copilot_system_to_assistant | boolean | If false (default), converts all 'system' role messages to 'assistant' for GitHub Copilot compatibility. Set to true to disable this behavior. Useful for tools (like Claude Code) that send system messages, which Copilot does not support. |
+| disable_copilot_system_to_assistant | boolean | **DEPRECATED** - GitHub Copilot API supports system prompts. |
 
 ### general_settings - Reference
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2442,6 +2442,20 @@ def completion(  # type: ignore # noqa: PLR0915
 
             headers = headers or litellm.headers
 
+            # Add GitHub Copilot headers (same as /responses endpoint does)
+            if custom_llm_provider == "github_copilot":
+                from litellm.llms.github_copilot.common_utils import (
+                    get_copilot_default_headers,
+                )
+                from litellm.llms.github_copilot.authenticator import Authenticator
+
+                copilot_auth = Authenticator()
+                copilot_api_key = copilot_auth.get_api_key()
+                copilot_headers = get_copilot_default_headers(copilot_api_key)
+                if extra_headers:
+                    copilot_headers.update(extra_headers)
+                extra_headers = copilot_headers
+
             if extra_headers is not None:
                 optional_params["extra_headers"] = extra_headers
 


### PR DESCRIPTION
## Relevant issues

Fixes #19873

## Pre-Submission checklist

- [ ] I have added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

GitHub Copilot system prompts are not passed when routing requests because LiteLLM was converting `role: system` to `role: assistant` by default.

**Why?** This was a legacy workaround when the GitHub Copilot API didn't support system prompts.

### Solution

1. **Remove system→assistant conversion** - The API now supports system prompts natively for all models (Claude, GPT, etc.)

2. **Auto-add Copilot headers** - Required headers (`editor-version`, `user-agent`, etc.) are now automatically injected for `/chat/completions`, same as `/responses` endpoint.

3. **Deprecate flag** - `disable_copilot_system_to_assistant` is now deprecated

### Before

```python
# Required extra_headers, system prompt ignored for Claude
response = completion(
    model="github_copilot/claude-haiku-4.5",
    messages=[
        {"role": "system", "content": "You are a coding assistant"},  # ❌ Converted to assistant
        {"role": "user", "content": "Hello"}
    ],
    extra_headers={  # ❌ Required manually
        "editor-version": "vscode/1.85.1",
        "Copilot-Integration-Id": "vscode-chat"
    }
)
```

### After

```python
# No extra_headers needed, system prompt works
response = completion(
    model="github_copilot/claude-haiku-4.5",
    messages=[
        {"role": "system", "content": "You are a coding assistant"},  # ✅ Works
        {"role": "user", "content": "Hello"}
    ]
)
```

### Backwards Compatibility

- Manual `extra_headers` still work (user headers override defaults)
- `disable_copilot_system_to_assistant` flag exists but is ignored (deprecated)

## Docs

- [GitHub Copilot Provider](https://docs.litellm.ai/docs/providers/github_copilot)
