### PR TITLE
fix: allow Management keys to access user/daily/activity and team

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -511,6 +511,8 @@ class LiteLLMRoutes(enum.Enum):
         "/user/delete",
         "/user/info",
         "/user/list",
+        "/user/daily/activity",
+        "/user/daily/activity/aggregated",
         # team
         "/team/new",
         "/team/update",
@@ -523,6 +525,7 @@ class LiteLLMRoutes(enum.Enum):
         "/team/available",
         "/team/permissions_list",
         "/team/permissions_update",
+        "/team/daily/activity",
         # model
         "/model/new",
         "/model/update",


### PR DESCRIPTION
### Type: Bug fix

- Changes
- Add /user/daily/activity, /user/daily/activity/aggregated, and /team/daily/activity to management_routes in litellm/proxy/_types.py.
- Management keys (allowed_routes = ["management_routes"]) can now access these endpoints.

fix: #20061
