### PR TITLE
feat(azure): Auto-fallback to DefaultAzureCredential when no api_key

### DIFF
--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -304,6 +304,7 @@ def get_azure_ad_token(
     client_secret = litellm_params.get("client_secret") or os.getenv("AZURE_CLIENT_SECRET")
     azure_username = litellm_params.get("azure_username") or os.getenv("AZURE_USERNAME")
     azure_password = litellm_params.get("azure_password") or os.getenv("AZURE_PASSWORD")
+    azure_default_credential_options = litellm_params.get("azure_default_credential_options")
     scope = litellm_params.get("azure_scope") or os.getenv(
         "AZURE_SCOPE", "https://cognitiveservices.azure.com/.default"
     )
@@ -352,31 +353,34 @@ def get_azure_ad_token(
             scope=scope,
         )
     # Try to get token provider from service principal or DefaultAzureCredential
-    elif (
-        azure_ad_token_provider is None
-        and litellm.enable_azure_ad_token_refresh is True
-    ):
-        verbose_logger.debug(
-            "Using Azure AD token provider based on Service Principal with Secret workflow or DefaultAzureCredential for Azure Auth"
-        )
-        try:
-            azure_ad_token_provider = get_azure_ad_token_provider(azure_scope=scope)
-        except ValueError:
-            verbose_logger.debug("Azure AD Token Provider could not be used.")
-        except Exception as e:
-            verbose_logger.error(
-                f"Error calling Azure AD token provider: {str(e)}. Follow docs - https://docs.litellm.ai/docs/providers/azure/#azure-ad-token-refresh---defaultazurecredential"
+    elif azure_ad_token_provider is None:
+        if litellm.enable_azure_ad_token_refresh is True:
+            # If explicitly enabled, try the configured credential type first
+            verbose_logger.debug(
+                "Using Azure AD token provider based on Service Principal with Secret workflow or DefaultAzureCredential for Azure Auth"
             )
-            raise e
+            try:
+                azure_ad_token_provider = get_azure_ad_token_provider(azure_scope=scope)
+            except ValueError:
+                verbose_logger.debug("Azure AD Token Provider could not be used.")
+            except Exception as e:
+                verbose_logger.error(
+                    f"Error calling Azure AD token provider: {str(e)}. Follow docs - https://docs.litellm.ai/docs/providers/azure/#azure-ad-token-refresh---defaultazurecredential"
+                )
+                raise e
 
         #########################################################
-        # If litellm.enable_azure_ad_token_refresh is True and no other token provider is available,
-        # try to get DefaultAzureCredential provider
+        # Auto-fallback to DefaultAzureCredential when no other auth is available
+        # This enables secure, keyless authentication using managed identity, az login, etc.
         #########################################################
         if azure_ad_token_provider is None and azure_ad_token is None:
+            verbose_logger.debug(
+                "No explicit credentials - attempting DefaultAzureCredential for Azure Auth"
+            )
             azure_ad_token_provider = (
                 BaseAzureLLM._try_get_default_azure_credential_provider(
                     scope=scope,
+                    azure_default_credential_options=azure_default_credential_options,
                 )
             )
 
@@ -405,12 +409,14 @@ class BaseAzureLLM(BaseOpenAILLM):
     @staticmethod
     def _try_get_default_azure_credential_provider(
         scope: str,
+        azure_default_credential_options: Optional[dict] = None,
     ) -> Optional[Callable[[], str]]:
         """
         Try to get DefaultAzureCredential provider
 
         Args:
             scope: Azure scope for the token
+            azure_default_credential_options: Options to pass to DefaultAzureCredential
 
         Returns:
             Token provider callable if DefaultAzureCredential is enabled and available, None otherwise
@@ -425,9 +431,11 @@ class BaseAzureLLM(BaseOpenAILLM):
             azure_ad_token_provider = get_azure_ad_token_provider(
                 azure_scope=scope,
                 azure_credential=AzureCredentialType.DefaultAzureCredential,
+                azure_default_credential_options=azure_default_credential_options,
             )
-            verbose_logger.debug(
-                "Successfully obtained Azure AD token provider using DefaultAzureCredential"
+            verbose_logger.info(
+                "Using DefaultAzureCredential for Azure authentication. "
+                "Set api_key to skip credential discovery."
             )
             return azure_ad_token_provider
         except Exception as e:
@@ -530,6 +538,7 @@ class BaseAzureLLM(BaseOpenAILLM):
         azure_username = self._resolve_env_var(litellm_params, "azure_username", "AZURE_USERNAME")
         azure_password = self._resolve_env_var(litellm_params, "azure_password", "AZURE_PASSWORD")
         scope = self._resolve_env_var(litellm_params, "azure_scope", "AZURE_SCOPE")
+        azure_default_credential_options = litellm_params.get("azure_default_credential_options")
         if scope is None:
             scope = "https://cognitiveservices.azure.com/.default"
 
@@ -573,20 +582,32 @@ class BaseAzureLLM(BaseOpenAILLM):
                 azure_tenant_id=tenant_id,
                 scope=scope,
             )
-        elif (
-            not api_key
-            and azure_ad_token_provider is None
-            and litellm.enable_azure_ad_token_refresh is True
-        ):
-            verbose_logger.debug(
-                "Using Azure AD token provider based on Service Principal with Secret workflow for Azure Auth"
-            )
-            try:
-                azure_ad_token_provider = get_azure_ad_token_provider(
-                    azure_scope=scope,
+        elif not api_key and azure_ad_token_provider is None:
+            # No API key and no explicit token provider - try auto-detection
+            if litellm.enable_azure_ad_token_refresh is True:
+                # If explicitly enabled, try the configured credential type first
+                verbose_logger.debug(
+                    "Using Azure AD token provider based on Service Principal with Secret workflow for Azure Auth"
                 )
-            except ValueError:
-                verbose_logger.debug("Azure AD Token Provider could not be used.")
+                try:
+                    azure_ad_token_provider = get_azure_ad_token_provider(
+                        azure_scope=scope,
+                    )
+                except ValueError:
+                    verbose_logger.debug("Azure AD Token Provider could not be used.")
+
+            # Auto-fallback to DefaultAzureCredential when no other auth method is available
+            # This enables secure, keyless authentication using managed identity, az login, etc.
+            if azure_ad_token_provider is None and azure_ad_token is None:
+                verbose_logger.debug(
+                    "No API key or explicit token provider - attempting DefaultAzureCredential for Azure Auth"
+                )
+                azure_ad_token_provider = (
+                    BaseAzureLLM._try_get_default_azure_credential_provider(
+                        scope=scope,
+                        azure_default_credential_options=azure_default_credential_options,
+                    )
+                )
         if api_version is None:
             api_version = os.getenv(
                 "AZURE_API_VERSION", litellm.AZURE_DEFAULT_API_VERSION


### PR DESCRIPTION
## Summary

When no `api_key` or explicit `azure_ad_token_provider` is provided, automatically attempt authentication via `DefaultAzureCredential`. This matches the behavior of other providers (Bedrock uses boto3 auto-credentials, Vertex uses ADC).

## Changes

### Core Functionality
- **Auto-fallback to DefaultAzureCredential**: When no `api_key` is set, LiteLLM automatically attempts `DefaultAzureCredential` authentication
- **Configuration via `litellm_params`**: Users can customize `DefaultAzureCredential` options (e.g., managed identity client ID, credential exclusions) through `azure_default_credential_options`

### Mitigations for PR Rejection Risks
1. **Performance**: Added default `process_timeout=10` to prevent slow CLI/PowerShell credential discovery from blocking requests
2. **Observability**: Added INFO-level log when `DefaultAzureCredential` is used, so users know which auth method is active

### Files Changed
- `litellm/llms/azure/common_utils.py` - Core fallback logic
- `litellm/secret_managers/get_azure_ad_token_provider.py` - Options handling
- `tests/test_litellm/llms/azure/test_azure_common_utils.py` - 6 new tests
- `docs/my-website/docs/providers/azure/azure.md` - Simplified documentation

## Usage

### Zero-config (Managed Identity, Workload Identity, az login)
```python
import litellm
# No api_key needed - uses DefaultAzureCredential automatically
response = litellm.completion(
    model="azure/gpt-4",
    api_base="https://myresource.openai.azure.com",
    messages=[{"role": "user", "content": "Hello"}]
)
```

### With User-Assigned Managed Identity
```python
response = litellm.completion(
    model="azure/gpt-4",
    api_base="https://myresource.openai.azure.com",
    messages=[{"role": "user", "content": "Hello"}],
    azure_default_credential_options={
        "managed_identity_client_id": "<client-id>"
    }
)
```

### Via Proxy config.yaml
```yaml
model_list:
  - model_name: gpt-4
    litellm_params:
      model: azure/gpt-4
      api_base: https://myresource.openai.azure.com
      azure_default_credential_options:
        managed_identity_client_id: "<client-id>"
```

## Testing
- End-to-end tested with real Azure OpenAI endpoint
- 6 unit tests covering with/without options, auto-fallback scenarios

## Related
Builds upon #12841 which added `DefaultAzureCredential` support but required `enable_azure_ad_token_refresh=True`. This PR moves the fallback outside that flag for zero-config experience.