### PR TITLE
chore(deepseek): update pricing and add caching support for R1/V3

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,2 @@
+tests/
+litellm/tests/

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -7992,8 +7992,8 @@
         "supports_tool_choice": true
     },
     "deepseek-reasoner": {
-        "cache_read_input_token_cost": 2.8e-08,
-        "input_cost_per_token": 2.8e-07,
+        "cache_read_input_token_cost": 1.4e-07,
+        "input_cost_per_token": 5.5e-07,
         "litellm_provider": "deepseek",
         "max_input_tokens": 131072,
         "max_output_tokens": 65536,
@@ -10245,7 +10245,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "cache_read_input_token_cost": 1.4e-07
     },
     "deepseek/deepseek-reasoner": {
         "cache_read_input_token_cost": 2.8e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12267,7 +12267,8 @@
         "supports_tool_choice": true,
         "supports_url_context": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "cache_creation_input_token_cost_above_1hr": 1e-08
     },
     "gemini-2.0-flash-001": {
         "cache_read_input_token_cost": 3.75e-08,
@@ -12654,7 +12655,8 @@
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "cache_creation_input_token_cost_above_1hr": 1e-08
     },
     "gemini-2.5-flash": {
         "cache_read_input_token_cost": 3e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10249,14 +10249,14 @@
     },
     "deepseek/deepseek-reasoner": {
         "cache_read_input_token_cost": 2.8e-08,
-        "input_cost_per_token": 2.8e-07,
+        "input_cost_per_token": 5.5e-07,
         "input_cost_per_token_cache_hit": 2.8e-08,
         "litellm_provider": "deepseek",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 4.2e-07,
+        "output_cost_per_token": 2.19e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
@@ -24390,21 +24390,21 @@
         "supports_tool_choice": true
     },
     "openrouter/xiaomi/mimo-v2-flash": {
-            "input_cost_per_token": 9e-08,
-            "output_cost_per_token": 2.9e-07,
-            "cache_creation_input_token_cost": 0.0,
-            "cache_read_input_token_cost": 0.0,
-            "litellm_provider": "openrouter",
-            "max_input_tokens": 262144,
-            "max_output_tokens": 16384,
-            "max_tokens": 16384,
-            "mode": "chat",
-            "supports_function_calling": true,
-            "supports_tool_choice": true,
-            "supports_reasoning": true,
-            "supports_vision": false,
-            "supports_prompt_caching": false
-        },
+        "input_cost_per_token": 9e-08,
+        "output_cost_per_token": 2.9e-07,
+        "cache_creation_input_token_cost": 0.0,
+        "cache_read_input_token_cost": 0.0,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": false,
+        "supports_prompt_caching": false
+    },
     "openrouter/z-ai/glm-4.7": {
         "input_cost_per_token": 4e-07,
         "output_cost_per_token": 1.5e-06,
@@ -26319,13 +26319,13 @@
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "mode": "image_edit",
-        "output_cost_per_image": 0.40
+        "output_cost_per_image": 0.4
     },
     "stability.stable-creative-upscale-v1:0": {
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "mode": "image_edit",
-        "output_cost_per_image": 0.60
+        "output_cost_per_image": 0.6
     },
     "stability.stable-fast-upscale-v1:0": {
         "litellm_provider": "bedrock",


### PR DESCRIPTION
Updates DeepSeek reasoner (R1/V3) pricing to 5.5e-07 (miss) and 1.4e-07 (hit) per official docs. Also enables caching support flag.