### PR TITLE
fix embed issue with text-embedding-ada-002 model

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -4709,7 +4709,7 @@ def embedding(  # noqa: PLR0915
                 litellm_params=litellm_params_dict,
             )
         elif (
-            model in litellm.open_ai_embedding_models
+            (model in litellm.open_ai_embedding_models and custom_llm_provider != "sap")
             or custom_llm_provider == "openai"
             or custom_llm_provider == "together_ai"
             or custom_llm_provider == "nvidia_nim"


### PR DESCRIPTION
## Relevant issues

Fixes #19407 

This PR addresses an issue specific to the text-embedding-ada-002 model. In this model, the if-elif statements in the main embedding function always enter the branch related to the base OpenAI classes, effectively ignoring the SAP provider. As a result, requests are sent to the OpenAI endpoint instead of SAP resources.

[link to the code](https://github.com/BerriAI/litellm/blob/main/litellm/main.py#L4712)

` elif (
            model in litellm.open_ai_embedding_models
            or custom_llm_provider == "openai"
            or custom_llm_provider == "together_ai"
            or custom_llm_provider == "nvidia_nim"
            or custom_llm_provider == "litellm_proxy"
        ):`

This bug is fixed in this PR by a small modification to the elif condition, ensuring that requests are correctly routed to SAP when appropriate.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Adjusted elif condition in the main embedding function to fix routing for text-embedding-ada-002.