### PR TITLE
fix(cache): Prevent 'multiple values' TypeError in get_cache_key

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -302,8 +302,11 @@ class Cache:
         verbose_logger.debug("\nCreated cache key: %s", cache_key)
         hashed_cache_key = Cache._get_hashed_cache_key(cache_key)
         hashed_cache_key = self._add_namespace_to_cache_key(hashed_cache_key, **kwargs)
+        # Remove preset_cache_key from kwargs to avoid "got multiple values" TypeError
+        # when kwargs already contains preset_cache_key from upstream callers
+        kwargs_for_preset = {k: v for k, v in kwargs.items() if k != "preset_cache_key"}
         self._set_preset_cache_key_in_kwargs(
-            preset_cache_key=hashed_cache_key, **kwargs
+            preset_cache_key=hashed_cache_key, **kwargs_for_preset
         )
         return hashed_cache_key
 

--- a/tests/local_testing/test_cache_preset_key.py
+++ b/tests/local_testing/test_cache_preset_key.py
@@ -1,0 +1,87 @@
+"""
+Test for preset_cache_key multiple values bug fix.
+
+This test verifies that get_cache_key doesn't raise TypeError when kwargs
+already contains preset_cache_key.
+
+Issue: When get_cache_key(**kwargs) is called with kwargs containing 
+preset_cache_key, the call to _set_preset_cache_key_in_kwargs() would fail with:
+    TypeError: got multiple values for keyword argument 'preset_cache_key'
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestPresetCacheKeyFix:
+    """Tests for the preset_cache_key multiple values fix."""
+
+    def test_get_cache_key_with_preset_cache_key_in_kwargs(self):
+        """
+        Test that get_cache_key handles kwargs that already contain preset_cache_key.
+        
+        This was causing:
+        TypeError: _set_preset_cache_key_in_kwargs() got multiple values 
+        for keyword argument 'preset_cache_key'
+        """
+        from litellm.caching.caching import Cache
+        
+        cache = Cache()
+        
+        # Simulate kwargs that already has preset_cache_key (as can happen
+        # when the cache key is recomputed in certain code paths)
+        kwargs_with_preset = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "preset_cache_key": "existing_key_12345",  # This caused the bug
+            "litellm_params": {},
+        }
+        
+        # This should NOT raise TypeError
+        try:
+            result = cache.get_cache_key(**kwargs_with_preset)
+            assert result is not None
+            assert isinstance(result, str)
+        except TypeError as e:
+            if "multiple values for keyword argument" in str(e):
+                pytest.fail(f"Bug not fixed: {e}")
+            raise
+
+    def test_get_cache_key_without_preset_cache_key(self):
+        """Test normal case without preset_cache_key in kwargs still works."""
+        from litellm.caching.caching import Cache
+        
+        cache = Cache()
+        
+        kwargs_normal = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "litellm_params": {},
+        }
+        
+        result = cache.get_cache_key(**kwargs_normal)
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_preset_cache_key_is_set_in_litellm_params(self):
+        """Verify that preset_cache_key is correctly set in litellm_params."""
+        from litellm.caching.caching import Cache
+        
+        cache = Cache()
+        
+        litellm_params = {}
+        kwargs = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "litellm_params": litellm_params,
+        }
+        
+        result = cache.get_cache_key(**kwargs)
+        
+        # The method should set preset_cache_key in litellm_params
+        assert "preset_cache_key" in litellm_params
+        assert litellm_params["preset_cache_key"] == result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes a TypeError that occurs when `get_cache_key(**kwargs)` is called with kwargs that already contains `preset_cache_key`.

## Problem

When using LiteLLM proxy with caching enabled, certain code paths can result in `preset_cache_key` being present in kwargs when `get_cache_key()` is called. This causes:

```
TypeError: litellm.caching.caching.Cache._set_preset_cache_key_in_kwargs() got multiple values for keyword argument 'preset_cache_key'
```

**Stack trace:**
```python
File "litellm/caching/caching.py", line 305, in get_cache_key
    self._set_preset_cache_key_in_kwargs(
        preset_cache_key=hashed_cache_key, **kwargs
    )
TypeError: ... got multiple values for keyword argument 'preset_cache_key'
```

This happens because `preset_cache_key` is passed both:
1. Explicitly as `preset_cache_key=hashed_cache_key`
2. Implicitly via `**kwargs` unpacking (when `kwargs["preset_cache_key"]` exists)

## Root Cause

`preset_cache_key` is a valid top-level LiteLLM parameter defined in:
- `litellm/types/utils.py` (StandardLoggingPayload)
- `litellm/main.py` (completion function)

When caching is used in certain flows, this key can already be present in kwargs.

## Solution

Filter out `preset_cache_key` from kwargs before passing to `_set_preset_cache_key_in_kwargs()`:

```python
kwargs_for_preset = {k: v for k, v in kwargs.items() if k != "preset_cache_key"}
self._set_preset_cache_key_in_kwargs(
    preset_cache_key=hashed_cache_key, **kwargs_for_preset
)
```

## Impact

- **Affected:** Users with caching enabled who hit certain code paths where `preset_cache_key` is already set
- **Frequency:** We observed ~62 errors/hour in production with this bug
- **Severity:** Error is caught and logged, caching continues to function, but generates noise in logs

## Test plan

- [x] Added unit tests covering:
  - kwargs with existing preset_cache_key (the bug case)
  - kwargs without preset_cache_key (regression test)
  - Verification that preset_cache_key is correctly set in litellm_params
- [ ] Manual testing with LiteLLM proxy

## Related

- This was discovered while running LiteLLM proxy `v1.81.3-nightly` with Redis caching enabled
- Similar pattern to #6264 but different specific issue

🤖 Generated with [Claude Code](https://claude.ai/code)