### PR TITLE
fix: prevent truncated first characters in anthropic responses streaming

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -869,9 +869,6 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 try:
                     chunk = self.litellm_custom_stream_wrapper.__next__()
                     self._ensure_output_item_for_chunk(chunk)
-                    # Emit any just-queued output_item event
-                    if self._pending_response_events:
-                        return self._pending_response_events.pop(0)
                     self.collected_chat_completion_chunks.append(chunk)
                     response_api_chunk = (
                         self._transform_chat_completion_chunk_to_response_api_chunk(
@@ -879,7 +876,9 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                         )
                     )
                     if response_api_chunk:
-                        return response_api_chunk
+                        self._pending_response_events.append(response_api_chunk)
+                    if self._pending_response_events:
+                        return self._pending_response_events.pop(0)
                     # Otherwise, loop to next chunk
                 except StopIteration:
                     return self.common_done_event_logic(sync_mode=True)

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1615,7 +1615,7 @@ class TestStreamingIDConsistency:
         mock_stream_wrapper.logging_obj._response_cost_calculator = Mock(return_value=0.001)
         chunk_list = [chunk_with_initial_text, chunk_continuation]
 
-        def next_chunk():
+        def next_chunk(*_args, **_kwargs):
             if not chunk_list:
                 raise StopIteration
             return chunk_list.pop(0)

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1567,3 +1567,81 @@ class TestStreamingIDConsistency:
         # Verify it matches the cached ID
         assert iterator._cached_item_id is not None
         assert iterator._cached_item_id == text_done_id
+
+    def test_first_chunk_text_delta_emitted_anthropic_style(self):
+        """
+        When the first chunk has content (e.g. Anthropic content_block_start with initial text),
+        that content must be emitted as output_text.delta. Previously the first chunk was
+        dropped because we returned output_item_added and never transformed the chunk.
+        """
+        from unittest.mock import Mock
+
+        import litellm
+        from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+            LiteLLMCompletionStreamingIterator,
+        )
+        from litellm.types.llms.openai import ResponsesAPIStreamEvents
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        chunk_with_initial_text = ModelResponseStream(
+            id="msg_abc",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content="I", role="assistant"),
+                    finish_reason=None,
+                )
+            ],
+            created=1234567890,
+            model="anthropic/claude-sonnet-4-5",
+            object="chat.completion.chunk",
+        )
+        chunk_continuation = ModelResponseStream(
+            id="msg_abc",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content="'m happy", role=None),
+                    finish_reason=None,
+                )
+            ],
+            created=1234567890,
+            model="anthropic/claude-sonnet-4-5",
+            object="chat.completion.chunk",
+        )
+
+        mock_stream_wrapper = Mock(spec=litellm.CustomStreamWrapper)
+        mock_stream_wrapper.logging_obj = Mock()
+        mock_stream_wrapper.logging_obj._response_cost_calculator = Mock(return_value=0.001)
+        chunk_list = [chunk_with_initial_text, chunk_continuation]
+
+        def next_chunk():
+            if not chunk_list:
+                raise StopIteration
+            return chunk_list.pop(0)
+
+        mock_stream_wrapper.__next__ = next_chunk
+
+        iterator = LiteLLMCompletionStreamingIterator(
+            model="anthropic/claude-sonnet-4-5",
+            litellm_custom_stream_wrapper=mock_stream_wrapper,
+            request_input=[{"type": "message", "role": "user", "content": [{"type": "text", "text": "repeat after me: I'm happy to be here"}]}],
+            responses_api_request={},
+            custom_llm_provider="anthropic",
+        )
+
+        collected_deltas = []
+        max_events = 20
+        for i, event in enumerate(iterator):
+            if i >= max_events:
+                break
+            if getattr(event, "type", None) == ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA and hasattr(event, "delta"):
+                collected_deltas.append(event.delta)
+            if getattr(event, "type", None) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED:
+                break
+
+        full_text = "".join(collected_deltas)
+        assert full_text == "I'm happy", (
+            f"First character from Anthropic content_block_start was truncated. "
+            f"Expected \"I'm happy\", got {repr(full_text)}"
+        )


### PR DESCRIPTION
### Relevant issues

- Fixes truncated first characters when streaming anthropic models via litellm.responses (e.g. expected “I’m happy”, got “’m happy”).

### Type

- Bug Fix

### Changes

- Ensure the first streamed completion chunk is transformed before returning queued response events, so initial text deltas are not dropped.
- Add a regression test that simulates an anthropic-style first chunk and asserts the full streamed text is preserved.

closes: #20097
