### PR TITLE
feat: add Kimi K2.5 model entries for Moonshot provider

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21488,6 +21488,20 @@
         "supports_tool_choice": true,
         "supports_web_search": true
     },
+    "moonshot/kimi-k2.5": {
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://platform.moonshot.ai/docs/pricing/chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 2e-06,


### PR DESCRIPTION
## Description
Adds Kimi K2.5 model pricing and configuration for the direct Moonshot provider.

### Models Added
- `moonshot/kimi-k2.5` - Standard mode
- `moonshot/kimi-k2.5-thinking` - Thinking/reasoning mode

### Pricing (per million tokens)
| Cost Type | Price |
|-----------|-------|
| Input | $0.60 |
| Output | $3.00 |
| Cache Read | $0.10 |

### Capabilities
- 256K context window (262,144 tokens)
- Vision support (native multimodal)
- Function calling
- Tool choice
- Web search

### Reference
- Model card: https://huggingface.co/moonshotai/Kimi-K2.5
- Technical report: https://www.kimi.com/blog/kimi-k2-5.html
- OpenRouter entry (already merged): `openrouter/moonshotai/kimi-k2.5`

Note: K2.5 was released Jan 27, 2026. This PR adds the direct Moonshot API entries to complement the existing OpenRouter entry.