### PR TITLE
[Feat] /chat/completions - allow using OpenAI style tools for `web_search` with VertexAI/gemini models 

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -478,6 +478,13 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             if "type" in tool and tool["type"] == "computer_use":
                 computer_use_config = {k: v for k, v in tool.items() if k != "type"}
                 tool = {VertexToolName.COMPUTER_USE.value: computer_use_config}
+            # Handle OpenAI-style web_search and web_search_preview tools
+            # Transform them to Gemini's googleSearch tool
+            elif "type" in tool and tool["type"] in ("web_search", "web_search_preview"):
+                verbose_logger.info(
+                    f"Gemini: Transforming OpenAI-style '{tool['type']}' tool to googleSearch"
+                )
+                tool = {VertexToolName.GOOGLE_SEARCH.value: {}}
             # Handle tools with 'type' field (OpenAI spec compliance) Ignore this field -> https://github.com/BerriAI/litellm/issues/14644#issuecomment-3342061838
             elif "type" in tool:
                 tool = {k: tool[k] for k in tool if k != "type"}

--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -1435,3 +1435,20 @@ def test_gemini_image_size_limit_exceeded():
     error_message = str(excinfo.value)
     assert "Image size" in error_message
     assert "exceeds maximum allowed size" in error_message
+
+@pytest.mark.asyncio
+async def test_gemini_openai_web_search_tool_to_google_search():
+    """
+    Test that OpenAI-style web_search tools are transformed to Gemini's googleSearch.
+
+    When passing {"type": "web_search"} or {"type": "web_search_preview"} to Gemini,
+    these should be transformed to googleSearch, not silently ignored.
+    """
+    response = await litellm.acompletion(
+        model="gemini/gemini-2.5-flash",
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        tools=[{"type": "web_search"}],
+    )
+    print("response: ", response.model_dump_json(indent=4))
+    assert hasattr(response, "vertex_ai_grounding_metadata")
+    assert getattr(response, "vertex_ai_grounding_metadata") is not None


### PR DESCRIPTION
## [Feat] /chat/completions - allow using OpenAI style tools for `web_search` with VertexAI/gemini models 

Fixes OpenAI-style web search tools being silently ignored when used with Vertex AI Gemini models. The transformation now properly converts web_search and web_search_preview tool types to Gemini's googleSearch format.

When passing OpenAI Style tools 

```
tools=[{"type": "web_search"}]
```

The request would succeed but grounding would not be applied. The tools were silently ignored because Gemini requires a different format.

## Fix 

Added transformation logic in VertexGeminiConfig._map_function() to detect OpenAI-style web search tool types and convert them to Gemini's expected format:
{"type": "web_search"} → {"googleSearch": {}}
{"type": "web_search_preview"} → {"googleSearch": {}}

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
