### PR TITLE
fix(slack-alerting): prevent false 'Requests are hanging' alerts

### DIFF
--- a/litellm/integrations/SlackAlerting/hanging_request_check.py
+++ b/litellm/integrations/SlackAlerting/hanging_request_check.py
@@ -8,6 +8,8 @@ Notes:
 """
 
 import asyncio
+import math
+import time
 from typing import TYPE_CHECKING, Any, Optional
 
 import litellm
@@ -37,10 +39,30 @@ class AlertingHangingRequestCheck:
     ):
         self.slack_alerting_object = slack_alerting_object
         self.hanging_request_cache = InMemoryCache(
-            default_ttl=int(
-                self.slack_alerting_object.alerting_threshold
+            default_ttl=self._hanging_request_cache_ttl_seconds(),
+        )
+
+    def _hanging_request_cache_ttl_seconds(self) -> int:
+        """TTL for entries tracked by the hanging request checker.
+
+        The background checker runs every `alerting_threshold / 2` seconds.
+        With time-based gating (only alert once `alerting_threshold` has elapsed since
+        registration), the *first* eligible check can occur up to ~1.5x the threshold
+        after a request is registered (e.g. if it is registered just after a check).
+
+        We keep entries long enough to ensure at least one post-threshold check occurs,
+        plus a small buffer to avoid edge-case scheduling jitter.
+        """
+
+        alerting_threshold_seconds = float(
+            self.slack_alerting_object.alerting_threshold
+        )
+        return int(
+            math.ceil(
+                alerting_threshold_seconds
+                + (alerting_threshold_seconds / 2)
                 + HANGING_ALERT_BUFFER_TIME_SECONDS
-            ),
+            )
         )
 
     async def add_request_to_hanging_request_check(
@@ -54,9 +76,15 @@ class AlertingHangingRequestCheck:
             return
 
         request_metadata = get_litellm_metadata_from_kwargs(kwargs=request_data)
+        request_id = request_data.get("litellm_call_id")
+        if not request_id:
+            return
         model = request_data.get("model", "")
         api_base: Optional[str] = None
 
+        # Best-effort API base resolution.
+        # In some proxy paths, `deployment` may be absent and `litellm_params` contains
+        # the routing params used to compute api_base.
         if request_data.get("deployment", None) is not None and isinstance(
             request_data["deployment"], dict
         ):
@@ -64,22 +92,39 @@ class AlertingHangingRequestCheck:
                 model=model,
                 optional_params=request_data["deployment"].get("litellm_params", {}),
             )
+        elif isinstance(request_data.get("litellm_params"), dict):
+            api_base = litellm.get_api_base(
+                model=model,
+                optional_params=request_data.get("litellm_params", {}),
+            )
+        elif isinstance(request_data.get("api_base"), str):
+            api_base = request_data.get("api_base")
+
+        alerting_metadata = request_metadata.get("alerting_metadata")
+        if not isinstance(alerting_metadata, dict):
+            alerting_metadata = None
+
+        model_info = request_metadata.get("model_info")
+        deployment_id: Optional[str] = None
+        if isinstance(model_info, dict) and isinstance(model_info.get("id"), str):
+            deployment_id = model_info.get("id")
 
         hanging_request_data = HangingRequestData(
-            request_id=request_data.get("litellm_call_id", ""),
+            request_id=request_id,
             model=model,
             api_base=api_base,
+            organization_id=request_metadata.get("user_api_key_org_id"),
+            team_id=request_metadata.get("user_api_key_team_id"),
+            deployment_id=deployment_id,
             key_alias=request_metadata.get("user_api_key_alias", ""),
             team_alias=request_metadata.get("user_api_key_team_alias", ""),
+            alerting_metadata=alerting_metadata,
         )
 
         await self.hanging_request_cache.async_set_cache(
-            key=hanging_request_data.request_id,
+            key=request_id,
             value=hanging_request_data,
-            ttl=int(
-                self.slack_alerting_object.alerting_threshold
-                + HANGING_ALERT_BUFFER_TIME_SECONDS
-            ),
+            ttl=self._hanging_request_cache_ttl_seconds(),
         )
         return
 
@@ -91,7 +136,7 @@ class AlertingHangingRequestCheck:
 
         #########################################################
         # Find all requests that have been hanging for more than the alerting threshold
-        # Get the last 50 oldest items in the cache and check if they have completed
+        # Get the last N oldest items in the cache and check if they have completed
         #########################################################
         # check if request_id is in internal usage cache
         if proxy_logging_obj.internal_usage_cache is None:
@@ -101,11 +146,16 @@ class AlertingHangingRequestCheck:
             n=MAX_OLDEST_HANGING_REQUESTS_TO_CHECK,
         )
 
+        hanging_request_ttl_seconds = self._hanging_request_cache_ttl_seconds()
+        alerting_threshold_seconds = float(
+            self.slack_alerting_object.alerting_threshold
+        )
+
         for request_id in hanging_requests:
-            hanging_request_data: Optional[HangingRequestData] = (
-                await self.hanging_request_cache.async_get_cache(
-                    key=request_id,
-                )
+            hanging_request_data: Optional[
+                HangingRequestData
+            ] = await self.hanging_request_cache.async_get_cache(
+                key=request_id,
             )
 
             if hanging_request_data is None:
@@ -127,11 +177,50 @@ class AlertingHangingRequestCheck:
                 )
                 continue
 
+            # Prevent errant alerts before alerting_threshold has elapsed.
+            # NOTE: This class historically only checked for a missing request_status marker,
+            # which could send "Requests are hanging" alerts for in-flight requests that
+            # were still within the configured threshold window.
+            time_since_start = time.time() - hanging_request_data.start_time
+            if time_since_start < alerting_threshold_seconds:
+                continue
+
+            # Avoid repeated alerts for the same request.
+            if hanging_request_data.alert_sent:
+                continue
+
+            # Reduce completion-race false positives: request may complete between the
+            # first status check above and the Slack send below.
+            request_status = (
+                await proxy_logging_obj.internal_usage_cache.async_get_cache(
+                    key="request_status:{}".format(hanging_request_data.request_id),
+                    litellm_parent_otel_span=None,
+                    local_only=True,
+                )
+            )
+            if request_status is not None:
+                self.hanging_request_cache._remove_key(
+                    key=request_id,
+                )
+                continue
+
             ################
             # Send the Alert on Slack
             ################
             await self.send_hanging_request_alert(
-                hanging_request_data=hanging_request_data
+                hanging_request_data=hanging_request_data,
+                elapsed_seconds=time_since_start,
+                threshold_seconds=alerting_threshold_seconds,
+            )
+
+            # Mark as alerted to avoid repeated messages for the same request_id.
+            hanging_request_data.alert_sent = True
+
+            # Persist updated object back into cache (do not rely on object reference semantics).
+            await self.hanging_request_cache.async_set_cache(
+                key=request_id,
+                value=hanging_request_data,
+                ttl=hanging_request_ttl_seconds,
             )
 
         return
@@ -152,6 +241,8 @@ class AlertingHangingRequestCheck:
     async def send_hanging_request_alert(
         self,
         hanging_request_data: HangingRequestData,
+        elapsed_seconds: Optional[float] = None,
+        threshold_seconds: Optional[float] = None,
     ):
         """
         Send a hanging request alert
@@ -161,8 +252,24 @@ class AlertingHangingRequestCheck:
         ################
         # Send the Alert on Slack
         ################
-        request_info = f"""Request Model: `{hanging_request_data.model}`
+        elapsed_str = (
+            f"{round(elapsed_seconds, 2)}s"
+            if isinstance(elapsed_seconds, (int, float))
+            else "unknown"
+        )
+        threshold_str = (
+            f"{round(threshold_seconds, 2)}s"
+            if isinstance(threshold_seconds, (int, float))
+            else "unknown"
+        )
+
+        request_info = f"""Request ID: `{hanging_request_data.request_id}`
+Request Model: `{hanging_request_data.model}`
+Elapsed: `{elapsed_str}` (threshold: `{threshold_str}`)
 API Base: `{hanging_request_data.api_base}`
+Deployment ID: `{hanging_request_data.deployment_id}`
+Organization ID: `{hanging_request_data.organization_id}`
+Team ID: `{hanging_request_data.team_id}`
 Key Alias: `{hanging_request_data.key_alias}`
 Team Alias: `{hanging_request_data.team_alias}`"""
 

--- a/litellm/types/integrations/slack_alerting.py
+++ b/litellm/types/integrations/slack_alerting.py
@@ -1,7 +1,8 @@
 import os
+import time
 from datetime import datetime as dt
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Set
+from typing import List, Optional, Set
 
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
@@ -196,6 +197,22 @@ class HangingRequestData(BaseModel):
     request_id: str
     model: str
     api_base: Optional[str] = None
+
+    # Organization / team metadata (best-effort).
+    # NOTE: In proxy flows, organization id is typically stored as `user_api_key_org_id`.
+    organization_id: Optional[str] = None
+    team_id: Optional[str] = None
+
+    # Routing metadata (best-effort).
+    deployment_id: Optional[str] = None
+
     key_alias: Optional[str] = None
     team_alias: Optional[str] = None
     alerting_metadata: Optional[dict] = None
+
+    # Timestamp (epoch seconds) when the request was registered for hanging checks.
+    # Used to prevent errant alerts before `alerting_threshold` has elapsed.
+    start_time: float = Field(default_factory=lambda: time.time())
+
+    # Internal flag to avoid sending repeated alerts for the same request_id.
+    alert_sent: bool = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ plugins = "pydantic.mypy"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+addopts = "--import-mode=importlib"
 retries = 20
 retry_delay = 5
 markers = [


### PR DESCRIPTION
## Relevant issues

Fixes #12355
Related: HYOSUNG-ITX-AI-Business-Department/litellm#3

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - Notes: ran `make test-unit` locally; suite currently fails due to unrelated upstream test failures. The SlackAlerting-specific tests added/updated in this PR pass.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

- Only send `llm_requests_hanging` Slack alerts once `alerting_threshold` seconds have elapsed since the request was registered (prevents false positives for in-flight requests)
- De-duplicate hanging alerts per request id and re-check completion status immediately before sending
- Include request id + elapsed/threshold + best-effort metadata (org/team/deployment/api_base) in the Slack alert message

### Tests

- `pytest tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py -vv`