### PR TITLE
Model request tags documentation

### DIFF
--- a/docs/my-website/docs/proxy/request_tags.md
+++ b/docs/my-website/docs/proxy/request_tags.md
@@ -5,35 +5,26 @@ import TabItem from '@theme/TabItem';
 
 Add tags to your LLM requests to track spend by environment, AWS account, team, or any custom label.
 
-Tags appear in the `request_tags` field of LiteLLM spend logs, making it easy to filter and analyze costs.
+Tags appear in the `request_tags` field of LiteLLM spend logs.
 
-## Quick Start
+## Set Default Tags in Config
 
-Add tags via the `metadata.tags` field in your request:
+Set default tags for all API keys generated through the proxy:
 
-<Tabs>
-<TabItem value="python" label="Python SDK">
-
-```python
-from openai import OpenAI
-
-client = OpenAI(
-    api_key="sk-1234",
-    base_url="http://0.0.0.0:4000"
-)
-
-response = client.chat.completions.create(
-    model="gpt-4",
-    messages=[{"role": "user", "content": "Hello"}],
-    extra_body={
-        "metadata": {
-            "tags": ["AWS_IAM_PROD", "us-east-1"]
-        }
-    }
-)
+```yaml title="config.yaml"
+litellm_settings:
+  default_key_generate_params:
+    metadata:
+      tags: ["AWS_IAM_PROD", "us-east-1"]
 ```
 
-</TabItem>
+All keys created via `/key/generate` will automatically include these tags.
+
+## Send Tags in Request
+
+Pass tags in the request body:
+
+<Tabs>
 <TabItem value="curl" label="cURL">
 
 ```bash
@@ -50,48 +41,36 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 ```
 
 </TabItem>
+<TabItem value="header" label="Header">
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/chat/completions' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -H 'x-litellm-tags: AWS_IAM_PROD,us-east-1' \
+  -d '{
+    "model": "gpt-4",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+</TabItem>
 </Tabs>
 
 ## Where Tags Appear
 
-Tags are stored in the `LiteLLM_SpendLogs` table under `request_tags`:
+Tags are stored in `LiteLLM_SpendLogs` under `request_tags`:
 
 ```json
 {
   "request_id": "chatcmpl-abc123",
   "request_tags": ["AWS_IAM_PROD", "us-east-1"],
   "spend": 0.002,
-  "model": "gpt-4",
-  ...
+  "model": "gpt-4"
 }
-```
-
-## Common Use Cases
-
-| Tag Example | Purpose |
-|-------------|---------|
-| `AWS_IAM_PROD` | Track requests from production AWS account |
-| `AWS_IAM_DEV` | Track requests from development AWS account |
-| `team-backend` | Attribute costs to backend team |
-| `project-chatbot` | Track spend for a specific project |
-
-## Set Default Tags on API Keys
-
-Set tags at the API key level so all requests automatically inherit them:
-
-```bash
-curl -X POST 'http://0.0.0.0:4000/key/generate' \
-  -H 'Authorization: Bearer sk-1234' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "metadata": {
-      "tags": ["AWS_IAM_PROD", "team-backend"]
-    }
-  }'
 ```
 
 ## Related
 
 - [Spend Tracking Overview](cost_tracking.md)
 - [Tag Budgets](tag_budgets.md) - Set budget limits per tag
-- [Tag Routing](tag_routing.md) - Route requests based on tags

--- a/docs/my-website/docs/proxy/request_tags.md
+++ b/docs/my-website/docs/proxy/request_tags.md
@@ -1,0 +1,97 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Request Tags for Spend Tracking
+
+Add tags to your LLM requests to track spend by environment, AWS account, team, or any custom label.
+
+Tags appear in the `request_tags` field of LiteLLM spend logs, making it easy to filter and analyze costs.
+
+## Quick Start
+
+Add tags via the `metadata.tags` field in your request:
+
+<Tabs>
+<TabItem value="python" label="Python SDK">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="sk-1234",
+    base_url="http://0.0.0.0:4000"
+)
+
+response = client.chat.completions.create(
+    model="gpt-4",
+    messages=[{"role": "user", "content": "Hello"}],
+    extra_body={
+        "metadata": {
+            "tags": ["AWS_IAM_PROD", "us-east-1"]
+        }
+    }
+)
+```
+
+</TabItem>
+<TabItem value="curl" label="cURL">
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/chat/completions' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-4",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "metadata": {
+      "tags": ["AWS_IAM_PROD", "us-east-1"]
+    }
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Where Tags Appear
+
+Tags are stored in the `LiteLLM_SpendLogs` table under `request_tags`:
+
+```json
+{
+  "request_id": "chatcmpl-abc123",
+  "request_tags": ["AWS_IAM_PROD", "us-east-1"],
+  "spend": 0.002,
+  "model": "gpt-4",
+  ...
+}
+```
+
+## Common Use Cases
+
+| Tag Example | Purpose |
+|-------------|---------|
+| `AWS_IAM_PROD` | Track requests from production AWS account |
+| `AWS_IAM_DEV` | Track requests from development AWS account |
+| `team-backend` | Attribute costs to backend team |
+| `project-chatbot` | Track spend for a specific project |
+
+## Set Default Tags on API Keys
+
+Set tags at the API key level so all requests automatically inherit them:
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/key/generate' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "metadata": {
+      "tags": ["AWS_IAM_PROD", "team-backend"]
+    }
+  }'
+```
+
+## Related
+
+- [Spend Tracking Overview](cost_tracking.md)
+- [Tag Budgets](tag_budgets.md) - Set budget limits per tag
+- [Tag Routing](tag_routing.md) - Route requests based on tags

--- a/docs/my-website/docs/proxy/request_tags.md
+++ b/docs/my-website/docs/proxy/request_tags.md
@@ -1,70 +1,52 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Request Tags for Spend Tracking
 
-Add tags to your LLM requests to track spend by environment, AWS account, team, or any custom label.
+Add tags to model deployments to track spend by environment, AWS account, or any custom label.
 
 Tags appear in the `request_tags` field of LiteLLM spend logs.
 
-## Set Default Tags in Config
+## Config Setup
 
-Set default tags for all API keys generated through the proxy:
+Set tags on model deployments in `config.yaml`:
 
 ```yaml title="config.yaml"
-litellm_settings:
-  default_key_generate_params:
-    metadata:
-      tags: ["AWS_IAM_PROD", "us-east-1"]
+model_list:
+  - model_name: gpt-4
+    litellm_params:
+      model: azure/gpt-4-prod
+      api_key: os.environ/AZURE_PROD_API_KEY
+      api_base: https://prod.openai.azure.com/
+      tags: ["AWS_IAM_PROD"]  # 👈 Tag for production
+
+  - model_name: gpt-4-dev
+    litellm_params:
+      model: azure/gpt-4-dev
+      api_key: os.environ/AZURE_DEV_API_KEY
+      api_base: https://dev.openai.azure.com/
+      tags: ["AWS_IAM_DEV"]  # 👈 Tag for development
 ```
 
-All keys created via `/key/generate` will automatically include these tags.
+## Make Request
 
-## Send Tags in Request
-
-Pass tags in the request body:
-
-<Tabs>
-<TabItem value="curl" label="cURL">
+Requests just specify the model - tags are automatically applied:
 
 ```bash
 curl -X POST 'http://0.0.0.0:4000/chat/completions' \
   -H 'Authorization: Bearer sk-1234' \
   -H 'Content-Type: application/json' \
-  -d '{
-    "model": "gpt-4",
-    "messages": [{"role": "user", "content": "Hello"}],
-    "metadata": {
-      "tags": ["AWS_IAM_PROD", "us-east-1"]
-    }
-  }'
-```
-
-</TabItem>
-<TabItem value="header" label="Header">
-
-```bash
-curl -X POST 'http://0.0.0.0:4000/chat/completions' \
-  -H 'Authorization: Bearer sk-1234' \
-  -H 'Content-Type: application/json' \
-  -H 'x-litellm-tags: AWS_IAM_PROD,us-east-1' \
   -d '{
     "model": "gpt-4",
     "messages": [{"role": "user", "content": "Hello"}]
   }'
 ```
 
-</TabItem>
-</Tabs>
+## Spend Logs
 
-## Where Tags Appear
-
-Tags are stored in `LiteLLM_SpendLogs` under `request_tags`:
+The tag from the model config appears in `LiteLLM_SpendLogs`:
 
 ```json
 {
   "request_id": "chatcmpl-abc123",
-  "request_tags": ["AWS_IAM_PROD", "us-east-1"],
+  "request_tags": ["AWS_IAM_PROD"],
   "spend": 0.002,
   "model": "gpt-4"
 }

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -442,6 +442,7 @@ const sidebars = {
           label: "Spend Tracking",
           items: [
             "proxy/cost_tracking",
+            "proxy/request_tags",
             "proxy/custom_pricing",
             "proxy/pricing_calculator",
             "proxy/provider_margins",


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->
N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
📖 Documentation

## Changes

Adds a new, concise documentation page (`proxy/request_tags.md`) focused on how AI Gateway users can add tags to model requests for spend tracking.

This new document specifically covers:
- Setting default request tags via `config.yaml` using `litellm_settings.default_key_generate_params.metadata.tags`.
- Sending tags directly in request bodies (`metadata.tags`) or via `x-litellm-tags` headers.
- Explaining where these tags appear in LiteLLM spend logs.

The page is integrated into the sidebar under the "Spend Tracking" section. This addresses the need for a simple, dedicated guide for AI Gateway users on spend tracking tags.

---
<a href="https://cursor.com/background-agent?bcId=bc-63781ed3-1098-4b0e-b894-3a8e3fb54ef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63781ed3-1098-4b0e-b894-3a8e3fb54ef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

