### PR TITLE
[Feature] UI - SSO: Add Team Mappings

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/sso/useSSOSettings.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/sso/useSSOSettings.ts
@@ -41,7 +41,7 @@ export interface RoleMappings {
 }
 
 export interface TeamMappings {
-  team_id_jwt_field: string;
+  team_ids_jwt_field: string;
 }
 
 export interface SSOSettingsResponse {

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/sso/useSSOSettings.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/sso/useSSOSettings.ts
@@ -28,6 +28,7 @@ export interface SSOSettingsValues {
   user_email: string | null;
   ui_access_mode: string | null;
   role_mappings: RoleMappings;
+  team_mappings: TeamMappings;
 }
 
 export interface RoleMappings {
@@ -37,6 +38,10 @@ export interface RoleMappings {
   roles: {
     [key: string]: string[];
   };
+}
+
+export interface TeamMappings {
+  team_id_jwt_field: string;
 }
 
 export interface SSOSettingsResponse {

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.test.tsx
@@ -151,6 +151,117 @@ describe("BaseSSOSettingsForm", () => {
       expect(screen.getByText("Default Role")).toBeInTheDocument();
     });
   });
+
+  it("should show team mappings checkbox for okta provider", async () => {
+    const TestWrapper = () => {
+      const [form] = Form.useForm();
+      const handleSubmit = vi.fn();
+
+      return <BaseSSOSettingsForm form={form} onFormSubmit={handleSubmit} />;
+    };
+
+    renderWithProviders(<TestWrapper />);
+
+    const providerSelect = screen.getByLabelText("SSO Provider");
+    await act(async () => {
+      fireEvent.mouseDown(providerSelect);
+    });
+
+    await waitFor(() => {
+      const oktaOption = screen.getByText(/okta/i);
+      fireEvent.click(oktaOption);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Use Team Mappings")).toBeInTheDocument();
+    });
+  });
+
+  it("should show team mappings checkbox for generic provider", async () => {
+    const TestWrapper = () => {
+      const [form] = Form.useForm();
+      const handleSubmit = vi.fn();
+
+      return <BaseSSOSettingsForm form={form} onFormSubmit={handleSubmit} />;
+    };
+
+    renderWithProviders(<TestWrapper />);
+
+    const providerSelect = screen.getByLabelText("SSO Provider");
+    await act(async () => {
+      fireEvent.mouseDown(providerSelect);
+    });
+
+    await waitFor(() => {
+      const genericOption = screen.getByText(/generic sso/i);
+      fireEvent.click(genericOption);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Use Team Mappings")).toBeInTheDocument();
+    });
+  });
+
+  it("should show team IDs JWT field when use_team_mappings is checked for okta provider", async () => {
+    const TestWrapper = () => {
+      const [form] = Form.useForm();
+      const handleSubmit = vi.fn();
+
+      return <BaseSSOSettingsForm form={form} onFormSubmit={handleSubmit} />;
+    };
+
+    renderWithProviders(<TestWrapper />);
+
+    const providerSelect = screen.getByLabelText("SSO Provider");
+    await act(async () => {
+      fireEvent.mouseDown(providerSelect);
+    });
+
+    await waitFor(() => {
+      const oktaOption = screen.getByText(/okta/i);
+      fireEvent.click(oktaOption);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Use Team Mappings")).toBeInTheDocument();
+    });
+
+    const checkbox = screen.getByLabelText("Use Team Mappings");
+    await act(async () => {
+      fireEvent.click(checkbox);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Team IDs JWT Field")).toBeInTheDocument();
+    });
+  });
+
+  it("should not show team mappings checkbox for google provider", async () => {
+    const TestWrapper = () => {
+      const [form] = Form.useForm();
+      const handleSubmit = vi.fn();
+
+      return <BaseSSOSettingsForm form={form} onFormSubmit={handleSubmit} />;
+    };
+
+    renderWithProviders(<TestWrapper />);
+
+    const providerSelect = screen.getByLabelText("SSO Provider");
+    await act(async () => {
+      fireEvent.mouseDown(providerSelect);
+    });
+
+    await waitFor(() => {
+      const googleOption = screen.getByText(/google sso/i);
+      fireEvent.click(googleOption);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Google Client ID")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Use Team Mappings")).not.toBeInTheDocument();
+  });
 });
 
 describe("renderProviderFields", () => {

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.tsx
@@ -251,6 +251,43 @@ const BaseSSOSettingsForm: React.FC<BaseSSOSettingsFormProps> = ({ form, onFormS
             ) : null;
           }}
         </Form.Item>
+
+        <Form.Item
+          noStyle
+          shouldUpdate={(prevValues, currentValues) => prevValues.sso_provider !== currentValues.sso_provider}
+        >
+          {({ getFieldValue }) => {
+            const provider = getFieldValue("sso_provider");
+            return provider === "okta" || provider === "generic" ? (
+              <Form.Item label="Use Team Mappings" name="use_team_mappings" valuePropName="checked">
+                <Checkbox />
+              </Form.Item>
+            ) : null;
+          }}
+        </Form.Item>
+
+        <Form.Item
+          noStyle
+          shouldUpdate={(prevValues, currentValues) =>
+            prevValues.use_team_mappings !== currentValues.use_team_mappings ||
+            prevValues.sso_provider !== currentValues.sso_provider
+          }
+        >
+          {({ getFieldValue }) => {
+            const useTeamMappings = getFieldValue("use_team_mappings");
+            const provider = getFieldValue("sso_provider");
+            const supportsTeamMappings = provider === "okta" || provider === "generic";
+            return useTeamMappings && supportsTeamMappings ? (
+              <Form.Item
+                label="Team IDs JWT Field"
+                name="team_ids_jwt_field"
+                rules={[{ required: true, message: "Please enter the team IDs JWT field" }]}
+              >
+                <TextInput />
+              </Form.Item>
+            ) : null;
+          }}
+        </Form.Item>
       </Form>
     </div>
   );

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/DeleteSSOSettingsModal.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/DeleteSSOSettingsModal.tsx
@@ -33,6 +33,7 @@ const DeleteSSOSettingsModal: React.FC<DeleteSSOSettingsModalProps> = ({ isVisib
       user_email: null,
       sso_provider: null,
       role_mappings: null,
+      team_mappings: null,
     };
 
     await editSSOSettings(clearSettings, {

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/EditSSOSettingsModal.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/EditSSOSettingsModal.tsx
@@ -68,11 +68,22 @@ const EditSSOSettingsModal: React.FC<EditSSOSettingsModalProps> = ({ isVisible, 
         };
       }
 
+      // Extract team mappings if they exist
+      let teamMappingFields = {};
+      if (ssoData.values.team_mappings) {
+        const teamMappings = ssoData.values.team_mappings;
+        teamMappingFields = {
+          use_team_mappings: true,
+          team_ids_jwt_field: teamMappings.team_ids_jwt_field,
+        };
+      }
+
       // Set form values with existing data (excluding UI access control fields)
       const formValues = {
         sso_provider: selectedProvider,
         ...ssoData.values,
         ...roleMappingFields,
+        ...teamMappingFields,
       };
 
       console.log("Setting form values:", formValues); // Debug log

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/SSOSettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/SSOSettings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSSOSettings, type SSOSettingsValues } from "@/app/(dashboard)/hooks/sso/useSSOSettings";
-import { Button, Card, Descriptions, Space, Typography } from "antd";
+import { Button, Card, Descriptions, Space, Tag, Typography } from "antd";
 import { Edit, Shield, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { ssoProviderDisplayNames, ssoProviderLogoMap } from "./constants";
@@ -28,6 +28,7 @@ export default function SSOSettings() {
 
   const selectedProvider = ssoSettings?.values ? detectSSOProvider(ssoSettings.values) : null;
   const isRoleMappingsEnabled = Boolean(ssoSettings?.values.role_mappings);
+  const isTeamMappingsEnabled = Boolean(ssoSettings?.values.team_mappings);
 
   const renderEndpointValue = (value?: string | null) => (
     <Text className="font-mono text-gray-600 text-sm" copyable={!!value}>
@@ -37,6 +38,15 @@ export default function SSOSettings() {
 
   const renderSimpleValue = (value?: string | null) =>
     value ? value : <span className="text-gray-400 italic">Not configured</span>;
+
+  const renderTeamMappingsField = (values: SSOSettingsValues) => {
+    if (!values.team_mappings?.team_ids_jwt_field) {
+      return <span className="text-gray-400 italic">Not configured</span>;
+    }
+    return (
+      <Tag>{values.team_mappings.team_ids_jwt_field}</Tag>
+    );
+  };
 
   const descriptionsConfig = {
     column: {
@@ -103,6 +113,10 @@ export default function SSOSettings() {
           render: (values: SSOSettingsValues) => renderEndpointValue(values.generic_userinfo_endpoint),
         },
         { label: "Proxy Base URL", render: (values: SSOSettingsValues) => renderSimpleValue(values.proxy_base_url) },
+        isTeamMappingsEnabled ? {
+          label: "Team IDs JWT Field",
+          render: (values: SSOSettingsValues) => renderTeamMappingsField(values),
+        } : null,
       ],
     },
     generic: {
@@ -129,6 +143,10 @@ export default function SSOSettings() {
           render: (values: SSOSettingsValues) => renderEndpointValue(values.generic_userinfo_endpoint),
         },
         { label: "Proxy Base URL", render: (values: SSOSettingsValues) => renderSimpleValue(values.proxy_base_url) },
+        isTeamMappingsEnabled ? {
+          label: "Team IDs JWT Field",
+          render: (values: SSOSettingsValues) => renderTeamMappingsField(values),
+        } : null,
       ],
     },
   };
@@ -155,7 +173,7 @@ export default function SSOSettings() {
             <span>{config.providerText}</span>
           </div>
         </Descriptions.Item>
-        {config.fields.map((field, index) => (
+        {config.fields.map((field, index) => field && (
           <Descriptions.Item key={index} label={field.label}>
             {field.render(values)}
           </Descriptions.Item>

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/utils.ts
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/utils.ts
@@ -13,6 +13,8 @@ export const processSSOSettingsPayload = (formValues: Record<string, any>): Reco
     default_role,
     group_claim,
     use_role_mappings,
+    use_team_mappings,
+    team_ids_jwt_field,
     ...rest
   } = formValues;
 
@@ -49,6 +51,13 @@ export const processSSOSettingsPayload = (formValues: Record<string, any>): Reco
         internal_user: splitTeams(internal_user_teams),
         internal_user_viewer: splitTeams(internal_viewer_teams),
       },
+    };
+  }
+
+  // Add team mappings only if use_team_mappings is checked
+  if (use_team_mappings) {
+    payload.team_mappings = {
+      team_ids_jwt_field: team_ids_jwt_field,
     };
   }
 

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/utils.ts
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/utils.ts
@@ -23,7 +23,9 @@ export const processSSOSettingsPayload = (formValues: Record<string, any>): Reco
   };
 
   // Add role mappings only if use_role_mappings is checked AND provider supports role mappings
-  if (use_role_mappings) {
+  const provider = rest.sso_provider;
+  const supportsRoleMappings = provider === "okta" || provider === "generic";
+  if (use_role_mappings && supportsRoleMappings) {
     // Helper function to split comma-separated string into array
     const splitTeams = (teams: string | undefined): string[] => {
       if (!teams || teams.trim() === "") return [];
@@ -54,8 +56,9 @@ export const processSSOSettingsPayload = (formValues: Record<string, any>): Reco
     };
   }
 
-  // Add team mappings only if use_team_mappings is checked
-  if (use_team_mappings) {
+  // Add team mappings only if use_team_mappings is checked AND provider supports team mappings
+  const supportsTeamMappings = provider === "okta" || provider === "generic";
+  if (use_team_mappings && supportsTeamMappings) {
     payload.team_mappings = {
       team_ids_jwt_field: team_ids_jwt_field,
     };


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
✅ Test

## Changes

Adds team mappings UI to SSO settings. Users can configure team mappings for Okta and Generic SSO providers by enabling a checkbox and specifying the JWT field name that contains team IDs. The team mappings configuration is displayed in the SSO settings view and properly handled during edit and delete operations.

## Screenshots
<img width="840" height="786" alt="image" src="https://github.com/user-attachments/assets/a8567fa0-d6be-4747-908a-e7942db83b1e" />
<img width="701" height="300" alt="image" src="https://github.com/user-attachments/assets/0972c9d9-8e59-42b2-944b-e46dc0ce643b" />
