### PR TITLE
perf: replace enum construction with frozenset lookup

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2074,6 +2074,14 @@ def _is_async_request(
     return False
 
 
+_STREAMING_CALL_TYPES = frozenset({
+    CallTypes.generate_content_stream,
+    CallTypes.agenerate_content_stream,
+    CallTypes.generate_content_stream.value,
+    CallTypes.agenerate_content_stream.value,
+})
+
+
 def _is_streaming_request(
     kwargs: Dict[str, Any],
     call_type: Union[CallTypes, str],
@@ -2086,23 +2094,7 @@ def _is_streaming_request(
     """
     if "stream" in kwargs and kwargs["stream"] is True:
         return True
-
-    #########################################################
-    # Check if it's a google genai streaming request
-    if isinstance(call_type, str):
-        # check if it can be casted to CallTypes
-        try:
-            call_type = CallTypes(call_type)
-        except ValueError:
-            return False
-
-    if (
-        call_type == CallTypes.generate_content_stream
-        or call_type == CallTypes.agenerate_content_stream
-    ):
-        return True
-    #########################################################
-    return False
+    return call_type in _STREAMING_CALL_TYPES
 
 
 def _select_tokenizer(

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -18,10 +18,12 @@ from litellm.types.utils import (
     ModelResponseStream,
     StreamingChoices,
 )
+from litellm.types.utils import CallTypes
 from litellm.utils import (
     ProviderConfigManager,
     TextCompletionStreamWrapper,
     _check_provider_match,
+    _is_streaming_request,
     get_llm_provider,
     get_optional_params_image_gen,
     is_cached_message,
@@ -3169,3 +3171,35 @@ class TestDropParamsWithPromptCacheKey:
         assert "prompt_cache_key" not in result
         # temperature should remain (it's supported by Bedrock)
         assert result.get("temperature") == 0.7
+
+
+class TestIsStreamingRequest:
+    def test_stream_true_in_kwargs(self):
+        assert _is_streaming_request(kwargs={"stream": True}, call_type="acompletion") is True
+
+    def test_stream_false_in_kwargs(self):
+        assert _is_streaming_request(kwargs={"stream": False}, call_type="acompletion") is False
+
+    def test_no_stream_in_kwargs(self):
+        assert _is_streaming_request(kwargs={}, call_type="acompletion") is False
+
+    def test_generate_content_stream_string(self):
+        assert _is_streaming_request(kwargs={}, call_type=CallTypes.generate_content_stream.value) is True
+
+    def test_agenerate_content_stream_string(self):
+        assert _is_streaming_request(kwargs={}, call_type=CallTypes.agenerate_content_stream.value) is True
+
+    def test_generate_content_stream_enum(self):
+        assert _is_streaming_request(kwargs={}, call_type=CallTypes.generate_content_stream) is True
+
+    def test_agenerate_content_stream_enum(self):
+        assert _is_streaming_request(kwargs={}, call_type=CallTypes.agenerate_content_stream) is True
+
+    def test_non_streaming_call_type_string(self):
+        assert _is_streaming_request(kwargs={}, call_type="acompletion") is False
+
+    def test_non_streaming_call_type_enum(self):
+        assert _is_streaming_request(kwargs={}, call_type=CallTypes.acompletion) is False
+
+    def test_stream_true_overrides_non_streaming_call_type(self):
+        assert _is_streaming_request(kwargs={"stream": True}, call_type=CallTypes.acompletion) is True


### PR DESCRIPTION
CallTypes(call_type) was constructing an enum from string on every call, taking ~4.6µs/call (69.6% of total function time). Replace with a frozenset membership test for ~0.8µs/call (8.3x faster).

Before 

<img width="511" height="136" alt="Screenshot 2026-02-02 at 2 58 24 PM" src="https://github.com/user-attachments/assets/4d463d0a-5410-4446-b9b5-2fc504280ab9" />

After

<img width="488" height="128" alt="Screenshot 2026-02-02 at 2 58 42 PM" src="https://github.com/user-attachments/assets/9806b2ac-e71f-4887-97c5-732c3310abc5" />

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

Performance
🧹 Refactoring

## Changes
