### PR TITLE
fix(slack-alerting): prevent false hanging-request alerts

### DIFF
--- a/litellm/types/integrations/slack_alerting.py
+++ b/litellm/types/integrations/slack_alerting.py
@@ -1,7 +1,8 @@
 import os
+import time
 from datetime import datetime as dt
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Set
+from typing import List, Optional, Set
 
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
@@ -199,3 +200,10 @@ class HangingRequestData(BaseModel):
     key_alias: Optional[str] = None
     team_alias: Optional[str] = None
     alerting_metadata: Optional[dict] = None
+
+    # When the request was registered for hanging checks.
+    # Used to ensure we only alert after `alerting_threshold` has elapsed.
+    start_time: float = Field(default_factory=time.time)
+
+    # Prevent duplicate alerts for the same request.
+    alert_sent: bool = False

--- a/tests/litellm/integrations/slack_alerting/test_hanging_request_check_gate.py
+++ b/tests/litellm/integrations/slack_alerting/test_hanging_request_check_gate.py
@@ -1,0 +1,88 @@
+"""Regression tests for Slack hanging-request alerting.
+
+This is a minimal suite under `tests/litellm/` to satisfy the upstream PR
+requirement of adding at least one test in that directory.
+
+Focus: prevent false-positive "Requests are hanging" alerts by gating on elapsed
+time since the request was registered for hanging checks.
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from litellm.integrations.SlackAlerting.hanging_request_check import (
+    AlertingHangingRequestCheck,
+)
+from litellm.types.integrations.slack_alerting import HangingRequestData
+
+
+class TestHangingRequestCheck:
+    """Tests for AlertingHangingRequestCheck."""
+
+    @pytest.fixture
+    def checker(self):
+        mock_slack = MagicMock()
+        mock_slack.alerting_threshold = 300
+        mock_slack.send_alert = AsyncMock()
+        mock_slack.internal_usage_cache = AsyncMock()
+        return AlertingHangingRequestCheck(slack_alerting_object=mock_slack)
+
+    @pytest.mark.asyncio
+    async def test_does_not_alert_before_threshold(self, checker):
+        """Should not alert for in-flight requests within threshold window."""
+        request_id = "not_yet_hanging_request"
+        hanging_data = HangingRequestData(
+            request_id=request_id,
+            model="gpt-4",
+            api_base="https://api.openai.com/v1",
+        )
+        hanging_data.start_time = time.time()  # just started
+
+        await checker.hanging_request_cache.async_set_cache(
+            key=request_id,
+            value=hanging_data,
+            ttl=300,
+        )
+
+        checker.slack_alerting_object.internal_usage_cache.async_get_cache.return_value = (
+            None
+        )
+        checker.hanging_request_cache.async_get_oldest_n_keys = AsyncMock(
+            return_value=[request_id]
+        )
+        await checker.send_alerts_for_hanging_requests()
+
+        checker.slack_alerting_object.send_alert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_alerts_once_after_threshold(self, checker):
+        """Should alert exactly once after elapsed time crosses threshold."""
+        request_id = "hanging_request"
+        hanging_data = HangingRequestData(
+            request_id=request_id,
+            model="gpt-4",
+            api_base="https://api.openai.com/v1",
+        )
+        hanging_data.start_time = time.time() - 301
+
+        await checker.hanging_request_cache.async_set_cache(
+            key=request_id,
+            value=hanging_data,
+            ttl=checker._get_hanging_request_cache_ttl_seconds(),
+        )
+
+        checker.slack_alerting_object.internal_usage_cache.async_get_cache.return_value = (
+            None
+        )
+        checker.hanging_request_cache.async_get_oldest_n_keys = AsyncMock(
+            return_value=[request_id]
+        )
+
+        await checker.send_alerts_for_hanging_requests()
+        assert checker.slack_alerting_object.send_alert.await_count == 1
+
+        # Second run: should not re-alert (alert_sent persisted in cache)
+        await checker.send_alerts_for_hanging_requests()
+        assert checker.slack_alerting_object.send_alert.await_count == 1


### PR DESCRIPTION
## Relevant issues

Fixes #12355

Related: HYOSUNG-ITX-AI-Business-Department/litellm#3

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory (added `tests/litellm/integrations/slack_alerting/test_hanging_request_check_gate.py`).
- [ ] My PR passes all unit tests on `make test-unit`.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem.

**Notes on checks run locally (non-poetry environment):**
- ✅ Targeted pytest: `tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py` + new `tests/litellm/...` regression test
- ✅ mypy (repo-style): `cd litellm && mypy . --ignore-missing-imports`
- ✅ ruff/black (repo-pinned versions from poetry.lock)

## Type

🐛 Bug Fix
✅ Test

## Changes

- Gate "Requests are hanging" Slack alerts by elapsed time since request registration (prevents alerts firing before `alerting_threshold`).
- Suppress duplicate hanging alerts for the same request by persisting an `alert_sent` flag in the hanging request cache.
- Avoid importing `proxy_server` from the hanging request checker (uses `slack_alerting_object.internal_usage_cache`), improving testability.