### PR TITLE
Fix httpx client cache race

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -3,6 +3,7 @@ import os
 import ssl
 import sys
 import time
+import threading
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -68,6 +69,9 @@ headers = get_default_headers()
 
 # https://www.python-httpx.org/advanced/timeouts
 _DEFAULT_TIMEOUT = httpx.Timeout(timeout=5.0, connect=5.0)
+
+_httpx_client_cache_lock = threading.Lock()
+_async_httpx_client_cache_lock = threading.Lock()
 
 
 def _prepare_request_data_and_content(
@@ -1212,27 +1216,28 @@ def get_async_httpx_client(
         cache = LLMClientCache()
         setattr(litellm, "in_memory_llm_clients_cache", cache)
 
-    _cached_client = cache.get_cache(_cache_key_name)
-    if _cached_client:
-        return _cached_client
+    with _async_httpx_client_cache_lock:
+        _cached_client = cache.get_cache(_cache_key_name)
+        if _cached_client:
+            return _cached_client
 
-    if params is not None:
-        # Filter out params that are only used for cache key, not for AsyncHTTPHandler.__init__
-        handler_params = {k: v for k, v in params.items() if k != "disable_aiohttp_transport"}
-        handler_params["shared_session"] = shared_session
-        _new_client = AsyncHTTPHandler(**handler_params)
-    else:
-        _new_client = AsyncHTTPHandler(
-            timeout=httpx.Timeout(timeout=600.0, connect=5.0),
-            shared_session=shared_session,
+        if params is not None:
+            # Filter out params that are only used for cache key, not for AsyncHTTPHandler.__init__
+            handler_params = {k: v for k, v in params.items() if k != "disable_aiohttp_transport"}
+            handler_params["shared_session"] = shared_session
+            _new_client = AsyncHTTPHandler(**handler_params)
+        else:
+            _new_client = AsyncHTTPHandler(
+                timeout=httpx.Timeout(timeout=600.0, connect=5.0),
+                shared_session=shared_session,
+            )
+
+        cache.set_cache(
+            key=_cache_key_name,
+            value=_new_client,
+            ttl=_DEFAULT_TTL_FOR_HTTPX_CLIENTS,
         )
-
-    cache.set_cache(
-        key=_cache_key_name,
-        value=_new_client,
-        ttl=_DEFAULT_TTL_FOR_HTTPX_CLIENTS,
-    )
-    return _new_client
+        return _new_client
 
 
 def _get_httpx_client(params: Optional[dict] = None) -> HTTPHandler:
@@ -1261,20 +1266,21 @@ def _get_httpx_client(params: Optional[dict] = None) -> HTTPHandler:
         cache = LLMClientCache()
         setattr(litellm, "in_memory_llm_clients_cache", cache)
 
-    _cached_client = cache.get_cache(_cache_key_name)
-    if _cached_client:
-        return _cached_client
+    with _httpx_client_cache_lock:
+        _cached_client = cache.get_cache(_cache_key_name)
+        if _cached_client:
+            return _cached_client
 
-    if params is not None:
-        # Filter out params that are only used for cache key, not for HTTPHandler.__init__
-        handler_params = {k: v for k, v in params.items() if k != "disable_aiohttp_transport"}
-        _new_client = HTTPHandler(**handler_params)
-    else:
-        _new_client = HTTPHandler(timeout=httpx.Timeout(timeout=600.0, connect=5.0))
+        if params is not None:
+            # Filter out params that are only used for cache key, not for HTTPHandler.__init__
+            handler_params = {k: v for k, v in params.items() if k != "disable_aiohttp_transport"}
+            _new_client = HTTPHandler(**handler_params)
+        else:
+            _new_client = HTTPHandler(timeout=httpx.Timeout(timeout=600.0, connect=5.0))
 
-    cache.set_cache(
-        key=_cache_key_name,
-        value=_new_client,
-        ttl=_DEFAULT_TTL_FOR_HTTPX_CLIENTS,
-    )
-    return _new_client
+        cache.set_cache(
+            key=_cache_key_name,
+            value=_new_client,
+            ttl=_DEFAULT_TTL_FOR_HTTPX_CLIENTS,
+        )
+        return _new_client

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -1207,16 +1207,16 @@ def get_async_httpx_client(
 
     _cache_key_name = "async_httpx_client" + _params_key_name + llm_provider
 
-    # Lazily initialize the global in-memory client cache to avoid relying on
-    # litellm globals being fully populated during import time.
-    cache = getattr(litellm, "in_memory_llm_clients_cache", None)
-    if cache is None:
-        from litellm.caching.llm_caching_handler import LLMClientCache
-
-        cache = LLMClientCache()
-        setattr(litellm, "in_memory_llm_clients_cache", cache)
-
     with _async_httpx_client_cache_lock:
+        # Lazily initialize the global in-memory client cache to avoid relying on
+        # litellm globals being fully populated during import time.
+        cache = getattr(litellm, "in_memory_llm_clients_cache", None)
+        if cache is None:
+            from litellm.caching.llm_caching_handler import LLMClientCache
+
+            cache = LLMClientCache()
+            setattr(litellm, "in_memory_llm_clients_cache", cache)
+
         _cached_client = cache.get_cache(_cache_key_name)
         if _cached_client:
             return _cached_client
@@ -1257,16 +1257,16 @@ def _get_httpx_client(params: Optional[dict] = None) -> HTTPHandler:
 
     _cache_key_name = "httpx_client" + _params_key_name
 
-    # Lazily initialize the global in-memory client cache to avoid relying on
-    # litellm globals being fully populated during import time.
-    cache = getattr(litellm, "in_memory_llm_clients_cache", None)
-    if cache is None:
-        from litellm.caching.llm_caching_handler import LLMClientCache
-
-        cache = LLMClientCache()
-        setattr(litellm, "in_memory_llm_clients_cache", cache)
-
     with _httpx_client_cache_lock:
+        # Lazily initialize the global in-memory client cache to avoid relying on
+        # litellm globals being fully populated during import time.
+        cache = getattr(litellm, "in_memory_llm_clients_cache", None)
+        if cache is None:
+            from litellm.caching.llm_caching_handler import LLMClientCache
+
+            cache = LLMClientCache()
+            setattr(litellm, "in_memory_llm_clients_cache", cache)
+
         _cached_client = cache.get_cache(_cache_key_name)
         if _cached_client:
             return _cached_client


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/19608

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
- add thread-safe locks around httpx client cache creation to prevent handler races
- add regression test covering concurrent cache misses

## Testing
- `pytest tests/test_litellm/llms/custom_httpx/test_http_handler.py -k httpx_client_cache_race`
