### PR TITLE
Chore: Antd Modal Deprecated Props

### DIFF
--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -483,7 +483,7 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
       <Modal
         title="Public Model Hub"
         width={600}
-        visible={isPublicPageModalVisible}
+        open={isPublicPageModalVisible}
         footer={null}
         onOk={handleOk}
         onCancel={handleCancel}
@@ -505,7 +505,7 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
       <Modal
         title={selectedModel?.model_group || "Model Details"}
         width={1000}
-        visible={isModalVisible}
+        open={isModalVisible}
         footer={null}
         onOk={handleOk}
         onCancel={handleCancel}
@@ -656,7 +656,7 @@ print(response.choices[0].message.content)`}
       <Modal
         title={selectedAgent?.name || "Agent Details"}
         width={1000}
-        visible={isAgentModalVisible}
+        open={isAgentModalVisible}
         footer={null}
         onOk={handleOk}
         onCancel={handleCancel}
@@ -795,7 +795,7 @@ print(response.choices[0].message.content)`}
       <Modal
         title={selectedMcpServer?.server_name || "MCP Server Details"}
         width={1000}
-        visible={isMcpModalVisible}
+        open={isMcpModalVisible}
         footer={null}
         onOk={handleOk}
         onCancel={handleCancel}

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -1018,7 +1018,7 @@ const Teams: React.FC<TeamProps> = ({
           {canCreateOrManageTeams(userRole, userID, organizations) && (
             <Modal
               title="Create Team"
-              visible={isTeamModalVisible}
+              open={isTeamModalVisible}
               width={1000}
               footer={null}
               onOk={handleOk}

--- a/ui/litellm-dashboard/src/components/SSOModals.tsx
+++ b/ui/litellm-dashboard/src/components/SSOModals.tsx
@@ -323,7 +323,7 @@ const SSOModals: React.FC<SSOModalsProps> = ({
     <>
       <Modal
         title={ssoConfigured ? "Edit SSO Settings" : "Add SSO"}
-        visible={isAddSSOModalVisible}
+        open={isAddSSOModalVisible}
         width={800}
         footer={null}
         onOk={handleAddSSOOk}
@@ -517,7 +517,7 @@ const SSOModals: React.FC<SSOModalsProps> = ({
       {/* Clear Confirmation Modal */}
       <Modal
         title="Confirm Clear SSO Settings"
-        visible={isClearConfirmModalVisible}
+        open={isClearConfirmModalVisible}
         onOk={handleClearSSO}
         onCancel={() => setIsClearConfirmModalVisible(false)}
         okText="Yes, Clear"
@@ -536,7 +536,7 @@ const SSOModals: React.FC<SSOModalsProps> = ({
 
       <Modal
         title="SSO Setup Instructions"
-        visible={isInstructionsModalVisible}
+        open={isInstructionsModalVisible}
         width={800}
         footer={null}
         onOk={handleInstructionsOk}

--- a/ui/litellm-dashboard/src/components/admins.tsx
+++ b/ui/litellm-dashboard/src/components/admins.tsx
@@ -91,7 +91,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
 
   const isLocal = process.env.NODE_ENV === "development";
   if (isLocal != true) {
-    console.log = function () {};
+    console.log = function () { };
   }
 
   const baseUrl = useBaseUrl();
@@ -565,7 +565,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
               <Modal
                 title="Manage Allowed IP Addresses"
                 width={800}
-                visible={isAllowedIPModalVisible}
+                open={isAllowedIPModalVisible}
                 onCancel={() => setIsAllowedIPModalVisible(false)}
                 footer={[
                   <Button className="mx-1" key="add" onClick={() => setIsAddIPModalVisible(true)}>
@@ -602,7 +602,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
 
               <Modal
                 title="Add Allowed IP Address"
-                visible={isAddIPModalVisible}
+                open={isAddIPModalVisible}
                 onCancel={() => setIsAddIPModalVisible(false)}
                 footer={null}
               >
@@ -618,7 +618,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
 
               <Modal
                 title="Confirm Delete"
-                visible={isDeleteIPModalVisible}
+                open={isDeleteIPModalVisible}
                 onCancel={() => setIsDeleteIPModalVisible(false)}
                 onOk={confirmDeleteIP}
                 footer={[
@@ -636,7 +636,7 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
               {/* UI Access Control Modal */}
               <Modal
                 title="UI Access Control Settings"
-                visible={isUIAccessControlModalVisible}
+                open={isUIAccessControlModalVisible}
                 width={600}
                 footer={null}
                 onOk={handleUIAccessControlOk}

--- a/ui/litellm-dashboard/src/components/budgets/budget_modal.tsx
+++ b/ui/litellm-dashboard/src/components/budgets/budget_modal.tsx
@@ -43,7 +43,7 @@ const BudgetModal: React.FC<BudgetModalProps> = ({ isModalVisible, accessToken, 
   return (
     <Modal
       title="Create Budget"
-      visible={isModalVisible}
+      open={isModalVisible}
       width={800}
       footer={null}
       onOk={handleOk}

--- a/ui/litellm-dashboard/src/components/budgets/edit_budget_modal.tsx
+++ b/ui/litellm-dashboard/src/components/budgets/edit_budget_modal.tsx
@@ -59,7 +59,7 @@ const EditBudgetModal: React.FC<BudgetModalProps> = ({
   return (
     <Modal
       title="Edit Budget"
-      visible={isModalVisible}
+      open={isModalVisible}
       width={800}
       footer={null}
       onOk={handleOk}

--- a/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
+++ b/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
@@ -370,11 +370,11 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
                 current.map((u, i) =>
                   i === index
                     ? {
-                        ...u,
-                        status: "success",
-                        key: response.key || response.user_id,
-                        invitation_link: invitationUrl,
-                      }
+                      ...u,
+                      status: "success",
+                      key: response.key || response.user_id,
+                      invitation_link: invitationUrl,
+                    }
                     : u,
                 ),
               );
@@ -386,11 +386,11 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
                 current.map((u, i) =>
                   i === index
                     ? {
-                        ...u,
-                        status: "success",
-                        key: response.key || response.user_id,
-                        invitation_link: invitationUrl,
-                      }
+                      ...u,
+                      status: "success",
+                      key: response.key || response.user_id,
+                      invitation_link: invitationUrl,
+                    }
                     : u,
                 ),
               );
@@ -401,11 +401,11 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
               current.map((u, i) =>
                 i === index
                   ? {
-                      ...u,
-                      status: "success",
-                      key: response.key || response.user_id,
-                      error: "User created but failed to generate invitation link",
-                    }
+                    ...u,
+                    status: "success",
+                    key: response.key || response.user_id,
+                    error: "User created but failed to generate invitation link",
+                  }
                   : u,
               ),
             );
@@ -546,7 +546,7 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
 
       <Modal
         title="Bulk Invite Users"
-        visible={isModalVisible}
+        open={isModalVisible}
         width={800}
         onCancel={() => setIsModalVisible(false)}
         bodyStyle={{ maxHeight: "70vh", overflow: "auto" }}

--- a/ui/litellm-dashboard/src/components/cloudzero_export_modal.tsx
+++ b/ui/litellm-dashboard/src/components/cloudzero_export_modal.tsx
@@ -226,7 +226,7 @@ const CloudZeroExportModal: React.FC<CloudZeroExportModalProps> = ({ isOpen, onC
   ];
 
   return (
-    <Modal title="Export Data" open={isOpen} onCancel={handleModalClose} footer={null} width={600} destroyOnClose>
+    <Modal title="Export Data" open={isOpen} onCancel={handleModalClose} footer={null} width={600} destroyOnHidden>
       <div className="space-y-4">
         {/* Export Type Selection */}
         <div>

--- a/ui/litellm-dashboard/src/components/create_user_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_user_button.tsx
@@ -228,7 +228,7 @@ const Createuser: React.FC<CreateuserProps> = ({
       <BulkCreateUsers accessToken={accessToken} teams={teams} possibleUIRoles={possibleUIRoles} />
       <Modal
         title="Invite User"
-        visible={isModalVisible}
+        open={isModalVisible}
         width={800}
         footer={null}
         onOk={handleOk}

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -160,7 +160,7 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
         </Button>,
       ]}
       width={1000}
-      destroyOnClose
+      destroyOnHidden
     >
       <div className="space-y-6">
         <Text className="text-gray-600">

--- a/ui/litellm-dashboard/src/components/edit_model/edit_model_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_model/edit_model_modal.tsx
@@ -53,8 +53,8 @@ export const handleEditModelSubmit = async (
     model_info:
       model_info_model_id !== undefined
         ? {
-            id: model_info_model_id,
-          }
+          id: model_info_model_id,
+        }
         : undefined,
   };
 
@@ -119,7 +119,7 @@ const EditModelModal: React.FC<EditModelModalProps> = ({ visible, onCancel, mode
   return (
     <Modal
       title={"Edit '" + model_name + "' LiteLLM Params"}
-      visible={visible}
+      open={visible}
       width={800}
       footer={null}
       onOk={handleOk}

--- a/ui/litellm-dashboard/src/components/edit_user.tsx
+++ b/ui/litellm-dashboard/src/components/edit_user.tsx
@@ -39,7 +39,7 @@ const EditUserModal: React.FC<EditUserModalProps> = ({ visible, possibleUIRoles,
   }
 
   return (
-    <Modal visible={visible} onCancel={handleCancel} footer={null} title={"Edit User " + user.user_id} width={1000}>
+    <Modal open={visible} onCancel={handleCancel} footer={null} title={"Edit User " + user.user_id} width={1000}>
       <Form
         form={form}
         onFinish={handleEditSubmit}

--- a/ui/litellm-dashboard/src/components/model_add/CredentialDeleteModal.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/CredentialDeleteModal.tsx
@@ -43,7 +43,7 @@ const CredentialDeleteModal: React.FC<CredentialDeleteModalProps> = ({
       footer={null}
       onCancel={handleCancel}
       closable={true}
-      destroyOnClose={true}
+      destroyOnHidden={true}
       maskClosable={false}
     >
       <div className="mt-4">

--- a/ui/litellm-dashboard/src/components/model_add/reuse_credentials.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/reuse_credentials.tsx
@@ -32,7 +32,7 @@ const ReuseCredentialsModal: React.FC<ReuseCredentialsModalProps> = ({
   return (
     <Modal
       title="Reuse Credentials"
-      visible={isVisible}
+      open={isVisible}
       onCancel={() => {
         onCancel();
         form.resetFields();

--- a/ui/litellm-dashboard/src/components/onboarding_link.tsx
+++ b/ui/litellm-dashboard/src/components/onboarding_link.tsx
@@ -63,7 +63,7 @@ export default function OnboardingModal({
   return (
     <Modal
       title={modalType === "invitation" ? "Invitation Link" : "Reset Password Link"}
-      visible={isInvitationLinkModalVisible}
+      open={isInvitationLinkModalVisible}
       width={800}
       footer={null}
       onOk={handleInvitationOk}

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -1342,7 +1342,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
       {isCreateUserModalVisible && (
         <Modal
           title="Create New User"
-          visible={isCreateUserModalVisible}
+          open={isCreateUserModalVisible}
           onCancel={() => setIsCreateUserModalVisible(false)}
           footer={null}
           width={800}
@@ -1359,7 +1359,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
       )}
 
       {apiKey && (
-        <Modal visible={isModalVisible} onOk={handleOk} onCancel={handleCancel} footer={null}>
+        <Modal open={isModalVisible} onOk={handleOk} onCancel={handleCancel} footer={null}>
           <Grid numItems={1} className="gap-2 w-full">
             <Title>Save your Key</Title>
             <Col numColSpan={1}>

--- a/ui/litellm-dashboard/src/components/organization/add_org_admin.tsx
+++ b/ui/litellm-dashboard/src/components/organization/add_org_admin.tsx
@@ -45,7 +45,7 @@ const AddOrgAdmin: FC<AddOrgAdminProps> = ({ userRole, userID, selectedOrganizat
 
       <Modal
         title="Add member"
-        visible={isAddMemberModalVisible}
+        open={isAddMemberModalVisible}
         width={800}
         footer={null}
         onOk={handleMemberOk}

--- a/ui/litellm-dashboard/src/components/request_model_access.tsx
+++ b/ui/litellm-dashboard/src/components/request_model_access.tsx
@@ -60,7 +60,7 @@ const RequestAccess: React.FC<RequestAccessProps> = ({ userModels, accessToken, 
       </Button>
       <Modal
         title="Request Access"
-        visible={isModalVisible}
+        open={isModalVisible}
         width={800}
         footer={null}
         onOk={handleOk}

--- a/ui/litellm-dashboard/src/components/tag_management/components/CreateTagModal.tsx
+++ b/ui/litellm-dashboard/src/components/tag_management/components/CreateTagModal.tsx
@@ -36,7 +36,7 @@ const CreateTagModal: React.FC<CreateTagModalProps> = ({ visible, onCancel, onSu
   };
 
   return (
-    <Modal title="Create New Tag" visible={visible} width={800} footer={null} onCancel={handleCancel}>
+    <Modal title="Create New Tag" open={visible} width={800} footer={null} onCancel={handleCancel}>
       <Form form={form} onFinish={handleFinish} labelCol={{ span: 8 }} wrapperCol={{ span: 16 }} labelAlign="left">
         <Form.Item label="Tag Name" name="tag_name" rules={[{ required: true, message: "Please input a tag name" }]}>
           <TextInput />

--- a/ui/litellm-dashboard/src/components/vector_store_management/VectorStoreForm.tsx
+++ b/ui/litellm-dashboard/src/components/vector_store_management/VectorStoreForm.tsx
@@ -108,7 +108,7 @@ const VectorStoreForm: React.FC<VectorStoreFormProps> = ({
   };
 
   return (
-    <Modal title="Add New Vector Store" visible={isVisible} width={1000} footer={null} onCancel={handleCancel}>
+    <Modal title="Add New Vector Store" open={isVisible} width={1000} footer={null} onCancel={handleCancel}>
       <Form form={form} onFinish={handleCreate} labelCol={{ span: 8 }} wrapperCol={{ span: 16 }} labelAlign="left">
         <Form.Item
           label={


### PR DESCRIPTION
## Relevant issues
This PR changes the Antd modal props from `visible` to `open` and `destroyOnClose` to `destroyOnHidden`. This is in preparation potentially move antd to version 6 for future proofing
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes
