### PR TITLE
Fix: Managed Batches: Inconsistent State Management for list and cancel batches

### DIFF
--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -53,7 +53,7 @@ class CheckBatchCost:
 
         jobs = await self.prisma_client.db.litellm_managedobjecttable.find_many(
             where={
-                "status": "validating",
+                "status": {"in": ["validating", "in_progress", "finalizing"]},
                 "file_purpose": "batch",
             }
         )

--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -166,7 +166,11 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                     "updated_by": user_api_key_dict.user_id,
                     "status": file_object.status,
                 },
-                "update": {},  # don't do anything if it already exists
+                "update": {
+                    "file_object": file_object.model_dump_json(),
+                    "status": file_object.status,
+                    "updated_by": user_api_key_dict.user_id,
+                },  # FIX: Update status and file_object on every operation to keep state in sync
             },
         )
 
@@ -460,8 +464,6 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                 if retrieve_object_id
                 else False
             )
-            print(f"🔥potential_llm_object_id: {potential_llm_object_id}")
-            print(f"🔥retrieve_object_id: {retrieve_object_id}")
             if potential_llm_object_id and retrieve_object_id:
                 ## VALIDATE USER HAS ACCESS TO THE OBJECT ##
                 if not await self.can_user_call_unified_object_id(

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -24,10 +24,12 @@ from litellm.proxy.openai_files_endpoints.common_utils import (
     _is_base64_encoded_unified_file_id,
     decode_model_from_file_id,
     encode_file_id_with_model,
+    get_batch_from_database,
     get_credentials_for_model,
     get_models_from_unified_file_id,
     get_original_file_id,
     prepare_data_with_credentials,
+    update_batch_in_database,
 )
 from litellm.proxy.utils import handle_exception_on_proxy, is_known_model
 from litellm.types.llms.openai import LiteLLMBatchCreateRequest
@@ -357,6 +359,57 @@ async def retrieve_batch(
             route_type="aretrieve_batch",
         )
 
+        # FIX: First, try to read from ManagedObjectTable for consistent state
+        managed_files_obj = proxy_logging_obj.get_proxy_hook("managed_files")
+        from litellm.proxy.proxy_server import prisma_client
+        
+        db_batch_object, response = await get_batch_from_database(
+            batch_id=batch_id,
+            unified_batch_id=unified_batch_id,
+            managed_files_obj=managed_files_obj,
+            prisma_client=prisma_client,
+            verbose_proxy_logger=verbose_proxy_logger,
+        )
+        
+        # If batch is in a terminal state, return immediately
+        if response is not None and response.status in ["completed", "failed", "cancelled", "expired"]:
+            # Call hooks and return
+            response = await proxy_logging_obj.post_call_success_hook(
+                data=data, user_api_key_dict=user_api_key_dict, response=response
+            )
+            
+            asyncio.create_task(
+                proxy_logging_obj.update_request_status(
+                    litellm_call_id=data.get("litellm_call_id", ""), status="success"
+                )
+            )
+            
+            hidden_params = getattr(response, "_hidden_params", {}) or {}
+            model_id = hidden_params.get("model_id", None) or ""
+            cache_key = hidden_params.get("cache_key", None) or ""
+            api_base = hidden_params.get("api_base", None) or ""
+            
+            fastapi_response.headers.update(
+                ProxyBaseLLMRequestProcessing.get_custom_headers(
+                    user_api_key_dict=user_api_key_dict,
+                    model_id=model_id,
+                    cache_key=cache_key,
+                    api_base=api_base,
+                    version=version,
+                    model_region=getattr(user_api_key_dict, "allowed_model_region", ""),
+                    request_data=data,
+                )
+            )
+            
+            return response
+        
+        # If batch is still processing, sync with provider to get latest state
+        if response is not None:
+            verbose_proxy_logger.debug(
+                f"Batch {batch_id} is in non-terminal state {response.status}, syncing with provider"
+            )
+
+        # Retrieve from provider (for non-terminal states or if DB lookup failed)
         # SCENARIO 1: Batch ID is encoded with model info
         if model_from_id is not None:
             credentials = get_credentials_for_model(
@@ -408,6 +461,18 @@ async def retrieve_batch(
             response = await litellm.aretrieve_batch(
                 custom_llm_provider=custom_llm_provider, **data  # type: ignore
             )
+        
+        # FIX: Update the database with the latest state from provider
+        await update_batch_in_database(
+            batch_id=batch_id,
+            unified_batch_id=unified_batch_id,
+            response=response,
+            managed_files_obj=managed_files_obj,
+            prisma_client=prisma_client,
+            verbose_proxy_logger=verbose_proxy_logger,
+            db_batch_object=db_batch_object,
+            operation="retrieve",
+        )
 
         ### CALL HOOKS ### - modify outgoing data
         response = await proxy_logging_obj.post_call_success_hook(
@@ -768,6 +833,20 @@ async def cancel_batch(
                 custom_llm_provider=custom_llm_provider,  # type: ignore
                 **_cancel_batch_data,
             )
+
+        # FIX: Update the database with the new cancelled state
+        managed_files_obj = proxy_logging_obj.get_proxy_hook("managed_files")
+        from litellm.proxy.proxy_server import prisma_client
+        
+        await update_batch_in_database(
+            batch_id=batch_id,
+            unified_batch_id=unified_batch_id,
+            response=response,
+            managed_files_obj=managed_files_obj,
+            prisma_client=prisma_client,
+            verbose_proxy_logger=verbose_proxy_logger,
+            operation="cancel",
+        )
 
         ### CALL HOOKS ### - modify outgoing data
         response = await proxy_logging_obj.post_call_success_hook(

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -637,3 +637,127 @@ def _extract_model_param(request: "Request", request_body: dict) -> Optional[str
         or request.query_params.get("model")
         or request.headers.get("x-litellm-model")
     )
+
+
+# ============================================================================
+#                    BATCH DATABASE OPERATIONS
+# ============================================================================
+
+
+async def get_batch_from_database(
+    batch_id: str,
+    unified_batch_id: Union[str, Literal[False]],
+    managed_files_obj,
+    prisma_client,
+    verbose_proxy_logger,
+):
+    """
+    Try to retrieve batch object from ManagedObjectTable for consistent state.
+    
+    Args:
+        batch_id: The batch ID (may be unified/encoded)
+        unified_batch_id: Result from _is_base64_encoded_unified_file_id()
+        managed_files_obj: The managed_files proxy hook object
+        prisma_client: Prisma database client
+        verbose_proxy_logger: Logger instance
+        
+    Returns:
+        Tuple of (db_batch_object, response_batch)
+        - db_batch_object: Raw database object (or None)
+        - response_batch: Parsed LiteLLMBatch object (or None)
+    """
+    import json
+    from litellm.types.utils import LiteLLMBatch
+    
+    if managed_files_obj is None or not unified_batch_id:
+        return None, None
+    
+    try:
+        if not prisma_client:
+            return None, None
+            
+        db_batch_object = await prisma_client.db.litellm_managedobjecttable.find_first(
+            where={"unified_object_id": batch_id}
+        )
+        
+        if not db_batch_object or not db_batch_object.file_object:
+            return None, None
+        
+        # Parse the batch object from database
+        batch_data = json.loads(db_batch_object.file_object) if isinstance(db_batch_object.file_object, str) else db_batch_object.file_object
+        response = LiteLLMBatch(**batch_data)
+        response.id = batch_id
+        
+        verbose_proxy_logger.debug(
+            f"Retrieved batch {batch_id} from ManagedObjectTable with status={response.status}"
+        )
+        
+        return db_batch_object, response
+        
+    except Exception as e:
+        verbose_proxy_logger.warning(
+            f"Failed to retrieve batch from ManagedObjectTable: {e}, falling back to provider"
+        )
+        return None, None
+
+
+async def update_batch_in_database(
+    batch_id: str,
+    unified_batch_id: Union[str, Literal[False]],
+    response,
+    managed_files_obj,
+    prisma_client,
+    verbose_proxy_logger,
+    db_batch_object=None,
+    operation: str = "update",
+):
+    """
+    Update batch status and object in ManagedObjectTable.
+    
+    Args:
+        batch_id: The batch ID (unified/encoded)
+        unified_batch_id: Result from _is_base64_encoded_unified_file_id()
+        response: The batch response object with updated state
+        managed_files_obj: The managed_files proxy hook object
+        prisma_client: Prisma database client
+        verbose_proxy_logger: Logger instance
+        db_batch_object: Optional existing database object (for comparison)
+        operation: Description of operation ("update", "cancel", etc.)
+    """
+    import litellm.utils
+    
+    if managed_files_obj is None or not unified_batch_id:
+        return
+    
+    try:
+        if not prisma_client:
+            return
+        
+        # Only update if status has changed (when db_batch_object is provided)
+        if db_batch_object and response.status == db_batch_object.status:
+            return
+        
+        if db_batch_object:
+            verbose_proxy_logger.info(
+                f"Updating batch {batch_id} status from {db_batch_object.status} to {response.status}"
+            )
+        else:
+            verbose_proxy_logger.info(
+                f"Updating batch {batch_id} status to {response.status} after {operation}"
+            )
+        
+        # Normalize status for database storage
+        db_status = response.status if response.status != "completed" else "complete"
+        
+        await prisma_client.db.litellm_managedobjecttable.update(
+            where={"unified_object_id": batch_id},
+            data={
+                "status": db_status if db_status != "completed" else "complete",
+                "file_object": response.model_dump_json(),
+                "updated_at": litellm.utils.get_utc_datetime(),
+            },
+        )
+    except Exception as e:
+        verbose_proxy_logger.error(
+            f"Failed to update batch status in ManagedObjectTable: {e}"
+        )

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -752,7 +752,7 @@ async def update_batch_in_database(
         await prisma_client.db.litellm_managedobjecttable.update(
             where={"unified_object_id": batch_id},
             data={
-                "status": db_status if db_status != "completed" else "complete",
+                "status": db_status,
                 "file_object": response.model_dump_json(),
                 "updated_at": litellm.utils.get_utc_datetime(),
             },


### PR DESCRIPTION

## Relevant issues

Managed Batches: Inconsistent State Management - Not all batch APIs read/write from the same state


Create file - writes to db 
	user -> proxy: POST /v1/files
	proxy -> storage (azure) : POST /v1/file
	proxy -> proxy : add ManagedFileTable

Create batch - writes to db 
	user -> proxy: POST /v1/batch
	proxy -> provider : POST /v1/batch 
	proxy -> proxy : add ManagedObjectTable : {batch1, validating, … }

Get batch - reads from provider <--------- This is not reading from the db 
	user -> proxy: GET /v1/batch/batch1
	proxy -> provider: GET /v1/batch/batch1

Batch list - reads from db 
	user -> proxy: GET /v1/batch
	poxy -> proxy : Read from ManagedObjectTable

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
