### PR TITLE
Fix: Extra inputs are not permitted, field: 'messages[2].provider_specific_fields

### DIFF
--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -236,6 +236,10 @@ class FireworksAIConfig(OpenAIGPTConfig):
                                 disable_add_transform_inline_image_block=disable_add_transform_inline_image_block,
                             )
             filter_value_from_dict(cast(dict, message), "cache_control")
+            # Remove fields not permitted by FireworksAI that may cause:
+            # "Not permitted, field: 'messages[n].provider_specific_fields'"
+            if isinstance(message, dict) and "provider_specific_fields" in message:
+                message.pop("provider_specific_fields", None)
 
         return messages
 

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -108,3 +108,32 @@ def test_get_supported_openai_params_reasoning_effort():
         "fireworks_ai/accounts/fireworks/models/llama-v3-70b-instruct"
     )
     assert "reasoning_effort" not in unsupported_params
+
+
+def test_transform_messages_helper_removes_provider_specific_fields():
+    """
+    Test that _transform_messages_helper removes provider_specific_fields from messages.
+    """
+    config = FireworksAIConfig()
+    # Simulated messages, as dicts, including provider_specific_fields
+    messages = [
+        {
+            "role": "user",
+            "content": "Hello!",
+            "provider_specific_fields": {"extra": "should be removed"},
+        },
+        {
+            "role": "assistant",
+            "content": "Hi there!",
+            "provider_specific_fields": {"more": "remove this"},
+        },
+        {
+            "role": "user",
+            "content": "How are you?",
+            # no provider_specific_fields
+        }
+    ]
+    # Call helper
+    out = config._transform_messages_helper(messages, model="fireworks/test", litellm_params={})
+    for msg in out:
+        assert "provider_specific_fields" not in msg


### PR DESCRIPTION

## Relevant issues
Fireworks doesn't like messages[2].provider_specific_fields in its request and throws an error. This Pr removes this field. The transform response doesn't add any provider_specific_fields in the response, so this means that some other LLMs provider_specific_fields from history had gotten added
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
<img width="1044" height="710" alt="image" src="https://github.com/user-attachments/assets/d71e7be5-e144-482f-a017-1fb422ce99ea" />
