### PR TITLE
bugfix: Disable merging of consecutive user messages for GigaChat provider

### DIFF
--- a/litellm/llms/gigachat/chat/transformation.py
+++ b/litellm/llms/gigachat/chat/transformation.py
@@ -386,33 +386,7 @@ class GigaChatConfig(BaseConfig):
 
             transformed.append(message)
 
-        # Collapse consecutive user messages
-        return self._collapse_user_messages(transformed)
-
-    def _collapse_user_messages(self, messages: List[dict]) -> List[dict]:
-        """Collapse consecutive user messages into one."""
-        collapsed: List[dict] = []
-        prev_user_msg: Optional[dict] = None
-        content_parts: List[str] = []
-
-        for msg in messages:
-            if msg.get("role") == "user" and prev_user_msg is not None:
-                content_parts.append(msg.get("content", ""))
-            else:
-                if content_parts and prev_user_msg:
-                    prev_user_msg["content"] = "\n".join(
-                        [prev_user_msg.get("content", "")] + content_parts
-                    )
-                    content_parts = []
-                collapsed.append(msg)
-                prev_user_msg = msg if msg.get("role") == "user" else None
-
-        if content_parts and prev_user_msg:
-            prev_user_msg["content"] = "\n".join(
-                [prev_user_msg.get("content", "")] + content_parts
-            )
-
-        return collapsed
+        return transformed
 
     def transform_response(
         self,

--- a/tests/llm_translation/test_gigachat.py
+++ b/tests/llm_translation/test_gigachat.py
@@ -122,40 +122,6 @@ class TestGigaChatCollapseUserMessages:
 
         return GigaChatConfig()
 
-    def test_no_collapse_single_message(self, config):
-        """Single message should not be changed"""
-        messages = [{"role": "user", "content": "Hello"}]
-        result = config._collapse_user_messages(messages)
-
-        assert len(result) == 1
-        assert result[0]["content"] == "Hello"
-
-    def test_collapse_consecutive_user_messages(self, config):
-        """Consecutive user messages should be collapsed"""
-        messages = [
-            {"role": "user", "content": "First"},
-            {"role": "user", "content": "Second"},
-            {"role": "user", "content": "Third"},
-        ]
-        result = config._collapse_user_messages(messages)
-
-        assert len(result) == 1
-        assert "First" in result[0]["content"]
-        assert "Second" in result[0]["content"]
-        assert "Third" in result[0]["content"]
-
-    def test_no_collapse_with_assistant_between(self, config):
-        """Messages with assistant between should not be collapsed"""
-        messages = [
-            {"role": "user", "content": "First"},
-            {"role": "assistant", "content": "Response"},
-            {"role": "user", "content": "Second"},
-        ]
-        result = config._collapse_user_messages(messages)
-
-        assert len(result) == 3
-
-
 class TestGigaChatToolsTransformation:
     """Tests for tools -> functions conversion"""
 


### PR DESCRIPTION
There is no reason to merge user messages.

## Relevant issues

Fixes #20281 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

User messages were previously merged before sending to the GigaChat provider.
This caused attachments from intermediate messages to be dropped.

Merging of consecutive user messages is now disabled to preserve all attachments.
