### PR TITLE
fix: map global location to us-central1 for vertex's claude models count_tokens endpoint

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -107,6 +107,11 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
         vertex_project = self.get_vertex_ai_project(litellm_params)
         vertex_location = self.get_vertex_ai_location(litellm_params)
 
+        # Map "global" to a supported region for Claude count_tokens only
+        # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
+        if not vertex_location or (vertex_location == "global" and "claude" in model.lower()):
+            vertex_location = "us-central1"
+
         # Get access token and resolved project ID
         access_token, project_id = await self._ensure_access_token_async(
             credentials=vertex_credentials,
@@ -118,7 +123,7 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
         endpoint_url = self._build_count_tokens_endpoint(
             model=model,
             project_id=project_id,
-            vertex_location=vertex_location or "us-central1",
+            vertex_location=vertex_location,
             api_base=litellm_params.get("api_base"),
         )
 

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -107,9 +107,9 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
         vertex_project = self.get_vertex_ai_project(litellm_params)
         vertex_location = self.get_vertex_ai_location(litellm_params)
 
-        # Map "global" to a supported region for Claude count_tokens only
+        # Map empty location/cluade models to a supported region for count-tokens endpoint
         # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
-        if not vertex_location or (vertex_location == "global" and "claude" in model.lower()):
+        if not vertex_location or "claude" in model.lower():
             vertex_location = "us-central1"
 
         # Get access token and resolved project ID


### PR DESCRIPTION
- Vertex AI doesn't support count_tokens endpoint for Claude models with global location
- Map global -> us-central1for count_tokens only, keeping global for inference
- Fixes 404 error when calling count_tokens with vertex_location: global
- Reference: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes
- map global vertex_location-> us-central1 for count_tokens only