### PR TITLE
fix(aiohttp): respect ssl_verify with shared sessions

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import os
+import ssl
 import typing
 import urllib.request
 from typing import Callable, Dict, Optional, Union
@@ -139,8 +140,13 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
     Credit to: https://github.com/karpetrosyan/httpx-aiohttp for this implementation
     """
 
-    def __init__(self, client: Union[ClientSession, Callable[[], ClientSession]]):
+    def __init__(
+        self,
+        client: Union[ClientSession, Callable[[], ClientSession]],
+        ssl_verify: Optional[Union[bool, ssl.SSLContext]] = None,
+    ):
         self.client = client
+        self._ssl_verify = ssl_verify  # Store for per-request SSL override
         super().__init__(client=client)
         # Store the client factory for recreating sessions when needed
         if callable(client):
@@ -214,6 +220,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
         timeout: dict,
         proxy: Optional[str],
         sni_hostname: Optional[str],
+        ssl_verify: Optional[Union[bool, ssl.SSLContext]] = None,
     ) -> ClientResponse:
         """
         Helper function to make an aiohttp request with the given parameters.
@@ -224,6 +231,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
             timeout: Timeout settings dict with 'connect', 'read', 'pool' keys
             proxy: Optional proxy URL
             sni_hostname: Optional SNI hostname for SSL
+            ssl_verify: Optional SSL verification setting (False to disable, SSLContext for custom)
 
         Returns:
             ClientResponse from aiohttp
@@ -250,6 +258,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
                 connect=timeout.get("pool"),
             ),
             proxy=proxy,
+            ssl=ssl_verify,
             server_hostname=sni_hostname,
         ).__aenter__()
 
@@ -268,6 +277,9 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
         # Resolve proxy settings from environment variables
         proxy = await self._get_proxy_settings(request)
 
+        # Use stored SSL configuration for per-request override
+        ssl_config = self._ssl_verify
+
         try:
             with map_aiohttp_exceptions():
                 response = await self._make_aiohttp_request(
@@ -276,6 +288,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
                     timeout=timeout,
                     proxy=proxy,
                     sni_hostname=sni_hostname,
+                    ssl_verify=ssl_config,
                 )
         except RuntimeError as e:
             # Handle the case where session was closed between our check and actual use
@@ -296,6 +309,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
                         timeout=timeout,
                         proxy=proxy,
                         sni_hostname=sni_hostname,
+                        ssl_verify=ssl_config,
                     )
             else:
                 # Re-raise if it's a different RuntimeError


### PR DESCRIPTION
## Relevant issues

Fixes ssl_verify setting not being respected when using aiohttp transport with shared sessions
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

When `ssl_verify: False` is set in `litellm_settings` in config.yaml, it was not being applied when using aiohttp transport with shared sessions.

**Root cause**: `_create_aiohttp_transport()` returned immediately when a `shared_session` was provided, bypassing all SSL configuration.

**Fix**:
- Store `ssl_verify` in `LiteLLMAiohttpTransport` constructor
- Pass it per-request to aiohttp's `client_session.request()` via the `ssl` parameter
- This ensures SSL settings are respected even when reusing shared sessions

**Tests added**:
- `test_ssl_verification_with_shared_session`
- `test_ssl_context_with_shared_session`