### PR TITLE
perf: guard debug f-string in update_environment_variables

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -522,7 +522,8 @@ class Logging(LiteLLMLoggingBaseClass):
         }
         self.litellm_request_debug = litellm_params.get("litellm_request_debug", False)
         self.logger_fn = litellm_params.get("logger_fn", None)
-        verbose_logger.debug(f"self.optional_params: {self.optional_params}")
+        if _is_debugging_on() or self.litellm_request_debug:
+            verbose_logger.debug(f"self.optional_params: {self.optional_params}")
 
         self.model_call_details.update(
             {


### PR DESCRIPTION

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring
Performance

## Changes

What this does is checks if the debug logging is on and if it is then it logs the optional params, because if it isnt on then there's no reason to build the optional params dict and not log it. Its additional overhead for no reason. 

Before 

<img width="1065" height="79" alt="Screenshot 2026-02-03 at 12 49 53 PM" src="https://github.com/user-attachments/assets/def29cf1-fba7-4497-9223-04cdd7f16d04" />


After 

<img width="1101" height="84" alt="Screenshot 2026-02-03 at 12 50 16 PM" src="https://github.com/user-attachments/assets/467bf03f-fc2b-4e3d-a161-0f42923b5a02" />


