### PR TITLE
perf: cache get_model_access_groups() no-args result on Router

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -470,6 +470,8 @@ class Router:
                 []
             )  # initialize an empty list - to allow _add_deployment and delete_deployment to work
 
+        self._access_groups_cache: Optional[Dict[str, List[str]]] = None
+
         if allowed_fails is not None:
             self.allowed_fails = allowed_fails
         else:
@@ -6055,6 +6057,7 @@ class Router:
         self.model_list = []
         self.model_id_to_deployment_index_map = {}  # Reset the index
         self.model_name_to_deployment_indices = {}  # Reset the model_name index
+        self._invalidate_access_groups_cache()
         # we add api_base/api_key each model so load balancing between azure/gpt on api_base1 and api_base2 works
 
         for model in original_model_list:
@@ -6358,6 +6361,7 @@ class Router:
         """
         idx = len(self.model_list)
         self.model_list.append(model)
+        self._invalidate_access_groups_cache()
 
         # Update model_id index for O(1) lookup
         if model_id is not None:
@@ -6405,6 +6409,7 @@ class Router:
 
                     if removal_idx is not None:
                         self.model_list.pop(removal_idx)
+                        self._invalidate_access_groups_cache()
                         self._update_deployment_indices_after_removal(
                             model_id=deployment_id, removal_idx=removal_idx
                         )
@@ -6438,6 +6443,7 @@ class Router:
             if deployment_idx is not None:
                 # Pop the item from the list first
                 item = self.model_list.pop(deployment_idx)
+                self._invalidate_access_groups_cache()
                 self._update_deployment_indices_after_removal(
                     model_id=id, removal_idx=deployment_idx
                 )
@@ -7172,6 +7178,7 @@ class Router:
         """
         # First populate the model_list
         self.model_list = []
+        self._invalidate_access_groups_cache()
         for _, model in enumerate(model_list):
             # Extract model_info from the model dict
             model_info = model.get("model_info", {})
@@ -7508,6 +7515,13 @@ class Router:
 
         return returned_models
 
+    def _invalidate_access_groups_cache(self) -> None:
+        """Invalidate the cached access groups.
+
+        Call this whenever self.model_list is modified to ensure the cache is rebuilt.
+        """
+        self._access_groups_cache = None
+
     def get_model_access_groups(
         self,
         model_name: Optional[str] = None,
@@ -7522,6 +7536,13 @@ class Router:
         - model_access_group: Optional[str] - the received model access group from the user. If set, will only return models for that access group.
         - team_id: Optional[str] - the team id, to resolve team-specific models
         """
+        # Check if this is the no-args hot path (cacheable)
+        _use_cache = model_name is None and model_access_group is None and team_id is None
+
+        # Return cached result for the no-args hot path
+        if _use_cache and self._access_groups_cache is not None:
+            return self._access_groups_cache
+
         from collections import defaultdict
 
         access_groups = defaultdict(list)
@@ -7539,6 +7560,11 @@ class Router:
                         else:
                             model_name = m["model_name"]
                             access_groups[group].append(model_name)
+
+        # Cache the result for the no-args hot path
+        if _use_cache:
+            self._access_groups_cache = dict(access_groups)
+            return self._access_groups_cache
 
         return access_groups
 


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring
✅ Test

## Changes

Made a cache that is either none or has the access groups to models dictionary in it. This saves us from having to recompute what the access group to models looks like on every request. 

This makes it so that repeated requests dont have to iterate through the entire model list creating this dictionary and results in 91% speed increase for this method. Follows the same pattern of caching as shown by model_cost_lowercase_map. 

Invalidated the cache when setting model list (config comes in), adding model list, adding deployment, deleting deployment and in router setup when its building the index map for deployment lookups (_build_model_id_to_deployment_index_map). 

Added tests to confirm the caches functionality. 

[Before](https://gist.github.com/ryan-crabbe/3f77f1876e48e2e6f5c7b866d96bc2dc) 

<img width="501" height="134" alt="Screenshot 2026-02-03 at 4 23 00 PM" src="https://github.com/user-attachments/assets/9c17f22f-f830-43a3-9535-b607b4ea7d5c" />

[After](https://gist.github.com/ryan-crabbe/76edb6922f2fcf61468fb79c1ecf9d91)

<img width="508" height="131" alt="Screenshot 2026-02-03 at 4 23 11 PM" src="https://github.com/user-attachments/assets/7cd0f34c-6277-43a6-9f12-57fd86d33ec8" />
