### PR TITLE
[Fix] /user/update Allow for max_budget Resets

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -813,9 +813,12 @@ def _update_internal_user_params(
     data_json: dict, data: Union[UpdateUserRequest, UpdateUserRequestNoUserIDorEmail]
 ) -> dict:
     non_default_values = {}
+    fields_set = data.fields_set() if hasattr(data, 'fields_set') else set()
+    
     for k, v in data_json.items():
         if k == "max_budget":
-            non_default_values[k] = v
+            if "max_budget" in fields_set:
+                non_default_values[k] = v
         elif (
             v is not None
             and v

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -1133,6 +1133,24 @@ def test_update_internal_user_params_ignores_other_nones():
     assert non_default_values["max_budget"] == 100.0
 
 
+def test_update_internal_user_params_keeps_original_max_budget_when_not_provided():
+    """
+    Test that _update_internal_user_params does not include max_budget 
+    when it's not provided in the request (should keep original value).
+    """
+    # Create test data without max_budget
+    data_json = {"user_id": "test_user", "user_alias": "test_alias"}
+    data = UpdateUserRequest(user_id="test_user", user_alias="test_alias")
+
+    # Call the function
+    non_default_values = _update_internal_user_params(data_json=data_json, data=data)
+
+    # Assertions: max_budget should NOT be in non_default_values
+    assert "max_budget" not in non_default_values
+    assert "user_id" in non_default_values
+    assert "user_alias" in non_default_values
+
+
 def test_generate_request_base_validator():
     """
     Test that GenerateRequestBase validator converts empty string to None for max_budget


### PR DESCRIPTION
## Relevant issues



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

Fixes an issue where `max_budget` could not be reset because `_update_internal_user_params` always included it in `non_default_values` even when not provided in the request. The function now checks if `max_budget` is explicitly set using `fields_set()` before including it, allowing it to be reset when provided while preserving the original value when omitted.

## Screenshots
BEFORE:
<img width="765" height="989" alt="image" src="https://github.com/user-attachments/assets/f1fceea8-c837-4a6c-8d67-6236f87fc291" />


AFTER:
<img width="738" height="1002" alt="image" src="https://github.com/user-attachments/assets/dad4ab52-00a3-444f-95fc-fdd5ab160f65" />

TESTS:
<img width="1111" height="283" alt="image" src="https://github.com/user-attachments/assets/9ccee10f-67b5-42d9-b2d9-e6f945e1bb30" />
