### PR TITLE
fix: Sanitize empty text content blocks for databricks provider

### DIFF
--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -60,6 +60,38 @@ from ...anthropic.chat.transformation import AnthropicConfig
 from ...openai_like.chat.transformation import OpenAILikeChatConfig
 from ..common_utils import DatabricksBase, DatabricksException
 
+def _sanitize_empty_content(message_dict: dict) -> None:
+    """
+    Remove or filter content so empty text blocks are not sent.
+    Databricks Model Serving uses Anthropic Messages API spec and rejects empty text blocks.
+    """
+    content = message_dict.get("content")
+    if content is None:
+        message_dict.pop("content", None)
+        return
+    if isinstance(content, str):
+        if not content.strip():
+            message_dict.pop("content")
+        return
+    if isinstance(content, list):
+        if not content:
+            message_dict.pop("content")
+            return
+        filtered = [
+            block
+            for block in content
+            if not (
+                isinstance(block, dict)
+                and block.get("type") == "text"
+                and not (block.get("text") or "").strip()
+            )
+        ]
+        if not filtered:
+            message_dict.pop("content")
+        else:
+            message_dict["content"] = filtered
+
+
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
 
@@ -349,6 +381,7 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
             # Move message-level cache_control into a content block when content is a string.
             if "cache_control" in _message and isinstance(_message.get("content"), str):
                 _message = self._move_cache_control_into_string_content_block(_message)
+            _sanitize_empty_content(_message)
             new_messages.append(_message)
 
         if is_async:


### PR DESCRIPTION
### Relevant issues

- Fixes empty text content blocks not being sanitized for the databricks provider.

### Type

- Bug Fix :  #20370

### Changes

- Databricks uses the Anthropic Messages API, which rejects empty text blocks.
- Add the same empty-content sanitization used for bedrock/anthropic to the databricks path.
- In _transform_messages: remove or filter empty/whitespace-only text so no such blocks are sent.
- Add tests for the sanitization helper and for _transform_messages.