### PR TITLE
[Improvement] Add functionality to propagate bedrock guardrail errors down to lit…

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -461,12 +461,37 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 data=prepared_request.body,  # type: ignore
                 headers=prepared_request.headers,  # type: ignore
             )
+        except HTTPException:
+            # Propagate HTTPException (e.g. from non-200 path) as-is
+            raise
         except Exception as e:
+            # If this is an HTTP error with a response body (e.g. httpx.HTTPStatusError),
+            # extract the AWS error message and propagate it
+            response = getattr(e, "response", None)
+            if isinstance(response, httpx.Response):
+                try:
+                    status_code, detail_message = (
+                        self._parse_bedrock_guardrail_error_response(response)
+                    )
+                    self.add_standard_logging_guardrail_information_to_request_data(
+                        guardrail_provider=self.guardrail_provider,
+                        guardrail_json_response={"error": detail_message},
+                        request_data=request_data or {},
+                        guardrail_status="guardrail_failed_to_respond",
+                        start_time=start_time.timestamp(),
+                        end_time=datetime.now().timestamp(),
+                        duration=(datetime.now() - start_time).total_seconds(),
+                        event_type=event_type,
+                    )
+                    raise HTTPException(
+                        status_code=status_code, detail=detail_message
+                    ) from e
+                except HTTPException:
+                    raise
             # Endpoint down, timeout, or other HTTP/network errors
             verbose_proxy_logger.error(
                 "Bedrock AI: failed to make guardrail request: %s", str(e)
             )
-            # Add guardrail information with failure status
             self.add_standard_logging_guardrail_information_to_request_data(
                 guardrail_provider=self.guardrail_provider,
                 guardrail_json_response={"error": str(e)},
@@ -477,7 +502,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 duration=(datetime.now() - start_time).total_seconds(),
                 event_type=event_type,
             )
-            # Re-raise the exception to maintain existing behavior
             raise
 
         #########################################################
@@ -509,11 +533,15 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     bedrock_guardrail_response
                 )
         else:
+            status_code, detail_message = self._parse_bedrock_guardrail_error_response(
+                httpx_response
+            )
             verbose_proxy_logger.error(
                 "Bedrock AI: error in response. Status code: %s, response: %s",
                 httpx_response.status_code,
                 httpx_response.text,
             )
+            raise HTTPException(status_code=status_code, detail=detail_message)
 
         return bedrock_guardrail_response
 
@@ -578,6 +606,34 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
             return "success"
         return "guardrail_failed_to_respond"
+
+    def _parse_bedrock_guardrail_error_response(
+        self, response: httpx.Response
+    ) -> Tuple[int, str]:
+        """
+        Parse AWS Bedrock guardrail error response body to extract status code and message.
+
+        AWS may return shapes like {"message": "..."} or {"error": {"message": "..."}}.
+        Returns (status_code, message) for use in HTTPException.
+        """
+        status_code = response.status_code
+        message = "Bedrock guardrail request failed"
+        try:
+            body = response.json()
+        except Exception:
+            text = getattr(response, "text", None) or ""
+            if isinstance(text, str) and text.strip():
+                return (status_code, text.strip())
+            return (status_code, message)
+        if isinstance(body, dict):
+            if isinstance(body.get("message"), str):
+                return (status_code, body["message"])
+            err = body.get("error")
+            if isinstance(err, dict) and isinstance(err.get("message"), str):
+                return (status_code, err["message"])
+            if isinstance(err, str):
+                return (status_code, err)
+        return (status_code, message)
 
     def _get_http_exception_for_blocked_guardrail(
         self, response: BedrockGuardrailResponse
@@ -1392,6 +1448,9 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             inputs["texts"] = masked_texts
             return inputs
 
+        except HTTPException:
+            # Propagate AWS guardrail error (e.g. "input is too long") to the client
+            raise
         except Exception as e:
             verbose_proxy_logger.error(
                 "Bedrock Guardrail: Failed to apply guardrail: %s", str(e)


### PR DESCRIPTION
## Relevant issues
Issue: Chat/completions calls that hit the AWS Bedrock guardrail and get a real error (e.g. “input is too long”) were returning a generic 500 with a message like “Bedrock guardrail failed: Client error '400 Bad Request' for url…”. The actual AWS error message and status code were not passed through to the client.

Before:
<img width="825" height="718" alt="Screenshot 2026-02-03 at 10 03 19 PM" src="https://github.com/user-attachments/assets/0ef125d2-4871-4cc9-8c2d-9e6114a90210" />

After:
<img width="815" height="741" alt="Screenshot 2026-02-03 at 10 06 06 PM" src="https://github.com/user-attachments/assets/790426d3-ab7e-4b89-b307-8a98f84b8936" />
Tests
<img width="574" height="237" alt="Screenshot 2026-02-03 at 10 13 24 PM" src="https://github.com/user-attachments/assets/2751028a-b090-47f7-9f7c-fe64af467d93" />

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
Fix: Parse the Bedrock guardrail error response body (e.g. {"message": "input is too long"} or {"error": {"message": "..."}}), raise HTTPException(status_code=..., detail=parsed_message) instead of a generic exception, and re-raise HTTPException in the transform/apply path instead of wrapping it. The client now gets the correct status (e.g. 400) and the real AWS error message.
