### PR TITLE
fix: add prompt_cache_key and prompt_cache_retention support for OpenAI

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -162,6 +162,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             "service_tier",
             "safety_identifier",
             "prompt_cache_key",
+            "prompt_cache_retention",
             "store",
         ]  # works across all models
 

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1125,6 +1125,7 @@ class ResponsesAPIOptionalRequestParams(TypedDict, total=False):
     prompt: Optional[PromptObject]
     max_tool_calls: Optional[int]
     prompt_cache_key: Optional[str]
+    prompt_cache_retention: Optional[str]
     stream_options: Optional[dict]
     top_logprobs: Optional[int]
     partial_images: Optional[

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -207,10 +207,10 @@ class TestOpenAIChatCompletionStreamingHandler:
     def test_chunk_parser_maps_reasoning_to_reasoning_content(self):
         """
         Test that chunk_parser maps 'reasoning' field to 'reasoning_content'.
-        
+
         Some OpenAI-compatible providers (e.g., GLM-5, hosted_vllm) return
         delta.reasoning, but LiteLLM expects delta.reasoning_content.
-        
+
         Regression test for: Streaming responses with delta.reasoning field
         coming back empty when using openai/ or hosted_vllm/ providers.
         """
@@ -293,3 +293,34 @@ class TestPromptCacheKeyIntegration:
             prompt_cache_key="test-cache-key-123",
         )
         assert optional_params.get("prompt_cache_key") == "test-cache-key-123"
+
+
+class TestPromptCacheParams:
+    """Tests for prompt_cache_key and prompt_cache_retention support."""
+
+    def setup_method(self):
+        self.config = OpenAIGPTConfig()
+
+    def test_prompt_cache_key_in_supported_params(self):
+        """Test that prompt_cache_key is in supported params for OpenAI models."""
+        supported_params = self.config.get_supported_openai_params("gpt-4o")
+        assert "prompt_cache_key" in supported_params
+
+    def test_prompt_cache_retention_in_supported_params(self):
+        """Test that prompt_cache_retention is in supported params for OpenAI models."""
+        supported_params = self.config.get_supported_openai_params("gpt-4o")
+        assert "prompt_cache_retention" in supported_params
+
+    def test_prompt_cache_params_passed_through(self):
+        """Test that prompt_cache_key and prompt_cache_retention are passed through by map_openai_params."""
+        optional_params = self.config.map_openai_params(
+            non_default_params={
+                "prompt_cache_key": "my-cache-key",
+                "prompt_cache_retention": "24h",
+            },
+            optional_params={},
+            model="gpt-4o",
+            drop_params=False,
+        )
+        assert optional_params.get("prompt_cache_key") == "my-cache-key"
+        assert optional_params.get("prompt_cache_retention") == "24h"


### PR DESCRIPTION
## Relevant issues

fixes #13175 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

✅ Test
🐛 Bug Fix
📖 Documentation

## Changes

On hitting the completion route: we get the params the user sent in and then we get the supported openai params ([hardcoded and missing `prompt_cache_key` and `prompt_cache_retention` are missing](https://platform.openai.com/docs/guides/prompt-caching)) so then when filtering those params would get filtered out. Responses api was just missing the `prompt_cache_retention` from the typed dict of openai params. 

Updated the docs to reflect these changes and be more clear about it. 

