### PR TITLE
docs: clarify litellm_deployment_latency_per_output_token

### DIFF
--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -178,6 +178,17 @@ Use this for LLM API Error monitoring and tracking remaining rate limits and tok
 | `litellm_deployment_state`             | The state of the deployment: 0 = healthy, 1 = partial outage, 2 = complete outage. Labels: `"litellm_model_name", "model_id", "api_base", "api_provider"` |
 | `litellm_deployment_latency_per_output_token`       | Latency per output token for deployment. Labels: `"litellm_model_name", "model_id", "api_base", "api_provider", "hashed_api_key", "api_key_alias", "team", "team_alias"` |
 
+**What does `litellm_deployment_latency_per_output_token` measure?**
+
+This metric is computed **inside LiteLLM** as `latency_seconds / output_tokens`:
+
+- **Non-streaming requests**: `latency_seconds` is the time from when LiteLLM starts the deployment request to when it receives the final response.
+- **Streaming requests**: `latency_seconds` is the **time-to-first-token (TTFT)** (time until LiteLLM receives the first token from the provider).
+
+Because the timer is taken at the LiteLLM boundary, it reflects **provider latency + any LiteLLM proxy overhead** that occurs during that interval (and can include network overhead).
+
+If you need a metric that targets *just the provider LLM API call latency*, use `litellm_llm_api_latency_metric`.
+
 #### Fallback (Failover) Metrics
 
 | Metric Name          | Description                          |

--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -182,12 +182,17 @@ Use this for LLM API Error monitoring and tracking remaining rate limits and tok
 
 This metric is computed **inside LiteLLM** as `latency_seconds / output_tokens`:
 
-- **Non-streaming requests**: `latency_seconds` is the time from when LiteLLM starts the deployment request to when it receives the final response.
-- **Streaming requests**: `latency_seconds` is the **time-to-first-token (TTFT)** (time until LiteLLM receives the first token from the provider).
+- **Non-streaming requests**: `latency_seconds` is the time from when LiteLLM
+  starts the deployment request to when it receives the final response.
+- **Streaming requests**: `latency_seconds` is the **time-to-first-token
+  (TTFT)** (time until LiteLLM receives the first token from the provider).
 
-Because the timer is taken at the LiteLLM boundary, it reflects **provider latency + any LiteLLM proxy overhead** that occurs during that interval (and can include network overhead).
+Because the timer is taken at the LiteLLM boundary, it reflects **provider
+latency + any LiteLLM proxy overhead** that occurs during that interval (and can
+include network overhead).
 
-If you need a metric that targets *just the provider LLM API call latency*, use `litellm_llm_api_latency_metric`.
+If you need a metric that targets *just the provider LLM API call latency*, use
+`litellm_llm_api_latency_metric`.
 
 #### Fallback (Failover) Metrics
 


### PR DESCRIPTION
## Relevant issues

Fixes #20345

## Pre-Submission checklist

- [ ] Added test under `tests/litellm/` (N/A: docs-only change)
- [ ] `make test-unit` passes (currently failing on upstream/main due to a pre-existing container import issue; see PR #19786)
- [x] Scope isolated to 1 problem (Prometheus metric docs clarification)

## Type

📖 Documentation

## Changes

- Clarify how `litellm_deployment_latency_per_output_token` is computed.
- Document streaming behavior (uses TTFT as the latency component).
- Clarify this is end-to-end from the LiteLLM boundary (provider + proxy overhead) and point to `litellm_llm_api_latency_metric` for provider-only call latency.

## Test / evidence

```bash
make test-unit
```

Observed failure on upstream/main during test collection:
- `TypeError: Cannot subclass typing.Any` in `litellm/llms/openai/containers/transformation.py`
- Tracking fix: https://github.com/BerriAI/litellm/pull/19786