### PR TITLE
Fix ollama_chat reasoning_context.

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -502,13 +502,12 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             reasoning_content: Optional[str] = None
             content: Optional[str] = None
             if chunk["message"].get("thinking") is not None:
-                if self.started_reasoning_content is False:
-                    reasoning_content = chunk["message"].get("thinking")
-                    self.started_reasoning_content = True
-                elif self.finished_reasoning_content is False:
-                    reasoning_content = chunk["message"].get("thinking")
-                    self.finished_reasoning_content = True
+                reasoning_content = chunk["message"].get("thinking")
+                self.started_reasoning_content = True
             elif chunk["message"].get("content") is not None:
+                if self.started_reasoning_content and not self.finished_reasoning_content:
+                    self.finished_reasoning_content = True
+
                 message_content = chunk["message"].get("content")
                 if "<think>" in message_content:
                     message_content = message_content.replace("<think>", "")


### PR DESCRIPTION
For ollama_chat models, reasoning context is ignored after 2 consecutive thinking chunks.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
