### PR TITLE
Fix MCP streaming test skip logic and metadata None check

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -51,7 +51,7 @@ def handle_cohere_chat_model_custom_llm_provider(
         if custom_llm_provider == "cohere" and model in litellm.cohere_chat_models:
             return model, "cohere_chat"
 
-    if "/" in model:
+    if model and "/" in model:
         _custom_llm_provider, _model = model.split("/", 1)
         if (
             _custom_llm_provider
@@ -84,7 +84,7 @@ def handle_anthropic_text_model_custom_llm_provider(
         ):
             return model, "anthropic_text"
 
-    if "/" in model:
+    if model and "/" in model:
         _custom_llm_provider, _model = model.split("/", 1)
         if (
             _custom_llm_provider
@@ -113,6 +113,12 @@ def get_llm_provider(  # noqa: PLR0915
     Return model, custom_llm_provider, dynamic_api_key, api_base
     """
     try:
+        # Early validation - model is required
+        if model is None:
+            raise ValueError(
+                "model parameter is required but was None. Please provide a valid model name."
+            )
+
         if litellm.LiteLLMProxyChatConfig._should_use_litellm_proxy_by_default(
             litellm_params=litellm_params
         ):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2008,9 +2008,9 @@ def client(original_function):  # noqa: PLR0915
                         kwargs["model"] = context_window_fallback_dict[model]
                     return await original_function(*args, **kwargs)
             elif call_type == CallTypes.aresponses.value:
-                _is_litellm_router_call = "model_group" in kwargs.get(
+                _is_litellm_router_call = "model_group" in (kwargs.get(
                     "metadata", {}
-                )  # check if call from litellm.router/proxy
+                ) or {})  # check if call from litellm.router/proxy
 
                 if (
                     num_retries and not _is_litellm_router_call

--- a/tests/mcp_tests/test_aresponses_api_with_mcp.py
+++ b/tests/mcp_tests/test_aresponses_api_with_mcp.py
@@ -683,8 +683,8 @@ async def test_streaming_responses_api_with_mcp_tools(
 
     Return the user the result of request 2
     """
-    # Skip test if required API keys are not set
-    if ("anthropic" in model.lower() or "claude" in model.lower()) and not os.getenv("ANTHROPIC_API_KEY"):
+    # Skip test if API keys are not set for the respective models
+    if ("claude" in model.lower() or "anthropic" in model.lower()) and not os.getenv("ANTHROPIC_API_KEY"):
         pytest.skip("ANTHROPIC_API_KEY not set, skipping anthropic model test")
     if ("gpt" in model.lower() or "openai" in model.lower()) and not os.getenv("OPENAI_API_KEY"):
         pytest.skip("OPENAI_API_KEY not set, skipping openai model test")


### PR DESCRIPTION
## Summary

- Fix `TypeError` when `model` is `None` in `get_llm_provider_logic.py` — adds `model and` guards before `"/" in model` and early validation in `get_llm_provider()`
- Fix `TypeError` when `metadata` is explicitly `None` in `utils.py` — `kwargs.get("metadata", {})` returns `None` when the key exists with value `None`, causing `"model_group" in None` to fail. Uses `or {}` fallback.
- Minor test comment cleanup in `test_aresponses_api_with_mcp.py`

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- `litellm/litellm_core_utils/get_llm_provider_logic.py`: Add defensive `None` guards — `model and` before `"/" in model` in `handle_cohere_chat_model_custom_llm_provider()` and `handle_anthropic_text_model_custom_llm_provider()`, plus early `model is None` validation in `get_llm_provider()` with a clear error message
- `litellm/utils.py`: Guard against `metadata` being explicitly `None` (vs absent) by using `or {}` fallback before the `in` operator, preventing `TypeError: argument of type 'NoneType' is not iterable`
- `tests/mcp_tests/test_aresponses_api_with_mcp.py`: Minor comment cleanup