### PR TITLE
feat: support Anthropic OAuth tokens in passthrough endpoint

### DIFF
--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -36,11 +36,10 @@ class BasePassthroughUtils:
         e.g., 'x-pass-anthropic-beta: value' becomes 'anthropic-beta: value'
         """
         if forward_headers is True:
-            # Header We Should NOT forward
             request_headers.pop("content-length", None)
             request_headers.pop("host", None)
+            request_headers.pop("x-litellm-api-key", None)
 
-            # Combine request headers with custom headers
             headers = {**request_headers, **headers}
 
         # Always process x-pass- prefixed headers (strip prefix and forward)

--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -51,6 +51,7 @@ class BasePassthroughUtils:
 
         return headers
 
+
 class CommonUtils:
     @staticmethod
     def encode_bedrock_runtime_modelid_arn(endpoint: str) -> str:
@@ -63,37 +64,36 @@ class CommonUtils:
             arn:aws:bedrock:ap-southeast-1:123456789012:application-inference-profile%2Fabdefg12334
         so that it is treated as one part of the path.
         Otherwise, the encoded endpoint will return 500 error when passed to Bedrock endpoint.
-            
+
         See the apis in https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Operations_Amazon_Bedrock_Runtime.html
         for more details on the regex patterns of modelId which we use in the regex logic below.
-        
+
         Args:
             endpoint (str): The original endpoint string which may contain ARNs that contain slashes.
-            
+
         Returns:
             str: The endpoint with properly encoded ARN slashes
         """
         import re
 
         # Early exit: if no ARN detected, return unchanged
-        if 'arn:aws:' not in endpoint:
+        if "arn:aws:" not in endpoint:
             return endpoint
 
         # Handle all patterns in one go - more efficient and cleaner
         patterns = [
             # Custom model with 2 slashes (order matters - do this first)
-            (r'(custom-model)/([a-z0-9.-]+)/([a-z0-9]+)', r'\1%2F\2%2F\3'),
-
+            (r"(custom-model)/([a-z0-9.-]+)/([a-z0-9]+)", r"\1%2F\2%2F\3"),
             # All other resource types with 1 slash
-            (r'(:application-inference-profile)/', r'\1%2F'),
-            (r'(:inference-profile)/', r'\1%2F'),
-            (r'(:foundation-model)/', r'\1%2F'),
-            (r'(:imported-model)/', r'\1%2F'),
-            (r'(:provisioned-model)/', r'\1%2F'),
-            (r'(:prompt)/', r'\1%2F'),
-            (r'(:endpoint)/', r'\1%2F'),
-            (r'(:prompt-router)/', r'\1%2F'),
-            (r'(:default-prompt-router)/', r'\1%2F'),
+            (r"(:application-inference-profile)/", r"\1%2F"),
+            (r"(:inference-profile)/", r"\1%2F"),
+            (r"(:foundation-model)/", r"\1%2F"),
+            (r"(:imported-model)/", r"\1%2F"),
+            (r"(:provisioned-model)/", r"\1%2F"),
+            (r"(:prompt)/", r"\1%2F"),
+            (r"(:endpoint)/", r"\1%2F"),
+            (r"(:prompt-router)/", r"\1%2F"),
+            (r"(:default-prompt-router)/", r"\1%2F"),
         ]
 
         for pattern, replacement in patterns:


### PR DESCRIPTION
## Summary

Enables Anthropic OAuth token authentication (used by Claude Code / Claude Max) through the `/anthropic/{endpoint:path}` passthrough endpoint.

### Problem

When users authenticate with Claude Max OAuth tokens (`sk-ant-oat...`), the passthrough endpoint was overwriting the `Authorization` header with the server's `x-api-key`, causing authentication failures.

### Solution

- Detect OAuth tokens by checking if `Authorization` header starts with `Bearer sk-ant-oat`
- For OAuth requests: forward all headers as-is (don't set `x-api-key`)
- For non-OAuth requests: use server's `ANTHROPIC_API_KEY` as before
- Customer can still override headers via `x-pass-*` prefix in both cases

### Changes

- `litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py`: Add OAuth detection logic
- `tests/pass_through_unit_tests/test_anthropic_passthrough_oauth.py`: Add unit tests

### Testing

- Added 8 unit tests covering OAuth detection, non-OAuth fallback, case sensitivity, and header forwarding
- All existing passthrough tests continue to pass