### PR TITLE
fix(otel): auto-infer otlp_http exporter when endpoint is configured

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -70,6 +70,13 @@ class OpenTelemetryConfig:
     model_id: Optional[str] = None
 
     def __post_init__(self) -> None:
+        # If endpoint is specified but exporter is still the default "console",
+        # automatically infer "otlp_http" to send traces to the endpoint.
+        # This fixes an issue where UI-configured OTEL settings would default
+        # to console output instead of sending traces to the configured endpoint.
+        if self.endpoint and isinstance(self.exporter, str) and self.exporter == "console":
+            self.exporter = "otlp_http"
+
         if not self.service_name:
             self.service_name = os.getenv("OTEL_SERVICE_NAME", "litellm")
         if not self.deployment_environment:


### PR DESCRIPTION
When OpenTelemetry is configured via the UI, only OTEL_ENDPOINT and OTEL_HEADERS are set, but OTEL_EXPORTER is not specified. This caused the exporter to default to "console", meaning traces were printed to stdout instead of being sent to the configured endpoint.

This fix adds logic in OpenTelemetryConfig.__post_init__ to automatically infer "otlp_http" as the exporter when an endpoint is specified but the exporter is still the default "console".

Fixes issue reported by Elastic team where traces weren't being sent to their OTEL endpoint when configured through the LiteLLM UI.

## Relevant issues
 <!-- e.g. "Fixes #000" -->

## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type
🐛 Bug Fix

## Changes
- Added auto-inference logic in `OpenTelemetryConfig.__post_init__` to set `exporter="otlp_http"` when an endpoint is configured but exporter is still the default `"console"`
- Added unit test `test_open_telemetry_config_auto_infer_otlp_http_when_endpoint_set` to verify the fix

## Screenshots
<img width="1467" height="464" alt="Screenshot 2026-02-04 alle 22 03 09" src="https://github.com/user-attachments/assets/b1d389a2-a5f6-4d84-9fa1-46387c69971a" />
