### PR TITLE
perf: skip duplicate get_standard_logging_object_payload for non-streaming req's 

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1639,6 +1639,13 @@ class Logging(LiteLLMLoggingBaseClass):
             logging_result, start_time, end_time
         )
 
+        if (
+            standard_logging_payload := self.model_call_details.get(
+                "standard_logging_object"
+            )
+        ) is not None:
+            emit_standard_logging_payload(standard_logging_payload)
+
     def _build_standard_logging_payload(
         self, init_response_obj: Any, start_time: Any, end_time: Any
     ) -> Any:
@@ -1752,6 +1759,12 @@ class Logging(LiteLLMLoggingBaseClass):
                     ] = self._build_standard_logging_payload(
                         result, start_time, end_time
                     )
+                    if (
+                        standard_logging_payload := self.model_call_details.get(
+                            "standard_logging_object"
+                        )
+                    ) is not None:
+                        emit_standard_logging_payload(standard_logging_payload)
             elif standard_logging_object is not None:
                 self.model_call_details[
                     "standard_logging_object"
@@ -3211,6 +3224,8 @@ class Logging(LiteLLMLoggingBaseClass):
         is_async: bool,
         streaming_chunks: List[Any],
     ) -> Optional[Union[ModelResponse, TextCompletionResponse, ResponsesAPIResponse]]:
+        if self.stream is not True:
+            return None
         if isinstance(result, ModelResponse):
             return result
         elif isinstance(result, TextCompletionResponse):

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -14,7 +14,7 @@ import time
 from litellm.constants import SENTRY_DENYLIST, SENTRY_PII_DENYLIST
 from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
 from litellm.litellm_core_utils.litellm_logging import set_callbacks
-from litellm.types.utils import ModelResponse
+from litellm.types.utils import ModelResponse, TextCompletionResponse
 
 
 @pytest.fixture
@@ -264,7 +264,7 @@ async def test_logging_result_for_bridge_calls(logging_obj):
             mock_response="Hello, world!",
         )
         await asyncio.sleep(1)
-        assert mock_should_run_logging.call_count == 2  # called twice per call
+        assert mock_should_run_logging.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -1355,5 +1355,118 @@ def test_get_error_information_error_code_priority():
     result = StandardLoggingPayloadSetup.get_error_information(no_code_exception)
     assert result["error_code"] == ""
     assert result["error_class"] == "NoCodeException"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tests for _get_assembled_streaming_response non-streaming early return
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _make_logging_obj(stream: bool) -> LitellmLogging:
+    return LitellmLogging(
+        model="openai/codex-mini-latest",
+        messages=[{"role": "user", "content": "Hey"}],
+        stream=stream,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="test-123",
+        function_id="test-fn",
+    )
+
+
+def test_get_assembled_streaming_response_returns_none_for_non_streaming():
+    """Non-streaming requests should return None so the streaming block is skipped."""
+    import datetime
+
+    logging_obj = _make_logging_obj(stream=False)
+    result = ModelResponse(id="resp-1", choices=[], model="test")
+    assembled = logging_obj._get_assembled_streaming_response(
+        result=result,
+        start_time=datetime.datetime.now(),
+        end_time=datetime.datetime.now(),
+        is_async=True,
+        streaming_chunks=[],
+    )
+    assert assembled is None
+
+
+def test_get_assembled_streaming_response_returns_result_for_streaming():
+    """Streaming requests should return the ModelResponse for further processing."""
+    import datetime
+
+    logging_obj = _make_logging_obj(stream=True)
+    result = ModelResponse(id="resp-1", choices=[], model="test")
+    assembled = logging_obj._get_assembled_streaming_response(
+        result=result,
+        start_time=datetime.datetime.now(),
+        end_time=datetime.datetime.now(),
+        is_async=True,
+        streaming_chunks=[],
+    )
+    assert assembled is result
+
+
+def test_get_assembled_streaming_response_returns_none_for_non_streaming_text_completion():
+    """Non-streaming TextCompletionResponse should also return None."""
+    import datetime
+
+    logging_obj = _make_logging_obj(stream=False)
+    result = TextCompletionResponse(id="resp-1", choices=[], model="test")
+    assembled = logging_obj._get_assembled_streaming_response(
+        result=result,
+        start_time=datetime.datetime.now(),
+        end_time=datetime.datetime.now(),
+        is_async=True,
+        streaming_chunks=[],
+    )
+    assert assembled is None
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_computes_standard_logging_object_once():
+    """
+    Non-streaming acompletion should call get_standard_logging_object_payload
+    exactly once, not twice.
+    """
+    import asyncio
+
+    import litellm
+
+    with patch.object(
+        litellm.litellm_core_utils.litellm_logging,
+        "get_standard_logging_object_payload",
+    ) as mock_payload:
+        await litellm.acompletion(
+            max_tokens=100,
+            messages=[{"role": "user", "content": "Hey"}],
+            model="openai/codex-mini-latest",
+            mock_response="Hello, world!",
+        )
+        await asyncio.sleep(1)
+        assert mock_payload.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_emit_standard_logging_payload_called_for_non_streaming():
+    """
+    emit_standard_logging_payload should still be called for non-streaming
+    requests (moved from the streaming block to _process_hidden_params_and_response_cost).
+    """
+    import asyncio
+
+    import litellm
+
+    with patch.object(
+        litellm.litellm_core_utils.litellm_logging,
+        "emit_standard_logging_payload",
+    ) as mock_emit:
+        await litellm.acompletion(
+            max_tokens=100,
+            messages=[{"role": "user", "content": "Hey"}],
+            model="openai/codex-mini-latest",
+            mock_response="Hello, world!",
+        )
+        await asyncio.sleep(1)
+        assert mock_emit.call_count >= 1
 
 


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test
Performance 

## Changes

`_get_assembled_streaming_response` returned the model response (or whatever result was) everytime it was called and this meant this means that in an async completion request (not a streamed request) we were going down the streamed path in the `async_success_handler` because we were setting `model_call_details[async_complete_streaming_response]` this lead to a bunch of redundant calls to methods like `_response_cost_calculator`, `get_standard_logging_object_payload` and `_get_base_model_from_metadata` 

Ended up optimizing `async_success_handler` to be ~18% faster

3 unit tests to verify `_get_assembled_streaming_response` returns None for non-streaming and returns the result for if its streaming. 

2 end-to-end tests verify `get_standard_logging_object_payload` is called exactly one time and `emit_standard_payload `still fires for non-streaming requests.

Also changed `test_logging_result_for_bridge_calls` because it asserted call_count = 2 which was testing the double call behavior because we werent correctly checking if streamed, updated it to be 1

Before 

<img width="815" height="159" alt="Screenshot 2026-02-04 at 2 39 57 PM" src="https://github.com/user-attachments/assets/f98fcc4c-6177-4389-8f42-67262ebfb491" />

After

<img width="815" height="157" alt="Screenshot 2026-02-04 at 2 40 13 PM" src="https://github.com/user-attachments/assets/8783d7f1-5f9f-4f79-b640-bb73fcd52958" />

