### PR TITLE
[Feature] UI - Admin Settings: Add option for Authentication for public AI Hub

### DIFF
--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -83,6 +83,11 @@ class UISettings(BaseModel):
         description="List of page keys that internal users (non-admins) can see in the UI sidebar. If not set, all pages are visible based on role permissions.",
     )
 
+    require_auth_for_public_ai_hub: bool = Field(
+        default=False,
+        description="If true, requires authentication for accessing the public AI Hub."
+    )
+
 
 class UISettingsResponse(SettingsResponse):
     """Response model for UI settings"""
@@ -95,6 +100,7 @@ ALLOWED_UI_SETTINGS_FIELDS = {
     "disable_model_add_for_internal_users",
     "disable_team_admin_delete_team_user",
     "enabled_ui_pages_internal_users",
+    "require_auth_for_public_ai_hub",
 }
 
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/uiSettings/useUISettings.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/uiSettings/useUISettings.test.ts
@@ -10,12 +10,6 @@ vi.mock("@/components/networking", () => ({
   getUiSettings: vi.fn(),
 }));
 
-// Mock useAuthorized hook - we can override this in individual tests
-const mockUseAuthorized = vi.fn();
-vi.mock("../useAuthorized", () => ({
-  default: () => mockUseAuthorized(),
-}));
-
 // Mock data
 const mockUISettings: Record<string, any> = {
   theme: "dark",
@@ -39,18 +33,6 @@ describe("useUISettings", () => {
 
     // Reset all mocks
     vi.clearAllMocks();
-
-    // Set default mock for useAuthorized (enabled state)
-    mockUseAuthorized.mockReturnValue({
-      accessToken: "test-access-token",
-      userRole: "Admin",
-      userId: "test-user-id",
-      token: "test-token",
-      userEmail: "test@example.com",
-      premiumUser: false,
-      disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
-    });
   });
 
   const wrapper = ({ children }: { children: ReactNode }) =>
@@ -74,7 +56,7 @@ describe("useUISettings", () => {
 
     expect(result.current.data).toEqual(mockUISettings);
     expect(result.current.error).toBeNull();
-    expect(getUiSettings).toHaveBeenCalledWith("test-access-token");
+    expect(getUiSettings).toHaveBeenCalledWith();
     expect(getUiSettings).toHaveBeenCalledTimes(1);
   });
 
@@ -98,56 +80,8 @@ describe("useUISettings", () => {
 
     expect(result.current.error).toEqual(testError);
     expect(result.current.data).toBeUndefined();
-    expect(getUiSettings).toHaveBeenCalledWith("test-access-token");
+    expect(getUiSettings).toHaveBeenCalledWith();
     expect(getUiSettings).toHaveBeenCalledTimes(1);
-  });
-
-  it("should not execute query when accessToken is missing", async () => {
-    // Mock missing accessToken
-    mockUseAuthorized.mockReturnValue({
-      accessToken: null,
-      userRole: "Admin",
-      userId: "test-user-id",
-      token: null,
-      userEmail: "test@example.com",
-      premiumUser: false,
-      disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
-    });
-
-    const { result } = renderHook(() => useUISettings(), { wrapper });
-
-    // Query should not execute
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.data).toBeUndefined();
-    expect(result.current.isFetched).toBe(false);
-
-    // API should not be called
-    expect(getUiSettings).not.toHaveBeenCalled();
-  });
-
-  it("should not execute query when accessToken is empty string", async () => {
-    // Mock empty accessToken
-    mockUseAuthorized.mockReturnValue({
-      accessToken: "",
-      userRole: "Admin",
-      userId: "test-user-id",
-      token: "",
-      userEmail: "test@example.com",
-      premiumUser: false,
-      disabledPersonalKeyCreation: null,
-      showSSOBanner: false,
-    });
-
-    const { result } = renderHook(() => useUISettings(), { wrapper });
-
-    // Query should not execute
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.data).toBeUndefined();
-    expect(result.current.isFetched).toBe(false);
-
-    // API should not be called
-    expect(getUiSettings).not.toHaveBeenCalled();
   });
 
   it("should return empty object when API returns empty settings", async () => {
@@ -163,7 +97,7 @@ describe("useUISettings", () => {
     });
 
     expect(result.current.data).toEqual({});
-    expect(getUiSettings).toHaveBeenCalledWith("test-access-token");
+    expect(getUiSettings).toHaveBeenCalledWith();
   });
 
   it("should handle network timeout error", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/uiSettings/useUISettings.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/uiSettings/useUISettings.ts
@@ -1,7 +1,6 @@
 import { getUiSettings } from "@/components/networking";
 import { useQuery } from "@tanstack/react-query";
 import { createQueryKeys } from "../common/queryKeysFactory";
-import useAuthorized from "../useAuthorized";
 
 const uiSettingsKeys = createQueryKeys("uiSettings");
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/uiSettings/useUISettings.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/uiSettings/useUISettings.ts
@@ -6,11 +6,9 @@ import useAuthorized from "../useAuthorized";
 const uiSettingsKeys = createQueryKeys("uiSettings");
 
 export const useUISettings = () => {
-  const { accessToken } = useAuthorized();
   return useQuery<Record<string, any>>({
     queryKey: uiSettingsKeys.list({}),
-    queryFn: async () => await getUiSettings(accessToken),
-    enabled: !!accessToken,
+    queryFn: async () => await getUiSettings(),
     staleTime: 60 * 60 * 1000, // 1 hour - data rarely changes
     gcTime: 60 * 60 * 1000, // 1 hour - keep in cache for 1 hour
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
@@ -8,12 +8,13 @@ import useAuthorized from "./useAuthorized";
 // Unmock useAuthorized to test the actual implementation
 vi.unmock("@/app/(dashboard)/hooks/useAuthorized");
 
-const { replaceMock, clearTokenCookiesMock, getProxyBaseUrlMock, getUiConfigMock, isJwtExpiredMock } = vi.hoisted(() => ({
+const { replaceMock, clearTokenCookiesMock, getProxyBaseUrlMock, getUiConfigMock, decodeTokenMock, checkTokenValidityMock } = vi.hoisted(() => ({
   replaceMock: vi.fn(),
   clearTokenCookiesMock: vi.fn(),
   getProxyBaseUrlMock: vi.fn(() => "http://proxy.example"),
   getUiConfigMock: vi.fn(),
-  isJwtExpiredMock: vi.fn(),
+  decodeTokenMock: vi.fn(),
+  checkTokenValidityMock: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -43,7 +44,8 @@ vi.mock("@/utils/jwtUtils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/utils/jwtUtils")>();
   return {
     ...actual,
-    isJwtExpired: isJwtExpiredMock,
+    decodeToken: decodeTokenMock,
+    checkTokenValidity: checkTokenValidityMock,
   };
 });
 
@@ -77,7 +79,8 @@ describe("useAuthorized", () => {
     clearTokenCookiesMock.mockReset();
     getProxyBaseUrlMock.mockClear();
     getUiConfigMock.mockReset();
-    isJwtExpiredMock.mockReset();
+    decodeTokenMock.mockReset();
+    checkTokenValidityMock.mockReset();
     clearCookie();
   });
 
@@ -88,9 +91,8 @@ describe("useAuthorized", () => {
       auto_redirect_to_sso: false,
       admin_ui_disabled: false,
     });
-    isJwtExpiredMock.mockReturnValue(false);
-
-    const token = createJwt({
+    
+    const decodedPayload = {
       key: "api-key-123",
       user_id: "user-1",
       user_email: "user@example.com",
@@ -98,7 +100,12 @@ describe("useAuthorized", () => {
       premium_user: true,
       disabled_non_admin_personal_key_creation: false,
       login_method: "username_password",
-    });
+    };
+    
+    decodeTokenMock.mockReturnValue(decodedPayload);
+    checkTokenValidityMock.mockReturnValue(true);
+
+    const token = createJwt(decodedPayload);
     document.cookie = `token=${token}; path=/;`;
 
     const { result } = renderHook(() => useAuthorized(), { wrapper });
@@ -126,6 +133,9 @@ describe("useAuthorized", () => {
       admin_ui_disabled: false,
     });
 
+    decodeTokenMock.mockReturnValue(null);
+    checkTokenValidityMock.mockReturnValue(false);
+
     document.cookie = "token=invalid-token; path=/;";
 
     const { result } = renderHook(() => useAuthorized(), { wrapper });
@@ -146,9 +156,8 @@ describe("useAuthorized", () => {
       auto_redirect_to_sso: false,
       admin_ui_disabled: true,
     });
-    isJwtExpiredMock.mockReturnValue(false);
 
-    const token = createJwt({
+    const decodedPayload = {
       key: "api-key-123",
       user_id: "user-1",
       user_email: "user@example.com",
@@ -156,7 +165,12 @@ describe("useAuthorized", () => {
       premium_user: true,
       disabled_non_admin_personal_key_creation: false,
       login_method: "username_password",
-    });
+    };
+
+    decodeTokenMock.mockReturnValue(decodedPayload);
+    checkTokenValidityMock.mockReturnValue(true);
+
+    const token = createJwt(decodedPayload);
     document.cookie = `token=${token}; path=/;`;
 
     const { result } = renderHook(() => useAuthorized(), { wrapper });
@@ -178,6 +192,9 @@ describe("useAuthorized", () => {
       admin_ui_disabled: false,
     });
 
+    decodeTokenMock.mockReturnValue(null);
+    checkTokenValidityMock.mockReturnValue(false);
+
     // No token cookie set
     const { result } = renderHook(() => useAuthorized(), { wrapper });
 
@@ -196,14 +213,18 @@ describe("useAuthorized", () => {
       auto_redirect_to_sso: false,
       admin_ui_disabled: false,
     });
-    isJwtExpiredMock.mockReturnValue(true);
 
-    const token = createJwt({
+    const decodedPayload = {
       key: "api-key-123",
       user_id: "user-1",
       user_email: "user@example.com",
       user_role: "app_admin",
-    });
+    };
+
+    decodeTokenMock.mockReturnValue(decodedPayload);
+    checkTokenValidityMock.mockReturnValue(false);
+
+    const token = createJwt(decodedPayload);
     document.cookie = `token=${token}; path=/;`;
 
     const { result } = renderHook(() => useAuthorized(), { wrapper });
@@ -213,6 +234,6 @@ describe("useAuthorized", () => {
     });
 
     expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login");
-    expect(isJwtExpiredMock).toHaveBeenCalledWith(token);
+    expect(checkTokenValidityMock).toHaveBeenCalledWith(token);
   });
 });

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.test.tsx
@@ -1,6 +1,6 @@
 import * as networking from "@/components/networking";
-import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, waitFor } from "../../../tests/test-utils";
 import ModelHubTable from "./ModelHubTable";
 
 vi.mock("@/components/networking", () => ({
@@ -11,6 +11,8 @@ vi.mock("@/components/networking", () => ({
   getProxyBaseUrl: vi.fn(() => "http://localhost:4000"),
   getAgentsList: vi.fn(),
   fetchMCPServers: vi.fn(),
+  getUiSettings: vi.fn(),
+  getClaudeCodeMarketplace: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -39,8 +41,11 @@ describe("ModelHubTable", () => {
       agents: [],
     });
     vi.mocked(networking.fetchMCPServers).mockResolvedValue([]);
+    vi.mocked(networking.getUiSettings).mockResolvedValue({
+      values: {},
+    });
 
-    render(<ModelHubTable accessToken="test-token" publicPage={false} premiumUser={false} userRole={null} />);
+    renderWithProviders(<ModelHubTable accessToken="test-token" publicPage={false} premiumUser={false} userRole={null} />);
 
     await waitFor(() => {
       expect(screen.getByText("AI Hub")).toBeInTheDocument();
@@ -58,8 +63,11 @@ describe("ModelHubTable", () => {
       admin_ui_disabled: false,
     });
     modelHubPublicModelsCallMock.mockResolvedValue([]);
+    vi.mocked(networking.getUiSettings).mockResolvedValue({
+      values: {},
+    });
 
-    render(<ModelHubTable accessToken={null} publicPage={true} premiumUser={false} userRole={null} />);
+    renderWithProviders(<ModelHubTable accessToken={null} publicPage={true} premiumUser={false} userRole={null} />);
 
     await waitFor(() => {
       expect(getUiConfigMock).toHaveBeenCalled();

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -27,6 +27,9 @@ import { Copy } from "lucide-react";
 import { useRouter } from "next/navigation";
 import React, { useCallback, useEffect, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
+import { checkTokenValidity } from "@/utils/jwtUtils";
+import { getCookie } from "@/utils/cookieUtils";
 
 interface ModelHubTableProps {
   accessToken: string | null;
@@ -76,6 +79,30 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
   const [isMcpModalVisible, setIsMcpModalVisible] = useState(false);
   const [isMakeMcpPublicModalVisible, setIsMakeMcpPublicModalVisible] = useState(false);
   const router = useRouter();
+  const { data: uiSettings, isLoading: isUISettingsLoading } = useUISettings();
+
+  // Check authentication requirement for public AI Hub
+  useEffect(() => {
+    // Only check when UI settings are loaded and this is a public page
+    if (isUISettingsLoading || !publicPage) {
+      return;
+    }
+
+    const requireAuth = uiSettings?.values?.require_auth_for_public_ai_hub;
+
+    // If require_auth_for_public_ai_hub is true, verify token
+    if (requireAuth === true) {
+      const token = getCookie("token");
+      const isTokenValid = checkTokenValidity(token);
+
+      // If token is invalid, redirect to login
+      if (!isTokenValid) {
+        router.replace(`${getProxyBaseUrl()}/ui/login`);
+        return;
+      }
+    }
+    // If require_auth_for_public_ai_hub is false, allow public access (no change)
+  }, [isUISettingsLoading, publicPage, uiSettings, router]);
 
   useEffect(() => {
     const fetchData = async (accessToken: string) => {

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.test.tsx
@@ -20,6 +20,13 @@ vi.mock("@/app/(dashboard)/hooks/uiSettings/useUpdateUISettings", () => ({
   useUpdateUISettings: mockUseUpdateUISettings,
 }));
 
+vi.mock("@/components/molecules/notifications_manager", () => ({
+  default: {
+    success: vi.fn(),
+    fromBackend: vi.fn(),
+  },
+}));
+
 const buildSettingsResponse = (overrides?: Partial<Record<string, unknown>>) => ({
   data: {
     field_schema: {
@@ -28,10 +35,18 @@ const buildSettingsResponse = (overrides?: Partial<Record<string, unknown>>) => 
         disable_model_add_for_internal_users: {
           description: "Disable model add for internal users",
         },
+        disable_team_admin_delete_team_user: {
+          description: "Disable team admin delete team user",
+        },
+        require_auth_for_public_ai_hub: {
+          description: "Require authentication for public AI Hub",
+        },
       },
     },
     values: {
       disable_model_add_for_internal_users: false,
+      disable_team_admin_delete_team_user: false,
+      require_auth_for_public_ai_hub: false,
     },
   },
   isLoading: false,
@@ -57,6 +72,8 @@ describe("UISettings", () => {
 
     expect(screen.getByText("UI Settings")).toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "Disable model add for internal users" })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Disable team admin delete team user" })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Require authentication for public AI Hub" })).toBeInTheDocument();
   });
 
   it("should toggle setting and call update", () => {
@@ -80,6 +97,64 @@ describe("UISettings", () => {
 
     expect(mutateMock).toHaveBeenCalledWith(
       { disable_model_add_for_internal_users: true },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+    expect(NotificationManager.success).toHaveBeenCalledWith("UI settings updated successfully");
+  });
+
+  it("should toggle disable team admin delete team user setting and call update", () => {
+    const mutateMock = vi.fn((_settings, options) => {
+      options?.onSuccess?.();
+    });
+
+    mockUseUpdateUISettings.mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+      error: null,
+    });
+
+    render(<UISettings />);
+
+    const toggle = screen.getByRole("switch", { name: "Disable team admin delete team user" });
+
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      { disable_team_admin_delete_team_user: true },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+    expect(NotificationManager.success).toHaveBeenCalledWith("UI settings updated successfully");
+  });
+
+  it("should toggle require auth for public AI Hub setting and call update", () => {
+    const mutateMock = vi.fn((_settings, options) => {
+      options?.onSuccess?.();
+    });
+
+    mockUseUpdateUISettings.mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+      error: null,
+    });
+
+    render(<UISettings />);
+
+    const toggle = screen.getByRole("switch", { name: "Require authentication for public AI Hub" });
+
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      { require_auth_for_public_ai_hub: true },
       expect.objectContaining({
         onSuccess: expect.any(Function),
         onError: expect.any(Function),

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
@@ -15,6 +15,7 @@ export default function UISettings() {
   const schema = data?.field_schema;
   const property = schema?.properties?.disable_model_add_for_internal_users;
   const disableTeamAdminDeleteProperty = schema?.properties?.disable_team_admin_delete_team_user;
+  const requireAuthForPublicAIHubProperty = schema?.properties?.require_auth_for_public_ai_hub;
   const enabledPagesProperty = schema?.properties?.enabled_ui_pages_internal_users;
   const values = data?.values ?? {};
   const isDisabledForInternalUsers = Boolean(values.disable_model_add_for_internal_users);
@@ -57,6 +58,20 @@ export default function UISettings() {
         NotificationManager.fromBackend(error);
       },
     });
+  };
+
+  const handleToggleRequireAuthForPublicAIHub = (checked: boolean) => {
+    updateSettings(
+      { require_auth_for_public_ai_hub: checked },
+      {
+        onSuccess: () => {
+          NotificationManager.success("UI settings updated successfully");
+        },
+        onError: (error) => {
+          NotificationManager.fromBackend(error);
+        },
+      },
+    );
   };
 
   return (
@@ -109,6 +124,22 @@ export default function UISettings() {
               <Typography.Text strong>Disable team admin delete team user</Typography.Text>
               {disableTeamAdminDeleteProperty?.description && (
                 <Typography.Text type="secondary">{disableTeamAdminDeleteProperty.description}</Typography.Text>
+              )}
+            </Space>
+          </Space>
+
+          <Space align="start" size="middle">
+            <Switch
+              checked={values.require_auth_for_public_ai_hub}
+              disabled={isUpdating}
+              loading={isUpdating}
+              onChange={handleToggleRequireAuthForPublicAIHub}
+              aria-label={requireAuthForPublicAIHubProperty?.description ?? "Require authentication for public AI Hub"}
+            />
+            <Space direction="vertical" size={4}>
+              <Typography.Text strong>Require authentication for public AI Hub</Typography.Text>
+              {requireAuthForPublicAIHubProperty?.description && (
+                <Typography.Text type="secondary">{requireAuthForPublicAIHubProperty.description}</Typography.Text>
               )}
             </Space>
           </Space>

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -8736,14 +8736,11 @@ export const loginCall = async (username: string, password: string): Promise<Log
   return data;
 };
 
-export const getUiSettings = async (accessToken: string) => {
+export const getUiSettings = async () => {
   const proxyBaseUrl = getProxyBaseUrl();
   const url = proxyBaseUrl ? `${proxyBaseUrl}/get/ui_settings` : `/get/ui_settings`;
   const response = await fetch(url, {
     method: "GET",
-    headers: {
-      [globalLitellmHeaderName]: `Bearer ${accessToken}`,
-    },
   });
   if (!response.ok) {
     const errorData = await response.json();

--- a/ui/litellm-dashboard/src/utils/jwtUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/jwtUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { isJwtExpired } from "./jwtUtils";
+import { isJwtExpired, decodeToken, checkTokenValidity } from "./jwtUtils";
 import { jwtDecode } from "jwt-decode";
 
 vi.mock("jwt-decode");
@@ -49,5 +49,82 @@ describe("jwtUtils", () => {
     });
 
     expect(isJwtExpired("invalid-token")).toBe(true);
+  });
+
+  describe("decodeToken", () => {
+    it("should return null if token is null", () => {
+      expect(decodeToken(null)).toBeNull();
+    });
+
+    it("should return null if token is empty string", () => {
+      expect(decodeToken("")).toBeNull();
+    });
+
+    it("should decode a valid token", () => {
+      const mockPayload = {
+        key: "api-key-123",
+        user_id: "user-1",
+        user_email: "user@example.com",
+        user_role: "app_admin",
+      };
+      vi.mocked(jwtDecode).mockReturnValue(mockPayload);
+
+      expect(decodeToken("valid-token")).toEqual(mockPayload);
+      expect(jwtDecode).toHaveBeenCalledWith("valid-token");
+    });
+
+    it("should return null if jwtDecode throws an error", () => {
+      vi.mocked(jwtDecode).mockImplementation(() => {
+        throw new Error("Invalid token");
+      });
+
+      expect(decodeToken("invalid-token")).toBeNull();
+    });
+  });
+
+  describe("checkTokenValidity", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("should return false if token is null", () => {
+      expect(checkTokenValidity(null)).toBe(false);
+    });
+
+    it("should return false if token is empty string", () => {
+      expect(checkTokenValidity("")).toBe(false);
+    });
+
+    it("should return true for a valid, non-expired token", () => {
+      const mockDateNow = 1716838401000;
+      vi.spyOn(Date, "now").mockReturnValue(mockDateNow);
+      const mockPayload = {
+        exp: Math.floor(mockDateNow / 1000) + 1000,
+        user_id: "user-1",
+      };
+      vi.mocked(jwtDecode).mockReturnValue(mockPayload);
+
+      expect(checkTokenValidity("valid-token")).toBe(true);
+    });
+
+    it("should return false for an expired token", () => {
+      const mockDateNow = 1716838401000;
+      vi.spyOn(Date, "now").mockReturnValue(mockDateNow);
+      const mockPayload = {
+        exp: Math.floor(mockDateNow / 1000) - 1,
+        user_id: "user-1",
+      };
+      vi.mocked(jwtDecode).mockReturnValue(mockPayload);
+
+      expect(checkTokenValidity("expired-token")).toBe(false);
+    });
+
+    it("should return false if token cannot be decoded", () => {
+      vi.mocked(jwtDecode).mockImplementation(() => {
+        throw new Error("Invalid token");
+      });
+
+      expect(checkTokenValidity("invalid-token")).toBe(false);
+    });
   });
 });

--- a/ui/litellm-dashboard/src/utils/jwtUtils.ts
+++ b/ui/litellm-dashboard/src/utils/jwtUtils.ts
@@ -12,3 +12,18 @@ export function isJwtExpired(token: string): boolean {
     return true;
   }
 }
+
+export function decodeToken(token: string | null): Record<string, any> | null {
+  if (!token) return null;
+  try {
+    return jwtDecode(token) as Record<string, any>;
+  } catch {
+    return null;
+  }
+}
+
+export function checkTokenValidity(token: string | null): boolean {
+  if (!token) return false;
+  const decoded = decodeToken(token);
+  return decoded !== null && !isJwtExpired(token);
+}


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🧹 Refactoring
✅ Test

## Changes

Adds a UI setting `require_auth_for_public_ai_hub` that allows administrators to require authentication for accessing the public AI Hub. When enabled, unauthenticated users are redirected to the login page. Refactors `useAuthorized` hook to consolidate token validation logic using `checkTokenValidity` and `decodeToken` utilities. Adds tests for ModelHubTable authentication flow, UISettings component, useAuthorized hook, and jwtUtils functions.

## Screenshots
<img width="1164" height="749" alt="image" src="https://github.com/user-attachments/assets/9178a059-dac6-4a9c-9861-e36a5e4a5a59" />
<img width="855" height="283" alt="image" src="https://github.com/user-attachments/assets/28272224-c7ca-4e29-bb48-7cf08e2b4481" />
