### PR TITLE
perf: optimize completion_cost()

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -119,6 +119,42 @@ if TYPE_CHECKING:
 else:
     LitellmLoggingObject = Any
 
+# Pre-resolved CallTypes enum values for fast membership checks
+_A2A_CALL_TYPES = frozenset({
+    CallTypes.asend_message.value,
+    CallTypes.send_message.value,
+})
+
+_VIDEO_CALL_TYPES = frozenset({
+    CallTypes.create_video.value,
+    CallTypes.acreate_video.value,
+    CallTypes.video_remix.value,
+    CallTypes.avideo_remix.value,
+})
+
+_SPEECH_CALL_TYPES = frozenset({
+    CallTypes.speech.value,
+    CallTypes.aspeech.value,
+})
+
+_TRANSCRIPTION_CALL_TYPES = frozenset({
+    CallTypes.atranscription.value,
+    CallTypes.transcription.value,
+})
+
+_RERANK_CALL_TYPES = frozenset({
+    CallTypes.rerank.value,
+    CallTypes.arerank.value,
+})
+
+_SEARCH_CALL_TYPES = frozenset({
+    CallTypes.search.value,
+    CallTypes.asearch.value,
+})
+
+_AREALTIME_CALL_TYPE = CallTypes.arealtime.value
+_MCP_CALL_TYPE = CallTypes.call_mcp_tool.value
+
 
 def _cost_per_token_custom_pricing_helper(
     prompt_tokens: float = 0,
@@ -1121,10 +1157,7 @@ def completion_cost(  # noqa: PLR0915
                     completion_tokens = token_counter(model=model, text=completion)
 
                 # Handle A2A calls before model check - A2A doesn't require a model
-                if call_type in (
-                    CallTypes.asend_message.value,
-                    CallTypes.send_message.value,
-                ):
+                if call_type in _A2A_CALL_TYPES:
                     from litellm.a2a_protocol.cost_calculator import A2ACostCalculator
 
                     return A2ACostCalculator.calculate_a2a_cost(
@@ -1160,12 +1193,7 @@ def completion_cost(  # noqa: PLR0915
                         optional_params=optional_params,
                         call_type=call_type,
                     )
-                elif (
-                    call_type == CallTypes.create_video.value
-                    or call_type == CallTypes.acreate_video.value
-                    or call_type == CallTypes.video_remix.value
-                    or call_type == CallTypes.avideo_remix.value
-                ):
+                elif call_type in _VIDEO_CALL_TYPES:
                     ### VIDEO GENERATION COST CALCULATION ###
                     usage_obj = getattr(completion_response, "usage", None)
                     if completion_response is not None and usage_obj:
@@ -1194,22 +1222,13 @@ def completion_cost(  # noqa: PLR0915
                         duration_seconds=0.0,  # Default to 0 if no duration available
                         custom_llm_provider=custom_llm_provider,
                     )
-                elif (
-                    call_type == CallTypes.speech.value
-                    or call_type == CallTypes.aspeech.value
-                ):
+                elif call_type in _SPEECH_CALL_TYPES:
                     prompt_characters = litellm.utils._count_characters(text=prompt)
-                elif (
-                    call_type == CallTypes.atranscription.value
-                    or call_type == CallTypes.transcription.value
-                ):
+                elif call_type in _TRANSCRIPTION_CALL_TYPES:
                     audio_transcription_file_duration = getattr(
                         completion_response, "duration", 0.0
                     )
-                elif (
-                    call_type == CallTypes.rerank.value
-                    or call_type == CallTypes.arerank.value
-                ):
+                elif call_type in _RERANK_CALL_TYPES:
                     if completion_response is not None and isinstance(
                         completion_response, RerankResponse
                     ):
@@ -1228,10 +1247,7 @@ def completion_cost(  # noqa: PLR0915
                             billed_units.get("search_units") or 1
                         )  # cohere charges per request by default.
                         completion_tokens = search_units
-                elif (
-                    call_type == CallTypes.search.value
-                    or call_type == CallTypes.asearch.value
-                ):
+                elif call_type in _SEARCH_CALL_TYPES:
                     from litellm.search import search_provider_cost_per_query
 
                     # Extract number_of_queries from optional_params or default to 1
@@ -1300,7 +1316,7 @@ def completion_cost(  # noqa: PLR0915
                     )
 
                     return _final_cost
-                elif call_type == CallTypes.arealtime.value and isinstance(
+                elif call_type == _AREALTIME_CALL_TYPE and isinstance(
                     completion_response, LiteLLMRealtimeStreamLoggingObject
                 ):
                     if (
@@ -1319,7 +1335,7 @@ def completion_cost(  # noqa: PLR0915
                         custom_llm_provider=custom_llm_provider,
                         litellm_model_name=model,
                     )
-                elif call_type == CallTypes.call_mcp_tool.value:
+                elif call_type == _MCP_CALL_TYPE:
                     from litellm.proxy._experimental.mcp_server.cost_calculator import (
                         MCPCostCalculator,
                     )
@@ -1393,7 +1409,7 @@ def completion_cost(  # noqa: PLR0915
                     cache_creation_input_tokens=cache_creation_input_tokens,
                     cache_read_input_tokens=cache_read_input_tokens,
                     usage_object=cost_per_token_usage_object,
-                    call_type=cast(CallTypesLiteral, call_type),
+                    call_type=call_type,
                     audio_transcription_file_duration=audio_transcription_file_duration,
                     rerank_billed_units=rerank_billed_units,
                     service_tier=service_tier,
@@ -1401,12 +1417,17 @@ def completion_cost(  # noqa: PLR0915
                 )
 
                 # Get additional costs from provider (e.g., routing fees, infrastructure costs)
-                additional_costs = _get_additional_costs(
-                    model=model,
-                    custom_llm_provider=custom_llm_provider,
-                    prompt_tokens=prompt_tokens,
-                    completion_tokens=completion_tokens,
-                )
+                # Only azure_ai implements additional costs
+                if custom_llm_provider == "azure_ai":
+                    additional_costs = _get_additional_costs(
+                        model=model,
+                        custom_llm_provider=custom_llm_provider,
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion_tokens,
+                    )
+                else:
+                    additional_costs = None
+
 
                 _final_cost = (
                     prompt_tokens_cost_usd_dollar + completion_tokens_cost_usd_dollar

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -16,6 +16,15 @@ from litellm.types.utils import (
 )
 from litellm.utils import get_model_info
 
+# Pre-resolved CallTypes enum values for fast membership checks
+_IMAGE_RESPONSE_CALL_TYPES = frozenset({
+    CallTypes.image_generation.value,
+    CallTypes.aimage_generation.value,
+    PassthroughCallTypes.passthrough_image_generation.value,
+    CallTypes.image_edit.value,
+    CallTypes.aimage_edit.value,
+})
+
 
 def _is_above_128k(tokens: float) -> bool:
     if tokens > 128000:
@@ -718,18 +727,7 @@ class CostCalculatorUtils:
         - Image Edit
         - Passthrough Image Generation
         """
-        if call_type in [
-            # image generation
-            CallTypes.image_generation.value,
-            CallTypes.aimage_generation.value,
-            # passthrough image generation
-            PassthroughCallTypes.passthrough_image_generation.value,
-            # image edit
-            CallTypes.image_edit.value,
-            CallTypes.aimage_edit.value,
-        ]:
-            return True
-        return False
+        return call_type in _IMAGE_RESPONSE_CALL_TYPES
 
     @staticmethod
     def route_image_generation_cost_calculator(


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring
✅ Test

## Changes

- Pre-resolve CallTypes enum values into module-level frozensets to avoid repeated .value attribute access in the elif chain, was doing CallTypes.___.value on enum twice per if branch which was a lot of redundant enum accesses 

- Remove unnecessary cast(CallTypesLiteral, call_type) because it's already correctly typed no need to cast

- Guard _get_additional_costs() with azure_ai-only check since no other provider implements additional costs: 

litellm/llms/base_llm/chat/transformation.py:441: BaseConfig.calculate_additional_costs() returns None
litellm/cost_calculator.py:180: _get_additional_costs() only branches on custom_llm_provider == "azure_ai" for every other provider it returns None

Line profile shows ~50% reduction in completion_cost() total time (7.14s → 3.58s across 6,006 calls)

All tests pass before and after + added test to make sure its only Azure that gets additional costs

Before 

<img width="631" height="162" alt="Screenshot 2026-02-04 at 3 50 56 PM" src="https://github.com/user-attachments/assets/4ea98b25-baa0-42d5-b477-7afa8b3cb2b7" />

After 

<img width="672" height="162" alt="Screenshot 2026-02-04 at 4 12 58 PM" src="https://github.com/user-attachments/assets/73e48dd3-a1f9-4bf0-a617-f4f5c92f985f" />