### PR TITLE
perf: optimize should_run_callback()

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1538,8 +1538,13 @@ class Logging(LiteLLMLoggingBaseClass):
                 return False
 
         # Check for dynamically disabled callbacks via headers
+        # Skip the enterprise call entirely when no dynamic disabling is configured
         if (
             EnterpriseCallbackControls is not None
+            and (
+                self.standard_callback_dynamic_params.get("litellm_disabled_callbacks") is not None
+                or litellm_params.get("proxy_server_request", {}).get("headers", {}).get("x-litellm-disable-callbacks") is not None
+            )
             and EnterpriseCallbackControls.is_callback_disabled_dynamically(
                 callback=callback,
                 litellm_params=litellm_params,


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring
✅ Test
Performance

## Changes

Add cheap .get() guards in should_run_callback() to short-circuit the expensive `EnterpriseCallbackControls.is_callback_disabled_dynamically()` call. 

When neither litellm_disabled_callbacks nor x-litellm-disable-callbacks header is set, the enterprise function is never entered, reducing should_run_callback from ~485ms to ~93-165ms across 54k calls, ~81% improvement 

Before 

<img width="823" height="159" alt="Screenshot 2026-02-04 at 4 59 26 PM" src="https://github.com/user-attachments/assets/4f731770-f81f-4d7d-99a0-716951ca889b" />

After

<img width="824" height="158" alt="Screenshot 2026-02-04 at 4 59 30 PM" src="https://github.com/user-attachments/assets/af02258e-99f9-4eb3-8d03-f2bcb65aaef9" />

