### PR TITLE
feat(openrouter): add Qwen3-235B models

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -24096,6 +24096,31 @@
         "supports_tool_choice": true,
         "supports_function_calling": true
     },
+    "openrouter/qwen/qwen3-235b-a22b-2507": {
+        "input_cost_per_token": 7.1e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "source": "https://openrouter.ai/qwen/qwen3-235b-a22b-2507",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "openrouter/qwen/qwen3-235b-a22b-thinking-2507": {
+        "input_cost_per_token": 1.1e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "source": "https://openrouter.ai/qwen/qwen3-235b-a22b-thinking-2507",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "openrouter/switchpoint/router": {
         "input_cost_per_token": 8.5e-07,
         "litellm_provider": "openrouter",


### PR DESCRIPTION
## Relevant issues

Addresses request from [PR #13019 comment](https://github.com/BerriAI/litellm/pull/13019#issuecomment-3821067376)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - N/A (pricing data only, no code changes)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Add OpenRouter Qwen3-235B-A22B models to `model_prices_and_context_window.json`:

| Model | Input $/M | Output $/M | Context | Features |
|-------|-----------|------------|---------|----------|
| `openrouter/qwen/qwen3-235b-a22b-2507` | $0.071 | $0.10 | 262,144 | function_calling, tool_choice |
| `openrouter/qwen/qwen3-235b-a22b-thinking-2507` | $0.11 | $0.60 | 262,144 | function_calling, tool_choice, reasoning |

Pricing verified from OpenRouter documentation:
- https://openrouter.ai/qwen/qwen3-235b-a22b-2507
- https://openrouter.ai/qwen/qwen3-235b-a22b-thinking-2507