### PR TITLE
Fix websearch interception with extended thinking mode support

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6352,6 +6352,11 @@ class Router:
             ):
                 raise Exception(f"Unsupported provider - {custom_llm_provider}")
 
+            # Store custom_llm_provider in litellm_params so it's available to callbacks
+            # after alias resolution (e.g., websearch_interception pre-call hooks)
+            if custom_llm_provider:
+                deployment.litellm_params.custom_llm_provider = custom_llm_provider
+
         #### DEPLOYMENT NAMES INIT ########
         self.deployment_names.append(deployment.litellm_params.model)
         ############ Users can either pass tpm/rpm as a litellm_param or a router param ###########

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
@@ -4,14 +4,108 @@ Unit tests for WebSearch Interception Handler
 Tests the WebSearchInterceptionLogger class and helper functions.
 """
 
+import asyncio
 from unittest.mock import Mock
 
-import pytest
 
+from litellm.constants import LITELLM_WEB_SEARCH_TOOL_NAME
 from litellm.integrations.websearch_interception.handler import (
     WebSearchInterceptionLogger,
 )
+from litellm.integrations.websearch_interception.tools import (
+    get_litellm_web_search_tool,
+    is_web_search_tool,
+)
+from litellm.litellm_core_utils.core_helpers import filter_internal_params
 from litellm.types.utils import LlmProviders
+
+
+class TestIsWebSearchTool:
+    """Tests for is_web_search_tool() helper function"""
+
+    def test_litellm_standard_tool(self):
+        """Should detect LiteLLM standard web search tool"""
+        tool = {"name": LITELLM_WEB_SEARCH_TOOL_NAME}
+        assert is_web_search_tool(tool) is True
+
+    def test_anthropic_native_web_search(self):
+        """Should detect Anthropic native web_search_* type"""
+        tool = {"type": "web_search_20250305", "name": "web_search"}
+        assert is_web_search_tool(tool) is True
+
+    def test_anthropic_native_future_version(self):
+        """Should detect future versions of Anthropic web_search type"""
+        tool = {"type": "web_search_20260101", "name": "web_search"}
+        assert is_web_search_tool(tool) is True
+
+    def test_claude_code_web_search(self):
+        """Should detect Claude Code's web_search with type field"""
+        tool = {"name": "web_search", "type": "web_search_20250305"}
+        assert is_web_search_tool(tool) is True
+
+    def test_legacy_websearch_format(self):
+        """Should detect legacy WebSearch format"""
+        tool = {"name": "WebSearch"}
+        assert is_web_search_tool(tool) is True
+
+    def test_non_websearch_tool(self):
+        """Should not detect non-web-search tools"""
+        assert is_web_search_tool({"name": "calculator"}) is False
+        assert is_web_search_tool({"name": "read_file"}) is False
+        assert is_web_search_tool({"type": "function", "name": "search"}) is False
+
+    def test_web_search_name_without_type(self):
+        """Should NOT detect 'web_search' name without type field (could be custom tool)"""
+        tool = {"name": "web_search"}  # No type field
+        assert is_web_search_tool(tool) is False
+
+
+class TestGetLitellmWebSearchTool:
+    """Tests for get_litellm_web_search_tool() helper function"""
+
+    def test_returns_valid_tool_definition(self):
+        """Should return a valid tool definition"""
+        tool = get_litellm_web_search_tool()
+
+        assert tool["name"] == LITELLM_WEB_SEARCH_TOOL_NAME
+        assert "description" in tool
+        assert "input_schema" in tool
+        assert tool["input_schema"]["type"] == "object"
+        assert "query" in tool["input_schema"]["properties"]
+
+
+class TestWebSearchInterceptionLoggerInit:
+    """Tests for WebSearchInterceptionLogger initialization"""
+
+    def test_default_initialization(self):
+        """Test default initialization with no parameters"""
+        logger = WebSearchInterceptionLogger()
+
+        # Default should have bedrock enabled
+        assert "bedrock" in logger.enabled_providers
+        assert logger.search_tool_name is None
+
+    def test_custom_providers(self):
+        """Test initialization with custom providers"""
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock", "vertex_ai", "openai"])
+
+        assert "bedrock" in logger.enabled_providers
+        assert "vertex_ai" in logger.enabled_providers
+        assert "openai" in logger.enabled_providers
+
+    def test_custom_search_tool_name(self):
+        """Test initialization with custom search tool name"""
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"], search_tool_name="custom-search-tool")
+
+        assert logger.search_tool_name == "custom-search-tool"
+
+    def test_llm_providers_enum_conversion(self):
+        """Test that LlmProviders enum values are converted to strings"""
+        logger = WebSearchInterceptionLogger(enabled_providers=[LlmProviders.BEDROCK, LlmProviders.VERTEX_AI])
+
+        # Should be stored as string values
+        assert "bedrock" in logger.enabled_providers
+        assert "vertex_ai" in logger.enabled_providers
 
 
 def test_initialize_from_proxy_config():
@@ -34,50 +128,221 @@ def test_initialize_from_proxy_config():
     assert logger.search_tool_name == "my-search"
 
 
-@pytest.mark.asyncio
-async def test_async_should_run_agentic_loop():
-    """Test that agentic loop is NOT triggered for wrong provider or missing WebSearch tool"""
-    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+def test_initialize_from_proxy_config_defaults():
+    """Test initialization from proxy config with defaults when params missing"""
+    litellm_settings = {}
+    callback_specific_params = {}
 
-    # Test 1: Wrong provider (not in enabled_providers)
-    response = Mock()
-    should_run, tools_dict = await logger.async_should_run_agentic_loop(
-        response=response,
-        model="gpt-4",
-        messages=[],
-        tools=[{"name": "WebSearch"}],
-        stream=False,
-        custom_llm_provider="openai",  # Not in enabled_providers
-        kwargs={},
+    logger = WebSearchInterceptionLogger.initialize_from_proxy_config(
+        litellm_settings=litellm_settings,
+        callback_specific_params=callback_specific_params,
     )
 
-    assert should_run is False
-    assert tools_dict == {}
-
-    # Test 2: No WebSearch tool in request
-    should_run, tools_dict = await logger.async_should_run_agentic_loop(
-        response=response,
-        model="bedrock/claude",
-        messages=[],
-        tools=[{"name": "SomeOtherTool"}],  # No WebSearch
-        stream=False,
-        custom_llm_provider="bedrock",
-        kwargs={},
-    )
-
-    assert should_run is False
-    assert tools_dict == {}
+    # Should use default bedrock provider
+    assert "bedrock" in logger.enabled_providers
 
 
-@pytest.mark.asyncio
-async def test_internal_flags_filtered_from_followup_kwargs():
+def test_async_should_run_agentic_loop_wrong_provider():
+    """Test that agentic loop is NOT triggered for wrong provider"""
+
+    async def _test():
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+        response = Mock()
+        should_run, tools_dict = await logger.async_should_run_agentic_loop(
+            response=response,
+            model="gpt-4",
+            messages=[],
+            tools=[{"type": "web_search_20250305", "name": "web_search"}],
+            stream=False,
+            custom_llm_provider="openai",  # Not in enabled_providers
+            kwargs={},
+        )
+
+        assert should_run is False
+        assert tools_dict == {}
+
+    asyncio.run(_test())
+
+
+def test_async_should_run_agentic_loop_no_websearch_tool():
+    """Test that agentic loop is NOT triggered when no WebSearch tool in request"""
+
+    async def _test():
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+        response = Mock()
+        should_run, tools_dict = await logger.async_should_run_agentic_loop(
+            response=response,
+            model="bedrock/claude",
+            messages=[],
+            tools=[{"name": "calculator"}],  # No WebSearch tool
+            stream=False,
+            custom_llm_provider="bedrock",
+            kwargs={},
+        )
+
+        assert should_run is False
+        assert tools_dict == {}
+
+    asyncio.run(_test())
+
+
+def test_async_should_run_agentic_loop_no_websearch_in_response():
+    """Test that agentic loop is NOT triggered when response has no WebSearch tool_use"""
+
+    async def _test():
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+        # Response with text only, no tool_use
+        response = {"content": [{"type": "text", "text": "I don't need to search for this."}]}
+
+        should_run, tools_dict = await logger.async_should_run_agentic_loop(
+            response=response,
+            model="bedrock/claude",
+            messages=[],
+            tools=[{"type": "web_search_20250305", "name": "web_search"}],
+            stream=False,
+            custom_llm_provider="bedrock",
+            kwargs={},
+        )
+
+        assert should_run is False
+        assert tools_dict == {}
+
+    asyncio.run(_test())
+
+
+def test_async_should_run_agentic_loop_positive_case():
+    """Test that agentic loop IS triggered when WebSearch tool_use in response"""
+
+    async def _test():
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+        # Response with WebSearch tool_use
+        response = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tool_123",
+                    "name": "WebSearch",
+                    "input": {"query": "weather in SF"},
+                }
+            ]
+        }
+
+        should_run, tools_dict = await logger.async_should_run_agentic_loop(
+            response=response,
+            model="bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0",
+            messages=[],
+            tools=[{"type": "web_search_20250305", "name": "web_search"}],
+            stream=False,
+            custom_llm_provider="bedrock",
+            kwargs={},
+        )
+
+        assert should_run is True
+        assert "tool_calls" in tools_dict
+        assert len(tools_dict["tool_calls"]) == 1
+        assert tools_dict["tool_calls"][0]["id"] == "tool_123"
+        assert tools_dict["tool_type"] == "websearch"
+
+    asyncio.run(_test())
+
+
+def test_async_should_run_agentic_loop_includes_thinking_blocks():
+    """Test that thinking blocks are captured in tools_dict"""
+
+    async def _test():
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+        # Response with thinking block and WebSearch tool_use
+        response = {
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "Let me search for the weather...",
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tool_456",
+                    "name": "WebSearch",
+                    "input": {"query": "current weather SF"},
+                },
+            ]
+        }
+
+        should_run, tools_dict = await logger.async_should_run_agentic_loop(
+            response=response,
+            model="bedrock/claude",
+            messages=[],
+            tools=[{"type": "web_search_20250305", "name": "web_search"}],
+            stream=False,
+            custom_llm_provider="bedrock",
+            kwargs={},
+        )
+
+        assert should_run is True
+        assert "thinking_blocks" in tools_dict
+        assert len(tools_dict["thinking_blocks"]) == 1
+        assert tools_dict["thinking_blocks"][0]["type"] == "thinking"
+
+    asyncio.run(_test())
+
+
+def test_async_should_run_agentic_loop_empty_tools_list():
+    """Test with empty tools list"""
+
+    async def _test():
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+        response = Mock()
+        should_run, tools_dict = await logger.async_should_run_agentic_loop(
+            response=response,
+            model="bedrock/claude",
+            messages=[],
+            tools=[],  # Empty tools list
+            stream=False,
+            custom_llm_provider="bedrock",
+            kwargs={},
+        )
+
+        assert should_run is False
+        assert tools_dict == {}
+
+    asyncio.run(_test())
+
+
+def test_async_should_run_agentic_loop_none_tools():
+    """Test with None tools"""
+
+    async def _test():
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+        response = Mock()
+        should_run, tools_dict = await logger.async_should_run_agentic_loop(
+            response=response,
+            model="bedrock/claude",
+            messages=[],
+            tools=None,  # None tools
+            stream=False,
+            custom_llm_provider="bedrock",
+            kwargs={},
+        )
+
+        assert should_run is False
+        assert tools_dict == {}
+
+    asyncio.run(_test())
+
+
+def test_internal_flags_filtered_from_followup_kwargs():
     """Test that internal _websearch_interception flags are filtered from follow-up request kwargs.
 
     Regression test for bug where _websearch_interception_converted_stream was passed
     to the follow-up LLM request, causing "Extra inputs are not permitted" errors
     from providers like Bedrock that use strict parameter validation.
     """
-    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
 
     # Simulate kwargs that would be passed during agentic loop execution
     kwargs_with_internal_flags = {
@@ -87,11 +352,8 @@ async def test_internal_flags_filtered_from_followup_kwargs():
         "max_tokens": 1024,
     }
 
-    # Apply the same filtering logic used in _execute_agentic_loop
-    kwargs_for_followup = {
-        k: v for k, v in kwargs_with_internal_flags.items()
-        if not k.startswith('_websearch_interception')
-    }
+    # Use the actual filter function from the codebase
+    kwargs_for_followup = filter_internal_params(kwargs_with_internal_flags)
 
     # Verify internal flags are filtered out
     assert "_websearch_interception_converted_stream" not in kwargs_for_followup

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_transformation.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_transformation.py
@@ -1,0 +1,427 @@
+"""
+Unit tests for WebSearch Interception Transformation
+
+Tests the WebSearchTransformation class methods:
+- transform_request: Extract WebSearch tool calls and thinking blocks from responses
+- transform_response: Build follow-up messages with tool_use and tool_result blocks
+- format_search_response: Format search results for tool_result content
+"""
+
+from unittest.mock import Mock
+
+
+from litellm.constants import LITELLM_WEB_SEARCH_TOOL_NAME
+from litellm.integrations.websearch_interception.transformation import (
+    WebSearchTransformation,
+)
+
+
+class TestTransformRequest:
+    """Tests for WebSearchTransformation.transform_request()"""
+
+    def test_streaming_response_returns_empty(self):
+        """Streaming responses should return empty result (we handle by converting to non-streaming)"""
+        response = {"content": [{"type": "tool_use", "name": "WebSearch"}]}
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=True,
+        )
+
+        assert result.has_websearch is False
+        assert result.tool_calls == []
+        assert result.thinking_blocks == []
+
+    def test_dict_response_with_websearch_tool(self):
+        """Dict response with WebSearch tool_use should be detected"""
+        response = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tool_123",
+                    "name": "WebSearch",
+                    "input": {"query": "weather in SF"},
+                }
+            ]
+        }
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=False,
+        )
+
+        assert result.has_websearch is True
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["id"] == "tool_123"
+        assert result.tool_calls[0]["name"] == "WebSearch"
+        assert result.tool_calls[0]["input"]["query"] == "weather in SF"
+
+    def test_object_response_with_websearch_tool(self):
+        """Object response (with attributes) with WebSearch tool_use should be detected"""
+        tool_block = Mock()
+        tool_block.type = "tool_use"
+        tool_block.id = "tool_456"
+        tool_block.name = "WebSearch"
+        tool_block.input = {"query": "latest news"}
+
+        response = Mock()
+        response.content = [tool_block]
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=False,
+        )
+
+        assert result.has_websearch is True
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["id"] == "tool_456"
+        assert result.tool_calls[0]["input"]["query"] == "latest news"
+
+    def test_detects_litellm_web_search_tool_name(self):
+        """Should detect the LiteLLM standard web search tool name"""
+        response = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tool_789",
+                    "name": LITELLM_WEB_SEARCH_TOOL_NAME,
+                    "input": {"query": "test query"},
+                }
+            ]
+        }
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=False,
+        )
+
+        assert result.has_websearch is True
+        assert result.tool_calls[0]["name"] == LITELLM_WEB_SEARCH_TOOL_NAME
+
+    def test_detects_web_search_lowercase(self):
+        """Should detect 'web_search' tool name (lowercase variant)"""
+        response = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tool_abc",
+                    "name": "web_search",
+                    "input": {"query": "another query"},
+                }
+            ]
+        }
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=False,
+        )
+
+        assert result.has_websearch is True
+        assert result.tool_calls[0]["name"] == "web_search"
+
+    def test_captures_thinking_blocks(self):
+        """Should capture thinking blocks from response"""
+        response = {
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "Let me search for this information...",
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tool_def",
+                    "name": "WebSearch",
+                    "input": {"query": "AI news"},
+                },
+            ]
+        }
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=False,
+        )
+
+        assert result.has_websearch is True
+        assert len(result.thinking_blocks) == 1
+        assert result.thinking_blocks[0]["type"] == "thinking"
+
+    def test_captures_redacted_thinking_blocks(self):
+        """Should capture redacted_thinking blocks from response"""
+        response = {
+            "content": [
+                {
+                    "type": "redacted_thinking",
+                    "data": "base64redacteddata",
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tool_ghi",
+                    "name": "WebSearch",
+                    "input": {"query": "sensitive query"},
+                },
+            ]
+        }
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=False,
+        )
+
+        assert result.has_websearch is True
+        assert len(result.thinking_blocks) == 1
+        assert result.thinking_blocks[0]["type"] == "redacted_thinking"
+
+    def test_thinking_blocks_normalized_to_dict_from_sdk_objects(self):
+        """SDK object thinking blocks should be normalized to dicts for JSON serialization"""
+        # Create mock SDK objects (not dicts)
+        thinking_block = Mock()
+        thinking_block.type = "thinking"
+        thinking_block.thinking = "Let me search for this..."
+        thinking_block.signature = "sig123"
+
+        redacted_block = Mock()
+        redacted_block.type = "redacted_thinking"
+        redacted_block.data = "base64redacteddata"
+
+        tool_block = Mock()
+        tool_block.type = "tool_use"
+        tool_block.id = "tool_xyz"
+        tool_block.name = "WebSearch"
+        tool_block.input = {"query": "test"}
+
+        response = Mock()
+        response.content = [thinking_block, redacted_block, tool_block]
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=False,
+        )
+
+        assert result.has_websearch is True
+        assert len(result.thinking_blocks) == 2
+
+        # Verify blocks were normalized to dicts (not Mock objects)
+        assert isinstance(result.thinking_blocks[0], dict)
+        assert isinstance(result.thinking_blocks[1], dict)
+
+        # Verify thinking block content including signature
+        assert result.thinking_blocks[0]["type"] == "thinking"
+        assert result.thinking_blocks[0]["thinking"] == "Let me search for this..."
+        assert result.thinking_blocks[0]["signature"] == "sig123"
+
+        # Verify redacted_thinking block content
+        assert result.thinking_blocks[1]["type"] == "redacted_thinking"
+        assert result.thinking_blocks[1]["data"] == "base64redacteddata"
+
+    def test_multiple_tool_calls(self):
+        """Should handle multiple WebSearch tool_use blocks"""
+        response = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tool_1",
+                    "name": "WebSearch",
+                    "input": {"query": "query 1"},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tool_2",
+                    "name": "WebSearch",
+                    "input": {"query": "query 2"},
+                },
+            ]
+        }
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=False,
+        )
+
+        assert result.has_websearch is True
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0]["input"]["query"] == "query 1"
+        assert result.tool_calls[1]["input"]["query"] == "query 2"
+
+    def test_no_websearch_in_response(self):
+        """Response without WebSearch tool should return has_websearch=False"""
+        response = {
+            "content": [
+                {"type": "text", "text": "Here is a response"},
+                {
+                    "type": "tool_use",
+                    "id": "tool_other",
+                    "name": "calculator",
+                    "input": {"expression": "2+2"},
+                },
+            ]
+        }
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=False,
+        )
+
+        assert result.has_websearch is False
+        assert result.tool_calls == []
+
+    def test_empty_content_returns_empty_result(self):
+        """Empty content should return empty result"""
+        response = {"content": []}
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=False,
+        )
+
+        assert result.has_websearch is False
+        assert result.tool_calls == []
+        assert result.thinking_blocks == []
+
+    def test_response_without_content_attribute(self):
+        """Response object without content attribute should return empty result"""
+        response = Mock(spec=[])  # Mock with no attributes
+
+        result = WebSearchTransformation.transform_request(
+            response=response,
+            stream=False,
+        )
+
+        assert result.has_websearch is False
+
+
+class TestTransformResponse:
+    """Tests for WebSearchTransformation.transform_response()"""
+
+    def test_builds_messages_without_thinking_blocks(self):
+        """Should build correct messages without thinking blocks"""
+        tool_calls = [
+            {
+                "id": "tool_1",
+                "name": "WebSearch",
+                "input": {"query": "test query"},
+            }
+        ]
+        search_results = ["Title: Result\nURL: http://example.com\nSnippet: Test snippet"]
+        thinking_blocks = []
+
+        assistant_msg, user_msg = WebSearchTransformation.transform_response(
+            tool_calls=tool_calls,
+            search_results=search_results,
+            thinking_blocks=thinking_blocks,
+        )
+
+        # Check assistant message
+        assert assistant_msg["role"] == "assistant"
+        assert len(assistant_msg["content"]) == 1
+        assert assistant_msg["content"][0]["type"] == "tool_use"
+        assert assistant_msg["content"][0]["id"] == "tool_1"
+        assert assistant_msg["content"][0]["name"] == "WebSearch"
+
+        # Check user message
+        assert user_msg["role"] == "user"
+        assert len(user_msg["content"]) == 1
+        assert user_msg["content"][0]["type"] == "tool_result"
+        assert user_msg["content"][0]["tool_use_id"] == "tool_1"
+        assert "Test snippet" in user_msg["content"][0]["content"]
+
+    def test_builds_messages_with_thinking_blocks(self):
+        """Should include thinking blocks at start of assistant message"""
+        tool_calls = [
+            {
+                "id": "tool_2",
+                "name": "WebSearch",
+                "input": {"query": "another query"},
+            }
+        ]
+        search_results = ["Search result text"]
+        thinking_blocks = [{"type": "thinking", "thinking": "I need to search for this..."}]
+
+        assistant_msg, user_msg = WebSearchTransformation.transform_response(
+            tool_calls=tool_calls,
+            search_results=search_results,
+            thinking_blocks=thinking_blocks,
+        )
+
+        # Check assistant message has thinking block first, then tool_use
+        assert len(assistant_msg["content"]) == 2
+        assert assistant_msg["content"][0]["type"] == "thinking"
+        assert assistant_msg["content"][1]["type"] == "tool_use"
+
+    def test_multiple_tool_calls_and_results(self):
+        """Should handle multiple tool calls and their results"""
+        tool_calls = [
+            {"id": "tool_a", "name": "WebSearch", "input": {"query": "q1"}},
+            {"id": "tool_b", "name": "WebSearch", "input": {"query": "q2"}},
+        ]
+        search_results = ["Result A", "Result B"]
+        thinking_blocks = []
+
+        assistant_msg, user_msg = WebSearchTransformation.transform_response(
+            tool_calls=tool_calls,
+            search_results=search_results,
+            thinking_blocks=thinking_blocks,
+        )
+
+        # Check tool_use blocks in assistant message
+        assert len(assistant_msg["content"]) == 2
+        assert assistant_msg["content"][0]["id"] == "tool_a"
+        assert assistant_msg["content"][1]["id"] == "tool_b"
+
+        # Check tool_result blocks in user message
+        assert len(user_msg["content"]) == 2
+        assert user_msg["content"][0]["tool_use_id"] == "tool_a"
+        assert user_msg["content"][0]["content"] == "Result A"
+        assert user_msg["content"][1]["tool_use_id"] == "tool_b"
+        assert user_msg["content"][1]["content"] == "Result B"
+
+
+class TestFormatSearchResponse:
+    """Tests for WebSearchTransformation.format_search_response()"""
+
+    def test_formats_search_response_with_results(self):
+        """Should format SearchResponse with results into readable text"""
+        # Create mock SearchResponse
+        result1 = Mock()
+        result1.title = "First Result"
+        result1.url = "https://example.com/1"
+        result1.snippet = "This is the first snippet."
+
+        result2 = Mock()
+        result2.title = "Second Result"
+        result2.url = "https://example.com/2"
+        result2.snippet = "This is the second snippet."
+
+        search_response = Mock()
+        search_response.results = [result1, result2]
+
+        formatted = WebSearchTransformation.format_search_response(search_response)
+
+        assert "Title: First Result" in formatted
+        assert "URL: https://example.com/1" in formatted
+        assert "Snippet: This is the first snippet." in formatted
+        assert "Title: Second Result" in formatted
+
+    def test_formats_empty_results(self):
+        """Should handle SearchResponse with no results"""
+        search_response = Mock()
+        search_response.results = []
+
+        formatted = WebSearchTransformation.format_search_response(search_response)
+
+        # Should fallback to str(result)
+        assert formatted  # Not empty
+
+    def test_formats_response_without_results_attribute(self):
+        """Should fallback to str() for responses without results attribute"""
+
+        # Create a simple class without 'results' attribute that converts to string
+        class SimpleResponse:
+            def __str__(self):
+                return "Fallback string representation"
+
+        search_response = SimpleResponse()
+
+        formatted = WebSearchTransformation.format_search_response(search_response)
+
+        # Should use str() fallback since no results attribute
+        assert formatted == "Fallback string representation"

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,3 @@
 version = 1
 revision = 3
-requires-python = ">=3.13"
+requires-python = ">=3.12"


### PR DESCRIPTION
## Motivation
When Anthropic's extended thinking is enabled, assistant messages must start with thinking blocks before tool_use blocks. The agentic loop was creating follow-up messages with only tool_use blocks, causing validation errors. This change ensures thinking blocks from the original response are preserved and included at the start of follow-up assistant messages.

## Implementation
- Created `TransformRequestResult` NamedTuple to capture both tool_calls and thinking_blocks from `transform_request()`, making the contract explicit and extensible
- Modified `transform_request()` to extract and return thinking/redacted_thinking blocks alongside tool calls
- Updated `transform_response()` to accept thinking_blocks and prepend them to follow-up assistant messages
- Passed thinking_blocks through the agentic loop chain: detection → execution → message transformation
- Fixed `transform_request()` to return full kwargs (not just tools) to preserve other request parameters
- Used `filter_internal_params()` utility instead of manual filtering for consistency

## Additional Context
This change fixes websearch interception when extended thinking mode is enabled.

**Problem**: When Anthropic's extended thinking is enabled, assistant messages must start with thinking blocks before tool_use blocks. The agentic loop was creating follow-up messages with only tool_use blocks, causing the error: `messages.1.content.0.type: Expected 'thinking' or 'redacted_thinking', but found 'tool_use'`

**Solution**: Modified `transform_request()` to capture thinking/redacted_thinking blocks from the original response, and `transform_response()` to include them at the start of the assistant message in follow-up requests.

**Testing**: Successfully tested end-to-end with Claude Code → LiteLLM Proxy → AWS Bedrock → Claude Opus 4.5.

## Configuration Example
```yaml
model_list:
  - model_name: claude-opus-4-5-20251101
    litellm_params:
      model: bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0
      aws_region_name: us-west-2
    model_info:
      supports_web_search: true
litellm_settings:
  callbacks: ["websearch_interception"]
  websearch_interception_params:
    enabled_providers: ["bedrock"]
    search_tool_name: "searxng-search"
search_tools:
  - search_tool_name: searxng-search
    litellm_params:
      search_provider: searxng
      api_base: "https://searxng.example.com"
```

**Note**: Uses `bedrock/` (not `bedrock/converse/`) to route through `anthropic_messages_handler()` which supports agentic hooks.