### PR TITLE
Fix unauthenticated proxy key logs for config-defined models

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3000,6 +3000,12 @@ class ProxyException(Exception):
             error_dict["provider_specific_fields"] = self.provider_specific_fields
         return error_dict
 
+class ProxyAuthenticationException(ProxyException):
+    """
+    Expected auth error (401) for invalid or missing proxy token.
+    Logged as unauthenticated, not as an internal crash.
+    """
+    pass
 
 class CommonProxyErrors(str, enum.Enum):
     db_not_connected_error = (

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1798,7 +1798,7 @@ async def get_key_object(
     )
 
     if _valid_token is None:
-        raise ProxyException(
+        raise ProxyAuthenticationException(
             message="Authentication Error, Invalid proxy server token passed. key={}, not found in db. Create key via `/key/generate` call.".format(
                 hashed_token
             ),

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -48,6 +48,7 @@ from litellm.proxy._types import (
     LitellmUserRoles,
     NewTeamRequest,
     ProxyErrorTypes,
+    ProxyAuthenticationException,
     ProxyException,
     RoleBasedPermissions,
     SpecialModelNames,


### PR DESCRIPTION
## Relevant issues

Fixes #20482

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
  Link:
- [ ] **CI run for the last commit**  
  Link:
- [ ] **Merge / cherry-pick CI run**  
  Links:

## Type

🐛 Bug Fix

## Changes

- Add `ProxyAuthenticationException(ProxyException)` in `litellm/proxy/_types.py` to represent expected 401 auth errors for invalid or missing proxy tokens. [file:140]
- Use `ProxyAuthenticationException` in `get_key_object` when a syntactically valid proxy key is not found in cache/DB, keeping the client response as 401 with `type: "token_not_found_in_db"`. [file:140]
- This lets `{+request log}` and internal logging distinguish unauthenticated requests from other `ProxyException` errors without changing external
