### PR TITLE
[Feat] add ElevenLabs eleven_v3 and eleven_multilingual_v2 to model cost map

### DIFF
--- a/docs/my-website/docs/providers/elevenlabs.md
+++ b/docs/my-website/docs/providers/elevenlabs.md
@@ -250,12 +250,6 @@ ElevenLabs provides high-quality text-to-speech capabilities through their TTS A
 | Eleven v3 | `elevenlabs/eleven_v3` | Most expressive model. 70+ languages, audio tags support for sound effects and pauses. |
 | Eleven Multilingual v2 | `elevenlabs/eleven_multilingual_v2` | Default TTS model. 29 languages, stable and production-ready. |
 
-:::tip
-
-ElevenLabs integration is model-agnostic — any valid `model_id` from ElevenLabs will work (e.g. `elevenlabs/eleven_turbo_v2`). The models listed above are officially registered for cost tracking.
-
-:::
-
 ### Quick Start
 
 #### LiteLLM Python SDK

--- a/docs/my-website/docs/providers/elevenlabs.md
+++ b/docs/my-website/docs/providers/elevenlabs.md
@@ -243,6 +243,19 @@ ElevenLabs provides high-quality text-to-speech capabilities through their TTS A
 | Supported Operations | `/audio/speech` |
 | Link to Provider Doc | [ElevenLabs TTS API ↗](https://elevenlabs.io/docs/api-reference/text-to-speech) |
 
+### Supported Models
+
+| Model | Route | Description |
+|-------|-------|-------------|
+| Eleven v3 | `elevenlabs/eleven_v3` | Most expressive model. 70+ languages, audio tags support for sound effects and pauses. |
+| Eleven Multilingual v2 | `elevenlabs/eleven_multilingual_v2` | Default TTS model. 29 languages, stable and production-ready. |
+
+:::tip
+
+ElevenLabs integration is model-agnostic — any valid `model_id` from ElevenLabs will work (e.g. `elevenlabs/eleven_turbo_v2`). The models listed above are officially registered for cost tracking.
+
+:::
+
 ### Quick Start
 
 #### LiteLLM Python SDK
@@ -262,6 +275,26 @@ audio = litellm.speech(
 
 # Save audio to file
 with open("test_output.mp3", "wb") as f:
+    f.write(audio.read())
+```
+
+#### Using Eleven v3 with Audio Tags
+
+Eleven v3 supports [audio tags](https://elevenlabs.io/docs/overview/capabilities/text-to-speech#audio-tags) for adding sound effects and pauses directly in the text:
+
+```python showLineNumbers title="Eleven v3 with audio tags"
+import litellm
+import os
+
+os.environ["ELEVENLABS_API_KEY"] = "your-elevenlabs-api-key"
+
+audio = litellm.speech(
+    model="elevenlabs/eleven_v3",
+    input='Welcome back. <sfx>applause</sfx> Today we have a special guest. <pause duration="1.5s"/> Let me introduce them.',
+    voice="alloy",
+)
+
+with open("eleven_v3_output.mp3", "wb") as f:
     f.write(audio.read())
 ```
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10810,6 +10810,32 @@
             "/v1/audio/transcriptions"
         ]
     },
+    "elevenlabs/eleven_v3": {
+        "input_cost_per_character": 0.00018,
+        "litellm_provider": "elevenlabs",
+        "metadata": {
+            "calculation": "$0.18/1000 characters (Scale plan pricing, 1 credit per character)",
+            "notes": "ElevenLabs Eleven v3 - most expressive TTS model with 70+ languages and audio tags support"
+        },
+        "mode": "audio_speech",
+        "source": "https://elevenlabs.io/pricing",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ]
+    },
+    "elevenlabs/eleven_multilingual_v2": {
+        "input_cost_per_character": 0.00018,
+        "litellm_provider": "elevenlabs",
+        "metadata": {
+            "calculation": "$0.18/1000 characters (Scale plan pricing, 1 credit per character)",
+            "notes": "ElevenLabs Eleven Multilingual v2 - default TTS model with 29 languages support"
+        },
+        "mode": "audio_speech",
+        "source": "https://elevenlabs.io/pricing",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ]
+    },
     "embed-english-light-v2.0": {
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10810,6 +10810,32 @@
             "/v1/audio/transcriptions"
         ]
     },
+    "elevenlabs/eleven_v3": {
+        "input_cost_per_character": 0.00018,
+        "litellm_provider": "elevenlabs",
+        "metadata": {
+            "calculation": "$0.18/1000 characters (Scale plan pricing, 1 credit per character)",
+            "notes": "ElevenLabs Eleven v3 - most expressive TTS model with 70+ languages and audio tags support"
+        },
+        "mode": "audio_speech",
+        "source": "https://elevenlabs.io/pricing",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ]
+    },
+    "elevenlabs/eleven_multilingual_v2": {
+        "input_cost_per_character": 0.00018,
+        "litellm_provider": "elevenlabs",
+        "metadata": {
+            "calculation": "$0.18/1000 characters (Scale plan pricing, 1 credit per character)",
+            "notes": "ElevenLabs Eleven Multilingual v2 - default TTS model with 29 languages support"
+        },
+        "mode": "audio_speech",
+        "source": "https://elevenlabs.io/pricing",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ]
+    },
     "embed-english-light-v2.0": {
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",


### PR DESCRIPTION
## Relevant issues

N/A - New model registration

## Pre-Submission checklist

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature
📖 Documentation

## Changes

Register ElevenLabs TTS models in the model cost map for cost tracking:

- `elevenlabs/eleven_v3` — most expressive model, 70+ languages, audio tags support for sound effects and pauses
- `elevenlabs/eleven_multilingual_v2` — default TTS model, 29 languages, stable and production-ready

Both models priced at $0.18/1000 characters (Scale plan, 1 credit per character).

No code changes needed — the ElevenLabs integration is already model-agnostic and passes any `model_id` directly to the API.

### Documentation updates

- Added supported models table to ElevenLabs provider docs
- Added example using `eleven_v3` with audio tags (`<sfx>`, `<pause>`)
- Added tip about model-agnostic support