### PR TITLE
fix(vertex): map IMAGE_PROHIBITED_CONTENT to content_filter

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1196,6 +1196,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             "PROHIBITED_CONTENT": "The token generation was stopped as the response was flagged for the prohibited contents.",
             "SPII": "The token generation was stopped as the response was flagged for Sensitive Personally Identifiable Information (SPII) contents.",
             "IMAGE_SAFETY": "The token generation was stopped as the response was flagged for image safety reasons.",
+            "IMAGE_PROHIBITED_CONTENT": "The token generation was stopped as the response was flagged for prohibited image content.",
         }
 
     @staticmethod
@@ -1218,6 +1219,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             "SPII": "content_filter",
             "MALFORMED_FUNCTION_CALL": "malformed_function_call",  # openai doesn't have a way of representing this
             "IMAGE_SAFETY": "content_filter",
+            "IMAGE_PROHIBITED_CONTENT": "content_filter",
         }
 
     def translate_exception_str(self, exception_string: str):


### PR DESCRIPTION
## Relevant issues

Fixes #20357

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - existing `test_check_finish_reason` already iterates all keys in `get_finish_reason_mapping()` and covers this change
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Adds `IMAGE_PROHIBITED_CONTENT` to `get_flagged_finish_reasons()` and `get_finish_reason_mapping()` so Gemini image generation models that return this finish reason are correctly mapped to `content_filter` instead of silently defaulting to `stop` with an empty response.