### PR TITLE
Perf: add_litellm_data_to_request optimizations

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -74,12 +74,14 @@ def _get_metadata_variable_name(request: Request) -> str:
 
     For all /thread or /assistant endpoints we need to call this "litellm_metadata"
 
-    For ALL other endpoints we call this "metadata
+    For ALL other endpoints we call this "metadata"
     """
-    if RouteChecks._is_assistants_api_request(request):
+    path = request.url.path
+
+    if "thread" in path or "assistant" in path:
         return "litellm_metadata"
 
-    if any(route in request.url.path for route in LITELLM_METADATA_ROUTES):
+    if any(route in path for route in LITELLM_METADATA_ROUTES):
         return "litellm_metadata"
 
     return "metadata"

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -15,6 +15,7 @@ from litellm.proxy.litellm_pre_call_utils import (
     LiteLLMProxyRequestSetup,
     _get_dynamic_logging_metadata,
     _get_enforced_params,
+    _get_metadata_variable_name,
     _update_model_if_key_alias_exists,
     add_guardrails_from_policy_engine,
     add_litellm_data_to_request,
@@ -45,6 +46,47 @@ def test_check_if_token_is_service_account():
         api_key="test-key", metadata={"user_id": "test-user"}
     )
     assert check_if_token_is_service_account(other_metadata_token) == False
+
+
+class TestGetMetadataVariableName:
+    """Tests for _get_metadata_variable_name()"""
+
+    def _make_request(self, path: str) -> MagicMock:
+        request = MagicMock(spec=Request)
+        request.url.path = path
+        return request
+
+    def test_returns_litellm_metadata_for_thread_routes(self):
+        request = self._make_request("/v1/threads/thread_123/messages")
+        assert _get_metadata_variable_name(request) == "litellm_metadata"
+
+    def test_returns_litellm_metadata_for_assistant_routes(self):
+        request = self._make_request("/v1/assistants/asst_123")
+        assert _get_metadata_variable_name(request) == "litellm_metadata"
+
+    def test_returns_litellm_metadata_for_batches_route(self):
+        request = self._make_request("/v1/batches")
+        assert _get_metadata_variable_name(request) == "litellm_metadata"
+
+    def test_returns_litellm_metadata_for_messages_route(self):
+        request = self._make_request("/v1/messages")
+        assert _get_metadata_variable_name(request) == "litellm_metadata"
+
+    def test_returns_litellm_metadata_for_files_route(self):
+        request = self._make_request("/v1/files")
+        assert _get_metadata_variable_name(request) == "litellm_metadata"
+
+    def test_returns_metadata_for_chat_completions(self):
+        request = self._make_request("/chat/completions")
+        assert _get_metadata_variable_name(request) == "metadata"
+
+    def test_returns_metadata_for_completions(self):
+        request = self._make_request("/v1/completions")
+        assert _get_metadata_variable_name(request) == "metadata"
+
+    def test_returns_metadata_for_embeddings(self):
+        request = self._make_request("/v1/embeddings")
+        assert _get_metadata_variable_name(request) == "metadata"
 
 
 def test_get_enforced_params_for_service_account_settings():


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring
✅ Test

## Changes

Net Improvement in `add_litellm_data_to_request` was 22% faster over 6k calls measured with line profiler. 

Accessed request.url.path 6 times per call in `_get_metadata_variable_name`, cached the path once and then accessed cached value after. 8 tests added covering the 8 return paths. 

Added an early return when no guardrails/policies are configured and then also removed duplicate `add_guardrails_from_policy_engine` call because it was called right before from inside `move_guardrails_to_metadata()` in the line before. Existing tests cover this.

Make the request.headers dictionary 3 times per each request, so just created a `_raw_headers` dictionary and then re used `_headers` from `clean_headers()`. So reduced dictionary creations from 3 to 1. 

Removed redundant data.update dead code. 

Before 

<img width="759" height="157" alt="Screenshot 2026-02-05 at 2 17 54 PM" src="https://github.com/user-attachments/assets/0d70fc00-35bc-4ece-afa9-82784838c902" />

After

<img width="770" height="164" alt="Screenshot 2026-02-05 at 2 18 15 PM" src="https://github.com/user-attachments/assets/3ac0ee4c-69be-46fb-a08c-d809594da88e" />



