### PR TITLE
Perf/cost calculator optimizations

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -688,18 +688,11 @@ def generic_cost_per_token(  # noqa: PLR0915
     ## TEXT COST
     completion_cost = float(text_tokens) * completion_base_cost
 
-    _output_cost_per_audio_token = _get_cost_per_unit(
-        model_info, "output_cost_per_audio_token", None
-    )
-    _output_cost_per_reasoning_token = _get_cost_per_unit(
-        model_info, "output_cost_per_reasoning_token", None
-    )
-    _output_cost_per_image_token = _get_cost_per_unit(
-        model_info, "output_cost_per_image_token", None
-    )
-
     ## AUDIO COST
     if not is_text_tokens_total and audio_tokens is not None and audio_tokens > 0:
+        _output_cost_per_audio_token = _get_cost_per_unit(
+            model_info, "output_cost_per_audio_token", None
+        )
         _output_cost_per_audio_token = (
             _output_cost_per_audio_token
             if _output_cost_per_audio_token is not None
@@ -709,6 +702,9 @@ def generic_cost_per_token(  # noqa: PLR0915
 
     ## REASONING COST
     if not is_text_tokens_total and reasoning_tokens and reasoning_tokens > 0:
+        _output_cost_per_reasoning_token = _get_cost_per_unit(
+            model_info, "output_cost_per_reasoning_token", None
+        )
         _output_cost_per_reasoning_token = (
             _output_cost_per_reasoning_token
             if _output_cost_per_reasoning_token is not None
@@ -718,6 +714,9 @@ def generic_cost_per_token(  # noqa: PLR0915
 
     ## IMAGE COST
     if not is_text_tokens_total and image_tokens and image_tokens > 0:
+        _output_cost_per_image_token = _get_cost_per_unit(
+            model_info, "output_cost_per_image_token", None
+        )
         _output_cost_per_image_token = (
             _output_cost_per_image_token
             if _output_cost_per_image_token is not None

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -518,47 +518,52 @@ def _calculate_input_cost(
     prompt_cost += float(prompt_tokens_details["cache_hit_tokens"]) * cache_read_cost
 
     ### AUDIO COST
-    prompt_cost += calculate_cost_component(
-        model_info, "input_cost_per_audio_token", prompt_tokens_details["audio_tokens"]
-    )
+    if prompt_tokens_details["audio_tokens"]:
+        prompt_cost += calculate_cost_component(
+            model_info, "input_cost_per_audio_token", prompt_tokens_details["audio_tokens"]
+        )
 
     ### IMAGE TOKEN COST
-    # For image token costs:
-    # First check if input_cost_per_image_token is available. If not, default to generic input_cost_per_token.
-    image_token_cost_key = "input_cost_per_image_token"
-    if model_info.get(image_token_cost_key) is None:
-        image_token_cost_key = "input_cost_per_token"
-    prompt_cost += calculate_cost_component(
-        model_info, image_token_cost_key, prompt_tokens_details["image_tokens"]
-    )
+    if prompt_tokens_details["image_tokens"]:
+        # For image token costs:
+        # First check if input_cost_per_image_token is available. If not, default to generic input_cost_per_token.
+        image_token_cost_key = "input_cost_per_image_token"
+        if model_info.get(image_token_cost_key) is None:
+            image_token_cost_key = "input_cost_per_token"
+        prompt_cost += calculate_cost_component(
+            model_info, image_token_cost_key, prompt_tokens_details["image_tokens"]
+        )
 
     ### CACHE WRITING COST - Now uses tiered pricing
-    prompt_cost += calculate_cache_writing_cost(
-        cache_creation_tokens=prompt_tokens_details["cache_creation_tokens"],
-        cache_creation_token_details=prompt_tokens_details[
-            "cache_creation_token_details"
-        ],
-        cache_creation_cost_above_1hr=cache_creation_cost_above_1hr,
-        cache_creation_cost=cache_creation_cost,
-    )
+    if prompt_tokens_details["cache_creation_tokens"]:
+        prompt_cost += calculate_cache_writing_cost(
+            cache_creation_tokens=prompt_tokens_details["cache_creation_tokens"],
+            cache_creation_token_details=prompt_tokens_details[
+                "cache_creation_token_details"
+            ],
+            cache_creation_cost_above_1hr=cache_creation_cost_above_1hr,
+            cache_creation_cost=cache_creation_cost,
+        )
 
     ### CHARACTER COST
-
-    prompt_cost += calculate_cost_component(
-        model_info, "input_cost_per_character", prompt_tokens_details["character_count"]
-    )
+    if prompt_tokens_details["character_count"]:
+        prompt_cost += calculate_cost_component(
+            model_info, "input_cost_per_character", prompt_tokens_details["character_count"]
+        )
 
     ### IMAGE COUNT COST
-    prompt_cost += calculate_cost_component(
-        model_info, "input_cost_per_image", prompt_tokens_details["image_count"]
-    )
+    if prompt_tokens_details["image_count"]:
+        prompt_cost += calculate_cost_component(
+            model_info, "input_cost_per_image", prompt_tokens_details["image_count"]
+        )
 
     ### VIDEO LENGTH COST
-    prompt_cost += calculate_cost_component(
-        model_info,
-        "input_cost_per_video_per_second",
-        prompt_tokens_details["video_length_seconds"],
-    )
+    if prompt_tokens_details["video_length_seconds"]:
+        prompt_cost += calculate_cost_component(
+            model_info,
+            "input_cost_per_video_per_second",
+            prompt_tokens_details["video_length_seconds"],
+        )
 
     return prompt_cost
 

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -535,7 +535,7 @@ def _calculate_input_cost(
         )
 
     ### CACHE WRITING COST - Now uses tiered pricing
-    if prompt_tokens_details["cache_creation_tokens"]:
+    if prompt_tokens_details["cache_creation_tokens"] or prompt_tokens_details["cache_creation_token_details"] is not None:
         prompt_cost += calculate_cache_writing_cost(
             cache_creation_tokens=prompt_tokens_details["cache_creation_tokens"],
             cache_creation_token_details=prompt_tokens_details[


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring
Performance 

## Changes

`_get_token_base_cost()`:  skip threshold loop for models without threshold keys, dont need to go through all 60+ fields when there's no threshold keys

In `_calculate_input_cost`: add early-out checks to skip `calculate_cost_component()` calls when usage values (audio_tokens, image_tokens, cache_creation_tokens, etc.) are 0 anyways 

In `generic_cost_per_token`: skip output cost lookups (similar to calc input cost) when we dont have those token types

No new tests were needed because the existing test cases already cover functionality and passed before/after. 

Resulted in a net 72% speed increase over 6k calls. 

Before 

<img width="845" height="146" alt="Screenshot 2026-02-05 at 4 33 11 PM" src="https://github.com/user-attachments/assets/8651eac5-c61f-426a-b2e6-711c277acc9b" />


After

<img width="859" height="164" alt="Screenshot 2026-02-05 at 4 32 52 PM" src="https://github.com/user-attachments/assets/3572f0d8-433a-43db-a94b-8a1e02d33216" />



