### PR TITLE
refactor: migrate Ant Design notifications to use `App.useApp()` cont…

### DIFF
--- a/ui/litellm-dashboard/src/app/layout.tsx
+++ b/ui/litellm-dashboard/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 
+import AntdGlobalProvider from "@/contexts/AntdGlobalProvider";
+
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
@@ -17,7 +19,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <AntdGlobalProvider>{children}</AntdGlobalProvider>
+      </body>
     </html>
   );
 }

--- a/ui/litellm-dashboard/src/components/molecules/notifications_manager.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/notifications_manager.tsx
@@ -1,7 +1,17 @@
 import React from "react";
-import { notification } from "antd";
+import { notification as staticNotification } from "antd";
+import type { NotificationInstance } from "antd/es/notification/interface";
 import { parseErrorMessage } from "../shared/errorUtils";
 import { ArgsProps } from "antd/es/notification";
+
+let notificationInstance: NotificationInstance | null = null;
+
+export const setNotificationInstance = (instance: NotificationInstance) => {
+  notificationInstance = instance;
+};
+
+// Helper to get the best available notification instance
+const getNotification = () => notificationInstance || staticNotification;
 
 type Placement = "top" | "topLeft" | "topRight" | "bottom" | "bottomLeft" | "bottomRight";
 
@@ -251,7 +261,7 @@ function looksErrorPayload(input: any, status?: number): boolean {
 const NotificationManager = {
   error(input: string | NotificationConfig) {
     const cfg = normalize(input, "Error");
-    notification.error({
+    getNotification().error({
       ...COMMON_NOTIFICATION_PROPS,
       ...cfg,
       placement: cfg.placement ?? defaultPlacement(),
@@ -261,7 +271,7 @@ const NotificationManager = {
 
   warning(input: string | NotificationConfig) {
     const cfg = normalize(input, "Warning");
-    notification.warning({
+    getNotification().warning({
       ...COMMON_NOTIFICATION_PROPS,
       ...cfg,
       placement: cfg.placement ?? defaultPlacement(),
@@ -271,7 +281,7 @@ const NotificationManager = {
 
   info(input: string | NotificationConfig) {
     const cfg = normalize(input, "Info");
-    notification.info({
+    getNotification().info({
       ...COMMON_NOTIFICATION_PROPS,
       ...cfg,
       placement: cfg.placement ?? defaultPlacement(),
@@ -281,7 +291,7 @@ const NotificationManager = {
 
   success(input: string | React.ReactNode | NotificationConfig) {
     if (React.isValidElement(input)) {
-      notification.success({
+      getNotification().success({
         ...COMMON_NOTIFICATION_PROPS,
         message: "Success",
         description: input,
@@ -291,7 +301,7 @@ const NotificationManager = {
       return;
     }
     const cfg = normalize(input as string | NotificationConfig, "Success");
-    notification.success({
+    getNotification().success({
       ...COMMON_NOTIFICATION_PROPS,
       ...cfg,
       placement: cfg.placement ?? defaultPlacement(),
@@ -316,11 +326,11 @@ const NotificationManager = {
         title === "Content Blocked" ||
         title === "Integration Error"
       ) {
-        notification.warning({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 7 });
+        getNotification().warning({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 7 });
         return;
       }
       if (title === "Server Error") {
-        notification.error({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 8 });
+        getNotification().error({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 8 });
         return;
       }
       if (
@@ -331,10 +341,10 @@ const NotificationManager = {
         title === "Error" ||
         title === "Already Exists"
       ) {
-        notification.error({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 6 });
+        getNotification().error({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 6 });
         return;
       }
-      notification.info({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 4 });
+      getNotification().info({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 4 });
       return;
     }
 
@@ -343,18 +353,18 @@ const NotificationManager = {
     const payload = { ...base, message: cls?.title ?? "Info" };
 
     if (cls?.kind === "success") {
-      notification.success({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 3.5 });
+      getNotification().success({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 3.5 });
       return;
     }
     if (cls?.kind === "warning") {
-      notification.warning({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 6 });
+      getNotification().warning({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 6 });
       return;
     }
-    notification.info({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 4 });
+    getNotification().info({ ...COMMON_NOTIFICATION_PROPS, ...payload, duration: extra?.duration ?? 4 });
   },
 
   clear() {
-    notification.destroy();
+    getNotification().destroy();
   },
 };
 

--- a/ui/litellm-dashboard/src/contexts/AntdGlobalProvider.tsx
+++ b/ui/litellm-dashboard/src/contexts/AntdGlobalProvider.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { App } from "antd";
 import { setNotificationInstance } from "@/components/molecules/notifications_manager";
 
 // Inner component to use the hook
 const AntdAppInit = () => {
   const { notification } = App.useApp();
+  const initialized = useRef(false);
 
   useEffect(() => {
-    setNotificationInstance(notification);
+    if (!initialized.current) {
+      setNotificationInstance(notification);
+      initialized.current = true;
+    }
   }, [notification]);
 
   return null;

--- a/ui/litellm-dashboard/src/contexts/AntdGlobalProvider.tsx
+++ b/ui/litellm-dashboard/src/contexts/AntdGlobalProvider.tsx
@@ -1,29 +1,24 @@
 "use client";
 
 import React, { useEffect, useRef } from "react";
-import { App } from "antd";
+import { notification } from "antd";
 import { setNotificationInstance } from "@/components/molecules/notifications_manager";
 
-// Inner component to use the hook
-const AntdAppInit = () => {
-  const { notification } = App.useApp();
+export default function AntdGlobalProvider({ children }: { children: React.ReactNode }) {
+  const [api, contextHolder] = notification.useNotification();
   const initialized = useRef(false);
 
   useEffect(() => {
     if (!initialized.current) {
-      setNotificationInstance(notification);
+      setNotificationInstance(api);
       initialized.current = true;
     }
-  }, [notification]);
+  }, [api]);
 
-  return null;
-};
-
-export default function AntdGlobalProvider({ children }: { children: React.ReactNode }) {
   return (
-    <App>
-      <AntdAppInit />
+    <>
+      {contextHolder}
       {children}
-    </App>
+    </>
   );
 }

--- a/ui/litellm-dashboard/src/contexts/AntdGlobalProvider.tsx
+++ b/ui/litellm-dashboard/src/contexts/AntdGlobalProvider.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { App } from "antd";
+import { setNotificationInstance } from "@/components/molecules/notifications_manager";
+
+// Inner component to use the hook
+const AntdAppInit = () => {
+  const { notification } = App.useApp();
+
+  useEffect(() => {
+    setNotificationInstance(notification);
+  }, [notification]);
+
+  return null;
+};
+
+export default function AntdGlobalProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <App>
+      <AntdAppInit />
+      {children}
+    </App>
+  );
+}


### PR DESCRIPTION
…ext via a new global provider.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix
🧹 Refactoring

## Changes
**1. [notifications_manager.tsx]** - Hybrid notification approach:
- Added `notificationInstance` variable to store the context-based instance
- Added [setNotificationInstance()] function to inject the instance from context
- Created [getNotification()]helper that prefers context instance, falls back to static
- Added exported `COMMON_NOTIFICATION_PROPS` with `showProgress: true` and `pauseOnHover: true`
- All notification methods now spread `COMMON_NOTIFICATION_PROPS`


**2. [AntdGlobalProvider.tsx]** - New context provider:
- Wraps app with Antd's `<App>` component
- Uses `App.useApp()` hook to get the context-based notification instance
- Injects it into `NotificationManager` via [setNotificationInstance()]

<img width="457" height="230" alt="Screenshot 2026-02-06 at 9 45 44 AM" src="https://github.com/user-attachments/assets/cf3f4b47-5ac9-486a-b381-d236b16f4326" />

<img width="524" height="659" alt="Screenshot 2026-02-06 at 9 46 36 AM" src="https://github.com/user-attachments/assets/69c6e094-f2a6-4ffa-817d-0005d918e10c" />
