### PR TITLE
Fix #20562: Correct Bedrock Claude Opus 4.6 model IDs

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -963,7 +963,7 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 159
     },
-    "anthropic.claude-opus-4-6-v1:0": {
+    "anthropic.claude-opus-4-6-v1": {
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_200k_tokens": 1.25e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -993,7 +993,7 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
     },
-    "global.anthropic.claude-opus-4-6-v1:0": {
+    "global.anthropic.claude-opus-4-6-v1": {
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_200k_tokens": 1.25e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1023,7 +1023,7 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
     },
-    "us.anthropic.claude-opus-4-6-v1:0": {
+    "us.anthropic.claude-opus-4-6-v1": {
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_200k_tokens": 1.375e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1053,7 +1053,7 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
     },
-    "eu.anthropic.claude-opus-4-6-v1:0": {
+    "eu.anthropic.claude-opus-4-6-v1": {
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_200k_tokens": 1.375e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1083,7 +1083,7 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
     },
-    "apac.anthropic.claude-opus-4-6-v1:0": {
+    "apac.anthropic.claude-opus-4-6-v1": {
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_200k_tokens": 1.375e-05,
         "cache_read_input_token_cost": 5.5e-07,


### PR DESCRIPTION
## Relevant issues

Fixes #20562

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Remove `:0` suffix from Claude Opus 4.6 Bedrock model IDs in `model_prices_and_context_window.json`
- Change `claude-opus-4-6-v1:0` → `claude-opus-4-6-v1` (global and regional variants)
- Fixes "invalid model identifier" error when using Opus 4.6 on AWS Bedrock