### PR TITLE
Fix AttributeError on NonRecordingSpan.name in OpenTelemetry integration

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -678,7 +678,8 @@ class OpenTelemetry(CustomLogger):
             # Ensure proxy-request parent span is annotated with the actual operation kind
             if (
                 parent_span is not None
-                and parent_span.name == LITELLM_PROXY_REQUEST_SPAN_NAME
+                and getattr(parent_span, "name", None)
+                == LITELLM_PROXY_REQUEST_SPAN_NAME
             ):
                 self.set_attributes(parent_span, kwargs, response_obj)
         else:
@@ -712,7 +713,8 @@ class OpenTelemetry(CustomLogger):
         # However, proxy-created spans should be closed here
         if (
             parent_span is not None
-            and parent_span.name == LITELLM_PROXY_REQUEST_SPAN_NAME
+            and getattr(parent_span, "name", None)
+            == LITELLM_PROXY_REQUEST_SPAN_NAME
         ):
             parent_span.end(end_time=self._to_ns(end_time))
 
@@ -1210,7 +1212,8 @@ class OpenTelemetry(CustomLogger):
         # However, proxy-created spans should be closed here
         if (
             parent_otel_span is not None
-            and parent_otel_span.name == LITELLM_PROXY_REQUEST_SPAN_NAME
+            and getattr(parent_otel_span, "name", None)
+            == LITELLM_PROXY_REQUEST_SPAN_NAME
         ):
             parent_otel_span.end(end_time=self._to_ns(end_time))
 


### PR DESCRIPTION
## Summary

- **Fixes #20350**: When OpenTelemetry tracing is sampled out (e.g., `OTEL_TRACES_SAMPLER=parentbased_always_off`), parent spans become `NonRecordingSpan` objects which lack a `.name` attribute. Accessing `.name` caused an `AttributeError` during success/failure logging.
- Uses `getattr(span, "name", None)` instead of `span.name` in all three places where parent span names are compared to `LITELLM_PROXY_REQUEST_SPAN_NAME` (lines 681, 715, and 1213 in `opentelemetry.py`).
- Adds 3 unit tests covering `_handle_success`, `_handle_failure` with `NonRecordingSpan` parents, and a premise-validation test.

## Test plan

- [x] `test_handle_success_with_non_recording_parent_span` -- verifies `_handle_success` does not raise `AttributeError` with a `NonRecordingSpan` parent
- [x] `test_handle_failure_with_non_recording_parent_span` -- verifies `_handle_failure` does not raise `AttributeError` with a `NonRecordingSpan` parent
- [x] `test_non_recording_span_lacks_name_attribute` -- validates the test premise that `NonRecordingSpan` has no `.name`
- [x] All existing `TestOpenTelemetryExternalSpan` tests continue to pass