### PR TITLE
Fix #20557: Fix Gemini multi-turn tool calling message formatting

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -479,7 +479,7 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                 messages[msg_i]["role"] not in tool_call_message_roles
             ):
                 if len(tool_call_responses) > 0:
-                    contents.append(ContentType(parts=tool_call_responses))
+                    contents.append(ContentType(role="user", parts=tool_call_responses))
                     tool_call_responses = []
 
             if msg_i == init_msg_i:  # prevent infinite loops
@@ -489,7 +489,7 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                     )
                 )
         if len(tool_call_responses) > 0:
-            contents.append(ContentType(parts=tool_call_responses))
+            contents.append(ContentType(role="user", parts=tool_call_responses))
 
         if len(contents) == 0:
             verbose_logger.warning(


### PR DESCRIPTION
## Relevant issues

Fixes #20557

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Add missing `role="user"` field to tool result `ContentType` objects in Gemini message transformation
- Fixes error `contents[2].parts[0].data: required oneof field 'data' must have one initialized field` on second turn of multi-turn conversations
- Ensures tool result messages have required role field per Gemini API spec

## Why

Tool result messages were missing the required `role` field when constructing `ContentType` objects. Gemini API requires all content objects to have a role field, and when omitted, the `parts[0].data` field becomes uninitialized, causing the API to reject the request on the second turn of a multi-turn conversation.

