### PR TITLE
feat: Add AWS RDS CA bundle to all Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,12 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 USER root
 
 # Install runtime dependencies (libsndfile needed for audio processing on ARM64)
-RUN apk add --no-cache bash openssl tzdata nodejs npm python3 py3-pip libsndfile && \
+RUN apk add --no-cache bash openssl tzdata nodejs npm python3 py3-pip libsndfile ca-certificates && \
     npm install -g npm@latest tar@latest
+
+# Add AWS RDS CA bundle to system trust store
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
 
 WORKDIR /app
 # Copy the current directory contents into the container at /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,8 @@ RUN apk add --no-cache bash openssl tzdata nodejs npm python3 py3-pip libsndfile
     npm install -g npm@latest tar@latest
 
 # Add AWS RDS CA bundle to system trust store
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /app
 # Copy the current directory contents into the container at /app

--- a/cookbook/litellm-ollama-docker-image/Dockerfile
+++ b/cookbook/litellm-ollama-docker-image/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update
 RUN apt-get install -y python3 python3-pip ca-certificates
 
 # Add AWS RDS CA bundle to system trust store
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 # Set the working directory in the container
 WORKDIR /app

--- a/cookbook/litellm-ollama-docker-image/Dockerfile
+++ b/cookbook/litellm-ollama-docker-image/Dockerfile
@@ -10,7 +10,11 @@ RUN echo "installing litellm"
 RUN apt-get update
 
 # Install Python
-RUN apt-get install -y python3 python3-pip
+RUN apt-get install -y python3 python3-pip ca-certificates
+
+# Add AWS RDS CA bundle to system trust store
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
 
 # Set the working directory in the container
 WORKDIR /app

--- a/deploy/Dockerfile.ghcr_base
+++ b/deploy/Dockerfile.ghcr_base
@@ -6,8 +6,8 @@ WORKDIR /app
 
 # Add AWS RDS CA bundle to system trust store
 RUN apk add --no-cache ca-certificates
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 # Copy the configuration file into the container at /app
 COPY config.yaml .

--- a/deploy/Dockerfile.ghcr_base
+++ b/deploy/Dockerfile.ghcr_base
@@ -4,6 +4,11 @@ FROM ghcr.io/berriai/litellm:main-latest
 # Set the working directory to /app
 WORKDIR /app
 
+# Add AWS RDS CA bundle to system trust store
+RUN apk add --no-cache ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
+
 # Copy the configuration file into the container at /app
 COPY config.yaml .
 

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -35,7 +35,11 @@ RUN pip wheel --no-cache-dir --wheel-dir=/wheels/ -r requirements.txt
 FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
 # Update dependencies and clean up, install libsndfile for audio processing
-RUN apk upgrade --no-cache && apk add --no-cache libsndfile
+RUN apk upgrade --no-cache && apk add --no-cache libsndfile ca-certificates
+
+# Add AWS RDS CA bundle to system trust store
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
 
 WORKDIR /app
 

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -38,8 +38,8 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 RUN apk upgrade --no-cache && apk add --no-cache libsndfile ca-certificates
 
 # Add AWS RDS CA bundle to system trust store
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /app
 

--- a/docker/Dockerfile.custom_ui
+++ b/docker/Dockerfile.custom_ui
@@ -9,8 +9,8 @@ RUN apt-get update && apt-get install -y nodejs npm ca-certificates && \
     npm install -g npm@latest tar@latest
 
 # Add AWS RDS CA bundle to system trust store
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 # Copy the UI source into the container
 COPY ./ui/litellm-dashboard /app/ui/litellm-dashboard

--- a/docker/Dockerfile.custom_ui
+++ b/docker/Dockerfile.custom_ui
@@ -5,8 +5,12 @@ FROM ghcr.io/berriai/litellm:litellm_fwd_server_root_path-dev
 WORKDIR /app
 
 # Install Node.js and npm (adjust version as needed)
-RUN apt-get update && apt-get install -y nodejs npm && \
+RUN apt-get update && apt-get install -y nodejs npm ca-certificates && \
     npm install -g npm@latest tar@latest
+
+# Add AWS RDS CA bundle to system trust store
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
 
 # Copy the UI source into the container
 COPY ./ui/litellm-dashboard /app/ui/litellm-dashboard

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -49,8 +49,12 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 USER root
 
 # Install runtime dependencies
-RUN apk add --no-cache bash openssl tzdata nodejs npm python3 py3-pip libsndfile && \
+RUN apk add --no-cache bash openssl tzdata nodejs npm python3 py3-pip libsndfile ca-certificates && \
     npm install -g npm@latest tar@latest
+
+# Add AWS RDS CA bundle to system trust store
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
 
 WORKDIR /app
 # Copy the current directory contents into the container at /app

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -53,8 +53,8 @@ RUN apk add --no-cache bash openssl tzdata nodejs npm python3 py3-pip libsndfile
     npm install -g npm@latest tar@latest
 
 # Add AWS RDS CA bundle to system trust store
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /app
 # Copy the current directory contents into the container at /app

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -66,8 +66,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && npm install -g npm@latest tar@latest
 
 # Add AWS RDS CA bundle to system trust store
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /app
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -61,8 +61,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libatomic1 \
     nodejs \
     npm \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g npm@latest tar@latest
+
+# Add AWS RDS CA bundle to system trust store
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
 
 WORKDIR /app
 

--- a/docker/Dockerfile.health_check
+++ b/docker/Dockerfile.health_check
@@ -1,5 +1,9 @@
 FROM python:3.11-slim
 
+# Add AWS RDS CA bundle to system trust store
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
+
 WORKDIR /app
 
 # Copy health check script and requirements

--- a/docker/Dockerfile.health_check
+++ b/docker/Dockerfile.health_check
@@ -1,8 +1,8 @@
 FROM python:3.11-slim
 
 # Add AWS RDS CA bundle to system trust store
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /app
 

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -102,9 +102,13 @@ RUN for i in 1 2 3; do \
     apk upgrade --no-cache && break || sleep 5; \
     done \
   && for i in 1 2 3; do \
-    apk add --no-cache python3 py3-pip bash openssl tzdata nodejs npm supervisor && break || sleep 5; \
+    apk add --no-cache python3 py3-pip bash openssl tzdata nodejs npm supervisor ca-certificates && break || sleep 5; \
     done \
   && npm install -g npm@latest tar@latest
+
+# Add AWS RDS CA bundle to system trust store
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
 
 # Copy artifacts from builder
 COPY --from=builder /app/requirements.txt /app/requirements.txt

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -107,8 +107,8 @@ RUN for i in 1 2 3; do \
   && npm install -g npm@latest tar@latest
 
 # Add AWS RDS CA bundle to system trust store
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 # Copy artifacts from builder
 COPY --from=builder /app/requirements.txt /app/requirements.txt

--- a/docker/build_from_pip/Dockerfile.build_from_pip
+++ b/docker/build_from_pip/Dockerfile.build_from_pip
@@ -13,8 +13,8 @@ RUN apk update && \
     apk add --no-cache gcc musl-dev libffi-dev openssl openssl-dev rust cargo ca-certificates
 
 # Add AWS RDS CA bundle to system trust store
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 RUN python -m venv ${HOME}/venv
 RUN ${HOME}/venv/bin/pip install --no-cache-dir --upgrade pip

--- a/docker/build_from_pip/Dockerfile.build_from_pip
+++ b/docker/build_from_pip/Dockerfile.build_from_pip
@@ -10,7 +10,11 @@ ENV PATH="${HOME}/venv/bin:$PATH"
 # rust and cargo are required for building ddtrace from source
 # musl-dev and libffi-dev are needed for some Python packages on Alpine
 RUN apk update && \
-    apk add --no-cache gcc musl-dev libffi-dev openssl openssl-dev rust cargo
+    apk add --no-cache gcc musl-dev libffi-dev openssl openssl-dev rust cargo ca-certificates
+
+# Add AWS RDS CA bundle to system trust store
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
 
 RUN python -m venv ${HOME}/venv
 RUN ${HOME}/venv/bin/pip install --no-cache-dir --upgrade pip

--- a/docs/my-website/Dockerfile
+++ b/docs/my-website/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.14.0a3-slim
 
 # Add AWS RDS CA bundle to system trust store
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 COPY . /app
 WORKDIR /app

--- a/docs/my-website/Dockerfile
+++ b/docs/my-website/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.14.0a3-slim
 
+# Add AWS RDS CA bundle to system trust store
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
+
 COPY . /app
 WORKDIR /app
 RUN pip install -r requirements.txt

--- a/litellm-js/spend-logs/Dockerfile
+++ b/litellm-js/spend-logs/Dockerfile
@@ -1,6 +1,11 @@
 # Use the specific Node.js v20.11.0 image
 FROM node:20.18.1-alpine3.20
 
+# Add AWS RDS CA bundle to system trust store
+RUN apk add --no-cache ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
+RUN update-ca-certificates
+
 # Set the working directory inside the container
 WORKDIR /app
 

--- a/litellm-js/spend-logs/Dockerfile
+++ b/litellm-js/spend-logs/Dockerfile
@@ -3,8 +3,8 @@ FROM node:20.18.1-alpine3.20
 
 # Add AWS RDS CA bundle to system trust store
 RUN apk add --no-cache ca-certificates
-ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.crt
-RUN update-ca-certificates
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/aws-rds-global-bundle.pem
+RUN cat /etc/ssl/certs/aws-rds-global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
This means folks using RDS for the databases can enable only serving database connections over TLS

## Relevant issues



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
🚄 Infrastructure

## Changes
- Add the RDS CA bundle to all built containers