### PR TITLE
fix(openrouter): fix crash of gpt-5.2-codex by using mode "chat"

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -24594,11 +24594,8 @@
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "responses",
+        "mode": "chat",
         "output_cost_per_token": 1.4e-05,
-        "supported_endpoints": [
-            "/v1/responses"
-        ],
         "supported_modalities": [
             "text",
             "image"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -24548,11 +24548,8 @@
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "responses",
+        "mode": "chat",
         "output_cost_per_token": 1.4e-05,
-        "supported_endpoints": [
-            "/v1/responses"
-        ],
         "supported_modalities": [
             "text",
             "image"


### PR DESCRIPTION
Commit 1cdda28b6 changed `openrouter/openai/gpt-5.2-codex` to mode `responses`, but this broke GPT-5.2-Codex with OpenRouter:

```
response = await litellm.acompletion(
            model="openrouter/openai/gpt-5.2-codex",
            messages=[{"role": "user", "content": "Hello"}],
            api_key=os.environ.get("OPENROUTER_API_KEY"),
)
```
crashes with: `OpenrouterException - argument of type 'NoneType' is not iterable`

Responses API is in beta in OpenRouter and no other OpenRouter models use "responses" mode. The commit that changed this probably did it by mistake.

Therefore change the mode back to "chat" and fix the crash.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix