### PR TITLE
fix(responses): handle ValidationError when provider omits required fields

### DIFF
--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast, get_type_hin
 
 import httpx
 from openai.types.responses import ResponseReasoningItem
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 import litellm
 from litellm._logging import verbose_logger
@@ -258,7 +258,16 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
             # instantiation and let higher-level handlers manage errors.
             verbose_logger.debug("Failed to coalesce error.code in parsed_chunk")
 
-        return event_pydantic_model(**parsed_chunk)
+        try:
+            return event_pydantic_model(**parsed_chunk)
+        except ValidationError:
+            verbose_logger.debug(
+                "Pydantic validation failed for %s with chunk %s, "
+                "falling back to model_construct",
+                event_pydantic_model.__name__,
+                parsed_chunk,
+            )
+            return event_pydantic_model.model_construct(**parsed_chunk)
 
     @staticmethod
     def get_event_model_class(event_type: str) -> Any:


### PR DESCRIPTION
## Summary

- When an OpenAI-compatible upstream provider emits minimal streaming event payloads that omit required fields (e.g. `created_at`, `output`, `output_index`, `content_index`), Pydantic raises a `ValidationError` which crashes the SSE stream and returns HTTP 500
- Added a `try/except ValidationError` around the Pydantic model instantiation in `transform_streaming_response`, falling back to `model_construct()` (which skips validation) — consistent with the existing pattern already used in `transform_response_api_response` for non-streaming responses
- Added 5 unit tests covering the four event types mentioned in the issue (`ResponseCreatedEvent`, `OutputTextDeltaEvent`, `ContentPartAddedEvent`, `OutputItemAddedEvent`) plus a regression test confirming valid chunks still work normally

Fixes https://github.com/BerriAI/litellm/issues/20570

## Test plan

- [x] `test_transform_streaming_response_missing_required_fields_response_created` — ResponseCreatedEvent with missing `created_at` and `output`
- [x] `test_transform_streaming_response_missing_required_fields_output_text_delta` — OutputTextDeltaEvent with missing `output_index` and `content_index`
- [x] `test_transform_streaming_response_missing_required_fields_content_part_added` — ContentPartAddedEvent with missing `output_index` and `content_index`
- [x] `test_transform_streaming_response_missing_required_fields_output_item_added` — OutputItemAddedEvent with missing `output_index`
- [x] `test_transform_streaming_response_valid_chunk_still_works` — valid chunks still pass through normal Pydantic validation
- [x] All 33 tests pass in `tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py`