### PR TITLE
fix(sso): extract user roles from JWT access token for Keycloak compa…

### DIFF
--- a/litellm/proxy/management_endpoints/types.py
+++ b/litellm/proxy/management_endpoints/types.py
@@ -28,17 +28,24 @@ def is_valid_litellm_user_role(role_str: str) -> bool:
         return False
 
 
-def get_litellm_user_role(role_str: str) -> Optional[LitellmUserRoles]:
+def get_litellm_user_role(role_str) -> Optional[LitellmUserRoles]:
     """
-    Convert a string to a LitellmUserRoles enum if valid (case-insensitive).
+    Convert a string (or list of strings) to a LitellmUserRoles enum if valid (case-insensitive).
+
+    Handles list inputs since some SSO providers (e.g., Keycloak) return roles
+    as arrays like ["proxy_admin"] instead of plain strings.
 
     Args:
-        role_str: String to convert (e.g., "proxy_admin", "PROXY_ADMIN", "internal_user")
+        role_str: String or list to convert (e.g., "proxy_admin", ["proxy_admin"])
 
     Returns:
         LitellmUserRoles enum if valid, None otherwise
     """
     try:
+        if isinstance(role_str, list):
+            if len(role_str) == 0:
+                return None
+            role_str = role_str[0]
         # Use _value2member_map_ for O(1) lookup, case-insensitive
         result = LitellmUserRoles._value2member_map_.get(role_str.lower())
         return cast(Optional[LitellmUserRoles], result)

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -25,6 +25,8 @@ from litellm.proxy.management_endpoints.ui_sso import (
     MicrosoftSSOHandler,
     SSOAuthenticationHandler,
     normalize_email,
+    process_sso_jwt_access_token,
+    determine_role_from_groups,
     _setup_team_mappings,
 )
 from litellm.types.proxy.management_endpoints.ui_sso import (
@@ -1298,6 +1300,7 @@ async def test_get_generic_sso_response_with_additional_headers():
     # Mock the SSO provider and its methods
     mock_sso_instance = MagicMock()
     mock_sso_instance.verify_and_process = AsyncMock(return_value=mock_sso_response)
+    mock_sso_instance.access_token = None  # Avoid triggering JWT decode in process_sso_jwt_access_token
 
     mock_sso_class = MagicMock(return_value=mock_sso_instance)
 
@@ -1359,6 +1362,7 @@ async def test_get_generic_sso_response_with_empty_headers():
     # Mock the SSO provider and its methods
     mock_sso_instance = MagicMock()
     mock_sso_instance.verify_and_process = AsyncMock(return_value=mock_sso_response)
+    mock_sso_instance.access_token = None  # Avoid triggering JWT decode in process_sso_jwt_access_token
 
     mock_sso_class = MagicMock(return_value=mock_sso_instance)
 
@@ -2546,22 +2550,25 @@ class TestProcessSSOJWTAccessToken:
             assert result.team_ids == []
 
     def test_process_sso_jwt_access_token_no_sso_jwt_handler(self, sample_jwt_token):
-        """Test that nothing happens when sso_jwt_handler is None"""
+        """Test that JWT is decoded for role extraction even when sso_jwt_handler is None,
+        but team_ids are not extracted (team extraction requires sso_jwt_handler)."""
         from litellm.proxy.management_endpoints.ui_sso import (
             process_sso_jwt_access_token,
         )
 
         result = CustomOpenID(id="test_user", email="test@example.com", team_ids=[])
 
-        with patch("jwt.decode") as mock_jwt_decode:
+        mock_payload = {"sub": "test_user", "email": "test@example.com"}
+        with patch("jwt.decode", return_value=mock_payload) as mock_jwt_decode:
             # Act
             process_sso_jwt_access_token(
                 access_token_str=sample_jwt_token, sso_jwt_handler=None, result=result
             )
 
-            # Assert nothing was processed
-            mock_jwt_decode.assert_not_called()
+            # JWT is decoded (for role extraction) but team_ids are not extracted
+            mock_jwt_decode.assert_called_once()
             assert result.team_ids == []
+            assert result.user_role is None
 
     def test_process_sso_jwt_access_token_no_result(
         self, mock_jwt_handler, sample_jwt_token
@@ -3848,3 +3855,219 @@ async def test_setup_team_mappings():
         mock_prisma.db.litellm_ssoconfig.find_unique.assert_called_once_with(
             where={"id": "sso_config"}
         )
+
+
+# ============================================================================
+# Tests for get_litellm_user_role with list inputs (Keycloak returns lists)
+# ============================================================================
+
+
+def test_get_litellm_user_role_with_string():
+    """Test that get_litellm_user_role works with a plain string."""
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.proxy.management_endpoints.types import get_litellm_user_role
+
+    result = get_litellm_user_role("proxy_admin")
+    assert result == LitellmUserRoles.PROXY_ADMIN
+
+
+def test_get_litellm_user_role_with_list():
+    """
+    Test that get_litellm_user_role handles list inputs.
+    Keycloak returns roles as arrays like ["proxy_admin"] instead of strings.
+    """
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.proxy.management_endpoints.types import get_litellm_user_role
+
+    result = get_litellm_user_role(["proxy_admin"])
+    assert result == LitellmUserRoles.PROXY_ADMIN
+
+
+def test_get_litellm_user_role_with_empty_list():
+    """Test that get_litellm_user_role returns None for empty lists."""
+    from litellm.proxy.management_endpoints.types import get_litellm_user_role
+
+    result = get_litellm_user_role([])
+    assert result is None
+
+
+def test_get_litellm_user_role_with_invalid_role():
+    """Test that get_litellm_user_role returns None for invalid roles."""
+    from litellm.proxy.management_endpoints.types import get_litellm_user_role
+
+    result = get_litellm_user_role("not_a_real_role")
+    assert result is None
+
+
+def test_get_litellm_user_role_with_list_multiple_roles():
+    """Test that get_litellm_user_role takes the first element from a multi-element list."""
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.proxy.management_endpoints.types import get_litellm_user_role
+
+    result = get_litellm_user_role(["proxy_admin", "internal_user"])
+    assert result == LitellmUserRoles.PROXY_ADMIN
+
+
+# ============================================================================
+# Tests for process_sso_jwt_access_token role extraction
+# ============================================================================
+
+
+def test_process_sso_jwt_access_token_extracts_role_from_access_token():
+    """
+    Test that process_sso_jwt_access_token extracts user role from the JWT
+    access token when the UserInfo response did not include it.
+
+    This is the core fix for the Keycloak SSO role mapping bug: Keycloak's
+    UserInfo endpoint does not return role claims, but the JWT access token
+    contains them.
+    """
+    import jwt as pyjwt
+
+    from litellm.proxy._types import LitellmUserRoles
+
+    # Create a JWT access token with role claims (as Keycloak would)
+    access_token_payload = {
+        "sub": "user-123",
+        "email": "admin@test.com",
+        "litellm_role": ["proxy_admin"],
+    }
+    access_token_str = pyjwt.encode(access_token_payload, "secret", algorithm="HS256")
+
+    # Result object with no role set (simulating UserInfo response without roles)
+    result = CustomOpenID(
+        id="user-123",
+        email="admin@test.com",
+        display_name="Admin User",
+        team_ids=[],
+        user_role=None,
+    )
+
+    # Call with GENERIC_USER_ROLE_ATTRIBUTE pointing to litellm_role
+    with patch.dict(os.environ, {"GENERIC_USER_ROLE_ATTRIBUTE": "litellm_role"}):
+        process_sso_jwt_access_token(
+            access_token_str=access_token_str,
+            sso_jwt_handler=None,
+            result=result,
+            role_mappings=None,
+        )
+
+    assert result.user_role == LitellmUserRoles.PROXY_ADMIN
+
+
+def test_process_sso_jwt_access_token_does_not_override_existing_role():
+    """
+    Test that process_sso_jwt_access_token does NOT override a role that was
+    already extracted from the UserInfo response.
+    """
+    import jwt as pyjwt
+
+    from litellm.proxy._types import LitellmUserRoles
+
+    access_token_payload = {
+        "sub": "user-123",
+        "litellm_role": ["internal_user"],
+    }
+    access_token_str = pyjwt.encode(access_token_payload, "secret", algorithm="HS256")
+
+    # Result already has a role (e.g., set from UserInfo)
+    result = CustomOpenID(
+        id="user-123",
+        email="admin@test.com",
+        display_name="Admin User",
+        team_ids=[],
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+
+    with patch.dict(os.environ, {"GENERIC_USER_ROLE_ATTRIBUTE": "litellm_role"}):
+        process_sso_jwt_access_token(
+            access_token_str=access_token_str,
+            sso_jwt_handler=None,
+            result=result,
+            role_mappings=None,
+        )
+
+    # Should keep the original role
+    assert result.user_role == LitellmUserRoles.PROXY_ADMIN
+
+
+def test_process_sso_jwt_access_token_extracts_role_from_nested_field():
+    """
+    Test role extraction from a nested JWT field like resource_access.client.roles.
+    """
+    import jwt as pyjwt
+
+    from litellm.proxy._types import LitellmUserRoles
+
+    access_token_payload = {
+        "sub": "user-123",
+        "resource_access": {
+            "my-client": {
+                "roles": ["proxy_admin"]
+            }
+        },
+    }
+    access_token_str = pyjwt.encode(access_token_payload, "secret", algorithm="HS256")
+
+    result = CustomOpenID(
+        id="user-123",
+        email="admin@test.com",
+        display_name="Admin User",
+        team_ids=[],
+        user_role=None,
+    )
+
+    with patch.dict(os.environ, {"GENERIC_USER_ROLE_ATTRIBUTE": "resource_access.my-client.roles"}):
+        process_sso_jwt_access_token(
+            access_token_str=access_token_str,
+            sso_jwt_handler=None,
+            result=result,
+            role_mappings=None,
+        )
+
+    assert result.user_role == LitellmUserRoles.PROXY_ADMIN
+
+
+def test_process_sso_jwt_access_token_with_role_mappings():
+    """
+    Test role extraction using role_mappings (group-based role determination)
+    from the JWT access token.
+    """
+    import jwt as pyjwt
+
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.types.proxy.management_endpoints.ui_sso import RoleMappings
+
+    access_token_payload = {
+        "sub": "user-123",
+        "groups": ["keycloak-admins", "developers"],
+    }
+    access_token_str = pyjwt.encode(access_token_payload, "secret", algorithm="HS256")
+
+    result = CustomOpenID(
+        id="user-123",
+        email="admin@test.com",
+        display_name="Admin User",
+        team_ids=[],
+        user_role=None,
+    )
+
+    role_mappings = RoleMappings(
+        provider="generic",
+        group_claim="groups",
+        default_role=LitellmUserRoles.INTERNAL_USER,
+        roles={
+            LitellmUserRoles.PROXY_ADMIN: ["keycloak-admins"],
+            LitellmUserRoles.INTERNAL_USER: ["developers"],
+        },
+    )
+
+    process_sso_jwt_access_token(
+        access_token_str=access_token_str,
+        sso_jwt_handler=None,
+        result=result,
+        role_mappings=role_mappings,
+    )
+
+    # Should get highest privilege role
+    assert result.user_role == LitellmUserRoles.PROXY_ADMIN


### PR DESCRIPTION
## Relevant issues

Fixes #20407

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

### Problem

Keycloak (and similar OIDC providers) include role claims in the **JWT access token** but **not** in the UserInfo endpoint response. Previously, `process_sso_jwt_access_token()` only extracted `team_ids` from the JWT — roles were only read from the UserInfo response via `generic_response_convertor()`. This caused all Keycloak SSO users to default to `internal_user_view_only` regardless of their actual role assignment.

Additionally, `get_litellm_user_role()` expected a plain string but Keycloak returns roles as arrays (e.g. `["proxy_admin"]`), causing an `AttributeError` that was silently caught, returning `None`.

### Root causes

1. **Roles not extracted from JWT access token** — `process_sso_jwt_access_token()` decoded the JWT but only used it for `team_ids` extraction. Role claims present in the token were ignored.
2. **List-type role values not handled** — `get_litellm_user_role()` called `.lower()` directly on the input. When Keycloak passes `["proxy_admin"]` (a list), this raised `AttributeError` → caught → returned `None` → user got `internal_user_view_only`.

### Fix

- **`ui_sso.py`** — `process_sso_jwt_access_token()` now extracts user roles from the JWT access token when UserInfo doesn't provide them. It tries `role_mappings` first (group-based), then falls back to `GENERIC_USER_ROLE_ATTRIBUTE`. Only sets the role if `existing_role is None` (never overrides UserInfo).
- **`types.py`** — `get_litellm_user_role()` now handles list inputs by taking the first element before validation.
- **`test_ui_sso.py`** — Added 9 new unit tests for role extraction from JWT and list handling. Updated 3 existing tests to match new behavior.

### Reproduction

Reproduced end-to-end with a local Keycloak instance (realm with client roles + protocol mapper) and LiteLLM proxy. Before fix: `/sso/debug/login` showed no `user_role`. After fix: correctly shows `proxy_admin` / `internal_user` based on Keycloak role assignment.

## Screenshots
<img width="918" height="728" alt="Screenshot 2026-02-06 alle 18 37 05" src="https://github.com/user-attachments/assets/e05f8fda-b7d3-4f1d-b2f3-04fc46e57fe4" />
