### PR TITLE
perf: reuse LiteLLM_Params

### DIFF
--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -2198,3 +2198,33 @@ def test_get_valid_args():
     # Verify it contains keyword-only arguments too
     # These are common Router.__init__ parameters
     assert "assistants_config" in valid_args or "search_tools" in valid_args
+
+
+def test_get_router_model_info_with_deployment_object():
+    """Test get_router_model_info accepts Deployment object directly and reuses LiteLLM_Params"""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "test-key"},
+                "model_info": {"id": "test-id"},
+            }
+        ]
+    )
+
+    # Get the Deployment object (not dict)
+    deployment = router.get_deployment(model_id="test-id")
+    assert deployment is not None
+    assert isinstance(deployment, Deployment)
+    assert isinstance(deployment.litellm_params, LiteLLM_Params)
+
+    # Pass Deployment directly (not .model_dump()) - this exercises the isinstance check
+    # that reuses the existing LiteLLM_Params instead of reconstructing it
+    model_info = router.get_router_model_info(
+        deployment=deployment,
+        received_model_name="gpt-4",
+    )
+
+    # Verify we got valid model info back
+    assert model_info is not None
+    assert isinstance(model_info, dict)


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring
✅ Test

## Changes

Before, after a request completed we would do `deployment_callback_on_success` and then that would get the deployment object (with LiteLLM params constructed by doing that) 

Then deployment_info.model_dump() would convert that Deployment object to a pure dict 

Then we would call `get_router_model_info(Deployment=dict,...` 

and basically from that dict we would reconstruct the LiteLLM params object from that, even though it was already created earlier. 

Change made it so that `get_router_model_info` would handle a Deployment object as well and  not have to do useless reconstructing. We can just then reuse it. 

Added `test_get_router_model_info_with_deployment_object` that tests deployment object with LIteLLM_Params, Dict with litellm_params, deployment=None with id lookup

~8% improvement in deployment_callback_on_success per callback total time measured with line profiler over 6000 requests.

Before 

<img width="627" height="162" alt="Screenshot 2026-02-06 at 10 28 06 AM" src="https://github.com/user-attachments/assets/e4f1ea11-2f06-4e95-bc25-4612ab31603e" />

After 

<img width="627" height="155" alt="Screenshot 2026-02-06 at 10 28 20 AM" src="https://github.com/user-attachments/assets/63c17df0-ce96-4b2c-93ae-c1cde4b3e8fe" />
