### PR TITLE
fix: add defensive None checks for model parameter

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -34,8 +34,8 @@ def _is_azure_claude_model(model: str) -> bool:
 
 
 def handle_cohere_chat_model_custom_llm_provider(
-    model: str, custom_llm_provider: Optional[str] = None
-) -> Tuple[str, Optional[str]]:
+    model: Optional[str], custom_llm_provider: Optional[str] = None
+) -> Tuple[Optional[str], Optional[str]]:
     """
     if user sets model = "cohere/command-r" -> use custom_llm_provider = "cohere_chat"
 
@@ -48,7 +48,7 @@ def handle_cohere_chat_model_custom_llm_provider(
     """
 
     if custom_llm_provider:
-        if custom_llm_provider == "cohere" and model in litellm.cohere_chat_models:
+        if custom_llm_provider == "cohere" and model and model in litellm.cohere_chat_models:
             return model, "cohere_chat"
 
     if model and "/" in model:
@@ -64,8 +64,8 @@ def handle_cohere_chat_model_custom_llm_provider(
 
 
 def handle_anthropic_text_model_custom_llm_provider(
-    model: str, custom_llm_provider: Optional[str] = None
-) -> Tuple[str, Optional[str]]:
+    model: Optional[str], custom_llm_provider: Optional[str] = None
+) -> Tuple[Optional[str], Optional[str]]:
     """
     if user sets model = "anthropic/claude-2" -> use custom_llm_provider = "anthropic_text"
 
@@ -80,6 +80,7 @@ def handle_anthropic_text_model_custom_llm_provider(
     if custom_llm_provider:
         if (
             custom_llm_provider == "anthropic"
+            and model
             and litellm.AnthropicTextConfig._is_anthropic_text_model(model)
         ):
             return model, "anthropic_text"

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional, Tuple, cast
 
 import litellm
 from litellm.constants import REPLICATE_MODEL_NAME_WITH_ID_LENGTH
@@ -146,13 +146,19 @@ def get_llm_provider(  # noqa: PLR0915
                 return model, custom_llm_provider, dynamic_api_key, api_base
 
         ### Handle cases when custom_llm_provider is set to cohere/command-r-plus but it should use cohere_chat route
-        model, custom_llm_provider = handle_cohere_chat_model_custom_llm_provider(
+        _model, _custom_llm_provider = handle_cohere_chat_model_custom_llm_provider(
             model, custom_llm_provider
         )
+        # model is validated at function entry and handlers preserve it
+        model = cast(str, _model)
+        custom_llm_provider = _custom_llm_provider
 
-        model, custom_llm_provider = handle_anthropic_text_model_custom_llm_provider(
+        _model, _custom_llm_provider = handle_anthropic_text_model_custom_llm_provider(
             model, custom_llm_provider
         )
+        # model is validated at function entry and handlers preserve it
+        model = cast(str, _model)
+        custom_llm_provider = _custom_llm_provider
 
         if custom_llm_provider and (
             model.split("/")[0] != custom_llm_provider

--- a/tests/test_litellm/litellm_core_utils/test_get_llm_provider_logic.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_llm_provider_logic.py
@@ -1,0 +1,76 @@
+"""
+Tests for get_llm_provider_logic.py
+
+Focuses on None model handling to prevent 'argument of type NoneType is not iterable' errors.
+"""
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.get_llm_provider_logic import (
+    get_llm_provider,
+    handle_anthropic_text_model_custom_llm_provider,
+    handle_cohere_chat_model_custom_llm_provider,
+)
+
+
+class TestHandleNoneModel:
+    """Tests for handling None model parameter"""
+
+    def test_handle_cohere_chat_model_with_none_model(self):
+        """Test that handle_cohere_chat_model_custom_llm_provider handles None model gracefully"""
+        # Should not raise TypeError: argument of type 'NoneType' is not iterable
+        result = handle_cohere_chat_model_custom_llm_provider(
+            model=None, custom_llm_provider="cohere"
+        )
+        assert result == (None, "cohere")
+
+    def test_handle_anthropic_text_model_with_none_model(self):
+        """Test that handle_anthropic_text_model_custom_llm_provider handles None model gracefully"""
+        # Should not raise TypeError: argument of type 'NoneType' is not iterable
+        result = handle_anthropic_text_model_custom_llm_provider(
+            model=None, custom_llm_provider="anthropic"
+        )
+        assert result == (None, "anthropic")
+
+    def test_get_llm_provider_with_none_model_raises_clear_error(self):
+        """Test that get_llm_provider raises a clear error when model is None"""
+        # The ValueError is caught by the function's exception handler and wrapped in BadRequestError
+        with pytest.raises(litellm.exceptions.BadRequestError) as exc_info:
+            get_llm_provider(model=None)
+
+        assert "model parameter is required but was None" in str(exc_info.value)
+
+
+class TestValidModelHandling:
+    """Tests to ensure valid models still work correctly after the None checks"""
+
+    def test_handle_cohere_chat_model_with_valid_model(self):
+        """Test that valid cohere models still work"""
+        result = handle_cohere_chat_model_custom_llm_provider(
+            model="cohere/command-r-plus", custom_llm_provider=None
+        )
+        # Should parse the model correctly
+        assert result[0] == "command-r-plus" or result[0] == "cohere/command-r-plus"
+
+    def test_handle_cohere_chat_model_with_model_without_slash(self):
+        """Test that models without slash work"""
+        result = handle_cohere_chat_model_custom_llm_provider(
+            model="command-r-plus", custom_llm_provider="cohere"
+        )
+        assert result[0] == "command-r-plus"
+
+    def test_handle_anthropic_text_model_with_valid_model(self):
+        """Test that valid anthropic models still work"""
+        result = handle_anthropic_text_model_custom_llm_provider(
+            model="anthropic/claude-2", custom_llm_provider=None
+        )
+        # Should parse the model correctly
+        assert "claude-2" in result[0]
+
+    def test_handle_anthropic_text_model_with_model_without_slash(self):
+        """Test that models without slash work"""
+        result = handle_anthropic_text_model_custom_llm_provider(
+            model="claude-2", custom_llm_provider="anthropic"
+        )
+        assert result[0] == "claude-2"


### PR DESCRIPTION
## Summary

This PR adds defensive None checks to prevent `TypeError: argument of type 'NoneType' is not iterable` errors when `model=None` is passed to `get_llm_provider` and related functions.

**Changes:**
- Add early validation in `get_llm_provider` to raise a clear `BadRequestError` when model is None
- Add defensive None checks in `handle_cohere_chat_model_custom_llm_provider`
- Add defensive None checks in `handle_anthropic_text_model_custom_llm_provider`
- Fix metadata None handling in `utils.py` for aresponses call type

## Test plan

- [x] Added 7 comprehensive unit tests for None model handling
- [x] Tests cover both error cases (None model) and success cases (valid models)
- [x] All tests pass locally: `poetry run pytest tests/test_litellm/litellm_core_utils/test_get_llm_provider_logic.py -v`

## Related

This is a focused extract from PR #19810, splitting unrelated changes into separate PRs.

