### PR TITLE
[Feature] Add RBAC support for AWS Bedrock models

### DIFF
--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -442,6 +442,7 @@ async def validate_aws_credential_endpoint(
             test_role_assumption=test_role_assumption,
         )
         return {"success": True, **result}
+    except HTTPException:
+        raise
     except Exception as e:
-        verbose_proxy_logger.exception(e)
         raise handle_exception_on_proxy(e)

--- a/tests/test_litellm/proxy/test_aws_credential_validation.py
+++ b/tests/test_litellm/proxy/test_aws_credential_validation.py
@@ -1,0 +1,144 @@
+"""
+Tests for AWS credential validation in credential_endpoints.
+
+This module tests the validate_aws_credential function and endpoint.
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)
+
+from fastapi import HTTPException
+from litellm.proxy.credential_endpoints.endpoints import validate_aws_credential
+
+
+class TestValidateAwsCredential:
+    """Tests for validate_aws_credential function"""
+
+    def test_credential_not_found_raises_404(self):
+        """Test that missing credential raises 404"""
+        with patch(
+            "litellm.proxy.credential_endpoints.endpoints.CredentialAccessor.get_credential_values"
+        ) as mock_get:
+            mock_get.return_value = {}
+
+            with pytest.raises(HTTPException) as exc_info:
+                validate_aws_credential("nonexistent-cred")
+
+            assert exc_info.value.status_code == 404
+            assert "not found" in exc_info.value.detail
+
+    def test_credential_without_aws_params_raises_400(self):
+        """Test that credential without AWS params raises 400"""
+        with patch(
+            "litellm.proxy.credential_endpoints.endpoints.CredentialAccessor.get_credential_values"
+        ) as mock_get:
+            mock_get.return_value = {
+                "api_key": "some-key",
+                "endpoint": "some-endpoint",
+            }
+
+            with pytest.raises(HTTPException) as exc_info:
+                validate_aws_credential("non-aws-cred")
+
+            assert exc_info.value.status_code == 400
+            assert "does not contain any AWS" in exc_info.value.detail
+
+    def test_valid_credential_returns_success(self):
+        """Test that valid AWS credential returns success"""
+        with patch(
+            "litellm.proxy.credential_endpoints.endpoints.CredentialAccessor.get_credential_values"
+        ) as mock_get:
+            mock_get.return_value = {
+                "aws_role_name": "arn:aws:iam::123456789:role/MyRole",
+                "aws_region_name": "us-west-2",
+            }
+
+            result = validate_aws_credential("my-aws-cred")
+
+            assert result["valid"] is True
+            assert "aws_role_name" in result["credential_params"]
+            assert "aws_region_name" in result["credential_params"]
+
+    def test_role_assumption_test_success(self):
+        """Test role assumption test succeeds"""
+        with patch(
+            "litellm.proxy.credential_endpoints.endpoints.CredentialAccessor.get_credential_values"
+        ) as mock_get:
+            mock_get.return_value = {
+                "aws_role_name": "arn:aws:iam::123456789:role/MyRole",
+                "aws_region_name": "us-west-2",
+            }
+
+            with patch(
+                "litellm.llms.bedrock.base_aws_llm.BaseAWSLLM"
+            ) as mock_llm:
+                mock_instance = MagicMock()
+                mock_llm.return_value = mock_instance
+                # Successful credential retrieval
+                mock_instance.get_credentials.return_value = MagicMock()
+
+                result = validate_aws_credential(
+                    "my-aws-cred", test_role_assumption=True
+                )
+
+                assert result["valid"] is True
+                assert result["role_assumption_tested"] is True
+                mock_instance.get_credentials.assert_called_once()
+
+    def test_role_assumption_test_failure(self):
+        """Test role assumption test failure raises 400"""
+        with patch(
+            "litellm.proxy.credential_endpoints.endpoints.CredentialAccessor.get_credential_values"
+        ) as mock_get:
+            mock_get.return_value = {
+                "aws_role_name": "arn:aws:iam::123456789:role/MyRole",
+                "aws_region_name": "us-west-2",
+            }
+
+            with patch(
+                "litellm.llms.bedrock.base_aws_llm.BaseAWSLLM"
+            ) as mock_llm:
+                mock_instance = MagicMock()
+                mock_llm.return_value = mock_instance
+                # Simulate role assumption failure
+                mock_instance.get_credentials.side_effect = Exception("AccessDenied")
+
+                with pytest.raises(HTTPException) as exc_info:
+                    validate_aws_credential("my-aws-cred", test_role_assumption=True)
+
+                assert exc_info.value.status_code == 400
+                assert "Failed to assume role" in exc_info.value.detail
+
+    def test_all_aws_params_detected(self):
+        """Test that all AWS params are detected"""
+        all_aws_params = {
+            "aws_access_key_id": "AKIAEXAMPLE",
+            "aws_secret_access_key": "secret",
+            "aws_session_token": "token",
+            "aws_region_name": "us-west-2",
+            "aws_session_name": "session",
+            "aws_profile_name": "profile",
+            "aws_role_name": "arn:aws:iam::123456789:role/MyRole",
+            "aws_web_identity_token": "token",
+            "aws_sts_endpoint": "endpoint",
+            "aws_bedrock_runtime_endpoint": "endpoint",
+            "aws_external_id": "external-id",
+        }
+
+        with patch(
+            "litellm.proxy.credential_endpoints.endpoints.CredentialAccessor.get_credential_values"
+        ) as mock_get:
+            mock_get.return_value = all_aws_params
+
+            result = validate_aws_credential("full-aws-cred")
+
+            assert result["valid"] is True
+            # All params should be detected
+            for param in all_aws_params.keys():
+                assert param in result["credential_params"]

--- a/tests/test_litellm/proxy/test_aws_credentials_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_aws_credentials_pre_call_utils.py
@@ -1,0 +1,293 @@
+"""
+Tests for AWS credentials support in litellm_pre_call_utils.py
+
+This module tests the per-request, per-key, and per-team AWS credential
+merging functionality that enables RBAC for AWS Bedrock models.
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.litellm_pre_call_utils import (
+    AWS_CREDENTIAL_PARAMS,
+    _extract_aws_credentials_from_metadata,
+    _get_aws_credentials_from_credential_name,
+    add_aws_credentials_to_request,
+)
+
+
+class TestExtractAwsCredentialsFromMetadata:
+    """Tests for _extract_aws_credentials_from_metadata function"""
+
+    def test_extract_aws_credentials_from_empty_metadata(self):
+        """Test that empty metadata returns empty dict"""
+        result = _extract_aws_credentials_from_metadata(None)
+        assert result == {}
+
+        result = _extract_aws_credentials_from_metadata({})
+        assert result == {}
+
+    def test_extract_aws_role_name_from_metadata(self):
+        """Test extraction of aws_role_name from metadata"""
+        metadata = {
+            "aws_role_name": "arn:aws:iam::123456789:role/MyRole",
+            "other_field": "value",
+        }
+        result = _extract_aws_credentials_from_metadata(metadata)
+        assert result == {"aws_role_name": "arn:aws:iam::123456789:role/MyRole"}
+
+    def test_extract_multiple_aws_params_from_metadata(self):
+        """Test extraction of multiple AWS params from metadata"""
+        metadata = {
+            "aws_role_name": "arn:aws:iam::123456789:role/MyRole",
+            "aws_region_name": "us-west-2",
+            "aws_session_name": "my-session",
+            "aws_external_id": "external-123",
+            "other_field": "value",
+        }
+        result = _extract_aws_credentials_from_metadata(metadata)
+        assert result == {
+            "aws_role_name": "arn:aws:iam::123456789:role/MyRole",
+            "aws_region_name": "us-west-2",
+            "aws_session_name": "my-session",
+            "aws_external_id": "external-123",
+        }
+
+    def test_extract_all_aws_params_from_metadata(self):
+        """Test that all AWS params are extracted correctly"""
+        metadata = {param: f"value_{param}" for param in AWS_CREDENTIAL_PARAMS}
+        metadata["non_aws_param"] = "should_not_be_extracted"
+
+        result = _extract_aws_credentials_from_metadata(metadata)
+
+        assert len(result) == len(AWS_CREDENTIAL_PARAMS)
+        assert "non_aws_param" not in result
+        for param in AWS_CREDENTIAL_PARAMS:
+            assert result[param] == f"value_{param}"
+
+
+class TestGetAwsCredentialsFromCredentialName:
+    """Tests for _get_aws_credentials_from_credential_name function"""
+
+    def test_credential_not_found_returns_empty(self):
+        """Test that missing credential returns empty dict"""
+        with patch(
+            "litellm.litellm_core_utils.credential_accessor.CredentialAccessor.get_credential_values"
+        ) as mock_get:
+            mock_get.return_value = {}
+            result = _get_aws_credentials_from_credential_name("nonexistent")
+            assert result == {}
+
+    def test_credential_with_aws_params(self):
+        """Test that credentials with AWS params are returned correctly"""
+        with patch(
+            "litellm.litellm_core_utils.credential_accessor.CredentialAccessor.get_credential_values"
+        ) as mock_get:
+            mock_get.return_value = {
+                "aws_role_name": "arn:aws:iam::123456789:role/MyRole",
+                "aws_region_name": "us-west-2",
+                "api_key": "should_not_be_included",
+            }
+            result = _get_aws_credentials_from_credential_name("my-credential")
+            assert result == {
+                "aws_role_name": "arn:aws:iam::123456789:role/MyRole",
+                "aws_region_name": "us-west-2",
+            }
+            assert "api_key" not in result
+
+
+class TestAddAwsCredentialsToRequest:
+    """Tests for add_aws_credentials_to_request function"""
+
+    def test_no_credentials_returns_unchanged_data(self):
+        """Test that data without credentials is unchanged"""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="test-key",
+            metadata={},
+            team_metadata={},
+        )
+        data = {"model": "bedrock/anthropic.claude-3-5-sonnet", "metadata": {}}
+
+        result = add_aws_credentials_to_request(data, user_api_key_dict, "metadata")
+
+        assert "aws_role_name" not in result
+
+    def test_team_level_aws_credential_name(self):
+        """Test that team-level aws_credential_name is used"""
+        with patch(
+            "litellm.proxy.litellm_pre_call_utils._get_aws_credentials_from_credential_name"
+        ) as mock_get:
+            mock_get.return_value = {
+                "aws_role_name": "arn:aws:iam::123456789:role/TeamRole",
+                "aws_region_name": "us-east-1",
+            }
+
+            user_api_key_dict = UserAPIKeyAuth(
+                api_key="test-key",
+                metadata={},
+                team_metadata={"aws_credential_name": "team-bedrock-creds"},
+            )
+            data = {"model": "bedrock/anthropic.claude-3-5-sonnet", "metadata": {}}
+
+            result = add_aws_credentials_to_request(data, user_api_key_dict, "metadata")
+
+            mock_get.assert_called_with("team-bedrock-creds")
+            assert result["aws_role_name"] == "arn:aws:iam::123456789:role/TeamRole"
+            assert result["aws_region_name"] == "us-east-1"
+
+    def test_key_level_aws_credential_name_overrides_team(self):
+        """Test that key-level credentials override team-level"""
+        with patch(
+            "litellm.proxy.litellm_pre_call_utils._get_aws_credentials_from_credential_name"
+        ) as mock_get:
+            # Return different credentials based on the credential name
+            def side_effect(name):
+                if name == "key-bedrock-creds":
+                    return {
+                        "aws_role_name": "arn:aws:iam::123456789:role/KeyRole",
+                        "aws_region_name": "us-west-2",
+                    }
+                elif name == "team-bedrock-creds":
+                    return {
+                        "aws_role_name": "arn:aws:iam::123456789:role/TeamRole",
+                        "aws_region_name": "us-east-1",
+                    }
+                return {}
+
+            mock_get.side_effect = side_effect
+
+            user_api_key_dict = UserAPIKeyAuth(
+                api_key="test-key",
+                metadata={"aws_credential_name": "key-bedrock-creds"},
+                team_metadata={"aws_credential_name": "team-bedrock-creds"},
+            )
+            data = {"model": "bedrock/anthropic.claude-3-5-sonnet", "metadata": {}}
+
+            result = add_aws_credentials_to_request(data, user_api_key_dict, "metadata")
+
+            # Key-level should override team-level
+            assert result["aws_role_name"] == "arn:aws:iam::123456789:role/KeyRole"
+            assert result["aws_region_name"] == "us-west-2"
+
+    def test_request_metadata_aws_credential_name_overrides_key(self):
+        """Test that request-level aws_credential_name overrides key-level"""
+        with patch(
+            "litellm.proxy.litellm_pre_call_utils._get_aws_credentials_from_credential_name"
+        ) as mock_get:
+            def side_effect(name):
+                if name == "request-bedrock-creds":
+                    return {
+                        "aws_role_name": "arn:aws:iam::123456789:role/RequestRole",
+                        "aws_region_name": "eu-west-1",
+                    }
+                elif name == "key-bedrock-creds":
+                    return {
+                        "aws_role_name": "arn:aws:iam::123456789:role/KeyRole",
+                        "aws_region_name": "us-west-2",
+                    }
+                return {}
+
+            mock_get.side_effect = side_effect
+
+            user_api_key_dict = UserAPIKeyAuth(
+                api_key="test-key",
+                metadata={"aws_credential_name": "key-bedrock-creds"},
+                team_metadata={},
+            )
+            data = {
+                "model": "bedrock/anthropic.claude-3-5-sonnet",
+                "metadata": {"aws_credential_name": "request-bedrock-creds"},
+            }
+
+            result = add_aws_credentials_to_request(data, user_api_key_dict, "metadata")
+
+            # Request-level should override key-level
+            assert result["aws_role_name"] == "arn:aws:iam::123456789:role/RequestRole"
+            assert result["aws_region_name"] == "eu-west-1"
+
+    def test_direct_aws_params_in_metadata_highest_priority(self):
+        """Test that direct AWS params in metadata have highest priority"""
+        with patch(
+            "litellm.proxy.litellm_pre_call_utils._get_aws_credentials_from_credential_name"
+        ) as mock_get:
+            mock_get.return_value = {
+                "aws_role_name": "arn:aws:iam::123456789:role/CredentialRole",
+                "aws_region_name": "us-west-2",
+            }
+
+            user_api_key_dict = UserAPIKeyAuth(
+                api_key="test-key",
+                metadata={"aws_credential_name": "key-bedrock-creds"},
+                team_metadata={},
+            )
+            # Direct AWS params in metadata override credential lookup
+            data = {
+                "model": "bedrock/anthropic.claude-3-5-sonnet",
+                "metadata": {
+                    "aws_credential_name": "request-bedrock-creds",
+                    "aws_role_name": "arn:aws:iam::123456789:role/DirectRole",
+                },
+            }
+
+            result = add_aws_credentials_to_request(data, user_api_key_dict, "metadata")
+
+            # Direct params should win
+            assert result["aws_role_name"] == "arn:aws:iam::123456789:role/DirectRole"
+
+    def test_existing_data_params_not_overwritten(self):
+        """Test that existing params in data are not overwritten"""
+        with patch(
+            "litellm.proxy.litellm_pre_call_utils._get_aws_credentials_from_credential_name"
+        ) as mock_get:
+            mock_get.return_value = {
+                "aws_role_name": "arn:aws:iam::123456789:role/CredentialRole",
+                "aws_region_name": "us-west-2",
+            }
+
+            user_api_key_dict = UserAPIKeyAuth(
+                api_key="test-key",
+                metadata={"aws_credential_name": "key-bedrock-creds"},
+                team_metadata={},
+            )
+            # Pre-existing param in data
+            data = {
+                "model": "bedrock/anthropic.claude-3-5-sonnet",
+                "metadata": {},
+                "aws_role_name": "arn:aws:iam::123456789:role/ExistingRole",
+            }
+
+            result = add_aws_credentials_to_request(data, user_api_key_dict, "metadata")
+
+            # Existing param should not be overwritten
+            assert result["aws_role_name"] == "arn:aws:iam::123456789:role/ExistingRole"
+            # But other params should be added
+            assert result["aws_region_name"] == "us-west-2"
+
+
+class TestAwsCredentialParams:
+    """Tests for the AWS_CREDENTIAL_PARAMS constant"""
+
+    def test_aws_credential_params_contains_expected_params(self):
+        """Test that AWS_CREDENTIAL_PARAMS contains all expected params"""
+        expected_params = [
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_session_token",
+            "aws_region_name",
+            "aws_session_name",
+            "aws_profile_name",
+            "aws_role_name",
+            "aws_web_identity_token",
+            "aws_sts_endpoint",
+            "aws_bedrock_runtime_endpoint",
+            "aws_external_id",
+        ]
+        for param in expected_params:
+            assert param in AWS_CREDENTIAL_PARAMS


### PR DESCRIPTION
This commit adds per-request, per-key, and per-team AWS credential support for Bedrock models, fixing "Invalid Security Token" errors when using aws_role_name.

Changes:
- Fix STS region handling in _auth_with_aws_role() to ensure regional consistency and prevent credential mismatches
- Add improved error handling and logging for common AWS STS errors
- Add per-request AWS credential override via request metadata
- Add per-key/per-team aws_credential_name lookup from credential store
- Add /credentials/{name}/validate_aws endpoint for credential validation
- Add comprehensive unit tests for all new functionality

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
