### PR TITLE
fix(helm): add OCI annotations so GHCR shows helm pull instead of docker pull

### DIFF
--- a/.github/actions/helm-oci-chart-releaser/action.yml
+++ b/.github/actions/helm-oci-chart-releaser/action.yml
@@ -40,36 +40,31 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Helm | Setup
+      uses: azure/setup-helm@v4
+      with:
+        version: v3.20.0
+
     - name: Helm | Login
       shell: bash
       run: echo ${{ inputs.registry_password }} | helm registry login -u ${{ inputs.registry_username }} --password-stdin ${{ inputs.registry }}
-      env:
-        HELM_EXPERIMENTAL_OCI: '1'
-    
+
     - name: Helm | Dependency
       if: inputs.update_dependencies == 'true'
       shell: bash
       run: helm dependency update ${{ inputs.path == null && format('{0}/{1}', 'charts', inputs.name) || inputs.path }}
-      env:
-        HELM_EXPERIMENTAL_OCI: '1'
 
     - name: Helm | Package
       shell: bash
       run: helm package ${{ inputs.path == null && format('{0}/{1}', 'charts', inputs.name) || inputs.path }} --version ${{ inputs.tag }} --app-version ${{ inputs.app_version }}
-      env:
-        HELM_EXPERIMENTAL_OCI: '1'
 
     - name: Helm | Push
       shell: bash
       run: helm push ${{ inputs.name }}-${{ inputs.tag }}.tgz oci://${{ inputs.registry }}/${{ inputs.repository }}
-      env:
-        HELM_EXPERIMENTAL_OCI: '1'
 
     - name: Helm | Logout
       shell: bash
       run: helm registry logout ${{ inputs.registry }}
-      env:
-        HELM_EXPERIMENTAL_OCI: '1'
 
     - name: Helm | Output
       id: output

--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -26,6 +26,10 @@ version: 1.1.0
 # It is recommended to use it with quotes.
 appVersion: v1.80.12
 
+annotations:
+  org.opencontainers.image.source: "https://github.com/BerriAI/litellm"
+  org.opencontainers.image.url: "https://docs.litellm.ai/"
+
 dependencies:
   - name: "postgresql"
     version: ">=13.3.0"


### PR DESCRIPTION
## Relevant issues

GHCR package page for `litellm-helm` shows `docker pull ghcr.io/berriai/litellm-helm:...` instead of the correct `helm pull oci://ghcr.io/berriai/litellm-helm --version ...`.

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - N/A: CI/infrastructure-only change (Chart.yaml annotations + GitHub Action config). No application code modified.
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

The Helm chart published to GHCR is missing OCI annotations, causing GitHub to display it as a Docker image with a `docker pull` command instead of the proper `helm pull oci://` command.

### Root cause
- `Chart.yaml` lacked the `org.opencontainers.image.source` annotation that GHCR uses to identify Helm charts and display the correct install command
- The custom GitHub Action used the deprecated `HELM_EXPERIMENTAL_OCI` env var (from Helm < 3.8) and relied on whatever Helm version was pre-installed on the runner

### Fix
1. **`deploy/charts/litellm-helm/Chart.yaml`** — Added `annotations` block with `org.opencontainers.image.source` and `org.opencontainers.image.url`. Helm 3.10+ ([helm/helm#11204](https://github.com/helm/helm/pull/11204)) propagates these to the OCI manifest on `helm push`.
2. **`.github/actions/helm-oci-chart-releaser/action.yml`** — Added `azure/setup-helm@v4` step pinned to Helm `v3.20.0` for reproducible builds and proper OCI annotation support. Removed deprecated `HELM_EXPERIMENTAL_OCI` env var (OCI is GA since Helm 3.8).

### Expected result
After the next Helm chart release, the GHCR package page should display:
```
$ helm pull oci://ghcr.io/berriai/litellm-helm --version X.Y.Z
```
instead of:
```
$ docker pull ghcr.io/berriai/litellm-helm:X.Y.Z
```

> **Note:** This fix only applies to newly published chart versions. Existing versions already on GHCR will continue showing `docker pull`.