### PR TITLE
[Feature] UI - Team Settings: Soft Budget + Alerting Emails

### DIFF
--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbo",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.test.tsx
@@ -44,7 +44,10 @@ const renderWithForm = (props = {}) => {
   it("should default allow_all_keys switch to unchecked for new servers", async () => {
     renderWithForm();
     await expandPanel();
-    const toggle = screen.getByRole("switch");
+    // Find the switch associated with "Allow All LiteLLM Keys" text
+    // The first switch in the component is for allow_all_keys
+    const switches = screen.getAllByRole("switch");
+    const toggle = switches[0];
     expect(toggle).toHaveAttribute("aria-checked", "false");
   });
 
@@ -62,7 +65,10 @@ const renderWithForm = (props = {}) => {
     });
 
     const user = await expandPanel();
-    const toggle = screen.getByRole("switch");
+    // Find the switch associated with "Allow All LiteLLM Keys" text
+    // The first switch in the component is for allow_all_keys
+    const switches = screen.getAllByRole("switch");
+    const toggle = switches[0];
     expect(toggle).toHaveAttribute("aria-checked", "true");
 
     await user.click(toggle);

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.test.tsx
@@ -11,6 +11,10 @@ vi.mock("../networking", () => ({
   fetchMCPServerHealth: vi.fn(),
   deleteMCPServer: vi.fn(),
   getProxyBaseUrl: vi.fn().mockReturnValue("http://localhost:4000"),
+  fetchMCPClientIp: vi.fn().mockResolvedValue(null),
+  getGeneralSettingsCall: vi.fn().mockResolvedValue([]),
+  updateConfigFieldSetting: vi.fn().mockResolvedValue(undefined),
+  deleteConfigFieldSetting: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock NotificationsManager

--- a/ui/litellm-dashboard/src/components/team/team_info.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.test.tsx
@@ -573,4 +573,63 @@ describe("TeamInfoView", () => {
       expect(teamNameElements.length).toBeGreaterThan(0);
     });
   });
+
+  it("should display soft budget in settings view when present", async () => {
+    const user = userEvent.setup();
+    vi.mocked(networking.teamInfoCall).mockResolvedValue(
+      createMockTeamData({
+        soft_budget: 500.75,
+        max_budget: 1000,
+      })
+    );
+
+    renderWithProviders(<TeamInfoView {...defaultProps} />);
+
+    await waitFor(() => {
+      const teamNameElements = screen.queryAllByText("Test Team");
+      expect(teamNameElements.length).toBeGreaterThan(0);
+    });
+
+    const settingsTab = screen.getByRole("tab", { name: "Settings" });
+    await user.click(settingsTab);
+
+    await waitFor(() => {
+      expect(screen.getByText("Team Settings")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Soft Budget:/)).toBeInTheDocument();
+      expect(screen.getByText(/\$500\.75/)).toBeInTheDocument();
+    });
+  });
+
+  it("should display soft budget alerting emails in settings view when present", async () => {
+    const user = userEvent.setup();
+    vi.mocked(networking.teamInfoCall).mockResolvedValue(
+      createMockTeamData({
+        metadata: {
+          soft_budget_alerting_emails: ["alert1@test.com", "alert2@test.com"],
+        },
+      })
+    );
+
+    renderWithProviders(<TeamInfoView {...defaultProps} />);
+
+    await waitFor(() => {
+      const teamNameElements = screen.queryAllByText("Test Team");
+      expect(teamNameElements.length).toBeGreaterThan(0);
+    });
+
+    const settingsTab = screen.getByRole("tab", { name: "Settings" });
+    await user.click(settingsTab);
+
+    await waitFor(() => {
+      expect(screen.getByText("Team Settings")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Soft Budget Alerting Emails:/)).toBeInTheDocument();
+      expect(screen.getByText(/alert1@test\.com, alert2@test\.com/)).toBeInTheDocument();
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -85,6 +85,7 @@ export interface TeamData {
     tpm_limit: number | null;
     rpm_limit: number | null;
     max_budget: number | null;
+    soft_budget?: number | null;
     budget_duration: string | null;
     models: string[];
     blocked: boolean;
@@ -424,7 +425,10 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
       let parsedMetadata = {};
       try {
-        parsedMetadata = values.metadata ? JSON.parse(values.metadata) : {};
+        const rawMetadata = values.metadata ? JSON.parse(values.metadata) : {};
+        // Exclude soft_budget_alerting_emails from parsed metadata since it's handled separately
+        const { soft_budget_alerting_emails, ...rest } = rawMetadata;
+        parsedMetadata = rest;
       } catch (e) {
         NotificationsManager.fromBackend("Invalid JSON in metadata field");
         return;
@@ -457,12 +461,20 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         tpm_limit: sanitizeNumeric(values.tpm_limit),
         rpm_limit: sanitizeNumeric(values.rpm_limit),
         max_budget: values.max_budget,
+        soft_budget: sanitizeNumeric(values.soft_budget),
         budget_duration: values.budget_duration,
         metadata: {
           ...parsedMetadata,
           guardrails: values.guardrails || [],
           logging: values.logging_settings || [],
           disable_global_guardrails: values.disable_global_guardrails || false,
+          soft_budget_alerting_emails:
+            typeof values.soft_budget_alerting_emails === "string"
+              ? values.soft_budget_alerting_emails
+                .split(",")
+                .map((email: string) => email.trim())
+                .filter((email: string) => email.length > 0)
+              : values.soft_budget_alerting_emails || [],
           ...(secretManagerSettings !== undefined ? { secret_manager_settings: secretManagerSettings } : {}),
         },
         policies: values.policies || [],
@@ -754,6 +766,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     tpm_limit: info.tpm_limit,
                     rpm_limit: info.rpm_limit,
                     max_budget: info.max_budget,
+                    soft_budget: info.soft_budget,
                     budget_duration: info.budget_duration,
                     team_member_tpm_limit: info.team_member_budget_table?.tpm_limit,
                     team_member_rpm_limit: info.team_member_budget_table?.rpm_limit,
@@ -762,9 +775,13 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     guardrails: info.metadata?.guardrails || [],
                     policies: info.policies || [],
                     disable_global_guardrails: info.metadata?.disable_global_guardrails || false,
+                    soft_budget_alerting_emails:
+                      Array.isArray(info.metadata?.soft_budget_alerting_emails)
+                        ? info.metadata.soft_budget_alerting_emails.join(", ")
+                        : "",
                     metadata: info.metadata
                       ? JSON.stringify(
-                        (({ logging, secret_manager_settings, ...rest }) => rest)(info.metadata),
+                        (({ logging, secret_manager_settings, soft_budget_alerting_emails, ...rest }) => rest)(info.metadata),
                         null,
                         2,
                       )
@@ -819,6 +836,18 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
                   <Form.Item label="Max Budget (USD)" name="max_budget">
                     <NumericalInput step={0.01} precision={2} style={{ width: "100%" }} />
+                  </Form.Item>
+
+                  <Form.Item label="Soft Budget (USD)" name="soft_budget">
+                    <NumericalInput step={0.01} precision={2} style={{ width: "100%" }} />
+                  </Form.Item>
+
+                  <Form.Item
+                    label="Soft Budget Alerting Emails"
+                    name="soft_budget_alerting_emails"
+                    tooltip="Comma-separated email addresses to receive alerts when the soft budget is reached"
+                  >
+                    <Input placeholder="example1@test.com, example2@test.com" />
                   </Form.Item>
 
                   <Form.Item
@@ -1096,7 +1125,20 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       Max Budget:{" "}
                       {info.max_budget !== null ? `$${formatNumberWithCommas(info.max_budget, 4)}` : "No Limit"}
                     </div>
+                    <div>
+                      Soft Budget:{" "}
+                      {info.soft_budget !== null && info.soft_budget !== undefined
+                        ? `$${formatNumberWithCommas(info.soft_budget, 4)}`
+                        : "No Limit"}
+                    </div>
                     <div>Budget Reset: {info.budget_duration || "Never"}</div>
+                    {info.metadata?.soft_budget_alerting_emails &&
+                      Array.isArray(info.metadata.soft_budget_alerting_emails) &&
+                      info.metadata.soft_budget_alerting_emails.length > 0 && (
+                        <div>
+                          Soft Budget Alerting Emails: {info.metadata.soft_budget_alerting_emails.join(", ")}
+                        </div>
+                      )}
                   </div>
                   <div>
                     <Text className="font-medium">

--- a/ui/litellm-dashboard/tsconfig.json
+++ b/ui/litellm-dashboard/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
✅ Test

## Changes

Adds soft budget and soft budget alerting emails fields to the team settings UI. Users can now set a soft budget value and configure comma-separated email addresses to receive alerts when the soft budget is reached. The soft budget and alerting emails are displayed in the team settings view and can be edited through the settings form.

## Screenshots
<img width="1172" height="403" alt="image" src="https://github.com/user-attachments/assets/091a6b5a-f595-4d49-8137-a1af6e40a823" />
<img width="712" height="250" alt="image" src="https://github.com/user-attachments/assets/77e446b3-89c0-4b4d-b7f2-fc6a95389784" />
