### PR TITLE
fix: correct typo 'occured' to 'occurred'

### DIFF
--- a/litellm/llms/vertex_ai/cost_calculator.py
+++ b/litellm/llms/vertex_ai/cost_calculator.py
@@ -122,7 +122,7 @@ def cost_per_character(
                 prompt_cost = prompt_characters * model_info["input_cost_per_character"]
         except Exception as e:
             verbose_logger.debug(
-                "litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occured - {}\nDefaulting to None".format(
+                "litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occurred - {}\nDefaulting to None".format(
                     str(e)
                 )
             )
@@ -169,7 +169,7 @@ def cost_per_character(
                 )
         except Exception as e:
             verbose_logger.debug(
-                "litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occured - {}\nDefaulting to None".format(
+                "litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occurred - {}\nDefaulting to None".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -119,7 +119,7 @@ async def anthropic_response(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.anthropic_response(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.anthropic_response(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -76,7 +76,7 @@ class UserAPIKeyAuthExceptionHandler:
                 use_x_forwarded_for=general_settings.get("use_x_forwarded_for", False),
             )
             verbose_proxy_logger.exception(
-                "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - {}\nRequester IP Address:{}".format(
+                "litellm.proxy.proxy_server.user_api_key_auth(): Exception occurred - {}\nRequester IP Address:{}".format(
                     str(e),
                     requester_ip,
                 ),

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -283,7 +283,7 @@ async def create_batch(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.create_batch(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.create_batch(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -510,7 +510,7 @@ async def retrieve_batch(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.retrieve_batch(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.retrieve_batch(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -684,7 +684,7 @@ async def list_batches(
             request_data={"after": after, "limit": limit},
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.retrieve_batch(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.retrieve_batch(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -884,7 +884,7 @@ async def cancel_batch(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.create_batch(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.create_batch(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1047,7 +1047,7 @@ class ProxyBaseLLMRequestProcessing:
     ):
         """Raises ProxyException (OpenAI API compatible) if an exception is raised"""
         verbose_proxy_logger.exception(
-            f"litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occured - {str(e)}"
+            f"litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occurred - {str(e)}"
         )
         # Allow callbacks to transform the error response
         transformed_exception = await proxy_logging_obj.post_call_failure_hook(
@@ -1240,7 +1240,7 @@ class ProxyBaseLLMRequestProcessing:
                 yield ProxyBaseLLMRequestProcessing.return_sse_chunk(chunk)
         except Exception as e:
             verbose_proxy_logger.exception(
-                "litellm.proxy.proxy_server.async_data_generator(): Exception occured - {}".format(
+                "litellm.proxy.proxy_server.async_data_generator(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -427,7 +427,7 @@ async def health_services_endpoint(  # noqa: PLR0915
 
     except Exception as e:
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.health_services_endpoint(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.health_services_endpoint(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -867,7 +867,7 @@ async def health_endpoint(
             )
     except Exception as e:
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.py::health_endpoint(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.py::health_endpoint(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/hooks/azure_content_safety.py
+++ b/litellm/proxy/hooks/azure_content_safety.py
@@ -127,7 +127,7 @@ class _PROXY_AzureContentSafety(
             raise e
         except Exception as e:
             verbose_proxy_logger.error(
-                "litellm.proxy.hooks.azure_content_safety.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.azure_content_safety.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/hooks/batch_redis_get.py
+++ b/litellm/proxy/hooks/batch_redis_get.py
@@ -98,7 +98,7 @@ class _PROXY_BatchRedisRequests(CustomLogger):
             raise e
         except Exception as e:
             verbose_proxy_logger.error(
-                "litellm.proxy.hooks.batch_redis_get.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.batch_redis_get.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/hooks/cache_control_check.py
+++ b/litellm/proxy/hooks/cache_control_check.py
@@ -52,7 +52,7 @@ class _PROXY_CacheControlCheck(CustomLogger):
             raise e
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.cache_control_check.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.cache_control_check.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/hooks/dynamic_rate_limiter.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter.py
@@ -66,7 +66,7 @@ class DynamicRateLimiterCache:
             )
         except Exception as e:
             verbose_proxy_logger.exception(
-                "litellm.proxy.hooks.dynamic_rate_limiter.py::async_set_cache_sadd(): Exception occured - {}".format(
+                "litellm.proxy.hooks.dynamic_rate_limiter.py::async_set_cache_sadd(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -296,7 +296,7 @@ class _PROXY_DynamicRateLimitHandler(CustomLogger):
             )
         except Exception as e:
             verbose_proxy_logger.exception(
-                "litellm.proxy.hooks.dynamic_rate_limiter.py::async_post_call_success_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.dynamic_rate_limiter.py::async_post_call_success_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -43,7 +43,7 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
             raise e
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.max_budget_limiter.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.max_budget_limiter.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/hooks/prompt_injection_detection.py
+++ b/litellm/proxy/hooks/prompt_injection_detection.py
@@ -211,7 +211,7 @@ class _OPTIONAL_PromptInjectionDetection(CustomLogger):
             raise e
         except Exception as e:
             verbose_proxy_logger.exception(
-                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -173,7 +173,7 @@ async def image_generation(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.image_generation(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.image_generation(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/management_endpoints/customer_endpoints.py
+++ b/litellm/proxy/management_endpoints/customer_endpoints.py
@@ -298,7 +298,7 @@ async def new_end_user(
         return end_user_record
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.management_endpoints.customer_endpoints.new_end_user(): Exception occured - {}".format(
+            "litellm.proxy.management_endpoints.customer_endpoints.new_end_user(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -365,7 +365,7 @@ async def end_user_info(
     
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.management_endpoints.customer_endpoints.end_user_info(): Exception occured - {}".format(
+            "litellm.proxy.management_endpoints.customer_endpoints.end_user_info(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -519,7 +519,7 @@ async def update_end_user(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.update_end_user(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.update_end_user(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -608,7 +608,7 @@ async def delete_end_user(
         # update based on remaining passed in values
     except Exception as e:
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.delete_end_user(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.delete_end_user(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -673,7 +673,7 @@ async def list_end_user(
     
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.management_endpoints.customer_endpoints.list_end_user(): Exception occured - {}".format(
+            "litellm.proxy.management_endpoints.customer_endpoints.list_end_user(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -241,7 +241,7 @@ async def _add_user_to_team(
             )
         else:
             verbose_proxy_logger.debug(
-                "litellm.proxy.management_endpoints.internal_user_endpoints.new_user(): Exception occured - {}".format(
+                "litellm.proxy.management_endpoints.internal_user_endpoints.new_user(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -496,7 +496,7 @@ async def new_user(
         return new_user_response
     except Exception as e:
         verbose_proxy_logger.exception(
-            "/user/new: Exception occured - {}".format(str(e))
+            "/user/new: Exception occurred - {}".format(str(e))
         )
         raise handle_exception_on_proxy(e)
 
@@ -706,7 +706,7 @@ async def user_info(
         return response_data
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.user_info(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.user_info(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1092,7 +1092,7 @@ async def user_update(
         return response
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.user_update(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.user_update(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1976,7 +1976,7 @@ async def get_user_daily_activity(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "/spend/daily/analytics: Exception occured - {}".format(str(e))
+            "/spend/daily/analytics: Exception occurred - {}".format(str(e))
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -2053,7 +2053,7 @@ async def get_user_daily_activity_aggregated(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "/user/daily/activity/aggregated: Exception occured - {}".format(str(e))
+            "/user/daily/activity/aggregated: Exception occurred - {}".format(str(e))
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1140,7 +1140,7 @@ async def generate_key_fn(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.generate_key_fn(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.generate_key_fn(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1320,7 +1320,7 @@ def prepare_metadata_fields(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.prepare_metadata_fields(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.prepare_metadata_fields(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1876,7 +1876,7 @@ async def update_key_fn(
         # update based on remaining passed in values
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.update_key_fn(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.update_key_fn(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -2237,7 +2237,7 @@ async def delete_key_fn(
         return {"deleted_keys": deleted_keys}
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.delete_key_fn(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.delete_key_fn(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -2687,7 +2687,7 @@ async def generate_key_helper_fn(  # noqa: PLR0915
                     key_data["router_settings"] = {}
     except Exception as e:
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.generate_key_helper_fn(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.generate_key_helper_fn(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -2909,7 +2909,7 @@ async def delete_verification_tokens(
             raise Exception("DB not connected. prisma_client is None")
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.delete_verification_tokens(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.delete_verification_tokens(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -956,7 +956,7 @@ async def add_new_model(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.add_new_model(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.add_new_model(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1114,7 +1114,7 @@ async def update_model(
             return model_response
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.update_model(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.update_model(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -143,7 +143,7 @@ async def add_team_callbacks(
         raise e
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.add_team_callbacks(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.add_team_callbacks(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -516,7 +516,7 @@ async def create_file(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.create_file(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.create_file(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -761,7 +761,7 @@ async def get_file_content(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.retrieve_file_content(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.retrieve_file_content(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -941,7 +941,7 @@ async def get_file(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.retrieve_file(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.retrieve_file(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1136,7 +1136,7 @@ async def delete_file(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.delete_file(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.delete_file(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1313,7 +1313,7 @@ async def list_files(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.list_files(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.list_files(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -293,7 +293,7 @@ async def chat_completion_pass_through_endpoint(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.completion(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.completion(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -920,7 +920,7 @@ async def pass_through_request(  # noqa: PLR0915
             api_base=str(url._uri_reference) if url else None,
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.pass_through_endpoint(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.pass_through_endpoint(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4689,7 +4689,7 @@ async def async_assistants_data_generator(
         yield f"data: {done_message}\n\n"
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.async_assistants_data_generator(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.async_assistants_data_generator(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -4837,7 +4837,7 @@ async def async_data_generator(
         yield f"data: {done_message}\n\n"
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.async_data_generator(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.async_data_generator(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -6109,7 +6109,7 @@ async def completion(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.completion(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.completion(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -6363,7 +6363,7 @@ async def moderations(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.moderations(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.moderations(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -6502,7 +6502,7 @@ async def audio_speech(
 
     except Exception as e:
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.audio_speech(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.audio_speech(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -6640,7 +6640,7 @@ async def audio_transcriptions(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.audio_transcription(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.audio_transcription(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -6879,7 +6879,7 @@ async def get_assistants(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.get_assistants(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.get_assistants(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -6978,7 +6978,7 @@ async def create_assistant(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.create_assistant(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.create_assistant(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -7075,7 +7075,7 @@ async def delete_assistant(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.delete_assistant(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.delete_assistant(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -7172,7 +7172,7 @@ async def create_threads(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.create_threads(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.create_threads(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -7267,7 +7267,7 @@ async def get_thread(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.get_thread(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.get_thread(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -7366,7 +7366,7 @@ async def add_messages(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.add_messages(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.add_messages(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -7461,7 +7461,7 @@ async def get_messages(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.get_messages(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.get_messages(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -7571,7 +7571,7 @@ async def run_thread(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.run_thread(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.run_thread(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -7704,7 +7704,7 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
             )
         except Exception:
             verbose_proxy_logger.exception(
-                "litellm.proxy.proxy_server.token_counter(): Exception occured while getting deployment"
+                "litellm.proxy.proxy_server.token_counter(): Exception occurred while getting deployment"
             )
             pass
     if deployment is not None:
@@ -10677,7 +10677,7 @@ async def update_config(config_info: ConfigYAML):  # noqa: PLR0915
         return {"message": "Config updated successfully"}
     except Exception as e:
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.update_config(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.update_config(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -11309,7 +11309,7 @@ async def get_config():  # noqa: PLR0915
         }
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.get_config(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.get_config(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/rerank_endpoints/endpoints.py
+++ b/litellm/proxy/rerank_endpoints/endpoints.py
@@ -108,7 +108,7 @@ async def rerank(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.rerank(): Exception occured - {}".format(str(e))
+            "litellm.proxy.proxy_server.rerank(): Exception occurred - {}".format(str(e))
         )
         if isinstance(e, HTTPException):
             raise ProxyException(

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2898,7 +2898,7 @@ async def provider_budgets() -> ProviderBudgetResponse:
         return ProviderBudgetResponse(providers=provider_budget_response_dict)
     except Exception as e:
         verbose_proxy_logger.exception(
-            "/provider/budgets: Exception occured - {}".format(str(e))
+            "/provider/budgets: Exception occurred - {}".format(str(e))
         )
         raise handle_exception_on_proxy(e)
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5394,7 +5394,7 @@ class Router:
 
         except Exception as e:
             verbose_router_logger.debug(
-                "litellm.router.Router::deployment_callback_on_success(): Exception occured - {}".format(
+                "litellm.router.Router::deployment_callback_on_success(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -98,7 +98,7 @@ class LowestCostLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.router_strategy.lowest_cost.py::log_success_event(): Exception occured - {}".format(
+                "litellm.router_strategy.lowest_cost.py::log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -186,7 +186,7 @@ class LowestCostLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -183,7 +183,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -252,7 +252,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 return
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -405,7 +405,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.router_strategy.lowest_latency.py::async_log_success_event(): Exception occured - {}".format(
+                "litellm.router_strategy.lowest_latency.py::async_log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -82,7 +82,7 @@ class LowestTPMLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_router_logger.error(
-                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occured - {}".format(
+                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -153,7 +153,7 @@ class LowestTPMLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_router_logger.exception(
-                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occured - {}".format(
+                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -269,7 +269,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                 self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.lowest_tpm_rpm_v2.py::log_success_event(): Exception occured - {}".format(
+                "litellm.proxy.hooks.lowest_tpm_rpm_v2.py::log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -320,7 +320,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                 self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.lowest_tpm_rpm_v2.py::async_log_success_event(): Exception occured - {}".format(
+                "litellm.proxy.hooks.lowest_tpm_rpm_v2.py::async_log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )


### PR DESCRIPTION
Fixed spelling across 28 files in error messages and comments.

- Changed `occured` to `occurred`