### PR TITLE
chore: add Next.js static export output to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ litellm/proxy/tests/package.json
 litellm/proxy/tests/package-lock.json
 ui/litellm-dashboard/.next
 ui/litellm-dashboard/node_modules
+litellm/proxy/_experimental/out/
 ui/litellm-dashboard/next-env.d.ts
 ui/litellm-dashboard/package.json
 ui/litellm-dashboard/package-lock.json


### PR DESCRIPTION
## Summary
- Adds `litellm/proxy/_experimental/out/` to `.gitignore`
- This directory contains Next.js static export build artifacts (HTML, JS, CSS) that are regenerated on each build

## Why
Build artifacts should not be committed to version control as they:
- Are regenerated on each build
- Can cause unnecessary merge conflicts
- Bloat the repository

## Test plan
- [x] Verify the path is correct
- [x] Similar to existing `.next` exclusion on line 43

🤖 Generated with [Claude Code](https://claude.com/claude-code)