### PR TITLE
fix(spend-tracking): avoid RLock pickle error when redaction is enabled

### DIFF
--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -960,7 +960,6 @@ def test_should_store_prompts_and_responses_in_spend_logs_case_insensitive_strin
 
 
 
-import threading
 from pydantic import BaseModel as PydanticBaseModel
 
 


### PR DESCRIPTION
## Summary
- Fixes spend logs creation failing with `cannot pickle '_thread.RLock' object` when request/response redaction is enabled
- Replaces `copy.deepcopy()` calls in `spend_tracking_utils.py` with a new `_safe_deepcopy()` helper that uses Pydantic's `model_dump()` for BaseModel instances instead of pickle-based deep copy
- The helper recursively handles nested dicts, lists, and Pydantic models, with a safe fallback for other types

Fixes #20647

## Root Cause
Pydantic v2 `BaseModel` instances (e.g. `UserAPIKeyAuth`) contain internal `_thread.RLock` objects for thread safety. When `copy.deepcopy()` is called on a request body containing these models during the redaction path, Python's pickle module fails because `RLock` objects cannot be serialized.

## Changes
- **`litellm/proxy/spend_tracking/spend_tracking_utils.py`**: Added `_safe_deepcopy()` helper function and replaced both `copy.deepcopy()` calls in the redaction paths with it
- **`tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py`**: Added 4 regression tests covering Pydantic model handling, nested structures, plain objects, and the end-to-end redaction flow with Pydantic models in the request body

## Test plan
- [x] `test_safe_deepcopy_with_pydantic_model` - verifies BaseModel instances are safely converted
- [x] `test_safe_deepcopy_with_nested_pydantic_model_in_dict` - verifies nested dicts/lists containing models work correctly and produce true copies
- [x] `test_safe_deepcopy_with_plain_objects` - verifies normal objects still deep-copy correctly
- [x] `test_spend_logs_redaction_with_pydantic_model_in_request_body` - end-to-end test reproducing the exact bug scenario (Pydantic model in request body + redaction enabled)
- [x] Existing test `test_spend_logs_redacts_request_and_response_when_turn_off_message_logging_enabled` still passes