### PR TITLE
fix(ui): add null guard for models in API keys table

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -542,3 +542,86 @@ it("should display 'Default Proxy Admin' for created_by when value is 'default_u
     expect(defaultProxyAdminElements.length).toBeGreaterThan(0);
   });
 });
+
+
+it("should render table without crashing when models is null", async () => {
+  const keyWithNullModels = {
+    ...mockKey,
+    models: null as unknown as string[],
+  };
+
+  mockUseFilterLogic.mockReturnValue({
+    filters: {
+      "Team ID": "",
+      "Organization ID": "",
+      "Key Alias": "",
+      "User ID": "",
+      "Sort By": "created_at",
+      "Sort Order": "desc",
+    },
+    filteredKeys: [keyWithNullModels],
+    allKeyAliases: ["test-key-alias"],
+    allTeams: [mockTeam],
+    allOrganizations: [mockOrganization],
+    handleFilterChange: vi.fn(),
+    handleFilterReset: vi.fn(),
+  });
+
+  const mockProps = {
+    teams: [mockTeam],
+    organizations: [mockOrganization],
+    onSortChange: vi.fn(),
+    currentSort: {
+      sortBy: "created_at",
+      sortOrder: "desc" as const,
+    },
+  };
+
+  // This should not throw an error
+  renderWithProviders(<VirtualKeysTable {...mockProps} />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Test Key Alias")).toBeInTheDocument();
+  });
+});
+
+it("should render table without crashing when models is undefined", async () => {
+  const keyWithUndefinedModels = {
+    ...mockKey,
+    models: undefined as unknown as string[],
+  };
+
+  mockUseFilterLogic.mockReturnValue({
+    filters: {
+      "Team ID": "",
+      "Organization ID": "",
+      "Key Alias": "",
+      "User ID": "",
+      "Sort By": "created_at",
+      "Sort Order": "desc",
+    },
+    filteredKeys: [keyWithUndefinedModels],
+    allKeyAliases: ["test-key-alias"],
+    allTeams: [mockTeam],
+    allOrganizations: [mockOrganization],
+    handleFilterChange: vi.fn(),
+    handleFilterReset: vi.fn(),
+  });
+
+  const mockProps = {
+    teams: [mockTeam],
+    organizations: [mockOrganization],
+    onSortChange: vi.fn(),
+    currentSort: {
+      sortBy: "created_at",
+      sortOrder: "desc" as const,
+    },
+  };
+
+  // This should not throw an error
+  renderWithProviders(<VirtualKeysTable {...mockProps} />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Test Key Alias")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -727,7 +727,7 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
                                 whiteSpace: "pre-wrap",
                                 overflow: "hidden",
                               }}
-                              className={`py-0.5 max-h-8 overflow-hidden text-ellipsis whitespace-nowrap ${cell.column.id === "models" && (cell.getValue() as string[]).length > 3 ? "px-0" : ""}`}
+                              className={`py-0.5 max-h-8 overflow-hidden text-ellipsis whitespace-nowrap ${cell.column.id === "models" && Array.isArray(cell.getValue()) && (cell.getValue() as string[]).length > 3 ? "px-0" : ""}`}
                             >
                               {flexRender(cell.column.columnDef.cell, cell.getContext())}
                             </TableCell>


### PR DESCRIPTION
## Summary
- Fix crash in the Virtual Keys table when a key's `models` field is `null` or `undefined`
- The `className` expression on the `TableCell` tried to access `.length` on a potentially null value, throwing a `TypeError` that broke the entire keys page
- Added `Array.isArray()` guard before accessing `.length` on the models value

## Root Cause
In `VirtualKeysTable.tsx` line 730, the expression:
```tsx
cell.column.id === "models" && (cell.getValue() as string[]).length > 3
```
crashes when `cell.getValue()` returns `null` or `undefined` (which happens when a key has no models set). JavaScript short-circuit evaluation evaluates the second operand when the first is truthy, causing `null.length` to throw.

## Fix
```tsx
cell.column.id === "models" && Array.isArray(cell.getValue()) && (cell.getValue() as string[]).length > 3
```

## Test plan
- [x] Added unit tests for keys with `null` models
- [x] Added unit tests for keys with `undefined` models
- [x] Existing tests continue to pass

Fixes #20611