### PR TITLE
fix: show error details instead of 'Data Not Available' for failed requests

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -85,7 +85,7 @@ export function LogDetailsDrawer({
   // Check if request/response data is present
   const hasMessages = checkHasMessages(logEntry.messages);
   const hasResponse = checkHasResponse(logEntry.response);
-  const missingData = !hasMessages && !hasResponse;
+  const missingData = !hasMessages && !hasResponse && !hasError;
 
   // Guardrail data
   const guardrailInfo = metadata?.guardrail_information;
@@ -206,6 +206,7 @@ export function LogDetailsDrawer({
         {/* Request/Response JSON - Collapsible */}
         <RequestResponseSection
           hasResponse={hasResponse}
+          hasError={hasError}
           getRawRequest={getRawRequest}
           getFormattedResponse={getFormattedResponse}
           logEntry={logEntry}
@@ -339,6 +340,7 @@ function MetricsSection({ logEntry, metadata }: { logEntry: LogEntry; metadata: 
 
 interface RequestResponseSectionProps {
   hasResponse: boolean;
+  hasError: boolean;
   getRawRequest: () => any;
   getFormattedResponse: () => any;
   logEntry: LogEntry;
@@ -346,6 +348,7 @@ interface RequestResponseSectionProps {
 
 function RequestResponseSection({
   hasResponse,
+  hasError,
   getRawRequest,
   getFormattedResponse,
   logEntry,
@@ -423,7 +426,7 @@ function RequestResponseSection({
                           text: getCopyText(),
                           tooltips: ["Copy JSON", "Copied!"]
                         }}
-                        disabled={activeTab === TAB_RESPONSE && !hasResponse}
+                        disabled={activeTab === TAB_RESPONSE && !hasResponse && !hasError}
                       />
                     }
                     items={[
@@ -441,7 +444,7 @@ function RequestResponseSection({
                         label: "Response",
                         children: (
                           <div style={{ paddingTop: SPACING_XLARGE, paddingBottom: SPACING_XLARGE }}>
-                            {hasResponse ? (
+                            {hasResponse || hasError ? (
                               <JsonViewer data={getFormattedResponse()} mode="formatted" />
                             ) : (
                               <div style={{ textAlign: "center", padding: 20, color: "#999", fontStyle: "italic" }}>

--- a/ui/litellm-dashboard/src/components/view_logs/RequestResponsePanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestResponsePanel.tsx
@@ -113,7 +113,7 @@ export function RequestResponsePanel({
             onClick={handleCopyResponse}
             className="p-1 hover:bg-gray-200 rounded"
             title="Copy response"
-            disabled={!hasResponse}
+            disabled={!hasResponse && !hasError}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -132,7 +132,7 @@ export function RequestResponsePanel({
           </button>
         </div>
         <div className="p-4 overflow-auto max-h-96 w-full max-w-full box-border">
-          {hasResponse ? (
+          {hasResponse || hasError ? (
             <div className="[&_[role='tree']]:bg-white [&_[role='tree']]:text-slate-900">
               <JsonView data={formattedResponse()} style={defaultStyles} clickToExpandNode />
             </div>

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -822,7 +822,7 @@ export function RequestViewer({ row, onOpenSettings }: { row: Row<LogEntry>; onO
       ? row.original.messages.length > 0
       : Object.keys(row.original.messages).length > 0);
   const hasResponse = row.original.response && Object.keys(formatData(row.original.response)).length > 0;
-  const missingData = !hasMessages && !hasResponse;
+  const missingData = !hasMessages && !hasResponse && !hasError;
 
   // Format the response with error details if present
   const formattedResponse = () => {


### PR DESCRIPTION
## Summary

Fixes #20614

When a request fails, the log detail views (both the expanded row and the right-side drawer) were incorrectly showing the "Request/Response Data Not Available" configuration message. This happened because the `missingData` check only looked at `hasMessages` and `hasResponse`, which are both empty/null for failed requests even though the error information is available in `metadata.error_information`.

### Changes

- **`index.tsx`** (`RequestViewer`): Added `&& !hasError` to the `missingData` computation so the config info banner is not shown for failures that have error information
- **`LogDetailsDrawer.tsx`**: Same `missingData` fix, plus passed `hasError` prop to `RequestResponseSection` so the response tab correctly shows the formatted error response instead of "Response data not available"
- **`RequestResponsePanel.tsx`**: Updated the response display condition from `hasResponse` to `hasResponse || hasError` so error responses are rendered, and enabled the copy button for error responses

### Before
Failed requests showed "Data Not Available" config message, misleading users into thinking `store_prompts_in_spend_logs` was not configured.

### After
Failed requests show the actual error response (error message, error class, HTTP status code) in the response panel, and the config info message is only shown when data is genuinely missing (successful requests without prompt storage enabled).

## Test plan

- [x] Added 3 new unit tests in `RequestResponsePanel.test.tsx`:
  - Verifies error response data is displayed when `hasError=true` and `hasResponse=false`
  - Verifies "Response data not available" is still shown when both `hasResponse` and `hasError` are false
  - Verifies the HTTP error code is shown in the response header for error responses