### PR TITLE
fix(ui): LITELLM_UI_API_DOC_BASE_URL works without PROXY_BASE_URL

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -2701,10 +2701,10 @@ async def test_get_ui_settings_api_doc_base_url_independent_of_proxy_base_url():
     )
 
     # Case 1: Only LITELLM_UI_API_DOC_BASE_URL set, no PROXY_BASE_URL
-    env_only_doc_url = {"LITELLM_UI_API_DOC_BASE_URL": "https://docs.example.com"}
-    with patch.dict(os.environ, env_only_doc_url, clear=False):
-        # Remove PROXY_BASE_URL if it exists
-        os.environ.pop("PROXY_BASE_URL", None)
+    saved_env = os.environ.copy()
+    env_case1 = {k: v for k, v in saved_env.items() if k != "PROXY_BASE_URL"}
+    env_case1["LITELLM_UI_API_DOC_BASE_URL"] = "https://docs.example.com"
+    with patch.dict(os.environ, env_case1, clear=True):
         response = await get_ui_settings(mock_request)
         assert response["LITELLM_UI_API_DOC_BASE_URL"] == "https://docs.example.com"
         assert response["PROXY_BASE_URL"] is None
@@ -2720,9 +2720,9 @@ async def test_get_ui_settings_api_doc_base_url_independent_of_proxy_base_url():
         assert response["PROXY_BASE_URL"] == "https://proxy.example.com"
 
     # Case 3: Neither set
-    with patch.dict(os.environ, {}, clear=False):
-        os.environ.pop("LITELLM_UI_API_DOC_BASE_URL", None)
-        os.environ.pop("PROXY_BASE_URL", None)
+    env_case3 = {k: v for k, v in os.environ.items()
+                 if k not in ("LITELLM_UI_API_DOC_BASE_URL", "PROXY_BASE_URL")}
+    with patch.dict(os.environ, env_case3, clear=True):
         response = await get_ui_settings(mock_request)
         assert response["LITELLM_UI_API_DOC_BASE_URL"] is None
         assert response["PROXY_BASE_URL"] is None

--- a/ui/litellm-dashboard/src/app/(dashboard)/api-reference/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/api-reference/page.tsx
@@ -1,16 +1,34 @@
 "use client";
 
 import APIReferenceView from "@/app/(dashboard)/api-reference/APIReferenceView";
-import { useState } from "react";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { fetchProxySettings } from "@/utils/proxyUtils";
+import { useState, useEffect } from "react";
 
 interface ProxySettings {
-  PROXY_BASE_URL: string;
-  PROXY_LOGOUT_URL: string;
+  PROXY_BASE_URL?: string;
   LITELLM_UI_API_DOC_BASE_URL?: string | null;
 }
 
 const APIReferencePage = () => {
-  const [proxySettings, setProxySettings] = useState<ProxySettings>({ PROXY_BASE_URL: "", PROXY_LOGOUT_URL: "" });
+  const { accessToken } = useAuthorized();
+  const [proxySettings, setProxySettings] = useState<ProxySettings>({});
+
+  useEffect(() => {
+    const initializeProxySettings = async () => {
+      if (accessToken) {
+        const settings = await fetchProxySettings(accessToken);
+        if (settings) {
+          setProxySettings({
+            PROXY_BASE_URL: settings.PROXY_BASE_URL || undefined,
+            LITELLM_UI_API_DOC_BASE_URL: settings.LITELLM_UI_API_DOC_BASE_URL,
+          });
+        }
+      }
+    };
+
+    initializeProxySettings();
+  }, [accessToken]);
 
   return <APIReferenceView proxySettings={proxySettings} />;
 };


### PR DESCRIPTION
## Summary
- Fixes the standalone API reference page to fetch proxy settings from the backend on mount, matching the existing pattern used by the playground and test-key pages
- Previously, LITELLM_UI_API_DOC_BASE_URL was never populated on the standalone API reference page because it initialized with empty settings and never called fetchProxySettings
- This allows LITELLM_UI_API_DOC_BASE_URL to work independently of PROXY_BASE_URL, as requested in the issue

## Changes
- ui/litellm-dashboard/src/app/(dashboard)/api-reference/page.tsx: Added useAuthorized hook and useEffect to fetch proxy settings from the backend (same pattern as playground/page.tsx and test-key/page.tsx)
- tests/test_litellm/proxy/management_endpoints/test_ui_sso.py: Added test verifying that LITELLM_UI_API_DOC_BASE_URL works independently from PROXY_BASE_URL in the backend get_ui_settings endpoint (only doc URL set, both set, neither set)

## Test plan
- [x] Backend test passes: test_get_ui_settings_api_doc_base_url_independent_of_proxy_base_url
- [ ] Manual: Set only LITELLM_UI_API_DOC_BASE_URL (without PROXY_BASE_URL), navigate to /api-reference standalone page, verify the custom doc URL appears in code examples
- [ ] Manual: Verify playground and test-key pages continue working as before

Fixes https://github.com/BerriAI/litellm/issues/20590