### PR TITLE
[Bug] PostHog JSON serialization error for non-serializable objects

### DIFF
--- a/litellm/integrations/posthog.py
+++ b/litellm/integrations/posthog.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Optional, Tuple
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.integrations.posthog_mock_client import (
     should_use_posthog_mock,
     create_mock_posthog_client,
@@ -100,7 +101,7 @@ class PostHogLogger(CustomBatchLogger):
 
             response = self.sync_client.post(
                 url=capture_url,
-                json=payload,
+                content=safe_dumps(payload),
                 headers=headers,
             )
             response.raise_for_status()
@@ -356,7 +357,7 @@ class PostHogLogger(CustomBatchLogger):
 
                 response = await self.async_client.post(
                     url=capture_url,
-                    json=payload,
+                    content=safe_dumps(payload),
                     headers=headers,
                 )
                 response.raise_for_status()
@@ -438,7 +439,7 @@ class PostHogLogger(CustomBatchLogger):
 
                 response = self.sync_client.post(
                     url=capture_url,
-                    json=payload,
+                    content=safe_dumps(payload),
                     headers=headers,
                 )
                 response.raise_for_status()


### PR DESCRIPTION
Closes: https://github.com/BerriAI/litellm/pull/18357


## Relevant issues
PostHog integration failed with TypeError: Object of type UserAPIKeyAuth is not JSON serializable when metadata contained Pydantic models (e.g., UserAPIKeyAuth). httpx's json= uses Python's json.dumps(), which cannot serialize custom objects.

The traces are now landing in Posthog.

<img width="1246" height="672" alt="Screenshot 2026-02-07 at 2 12 48 PM" src="https://github.com/user-attachments/assets/4ffa2381-a638-47b4-a570-abbda65451b4" />

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

Pre-serialize the request body with safe_dumps() (handles non-serializable objects) and send it via content= instead of json=. Applied consistently across:
log_success_event() (sync logging)
async_send_batch() (async batch sending)
_flush_on_exit() (atexit flush path)
Added tests verifying all three paths handle non-serializable objects without raising TypeError.