### PR TITLE
[Fix] UI - Teams: Available Teams

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -3095,12 +3095,7 @@ async def list_available_teams(
         ),
     )
     if available_teams is None:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": "No available teams for user to join. See how to set available teams here: https://docs.litellm.ai/docs/proxy/self_serve#all-settings-for-self-serve--sso-flow"
-            },
-        )
+        return []
 
     # filter out teams that the user is already a member of
     user_info = await prisma_client.db.litellm_usertable.find_unique(

--- a/ui/litellm-dashboard/src/components/team/available_teams.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/available_teams.test.tsx
@@ -58,7 +58,8 @@ describe("AvailableTeamsPanel", () => {
     renderWithProviders(<AvailableTeamsPanel accessToken="token-123" userID="user-123" />);
 
     await waitFor(() => {
-      expect(screen.getByText("No available teams to join")).toBeInTheDocument();
+      expect(screen.getByText(/No available teams to join/i)).toBeInTheDocument();
+      expect(screen.getByText(/See how to set available teams/i)).toBeInTheDocument();
     });
   });
 

--- a/ui/litellm-dashboard/src/components/team/available_teams.tsx
+++ b/ui/litellm-dashboard/src/components/team/available_teams.tsx
@@ -113,7 +113,16 @@ const AvailableTeamsPanel: React.FC<AvailableTeamsProps> = ({ accessToken, userI
           {availableTeams.length === 0 && (
             <TableRow>
               <TableCell colSpan={5} className="text-center">
-                <Text>No available teams to join</Text>
+                <Text>No available teams to join. See how to set available teams{" "}
+                  <a
+                    href="https://docs.litellm.ai/docs/proxy/self_serve#all-settings-for-self-serve--sso-flow"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-500 hover:text-blue-700 underline"
+                  >
+                    here
+                  </a>.
+                </Text>
               </TableCell>
             </TableRow>
           )}


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

The `/team/available` endpoint was throwing an HTTP 400 error when no available teams were configured, which violated standard API conventions and caused UI noise. This PR updates the endpoint to return an empty array `[]` instead of raising an exception. The documentation link that was previously included in the error message has been migrated to the UI component, where it's displayed when no teams are available.

## Screenshots
<img width="570" height="127" alt="image" src="https://github.com/user-attachments/assets/81de7644-11ff-4e02-9dc2-893275a5acfa" />
<img width="656" height="252" alt="image" src="https://github.com/user-attachments/assets/6ac2d9d6-06c1-4e31-ab1a-1099c3fd4f4b" />
