### PR TITLE
fix(gemini): Add role="user" to function_response content

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -479,7 +479,7 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                 messages[msg_i]["role"] not in tool_call_message_roles
             ):
                 if len(tool_call_responses) > 0:
-                    contents.append(ContentType(parts=tool_call_responses))
+                    contents.append(ContentType(role="user", parts=tool_call_responses))
                     tool_call_responses = []
 
             if msg_i == init_msg_i:  # prevent infinite loops
@@ -489,7 +489,7 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                     )
                 )
         if len(tool_call_responses) > 0:
-            contents.append(ContentType(parts=tool_call_responses))
+            contents.append(ContentType(role="user", parts=tool_call_responses))
 
         if len(contents) == 0:
             verbose_logger.warning(


### PR DESCRIPTION
## Summary
- Adds missing `role="user"` when constructing `ContentType` for function responses in Gemini/Vertex AI transformation
- Without this role, multi-turn function calling fails with `INVALID_ARGUMENT` (400) from the Google API

## The Bug
When using Gemini models with multi-turn function calling, LiteLLM fails to include `role="user"` when constructing the `function_response` part of the payload.

**Error**: 400 INVALID_ARGUMENT from Google API

## Changes
**File**: `litellm/llms/vertex_ai/gemini/transformation.py`

Two locations where `tool_call_responses` are appended without role:

```python
# Before (line 482)
contents.append(ContentType(parts=tool_call_responses))

# After
contents.append(ContentType(role="user", parts=tool_call_responses))
```

```python
# Before (line 492)  
contents.append(ContentType(parts=tool_call_responses))

# After
contents.append(ContentType(role="user", parts=tool_call_responses))
```

## Test plan
- [ ] Test multi-turn function calling with Gemini models
- [ ] Verify no 400 INVALID_ARGUMENT errors

Fixes #20690

🤖 Generated with [Claude Code](https://claude.com/claude-code)