### PR TITLE
fix(responses): preserve cached tool call objects in tool result recovery

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -617,7 +617,7 @@ class LiteLLMCompletionResponsesConfig:
         if callable(getter):
             try:
                 return getter(key, default)
-            except Exception:
+            except (TypeError, AttributeError):
                 pass
 
         return getattr(obj, key, default)


### PR DESCRIPTION
## Relevant issues

Fixes #20699

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

- Fixed `_ensure_tool_results_have_corresponding_tool_calls` to correctly handle cached tool-call values that are object-like (for example `ChatCompletionMessageToolCall`) instead of blindly requiring a `dict`.
- Added `_normalize_tool_use_definition(...)` to normalize cached tool-call payloads before creating tool call chunks.
- Updated `_create_tool_call_chunk(...)` to support object-like `function` payloads (e.g. `Function`) and preserve `name` / `arguments`.
- Added a regression test in `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py` to cover cache values stored as `ChatCompletionMessageToolCall` objects.

### Root cause

`transform_chat_completion_tools_to_responses_tools` writes `ChatCompletionMessageToolCall` objects into `TOOL_CALLS_CACHE`, but `_ensure_tool_results_have_corresponding_tool_calls` previously treated any non-`dict` cache hit as invalid and replaced it with `{}`. That dropped tool metadata and injected malformed tool calls (`name=''`, `arguments='{}'`).

### Validation

Executed locally:

- `poetry run pytest -q tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py`
- `poetry run pytest -q tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestFunctionCallTransformation::test_ensure_tool_results_preserves_cached_openai_object_tool_call tests/llm_responses_api_testing/test_anthropic_tool_result_fix.py::test_fix_ensures_tool_calls_for_tool_results`

Also re-ran the issue's reproduction flow and verified the recovered tool call now preserves:

- `function.name == "search_web"`
- `function.arguments == '{"query": "python bugs"}'`
