### PR TITLE
fix(cache): keep DualCache.batch_get_cache fully synchronous

### DIFF
--- a/tests/test_litellm/caching/test_dual_cache.py
+++ b/tests/test_litellm/caching/test_dual_cache.py
@@ -1,0 +1,42 @@
+import pytest
+
+from litellm.caching.dual_cache import DualCache
+
+
+class _InMemoryCacheStub:
+    def __init__(self) -> None:
+        self._store = {}
+
+    def set_cache(self, key, value, **kwargs):
+        self._store[key] = value
+
+    def batch_get_cache(self, keys, **kwargs):
+        return [self._store.get(key) for key in keys]
+
+    async def async_batch_get_cache(self, keys, **kwargs):
+        raise AssertionError(
+            "DualCache.batch_get_cache should not call async cache APIs"
+        )
+
+
+class _RedisCacheStub:
+    def batch_get_cache(self, key_list, parent_otel_span=None):
+        return {key: f"redis:{key}" for key in key_list}
+
+    async def async_batch_get_cache(self, key_list, parent_otel_span=None):
+        raise AssertionError(
+            "DualCache.batch_get_cache should not call async cache APIs"
+        )
+
+
+@pytest.mark.asyncio
+async def test_batch_get_cache_stays_sync_inside_event_loop():
+    in_memory_cache = _InMemoryCacheStub()
+    in_memory_cache.set_cache("key-1", "memory:key-1")
+    redis_cache = _RedisCacheStub()
+    dual_cache = DualCache(in_memory_cache=in_memory_cache, redis_cache=redis_cache)
+
+    result = dual_cache.batch_get_cache(keys=["key-1", "key-2"])
+
+    assert result == ["memory:key-1", "redis:key-2"]
+    assert in_memory_cache._store["key-2"] == "redis:key-2"


### PR DESCRIPTION
## Relevant issues

Fixes #20260

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

- Removed the `ThreadPoolExecutor` + new-event-loop bridge from `DualCache.batch_get_cache`.
- Reimplemented `DualCache.batch_get_cache` as fully synchronous logic using:
  - `in_memory_cache.batch_get_cache(...)`
  - `redis_cache.batch_get_cache(...)`
- Preserved Redis batch-throttling behavior via `last_redis_batch_access_time`.
- Kept in-memory warmup behavior by writing Redis hits back to in-memory cache.
- Added regression test: `tests/test_litellm/caching/test_dual_cache.py`
  - Verifies `batch_get_cache()` remains sync even when called inside an active asyncio event loop.
  - Fails if any async cache API is invoked from `batch_get_cache()`.

## Validation

Ran:

```bash
pytest -q tests/test_litellm/caching/test_dual_cache.py tests/test_litellm/caching/test_redis_cache.py
```

Result:

- 16 passed
- 1 pre-existing warning in `test_redis_cache.py` (`AsyncMock` coroutine not awaited in older-redis lpop test path)

## Why this fixes #20260

Issue #20260 reports event-loop deadlock risk when sync router cooldown retrieval ends up calling `DualCache.batch_get_cache` inside async request flows. The previous implementation always jumped to async cache calls under a running loop by creating a thread + new event loop, which could stall under Redis connection pressure/cross-loop contention.

This PR removes that async bridge entirely for the sync API. `batch_get_cache` now stays strictly sync and does not schedule async Redis operations, eliminating the deadlock vector described in the issue.
