### PR TITLE
fix(responses): preserve tool call argument deltas when streaming id is omitted

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -88,6 +88,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._pending_tool_events: List[BaseLiteLLMOpenAIResponseObject] = []
         self._tool_output_index_by_call_id: dict[str, int] = {}
         self._tool_args_by_call_id: dict[str, str] = {}
+        self._tool_call_id_by_index: dict[int, str] = {}
         self._next_tool_output_index: int = 1  # output_index=0 reserved for the message item
         self._final_tool_events_queued: bool = False
         self._sequence_number: int = 0  
@@ -110,6 +111,19 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._next_tool_output_index += 1
         self._tool_output_index_by_call_id[call_id] = idx
         return idx
+
+    def _normalize_tool_call_index(self, tool_call: object) -> Optional[int]:
+        idx_raw = (
+            tool_call.get("index")
+            if isinstance(tool_call, dict)
+            else getattr(tool_call, "index", None)
+        )
+        if idx_raw is None:
+            return None
+        try:
+            return int(idx_raw)
+        except (TypeError, ValueError):
+            return None
 
 
     def _is_reasoning_end(self, chunk):
@@ -143,10 +157,21 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             return
 
         for tc in tool_calls:
+            tc_index = self._normalize_tool_call_index(tc)
             call_id_raw = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
-            if not call_id_raw:
+            call_id = ""
+
+            if call_id_raw:
+                call_id = str(call_id_raw)
+                if tc_index is not None:
+                    self._tool_call_id_by_index[tc_index] = call_id
+            elif tc_index is not None:
+                mapped_call_id = self._tool_call_id_by_index.get(tc_index)
+                if mapped_call_id:
+                    call_id = mapped_call_id
+
+            if not call_id:
                 continue
-            call_id = str(call_id_raw)
 
             fn = tc.get("function") if isinstance(tc, dict) else getattr(tc, "function", None)
             fn_name = ""

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
@@ -229,3 +229,105 @@ def test_tool_call_arguments_are_chunked_to_match_openai_behavior():
     assert sequence_numbers == sorted(sequence_numbers)
     assert len(set(sequence_numbers)) == len(sequence_numbers)  # All unique
 
+
+def test_tool_call_delta_without_id_uses_index_mapping():
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=AsyncMock(),
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    chunks = [
+        [
+            {
+                "index": 0,
+                "id": "call_abc123",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"lo'},
+            }
+        ],
+        [{"index": 0, "type": "function", "function": {"arguments": 'cation":'}}],
+        [{"index": 0, "type": "function", "function": {"arguments": ' "New'}}],
+        [{"index": 0, "type": "function", "function": {"arguments": ' York"}'}}],
+    ]
+
+    for tool_calls in chunks:
+        iterator._queue_tool_call_delta_events(tool_calls)
+
+    all_events = []
+    while iterator._pending_tool_events:
+        all_events.append(iterator._pending_tool_events.pop(0))
+
+    delta_events = [
+        evt
+        for evt in all_events
+        if evt.type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA
+    ]
+    streamed_arguments = "".join(evt.delta for evt in delta_events)
+
+    assert streamed_arguments == '{"location": "New York"}'
+
+    output_item_added_events = [
+        evt
+        for evt in all_events
+        if evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
+    ]
+    assert len(output_item_added_events) == 1
+    assert output_item_added_events[0].item.id == "call_abc123"
+
+
+def test_parallel_tool_calls_without_ids_use_index_mapping():
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=AsyncMock(),
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    iterator._queue_tool_call_delta_events(
+        [
+            {
+                "index": 0,
+                "id": "call_a",
+                "type": "function",
+                "function": {"name": "tool_a", "arguments": '{"x":'},
+            },
+            {
+                "index": 1,
+                "id": "call_b",
+                "type": "function",
+                "function": {"name": "tool_b", "arguments": '{"y":'},
+            },
+        ]
+    )
+    iterator._queue_tool_call_delta_events(
+        [
+            {"index": 0, "type": "function", "function": {"arguments": "1}"}},
+            {"index": 1, "type": "function", "function": {"arguments": "2}"}},
+        ]
+    )
+
+    all_events = []
+    while iterator._pending_tool_events:
+        all_events.append(iterator._pending_tool_events.pop(0))
+
+    output_item_added_events = [
+        evt
+        for evt in all_events
+        if evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
+    ]
+    assert len(output_item_added_events) == 2
+
+    delta_events = [
+        evt
+        for evt in all_events
+        if evt.type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA
+    ]
+    arguments_by_call_id = {}
+    for evt in delta_events:
+        arguments_by_call_id.setdefault(evt.item_id, "")
+        arguments_by_call_id[evt.item_id] += evt.delta
+
+    assert arguments_by_call_id["call_a"] == '{"x":1}'
+    assert arguments_by_call_id["call_b"] == '{"y":2}'


### PR DESCRIPTION
## Relevant issues

Fixes #20711

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix  
✅ Test

## Changes

- Add tool-call index resolution in `LiteLLMCompletionStreamingIterator` so chunks with `id=None` can reuse a previously seen `call_id` from the same `index`.
- Preserve existing behavior when `id` is present, while populating `index -> call_id` mapping for later chunks.
- Keep skip behavior for chunks that have neither a resolvable `id` nor a mapped `index`.
- Add regression test for OpenAI-style streaming where only the first chunk has `id` and subsequent chunks only carry `index`.
- Add regression test for parallel tool calls to ensure per-index routing remains correct with `id=None` deltas.

## Validation

- Ran:
  - `poetry run pytest tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py`
- Result: `5 passed`
