### PR TITLE
fix #20715 - [Bug]: MCP Proxy returns 0 tools for external StreamableHTTP backends (asyncio.wait_for + anyio conflict)

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -14,7 +14,10 @@ from mcp.client.stdio import stdio_client
 streamable_http_client: Optional[Any] = None
 try:
     import mcp.client.streamable_http as streamable_http_module  # type: ignore
-    streamable_http_client = getattr(streamable_http_module, "streamable_http_client", None)
+
+    streamable_http_client = getattr(
+        streamable_http_module, "streamable_http_client", None
+    )
 except ImportError:
     pass
 from mcp.types import CallToolRequestParams as MCPCallToolRequestParams
@@ -39,6 +42,23 @@ from litellm.types.mcp import (
     MCPTransport,
     MCPTransportType,
 )
+
+
+async def patched_handle_get_stream(*args, **kwargs):
+    """
+    Handle GET stream for server-initiated messages with auto-reconnect.
+
+    Patched to be a no-op to prevent anyio TaskGroup cancellation with external MCP backends.
+    LiteLLM proxy only needs request/response (initialize -> list_tools -> call_tool).
+    """
+    return
+
+
+if streamable_http_client is not None:
+    verbose_logger.debug(
+        "Applying patch for mcp.client.streamable_http.handle_get_stream"
+    )
+    streamable_http_module.handle_get_stream = patched_handle_get_stream
 
 
 def to_basic_auth(auth_value: str) -> str:
@@ -105,12 +125,15 @@ class MCPClient:
         if self.transport_type == MCPTransport.sse:
             headers = self._get_auth_headers()
             httpx_client_factory = self._create_httpx_client_factory()
-            return sse_client(
-                url=self.server_url,
-                timeout=self.timeout,
-                headers=headers,
-                httpx_client_factory=httpx_client_factory,
-            ), None
+            return (
+                sse_client(
+                    url=self.server_url,
+                    timeout=self.timeout,
+                    headers=headers,
+                    httpx_client_factory=httpx_client_factory,
+                ),
+                None,
+            )
 
         # HTTP transport (default)
         if streamable_http_client is None:
@@ -118,12 +141,10 @@ class MCPClient:
                 "streamable_http_client is not available. "
                 "Please install mcp with HTTP support."
             )
-        
+
         headers = self._get_auth_headers()
         httpx_client_factory = self._create_httpx_client_factory()
-        verbose_logger.debug(
-            "litellm headers for streamable_http_client: %s", headers
-        )
+        verbose_logger.debug("litellm headers for streamable_http_client: %s", headers)
         http_client = httpx_client_factory(
             headers=headers,
             timeout=httpx.Timeout(self.timeout),
@@ -298,7 +319,7 @@ class MCPClient:
     async def call_tool(
         self,
         call_tool_request_params: MCPCallToolRequestParams,
-        host_progress_callback: Optional[Callable] = None
+        host_progress_callback: Optional[Callable] = None,
     ) -> MCPCallToolResult:
         """
         Call an MCP Tool.
@@ -307,13 +328,15 @@ class MCPClient:
             f"MCP client calling tool '{call_tool_request_params.name}' with arguments: {call_tool_request_params.arguments}"
         )
 
-        async def on_progress(progress: float, total: float | None, message: str | None):
+        async def on_progress(
+            progress: float, total: float | None, message: str | None
+        ):
             percentage = (progress / total * 100) if total else 0
             verbose_logger.info(
                 f"MCP Tool '{call_tool_request_params.name}' progress: "
                 f"{progress}/{total} ({percentage:.0f}%) - {message or ''}"
             )
-            
+
             # Forward to Host if callback provided
             if host_progress_callback:
                 try:
@@ -327,8 +350,8 @@ class MCPClient:
                 name=call_tool_request_params.name,
                 arguments=call_tool_request_params.arguments,
                 progress_callback=on_progress,
-
             )
+
         try:
             tool_result = await self.run_with_session(_call_tool_operation)
             verbose_logger.info(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -14,6 +14,7 @@ import re
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Union, cast
 from urllib.parse import urlparse
 
+import anyio
 from fastapi import HTTPException
 from httpx import HTTPStatusError
 from mcp import ReadResourceResult, Resource
@@ -1427,8 +1428,9 @@ class MCPServerManager:
                 return []
 
         try:
-            return await _list_tools_task()
-        except asyncio.TimeoutError:
+            with anyio.fail_after(30.0):
+                return await _list_tools_task()
+        except (asyncio.TimeoutError, TimeoutError):
             verbose_logger.warning(f"Timeout while listing tools from {server_name}")
             return []
         except asyncio.CancelledError:

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -476,12 +476,12 @@ class MCPServerManager:
                     )
 
                     # Update tool name to server name mapping (for both prefixed and base names)
-                    self.tool_name_to_mcp_server_name_mapping[base_tool_name] = (
-                        server_prefix
-                    )
-                    self.tool_name_to_mcp_server_name_mapping[prefixed_tool_name] = (
-                        server_prefix
-                    )
+                    self.tool_name_to_mcp_server_name_mapping[
+                        base_tool_name
+                    ] = server_prefix
+                    self.tool_name_to_mcp_server_name_mapping[
+                        prefixed_tool_name
+                    ] = server_prefix
 
                     registered_count += 1
                     verbose_logger.debug(
@@ -1427,7 +1427,7 @@ class MCPServerManager:
                 return []
 
         try:
-            return await asyncio.wait_for(_list_tools_task(), timeout=30.0)
+            return await _list_tools_task()
         except asyncio.TimeoutError:
             verbose_logger.warning(f"Timeout while listing tools from {server_name}")
             return []
@@ -2234,6 +2234,7 @@ class MCPServerManager:
             from litellm.proxy.proxy_server import (
                 general_settings as proxy_general_settings,
             )
+
             return proxy_general_settings
         except ImportError:
             # Fallback if proxy_server not available


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->
fixes #20715 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
