### PR TITLE
fix(router): use current retry exception for retry backoff

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5024,7 +5024,7 @@ class Router:
                     else:
                         _healthy_deployments = []
                     _timeout = self._time_to_sleep_before_retry(
-                        e=original_exception,
+                        e=e,
                         remaining_retries=remaining_retries,
                         num_retries=num_retries,
                         healthy_deployments=_healthy_deployments,

--- a/tests/litellm/test_router_retry_backoff_headers.py
+++ b/tests/litellm/test_router_retry_backoff_headers.py
@@ -1,0 +1,86 @@
+"""
+Tests for router retry backoff behavior.
+"""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+import litellm
+from litellm import Router
+
+
+@pytest.mark.asyncio
+async def test_retry_backoff_uses_current_exception_headers():
+    """
+    Ensure retry backoff uses the current retry exception, not the initial one.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "sk-test",
+                },
+            }
+        ],
+        num_retries=2,
+    )
+
+    first_error = litellm.RateLimitError(
+        message="Rate limited on first attempt",
+        model="gpt-3.5-turbo",
+        llm_provider="openai",
+    )
+    first_error.litellm_response_headers = httpx.Headers({"retry-after": "1"})
+
+    second_error = litellm.RateLimitError(
+        message="Rate limited on second attempt",
+        model="gpt-3.5-turbo",
+        llm_provider="openai",
+    )
+    second_error.litellm_response_headers = httpx.Headers({"retry-after": "15"})
+
+    third_error = litellm.RateLimitError(
+        message="Rate limited on third attempt",
+        model="gpt-3.5-turbo",
+        llm_provider="openai",
+    )
+    third_error.litellm_response_headers = httpx.Headers({"retry-after": "30"})
+
+    raised_errors = [first_error, second_error, third_error]
+    captured_backoff_errors = []
+
+    async def mock_make_call(*args, **kwargs):
+        raise raised_errors.pop(0)
+
+    def mock_time_to_sleep_before_retry(*args, **kwargs):
+        captured_backoff_errors.append(kwargs["e"])
+        return 0.01
+
+    with patch.object(router, "make_call", side_effect=mock_make_call):
+        with patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(
+                [{"model_info": {"id": "test-id"}}],
+                [{"model_info": {"id": "test-id"}}],
+            ),
+        ):
+            with patch.object(
+                router,
+                "_time_to_sleep_before_retry",
+                side_effect=mock_time_to_sleep_before_retry,
+            ):
+                with pytest.raises(litellm.RateLimitError):
+                    await router.acompletion(
+                        model="gpt-3.5-turbo",
+                        messages=[{"role": "user", "content": "Hello"}],
+                    )
+
+    assert len(captured_backoff_errors) == 3
+    assert captured_backoff_errors[0] is first_error
+    assert captured_backoff_errors[1] is second_error
+    assert captured_backoff_errors[2] is third_error

--- a/tests/litellm/test_router_retry_backoff_headers.py
+++ b/tests/litellm/test_router_retry_backoff_headers.py
@@ -80,7 +80,9 @@ async def test_retry_backoff_uses_current_exception_headers():
                         messages=[{"role": "user", "content": "Hello"}],
                     )
 
-    assert len(captured_backoff_errors) == 3
+    # Router computes backoff once after the initial failure, then once per failed retry.
+    # With num_retries=2 and all attempts failing, that's 1 + 2 = 3 invocations.
+    assert len(captured_backoff_errors) == router.num_retries + 1
     assert captured_backoff_errors[0] is first_error
     assert captured_backoff_errors[1] is second_error
     assert captured_backoff_errors[2] is third_error


### PR DESCRIPTION
## Relevant issues

Fixes #20722

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

- Fixes retry-loop backoff to use the current exception (`e`) instead of the initial `original_exception` in `Router.async_function_with_retries`.
- This ensures provider `Retry-After` headers from each retry attempt are honored.
- Adds regression test: `tests/litellm/test_router_retry_backoff_headers.py`.

- `poetry run ruff check litellm/router.py tests/litellm/test_router_retry_backoff_headers.py`
