### PR TITLE
Generic Guardrails: Forward request headers + litellm_version to gene…

### DIFF
--- a/docs/my-website/docs/adding_provider/generic_guardrail_api.md
+++ b/docs/my-website/docs/adding_provider/generic_guardrail_api.md
@@ -93,6 +93,11 @@ Implement `POST /beta/litellm_basic_guardrail_api`
     "user_api_key_end_user_id": "end user id associated with the litellm virtual key used",
     "user_api_key_org_id": "org id associated with the litellm virtual key used"
   },
+  "request_headers": {  // optional: sanitized inbound request headers from the original proxy request
+    "User-Agent": "OpenAI/Python 2.17.0",
+    "X-Request-Id": "req_123"
+  },
+  "litellm_version": "1.x.y",  // optional: LiteLLM library version running this proxy
   "input_type": "request",  // "request" or "response"
   "litellm_call_id": "unique_call_id",  // the call id of the individual LLM call
   "litellm_trace_id": "trace_id",  // the trace id of the LLM call - useful if there are multiple LLM calls for the same conversation

--- a/docs/my-website/docs/adding_provider/generic_guardrail_api.md
+++ b/docs/my-website/docs/adding_provider/generic_guardrail_api.md
@@ -93,9 +93,10 @@ Implement `POST /beta/litellm_basic_guardrail_api`
     "user_api_key_end_user_id": "end user id associated with the litellm virtual key used",
     "user_api_key_org_id": "org id associated with the litellm virtual key used"
   },
-  "request_headers": {  // optional: sanitized inbound request headers from the original proxy request
+  "request_headers": {  // optional: inbound request headers (allowlist). Allowed headers show their value; all others show "[present]" to indicate the header existed.
     "User-Agent": "OpenAI/Python 2.17.0",
-    "X-Request-Id": "req_123"
+    "Content-Type": "application/json",
+    "X-Request-Id": "[present]"
   },
   "litellm_version": "1.x.y",  // optional: LiteLLM library version running this proxy
   "input_type": "request",  // "request" or "response"

--- a/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
@@ -60,6 +60,14 @@ class GenericGuardrailAPIRequest(BaseModel):
     tools: Optional[List[ChatCompletionToolParam]] = None
     texts: Optional[List[str]] = None
     request_data: GenericGuardrailAPIMetadata
+    request_headers: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Sanitized inbound request headers from the original proxy request.",
+    )
+    litellm_version: Optional[str] = Field(
+        default=None,
+        description="LiteLLM library version running this proxy.",
+    )
     additional_provider_specific_params: Optional[Dict[str, Any]] = None
     tool_calls: Optional[
         Union[List[ChatCompletionToolCallChunk], List[ChatCompletionMessageToolCall]]


### PR DESCRIPTION
Generic Guardrails: forward relevant fields like request headers and litellm_version to generic guardrail API

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
📖 Documentation
✅ Test

## Changes
- Forward sanitized inbound request headers (e.g. User-Agent) to Generic Guardrail API as request_headers in the JSON payload (drops sensitive headers like Authorization/Cookie).
- Include litellm_version in the Generic Guardrail API request payload.
- Add unit test coverage verifying header forwarding + sanitization + version field.
- Update docs contract for Generic Guardrail API request shape.

### Test plan
```
poetry run pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py -v
```
Results - 
<img width="1309" height="392" alt="image" src="https://github.com/user-attachments/assets/a12be645-31b2-461e-8e82-0a1db048e408" />
<img width="1055" height="145" alt="image" src="https://github.com/user-attachments/assets/80c9a1a5-145f-4ed5-b122-2a9f9cccb1e0" />
