### PR TITLE
fix: handle empty string finish_reason in API responses

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -588,7 +588,7 @@ def convert_to_model_response_object(  # noqa: PLR0915
                         images=choice["message"].get("images", None),
                     )
                     finish_reason = choice.get("finish_reason", None)
-                if finish_reason is None:
+                if not finish_reason:  # Handle both None and empty string
                     # gpt-4 vision can return 'finish_reason' or 'finish_details'
                     finish_reason = choice.get("finish_details") or "stop"
                 if (


### PR DESCRIPTION
## Problem

Some OpenAI-compatible API providers (e.g., packyapi) return an empty string `""` for the `finish_reason` field instead of a valid value like `"stop"`. This causes pydantic validation errors when litellm tries to parse the response.

## Error

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Choices
finish_reason
  Input should be 'stop', 'content_filter', 'function_call', 'tool_calls',
  'length', 'guardrail_intervened', 'eos', 'finish_reason_unspecified' or
  'malformed_function_call'
```

## Solution

Changed the condition from `if finish_reason is None:` to `if not finish_reason:` in `convert_dict_to_response.py` to handle both `None` and empty string cases, defaulting to `"stop"` when `finish_reason` is falsy.

## Testing

Tested with packyapi which returns empty string for `finish_reason`. After this fix, the response is parsed successfully with `finish_reason` defaulting to `"stop"`.

## Changes

- Modified `litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py` line 591
- Changed `if finish_reason is None:` to `if not finish_reason:  # Handle both None and empty string`

This is a minimal, backward-compatible fix that improves compatibility with OpenAI-compatible API providers that don't strictly follow the spec.