### PR TITLE
fix(bedrock): handle concatenated JSON in tool call arguments

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260209085821_add_verificationtoken_indexes/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260209085821_add_verificationtoken_indexes/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX "LiteLLM_VerificationToken_user_id_team_id_idx" ON "LiteLLM_VerificationToken"("user_id", "team_id");
+
+-- CreateIndex
+CREATE INDEX "LiteLLM_VerificationToken_team_id_idx" ON "LiteLLM_VerificationToken"("team_id");
+
+-- CreateIndex
+CREATE INDEX "LiteLLM_VerificationToken_budget_reset_at_expires_idx" ON "LiteLLM_VerificationToken"("budget_reset_at", "expires");

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -310,6 +310,16 @@ model LiteLLM_VerificationToken {
     litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
     litellm_organization_table LiteLLM_OrganizationTable?   @relation(fields: [organization_id], references: [organization_id])
     object_permission LiteLLM_ObjectPermissionTable?   @relation(fields: [object_permission_id], references: [object_permission_id])
+
+    // SELECT COUNT(*) FROM (SELECT "public"."LiteLLM_VerificationToken"."token" FROM "public"."LiteLLM_VerificationToken" WHERE ("public"."LiteLLM_VerificationToken"."user_id" = $1 AND ("public"."LiteLLM_VerificationToken"."team_id" IS NULL OR "public"."LiteLLM_VerificationToken"."team_id" <> $2)) OFFSET $3 ) AS "sub"
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE "public"."LiteLLM_VerificationToken"."user_id" = $1 OFFSET $2
+    @@index([user_id, team_id])
+
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE "public"."LiteLLM_VerificationToken"."team_id" = $1 OFFSET $2
+    @@index([team_id])
+
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE (("public"."LiteLLM_VerificationToken"."expires" IS NULL OR "public"."LiteLLM_VerificationToken"."expires" > $1) AND "public"."LiteLLM_VerificationToken"."budget_reset_at" < $2) OFFSET $3
+    @@index([budget_reset_at, expires])
 }
 
 // Audit table for deleted keys - preserves spend and key information for historical tracking

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3287,25 +3287,68 @@ def _convert_to_bedrock_tool_call_invoke(
     - extract name 
     - extract id
     """
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        split_concatenated_json_objects,
+    )
 
     try:
         _parts_list: List[BedrockContentBlock] = []
         for tool in tool_calls:
             if "function" in tool:
-                id = tool["id"]
+                tool_id = tool["id"]
                 name = tool["function"].get("name", "")
                 arguments = tool["function"].get("arguments", "")
-                arguments_dict = json.loads(arguments) if arguments else {}
-                # Ensure arguments_dict is always a dict (Bedrock requires toolUse.input to be an object)
-                # When some providers return arguments: '""' (JSON-encoded empty string), json.loads returns ""
-                if not isinstance(arguments_dict, dict):
-                    arguments_dict = {}
+
                 if not arguments or not arguments.strip():
                     arguments_dict = {}
                 else:
-                    arguments_dict = json.loads(arguments)
+                    try:
+                        arguments_dict = json.loads(arguments)
+                        # Ensure arguments_dict is always a dict
+                        # (Bedrock requires toolUse.input to be an object).
+                        # Some providers return arguments: '""' which
+                        # json.loads decodes to a bare string.
+                        if not isinstance(arguments_dict, dict):
+                            arguments_dict = {}
+                    except json.JSONDecodeError:
+                        # The model may return multiple JSON objects
+                        # concatenated in a single arguments string, e.g.
+                        #   '{"cmd":"a"}{"cmd":"b"}{"cmd":"c"}'
+                        # Split them and emit one toolUse block per object.
+                        # Fixes: https://github.com/BerriAI/litellm/issues/20543
+                        parsed_objects = split_concatenated_json_objects(
+                            arguments
+                        )
+                        if parsed_objects:
+                            # First object keeps the original tool id.
+                            for obj_idx, obj in enumerate(parsed_objects):
+                                block_id = (
+                                    tool_id
+                                    if obj_idx == 0
+                                    else f"{tool_id}_{obj_idx}"
+                                )
+                                bedrock_tool = BedrockToolUseBlock(
+                                    input=obj, name=name, toolUseId=block_id
+                                )
+                                _parts_list.append(
+                                    BedrockContentBlock(toolUse=bedrock_tool)
+                                )
+                            # cache_control applies to the whole original
+                            # tool call; attach after the last split block.
+                            if tool.get("cache_control", None) is not None:
+                                _parts_list.append(
+                                    BedrockContentBlock(
+                                        cachePoint=CachePointBlock(
+                                            type="default"
+                                        )
+                                    )
+                                )
+                            continue
+                        # Fallback: no objects extracted — use empty dict.
+                        arguments_dict = {}
+
                 bedrock_tool = BedrockToolUseBlock(
-                    input=arguments_dict, name=name, toolUseId=id
+                    input=arguments_dict, name=name, toolUseId=tool_id
                 )
                 bedrock_content_block = BedrockContentBlock(toolUse=bedrock_tool)
                 _parts_list.append(bedrock_content_block)

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -308,6 +308,16 @@ model LiteLLM_VerificationToken {
     litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
     litellm_organization_table LiteLLM_OrganizationTable?   @relation(fields: [organization_id], references: [organization_id])
     object_permission LiteLLM_ObjectPermissionTable?   @relation(fields: [object_permission_id], references: [object_permission_id])
+
+    // SELECT COUNT(*) FROM (SELECT "public"."LiteLLM_VerificationToken"."token" FROM "public"."LiteLLM_VerificationToken" WHERE ("public"."LiteLLM_VerificationToken"."user_id" = $1 AND ("public"."LiteLLM_VerificationToken"."team_id" IS NULL OR "public"."LiteLLM_VerificationToken"."team_id" <> $2)) OFFSET $3 ) AS "sub"
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE "public"."LiteLLM_VerificationToken"."user_id" = $1 OFFSET $2
+    @@index([user_id, team_id])
+
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE "public"."LiteLLM_VerificationToken"."team_id" = $1 OFFSET $2
+    @@index([team_id])
+
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE (("public"."LiteLLM_VerificationToken"."expires" IS NULL OR "public"."LiteLLM_VerificationToken"."expires" > $1) AND "public"."LiteLLM_VerificationToken"."budget_reset_at" < $2) OFFSET $3
+    @@index([budget_reset_at, expires])
 }
 
 // Audit table for deleted keys - preserves spend and key information for historical tracking

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -88,6 +88,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._pending_tool_events: List[BaseLiteLLMOpenAIResponseObject] = []
         self._tool_output_index_by_call_id: dict[str, int] = {}
         self._tool_args_by_call_id: dict[str, str] = {}
+        self._tool_call_id_by_index: dict[int, str] = {}
         self._next_tool_output_index: int = 1  # output_index=0 reserved for the message item
         self._final_tool_events_queued: bool = False
         self._sequence_number: int = 0  
@@ -110,6 +111,19 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._next_tool_output_index += 1
         self._tool_output_index_by_call_id[call_id] = idx
         return idx
+
+    def _normalize_tool_call_index(self, tool_call: object) -> Optional[int]:
+        idx_raw = (
+            tool_call.get("index")
+            if isinstance(tool_call, dict)
+            else getattr(tool_call, "index", None)
+        )
+        if idx_raw is None:
+            return None
+        try:
+            return int(idx_raw)
+        except (TypeError, ValueError):
+            return None
 
 
     def _is_reasoning_end(self, chunk):
@@ -143,10 +157,21 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             return
 
         for tc in tool_calls:
+            tc_index = self._normalize_tool_call_index(tc)
             call_id_raw = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
-            if not call_id_raw:
+            call_id = ""
+
+            if call_id_raw:
+                call_id = str(call_id_raw)
+                if tc_index is not None:
+                    self._tool_call_id_by_index[tc_index] = call_id
+            elif tc_index is not None:
+                mapped_call_id = self._tool_call_id_by_index.get(tc_index)
+                if mapped_call_id:
+                    call_id = mapped_call_id
+
+            if not call_id:
                 continue
-            call_id = str(call_id_raw)
 
             fn = tc.get("function") if isinstance(tc, dict) else getattr(tc, "function", None)
             fn_name = ""

--- a/schema.prisma
+++ b/schema.prisma
@@ -310,6 +310,16 @@ model LiteLLM_VerificationToken {
     litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
     litellm_organization_table LiteLLM_OrganizationTable?   @relation(fields: [organization_id], references: [organization_id])
     object_permission LiteLLM_ObjectPermissionTable?   @relation(fields: [object_permission_id], references: [object_permission_id])
+
+    // SELECT COUNT(*) FROM (SELECT "public"."LiteLLM_VerificationToken"."token" FROM "public"."LiteLLM_VerificationToken" WHERE ("public"."LiteLLM_VerificationToken"."user_id" = $1 AND ("public"."LiteLLM_VerificationToken"."team_id" IS NULL OR "public"."LiteLLM_VerificationToken"."team_id" <> $2)) OFFSET $3 ) AS "sub"
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE "public"."LiteLLM_VerificationToken"."user_id" = $1 OFFSET $2
+    @@index([user_id, team_id])
+
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE "public"."LiteLLM_VerificationToken"."team_id" = $1 OFFSET $2
+    @@index([team_id])
+
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE (("public"."LiteLLM_VerificationToken"."expires" IS NULL OR "public"."LiteLLM_VerificationToken"."expires" > $1) AND "public"."LiteLLM_VerificationToken"."budget_reset_at" < $2) OFFSET $3
+    @@index([budget_reset_at, expires])
 }
 
 // Audit table for deleted keys - preserves spend and key information for historical tracking

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
@@ -229,3 +229,105 @@ def test_tool_call_arguments_are_chunked_to_match_openai_behavior():
     assert sequence_numbers == sorted(sequence_numbers)
     assert len(set(sequence_numbers)) == len(sequence_numbers)  # All unique
 
+
+def test_tool_call_delta_without_id_uses_index_mapping():
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=AsyncMock(),
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    chunks = [
+        [
+            {
+                "index": 0,
+                "id": "call_abc123",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"lo'},
+            }
+        ],
+        [{"index": 0, "type": "function", "function": {"arguments": 'cation":'}}],
+        [{"index": 0, "type": "function", "function": {"arguments": ' "New'}}],
+        [{"index": 0, "type": "function", "function": {"arguments": ' York"}'}}],
+    ]
+
+    for tool_calls in chunks:
+        iterator._queue_tool_call_delta_events(tool_calls)
+
+    all_events = []
+    while iterator._pending_tool_events:
+        all_events.append(iterator._pending_tool_events.pop(0))
+
+    delta_events = [
+        evt
+        for evt in all_events
+        if evt.type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA
+    ]
+    streamed_arguments = "".join(evt.delta for evt in delta_events)
+
+    assert streamed_arguments == '{"location": "New York"}'
+
+    output_item_added_events = [
+        evt
+        for evt in all_events
+        if evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
+    ]
+    assert len(output_item_added_events) == 1
+    assert output_item_added_events[0].item.id == "call_abc123"
+
+
+def test_parallel_tool_calls_without_ids_use_index_mapping():
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=AsyncMock(),
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    iterator._queue_tool_call_delta_events(
+        [
+            {
+                "index": 0,
+                "id": "call_a",
+                "type": "function",
+                "function": {"name": "tool_a", "arguments": '{"x":'},
+            },
+            {
+                "index": 1,
+                "id": "call_b",
+                "type": "function",
+                "function": {"name": "tool_b", "arguments": '{"y":'},
+            },
+        ]
+    )
+    iterator._queue_tool_call_delta_events(
+        [
+            {"index": 0, "type": "function", "function": {"arguments": "1}"}},
+            {"index": 1, "type": "function", "function": {"arguments": "2}"}},
+        ]
+    )
+
+    all_events = []
+    while iterator._pending_tool_events:
+        all_events.append(iterator._pending_tool_events.pop(0))
+
+    output_item_added_events = [
+        evt
+        for evt in all_events
+        if evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
+    ]
+    assert len(output_item_added_events) == 2
+
+    delta_events = [
+        evt
+        for evt in all_events
+        if evt.type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA
+    ]
+    arguments_by_call_id = {}
+    for evt in delta_events:
+        arguments_by_call_id.setdefault(evt.item_id, "")
+        arguments_by_call_id[evt.item_id] += evt.delta
+
+    assert arguments_by_call_id["call_a"] == '{"x":1}'
+    assert arguments_by_call_id["call_b"] == '{"y":2}'


### PR DESCRIPTION
## Relevant issues

Fixes #20543

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix

## Changes

### Problem

When using Bedrock Claude Sonnet 4.5 with tools enabled, the model sometimes returns **multiple tool call argument objects concatenated in a single `arguments` string**:

```
'{"command":["curl","-i","http://localhost:9009","-m","10"]}{"command":["curl","-i","http://localhost:9009/robots.txt","-m","5"]}{"command":["curl","-i","http://localhost:9009/sitemap.xml","-m","5"]}'
```

`json.loads()` fails with `JSONDecodeError: Extra data`, which crashes the entire request in `_convert_to_bedrock_tool_call_invoke()` and surfaces as:

```
litellm.APIConnectionError: Unable to convert openai tool calls=[...] to bedrock tool calls. Received error=Extra data: line 1 column 71 (char 70)
```

A previous fix attempt (PR #19198) was reverted (PR #19243) because it broke existing tests.

### Solution

**1. New helper: `split_concatenated_json_objects()`** (`common_utils.py`)

Uses `json.JSONDecoder.raw_decode()` to walk a string containing one or more concatenated JSON objects and extract each one individually. This is a robust, incremental parser that handles:
- Single valid JSON objects (normal case)
- Multiple concatenated objects with or without whitespace
- Non-dict JSON values (replaced with `{}` per Bedrock's `toolUse.input` requirement)

**2. Updated `_convert_to_bedrock_tool_call_invoke()`** (`factory.py`)

- Normal JSON arguments: parsed via `json.loads()` as before (happy path untouched)
- On `JSONDecodeError`: falls back to `split_concatenated_json_objects()` to split concatenated arguments into **separate `BedrockToolUseBlock` entries**
  - First block keeps the original tool ID
  - Subsequent blocks get suffixed IDs (`{original_id}_1`, `{original_id}_2`, ...)
  - `cache_control` is attached after the last split block
- Also fixes: duplicate `json.loads()` calls and shadowed `id` builtin

### Tests Added (12 total)

**`test_litellm_core_utils_prompt_templates_common_utils.py`** (6 tests):
- `test_split_concatenated_json_single_object` - normal single object
- `test_split_concatenated_json_multiple_objects` - exact reproduction of #20543
- `test_split_concatenated_json_with_whitespace` - whitespace between objects
- `test_split_concatenated_json_empty_string` - empty/whitespace input
- `test_split_concatenated_json_non_dict_value` - non-dict values → `{}`
- `test_split_concatenated_json_invalid_raises` - truly invalid JSON raises

**`test_litellm_core_utils_prompt_templates_factory.py`** (6 tests):
- `test_bedrock_tool_call_invoke_normal_single_tool` - normal happy path
- `test_bedrock_tool_call_invoke_empty_arguments` - empty args → `{}`
- `test_bedrock_tool_call_invoke_concatenated_json` - **core fix verification**: 3 concatenated objects → 3 separate toolUse blocks with correct IDs
- `test_bedrock_tool_call_invoke_concatenated_json_with_cache_control` - cache_control with split
- `test_bedrock_tool_call_invoke_non_dict_arguments` - `'""'` → `{}`
- `test_bedrock_tool_call_invoke_multiple_normal_tools` - parallel tool calls
