### PR TITLE
fix(anthropic): route thinking requests through OpenAI responses

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -31,6 +31,57 @@ ANTHROPIC_ADAPTER = AnthropicAdapter()
 
 class LiteLLMMessagesToCompletionTransformationHandler:
     @staticmethod
+    def _route_openai_thinking_to_responses_api_if_needed(
+        completion_kwargs: Dict[str, Any],
+        *,
+        thinking: Optional[Dict[str, Any]],
+    ) -> None:
+        """
+        When users call `litellm.anthropic.messages.*` with a non-Anthropic model and
+        `thinking={"type": "enabled", ...}`, LiteLLM converts this into OpenAI
+        `reasoning_effort`.
+
+        For OpenAI models, Chat Completions typically does not return reasoning text
+        (only token accounting). To return a thinking-like content block in the
+        Anthropic response format, we route the request through OpenAI's Responses API
+        and request a reasoning summary.
+        """
+        custom_llm_provider = completion_kwargs.get("custom_llm_provider")
+        if custom_llm_provider is None:
+            try:
+                _, inferred_provider, _, _ = litellm.utils.get_llm_provider(
+                    model=cast(str, completion_kwargs.get("model"))
+                )
+                custom_llm_provider = inferred_provider
+            except Exception:
+                custom_llm_provider = None
+
+        if custom_llm_provider != "openai":
+            return
+
+        if not isinstance(thinking, dict) or thinking.get("type") != "enabled":
+            return
+
+        model = completion_kwargs.get("model")
+        if isinstance(model, str) and not model.startswith("responses/"):
+            completion_kwargs["model"] = f"responses/{model}"
+
+        reasoning_effort = completion_kwargs.get("reasoning_effort")
+        if isinstance(reasoning_effort, str) and reasoning_effort:
+            completion_kwargs["reasoning_effort"] = {
+                "effort": reasoning_effort,
+                "summary": "detailed",
+            }
+        elif isinstance(reasoning_effort, dict):
+            if (
+                "summary" not in reasoning_effort
+                and "generate_summary" not in reasoning_effort
+            ):
+                updated_reasoning_effort = dict(reasoning_effort)
+                updated_reasoning_effort["summary"] = "detailed"
+                completion_kwargs["reasoning_effort"] = updated_reasoning_effort
+
+    @staticmethod
     def _prepare_completion_kwargs(
         *,
         max_tokens: int,
@@ -122,6 +173,11 @@ class LiteLLMMessagesToCompletionTransformationHandler:
                 and value is not None
             ):
                 completion_kwargs[key] = value
+
+        LiteLLMMessagesToCompletionTransformationHandler._route_openai_thinking_to_responses_api_if_needed(
+            completion_kwargs,
+            thinking=thinking,
+        )
 
         return completion_kwargs, tool_name_mapping
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -63,8 +63,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
             return
 
         model = completion_kwargs.get("model")
-        if isinstance(model, str) and not model.startswith("responses/"):
-            completion_kwargs["model"] = f"responses/{model}"
+        if isinstance(model, str) and model and not model.startswith("responses/"):
 
         reasoning_effort = completion_kwargs.get("reasoning_effort")
         if isinstance(reasoning_effort, str) and reasoning_effort:

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -185,7 +185,14 @@ def test_openai_model_with_thinking_converts_to_reasoning_effort():
         
         # Verify reasoning_effort is set (converted from thinking)
         assert "reasoning_effort" in call_kwargs, "reasoning_effort should be passed to completion"
-        assert call_kwargs["reasoning_effort"] == "minimal", f"reasoning_effort should be 'minimal' for budget_tokens=1024, got {call_kwargs.get('reasoning_effort')}"
+        assert call_kwargs["reasoning_effort"] == {
+            "effort": "minimal",
+            "summary": "detailed",
+        }, f"reasoning_effort should request a reasoning summary for OpenAI responses API, got {call_kwargs.get('reasoning_effort')}"
+
+        # Verify OpenAI thinking requests are routed to the Responses API
+        assert call_kwargs.get("model") == "responses/gpt-5.2"
+        
         
         # Verify thinking is NOT passed (non-Claude model)
         assert "thinking" not in call_kwargs, "thinking should NOT be passed for non-Claude models"


### PR DESCRIPTION
## Relevant issues
Fixes #20433 (OpenAI “thinking” requests routed via Anthropic adapter previously hit Chat Completions and returned only token counts).
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
-  Added targeted tests in tests/litellm/llms/anthropic/experimental_pass_through/... that exercise the OpenAI-thinking routing change.
- [ x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ x] My PR's scope is as isolated as possible, it only solves 1 specific problem
-  Change scope limited to the Anthropic experimental pass-through adapter, supporting test, and repro script.

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
1.)LiteLLMMessagesToCompletionTransformationHandler._route_openai_thinking_to_responses_api_if_needed in handler.py it now inspects the completion kwargs (inferring custom_llm_provider from the model when missing), rewrites OpenAI targets to responses/<model>, and ensures reasoning_effort includes summary: "detailed" whenever thinking={"type":"enabled"} so the request heads through the Responses API and returns a reasoning “thinking” block instead of just token counts.
2.) Updated the Anthropic handler tests test_anthropic_experimental_pass_through_messages_handler.py  to assert the new routing behavior.