### PR TITLE
Allow LLM API keys to access model info endpoints

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -477,8 +477,7 @@ class LiteLLMRoutes(enum.Enum):
         "/organization/list",
         "/team/available",
         "/user/info",
-        "/model/info",
-        "/v1/model/info",
+    ] + model_info_routes + [
         "/v2/model/info",
         "/v2/key/info",
         "/model_group/info",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -451,6 +451,11 @@ class LiteLLMRoutes(enum.Enum):
         "/guardrails/apply_guardrail",
     ]
 
+    model_info_routes = [
+        "/model/info",
+        "/v1/model/info",
+    ]
+
     llm_api_routes = (
         openai_routes
         + anthropic_routes
@@ -458,6 +463,7 @@ class LiteLLMRoutes(enum.Enum):
         + mapped_pass_through_routes
         + passthrough_routes_wildcard
         + apply_guardrail_routes
+        + model_info_routes
         + mcp_routes
         + litellm_native_routes
         + agent_routes

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -159,6 +159,27 @@ def test_virtual_key_llm_api_route_includes_passthrough_prefix(route):
 @pytest.mark.parametrize(
     "route",
     [
+        "/model/info",
+        "/v1/model/info",
+    ],
+)
+def test_virtual_key_llm_api_routes_allows_model_info(route):
+    """
+    Virtual key with llm_api_routes should allow model discovery routes.
+    """
+
+    valid_token = UserAPIKeyAuth(user_id="test_user", allowed_routes=["llm_api_routes"])
+
+    result = RouteChecks.is_virtual_key_allowed_to_call_route(
+        route=route, valid_token=valid_token
+    )
+
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
         "/v1beta/models/gemini-2.5-flash:countTokens",
         "/v1beta/models/gemini-2.0-flash:generateContent",
         "/v1beta/models/bedrock/claude-sonnet-3.7:generateContent",


### PR DESCRIPTION
## Summary
- Treat /model/info and /v1/model/info as LLM API routes so LLM API keys can access model discovery.
- Add a unit test to cover LLM API key access to model info routes.

## Related Issue
Fixes #20581

## Testing
- env POETRY_CACHE_DIR=/tmp/poetry-cache poetry run python -m pytest tests/test_litellm/proxy/auth/test_route_checks.py -v
