### PR TITLE
fix(router): propagate model-level tags from config to SpendLogs

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1924,6 +1924,17 @@ class Router:
                 "deployment_model_name": deployment_model_name,
             }
         )
+
+        ## DEPLOYMENT-LEVEL TAGS
+        deployment_tags = deployment.get("litellm_params", {}).get("tags")
+        if deployment_tags:
+            existing_tags = kwargs[metadata_variable_name].get("tags") or []
+            merged_tags = list(existing_tags)
+            for tag in deployment_tags:
+                if tag not in merged_tags:
+                    merged_tags.append(tag)
+            kwargs[metadata_variable_name]["tags"] = merged_tags
+
         kwargs["model_info"] = model_info
 
         kwargs["timeout"] = self._get_timeout(


### PR DESCRIPTION
## Relevant issues

Model-level tags defined in `config.yaml` under `litellm_params` were not appearing in SpendLogs `request_tags` field. Only tags passed explicitly in the request body were logged.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem

When a user defines `tags` at the model level in `config.yaml`:

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      tags: ["openai-account"]
```
The tags do not appear in SpendLogs. Only tags passed in the request body are logged. This is because _update_kwargs_with_deployment() in router.py adds deployment info (model_info, api_base, deployment name) to kwargs metadata but does not merge deployment-level tags.

### Fix

Added deployment-level tag merging in Router._update_kwargs_with_deployment() (litellm/router.py), right after the existing metadata update block.
This is consistent with how key-level tags (litellm_pre_call_utils.py:672-679) and team-level tags (litellm_pre_call_utils.py:957-963) are already merged.

The merge logic handles deduplication — if both request-level and deployment-level tags exist, they are combined without duplicates.

### Tests added (tests/test_litellm/test_router.py)

- test_update_kwargs_with_deployment_propagates_model_tags — verifies deployment tags appear in kwargs metadata
- test_update_kwargs_with_deployment_merges_tags_without_duplicates — verifies request + deployment tags merge correctly
- test_update_kwargs_with_deployment_no_tags — verifies no side effects when deployment has no tags

### Screenshot
<img width="815" height="446" alt="Screenshot 2026-02-09 alle 19 06 54" src="https://github.com/user-attachments/assets/81e0ac88-8171-47a0-abe9-02231e9247e1" />




