### PR TITLE
feat(ui): add SSO return URL preservation utilities

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
@@ -8,13 +8,14 @@ import useAuthorized from "./useAuthorized";
 // Unmock useAuthorized to test the actual implementation
 vi.unmock("@/app/(dashboard)/hooks/useAuthorized");
 
-const { replaceMock, clearTokenCookiesMock, getProxyBaseUrlMock, getUiConfigMock, decodeTokenMock, checkTokenValidityMock } = vi.hoisted(() => ({
+const { replaceMock, clearTokenCookiesMock, getProxyBaseUrlMock, getUiConfigMock, decodeTokenMock, checkTokenValidityMock, buildLoginUrlWithReturnMock } = vi.hoisted(() => ({
   replaceMock: vi.fn(),
   clearTokenCookiesMock: vi.fn(),
   getProxyBaseUrlMock: vi.fn(() => "http://proxy.example"),
   getUiConfigMock: vi.fn(),
   decodeTokenMock: vi.fn(),
   checkTokenValidityMock: vi.fn(),
+  buildLoginUrlWithReturnMock: vi.fn((baseUrl: string) => baseUrl),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -49,6 +50,14 @@ vi.mock("@/utils/jwtUtils", async (importOriginal) => {
   };
 });
 
+vi.mock("@/utils/returnUrlUtils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/returnUrlUtils")>();
+  return {
+    ...actual,
+    buildLoginUrlWithReturn: buildLoginUrlWithReturnMock,
+    storeReturnUrl: vi.fn(),
+  };
+});
 const createQueryClient = () =>
   new QueryClient({
     defaultOptions: {
@@ -81,6 +90,7 @@ describe("useAuthorized", () => {
     getUiConfigMock.mockReset();
     decodeTokenMock.mockReset();
     checkTokenValidityMock.mockReset();
+    buildLoginUrlWithReturnMock.mockClear();
     clearCookie();
   });
 

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
@@ -1,15 +1,116 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderWithProviders, screen } from "../../../tests/test-utils";
+import { renderWithProviders, screen, waitFor } from "../../../tests/test-utils";
 import CreateKey from "./create_key_button";
 
-const mockKeyCreateCall = vi.fn().mockResolvedValue({
-  key: "test-api-key",
-  soft_budget: null,
+const { formMock, setFieldsValueMock, radioGroupValueRef } = vi.hoisted(() => {
+  const formMock = {
+    setFieldsValue: vi.fn(),
+    setFieldValue: vi.fn(),
+    getFieldValue: vi.fn(),
+    resetFields: vi.fn(),
+  };
+  const radioGroupValueRef = { current: null as string | null };
+  return {
+    formMock,
+    setFieldsValueMock: formMock.setFieldsValue,
+    radioGroupValueRef,
+  };
 });
 
-vi.mock("./networking", () => ({
-  keyCreateCall: mockKeyCreateCall,
-  modelAvailableCall: vi.fn().mockResolvedValue({ data: [] }),
+const defaultAuthorizedState = {
+  accessToken: "test-token",
+  userId: "test-user-id",
+  userRole: "Admin",
+  premiumUser: false,
+};
+
+let authorizedState = { ...defaultAuthorizedState };
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => authorizedState,
+}));
+
+vi.mock("@/app/(dashboard)/hooks/keys/useKeys", () => ({
+  keyKeys: {
+    lists: () => ["keys"],
+  },
+}));
+
+vi.mock("@ant-design/icons", () => ({
+  InfoCircleOutlined: () => null,
+}));
+
+vi.mock("react-copy-to-clipboard", () => ({
+  CopyToClipboard: ({ children }: { children: any }) => children,
+}));
+
+vi.mock("@tremor/react", () => {
+  const React = require("react");
+  const Stub = ({ children }: { children?: any }) => React.createElement("div", null, children);
+  const Button = ({ children, ...props }: { children?: any }) =>
+    React.createElement("button", props, children);
+  const TextInput = (props: any) => React.createElement("input", props);
+
+  return {
+    Accordion: Stub,
+    AccordionBody: Stub,
+    AccordionHeader: Stub,
+    Button,
+    Col: Stub,
+    Grid: Stub,
+    Text: Stub,
+    TextInput,
+    Title: Stub,
+  };
+});
+
+vi.mock("antd", () => {
+  const React = require("react");
+
+  const Form = ({ children, ...props }: { children?: any }) =>
+    React.createElement("form", props, children);
+  Form.Item = ({ children }: { children?: any }) => React.createElement(React.Fragment, null, children);
+  Form.useForm = () => [formMock];
+
+  const Select = ({ children, ...props }: { children?: any }) =>
+    React.createElement("select", props, children);
+  Select.Option = ({ children, ...props }: { children?: any }) =>
+    React.createElement("option", props, children);
+
+  const Input = (props: any) => React.createElement("input", props);
+  Input.Password = (props: any) => React.createElement("input", { ...props, type: "password" });
+  Input.TextArea = (props: any) => React.createElement("textarea", props);
+
+  const Modal = ({ children, open }: { children?: any; open?: boolean }) =>
+    open ? React.createElement("div", null, children) : null;
+
+  const Radio = ({ children, ...props }: { children?: any }) =>
+    React.createElement("div", props, children);
+  Radio.Group = ({ children, value }: { children?: any; value?: string }) => {
+    radioGroupValueRef.current = value ?? null;
+    return React.createElement("div", null, children);
+  };
+
+  const Switch = (props: any) => React.createElement("input", { ...props, type: "checkbox" });
+  const Tooltip = ({ children }: { children?: any }) => React.createElement(React.Fragment, null, children);
+  const Button = ({ children, ...props }: { children?: any }) =>
+    React.createElement("button", props, children);
+
+  return {
+    Button,
+    Form,
+    Input,
+    Modal,
+    Radio,
+    Select,
+    Switch,
+    Tooltip,
+  };
+});
+
+vi.mock("../networking", () => ({
+  keyCreateCall: vi.fn(),
+  modelAvailableCall: vi.fn().mockResolvedValue({ data: [{ id: "gpt-4" }] }),
   getGuardrailsList: vi.fn().mockResolvedValue({ guardrails: [] }),
   getPromptsList: vi.fn().mockResolvedValue({ prompts: [] }),
   proxyBaseUrl: "http://localhost:4000",
@@ -22,10 +123,9 @@ vi.mock("./networking", () => ({
     key: "test-service-account-key",
     soft_budget: null,
   }),
-  fetchMCPAccessGroups: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("./molecules/notifications_manager", () => ({
+vi.mock("../molecules/notifications_manager", () => ({
   default: {
     success: vi.fn(),
     fromBackend: vi.fn(),
@@ -36,29 +136,137 @@ vi.mock("./molecules/notifications_manager", () => ({
   },
 }));
 
+vi.mock("../agent_management/AgentSelector", () => ({ default: () => null }));
+vi.mock("../common_components/budget_duration_dropdown", () => ({ default: () => null }));
+vi.mock("../common_components/check_openapi_schema", () => ({ default: () => null }));
+vi.mock("../common_components/KeyLifecycleSettings", () => ({ default: () => null }));
+vi.mock("../common_components/ModelAliasManager", () => ({ default: () => null }));
+vi.mock("../common_components/PassThroughRoutesSelector", () => ({ default: () => null }));
+vi.mock("../common_components/PremiumLoggingSettings", () => ({ default: () => null }));
+vi.mock("../common_components/RateLimitTypeFormItem", () => ({ default: () => null }));
+vi.mock("../common_components/team_dropdown", () => ({ default: () => null }));
+vi.mock("../create_user_button", () => ({ default: () => null }));
+vi.mock("../mcp_server_management/MCPServerSelector", () => ({ default: () => null }));
+vi.mock("../mcp_server_management/MCPToolPermissions", () => ({ default: () => null }));
+vi.mock("../shared/numerical_input", () => ({ default: () => null }));
+vi.mock("../vector_store_management/VectorStoreSelector", () => ({ default: () => null }));
+vi.mock("../key_team_helpers/fetch_available_models_team_key", () => ({
+  getModelDisplayName: (model: string) => model,
+}));
+
 describe("CreateKey", () => {
   const defaultProps = {
-    userID: "test-user-id",
     team: null,
-    userRole: "Admin",
-    accessToken: "test-token",
-    data: [],
     teams: [],
+    data: [],
     addKey: vi.fn(),
-    premiumUser: false,
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
-    mockKeyCreateCall.mockResolvedValue({
-      key: "test-api-key",
-      soft_budget: null,
-    });
+    if (typeof window !== "undefined" && window.localStorage && typeof window.localStorage.clear === "function") {
+      window.localStorage.clear();
+    }
+    authorizedState = { ...defaultAuthorizedState };
+    radioGroupValueRef.current = null;
   });
 
   it("should render the CreateKey component", () => {
     renderWithProviders(<CreateKey {...defaultProps} />);
     expect(screen.getByRole("button", { name: /create new key/i })).toBeInTheDocument();
+  });
+
+  it("should prefill models when provided without team_id", async () => {
+    renderWithProviders(
+      <CreateKey
+        {...defaultProps}
+        autoOpenCreate={true}
+        prefillData={{
+          models: ["gpt-4"],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(setFieldsValueMock).toHaveBeenCalledWith({ models: ["gpt-4"] });
+    });
+  });
+
+  it("should prefill team_id when it exists in teams", async () => {
+    renderWithProviders(
+      <CreateKey
+        {...defaultProps}
+        teams={[{ team_id: "team-1", models: [] } as any]}
+        autoOpenCreate={true}
+        prefillData={{ team_id: "team-1" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(setFieldsValueMock).toHaveBeenCalledWith({ team_id: "team-1" });
+    });
+  });
+
+  it("should ignore team_id when it does not exist in teams", async () => {
+    renderWithProviders(
+      <CreateKey
+        {...defaultProps}
+        teams={[{ team_id: "team-1", models: [] } as any]}
+        autoOpenCreate={true}
+        prefillData={{ team_id: "team-404", key_alias: "example-key" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(setFieldsValueMock).toHaveBeenCalledWith({ key_alias: "example-key" });
+    });
+
+    expect(setFieldsValueMock).not.toHaveBeenCalledWith({ team_id: "team-404" });
+  });
+
+  it("should fall back to \"you\" when owned_by is another_user for non-admin", async () => {
+    authorizedState = { ...defaultAuthorizedState, userRole: "Internal User" };
+
+    renderWithProviders(
+      <CreateKey
+        {...defaultProps}
+        autoOpenCreate={true}
+        prefillData={{ owned_by: "another_user", key_alias: "example-key" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(setFieldsValueMock).toHaveBeenCalledWith({ key_alias: "example-key" });
+    });
+
+    expect(radioGroupValueRef.current).toBe("you");
+  });
+
+  it("should apply owned_by another_user for admin", async () => {
+    renderWithProviders(
+      <CreateKey
+        {...defaultProps}
+        autoOpenCreate={true}
+        prefillData={{ owned_by: "another_user" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(radioGroupValueRef.current).toBe("another_user");
+    });
+  });
+
+  it("should prefill key_type when provided", async () => {
+    renderWithProviders(
+      <CreateKey
+        {...defaultProps}
+        autoOpenCreate={true}
+        prefillData={{ key_type: "management" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(setFieldsValueMock).toHaveBeenCalledWith({ key_type: "management" });
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/user_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/user_dashboard.tsx
@@ -16,7 +16,7 @@ import {
   Organization,
   userInfoCall,
 } from "./networking";
-import CreateKey from "./organisms/create_key_button";
+import CreateKey, { CreateKeyPrefillData } from "./organisms/create_key_button";
 import { VirtualKeysTable } from "./VirtualKeysPage/VirtualKeysTable";
 
 export interface ProxySettings {
@@ -55,6 +55,8 @@ interface UserDashboardProps {
   organizations: Organization[] | null;
   addKey: (data: any) => void;
   createClicked: boolean;
+  autoOpenCreate?: boolean;
+  prefillData?: CreateKeyPrefillData;
 }
 
 type TeamInterface = {
@@ -77,6 +79,8 @@ const UserDashboard: React.FC<UserDashboardProps> = ({
   organizations,
   addKey,
   createClicked,
+  autoOpenCreate,
+  prefillData,
 }) => {
   const [userSpendData, setUserSpendData] = useState<UserInfo | null>(null);
   const [currentOrg, setCurrentOrg] = useState<Organization | null>(null);
@@ -350,6 +354,8 @@ const UserDashboard: React.FC<UserDashboardProps> = ({
             teams={teams as Team[]}
             data={keys}
             addKey={addKey}
+            autoOpenCreate={autoOpenCreate}
+            prefillData={prefillData}
           />
           <VirtualKeysTable teams={teams} organizations={organizations} />
         </Col>

--- a/ui/litellm-dashboard/src/utils/returnUrlUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/returnUrlUtils.test.ts
@@ -1,0 +1,383 @@
+import {
+  buildLoginUrlWithReturn,
+  clearStoredReturnUrl,
+  consumeReturnUrl,
+  getCurrentUrl,
+  getReturnUrl,
+  getReturnUrlFromParams,
+  getStoredReturnUrl,
+  isValidReturnUrl,
+  storeReturnUrl,
+} from "./returnUrlUtils";
+
+describe("returnUrlUtils", () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // Clear cookies before each test
+    document.cookie.split(";").forEach((c) => {
+      document.cookie = c
+        .replace(/^ +/, "")
+        .replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/");
+    });
+
+    // Reset location mock
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "http://localhost:3000/ui?page=api-keys",
+        origin: "http://localhost:3000",
+        hostname: "localhost",
+        pathname: "/ui",
+        search: "?page=api-keys",
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    // Restore original location
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  describe("getCurrentUrl", () => {
+    it("should return the current URL", () => {
+      const url = getCurrentUrl();
+      expect(url).toBe("http://localhost:3000/ui?page=api-keys");
+    });
+  });
+
+  describe("storeReturnUrl and getStoredReturnUrl", () => {
+    it("should store and retrieve the return URL from cookie", () => {
+      storeReturnUrl();
+      const storedUrl = getStoredReturnUrl();
+      expect(storedUrl).toBe("http://localhost:3000/ui?page=api-keys");
+    });
+
+    it("should return null if no URL is stored", () => {
+      const storedUrl = getStoredReturnUrl();
+      expect(storedUrl).toBeNull();
+    });
+  });
+
+  describe("clearStoredReturnUrl", () => {
+    it("should clear the stored return URL", () => {
+      storeReturnUrl();
+      expect(getStoredReturnUrl()).not.toBeNull();
+
+      clearStoredReturnUrl();
+      expect(getStoredReturnUrl()).toBeNull();
+    });
+  });
+
+  describe("getReturnUrlFromParams", () => {
+    it("should return the redirect_to parameter from URL", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          search: "?redirect_to=http%3A%2F%2Flocalhost%3A3000%2Fui%3Fcreate%3Dtrue",
+        },
+        writable: true,
+      });
+
+      const returnUrl = getReturnUrlFromParams();
+      expect(returnUrl).toBe("http://localhost:3000/ui?create=true");
+    });
+
+    it("should return null if redirect_to parameter is not present", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          search: "?page=api-keys",
+        },
+        writable: true,
+      });
+
+      const returnUrl = getReturnUrlFromParams();
+      expect(returnUrl).toBeNull();
+    });
+  });
+
+  describe("buildLoginUrlWithReturn", () => {
+    it("should build login URL with return URL parameter", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          href: "http://localhost:3000/ui?create=true&team_id=123",
+        },
+        writable: true,
+      });
+
+      const loginUrl = buildLoginUrlWithReturn("/ui/login");
+      expect(loginUrl).toBe(
+        "/ui/login?redirect_to=http%3A%2F%2Flocalhost%3A3000%2Fui%3Fcreate%3Dtrue%26team_id%3D123"
+      );
+    });
+
+    it("should not add return URL if already on login page", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          href: "http://localhost:3000/ui/login",
+        },
+        writable: true,
+      });
+
+      const loginUrl = buildLoginUrlWithReturn("/ui/login");
+      expect(loginUrl).toBe("/ui/login");
+    });
+
+    it("should handle login URL with existing query parameters", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          href: "http://localhost:3000/ui?page=api-keys",
+        },
+        writable: true,
+      });
+
+      const loginUrl = buildLoginUrlWithReturn("/ui/login?foo=bar");
+      expect(loginUrl).toContain("&redirect_to=");
+    });
+  });
+
+  describe("getReturnUrl", () => {
+    it("should prefer URL params over cookie", () => {
+      // Store a URL in cookie
+      storeReturnUrl();
+
+      // Set a different URL in the params
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          search: "?redirect_to=http%3A%2F%2Flocalhost%3A3000%2Fui%3Fpage%3Dteams",
+        },
+        writable: true,
+      });
+
+      const returnUrl = getReturnUrl();
+      expect(returnUrl).toBe("http://localhost:3000/ui?page=teams");
+    });
+
+    it("should fall back to cookie if no URL param", () => {
+      // Store a URL in cookie first
+      Object.defineProperty(window, "location", {
+        value: {
+          href: "http://localhost:3000/ui?create=true",
+          origin: "http://localhost:3000",
+          hostname: "localhost",
+          pathname: "/ui",
+          search: "?create=true",
+        },
+        writable: true,
+      });
+      storeReturnUrl();
+
+      // Clear the URL params
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          search: "",
+        },
+        writable: true,
+      });
+
+      const returnUrl = getReturnUrl();
+      expect(returnUrl).toBe("http://localhost:3000/ui?create=true");
+    });
+
+    it("should return null if no return URL found", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          search: "",
+        },
+        writable: true,
+      });
+
+      const returnUrl = getReturnUrl();
+      expect(returnUrl).toBeNull();
+    });
+  });
+
+  describe("isValidReturnUrl", () => {
+    it("should validate relative URLs starting with /", () => {
+      expect(isValidReturnUrl("/ui?page=api-keys")).toBe(true);
+      expect(isValidReturnUrl("/ui/teams")).toBe(true);
+    });
+
+    it("should reject protocol-relative URLs", () => {
+      expect(isValidReturnUrl("//evil.com")).toBe(false);
+    });
+
+    it("should validate same-hostname URLs (even with different ports) in dev", () => {
+      // Same hostname, same port
+      expect(isValidReturnUrl("http://localhost:3000/ui?page=teams")).toBe(true);
+      // Same hostname, different port (important for dev environments)
+      expect(isValidReturnUrl("http://localhost:4000/ui?page=teams")).toBe(true);
+    });
+
+    it("should reject different-hostname URLs", () => {
+      expect(isValidReturnUrl("http://evil.com/ui")).toBe(false);
+      expect(isValidReturnUrl("https://google.com")).toBe(false);
+    });
+
+    it("should reject empty URLs", () => {
+      expect(isValidReturnUrl("")).toBe(false);
+    });
+
+    it("should reject invalid URLs", () => {
+      expect(isValidReturnUrl("not-a-url")).toBe(false);
+    });
+
+    it("should reject XSS attempts with javascript: protocol", () => {
+      expect(isValidReturnUrl('javascript:alert("xss")')).toBe(false);
+      expect(isValidReturnUrl("javascript:void(0)")).toBe(false);
+    });
+
+    it("should reject data: URLs", () => {
+      expect(isValidReturnUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+    });
+
+    it("should allow 127.x.x.x addresses in dev environment", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          href: "http://127.0.0.1:3000/ui",
+          origin: "http://127.0.0.1:3000",
+          hostname: "127.0.0.1",
+          protocol: "http:",
+          pathname: "/ui",
+          search: "",
+        },
+        writable: true,
+      });
+
+      expect(isValidReturnUrl("http://127.0.0.1:4000/ui")).toBe(true);
+    });
+
+    it("should allow .local domains in dev environment", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          href: "http://myapp.local:3000/ui",
+          origin: "http://myapp.local:3000",
+          hostname: "myapp.local",
+          protocol: "http:",
+          pathname: "/ui",
+          search: "",
+        },
+        writable: true,
+      });
+
+      // Same hostname with different port should be allowed in dev
+      expect(isValidReturnUrl("http://myapp.local:4000/ui")).toBe(true);
+    });
+
+    it("should reject cross-port redirects in production environment", () => {
+      // Simulate production environment
+      Object.defineProperty(window, "location", {
+        value: {
+          href: "https://app.example.com/ui",
+          origin: "https://app.example.com",
+          hostname: "app.example.com",
+          protocol: "https:",
+          pathname: "/ui",
+          search: "",
+        },
+        writable: true,
+      });
+
+      // Same origin should work
+      expect(isValidReturnUrl("https://app.example.com/ui?page=teams")).toBe(true);
+      // Different port should be rejected in production
+      expect(isValidReturnUrl("https://app.example.com:8080/ui")).toBe(false);
+      // Different hostname should be rejected
+      expect(isValidReturnUrl("https://evil.com/ui")).toBe(false);
+    });
+  });
+
+  describe("consumeReturnUrl", () => {
+    it("should return and clear the stored return URL", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          href: "http://localhost:3000/ui?create=true",
+          origin: "http://localhost:3000",
+          hostname: "localhost",
+          pathname: "/ui",
+          search: "?create=true",
+        },
+        writable: true,
+      });
+      storeReturnUrl();
+
+      // Clear the URL params for the consume call
+      Object.defineProperty(window, "location", {
+        value: {
+          href: "http://localhost:3000/ui/login",
+          origin: "http://localhost:3000",
+          hostname: "localhost",
+          pathname: "/ui/login",
+          search: "",
+        },
+        writable: true,
+      });
+
+      const returnUrl = consumeReturnUrl();
+      expect(returnUrl).toBe("http://localhost:3000/ui?create=true");
+      expect(getStoredReturnUrl()).toBeNull();
+    });
+
+    it("should return null for invalid return URLs (different hostname)", () => {
+      // Manually set an invalid URL in cookie
+      document.cookie = "litellm_return_url=" + encodeURIComponent("http://evil.com/phishing") + "; path=/";
+
+      const returnUrl = consumeReturnUrl();
+      expect(returnUrl).toBeNull();
+    });
+
+    it("should allow URLs with different ports on same hostname", () => {
+      // Store URL with port 3000
+      Object.defineProperty(window, "location", {
+        value: {
+          href: "http://localhost:3000/ui?create=true",
+          origin: "http://localhost:3000",
+          hostname: "localhost",
+          pathname: "/ui",
+          search: "?create=true",
+        },
+        writable: true,
+      });
+      storeReturnUrl();
+
+      // Now we're on port 4000
+      Object.defineProperty(window, "location", {
+        value: {
+          href: "http://localhost:4000/ui",
+          origin: "http://localhost:4000",
+          hostname: "localhost",
+          pathname: "/ui",
+          search: "",
+        },
+        writable: true,
+      });
+
+      const returnUrl = consumeReturnUrl();
+      // Should be valid because same hostname (localhost)
+      expect(returnUrl).toBe("http://localhost:3000/ui?create=true");
+    });
+
+    it("should return null if no return URL found", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          search: "",
+        },
+        writable: true,
+      });
+
+      const returnUrl = consumeReturnUrl();
+      expect(returnUrl).toBeNull();
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/utils/returnUrlUtils.ts
+++ b/ui/litellm-dashboard/src/utils/returnUrlUtils.ts
@@ -1,0 +1,304 @@
+/**
+ * Utility functions for managing return URLs during authentication flows.
+ *
+ * When a user is redirected to login, we store the original URL so they can be
+ * redirected back after successful authentication.
+ *
+ * NOTE: We use cookies instead of sessionStorage because the SSO flow may cross
+ * different ports (e.g., localhost:3000 -> localhost:4000), and sessionStorage
+ * is not shared across different origins. Cookies on the same hostname are shared
+ * across different ports.
+ */
+
+const RETURN_URL_COOKIE_NAME = "litellm_return_url";
+const RETURN_URL_PARAM = "redirect_to";
+
+/**
+ * Gets the current URL with all query parameters.
+ * Returns null if running on server-side.
+ */
+export function getCurrentUrl(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.location.href;
+}
+
+/**
+ * Sets a cookie with the given name and value.
+ * Automatically adds Secure flag when running over HTTPS.
+ */
+function setCookie(name: string, value: string, maxAgeSeconds: number = 300): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  // Set cookie with path=/ so it's available across all paths
+  // Use SameSite=Lax to allow the cookie to be sent on navigation from external sites (SSO redirect)
+  // Add Secure flag when running over HTTPS to prevent cookie from being sent over unencrypted connections
+  const isSecure = typeof window !== "undefined" && window.location.protocol === "https:";
+  const secureFlag = isSecure ? "; Secure" : "";
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${maxAgeSeconds}; SameSite=Lax${secureFlag}`;
+}
+
+/**
+ * Gets a cookie value by name.
+ */
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const match = document.cookie.match(new RegExp(`(^| )${name}=([^;]+)`));
+  if (match) {
+    try {
+      return decodeURIComponent(match[2]);
+    } catch {
+      return match[2];
+    }
+  }
+  return null;
+}
+
+/**
+ * Deletes a cookie by name.
+ */
+function deleteCookie(name: string): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  document.cookie = `${name}=; path=/; max-age=0`;
+}
+
+/**
+ * Stores the current URL in a cookie before redirecting to login.
+ * This allows us to redirect the user back to their original destination after login.
+ * Cookie expires in 5 minutes (300 seconds).
+ */
+export function storeReturnUrl(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const currentUrl = getCurrentUrl();
+  if (currentUrl) {
+    setCookie(RETURN_URL_COOKIE_NAME, currentUrl, 300);
+  }
+}
+
+/**
+ * Retrieves the stored return URL from the cookie.
+ * Returns null if no return URL is stored or if running on server-side.
+ */
+export function getStoredReturnUrl(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return getCookie(RETURN_URL_COOKIE_NAME);
+}
+
+/**
+ * Clears the stored return URL from the cookie.
+ * Should be called after redirecting to the return URL.
+ */
+export function clearStoredReturnUrl(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    deleteCookie(RETURN_URL_COOKIE_NAME);
+  } catch (error) {
+    console.error("Failed to clear return URL cookie:", error);
+  }
+}
+
+/**
+ * Gets the return URL from URL query parameters.
+ * Used when the return URL is passed via query string to the login page.
+ */
+export function getReturnUrlFromParams(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const searchParams = new URLSearchParams(window.location.search);
+  return searchParams.get(RETURN_URL_PARAM);
+}
+
+/**
+ * Builds a login URL with the return URL as a query parameter.
+ *
+ * @param baseLoginUrl - The base login URL (e.g., "/ui/login")
+ * @param returnUrl - The URL to redirect to after login (defaults to current URL)
+ */
+export function buildLoginUrlWithReturn(baseLoginUrl: string, returnUrl?: string): string {
+  const url = returnUrl || getCurrentUrl();
+
+  if (!url) {
+    return baseLoginUrl;
+  }
+
+  // Don't add return URL if we're already on the login page
+  if (url.includes("/login")) {
+    return baseLoginUrl;
+  }
+
+  const separator = baseLoginUrl.includes("?") ? "&" : "?";
+  return `${baseLoginUrl}${separator}${RETURN_URL_PARAM}=${encodeURIComponent(url)}`;
+}
+
+/**
+ * Gets the best return URL to use after login.
+ * Priority:
+ * 1. URL query parameter (redirect_to)
+ * 2. Cookie
+ * 3. null (caller should use default)
+ */
+export function getReturnUrl(): string | null {
+  // First check URL params
+  const paramUrl = getReturnUrlFromParams();
+  if (paramUrl) {
+    return paramUrl;
+  }
+
+  // Then check cookie
+  const storedUrl = getStoredReturnUrl();
+  if (storedUrl) {
+    return storedUrl;
+  }
+
+  return null;
+}
+
+/**
+ * Checks if we're running in a development environment.
+ * Returns true for localhost, 127.0.0.1, IPv6 localhost, or .local domains.
+ * This determines whether cross-port redirects are allowed (dev only).
+ */
+function isDevEnvironment(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  const hostname = window.location.hostname;
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname.startsWith("127.") || // Full IPv4 loopback range (127.0.0.0/8)
+    hostname.endsWith(".local") // Common dev domain suffix
+  );
+}
+
+/**
+ * Validates a return URL to prevent open redirect attacks.
+ * - Always allows relative URLs (starting with / but not //)
+ * - In dev (localhost): allows same hostname with any port
+ * - In production: requires exact origin match (protocol + hostname + port)
+ *
+ * @param url - The URL to validate
+ * @returns true if the URL is safe to redirect to
+ */
+export function isValidReturnUrl(url: string): boolean {
+  if (!url) {
+    return false;
+  }
+
+  // Allow relative URLs
+  if (url.startsWith("/") && !url.startsWith("//")) {
+    return true;
+  }
+
+  // For absolute URLs, validate against current origin
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    const returnUrlObj = new URL(url);
+    const currentHostname = window.location.hostname;
+
+    // Hostname must always match
+    if (returnUrlObj.hostname !== currentHostname) {
+      return false;
+    }
+
+    // In dev environments (localhost), allow any port on the same hostname
+    // This supports SSO flows that cross ports (e.g., localhost:3000 -> localhost:4000)
+    if (isDevEnvironment()) {
+      return true;
+    }
+
+    // In production, require exact origin match (protocol + hostname + port)
+    return returnUrlObj.origin === window.location.origin;
+  } catch {
+    // Invalid URL
+    return false;
+  }
+}
+
+export function normalizeUrlForCompare(url: string): string {
+  if (typeof window === "undefined") {
+    return url;
+  }
+
+  try {
+    const parsed = new URL(url, window.location.origin);
+    let pathname = parsed.pathname;
+    if (pathname.length > 1 && pathname.endsWith("/")) {
+      pathname = pathname.slice(0, -1);
+    }
+
+    const params = new URLSearchParams(parsed.search);
+    const sortedParams = new URLSearchParams();
+    Array.from(params.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .forEach(([key, value]) => {
+        sortedParams.append(key, value);
+      });
+
+    const search = sortedParams.toString();
+    const hash = parsed.hash || "";
+    return `${parsed.origin}${pathname}${search ? `?${search}` : ""}${hash}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Gets and clears the return URL in one operation.
+ * Returns the validated return URL or null if invalid/not found.
+ *
+ * Priority:
+ * 1. If redirect_to param is valid, use it and clear cookie
+ * 2. If redirect_to param is invalid/missing, check cookie
+ * 3. Only clear cookie when we have a valid URL to return
+ */
+export function consumeReturnUrl(): string | null {
+  // Check URL param first
+  const paramUrl = getReturnUrlFromParams();
+  if (paramUrl) {
+    if (isValidReturnUrl(paramUrl)) {
+      clearStoredReturnUrl();
+      return paramUrl;
+    }
+    // Log rejected URLs in development for debugging
+    if (isDevEnvironment()) {
+      console.warn("[returnUrlUtils] Invalid return URL in params rejected:", paramUrl);
+    }
+  }
+
+  // Fall back to cookie
+  const storedUrl = getStoredReturnUrl();
+  if (storedUrl) {
+    if (isValidReturnUrl(storedUrl)) {
+      clearStoredReturnUrl();
+      return storedUrl;
+    }
+    // Log rejected URLs in development for debugging
+    if (isDevEnvironment()) {
+      console.warn("[returnUrlUtils] Invalid return URL in cookie rejected:", storedUrl);
+    }
+  }
+
+  // No valid URL found - don't clear cookie (nothing to clear or already invalid)
+  return null;
+}

--- a/ui/litellm-dashboard/src/utils/roles.ts
+++ b/ui/litellm-dashboard/src/utils/roles.ts
@@ -31,3 +31,32 @@ export const isUserTeamAdminForSingleTeam = (teamMemberWithRoles: Member[] | nul
   }
   return teamMemberWithRoles.some((member) => member.user_id === userID && member.role === "admin");
 };
+
+export const formatUserRole = (userRole: string): string => {
+  if (!userRole) {
+    return "Undefined Role";
+  }
+  switch (userRole.toLowerCase()) {
+    case "app_owner":
+      return "App Owner";
+    case "demo_app_owner":
+      return "App Owner";
+    case "app_admin":
+      return "Admin";
+    case "proxy_admin":
+      return "Admin";
+    case "proxy_admin_viewer":
+      return "Admin Viewer";
+    case "org_admin":
+      return "Org Admin";
+    case "internal_user":
+      return "Internal User";
+    case "internal_user_viewer":
+    case "internal_viewer": // TODO:remove if deprecated
+      return "Internal Viewer";
+    case "app_user":
+      return "App User";
+    default:
+      return "Unknown Role";
+  }
+};


### PR DESCRIPTION
**Pending Verification**: `Exception occured - column t.soft_budget does not exist`

Adds utilities for preserving return URLs through authentication flows, allowing users to be redirected back to their original destination after SSO login.

Features:
- Cookie-based return URL storage (shared across ports for SSO flows)
- URL validation to prevent open redirect attacks
- Support for both dev (any port on same hostname) and production (exact origin)
- Return URL parameter support in login URLs
- Automatic Secure flag for HTTPS cookies
- Development-only debug logging for rejected URLs

Security:
- Validates URLs against same-origin policy
- Rejects protocol-relative URLs (//evil.com)
- Rejects javascript: and data: URLs
- Restricts cross-port redirects to dev environments only
- Enhanced dev detection (full loopback range, .local domains)

Files:
- returnUrlUtils.ts: Core utilities
- returnUrlUtils.test.ts: Comprehensive tests including security scenarios
- useAuthorized.ts: Integration with auth hook
- LoginPage.tsx: Return URL handling on login



feat(ui): add deep-link support for key creation modal

Enables users to deep-link directly to the key creation modal with pre-filled form data via URL parameters. This integrates with the SSO return URL feature to preserve deep-links through authentication.

Features:
- Auto-open key creation modal via ?create=true parameter
- Prefill form fields from URL parameters:
  - owned_by: key ownership (you, service_account, another_user)
  - team_id: pre-select team
  - key_alias: pre-fill key name
  - models: comma-separated list of models
  - key_type: default, llm_api, or management
- Return URL consumption after SSO redirect with race condition protection
- Role-based access control for auto-open (requires write access)

Security:
- Validates owned_by and key_type against allowed enum values
- Sanitizes key_alias (trim, length limit)
- Limits model array size to prevent DoS
- Only allows another_user ownership for Admin role
- Only auto-opens for users with write access roles
- Race condition protection using useRef for redirect attempts

Example URLs:
- /ui?create=true - Opens modal with defaults
- /ui?create=true&team_id=abc&key_alias=my-key - Opens with prefilled data
- /ui?create=true&models=gpt-4,claude-3 - Opens with models selected

Files:
- page.tsx: URL parsing, return URL consumption, props passing
- create_key_button.tsx: Auto-open logic, prefill handling
- user_dashboard.tsx: Props drilling for autoOpenCreate/prefillData
- CreateKeyPage.expiredToken.test.tsx: Test updates



fix(ui): harden return redirects and prefill

chore(ui): clarify prefill effects

refactor(ui): centralize role/URL helpers and expand prefill tests

test(ui): stabilize create key mocks

docs(ui): clarify model prefill timing in CreateKey comments

Add explanatory comments for the dual-useEffect pattern that handles model prefill from URL parameters. This helps reviewers understand the timing relationship between model fetching and prefill application.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
