### PR TITLE
fix: handle dict type for server_tool_use in Usage model

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1428,7 +1428,7 @@ class Usage(SafeAttributeModel, CompletionUsage):
         completion_tokens_details: Optional[
             Union[CompletionTokensDetailsWrapper, dict]
         ] = None,
-        server_tool_use: Optional[ServerToolUse] = None,
+        server_tool_use: Optional[Union[ServerToolUse, dict]] = None,
         cost: Optional[float] = None,
         **params,
     ):
@@ -1521,6 +1521,14 @@ class Usage(SafeAttributeModel, CompletionUsage):
                     "cache_creation_input_tokens"
                 ]
 
+        # Handle server_tool_use - convert dict to ServerToolUse object if needed
+        _server_tool_use: Optional[ServerToolUse] = None
+        if server_tool_use is not None:
+            if isinstance(server_tool_use, dict):
+                _server_tool_use = ServerToolUse(**server_tool_use)
+            elif isinstance(server_tool_use, ServerToolUse):
+                _server_tool_use = server_tool_use
+
         super().__init__(
             prompt_tokens=prompt_tokens or 0,
             completion_tokens=completion_tokens or 0,
@@ -1529,8 +1537,8 @@ class Usage(SafeAttributeModel, CompletionUsage):
             prompt_tokens_details=_prompt_tokens_details or None,
         )
 
-        if server_tool_use is not None:
-            self.server_tool_use = server_tool_use
+        if _server_tool_use is not None:
+            self.server_tool_use = _server_tool_use
         else:  # maintain openai compatibility in usage object if possible
             del self.server_tool_use
 


### PR DESCRIPTION
## Problem

Some API providers (e.g., NEXUS, custom Anthropic-compatible endpoints) return `server_tool_use` as a plain dict instead of a `ServerToolUse` object in the usage data:

```json
"server_tool_use": {
  "web_search_requests": 0,
  "tool_search_requests": null
}
```

This causes Pydantic serialization warnings:
```
PydanticSerializationUnexpectedValue(Expected `ServerToolUse` - 
serialized value may not be as expected [field_name='server_tool_use', 
input_value={'web_search_requests': 0, 'tool_search_requests': None}, 
input_type=dict])
```

## Solution

Modified `Usage.__init__` to accept `Union[ServerToolUse, dict]` for the `server_tool_use` parameter and added conversion logic to transform dict to `ServerToolUse` object when needed.

This follows the same pattern already used for `prompt_tokens_details` and `completion_tokens_details` fields.

## Changes

- Updated type annotation: `server_tool_use: Optional[Union[ServerToolUse, dict]] = None`
- Added conversion logic before `super().__init__()`:
  ```python
  _server_tool_use: Optional[ServerToolUse] = None
  if server_tool_use is not None:
      if isinstance(server_tool_use, dict):
          _server_tool_use = ServerToolUse(**server_tool_use)
      elif isinstance(server_tool_use, ServerToolUse):
          _server_tool_use = server_tool_use
  ```

## Testing

Tested with NEXUS API (Anthropic-compatible endpoint) that returns dict format for `server_tool_use`. The Pydantic serialization warning no longer appears, and functionality remains unchanged.

## Backward Compatibility

This change maintains full backward compatibility:
- Existing code passing `ServerToolUse` objects continues to work
- New code can pass dict format and it will be automatically converted
- No breaking changes to the API