### PR TITLE
fix(guardrails): pass kwargs to parent in ZscalerAIGuard to honor mode from config

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
@@ -56,7 +56,7 @@ class ZscalerAIGuard(CustomGuardrail):
             send_user_api_key_team_id:{self.send_user_api_key_team_id}"""
         )
 
-        super().__init__(default_on=True)
+        super().__init__(default_on=True, **kwargs)
 
         verbose_proxy_logger.debug("ZscalerAIGuard Initializing ...")
 

--- a/tests/guardrails_tests/test_zscaler_ai_guard.py
+++ b/tests/guardrails_tests/test_zscaler_ai_guard.py
@@ -225,6 +225,38 @@ async def test_policy_id_from_init(mock_api_call):
     mock_api_call.assert_called_once()
     assert mock_api_call.call_args.kwargs["policy_id"] == 100
 
+def test_event_hook_passed_through_kwargs():
+    """
+    Test that event_hook (mode) from config is correctly passed to the parent
+    CustomGuardrail class via kwargs.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/20772
+    """
+    guardrail = ZscalerAIGuard(
+        api_key="test_api_key",
+        api_base="http://example.com",
+        policy_id=1,
+        event_hook="pre_call",
+        guardrail_name="zscaler-guard",
+    )
+    assert guardrail.event_hook == "pre_call"
+    assert guardrail.guardrail_name == "zscaler-guard"
+
+
+def test_event_hook_list_passed_through_kwargs():
+    """
+    Test that event_hook as a list of modes is correctly passed through.
+    """
+    guardrail = ZscalerAIGuard(
+        api_key="test_api_key",
+        api_base="http://example.com",
+        policy_id=1,
+        event_hook=["pre_call", "post_call"],
+        guardrail_name="zscaler-guard",
+    )
+    assert guardrail.event_hook == ["pre_call", "post_call"]
+
+
 @pytest.mark.asyncio
 @patch(
     "litellm.proxy.guardrails.guardrail_hooks.zscaler_ai_guard.ZscalerAIGuard.make_zscaler_ai_guard_api_call",


### PR DESCRIPTION
Fixes #20772

The ZscalerAIGuard.__init__ was calling super().__init__(default_on=True) without forwarding **kwargs, which meant that event_hook (mode) and guardrail_name passed by the guardrail registry were silently dropped. This caused all guardrail hooks (pre_call, during_call, post_call) to fire regardless of the mode setting in config.yaml.

## Changes
- Pass **kwargs through to super().__init__() in ZscalerAIGuard so event_hook, guardrail_name, and other parent params are properly set
- Added regression tests verifying event_hook and guardrail_name are correctly propagated

## Root Cause
The guardrail registry passes event_hook=mode and guardrail_name as kwargs when instantiating guardrails. Other guardrails (e.g., PANW Prisma AIRS) correctly forward these to the parent CustomGuardrail, but ZscalerAIGuard did not. Without event_hook set, _event_hook_is_event_type() allows all event types.