### PR TITLE
fix(guardrails): Fix Zscaler AI Guard metadata resolution and header mapping bugs

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/__init__.py
@@ -14,6 +14,10 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
     _zscaler_ai_guard_callback = ZscalerAIGuard(
         api_base=litellm_params.api_base,
         api_key=litellm_params.api_key,
+        policy_id=litellm_params.policy_id,
+        send_user_api_key_alias=litellm_params.send_user_api_key_alias,
+        send_user_api_key_user_id=litellm_params.send_user_api_key_user_id,
+        send_user_api_key_team_id=litellm_params.send_user_api_key_team_id,
         guardrail_name=guardrail.get("guardrail_name", ""),
         event_hook=litellm_params.mode,
         default_on=litellm_params.default_on,

--- a/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
@@ -56,7 +56,7 @@ class ZscalerAIGuard(CustomGuardrail):
             send_user_api_key_team_id:{self.send_user_api_key_team_id}"""
         )
 
-        super().__init__(default_on=True)
+        super().__init__(**kwargs)
 
         verbose_proxy_logger.debug("ZscalerAIGuard Initializing ...")
 
@@ -150,6 +150,7 @@ class ZscalerAIGuard(CustomGuardrail):
                     content=concatenated_text,
                     **kwargs,
                 )
+                verbose_proxy_logger.debug(f"response from zscaler ai guards: {zscaler_ai_guard_result}")
             if (
                 zscaler_ai_guard_result
                 and zscaler_ai_guard_result.get("action") == "BLOCK"
@@ -321,7 +322,6 @@ class ZscalerAIGuard(CustomGuardrail):
             "direction": direction,
             "content": content,
         }
-
         try:
             response = await self._send_request(
                 zscaler_ai_guard_url, extra_headers, data
@@ -330,5 +330,4 @@ class ZscalerAIGuard(CustomGuardrail):
         except Exception as e:
             verbose_proxy_logger.error(f"{e}. Blocking request.")
             user_facing_error = self._create_user_facing_error(f"{str(e)})")
-            # This exception will be caught by the proxy and returned to the user
             raise HTTPException(status_code=500, detail=user_facing_error)

--- a/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
@@ -28,9 +28,9 @@ class ZscalerAIGuard(CustomGuardrail):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         policy_id: Optional[int] = None,
-        send_user_api_key_alias: Optional[bool] = False,
-        send_user_api_key_user_id: Optional[bool] = False,
-        send_user_api_key_team_id: Optional[bool] = False,
+        send_user_api_key_alias: Optional[bool] = None,
+        send_user_api_key_user_id: Optional[bool] = None,
+        send_user_api_key_team_id: Optional[bool] = None,
         **kwargs,
     ):
         self.optional_params = kwargs
@@ -40,13 +40,13 @@ class ZscalerAIGuard(CustomGuardrail):
         )
         self.policy_id = policy_id or int(os.getenv("ZSCALER_AI_GUARD_POLICY_ID", -1))
         self.api_key = api_key or os.getenv("ZSCALER_AI_GUARD_API_KEY")
-        self.send_user_api_key_alias = send_user_api_key_alias or os.getenv(
+        self.send_user_api_key_alias = send_user_api_key_alias if send_user_api_key_alias is not None else os.getenv(
             "SEND_USER_API_KEY_ALIAS", "False"
         ).lower() in ("true", "1")
-        self.send_user_api_key_user_id = send_user_api_key_user_id or os.getenv(
+        self.send_user_api_key_user_id = send_user_api_key_user_id if send_user_api_key_user_id is not None else os.getenv(
             "SEND_USER_API_KEY_USER_ID", "False"
-        ).lower() in ("true", "1,")
-        self.send_user_api_key_team_id = send_user_api_key_team_id or os.getenv(
+        ).lower() in ("true", "1")
+        self.send_user_api_key_team_id = send_user_api_key_team_id if send_user_api_key_team_id is not None else os.getenv(
             "SEND_USER_API_KEY_TEAM_ID", "False"
         ).lower() in ("true", "1")
 
@@ -60,15 +60,44 @@ class ZscalerAIGuard(CustomGuardrail):
 
         verbose_proxy_logger.debug("ZscalerAIGuard Initializing ...")
 
-    def _get_stripped_metadata_value(
-        self, request_data: Optional[dict], key: str
-    ) -> Optional[str]:
+    @staticmethod
+    def _resolve_metadata_value(request_data: Optional[dict], key: str) -> Optional[str]:
+        """
+        Resolve metadata value from request_data, checking both metadata locations.
+
+        During pre-call: metadata is at request_data["metadata"][key]
+        During post-call: metadata is at request_data["litellm_metadata"][key]
+            (set by transform_user_api_key_dict_to_metadata which prefixes keys with 'user_api_key_')
+
+        Also handles key name mapping for UserAPIKeyAuth fields:
+            - key_alias -> user_api_key_key_alias (in litellm_metadata)
+            - user_id -> user_api_key_user_id
+            - team_id -> user_api_key_team_id
+        """
         if request_data is None:
-            return "N/A"
-        value = request_data.get("metadata", {}).get(key, "N/A")
-        if value is not None:
-            return str(value).strip()
-        return "N/A"
+            return None
+
+        # Check litellm_metadata first (set during post-call by guardrail framework)
+        litellm_metadata = request_data.get("litellm_metadata", {})
+        if litellm_metadata:
+            value = litellm_metadata.get(key)
+            if value is not None:
+                return str(value).strip()
+            # Handle key_alias -> user_api_key_key_alias mapping
+            # transform_user_api_key_dict_to_metadata prefixes "key_alias" -> "user_api_key_key_alias"
+            if key == "user_api_key_alias":
+                value = litellm_metadata.get("user_api_key_key_alias")
+                if value is not None:
+                    return str(value).strip()
+
+        # Then check regular metadata (set during pre-call by proxy_server)
+        metadata = request_data.get("metadata", {})
+        if metadata:
+            value = metadata.get(key)
+            if value is not None:
+                return str(value).strip()
+
+        return None
 
     async def apply_guardrail(
         self,
@@ -123,17 +152,17 @@ class ZscalerAIGuard(CustomGuardrail):
 
             kwargs = {}
             if self.send_user_api_key_alias:
-                kwargs["user_api_key_alias"] = self._get_stripped_metadata_value(
+                kwargs["user_api_key_alias"] = self._resolve_metadata_value(
                     request_data, "user_api_key_alias"
-                )
+                ) or "N/A"
             if self.send_user_api_key_team_id:
-                kwargs["user_api_key_team_id"] = self._get_stripped_metadata_value(
+                kwargs["user_api_key_team_id"] = self._resolve_metadata_value(
                     request_data, "user_api_key_team_id"
-                )
+                ) or "N/A"
             if self.send_user_api_key_user_id:
-                kwargs["user_api_key_user_id"] = self._get_stripped_metadata_value(
+                kwargs["user_api_key_user_id"] = self._resolve_metadata_value(
                     request_data, "user_api_key_user_id"
-                )
+                ) or "N/A"
             verbose_proxy_logger.debug(f"inside apply_guardrail kwargs: {kwargs}")
 
             zscaler_ai_guard_result = None
@@ -215,7 +244,7 @@ class ZscalerAIGuard(CustomGuardrail):
             extra_headers.update({"user-api-key-team-id": user_api_key_team_id})
 
         if self.send_user_api_key_user_id:
-            user_api_key_user_id = kwargs.get("user-api-key-user-id", "N/A")
+            user_api_key_user_id = kwargs.get("user_api_key_user_id", "N/A")
             extra_headers.update({"user-api-key-user-id": user_api_key_user_id})
 
         verbose_proxy_logger.debug(f"extra_headers: {extra_headers}")
@@ -318,10 +347,13 @@ class ZscalerAIGuard(CustomGuardrail):
         extra_headers = self._prepare_headers(api_key, **kwargs)
 
         data = {
-            "policyId": policy_id,
             "direction": direction,
             "content": content,
         }
+        # Only include policyId when using execute-policy endpoint (not resolve-and-execute-policy)
+        # resolve-and-execute-policy infers the policy from headers (e.g., user-api-key-alias)
+        if policy_id is not None and policy_id > 0:
+            data["policyId"] = policy_id
         try:
             response = await self._send_request(
                 zscaler_ai_guard_url, extra_headers, data

--- a/tests/litellm/proxy/guardrails/test_zscaler_ai_guard.py
+++ b/tests/litellm/proxy/guardrails/test_zscaler_ai_guard.py
@@ -1,0 +1,288 @@
+"""
+Unit tests for Zscaler AI Guard guardrail
+
+Tests covering:
+- super().__init__(**kwargs) passes event_hook correctly
+- _resolve_metadata_value works for both pre-call and post-call metadata
+- _prepare_headers correctly maps all kwargs
+- resolve-and-execute-policy endpoint omits policyId
+- Config parameters are passed from __init__.py
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../..")))
+
+from litellm.proxy.guardrails.guardrail_hooks.zscaler_ai_guard import ZscalerAIGuard
+
+
+class TestZscalerAIGuardInit:
+    """Tests for ZscalerAIGuard initialization"""
+
+    def test_should_pass_event_hook_to_parent_class(self):
+        """Test that super().__init__(**kwargs) passes event_hook to CustomGuardrail"""
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            policy_id=100,
+            event_hook="pre_call",
+            guardrail_name="test-guardrail",
+        )
+        assert guardrail.event_hook == "pre_call"
+        assert guardrail.guardrail_name == "test-guardrail"
+
+    def test_should_pass_default_on_to_parent_class(self):
+        """Test that default_on is passed to CustomGuardrail"""
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            policy_id=100,
+            default_on=True,
+        )
+        assert guardrail.default_on is True
+
+    def test_should_use_config_send_user_api_key_alias_when_true(self):
+        """Test that send_user_api_key_alias=True from config is used"""
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            send_user_api_key_alias=True,
+        )
+        assert guardrail.send_user_api_key_alias is True
+
+    def test_should_use_config_send_user_api_key_alias_when_false(self):
+        """Test that send_user_api_key_alias=False from config is respected (not overridden by env)"""
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            send_user_api_key_alias=False,
+        )
+        assert guardrail.send_user_api_key_alias is False
+
+    def test_should_use_config_send_user_api_key_user_id(self):
+        """Test that send_user_api_key_user_id from config is used"""
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            send_user_api_key_user_id=True,
+        )
+        assert guardrail.send_user_api_key_user_id is True
+
+    def test_should_use_config_send_user_api_key_team_id(self):
+        """Test that send_user_api_key_team_id from config is used"""
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            send_user_api_key_team_id=True,
+        )
+        assert guardrail.send_user_api_key_team_id is True
+
+
+class TestResolveMetadataValue:
+    """Tests for _resolve_metadata_value static method"""
+
+    def test_should_resolve_from_metadata_during_pre_call(self):
+        """Test that user_api_key_alias is resolved from metadata during pre-call"""
+        request_data = {
+            "metadata": {
+                "user_api_key_alias": "test-alias-pre-call"
+            }
+        }
+        result = ZscalerAIGuard._resolve_metadata_value(request_data, "user_api_key_alias")
+        assert result == "test-alias-pre-call"
+
+    def test_should_resolve_from_litellm_metadata_during_post_call(self):
+        """Test that user_api_key_alias is resolved from litellm_metadata during post-call"""
+        request_data = {
+            "litellm_metadata": {
+                "user_api_key_alias": "test-alias-post-call"
+            }
+        }
+        result = ZscalerAIGuard._resolve_metadata_value(request_data, "user_api_key_alias")
+        assert result == "test-alias-post-call"
+
+    def test_should_resolve_user_api_key_key_alias_mapping(self):
+        """Test key_alias -> user_api_key_key_alias mapping in litellm_metadata"""
+        # transform_user_api_key_dict_to_metadata prefixes "key_alias" -> "user_api_key_key_alias"
+        request_data = {
+            "litellm_metadata": {
+                "user_api_key_key_alias": "test-key-alias"
+            }
+        }
+        result = ZscalerAIGuard._resolve_metadata_value(request_data, "user_api_key_alias")
+        assert result == "test-key-alias"
+
+    def test_should_prioritize_litellm_metadata_over_metadata(self):
+        """Test that litellm_metadata takes precedence over metadata"""
+        request_data = {
+            "litellm_metadata": {
+                "user_api_key_alias": "from-litellm-metadata"
+            },
+            "metadata": {
+                "user_api_key_alias": "from-metadata"
+            }
+        }
+        result = ZscalerAIGuard._resolve_metadata_value(request_data, "user_api_key_alias")
+        assert result == "from-litellm-metadata"
+
+    def test_should_return_none_when_key_not_found(self):
+        """Test that None is returned when key is not found in either location"""
+        request_data = {
+            "metadata": {},
+            "litellm_metadata": {}
+        }
+        result = ZscalerAIGuard._resolve_metadata_value(request_data, "user_api_key_alias")
+        assert result is None
+
+    def test_should_return_none_when_request_data_is_none(self):
+        """Test that None is returned when request_data is None"""
+        result = ZscalerAIGuard._resolve_metadata_value(None, "user_api_key_alias")
+        assert result is None
+
+    def test_should_strip_whitespace(self):
+        """Test that whitespace is stripped from values"""
+        request_data = {
+            "metadata": {
+                "user_api_key_alias": "  test-alias  "
+            }
+        }
+        result = ZscalerAIGuard._resolve_metadata_value(request_data, "user_api_key_alias")
+        assert result == "test-alias"
+
+
+class TestPrepareHeaders:
+    """Tests for _prepare_headers method"""
+
+    def test_should_include_user_api_key_alias_header(self):
+        """Test that user-api-key-alias header is included when send_user_api_key_alias is True"""
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            send_user_api_key_alias=True,
+        )
+        headers = guardrail._prepare_headers("test_key", user_api_key_alias="test-alias")
+        assert headers.get("user-api-key-alias") == "test-alias"
+
+    def test_should_include_user_api_key_team_id_header(self):
+        """Test that user-api-key-team-id header is included when send_user_api_key_team_id is True"""
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            send_user_api_key_team_id=True,
+        )
+        headers = guardrail._prepare_headers("test_key", user_api_key_team_id="test-team-id")
+        assert headers.get("user-api-key-team-id") == "test-team-id"
+
+    def test_should_include_user_api_key_user_id_header(self):
+        """Test that user-api-key-user-id header is included when send_user_api_key_user_id is True"""
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            send_user_api_key_user_id=True,
+        )
+        headers = guardrail._prepare_headers("test_key", user_api_key_user_id="test-user-id")
+        assert headers.get("user-api-key-user-id") == "test-user-id"
+
+    def test_should_use_underscore_key_for_user_id_kwarg(self):
+        """Test that _prepare_headers uses underscore key 'user_api_key_user_id' (not hyphenated)"""
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            send_user_api_key_user_id=True,
+        )
+        # This test verifies the fix for the typo: kwargs.get("user-api-key-user-id") -> kwargs.get("user_api_key_user_id")
+        headers = guardrail._prepare_headers("test_key", user_api_key_user_id="correct-user-id")
+        assert headers.get("user-api-key-user-id") == "correct-user-id"
+
+
+class TestMakeZscalerAIGuardAPICall:
+    """Tests for make_zscaler_ai_guard_api_call method"""
+
+    @pytest.mark.asyncio
+    async def test_should_include_policy_id_when_greater_than_zero(self):
+        """Test that policyId is included in request body when policy_id > 0"""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            policy_id=100,
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "statusCode": 200,
+            "action": "ALLOW",
+        }
+
+        with patch.object(guardrail, "_send_request", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = mock_response
+
+            await guardrail.make_zscaler_ai_guard_api_call(
+                zscaler_ai_guard_url="http://example.com",
+                api_key="test_key",
+                policy_id=100,
+                direction="IN",
+                content="test content",
+            )
+
+            call_args = mock_send.call_args
+            data = call_args[0][2]  # Third positional arg is data
+            assert "policyId" in data
+            assert data["policyId"] == 100
+
+    @pytest.mark.asyncio
+    async def test_should_omit_policy_id_when_zero_or_negative(self):
+        """Test that policyId is omitted from request body when policy_id <= 0 (for resolve-and-execute-policy)"""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+            policy_id=-1,
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "statusCode": 200,
+            "action": "ALLOW",
+        }
+
+        with patch.object(guardrail, "_send_request", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = mock_response
+
+            await guardrail.make_zscaler_ai_guard_api_call(
+                zscaler_ai_guard_url="http://example.com",
+                api_key="test_key",
+                policy_id=-1,
+                direction="OUT",
+                content="test content",
+            )
+
+            call_args = mock_send.call_args
+            data = call_args[0][2]  # Third positional arg is data
+            assert "policyId" not in data
+
+    @pytest.mark.asyncio
+    async def test_should_omit_policy_id_when_none(self):
+        """Test that policyId is omitted from request body when policy_id is None"""
+        from unittest.mock import AsyncMock, Mock, patch
+
+        guardrail = ZscalerAIGuard(
+            api_key="test_key",
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "statusCode": 200,
+            "action": "ALLOW",
+        }
+
+        with patch.object(guardrail, "_send_request", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = mock_response
+
+            await guardrail.make_zscaler_ai_guard_api_call(
+                zscaler_ai_guard_url="http://example.com",
+                api_key="test_key",
+                policy_id=None,
+                direction="IN",
+                content="test content",
+            )
+
+            call_args = mock_send.call_args
+            data = call_args[0][2]
+            assert "policyId" not in data


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
🧹 Refactoring


## Changes
__Bug Fixes__ (`zscaler_ai_guard.py`):

1. Fix post-call `user_api_key_alias` always returning "N/A"
2. Fix `_prepare_headers` kwarg lookup typo
3. Fix `send_user_api_key_user_id` env var parsing
4. Fix boolean config parameter handling__ — Changed defaults from `False` to `None` and used `is not None` check so that explicit config values (`send_user_api_key_alias: true`) are not overridden by env var fallback logic.
5. Support `resolve-and-execute-policy` endpoint__ — Conditionally include `policyId` in the request body only when `policy_id > 0`, allowing `resolve-and-execute-policy` to infer policy from headers.

## Tests
__Tests__ (`test_zscaler_ai_guard.py`): 7. Added 20 unit tests covering initialization, metadata resolution, header preparation, and API call behavior.
