### PR TITLE
fix(mcp): resolve OAuth2 root endpoints returning "MCP server not found"

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -31,6 +31,9 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
     MCPRequestHandler,
 )
+from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+    get_request_base_url,
+)
 from litellm.proxy._experimental.mcp_server.utils import (
     LITELLM_MCP_SERVER_DESCRIPTION,
     LITELLM_MCP_SERVER_NAME,
@@ -1972,7 +1975,7 @@ if MCP_AVAILABLE:
                 )
                 if server and server.auth_type == MCPAuth.oauth2 and not oauth2_headers:
                     request = StarletteRequest(scope)
-                    base_url = str(request.base_url).rstrip("/")
+                    base_url = get_request_base_url(request)
 
                     authorization_uri = (
                         f"Bearer authorization_uri="


### PR DESCRIPTION
When MCP SDK hits root-level /register, /authorize, /token without server name prefix, auto-resolve to the single configured OAuth2 server. Also fix WWW-Authenticate header to use correct public URL behind reverse proxy.

## Relevant issues

Follow-up to #20602 — separate bug reported by the same user.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem

After connecting an MCP client to a LiteLLM proxy behind a reverse proxy (e.g. `https://llm.example.com/mcp`), the OAuth2 flow fails with `{"detail":"MCP server not found"}` at the `/authorize` endpoint. The customer's URL showed: `/authorize?client_id=dummy_client` — the MCP SDK was hitting root-level OAuth endpoints without the server name prefix.

### Root Cause (3 issues chained together)

1. **`server.py`** — `WWW-Authenticate` header used `str(request.base_url)` (internal URL like `http://0.0.0.0:4000`) instead of `get_request_base_url(request)` (public URL). Behind a reverse proxy, the MCP SDK can't follow the internal URL and falls back to root-level OAuth discovery.

2. **`discoverable_endpoints.py` `/register`** — Root `/register` (no server name prefix) immediately returned `client_id: "dummy_client"` without trying to resolve the actual server.

3. **`discoverable_endpoints.py` `/authorize`** — `lookup_name = mcp_server_name or client_id` resolved to `"dummy_client"` which doesn't match any configured server → 404.

### Fix

- Added `_resolve_oauth2_server_for_root_endpoints()` helper that auto-resolves to the single configured OAuth2 server when root-level endpoints are hit without a server name prefix. Returns `None` when 0 or 2+ OAuth2 servers exist (ambiguous case).
- Applied the resolver to `/register`, `/authorize`, `/token` endpoints and both `_build_oauth_authorization_server_response()` and `_build_oauth_protected_resource_response()`.
- Fixed `WWW-Authenticate` header in `server.py` to use `get_request_base_url(request)` for correct public URL behind reverse proxy.

### E2E Verification (via ngrok → LiteLLM proxy → Atlassian MCP)

- **Test 1**: Root discovery (`/.well-known/oauth-authorization-server`) now returns endpoints with `/atlassian_mcp/` prefix
- **Test 2**: Root `/register` returns `client_id: "atlassian_mcp"` instead of `"dummy_client"`
- **Test 3**: Root `/authorize?client_id=dummy_client` returns **307 redirect to Atlassian** instead of 404

<img width="751" height="846" alt="Screenshot 2026-02-09 alle 22 55 48" src="https://github.com/user-attachments/assets/99ba910b-9015-46f8-9909-ce265c6fb04e" />

### Tests added

5 new tests in `tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py`:
- `test_authorize_root_resolves_single_oauth2_server`
- `test_authorize_root_fails_with_multiple_oauth2_servers`
- `test_token_root_resolves_single_oauth2_server`
- `test_register_root_resolves_single_oauth2_server`
- `test_discovery_root_includes_server_name_prefix`