### PR TITLE
cleanup(model_prices): 39 deprecated OpenRouter models

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -23462,36 +23462,6 @@
         "output_cost_per_token": 2e-07,
         "supports_system_messages": true
     },
-    "openrouter/anthropic/claude-2": {
-        "input_cost_per_token": 1.102e-05,
-        "litellm_provider": "openrouter",
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 3.268e-05,
-        "supports_tool_choice": true
-    },
-    "openrouter/anthropic/claude-3-5-haiku": {
-        "input_cost_per_token": 1e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 200000,
-        "mode": "chat",
-        "output_cost_per_token": 5e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true
-    },
-    "openrouter/anthropic/claude-3-5-haiku-20241022": {
-        "input_cost_per_token": 1e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 5e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "tool_use_system_prompt_tokens": 264
-    },
     "openrouter/anthropic/claude-3-haiku": {
         "input_cost_per_image": 0.0004,
         "input_cost_per_token": 2.5e-07,
@@ -23499,43 +23469,6 @@
         "max_tokens": 200000,
         "mode": "chat",
         "output_cost_per_token": 1.25e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "openrouter/anthropic/claude-3-haiku-20240307": {
-        "input_cost_per_token": 2.5e-07,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.25e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 264
-    },
-    "openrouter/anthropic/claude-3-opus": {
-        "input_cost_per_token": 1.5e-05,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 7.5e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 395
-    },
-    "openrouter/anthropic/claude-3-sonnet": {
-        "input_cost_per_image": 0.0048,
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 200000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -23549,20 +23482,6 @@
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
         "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
-    },
-    "openrouter/anthropic/claude-3.5-sonnet:beta": {
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
         "supports_computer_use": true,
         "supports_function_calling": true,
         "supports_tool_choice": true,
@@ -23585,31 +23504,6 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 159
-    },
-    "openrouter/anthropic/claude-3.7-sonnet:beta": {
-        "input_cost_per_image": 0.0048,
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
-    },
-    "openrouter/anthropic/claude-instant-v1": {
-        "input_cost_per_token": 1.63e-06,
-        "litellm_provider": "openrouter",
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 5.51e-06,
-        "supports_tool_choice": true
     },
     "openrouter/anthropic/claude-opus-4": {
         "input_cost_per_image": 0.0048,
@@ -23749,30 +23643,6 @@
         "source": "https://openrouter.ai/api/v1/models/bytedance/ui-tars-1.5-7b",
         "supports_tool_choice": true
     },
-    "openrouter/cognitivecomputations/dolphin-mixtral-8x7b": {
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 32769,
-        "mode": "chat",
-        "output_cost_per_token": 5e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/cohere/command-r-plus": {
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_tool_choice": true
-    },
-    "openrouter/databricks/dbrx-instruct": {
-        "input_cost_per_token": 6e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 6e-07,
-        "supports_tool_choice": true
-    },
     "openrouter/deepseek/deepseek-chat": {
         "input_cost_per_token": 1.4e-07,
         "litellm_provider": "openrouter",
@@ -23840,17 +23710,6 @@
         "supports_reasoning": false,
         "supports_tool_choice": true
     },
-    "openrouter/deepseek/deepseek-coder": {
-        "input_cost_per_token": 1.4e-07,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 66000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 2.8e-07,
-        "supports_prompt_caching": true,
-        "supports_tool_choice": true
-    },
     "openrouter/deepseek/deepseek-r1": {
         "input_cost_per_token": 5.5e-07,
         "input_cost_per_token_cache_hit": 1.4e-07,
@@ -23879,14 +23738,6 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
-    },
-    "openrouter/fireworks/firellava-13b": {
-        "input_cost_per_token": 2e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 2e-07,
         "supports_tool_choice": true
     },
     "openrouter/google/gemini-2.0-flash-001": {
@@ -24050,60 +23901,12 @@
         "supports_web_search": true,
         "tpm": 800000
     },
-    "openrouter/google/gemini-pro-1.5": {
-        "input_cost_per_image": 0.00265,
-        "input_cost_per_token": 2.5e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 7.5e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "openrouter/google/gemini-pro-vision": {
-        "input_cost_per_image": 0.0025,
-        "input_cost_per_token": 1.25e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 45875,
-        "mode": "chat",
-        "output_cost_per_token": 3.75e-07,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "openrouter/google/palm-2-chat-bison": {
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 25804,
-        "mode": "chat",
-        "output_cost_per_token": 5e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/google/palm-2-codechat-bison": {
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 20070,
-        "mode": "chat",
-        "output_cost_per_token": 5e-07,
-        "supports_tool_choice": true
-    },
     "openrouter/gryphe/mythomax-l2-13b": {
         "input_cost_per_token": 1.875e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 1.875e-06,
-        "supports_tool_choice": true
-    },
-    "openrouter/jondurbin/airoboros-l2-70b-2.1": {
-        "input_cost_per_token": 1.3875e-05,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.3875e-05,
         "supports_tool_choice": true
     },
     "openrouter/mancer/weaver": {
@@ -24114,68 +23917,12 @@
         "output_cost_per_token": 5.625e-06,
         "supports_tool_choice": true
     },
-    "openrouter/meta-llama/codellama-34b-instruct": {
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 5e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/meta-llama/llama-2-13b-chat": {
-        "input_cost_per_token": 2e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 2e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/meta-llama/llama-2-70b-chat": {
-        "input_cost_per_token": 1.5e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-06,
-        "supports_tool_choice": true
-    },
     "openrouter/meta-llama/llama-3-70b-instruct": {
         "input_cost_per_token": 5.9e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 7.9e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/meta-llama/llama-3-70b-instruct:nitro": {
-        "input_cost_per_token": 9e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 9e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/meta-llama/llama-3-8b-instruct:extended": {
-        "input_cost_per_token": 2.25e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 16384,
-        "mode": "chat",
-        "output_cost_per_token": 2.25e-06,
-        "supports_tool_choice": true
-    },
-    "openrouter/meta-llama/llama-3-8b-instruct:free": {
-        "input_cost_per_token": 0.0,
-        "litellm_provider": "openrouter",
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 0.0,
-        "supports_tool_choice": true
-    },
-    "openrouter/microsoft/wizardlm-2-8x22b:nitro": {
-        "input_cost_per_token": 1e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 65536,
-        "mode": "chat",
-        "output_cost_per_token": 1e-06,
         "supports_tool_choice": true
     },
     "openrouter/minimax/minimax-m2": {
@@ -24190,20 +23937,6 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
-    },
-    "openrouter/mistralai/devstral-2512:free": {
-        "input_cost_per_image": 0,
-        "input_cost_per_token": 0,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
-        "mode": "chat",
-        "output_cost_per_token": 0,
-        "supports_function_calling": true,
-        "supports_prompt_caching": false,
-        "supports_tool_choice": true,
-        "supports_vision": false
     },
     "openrouter/mistralai/devstral-2512": {
         "input_cost_per_image": 0,
@@ -24283,14 +24016,6 @@
         "output_cost_per_token": 1.3e-07,
         "supports_tool_choice": true
     },
-    "openrouter/mistralai/mistral-7b-instruct:free": {
-        "input_cost_per_token": 0.0,
-        "litellm_provider": "openrouter",
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 0.0,
-        "supports_tool_choice": true
-    },
     "openrouter/mistralai/mistral-large": {
         "input_cost_per_token": 8e-06,
         "litellm_provider": "openrouter",
@@ -24337,14 +24062,6 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "openrouter/nousresearch/nous-hermes-llama2-13b": {
-        "input_cost_per_token": 2e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 2e-07,
-        "supports_tool_choice": true
-    },
     "openrouter/openai/gpt-3.5-turbo": {
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "openrouter",
@@ -24369,35 +24086,7 @@
         "output_cost_per_token": 6e-05,
         "supports_tool_choice": true
     },
-    "openrouter/openai/gpt-4-vision-preview": {
-        "input_cost_per_image": 0.01445,
-        "input_cost_per_token": 1e-05,
-        "litellm_provider": "openrouter",
-        "max_tokens": 130000,
-        "mode": "chat",
-        "output_cost_per_token": 3e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
     "openrouter/openai/gpt-4.1": {
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 8e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "openrouter/openai/gpt-4.1-2025-04-14": {
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "openrouter",
@@ -24431,41 +24120,7 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "openrouter/openai/gpt-4.1-mini-2025-04-14": {
-        "cache_read_input_token_cost": 1e-07,
-        "input_cost_per_token": 4e-07,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1.6e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
     "openrouter/openai/gpt-4.1-nano": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "input_cost_per_token": 1e-07,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 4e-07,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "openrouter/openai/gpt-4.1-nano-2025-04-14": {
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
@@ -24718,58 +24373,6 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "openrouter/openai/o1-mini": {
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 65536,
-        "max_tokens": 65536,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": false
-    },
-    "openrouter/openai/o1-mini-2024-09-12": {
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 65536,
-        "max_tokens": 65536,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": false
-    },
-    "openrouter/openai/o1-preview": {
-        "input_cost_per_token": 1.5e-05,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 6e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": false
-    },
-    "openrouter/openai/o1-preview-2024-09-12": {
-        "input_cost_per_token": 1.5e-05,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 6e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": false
-    },
     "openrouter/openai/o3-mini": {
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "openrouter",
@@ -24797,14 +24400,6 @@
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": false
-    },
-    "openrouter/pygmalionai/mythalion-13b": {
-        "input_cost_per_token": 1.875e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.875e-06,
-        "supports_tool_choice": true
     },
     "openrouter/qwen/qwen-2.5-coder-32b-instruct": {
         "input_cost_per_token": 1.8e-07,
@@ -24896,20 +24491,6 @@
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
-    },
-    "openrouter/x-ai/grok-4-fast:free": {
-        "input_cost_per_token": 0,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 2000000,
-        "max_output_tokens": 30000,
-        "max_tokens": 30000,
-        "mode": "chat",
-        "output_cost_per_token": 0,
-        "source": "https://openrouter.ai/x-ai/grok-4-fast:free",
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_web_search": false
     },
     "openrouter/z-ai/glm-4.6": {
         "input_cost_per_token": 4e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23462,36 +23462,6 @@
         "output_cost_per_token": 2e-07,
         "supports_system_messages": true
     },
-    "openrouter/anthropic/claude-2": {
-        "input_cost_per_token": 1.102e-05,
-        "litellm_provider": "openrouter",
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 3.268e-05,
-        "supports_tool_choice": true
-    },
-    "openrouter/anthropic/claude-3-5-haiku": {
-        "input_cost_per_token": 1e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 200000,
-        "mode": "chat",
-        "output_cost_per_token": 5e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true
-    },
-    "openrouter/anthropic/claude-3-5-haiku-20241022": {
-        "input_cost_per_token": 1e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 5e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "tool_use_system_prompt_tokens": 264
-    },
     "openrouter/anthropic/claude-3-haiku": {
         "input_cost_per_image": 0.0004,
         "input_cost_per_token": 2.5e-07,
@@ -23499,43 +23469,6 @@
         "max_tokens": 200000,
         "mode": "chat",
         "output_cost_per_token": 1.25e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "openrouter/anthropic/claude-3-haiku-20240307": {
-        "input_cost_per_token": 2.5e-07,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.25e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 264
-    },
-    "openrouter/anthropic/claude-3-opus": {
-        "input_cost_per_token": 1.5e-05,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 7.5e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 395
-    },
-    "openrouter/anthropic/claude-3-sonnet": {
-        "input_cost_per_image": 0.0048,
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 200000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -23549,20 +23482,6 @@
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
         "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
-    },
-    "openrouter/anthropic/claude-3.5-sonnet:beta": {
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
         "supports_computer_use": true,
         "supports_function_calling": true,
         "supports_tool_choice": true,
@@ -23585,31 +23504,6 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 159
-    },
-    "openrouter/anthropic/claude-3.7-sonnet:beta": {
-        "input_cost_per_image": 0.0048,
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
-    },
-    "openrouter/anthropic/claude-instant-v1": {
-        "input_cost_per_token": 1.63e-06,
-        "litellm_provider": "openrouter",
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 5.51e-06,
-        "supports_tool_choice": true
     },
     "openrouter/anthropic/claude-opus-4": {
         "input_cost_per_image": 0.0048,
@@ -23749,30 +23643,6 @@
         "source": "https://openrouter.ai/api/v1/models/bytedance/ui-tars-1.5-7b",
         "supports_tool_choice": true
     },
-    "openrouter/cognitivecomputations/dolphin-mixtral-8x7b": {
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 32769,
-        "mode": "chat",
-        "output_cost_per_token": 5e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/cohere/command-r-plus": {
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_tool_choice": true
-    },
-    "openrouter/databricks/dbrx-instruct": {
-        "input_cost_per_token": 6e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 6e-07,
-        "supports_tool_choice": true
-    },
     "openrouter/deepseek/deepseek-chat": {
         "input_cost_per_token": 1.4e-07,
         "litellm_provider": "openrouter",
@@ -23840,17 +23710,6 @@
         "supports_reasoning": false,
         "supports_tool_choice": true
     },
-    "openrouter/deepseek/deepseek-coder": {
-        "input_cost_per_token": 1.4e-07,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 66000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 2.8e-07,
-        "supports_prompt_caching": true,
-        "supports_tool_choice": true
-    },
     "openrouter/deepseek/deepseek-r1": {
         "input_cost_per_token": 5.5e-07,
         "input_cost_per_token_cache_hit": 1.4e-07,
@@ -23879,14 +23738,6 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
-    },
-    "openrouter/fireworks/firellava-13b": {
-        "input_cost_per_token": 2e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 2e-07,
         "supports_tool_choice": true
     },
     "openrouter/google/gemini-2.0-flash-001": {
@@ -24050,60 +23901,12 @@
         "supports_web_search": true,
         "tpm": 800000
     },
-    "openrouter/google/gemini-pro-1.5": {
-        "input_cost_per_image": 0.00265,
-        "input_cost_per_token": 2.5e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 7.5e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "openrouter/google/gemini-pro-vision": {
-        "input_cost_per_image": 0.0025,
-        "input_cost_per_token": 1.25e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 45875,
-        "mode": "chat",
-        "output_cost_per_token": 3.75e-07,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "openrouter/google/palm-2-chat-bison": {
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 25804,
-        "mode": "chat",
-        "output_cost_per_token": 5e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/google/palm-2-codechat-bison": {
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 20070,
-        "mode": "chat",
-        "output_cost_per_token": 5e-07,
-        "supports_tool_choice": true
-    },
     "openrouter/gryphe/mythomax-l2-13b": {
         "input_cost_per_token": 1.875e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 1.875e-06,
-        "supports_tool_choice": true
-    },
-    "openrouter/jondurbin/airoboros-l2-70b-2.1": {
-        "input_cost_per_token": 1.3875e-05,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.3875e-05,
         "supports_tool_choice": true
     },
     "openrouter/mancer/weaver": {
@@ -24114,68 +23917,12 @@
         "output_cost_per_token": 5.625e-06,
         "supports_tool_choice": true
     },
-    "openrouter/meta-llama/codellama-34b-instruct": {
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 5e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/meta-llama/llama-2-13b-chat": {
-        "input_cost_per_token": 2e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 2e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/meta-llama/llama-2-70b-chat": {
-        "input_cost_per_token": 1.5e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-06,
-        "supports_tool_choice": true
-    },
     "openrouter/meta-llama/llama-3-70b-instruct": {
         "input_cost_per_token": 5.9e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 7.9e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/meta-llama/llama-3-70b-instruct:nitro": {
-        "input_cost_per_token": 9e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 9e-07,
-        "supports_tool_choice": true
-    },
-    "openrouter/meta-llama/llama-3-8b-instruct:extended": {
-        "input_cost_per_token": 2.25e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 16384,
-        "mode": "chat",
-        "output_cost_per_token": 2.25e-06,
-        "supports_tool_choice": true
-    },
-    "openrouter/meta-llama/llama-3-8b-instruct:free": {
-        "input_cost_per_token": 0.0,
-        "litellm_provider": "openrouter",
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 0.0,
-        "supports_tool_choice": true
-    },
-    "openrouter/microsoft/wizardlm-2-8x22b:nitro": {
-        "input_cost_per_token": 1e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 65536,
-        "mode": "chat",
-        "output_cost_per_token": 1e-06,
         "supports_tool_choice": true
     },
     "openrouter/minimax/minimax-m2": {
@@ -24190,20 +23937,6 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
-    },
-    "openrouter/mistralai/devstral-2512:free": {
-        "input_cost_per_image": 0,
-        "input_cost_per_token": 0,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
-        "mode": "chat",
-        "output_cost_per_token": 0,
-        "supports_function_calling": true,
-        "supports_prompt_caching": false,
-        "supports_tool_choice": true,
-        "supports_vision": false
     },
     "openrouter/mistralai/devstral-2512": {
         "input_cost_per_image": 0,
@@ -24283,14 +24016,6 @@
         "output_cost_per_token": 1.3e-07,
         "supports_tool_choice": true
     },
-    "openrouter/mistralai/mistral-7b-instruct:free": {
-        "input_cost_per_token": 0.0,
-        "litellm_provider": "openrouter",
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 0.0,
-        "supports_tool_choice": true
-    },
     "openrouter/mistralai/mistral-large": {
         "input_cost_per_token": 8e-06,
         "litellm_provider": "openrouter",
@@ -24337,14 +24062,6 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "openrouter/nousresearch/nous-hermes-llama2-13b": {
-        "input_cost_per_token": 2e-07,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 2e-07,
-        "supports_tool_choice": true
-    },
     "openrouter/openai/gpt-3.5-turbo": {
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "openrouter",
@@ -24369,35 +24086,7 @@
         "output_cost_per_token": 6e-05,
         "supports_tool_choice": true
     },
-    "openrouter/openai/gpt-4-vision-preview": {
-        "input_cost_per_image": 0.01445,
-        "input_cost_per_token": 1e-05,
-        "litellm_provider": "openrouter",
-        "max_tokens": 130000,
-        "mode": "chat",
-        "output_cost_per_token": 3e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
     "openrouter/openai/gpt-4.1": {
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 8e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "openrouter/openai/gpt-4.1-2025-04-14": {
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "openrouter",
@@ -24431,41 +24120,7 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "openrouter/openai/gpt-4.1-mini-2025-04-14": {
-        "cache_read_input_token_cost": 1e-07,
-        "input_cost_per_token": 4e-07,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1.6e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
     "openrouter/openai/gpt-4.1-nano": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "input_cost_per_token": 1e-07,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 4e-07,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "openrouter/openai/gpt-4.1-nano-2025-04-14": {
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
@@ -24718,58 +24373,6 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "openrouter/openai/o1-mini": {
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 65536,
-        "max_tokens": 65536,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": false
-    },
-    "openrouter/openai/o1-mini-2024-09-12": {
-        "input_cost_per_token": 3e-06,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 65536,
-        "max_tokens": 65536,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": false
-    },
-    "openrouter/openai/o1-preview": {
-        "input_cost_per_token": 1.5e-05,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 6e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": false
-    },
-    "openrouter/openai/o1-preview-2024-09-12": {
-        "input_cost_per_token": 1.5e-05,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 6e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": false
-    },
     "openrouter/openai/o3-mini": {
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "openrouter",
@@ -24797,14 +24400,6 @@
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": false
-    },
-    "openrouter/pygmalionai/mythalion-13b": {
-        "input_cost_per_token": 1.875e-06,
-        "litellm_provider": "openrouter",
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.875e-06,
-        "supports_tool_choice": true
     },
     "openrouter/qwen/qwen-2.5-coder-32b-instruct": {
         "input_cost_per_token": 1.8e-07,
@@ -24896,20 +24491,6 @@
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
-    },
-    "openrouter/x-ai/grok-4-fast:free": {
-        "input_cost_per_token": 0,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 2000000,
-        "max_output_tokens": 30000,
-        "max_tokens": 30000,
-        "mode": "chat",
-        "output_cost_per_token": 0,
-        "source": "https://openrouter.ai/x-ai/grok-4-fast:free",
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_web_search": false
     },
     "openrouter/z-ai/glm-4.6": {
         "input_cost_per_token": 4e-07,


### PR DESCRIPTION
## Relevant issues

Fixes #20521

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🧹 Refactoring

## Changes

Cleanup 39 OpenRouter model entries from `model_prices_and_context_window.json` (and its backup) that no longer work in the OpenRouter API.

**Models removed (39):**

| Provider | Models |
|---|---|
| Anthropic (9) | claude-2, claude-3-5-haiku, claude-3-5-haiku-20241022, claude-3-haiku-20240307, claude-3-opus, claude-3-sonnet, claude-3.5-sonnet:beta, claude-3.7-sonnet:beta, claude-instant-v1 |
| OpenAI (8) | gpt-4-vision-preview, gpt-4.1-2025-04-14, gpt-4.1-mini-2025-04-14, gpt-4.1-nano-2025-04-14, o1-mini, o1-mini-2024-09-12, o1-preview, o1-preview-2024-09-12 |
| Meta Llama (6) | codellama-34b-instruct, llama-2-13b-chat, llama-2-70b-chat, llama-3-70b-instruct:nitro, llama-3-8b-instruct:extended, llama-3-8b-instruct:free |
| Google (4) | gemini-pro-1.5, gemini-pro-vision, palm-2-chat-bison, palm-2-codechat-bison |
| Mistral/Microsoft (3) | devstral-2512:free, mistral-7b-instruct:free, wizardlm-2-8x22b:nitro |
| Others (9) | dolphin-mixtral-8x7b, command-r-plus, dbrx-instruct, deepseek-coder, firellava-13b, airoboros-l2-70b-2.1, nous-hermes-llama2-13b, mythalion-13b, grok-4-fast:free |