### PR TITLE
chore: standardize endpoint display_name naming convention

### DIFF
--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2453,7 +2453,7 @@
     },
     "messages": {
       "docs_label": "anthropic_unified",
-      "display_name": "Anthropic /v1/messages API",
+      "display_name": "Anthropic Messages API",
       "leftnav_label": "/messages",
       "provider_json_field": "messages",
       "url": "https://docs.litellm.ai/docs/anthropic_unified",
@@ -2461,7 +2461,7 @@
     },
     "anthropic_count_tokens": {
       "docs_label": "anthropic_count_tokens",
-      "display_name": "Anthropic /v1/messages/count_tokens API",
+      "display_name": "Anthropic Count Tokens API",
       "leftnav_label": "/count_tokens",
       "provider_json_field": "count_tokens",
       "url": "https://docs.litellm.ai/docs/anthropic_count_tokens"
@@ -2482,14 +2482,14 @@
     },
     "audio_transcription": {
       "docs_label": "audio_transcription",
-      "display_name": "Audio Transcription API",
+      "display_name": "OpenAI Audio Transcription API",
       "leftnav_label": "/audio/transcriptions",
       "provider_json_field": "audio_transcriptions",
       "url": "https://docs.litellm.ai/docs/audio_transcription"
     },
     "batches": {
       "docs_label": "batches",
-      "display_name": "Batches API",
+      "display_name": "OpenAI Batches API",
       "leftnav_label": "/batches",
       "provider_json_field": "batches",
       "url": "https://docs.litellm.ai/docs/batches"
@@ -2510,7 +2510,7 @@
     },
     "chat_completions": {
       "docs_label": "chat_completions",
-      "display_name": "Chat Completions API",
+      "display_name": "OpenAI Chat Completions API",
       "leftnav_label": "/chat/completions",
       "provider_json_field": "chat_completions",
       "url": "https://docs.litellm.ai/docs/chat_completions"
@@ -2531,7 +2531,7 @@
     },
     "embeddings": {
       "docs_label": "embedding/supported_embedding",
-      "display_name": "Embedding API (OpenAI Format)",
+      "display_name": "OpenAI Embeddings API",
       "leftnav_label": "/embeddings",
       "provider_json_field": "embeddings",
       "url": "https://docs.litellm.ai/docs/embedding/supported_embedding"
@@ -2552,7 +2552,7 @@
     },
     "generateContent": {
       "docs_label": "generateContent",
-      "display_name": "Google's GenerateContent API",
+      "display_name": "Google GenerateContent API",
       "leftnav_label": "/generateContent",
       "provider_json_field": "generateContent",
       "url": "https://docs.litellm.ai/docs/generateContent",
@@ -2596,14 +2596,14 @@
     },
     "moderation": {
       "docs_label": "moderation",
-      "display_name": "OpenAI Moderation API",
+      "display_name": "OpenAI Moderations API",
       "leftnav_label": "/moderations",
       "provider_json_field": "moderations",
       "url": "https://docs.litellm.ai/docs/moderation"
     },
     "ocr": {
       "docs_label": "ocr",
-      "display_name": "OCR API (Mistral Format)",
+      "display_name": "Mistral OCR API",
       "leftnav_label": "/ocr",
       "provider_json_field": "ocr",
       "url": "https://docs.litellm.ai/docs/ocr"
@@ -2631,14 +2631,14 @@
     },
     "rerank": {
       "docs_label": "rerank",
-      "display_name": "Rerank API (Cohere Format)",
+      "display_name": "Cohere Rerank API",
       "leftnav_label": "/rerank",
       "provider_json_field": "rerank",
       "url": "https://docs.litellm.ai/docs/rerank"
     },
     "responses": {
       "docs_label": "response_api",
-      "display_name": "Responses API (OpenAI Format)",
+      "display_name": "OpenAI Responses API",
       "leftnav_label": "/responses",
       "provider_json_field": "responses",
       "url": "https://docs.litellm.ai/docs/response_api",
@@ -2646,7 +2646,7 @@
     },
     "response_api_compact": {
       "docs_label": "response_api_compact",
-      "display_name": "Responses API (OpenAI Format)",
+      "display_name": "OpenAI Responses API",
       "leftnav_label": "/responses",
       "provider_json_field": "compact",
       "url": "https://docs.litellm.ai/docs/response_api"
@@ -2667,7 +2667,7 @@
     },
     "text_completion": {
       "docs_label": "text_completion",
-      "display_name": "Completions API (OpenAI Format)",
+      "display_name": "OpenAI Completions API",
       "leftnav_label": "/completions",
       "provider_json_field": "text_completion",
       "url": "https://docs.litellm.ai/docs/text_completion",
@@ -2675,7 +2675,7 @@
     },
     "text_to_speech": {
       "docs_label": "text_to_speech",
-      "display_name": "Text-to-Speech API (OpenAI Format)",
+      "display_name": "OpenAI Text-to-Speech API",
       "leftnav_label": "/audio/speech",
       "provider_json_field": "audio_speech",
       "url": "https://docs.litellm.ai/docs/text_to_speech"
@@ -2703,7 +2703,7 @@
     },
     "videos": {
       "docs_label": "videos",
-      "display_name": "OpenAI Video Generation API",
+      "display_name": "OpenAI Videos API",
       "leftnav_label": "/videos",
       "provider_json_field": "video_generations",
       "url": "https://docs.litellm.ai/docs/videos"


### PR DESCRIPTION
## Relevant issues

Closes https://github.com/fastrepl/contextlengthof/issues/11

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - N/A: metadata-only change to display names, no logic affected
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🧹 Refactoring

## Changes

Modifies `display_name` values in the `endpoints` section of `provider_endpoints_support.json` to follow a consistent `{Provider} {Endpoint} API` naming convention.

**Changes (15 total):**

| Key | Before | After |
|---|---|---|
| `chat_completions` | Chat Completions API | OpenAI Chat Completions API |
| `responses` | Responses API (OpenAI Format) | OpenAI Responses API |
| `response_api_compact` | Responses API (OpenAI Format) | OpenAI Responses API |
| `messages` | Anthropic /v1/messages API | Anthropic Messages API |
| `anthropic_count_tokens` | Anthropic /v1/messages/count_tokens API | Anthropic Count Tokens API |
| `embeddings` | Embedding API (OpenAI Format) | OpenAI Embeddings API |
| `text_completion` | Completions API (OpenAI Format) | OpenAI Completions API |
| `text_to_speech` | Text-to-Speech API (OpenAI Format) | OpenAI Text-to-Speech API |
| `audio_transcription` | Audio Transcription API | OpenAI Audio Transcription API |
| `moderation` | OpenAI Moderation API | OpenAI Moderations API |
| `videos` | OpenAI Video Generation API | OpenAI Videos API |
| `batches` | Batches API | OpenAI Batches API |
| `rerank` | Rerank API (Cohere Format) | Cohere Rerank API |
| `ocr` | OCR API (Mistral Format) | Mistral OCR API |
| `generateContent` | Google's GenerateContent API | Google GenerateContent API |

These values are display-only metadata — no logic, routing, or UI components depend on the specific strings.