### PR TITLE
fix: KeyError on `reasoning_effort` without `thinking` dict

### DIFF
--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -136,7 +136,10 @@ class BaseConfig(ABC):
         """
         is_thinking_enabled = self.is_thinking_enabled(optional_params)
         if is_thinking_enabled and ("max_tokens" not in non_default_params and "max_completion_tokens" not in non_default_params):
-            thinking_token_budget = cast(dict, optional_params["thinking"]).get(
+            thinking_params = optional_params.get("thinking")
+            if not isinstance(thinking_params, dict):
+                return
+            thinking_token_budget = thinking_params.get(
                 "budget_tokens", None
             )
             if thinking_token_budget is not None:


### PR DESCRIPTION
`is_thinking_enabled()` returns True when `reasoning_effort` is set, but `update_optional_params_with_thinking_tokens()` unconditionally accesses `optional_params["thinking"]`, which only exists when Anthropic-style thinking is configured.

This causes a KeyError for any provider passing `reasoning_effort` to non-Anthropic models (e.g. GPT), where the `thinking` dict is never populated.

Fix: safely access `optional_params.get("thinking")` and return early if it's not a dict.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
