### PR TITLE
docs: add native thinking param examples for Claude Opus 4.6

### DIFF
--- a/docs/my-website/blog/claude_opus_4_6/index.md
+++ b/docs/my-website/blog/claude_opus_4_6/index.md
@@ -389,6 +389,10 @@ Compaction blocks are also supported in streaming mode. You'll receive:
 
 ### Adaptive Thinking
 
+:::note
+When using `reasoning_effort` with Claude Opus 4.6, all values (`low`, `medium`, `high`) are mapped to `thinking: {type: "adaptive"}`. To use explicit thinking budgets with `type: "enabled"`, pass the native `thinking` parameter directly (see "Native thinking param" tab below).
+:::
+
 <Tabs>
 <TabItem value="completions" label="/chat/completions">
 
@@ -432,6 +436,21 @@ curl --location 'http://0.0.0.0:4000/v1/messages' \
         }
     ]
 }'
+```
+
+</TabItem>
+<TabItem value="native" label="Native thinking param">
+
+Use the `thinking` parameter directly for adaptive thinking via the SDK:
+
+```python
+import litellm
+
+response = litellm.completion(
+  model="anthropic/claude-opus-4-6",
+  messages=[{"role": "user", "content": "Solve this complex problem: What is the optimal strategy for..."}],
+  thinking={"type": "adaptive"},
+)
 ```
 
 </TabItem>

--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -1473,6 +1473,20 @@ LiteLLM translates OpenAI's `reasoning_effort` to Anthropic's `thinking` paramet
 | "medium"         | "budget_tokens": 2048 |
 | "high"           | "budget_tokens": 4096 |
 
+:::note
+For Claude Opus 4.6, all `reasoning_effort` values (`low`, `medium`, `high`) are mapped to `thinking: {type: "adaptive"}`. To use explicit thinking budgets, pass the native `thinking` parameter directly:
+
+```python
+from litellm import completion
+
+resp = completion(
+    model="anthropic/claude-opus-4-6",
+    messages=[{"role": "user", "content": "What is the capital of France?"}],
+    thinking={"type": "enabled", "budget_tokens": 1024},
+)
+```
+:::
+
 <Tabs>
 <TabItem value="sdk" label="SDK">
 

--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -1614,8 +1614,65 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 </TabItem>
 </Tabs>
 
+#### Adaptive Thinking (Claude Opus 4.6)
 
+<Tabs>
+<TabItem value="sdk" label="SDK">
 
+```python
+response = litellm.completion(
+  model="anthropic/claude-opus-4-6",
+  messages=[{"role": "user", "content": "What is the optimal strategy for solving this problem?"}],
+  thinking={"type": "adaptive"},
+)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```bash
+curl http://0.0.0.0:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LITELLM_KEY" \
+  -d '{
+    "model": "anthropic/claude-opus-4-6",
+    "messages": [{"role": "user", "content": "What is the optimal strategy for solving this problem?"}],
+    "thinking": {"type": "adaptive"}
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+#### Enabled Thinking with Budget
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+response = litellm.completion(
+  model="anthropic/claude-opus-4-6",
+  messages=[{"role": "user", "content": "What is the capital of France?"}],
+  thinking={"type": "enabled", "budget_tokens": 5000},
+)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```bash
+curl http://0.0.0.0:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LITELLM_KEY" \
+  -d '{
+    "model": "anthropic/claude-opus-4-6",
+    "messages": [{"role": "user", "content": "What is the capital of France?"}],
+    "thinking": {"type": "enabled", "budget_tokens": 5000}
+  }'
+```
+
+</TabItem>
+</Tabs>
 
 ## **Passing Extra Headers to Anthropic API**
 


### PR DESCRIPTION
## Relevant issues

<!-- No specific issue, documentation improvement -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

- **`docs/providers/anthropic.md`**: Added examples for using the native `thinking` parameter with Claude Opus 4.6:
  - Adaptive thinking: `thinking={"type": "adaptive"}`
  - Enabled thinking with explicit budget: `thinking={"type": "enabled", "budget_tokens": 5000}`
  
- **`blog/claude_opus_4_6/index.md`**: 
  - Added a note clarifying that `reasoning_effort` values (`low`, `medium`, `high`) are all mapped to `thinking: {type: "adaptive"}` for Opus 4.6
  - Added "Native thinking param" tab with SDK example for `thinking={"type": "adaptive"}`