### PR TITLE
fix: reasoning_effort=None and "none" should return None for Opus 4.6

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -664,35 +664,34 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         reasoning_effort: Optional[Union[REASONING_EFFORT, str]], 
         model: str,
     ) -> Optional[AnthropicThinkingParam]:
+        if reasoning_effort is None:
+            return None
         if AnthropicConfig._is_claude_opus_4_6(model):
             return AnthropicThinkingParam(
                 type="adaptive",
             )
+        elif reasoning_effort == "low":
+            return AnthropicThinkingParam(
+                type="enabled",
+                budget_tokens=DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
+            )
+        elif reasoning_effort == "medium":
+            return AnthropicThinkingParam(
+                type="enabled",
+                budget_tokens=DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
+            )
+        elif reasoning_effort == "high":
+            return AnthropicThinkingParam(
+                type="enabled",
+                budget_tokens=DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
+            )
+        elif reasoning_effort == "minimal":
+            return AnthropicThinkingParam(
+                type="enabled",
+                budget_tokens=DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET,
+            )
         else:
-            if reasoning_effort is None:
-                return None
-            elif reasoning_effort == "low":
-                return AnthropicThinkingParam(
-                    type="enabled",
-                    budget_tokens=DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
-                )
-            elif reasoning_effort == "medium":
-                return AnthropicThinkingParam(
-                    type="enabled",
-                    budget_tokens=DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
-                )
-            elif reasoning_effort == "high":
-                return AnthropicThinkingParam(
-                    type="enabled",
-                    budget_tokens=DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
-                )
-            elif reasoning_effort == "minimal":
-                return AnthropicThinkingParam(
-                    type="enabled",
-                    budget_tokens=DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET,
-                )
-            else:
-                raise ValueError(f"Unmapped reasoning effort: {reasoning_effort}")
+            raise ValueError(f"Unmapped reasoning effort: {reasoning_effort}")
 
     def _extract_json_schema_from_response_format(
         self, value: Optional[dict]

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -664,7 +664,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         reasoning_effort: Optional[Union[REASONING_EFFORT, str]], 
         model: str,
     ) -> Optional[AnthropicThinkingParam]:
-        if reasoning_effort is None:
+        if reasoning_effort is None or reasoning_effort == "none":
             return None
         if AnthropicConfig._is_claude_opus_4_6(model):
             return AnthropicThinkingParam(

--- a/tests/litellm/llms/anthropic/test_anthropic_reasoning_effort.py
+++ b/tests/litellm/llms/anthropic/test_anthropic_reasoning_effort.py
@@ -1,0 +1,51 @@
+"""
+Tests for _map_reasoning_effort in AnthropicConfig.
+
+Verifies that reasoning_effort=None returns None for all models,
+including Claude Opus 4.6.
+"""
+
+import pytest
+from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+
+class TestMapReasoningEffort:
+    def test_none_returns_none_for_opus_4_6(self):
+        """reasoning_effort=None should return None for Opus 4.6, not adaptive."""
+        result = AnthropicConfig._map_reasoning_effort(
+            reasoning_effort=None, model="claude-opus-4-6"
+        )
+        assert result is None
+
+    def test_none_returns_none_for_other_models(self):
+        """reasoning_effort=None should return None for non-Opus models."""
+        result = AnthropicConfig._map_reasoning_effort(
+            reasoning_effort=None, model="claude-3-7-sonnet-20250219"
+        )
+        assert result is None
+
+    def test_opus_4_6_returns_adaptive_for_low(self):
+        result = AnthropicConfig._map_reasoning_effort(
+            reasoning_effort="low", model="claude-opus-4-6"
+        )
+        assert result["type"] == "adaptive"
+
+    def test_opus_4_6_returns_adaptive_for_high(self):
+        result = AnthropicConfig._map_reasoning_effort(
+            reasoning_effort="high", model="claude-opus-4-6"
+        )
+        assert result["type"] == "adaptive"
+
+    def test_other_model_low_returns_enabled_with_budget(self):
+        result = AnthropicConfig._map_reasoning_effort(
+            reasoning_effort="low", model="claude-3-7-sonnet-20250219"
+        )
+        assert result["type"] == "enabled"
+        assert "budget_tokens" in result
+
+    def test_other_model_high_returns_enabled_with_budget(self):
+        result = AnthropicConfig._map_reasoning_effort(
+            reasoning_effort="high", model="claude-3-7-sonnet-20250219"
+        )
+        assert result["type"] == "enabled"
+        assert "budget_tokens" in result

--- a/tests/litellm/llms/anthropic/test_anthropic_reasoning_effort.py
+++ b/tests/litellm/llms/anthropic/test_anthropic_reasoning_effort.py
@@ -5,7 +5,6 @@ Verifies that reasoning_effort=None returns None for all models,
 including Claude Opus 4.6.
 """
 
-import pytest
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
 

--- a/tests/litellm/llms/anthropic/test_anthropic_reasoning_effort.py
+++ b/tests/litellm/llms/anthropic/test_anthropic_reasoning_effort.py
@@ -49,3 +49,17 @@ class TestMapReasoningEffort:
         )
         assert result["type"] == "enabled"
         assert "budget_tokens" in result
+
+    def test_none_string_returns_none_for_opus_4_6(self):
+        """reasoning_effort='none' should return None for Opus 4.6."""
+        result = AnthropicConfig._map_reasoning_effort(
+            reasoning_effort="none", model="claude-opus-4-6"
+        )
+        assert result is None
+
+    def test_none_string_returns_none_for_other_models(self):
+        """reasoning_effort='none' should return None for non-Opus models."""
+        result = AnthropicConfig._map_reasoning_effort(
+            reasoning_effort="none", model="claude-3-7-sonnet-20250219"
+        )
+        assert result is None


### PR DESCRIPTION
## Relevant issues

<!-- Fixes incorrect reasoning_effort=None and "none" behavior for Claude Opus 4.6 -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

In `_map_reasoning_effort`, the `_is_claude_opus_4_6` check ran before the `None`/`"none"` checks, so both returned `thinking: {type: "adaptive"}` instead of `None` for Opus 4.6. Default for users who want to use Opus 4.6 without extended thinking for lower costs (or explicit set to none).

```python
import litellm

litellm.completion(
    model="anthropic/claude-opus-4-6",
    messages=[{"role": "user", "content": "Hello"}],
)
```

```python
import litellm

litellm.completion(
    model="anthropic/claude-opus-4-6",
    messages=[{"role": "user", "content": "Hello"}],
    reasoning_effort="none",
)
```

Added 8 unit tests covering `None`, `"none"`, and level mappings for both Opus 4.6 and other models.