### PR TITLE
fix(arize-phoenix): dynamic project naming from metadata

### DIFF
--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -106,7 +106,7 @@ class ArizePhoenixLogger(OpenTelemetry):
         traces to different Phoenix projects dynamically.
         """
         standard_logging_payload = kwargs.get("standard_logging_object")
-        if standard_logging_payload is not None:
+        if isinstance(standard_logging_payload, dict):
             metadata = standard_logging_payload.get("metadata")
             if isinstance(metadata, dict):
                 project_name = metadata.get("phoenix_project_name")
@@ -114,8 +114,11 @@ class ArizePhoenixLogger(OpenTelemetry):
                     return str(project_name)
 
         # Also check litellm_params.metadata for SDK usage
-        litellm_params = kwargs.get("litellm_params") or {}
-        metadata = litellm_params.get("metadata") or {}
+        litellm_params = kwargs.get("litellm_params")
+        if isinstance(litellm_params, dict):
+            metadata = litellm_params.get("metadata") or {}
+        else:
+            metadata = {}
         if isinstance(metadata, dict):
             project_name = metadata.get("phoenix_project_name")
             if project_name:

--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -1,11 +1,15 @@
 import os
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.trace import SpanKind
+
 from litellm._logging import verbose_logger
 from litellm.integrations.arize import _utils
 from litellm.integrations.arize._utils import ArizeOTELAttributes
-from litellm.types.integrations.arize_phoenix import ArizePhoenixConfig
 from litellm.integrations.opentelemetry import OpenTelemetry
+from litellm.integrations.opentelemetry_utils.base_otel_llm_obs_attributes import safe_set_attribute
+from litellm.types.integrations.arize_phoenix import ArizePhoenixConfig
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span
@@ -46,9 +50,6 @@ class ArizePhoenixLogger(OpenTelemetry):
         By creating our own provider we guarantee Arize Phoenix always gets
         its own exporter pipeline, regardless of initialisation order.
         """
-        from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.trace import SpanKind
-
         if tracer_provider is not None:
             # Explicitly supplied (e.g. in tests) — honour it.
             self.tracer = tracer_provider.get_tracer("litellm")
@@ -81,8 +82,6 @@ class ArizePhoenixLogger(OpenTelemetry):
 
     @staticmethod
     def set_arize_phoenix_attributes(span: Span, kwargs, response_obj):
-        from litellm.integrations.opentelemetry_utils.base_otel_llm_obs_attributes import safe_set_attribute
-
         _utils.set_attributes(span, kwargs, response_obj, ArizeOTELAttributes)
 
         # Dynamic project name: check metadata first, then fall back to env var config

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3764,7 +3764,7 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
             from litellm.integrations.opentelemetry import OpenTelemetry
 
             for callback in _in_memory_loggers:
-                if isinstance(callback, OpenTelemetry):
+                if type(callback) is OpenTelemetry:
                     return callback  # type: ignore
             otel_logger = OpenTelemetry(
                 **_get_custom_logger_settings_from_proxy_server(

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -144,6 +144,12 @@ async def image_generation(
                 litellm_call_id=data.get("litellm_call_id", ""), status="success"
             )
         )
+
+        ### CALL HOOKS ### - modify outgoing data (guardrails, otel, etc.)
+        response = await proxy_logging_obj.post_call_success_hook(
+            data=data, user_api_key_dict=user_api_key_dict, response=response
+        )
+
         ### RESPONSE HEADERS ###
         hidden_params = getattr(response, "_hidden_params", {}) or {}
         model_id = hidden_params.get("model_id", None) or ""

--- a/tests/test_litellm/integrations/arize/test_arize_otel_coexistence.py
+++ b/tests/test_litellm/integrations/arize/test_arize_otel_coexistence.py
@@ -8,11 +8,9 @@ Covers the three root-cause fixes:
 3. Arize loggers do NOT overwrite ``proxy_server.open_telemetry_logger``.
 """
 
-import os
 import unittest
 from unittest.mock import patch
 
-import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter

--- a/tests/test_litellm/integrations/arize/test_arize_otel_coexistence.py
+++ b/tests/test_litellm/integrations/arize/test_arize_otel_coexistence.py
@@ -1,0 +1,171 @@
+"""
+Tests that Arize Phoenix / Arize and the generic ``otel`` callback can
+coexist, each sending spans to their own independent exporter.
+
+Covers the three root-cause fixes:
+1. ArizePhoenixLogger / ArizeLogger create *dedicated* TracerProviders.
+2. The ``otel`` dedup check does NOT match Arize subclasses.
+3. Arize loggers do NOT overwrite ``proxy_server.open_telemetry_logger``.
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_otel_logger(exporter: InMemorySpanExporter) -> OpenTelemetry:
+    """Create a generic ``otel`` callback backed by an in-memory exporter.
+
+    We build a dedicated TracerProvider explicitly so the test is isolated
+    from whatever global provider state may exist.
+    """
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    config = OpenTelemetryConfig(exporter=exporter)
+    return OpenTelemetry(config=config, callback_name="otel", tracer_provider=provider)
+
+
+def _make_arize_phoenix_logger(exporter: InMemorySpanExporter):
+    """Create an ``arize_phoenix`` callback backed by an in-memory exporter.
+
+    ArizePhoenixLogger._init_tracing creates its own TracerProvider, so we
+    pass the exporter via config and let it build the provider internally.
+    """
+    from litellm.integrations.arize.arize_phoenix import ArizePhoenixLogger
+
+    config = OpenTelemetryConfig(exporter=exporter)
+    return ArizePhoenixLogger(config=config, callback_name="arize_phoenix")
+
+
+def _make_arize_logger(exporter: InMemorySpanExporter):
+    """Create an ``arize`` callback backed by an in-memory exporter.
+
+    ArizeLogger._init_tracing creates its own TracerProvider, so we pass
+    the exporter via config and let it build the provider internally.
+    """
+    from litellm.integrations.arize.arize import ArizeLogger
+
+    config = OpenTelemetryConfig(exporter=exporter)
+    return ArizeLogger(config=config, callback_name="arize")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestIndependentTracerProviders(unittest.TestCase):
+    """Each integration must get its own TracerProvider so spans go to the right exporter."""
+
+    def test_otel_and_arize_phoenix_have_different_tracer_providers(self):
+        otel_exporter = InMemorySpanExporter()
+        phoenix_exporter = InMemorySpanExporter()
+
+        otel_logger = _make_otel_logger(otel_exporter)
+        phoenix_logger = _make_arize_phoenix_logger(phoenix_exporter)
+
+        # The tracers must come from different providers
+        assert otel_logger.tracer is not phoenix_logger.tracer
+
+    def test_otel_and_arize_have_different_tracer_providers(self):
+        otel_exporter = InMemorySpanExporter()
+        arize_exporter = InMemorySpanExporter()
+
+        otel_logger = _make_otel_logger(otel_exporter)
+        arize_logger = _make_arize_logger(arize_exporter)
+
+        assert otel_logger.tracer is not arize_logger.tracer
+
+    def test_arize_phoenix_and_arize_have_different_tracer_providers(self):
+        phoenix_exporter = InMemorySpanExporter()
+        arize_exporter = InMemorySpanExporter()
+
+        phoenix_logger = _make_arize_phoenix_logger(phoenix_exporter)
+        arize_logger = _make_arize_logger(arize_exporter)
+
+        assert phoenix_logger.tracer is not arize_logger.tracer
+
+
+class TestSpansRoutedToCorrectExporter(unittest.TestCase):
+    """Spans created by each logger must land in its own exporter, not the other's."""
+
+    def test_spans_go_to_respective_exporters(self):
+        otel_exporter = InMemorySpanExporter()
+        phoenix_exporter = InMemorySpanExporter()
+
+        otel_logger = _make_otel_logger(otel_exporter)
+        phoenix_logger = _make_arize_phoenix_logger(phoenix_exporter)
+
+        # Create a span on each — SimpleSpanProcessor exports synchronously on end()
+        otel_span = otel_logger.tracer.start_span("otel_test_span")
+        otel_span.end()
+
+        phoenix_span = phoenix_logger.tracer.start_span("phoenix_test_span")
+        phoenix_span.end()
+
+        # Read spans *before* shutdown (shutdown clears the in-memory store)
+        otel_span_names = [s.name for s in otel_exporter.get_finished_spans()]
+        phoenix_span_names = [s.name for s in phoenix_exporter.get_finished_spans()]
+
+        assert "otel_test_span" in otel_span_names
+        assert "phoenix_test_span" not in otel_span_names
+
+        assert "phoenix_test_span" in phoenix_span_names
+        assert "otel_test_span" not in phoenix_span_names
+
+
+class TestOtelDedupCheck(unittest.TestCase):
+    """The ``otel`` callback dedup must use exact type check, not isinstance."""
+
+    def test_arize_phoenix_logger_is_not_matched_by_otel_dedup(self):
+        from litellm.integrations.arize.arize_phoenix import ArizePhoenixLogger
+
+        phoenix_logger = _make_arize_phoenix_logger(InMemorySpanExporter())
+
+        # isinstance would match — but type() must not
+        assert isinstance(phoenix_logger, OpenTelemetry)
+        assert type(phoenix_logger) is not OpenTelemetry
+
+    def test_arize_logger_is_not_matched_by_otel_dedup(self):
+        from litellm.integrations.arize.arize import ArizeLogger
+
+        arize_logger = _make_arize_logger(InMemorySpanExporter())
+
+        assert isinstance(arize_logger, OpenTelemetry)
+        assert type(arize_logger) is not OpenTelemetry
+
+    def test_otel_logger_matches_own_dedup(self):
+        otel_logger = _make_otel_logger(InMemorySpanExporter())
+        assert type(otel_logger) is OpenTelemetry
+
+
+class TestProxyLoggerNotOverwritten(unittest.TestCase):
+    """Arize / Phoenix must not overwrite ``proxy_server.open_telemetry_logger``."""
+
+    @patch("litellm.proxy.proxy_server.open_telemetry_logger", None)
+    def test_arize_phoenix_does_not_set_proxy_otel_logger(self):
+        from litellm.proxy import proxy_server
+
+        _make_arize_phoenix_logger(InMemorySpanExporter())
+        assert proxy_server.open_telemetry_logger is None
+
+    @patch("litellm.proxy.proxy_server.open_telemetry_logger", None)
+    def test_arize_does_not_set_proxy_otel_logger(self):
+        from litellm.proxy import proxy_server
+
+        _make_arize_logger(InMemorySpanExporter())
+        assert proxy_server.open_telemetry_logger is None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_litellm/proxy/hooks/test_image_generation_guardrails.py
+++ b/tests/test_litellm/proxy/hooks/test_image_generation_guardrails.py
@@ -1,0 +1,293 @@
+"""
+Tests that guardrails (post_call_success_hook) fire for image generation requests.
+
+The /images/generations endpoint in proxy/image_endpoints/endpoints.py calls
+proxy_logging_obj.post_call_success_hook after a successful image generation.
+These tests verify:
+1. CustomGuardrail.async_post_call_success_hook is invoked for image generation.
+2. A guardrail can inspect and transform the image response.
+3. A guardrail that raises blocks the response (exception propagates).
+"""
+
+import os
+import sys
+from typing import Any, Optional
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm
+from litellm.caching.caching import DualCache
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.utils import ProxyLogging
+from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.utils import ImageObject, ImageResponse
+
+
+def _make_image_response(**kwargs) -> ImageResponse:
+    """Helper to build a minimal ImageResponse for tests."""
+    return ImageResponse(
+        data=[ImageObject(url="https://example.com/img.png")],
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Hook is invoked for image generation responses
+# ---------------------------------------------------------------------------
+
+
+class TrackingGuardrail(CustomGuardrail):
+    """Guardrail that records whether it was called and with what args."""
+
+    def __init__(self):
+        super().__init__(
+            guardrail_name="tracking_guardrail",
+            default_on=True,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+        self.called = False
+        self.received_data: Optional[dict] = None
+        self.received_response: Optional[Any] = None
+
+    async def async_post_call_success_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+    ) -> Any:
+        self.called = True
+        self.received_data = data
+        self.received_response = response
+        return response
+
+
+@pytest.mark.asyncio
+async def test_post_call_success_hook_invoked_for_image_generation():
+    """
+    Verify that a default-on guardrail's async_post_call_success_hook is
+    called when ProxyLogging.post_call_success_hook is invoked with an
+    ImageResponse (the same path used by the /images/generations endpoint).
+    """
+    guardrail = TrackingGuardrail()
+    image_response = _make_image_response()
+
+    with patch("litellm.callbacks", [guardrail]):
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        data = {"model": "dall-e-3", "prompt": "A sunset over mountains"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        result = await proxy_logging.post_call_success_hook(
+            data=data,
+            response=image_response,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+    assert guardrail.called is True, "Guardrail hook was not invoked for image generation"
+    assert guardrail.received_data is not None
+    assert guardrail.received_data["model"] == "dall-e-3"
+    assert isinstance(guardrail.received_response, ImageResponse)
+    # The response should be passed through unchanged
+    assert result is image_response
+
+
+# ---------------------------------------------------------------------------
+# 2. Guardrail can transform image generation response
+# ---------------------------------------------------------------------------
+
+
+class TransformingGuardrail(CustomGuardrail):
+    """Guardrail that replaces the image URL in the response."""
+
+    def __init__(self):
+        super().__init__(
+            guardrail_name="transforming_guardrail",
+            default_on=True,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+    async def async_post_call_success_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+    ) -> Any:
+        # Return a modified image response (e.g., watermarked URL)
+        return ImageResponse(
+            data=[ImageObject(url="https://example.com/watermarked.png")],
+        )
+
+
+@pytest.mark.asyncio
+async def test_guardrail_can_transform_image_response():
+    """
+    Verify that a guardrail can replace the ImageResponse returned to the client.
+    """
+    guardrail = TransformingGuardrail()
+    original_response = _make_image_response()
+
+    with patch("litellm.callbacks", [guardrail]):
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        data = {"model": "dall-e-3", "prompt": "A sunset"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        result = await proxy_logging.post_call_success_hook(
+            data=data,
+            response=original_response,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+    assert result is not original_response
+    assert isinstance(result, ImageResponse)
+    assert result.data[0].url == "https://example.com/watermarked.png"
+
+
+# ---------------------------------------------------------------------------
+# 3. Guardrail that raises blocks the image response
+# ---------------------------------------------------------------------------
+
+
+class BlockingGuardrail(CustomGuardrail):
+    """Guardrail that raises on unsafe image prompts."""
+
+    def __init__(self):
+        super().__init__(
+            guardrail_name="blocking_guardrail",
+            default_on=True,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+    async def async_post_call_success_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+    ) -> Any:
+        raise ValueError("Image content blocked by guardrail")
+
+
+@pytest.mark.asyncio
+async def test_guardrail_exception_propagates_for_image_generation():
+    """
+    Verify that an exception raised in a guardrail's post_call_success_hook
+    propagates up (the proxy endpoint wraps this in an error response).
+    """
+    guardrail = BlockingGuardrail()
+
+    with patch("litellm.callbacks", [guardrail]):
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        data = {"model": "dall-e-3", "prompt": "Something unsafe"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        with pytest.raises(ValueError, match="Image content blocked by guardrail"):
+            await proxy_logging.post_call_success_hook(
+                data=data,
+                response=_make_image_response(),
+                user_api_key_dict=user_api_key_dict,
+            )
+
+
+# ---------------------------------------------------------------------------
+# 4. Non-guardrail CustomLogger also fires for image generation
+# ---------------------------------------------------------------------------
+
+
+class TrackingLogger(CustomLogger):
+    """Plain CustomLogger (not a guardrail) that tracks invocations."""
+
+    def __init__(self):
+        self.called = False
+        self.received_response = None
+
+    async def async_post_call_success_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+    ) -> Any:
+        self.called = True
+        self.received_response = response
+        return response
+
+
+@pytest.mark.asyncio
+async def test_custom_logger_post_call_success_hook_fires_for_image_generation():
+    """
+    Verify that a plain CustomLogger (non-guardrail) callback also has its
+    async_post_call_success_hook invoked for image generation responses.
+    """
+    logger = TrackingLogger()
+    image_response = _make_image_response()
+
+    with patch("litellm.callbacks", [logger]):
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        data = {"model": "dall-e-3", "prompt": "A cat"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        result = await proxy_logging.post_call_success_hook(
+            data=data,
+            response=image_response,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+    assert logger.called is True
+    assert isinstance(logger.received_response, ImageResponse)
+    assert result is image_response
+
+
+# ---------------------------------------------------------------------------
+# 5. Guardrail with should_run_guardrail=False is skipped
+# ---------------------------------------------------------------------------
+
+
+class OptInGuardrail(CustomGuardrail):
+    """Guardrail that is NOT default_on, so it only runs if explicitly requested."""
+
+    def __init__(self):
+        super().__init__(
+            guardrail_name="opt_in_guardrail",
+            default_on=False,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+        self.called = False
+
+    async def async_post_call_success_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+    ) -> Any:
+        self.called = True
+        return response
+
+
+@pytest.mark.asyncio
+async def test_non_default_guardrail_skipped_for_image_generation():
+    """
+    Verify that a guardrail with default_on=False is NOT invoked for image
+    generation unless the request explicitly enables it.
+    """
+    guardrail = OptInGuardrail()
+
+    with patch("litellm.callbacks", [guardrail]):
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        # No guardrails key in data -> should_run_guardrail returns False
+        data = {"model": "dall-e-3", "prompt": "A sunset"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        await proxy_logging.post_call_success_hook(
+            data=data,
+            response=_make_image_response(),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+    assert guardrail.called is False, "Opt-in guardrail should not fire without explicit request"


### PR DESCRIPTION

- Allow per-request Phoenix project name via `metadata.phoenix_project_name`, falling back to PHOENIX_PROJECT_NAME env var
- Add missing `post_call_success_hook` to `/images/generations` endpoint so guardrails and OTEL tracing apply to image generation


## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
