### PR TITLE
fix: add role="user" to Gemini function_response content blocks

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -479,7 +479,7 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                 messages[msg_i]["role"] not in tool_call_message_roles
             ):
                 if len(tool_call_responses) > 0:
-                    contents.append(ContentType(parts=tool_call_responses))
+                    contents.append(ContentType(role="user", parts=tool_call_responses))
                     tool_call_responses = []
 
             if msg_i == init_msg_i:  # prevent infinite loops
@@ -489,7 +489,7 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                     )
                 )
         if len(tool_call_responses) > 0:
-            contents.append(ContentType(parts=tool_call_responses))
+            contents.append(ContentType(role="user", parts=tool_call_responses))
 
         if len(contents) == 0:
             verbose_logger.warning(


### PR DESCRIPTION
## Summary

Fixes #20690

**Root cause:** In `_gemini_convert_messages_with_history`, `ContentType` blocks for `tool_call_responses` were created without `role="user"`. The Gemini API requires `function_response` parts to have an explicit role, causing `INVALID_ARGUMENT` (400) errors during multi-turn function calling.

## Changes

- `litellm/llms/vertex_ai/gemini/transformation.py`: Added `role="user"` to both `ContentType(parts=tool_call_responses)` calls (lines ~482 and ~492), consistent with how all other `ContentType` calls in this function specify a role.

## Risk Assessment

**Low** - This is a data-only change that adds a required field. It aligns with [Google's API documentation](https://ai.google.dev/gemini-api/docs/function-calling) which specifies function_response should have user role.