### PR TITLE
fix: normalize queue items from cache to prevent heapq TypeError

### DIFF
--- a/litellm/scheduler.py
+++ b/litellm/scheduler.py
@@ -124,7 +124,10 @@ class Scheduler:
             if response is None or not isinstance(response, list):
                 return []
             elif isinstance(response, list):
-                return response
+                # Normalize items from cache - JSON serialization converts
+                # tuples to lists, causing TypeError in heapq comparisons
+                # when mixing cached (list) items with new (tuple) items
+                return [tuple(item) if isinstance(item, list) else item for item in response]
         return self.queue
 
     async def save_queue(self, queue: list, model_name: str) -> None:


### PR DESCRIPTION
## Summary

Fixes #14817

**Root cause:** When queue items `(priority, request_id)` are serialized to JSON (via Redis or in-memory cache), Python tuples are converted to JSON arrays (lists). When these deserialized list items are mixed with new tuple items in `heapq.heappush()`, Python raises:
```
TypeError: '<' not supported between instances of 'tuple' and 'list'
```

## Changes

- `litellm/scheduler.py`: In `get_queue()`, normalize all cached items back to tuples before returning them for heap operations.

## Risk Assessment

**Low** - Only affects the deserialization step. `tuple(item)` on a list is a safe, well-defined operation.