### PR TITLE
fix: convert Pydantic models from TOOL_CALLS_CACHE to dict

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -743,7 +743,14 @@ class LiteLLMCompletionResponsesConfig:
                     
                     if _tool_use_definition:
                         if not isinstance(_tool_use_definition, dict):
-                            _tool_use_definition = {}
+                            # Convert Pydantic models (e.g. ChatCompletionMessageToolCall
+                            # from TOOL_CALLS_CACHE) to dict to preserve tool call data
+                            if hasattr(_tool_use_definition, 'model_dump'):
+                                _tool_use_definition = _tool_use_definition.model_dump()
+                            elif hasattr(_tool_use_definition, 'dict'):
+                                _tool_use_definition = _tool_use_definition.dict()
+                            else:
+                                _tool_use_definition = {}
                         tool_call_chunk = (
                             LiteLLMCompletionResponsesConfig._create_tool_call_chunk(
                                 _tool_use_definition, tool_call_id, len(tool_calls)


### PR DESCRIPTION
## Summary

Fixes #20699

**Root cause:** `TOOL_CALLS_CACHE` stores `ChatCompletionMessageToolCall` Pydantic objects, but `_ensure_tool_results_have_corresponding_tool_calls` checks `isinstance(_, dict)` which fails for Pydantic models. The code replaces the cached value with `{}`, creating malformed tool calls with empty function names and arguments.

## Changes

- `litellm/responses/litellm_completion_transformation/transformation.py`: Instead of replacing non-dict cached values with `{}`, use `model_dump()` (Pydantic v2) or `dict()` (Pydantic v1) to properly convert the Pydantic model to a dict while preserving all tool call data.

## Risk Assessment

**Low** - The fix only changes the fallback behavior when a cached value isn't already a dict. It preserves data that was previously being discarded.