### PR TITLE
fix: parallelize batch_completion_models_all_responses execution

### DIFF
--- a/litellm/batch_completion/main.py
+++ b/litellm/batch_completion/main.py
@@ -244,9 +244,16 @@ def batch_completion_models_all_responses(*args, **kwargs):
 
     responses = []
 
+    futures = {}
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(models)) as executor:
         for idx, model in enumerate(models):
-            future = executor.submit(litellm.completion, *args, model=model, **kwargs)
+            futures[model] = executor.submit(
+                litellm.completion, *args, model=model, **kwargs
+            )
+
+        for model, future in sorted(
+            futures.items(), key=lambda x: models.index(x[0])
+        ):
             if future.result() is not None:
                 responses.append(future.result())
 


### PR DESCRIPTION
## Summary

Fixes #20704

**Root cause:** `batch_completion_models_all_responses()` called `future.result()` immediately after `executor.submit()` in the same `for` loop iteration, making each model's LLM call block until completion before the next model was even submitted. The `ThreadPoolExecutor` existed but achieved zero parallelism.

## Changes

- `litellm/batch_completion/main.py`: Separated submission and collection into two loops (submit all futures first, then collect results), matching the pattern already used by the correctly-implemented `batch_completion_models()` function.

## Before/After

**Before:** N models at ~2s each = ~2Ns total (sequential)
**After:** N models at ~2s each = ~2s total (parallel)

## Risk Assessment

**Low** - The fix matches the existing pattern in `batch_completion_models()`. Results are collected in the same order as models were provided.