### PR TITLE
fix: allow REDIS_SOCKET_TIMEOUT env var to take effect

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -96,7 +96,7 @@ class RedisCache(BaseCache):
         redis_flush_size: Optional[int] = 100,
         namespace: Optional[str] = None,
         startup_nodes: Optional[List] = None,  # for redis-cluster
-        socket_timeout: Optional[float] = 5.0,  # default 5 second timeout
+        socket_timeout: Optional[float] = None,  # default: from REDIS_SOCKET_TIMEOUT env var, falls back to 5.0
         **kwargs,
     ):
         from litellm._service_logger import ServiceLogging


### PR DESCRIPTION
## Summary

Fixes #20231

**Root cause:** `RedisCache.__init__` declared `socket_timeout: Optional[float] = 5.0`. This hardcoded default was always passed to `_get_redis_client_logic()`, where it overrode the `REDIS_SOCKET_TIMEOUT` environment variable because `env_overrides` was spread after `_redis_kwargs_from_environment()` in the kwargs dict.

## Changes

- `litellm/caching/redis_cache.py`: Changed `socket_timeout` default from `5.0` to `None`. When `None`, the existing `if socket_timeout is not None:` guard (line 115) skips adding it to `redis_kwargs`, allowing the env var to work as documented.

## Risk Assessment

**Low** - The downstream `_redis_kwargs_from_environment()` already handles the `REDIS_SOCKET_TIMEOUT` env var with its own default. Users explicitly passing `socket_timeout` in their config will still have it honored.