### PR TITLE
fix: handle client disconnect in PrometheusAuthMiddleware

### DIFF
--- a/litellm/proxy/middleware/prometheus_auth_middleware.py
+++ b/litellm/proxy/middleware/prometheus_auth_middleware.py
@@ -44,7 +44,13 @@ class PrometheusAuthMiddleware(BaseHTTPMiddleware):
                     )
 
         # Process the request and get the response
-        response = await call_next(request)
+        try:
+            response = await call_next(request)
+        except RuntimeError as e:
+            if "No response returned" in str(e):
+                # Client disconnected before response was produced (e.g., ALB timeout)
+                return Response(status_code=499)  # Client Closed Request
+            raise
 
         return response
 


### PR DESCRIPTION
## Summary

Fixes #20233

**Root cause:** `PrometheusAuthMiddleware` inherits from Starlette's `BaseHTTPMiddleware`. When a client disconnects before the downstream handler produces a response (e.g., ALB timeout, client cancellation), `call_next` raises `RuntimeError: No response returned.` This is harmless but produces large, noisy tracebacks.

## Changes

- `litellm/proxy/middleware/prometheus_auth_middleware.py`: Wrapped `call_next` in try/except to catch `RuntimeError` with "No response returned" and return a 499 (Client Closed Request) status instead.

## Risk Assessment

**Low** - Only catches a specific `RuntimeError` that occurs when the client is already gone. Normal requests are unaffected.