### PR TITLE
fix: clean up timed-out requests from scheduler queue

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2310,6 +2310,10 @@ class Router:
                 setattr(e, "priority", priority)
                 raise e
         else:
+            # Clean up the timed-out request from the queue to prevent memory leak
+            await self.scheduler.remove_request(
+                request_id=item.request_id, model_name=item.model_name
+            )
             raise litellm.Timeout(
                 message="Request timed out while polling queue",
                 model=model,
@@ -2371,6 +2375,10 @@ class Router:
                 setattr(e, "priority", priority)
                 raise e
         else:
+            # Clean up the timed-out request from the queue to prevent memory leak
+            await self.scheduler.remove_request(
+                request_id=item.request_id, model_name=item.model_name
+            )
             raise litellm.Timeout(
                 message="Request timed out while polling queue",
                 model=model,

--- a/litellm/scheduler.py
+++ b/litellm/scheduler.py
@@ -114,6 +114,16 @@ class Scheduler:
         """Get the status of items in the queue"""
         return self.queue
 
+    async def remove_request(self, request_id: str, model_name: str) -> None:
+        """Remove a request from the queue by its ID.
+
+        Used to clean up timed-out requests that would otherwise leak.
+        """
+        queue = await self.get_queue(model_name=model_name)
+        updated_queue = [item for item in queue if item[1] != request_id]
+        if len(updated_queue) != len(queue):
+            await self.save_queue(queue=updated_queue, model_name=model_name)
+
     async def get_queue(self, model_name: str) -> list:
         """
         Return a queue for that specific model group


### PR DESCRIPTION
## Summary

Fixes #20059

**Root cause:** When a request times out while polling the scheduler queue (no healthy deployments available or not at queue top), the `FlowItem` is never removed. This creates orphaned entries that persist forever, causing a memory leak. Over time, these entries accumulate and can block the entire queue.

## Changes

1. `litellm/scheduler.py`: Added `remove_request(request_id, model_name)` method that removes a specific item from the queue by its request ID.

2. `litellm/router.py`: In both `schedule_acompletion()` and `_schedule_factory()`, added a call to `scheduler.remove_request()` before raising `litellm.Timeout` in the timeout path.

## Risk Assessment

**Low** - Only adds cleanup in the error path. Normal request flow (where `poll()` succeeds) is unchanged. The `remove_request` method safely handles cases where the item is already gone.