### PR TITLE
fix: add `acreate_file` to `_is_async_request()` check

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2075,6 +2075,7 @@ def _is_async_request(
         or kwargs.get("_arealtime", False) is True
         or kwargs.get("acreate_batch", False) is True
         or kwargs.get("acreate_fine_tuning_job", False) is True
+        or kwargs.get("acreate_file", False) is True
         or is_pass_through is True
     ):
         return True


### PR DESCRIPTION
## Summary

Fixes #20798

`litellm.acreate_file()` sets `kwargs["acreate_file"] = True` in `litellm/files/main.py`, but `_is_async_request()` in `litellm/utils.py` never checks for it. This causes async callbacks to be dispatched synchronously, generating `RuntimeWarning: coroutine was never awaited`.

Added `kwargs.get("acreate_file", False) is True` to the check list, consistent with other async operations like `acreate_batch` and `acreate_fine_tuning_job`.