### PR TITLE
fix: handle RuntimeError during streaming response deep copy

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2035,11 +2035,17 @@ class CustomStreamWrapper:
                         "usage",
                         getattr(complete_streaming_response, "usage"),
                     )
+                    try:
+                        _cached_chunk = complete_streaming_response.model_copy(
+                            deep=True
+                        )
+                    except RuntimeError:
+                        # Fallback to shallow copy if dict mutated during deep copy
+                        # (concurrent async tasks modifying model internals)
+                        _cached_chunk = complete_streaming_response.model_copy()
                     asyncio.create_task(
                         self.async_cache_streaming_response(
-                            processed_chunk=complete_streaming_response.model_copy(
-                                deep=True
-                            ),
+                            processed_chunk=_cached_chunk,
                             cache_hit=cache_hit,
                         )
                     )


### PR DESCRIPTION
## Summary

Fixes #20389

During async streaming, `complete_streaming_response.model_copy(deep=True)` can raise `RuntimeError: dictionary changed size during iteration` when Pydantic's internal `__pydantic_private__` dict is concurrently modified by another async task.

This is a race condition: the streaming handler creates background tasks via `asyncio.create_task()` that may mutate the model while the deep copy is iterating its internals.

## Fix

Wrapped the `model_copy(deep=True)` call in a `try/except RuntimeError` block. On failure, falls back to a shallow copy (`model_copy()`), which is safe because the cached chunk only needs to be an independent snapshot for the cache write task.