### PR TITLE
fix: handle InMemoryCache auto-deserialization in ResponsePollingHandler

### DIFF
--- a/litellm/proxy/response_polling/polling_handler.py
+++ b/litellm/proxy/response_polling/polling_handler.py
@@ -148,7 +148,9 @@ class ResponsePollingHandler:
             return
         
         # Parse existing ResponsesAPIResponse from cache
-        state = json.loads(cached_state)
+        # InMemoryCache auto-deserializes JSON strings to dicts,
+        # while Redis returns raw strings - handle both cases
+        state = cached_state if isinstance(cached_state, dict) else json.loads(cached_state)
         
         # Update status (using OpenAI native status values)
         if status:
@@ -224,7 +226,7 @@ class ResponsePollingHandler:
         cached_state = await self.redis_cache.async_get_cache(cache_key)
         
         if cached_state:
-            return json.loads(cached_state)
+            return cached_state if isinstance(cached_state, dict) else json.loads(cached_state)
         
         return None
     


### PR DESCRIPTION
## Summary

Fixes #20707

`ResponsePollingHandler` stores JSON strings in the cache via `response.model_dump_json()`. When using `InMemoryCache`, `async_get_cache` auto-deserializes JSON strings into dicts. But `update_state()` and `get_state()` unconditionally call `json.loads(cached_state)`, causing `TypeError` when the value is already a dict.

This breaks background polling under the default in-memory cache configuration.

## Fix

Added type checks before `json.loads()` in both `update_state()` and `get_state()`: if `cached_state` is already a dict, use it directly. This handles both InMemoryCache (returns dict) and Redis cache (returns string) correctly.