### PR TITLE
fix: map VLLM `reasoning` field to `reasoning_content` in streaming responses

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -330,6 +330,18 @@ class OpenAIChatCompletionResponseIterator(BaseModelResponseIterator):
         {'choices': [{'delta': {'content': '', 'role': 'assistant'}, 'finish_reason': None, 'index': 0, 'logprobs': None}], 'created': 1735763082, 'id': 'a83a2b0fbfaf4aab9c2c93cb8ba346d7', 'model': 'mistral-large', 'object': 'chat.completion.chunk'}
         """
         try:
+            # Map provider-specific reasoning field names to the standard
+            # 'reasoning_content' field.  VLLM (and some other providers)
+            # return 'reasoning' instead of 'reasoning_content'.
+            if "choices" in chunk:
+                for choice in chunk.get("choices", []):
+                    delta = choice.get("delta")
+                    if (
+                        delta
+                        and "reasoning" in delta
+                        and "reasoning_content" not in delta
+                    ):
+                        delta["reasoning_content"] = delta.pop("reasoning")
             return ModelResponseStream(**chunk)
         except Exception as e:
             raise e


### PR DESCRIPTION
## Summary

Fixes #20246

When using LiteLLM Proxy with VLLM backends in streaming mode, the `reasoning` field from VLLM responses is silently dropped because `Delta` only recognizes `reasoning_content`.

## Root Cause

VLLM returns reasoning data in a `reasoning` field, but LiteLLM's `Delta` model only has `reasoning_content`. The `chunk_parser` passes chunks directly to `ModelResponseStream` without any field name mapping, so the `reasoning` field is ignored.

## Fix

Added field name mapping in `OpenAIChatCompletionResponseIterator.chunk_parser()` to translate `reasoning` -> `reasoning_content` before constructing the `ModelResponseStream`. This is done in-place on the chunk dict before passing to the constructor.

## Notes

- Only maps when `reasoning_content` is not already present (avoids overwriting)
- Handles the field at the `delta` level within each choice
- Regression introduced in v1.81.1+ when passthrough logging started parsing chunks