### PR TITLE
fix: capture all Ollama thinking stream deltas instead of only first two

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -502,12 +502,12 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             reasoning_content: Optional[str] = None
             content: Optional[str] = None
             if chunk["message"].get("thinking") is not None:
-                if self.started_reasoning_content is False:
-                    reasoning_content = chunk["message"].get("thinking")
-                    self.started_reasoning_content = True
-                elif self.finished_reasoning_content is False:
-                    reasoning_content = chunk["message"].get("thinking")
-                    self.finished_reasoning_content = True
+                # Capture ALL thinking chunks - not just the first two.
+                # The previous logic set finished_reasoning_content on the
+                # second chunk, silently dropping all subsequent thinking
+                # deltas.
+                reasoning_content = chunk["message"].get("thinking")
+                self.started_reasoning_content = True
             elif chunk["message"].get("content") is not None:
                 message_content = chunk["message"].get("content")
                 if "<think>" in message_content:


### PR DESCRIPTION
## Summary

Fixes #20737

When using thinking models (e.g. `qwen3:32b`) with Ollama, only the first 2 thinking deltas are streamed. All subsequent thinking content is silently dropped.

## Root Cause

In `OllamaChatCompletionResponseIterator.chunk_parser()`, when Ollama sends chunks with a `thinking` field:

1. First chunk: sets `started_reasoning_content = True`, captures content
2. Second chunk: sets `finished_reasoning_content = True`, captures content
3. **Third+ chunks: both flags are True, neither `if` nor `elif` matches** -> `reasoning_content` stays `None`

The state machine incorrectly assumes Ollama sends exactly 2 thinking deltas. In practice, Ollama streams many thinking deltas before switching to content.

## Fix

Simplified the `thinking` field handling to capture ALL chunks where `thinking` is present, without prematurely setting `finished_reasoning_content`. The `finished_reasoning_content` flag is only set when transitioning from thinking to content (via `</think>` tag detection in the content-field path), which is the correct transition signal.

## Impact

Full thinking/reasoning content is now streamed for all Ollama thinking models.