### PR TITLE
fix: serialize Pydantic models in PostHog metadata to prevent JSON errors

### DIFF
--- a/litellm/integrations/posthog.py
+++ b/litellm/integrations/posthog.py
@@ -276,6 +276,12 @@ class PostHogLogger(CustomBatchLogger):
 
         for key, value in metadata.items():
             if key not in litellm_internal_fields:
+                # Convert Pydantic models / non-serializable objects to dicts
+                # to avoid "Object of type X is not JSON serializable" errors
+                if hasattr(value, "model_dump"):
+                    value = value.model_dump()
+                elif hasattr(value, "dict"):
+                    value = value.dict()
                 properties[key] = value
 
     def _get_distinct_id(


### PR DESCRIPTION
## Summary

Fixes #18332

When using the PostHog integration, events fail to send with:
```
Object of type UserAPIKeyAuth is not JSON serializable
```

## Root Cause

In `_add_custom_metadata_properties()`, metadata values from `litellm_params.metadata` are added directly to the PostHog event properties. Some values (like `UserAPIKeyAuth`) are Pydantic models that aren't JSON-serializable by default.

## Fix

Added a check for Pydantic models before adding metadata values to properties. If a value has `model_dump()` (Pydantic v2) or `dict()` (Pydantic v1), it's converted to a dictionary first.

## Notes

- The previous PR #18357 was closed without merge
- Only affects the metadata forwarding path, not the core PostHog event fields which use `_safe_get()` already