### PR TITLE
fix: normalize timeout values to float in aiohttp transport to prevent TypeError

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -245,9 +245,9 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
             allow_redirects=False,
             auto_decompress=False,
             timeout=ClientTimeout(
-                sock_connect=timeout.get("connect"),
-                sock_read=timeout.get("read"),
-                connect=timeout.get("pool"),
+                sock_connect=_normalize_timeout(timeout.get("connect")),
+                sock_read=_normalize_timeout(timeout.get("read")),
+                connect=_normalize_timeout(timeout.get("pool")),
             ),
             proxy=proxy,
             server_hostname=sni_hostname,


### PR DESCRIPTION
## Summary

Fixes #15955

The router crashes with `TypeError: '<=' not supported between instances of 'str' and 'int'` when timeout values are passed as strings instead of numeric types to `aiohttp.ClientTimeout`.

## Root Cause

Timeout values from `request.extensions.get('timeout', {})` can be strings (e.g., from environment variables or YAML config), but `aiohttp.ClientTimeout` requires numeric types. When `ceil_timeout` internally compares `delay <= 0`, string values cause a `TypeError`.

## Fix

Added a `_normalize_timeout()` helper that safely converts timeout values to `float`, returning `None` for unconvertible values. Applied to all three timeout parameters (`sock_connect`, `sock_read`, `connect`) passed to `aiohttp.ClientTimeout`.