### PR TITLE
fix: emit closing `</think>` tag when reasoning content stops with empty delta

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1021,8 +1021,12 @@ class CustomStreamWrapper:
             elif (
                 self.sent_first_thinking_block is True
                 and not self.sent_last_thinking_block
-                and model_response.choices[0].delta.content
             ):
+                # Emit closing </think> tag when reasoning content stops,
+                # even if the current chunk has no content.  The previous
+                # condition required `delta.content` to be truthy, which
+                # caused the tag to be silently dropped when the model
+                # transitioned from thinking to an empty delta.
                 model_response.choices[0].delta.content = "</think>" + (
                     model_response.choices[0].delta.content or ""
                 )


### PR DESCRIPTION
## Summary

Fixes #17349

When using `merge_reasoning_content_in_choices=True` with Vertex Gemini, the closing `</think>` tag is intermittently missing from streaming responses.

## Root Cause

The `</think>` emission logic in `_handle_reasoning_content_in_chunk()` required `model_response.choices[0].delta.content` to be truthy. When the model transitions from reasoning to content, it sometimes sends a chunk where `reasoning_content` is None/empty AND `content` is also None/empty. In this case, the closing tag was never emitted because the condition wasn't met.

## Fix

Removed the `delta.content` truthiness check from the `</think>` emission condition. The closing tag is now emitted whenever:
1. The first thinking block was sent
2. The last thinking block hasn't been sent yet
3. Reasoning content is no longer present

This ensures `</think>` is always emitted when thinking ends, even if the transition chunk has empty content.