### PR TITLE
fix(proxy): read team callbacks from correct metadata key

### DIFF
--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -198,15 +198,24 @@ async def disable_team_logging(
 
         # Update team metadata to disable logging
         team_metadata = _existing_team.metadata
-        team_callback_settings = team_metadata.get("callback_settings", {})
+        # Read from "logging" key first (where add_team_callbacks stores data),
+        # falling back to "callback_settings" for backwards compatibility.
+        team_callback_settings = team_metadata.get("logging")
+        if team_callback_settings is None:
+            # Read from "logging" key first (where add_team_callbacks stores data),
+        # falling back to "callback_settings" for backwards compatibility.
+        team_callback_settings = team_metadata.get("logging")
+        if team_callback_settings is None:
+            team_callback_settings = team_metadata.get("callback_settings", {})
         team_callback_settings_obj = TeamCallbackMetadata(**team_callback_settings)
 
         # Reset callbacks
         team_callback_settings_obj.success_callback = []
         team_callback_settings_obj.failure_callback = []
 
-        # Update metadata
+        # Update metadata - clear both keys to ensure consistency
         team_metadata["callback_settings"] = team_callback_settings_obj.model_dump()
+        team_metadata["logging"] = []
         team_metadata_json = json.dumps(team_metadata)
 
         # Update team in database
@@ -307,7 +316,11 @@ async def get_team_callbacks(
 
         # Retrieve team callback settings from metadata
         team_metadata = _existing_team.metadata
-        team_callback_settings = team_metadata.get("callback_settings", {})
+        # Read from "logging" key first (where add_team_callbacks stores data),
+        # falling back to "callback_settings" for backwards compatibility.
+        team_callback_settings = team_metadata.get("logging")
+        if team_callback_settings is None:
+            team_callback_settings = team_metadata.get("callback_settings", {})
 
         # Convert to TeamCallbackMetadata object for consistent structure
         team_callback_settings_obj = TeamCallbackMetadata(**team_callback_settings)


### PR DESCRIPTION
## Summary

`add_team_callbacks()` stores callbacks under `metadata["logging"]`, but `get_team_callbacks()` and `disable_team_logging()` were reading from `metadata["callback_settings"]`. This mismatch causes the GET `/team/{id}/callback` endpoint to always return empty callbacks even when callbacks exist.

## Changes

- **`get_team_callbacks()`**: Now reads from `"logging"` key first, falling back to `"callback_settings"` for backwards compatibility
- **`disable_team_logging()`**: Same fix - reads from `"logging"` first, and clears both keys when disabling

Fixes #20294