### PR TITLE
fix(ui): add formatted org_admin role to all_admin_roles

### DIFF
--- a/ui/litellm-dashboard/src/utils/roles.ts
+++ b/ui/litellm-dashboard/src/utils/roles.ts
@@ -3,7 +3,7 @@ import { Member, Team } from "@/components/networking";
 // Define admin roles and permissions
 export const old_admin_roles = ["Admin", "Admin Viewer"];
 export const v2_admin_role_names = ["proxy_admin", "proxy_admin_viewer", "org_admin"];
-export const all_admin_roles = [...old_admin_roles, ...v2_admin_role_names];
+export const all_admin_roles = [...old_admin_roles, ...v2_admin_role_names, "Org Admin"];
 
 export const internalUserRoles = ["Internal User", "Internal Viewer"];
 export const rolesAllowedToSeeUsage = ["Admin", "Admin Viewer", "Internal User", "Internal Viewer"];


### PR DESCRIPTION
## Summary

`formatUserRole()` transforms `'org_admin'` to `'Org Admin'`, but the `all_admin_roles` array only includes the raw `'org_admin'` value. When the sidebar checks `all_admin_roles.includes(userRole)`, it fails for `'Org Admin'` and hides admin menu items (Internal Users, Organizations, Guardrails) from `org_admin` users.

## Changes

- Add `"Org Admin"` to `all_admin_roles` in `roles.ts` so the formatted role name is recognized

Fixes #18131