### PR TITLE
fix(types): add image/audio/video pricing fields to ModelGroupInfo

### DIFF
--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -571,6 +571,12 @@ class ModelGroupInfo(BaseModel):
     input_cost_per_token: Optional[float] = None
     output_cost_per_token: Optional[float] = None
     input_cost_per_pixel: Optional[float] = None
+    output_cost_per_image: Optional[float] = None
+    output_cost_per_audio_per_second: Optional[float] = None
+    input_cost_per_audio_per_second: Optional[float] = None
+    output_cost_per_video_per_second: Optional[float] = None
+    input_cost_per_request: Optional[float] = None
+    output_cost_per_request: Optional[float] = None
     mode: Optional[
         Union[
             str,


### PR DESCRIPTION
## Summary

`ModelGroupInfo` only exposes token-based pricing fields (`input_cost_per_token`, `output_cost_per_token`) and `input_cost_per_pixel`. Image generation models priced per-image, audio models priced per-second, and video models are completely missing from the schema, causing the admin UI and `/model_group/info` endpoint to show $0 cost.

## Changes

Add the following fields to `ModelGroupInfo`:
- `output_cost_per_image` - for image generation models (DALL-E, Flux, etc.)
- `input_cost_per_audio_per_second` / `output_cost_per_audio_per_second` - for audio models
- `output_cost_per_video_per_second` - for video generation models
- `input_cost_per_request` / `output_cost_per_request` - for per-request pricing

Fixes #18684