### PR TITLE
fix: guard against None litellm_metadata in batch logging path

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -2331,7 +2331,7 @@ class Logging(LiteLLMLoggingBaseClass):
             result, LiteLLMBatch
         ):
             litellm_params = self.litellm_params or {}
-            litellm_metadata = litellm_params.get("litellm_metadata", {})
+            litellm_metadata = litellm_params.get("litellm_metadata") or {}
             if (
                 litellm_metadata.get("batch_ignore_default_logging", False) is True
             ):  # polling job will query these frequently, don't spam db logs


### PR DESCRIPTION
## Summary

Fixes #15836

When using batch operations (`acreate_batch`/`aretrieve_batch`), `litellm_metadata` can be explicitly `None` in `litellm_params`. The existing code:

```python
litellm_metadata = litellm_params.get("litellm_metadata", {})
```

returns `None` (not `{}`) because the key exists with a `None` value - Python's `dict.get()` only uses the default when the key is missing, not when the value is `None`. The subsequent `litellm_metadata.get(...)` then raises:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

## Fix

Change to `or {}` pattern, which is already used elsewhere in the same file (line 4924):

```python
litellm_metadata = litellm_params.get("litellm_metadata") or {}
```

This correctly handles both missing keys and explicit `None` values.