### PR TITLE
fix: allow proxy_admin_viewer role to access /spend/logs and other spend tracking routes

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -647,6 +647,12 @@ class RouteChecks:
             # Allow access to admin viewer routes (read-only admin endpoints)
             return
         elif RouteChecks.check_route_access(
+            route=route, allowed_routes=LiteLLMRoutes.spend_tracking_routes.value
+        ):
+            # Allow access to per-user/key/team spend tracking routes
+            # proxy_admin_viewer role description: "view all keys, view all spend"
+            return
+        elif RouteChecks.check_route_access(
             route=route, allowed_routes=LiteLLMRoutes.global_spend_tracking_routes.value
         ):
             # Allow access to global spend tracking routes (read-only spend endpoints)


### PR DESCRIPTION
## Summary

Fixes #17086

The `proxy_admin_viewer` role is documented as being able to "view all keys, view all spend", but when a user with this role tries to access `/spend/logs`, they get a 403 error:

```json
{
    "error": {
        "message": "user not allowed to access this route, role= proxy_admin_viewer. Trying to access: /spend/logs",
        "type": "auth_error",
        "code": "403"
    }
}
```

## Root Cause

In `_check_proxy_admin_viewer_access`, the route is checked against `admin_viewer_routes` and `global_spend_tracking_routes`, but **not** against `spend_tracking_routes` which contains `/spend/logs`, `/spend/keys`, `/spend/users`, etc.

## Fix

Add `spend_tracking_routes` to the proxy_admin_viewer access checks, before the existing `global_spend_tracking_routes` check. These are all read-only spend viewing endpoints consistent with the role's documented permissions.

## Test plan

- [ ] Verify proxy_admin_viewer can now access `/spend/logs`
- [ ] Verify proxy_admin_viewer can access other spend_tracking_routes (`/spend/keys`, `/spend/users`)
- [ ] Verify proxy_admin_viewer still cannot access write routes (`/key/generate`, `/user/new`)