### PR TITLE
docs: fix incorrect allowed_fails comment (> 1 should be > 3)

### DIFF
--- a/docs/my-website/docs/proxy/configs.md
+++ b/docs/my-website/docs/proxy/configs.md
@@ -411,7 +411,7 @@ litellm_settings:
   request_timeout: 10 # raise Timeout error if call takes longer than 10s. Sets litellm.request_timeout 
   fallbacks: [{"zephyr-beta": ["gpt-4o"]}] # fallback to gpt-4o if call fails num_retries 
   context_window_fallbacks: [{"zephyr-beta": ["gpt-3.5-turbo-16k"]}, {"gpt-4o": ["gpt-3.5-turbo-16k"]}] # fallback to gpt-3.5-turbo-16k if context window error
-  allowed_fails: 3 # cooldown model if it fails > 1 call in a minute. 
+  allowed_fails: 3 # cooldown model if it fails > 3 calls in a minute. 
 
 router_settings: # router_settings are optional
   routing_strategy: simple-shuffle # Literal["simple-shuffle", "least-busy", "usage-based-routing","latency-based-routing"], default="simple-shuffle"

--- a/docs/my-website/docs/proxy/reliability.md
+++ b/docs/my-website/docs/proxy/reliability.md
@@ -584,7 +584,7 @@ litellm_settings:
   num_retries: 3 # retry call 3 times on each model_name (e.g. zephyr-beta)
   request_timeout: 10 # raise Timeout error if call takes longer than 10s. Sets litellm.request_timeout 
   fallbacks: [{"zephyr-beta": ["gpt-3.5-turbo"]}] # fallback to gpt-3.5-turbo if call fails num_retries 
-  allowed_fails: 3 # cooldown model if it fails > 1 call in a minute. 
+  allowed_fails: 3 # cooldown model if it fails > 3 calls in a minute. 
   cooldown_time: 30 # how long to cooldown model if fails/min > allowed_fails
 ```
 

--- a/docs/my-website/docs/routing.md
+++ b/docs/my-website/docs/routing.md
@@ -1019,7 +1019,7 @@ print(f"response: {response}")
 
 ```yaml
 router_settings:
-	allowed_fails: 3 # cooldown model if it fails > 1 call in a minute. 
+	allowed_fails: 3 # cooldown model if it fails > 3 calls in a minute. 
   	cooldown_time: 30 # (in seconds) how long to cooldown model if fails/min > allowed_fails
 ```
 


### PR DESCRIPTION
## Summary

Fixes #14284

The `allowed_fails` config comments say "cooldown model if it fails > 1 call in a minute" even when `allowed_fails` is set to 3. This is misleading — the comment should reflect the actual configured value.

## Changes

Updated comments in three docs files where `allowed_fails: 3` had an incorrect comment stating "> 1 call":
- `docs/my-website/docs/proxy/reliability.md`
- `docs/my-website/docs/routing.md`
- `docs/my-website/docs/proxy/configs.md`

Changed from:
```yaml
allowed_fails: 3 # cooldown model if it fails > 1 call in a minute.
```

To:
```yaml
allowed_fails: 3 # cooldown model if it fails > 3 calls in a minute.
```

Note: The `allowed_fails=1` case in `routing.md` was left unchanged since "> 1 call" is correct for that value.