### PR TITLE
fix: return clear auth error instead of 'No connected db' for invalid keys without database

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -885,9 +885,9 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             prisma_client is None
         ):  # if both master key + user key submitted, and user key != master key, and no db connected, raise an error
             raise ProxyException(
-                message="No connected db.",
-                type=ProxyErrorTypes.no_db_connection,
-                code=400,
+                message="Authentication Error: Invalid API key. No database connected — only the master key is accepted for authentication. Set DATABASE_URL to enable virtual keys.",
+                type=ProxyErrorTypes.auth_error,
+                code=401,
                 param=None,
             )
 


### PR DESCRIPTION
## Summary

Fixes #12273

When a non-master API key is used with a LiteLLM proxy that has no database connected, the error response is:

```json
{"error": {"message": "No connected db.", "type": "no_db_connection", "code": "400"}}
```

This is confusing because the actual issue is authentication failure. Users may not realize that without a database, only the master key can be used.

## Fix

Change the error to return a clear 401 authentication error:

```json
{
  "error": {
    "message": "Authentication Error: Invalid API key. No database connected — only the master key is accepted for authentication. Set DATABASE_URL to enable virtual keys.",
    "type": "auth_error",
    "code": "401"
  }
}
```

Changes:
- Error message: clearly explains the issue and how to fix it
- Error type: `auth_error` instead of `no_db_connection`
- Status code: `401` (Unauthorized) instead of `400` (Bad Request)

## Test plan

- [ ] Send request with wrong key, no DB connected - verify new error message
- [ ] Send request with master key, no DB connected - verify success
- [ ] Send request with wrong key, DB connected - verify standard auth flow