### PR TITLE
fix(proxy): show correct timeout value in error message instead of 'None seconds'

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -562,7 +562,7 @@ class AsyncHTTPHandler:
                     headers["response_headers-{}".format(key)] = value
 
             raise litellm.Timeout(
-                message=f"Connection timed out after {timeout} seconds.",
+                message=f"Connection timed out after {timeout} seconds." if timeout is not None else "Connection timed out.",
                 model="default-model-name",
                 llm_provider="litellm-httpx-handler",
                 headers=headers,
@@ -628,7 +628,7 @@ class AsyncHTTPHandler:
                     headers["response_headers-{}".format(key)] = value
 
             raise litellm.Timeout(
-                message=f"Connection timed out after {timeout} seconds.",
+                message=f"Connection timed out after {timeout} seconds." if timeout is not None else "Connection timed out.",
                 model="default-model-name",
                 llm_provider="litellm-httpx-handler",
                 headers=headers,
@@ -1011,7 +1011,7 @@ class HTTPHandler:
             return response
         except httpx.TimeoutException:
             raise litellm.Timeout(
-                message=f"Connection timed out after {timeout} seconds.",
+                message=f"Connection timed out after {timeout} seconds." if timeout is not None else "Connection timed out.",
                 model="default-model-name",
                 llm_provider="litellm-httpx-handler",
             )
@@ -1059,7 +1059,7 @@ class HTTPHandler:
             return response
         except httpx.TimeoutException:
             raise litellm.Timeout(
-                message=f"Connection timed out after {timeout} seconds.",
+                message=f"Connection timed out after {timeout} seconds." if timeout is not None else "Connection timed out.",
                 model="default-model-name",
                 llm_provider="litellm-httpx-handler",
             )
@@ -1107,7 +1107,7 @@ class HTTPHandler:
             return response
         except httpx.TimeoutException:
             raise litellm.Timeout(
-                message=f"Connection timed out after {timeout} seconds.",
+                message=f"Connection timed out after {timeout} seconds." if timeout is not None else "Connection timed out.",
                 model="default-model-name",
                 llm_provider="litellm-httpx-handler",
             )
@@ -1144,7 +1144,7 @@ class HTTPHandler:
             return response
         except httpx.TimeoutException:
             raise litellm.Timeout(
-                message=f"Connection timed out after {timeout} seconds.",
+                message=f"Connection timed out after {timeout} seconds." if timeout is not None else "Connection timed out.",
                 model="default-model-name",
                 llm_provider="litellm-httpx-handler",
             )


### PR DESCRIPTION
## Summary

Fixes #14635

When an HTTP request times out and the `timeout` parameter was not explicitly set (i.e., remains `None`), the error message reads:

> Connection timed out after None seconds.

This is confusing to users who see "None" instead of an actual timeout value.

### Change

For all 6 occurrences in `http_handler.py`, the error message now:
- Shows `"Connection timed out after {timeout} seconds."` when `timeout` has a value
- Shows `"Connection timed out."` when `timeout` is `None`

## Test plan

- [ ] Verify that timeout errors with an explicit timeout show the value (e.g., "Connection timed out after 30 seconds.")
- [ ] Verify that timeout errors without an explicit timeout show "Connection timed out." (no "None")
