### PR TITLE
fix(proxy): prevent is_premium() debug log spam on every request

### DIFF
--- a/litellm/proxy/auth/litellm_license.py
+++ b/litellm/proxy/auth/litellm_license.py
@@ -28,6 +28,7 @@ class LicenseCheck:
         self.license_str = os.getenv("LITELLM_LICENSE", None)
         verbose_proxy_logger.debug("License Str value - {}".format(self.license_str))
         self.http_handler = HTTPHandler(timeout=NON_LLM_CONNECTION_TIMEOUT)
+        self._premium_check_logged = False
         self.public_key = None
         self.read_public_key()
         self.airgapped_license_data: Optional["EnterpriseLicenseData"] = None
@@ -99,20 +100,23 @@ class LicenseCheck:
         2. _verify: checks if license is valid calling litellm API. This is the old way we were generating/validating license
         """
         try:
-            verbose_proxy_logger.debug(
-                "litellm.proxy.auth.litellm_license.py::is_premium() - ENTERING 'IS_PREMIUM' - LiteLLM License={}".format(
-                    self.license_str
+            if not self._premium_check_logged:
+                verbose_proxy_logger.debug(
+                    "litellm.proxy.auth.litellm_license.py::is_premium() - ENTERING 'IS_PREMIUM' - LiteLLM License={}".format(
+                        self.license_str
+                    )
                 )
-            )
 
             if self.license_str is None:
                 self.license_str = os.getenv("LITELLM_LICENSE", None)
 
-            verbose_proxy_logger.debug(
-                "litellm.proxy.auth.litellm_license.py::is_premium() - Updated 'self.license_str' - {}".format(
-                    self.license_str
+            if not self._premium_check_logged:
+                verbose_proxy_logger.debug(
+                    "litellm.proxy.auth.litellm_license.py::is_premium() - Updated 'self.license_str' - {}".format(
+                        self.license_str
+                    )
                 )
-            )
+                self._premium_check_logged = True
 
             if self.license_str is None:
                 return False


### PR DESCRIPTION
## Summary

Fixes #17953

The `LicenseCheck.is_premium()` method logs two DEBUG messages on every invocation:
1. `ENTERING 'IS_PREMIUM' - LiteLLM License=...`
2. `Updated 'self.license_str' - ...`

Since `is_premium()` is called on every proxy request (for feature gating), these messages flood the logs when DEBUG level is enabled. In the reported case, the user's entire log output was filled with these repeated messages, making it impossible to debug actual issues.

### Change

Add a `_premium_check_logged` flag to the `LicenseCheck` class. The debug messages are only emitted on the **first** call to `is_premium()`. The license check logic itself is unchanged and continues to run on every call — only the verbose debug logging is suppressed after the first invocation.

## Test plan

- [ ] Verify that the first call to `is_premium()` still logs the debug messages
- [ ] Verify that subsequent calls do not spam the logs
- [ ] Verify that license checking still works correctly (premium features gated properly)
