### PR TITLE
fix: pop default_redis_ttl from kwargs before passing to redis client

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -123,6 +123,12 @@ class RedisCache(BaseCache):
         else:
             self.service_logger_obj = ServiceLogging()
 
+        # Pop litellm-specific cache config params that should not be forwarded
+        # to the redis client. These are consumed by the Cache/DualCache layer.
+        _default_redis_ttl = kwargs.pop("default_redis_ttl", None)
+        if _default_redis_ttl is not None:
+            litellm.default_redis_ttl = float(_default_redis_ttl)
+
         redis_kwargs.update(kwargs)
         self.redis_client = get_redis_client(**redis_kwargs)
         self.redis_async_client: Optional[


### PR DESCRIPTION
## Summary
- Pop `default_redis_ttl` from kwargs in `RedisCache.__init__` before merging into `redis_kwargs`
- Set `litellm.default_redis_ttl` from the popped value so the TTL logic on line 151 picks it up
- Prevents `TypeError: Redis.__init__() got an unexpected keyword argument 'default_redis_ttl'` crash

## Root Cause
When `default_redis_ttl` is set in proxy config `cache_params`, it flows through `Cache(**cache_params)` into `**kwargs`, then into `RedisCache(**kwargs)`, where `redis_kwargs.update(kwargs)` merges it into the dict passed to `redis.Redis()`. Since `redis.Redis()` doesn't accept `default_redis_ttl`, it raises a `TypeError`.

## Fix
Pop `default_redis_ttl` from kwargs before the `redis_kwargs.update(kwargs)` call. If present, set `litellm.default_redis_ttl` so the existing TTL logic at line 151 (`if litellm.default_redis_ttl is not None`) works correctly.

Fixes #17197
