### PR TITLE
fix: compute correct day offset for large duration values in reset time calculations

### DIFF
--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -264,8 +264,9 @@ def _handle_hour_reset(
 
     # Handle overnight case
     if next_hour >= 24:
+        extra_days = next_hour // 24
         next_hour = next_hour % 24
-        next_day = base_midnight + timedelta(days=1)
+        next_day = base_midnight + timedelta(days=extra_days)
         return next_day.replace(hour=next_hour)
 
     return current_time.replace(hour=next_hour, minute=0, second=0, microsecond=0)
@@ -304,8 +305,9 @@ def _handle_minute_reset(
 
     # Handle overnight case
     if next_hour >= 24:
+        extra_days = next_hour // 24
         next_hour = next_hour % 24
-        next_day = base_midnight + timedelta(days=1)
+        next_day = base_midnight + timedelta(days=extra_days)
         return next_day.replace(
             hour=next_hour, minute=next_minute, second=0, microsecond=0
         )
@@ -353,8 +355,9 @@ def _handle_second_reset(
 
     # Handle overnight case
     if next_hour >= 24:
+        extra_days = next_hour // 24
         next_hour = next_hour % 24
-        next_day = base_midnight + timedelta(days=1)
+        next_day = base_midnight + timedelta(days=extra_days)
         return next_day.replace(
             hour=next_hour, minute=next_minute, second=next_second, microsecond=0
         )


### PR DESCRIPTION
## Summary

Fixes #17993 — Budget reset times are calculated incorrectly when large duration values are specified in seconds, minutes, or hours (e.g. `"31536000s"` for 1 year).

### Root Cause

In `litellm/litellm_core_utils/duration_parser.py`, the functions `_handle_hour_reset()`, `_handle_minute_reset()`, and `_handle_second_reset()` all contain the same bug:

When `next_hour` exceeds 24 (which happens with large durations), the code wraps with `% 24` but hardcodes `timedelta(days=1)`:

```python
if next_hour >= 24:
    next_hour = next_hour % 24
    next_day = base_midnight + timedelta(days=1)  # BUG: always 1 day
```

For `"31536000s"` (1 year in seconds), `next_hour` would be enormous, but the reset is scheduled only ~1 day out instead of 365 days.

### Fix

Compute the actual number of overflow days before the modulo:

```python
if next_hour >= 24:
    extra_days = next_hour // 24
    next_hour = next_hour % 24
    next_day = base_midnight + timedelta(days=extra_days)
```

Applied consistently to all three affected functions.

### Impact

| Duration | Before (days until reset) | After (days until reset) |
|---|---|---|
| `"365d"` | 365 (correct) | 365 (unchanged) |
| `"31536000s"` | ~1 (wrong) | 365 (correct) |
| `"525600m"` | ~1 (wrong) | 365 (correct) |
| `"8760h"` | ~1 (wrong) | 365 (correct) |

Note: `_handle_day_reset()` was already correct — it uses `timedelta(days=value)` directly.

### Test Plan

- Verify `get_next_standardized_reset_time("31536000s", now)` returns ~365 days from now
- Verify `get_next_standardized_reset_time("525600m", now)` returns ~365 days from now
- Verify `get_next_standardized_reset_time("8760h", now)` returns ~365 days from now
- Verify small values like `"60s"`, `"5m"`, `"1h"` remain unaffected