### PR TITLE
fix: coerce None teams/members to empty list in LiteLLM_OrganizationTableWithMembers

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2487,6 +2487,14 @@ class LiteLLM_OrganizationTableWithMembers(LiteLLM_OrganizationTable):
     created_at: datetime
     updated_at: datetime
 
+    @field_validator("members", "teams", mode="before")
+    @classmethod
+    def _coerce_none_to_empty_list(cls, v: Any) -> Any:
+        """Prisma returns None for empty relations; coerce to [] so List validation passes."""
+        if v is None:
+            return []
+        return v
+
 
 class NewOrganizationResponse(LiteLLM_OrganizationTable):
     organization_id: str  # type: ignore

--- a/tests/proxy_unit_tests/test_org_table_none_coercion.py
+++ b/tests/proxy_unit_tests/test_org_table_none_coercion.py
@@ -1,0 +1,81 @@
+"""
+Tests for _coerce_none_to_empty_list field validator on LiteLLM_OrganizationTableWithMembers.
+
+Validates that None values for members and teams are coerced to [] (Prisma returns None
+for empty relations), while populated and empty lists are preserved.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from litellm.proxy._types import LiteLLM_OrganizationTableWithMembers
+
+
+def _base_org_data():
+    """Minimal required fields for LiteLLM_OrganizationTableWithMembers."""
+    now = datetime(2025, 1, 1, 12, 0, 0)
+    return {
+        "budget_id": "budget-1",
+        "models": ["gpt-4"],
+        "created_by": "user-1",
+        "updated_by": "user-1",
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def test_teams_none_becomes_empty_list():
+    """teams=None -> becomes []"""
+    data = {**_base_org_data(), "members": [], "teams": None}
+    obj = LiteLLM_OrganizationTableWithMembers.model_validate(data)
+    assert obj.teams == []
+    assert obj.members == []
+
+
+def test_members_none_becomes_empty_list():
+    """members=None -> becomes []"""
+    data = {**_base_org_data(), "members": None, "teams": []}
+    obj = LiteLLM_OrganizationTableWithMembers.model_validate(data)
+    assert obj.members == []
+    assert obj.teams == []
+
+
+def test_both_none_become_empty_lists():
+    """Both None -> both become []"""
+    data = {**_base_org_data(), "members": None, "teams": None}
+    obj = LiteLLM_OrganizationTableWithMembers.model_validate(data)
+    assert obj.members == []
+    assert obj.teams == []
+
+
+def test_populated_lists_preserved():
+    """Populated lists -> preserved"""
+    now = datetime(2025, 1, 1, 12, 0, 0)
+    member_data = {
+        "user_id": "user-1",
+        "organization_id": "org-1",
+        "created_at": now,
+        "updated_at": now,
+    }
+    team_data = {"team_id": "team-1"}
+    data = {
+        **_base_org_data(),
+        "members": [member_data],
+        "teams": [team_data],
+    }
+    obj = LiteLLM_OrganizationTableWithMembers.model_validate(data)
+    assert len(obj.members) == 1
+    assert obj.members[0].user_id == "user-1"
+    assert len(obj.teams) == 1
+    assert obj.teams[0].team_id == "team-1"
+
+
+def test_empty_lists_preserved():
+    """Empty lists -> preserved"""
+    data = {**_base_org_data(), "members": [], "teams": []}
+    obj = LiteLLM_OrganizationTableWithMembers.model_validate(data)
+    assert obj.members == []
+    assert obj.teams == []


### PR DESCRIPTION
## Summary

Fixes #18138

When updating a team that belongs to an organization, the `fetch_and_validate_organization` function fetches the org row from Prisma with `include={"members": True, "teams": True}`. If the organization has no teams or members, Prisma returns `None` for those relations. The code then does:

```python
LiteLLM_OrganizationTableWithMembers(**organization_row.model_dump())
```

This unpacks `teams=None` into a field typed `List[LiteLLM_TeamTable]`, causing:

```
ValidationError: 1 validation error for LiteLLM_OrganizationTableWithMembers
teams
  Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
```

## Fix

Added a `field_validator` on `members` and `teams` in `LiteLLM_OrganizationTableWithMembers` that coerces `None` to `[]` before Pydantic validation. This matches the existing default value (`= []`) and is the standard Pydantic pattern for handling nullable ORM relations.

## Changes

- `litellm/proxy/_types.py`: Add `_coerce_none_to_empty_list` field validator.

## Test Plan

- Verify that creating `LiteLLM_OrganizationTableWithMembers` with `teams=None` or `members=None` no longer raises `ValidationError`.
- Verify that updating a team belonging to an organization (via `/team/update`) succeeds when the org has no other teams.
- Verify that existing behavior is unchanged when `teams` and `members` are populated lists.
