### PR TITLE
fix: stop leaking Python tracebacks in streaming SSE error responses

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4705,8 +4705,10 @@ async def async_assistants_data_generator(
         if isinstance(e, HTTPException):
             raise e
         else:
-            error_traceback = traceback.format_exc()
-            error_msg = f"{str(e)}\n\n{error_traceback}"
+            # Only include the error message, not the traceback.
+            # The traceback is already logged above via verbose_proxy_logger.exception().
+            # Including it in the SSE response leaks internal details to clients.
+            error_msg = str(e)
 
         proxy_exception = ProxyException(
             message=getattr(e, "message", error_msg),
@@ -4856,8 +4858,10 @@ async def async_data_generator(
         elif isinstance(e, StreamingCallbackError):
             error_msg = str(e)
         else:
-            error_traceback = traceback.format_exc()
-            error_msg = f"{str(e)}\n\n{error_traceback}"
+            # Only include the error message, not the traceback.
+            # The traceback is already logged above via verbose_proxy_logger.exception().
+            # Including it in the SSE response leaks internal details to clients.
+            error_msg = str(e)
 
         proxy_exception = ProxyException(
             message=getattr(e, "message", error_msg),


### PR DESCRIPTION
## Summary

Fixes #20610

When a guardrail (e.g. Zscaler AI Guard) raises an exception during streaming, the `async_data_generator` error handler includes the full Python traceback in the SSE response sent to clients. This leaks internal server details (file paths, line numbers, call stacks) to end users.

## Root Cause

In `proxy_server.py`, both streaming generators (`async_data_generator` and the assistants variant) construct the error message as:

```python
error_traceback = traceback.format_exc()
error_msg = f"{str(e)}\n\n{error_traceback}"
```

Then `ProxyException(message=getattr(e, "message", error_msg), ...)` falls back to `error_msg` for plain `Exception` instances (which lack a `.message` attribute), exposing the traceback to clients.

## Fix

Replace `error_msg = f"{str(e)}\n\n{error_traceback}"` with `error_msg = str(e)` in both streaming generators. The traceback is already logged server-side via `verbose_proxy_logger.exception()`.

This is consistent with how `StreamingCallbackError` is already handled (line 4856-4857), which only uses `str(e)`.

## Before

```
Hello! How canError fetching response:Error: Content blocked by Zscaler AI Guard: ...

Traceback (most recent call last):
  File "litellm/proxy/proxy_server.py", line 4713, in async_data_generator
  ...
  File "litellm/proxy/guardrails/.../zscaler_ai_guard.py", line 157
Exception: Content blocked by Zscaler AI Guard: ...
```

## After

```
Error fetching response: Content blocked by Zscaler AI Guard: ...
```

## Test plan
- [ ] Trigger a guardrail block during streaming (e.g. Zscaler AI Guard content violation)
- [ ] Verify the SSE error response contains only the error message, no traceback
- [ ] Verify the full traceback is still available in server logs
- [ ] Verify `StreamingCallbackError` behavior is unchanged
