### PR TITLE
fix(scheduler): convert Redis-deserialized lists back to tuples in queue

### DIFF
--- a/litellm/scheduler.py
+++ b/litellm/scheduler.py
@@ -124,7 +124,13 @@ class Scheduler:
             if response is None or not isinstance(response, list):
                 return []
             elif isinstance(response, list):
-                return response
+                # JSON serialization (used by Redis) converts tuples to
+                # lists.  heapq operations require consistent types for
+                # comparison, so convert inner lists back to tuples.
+                return [
+                    tuple(item) if isinstance(item, list) else item
+                    for item in response
+                ]
         return self.queue
 
     async def save_queue(self, queue: list, model_name: str) -> None:


### PR DESCRIPTION
## Summary

Fixes #18098

When using `/queue/chat/completions` with Redis caching, concurrent requests intermittently fail with:

```
'<' not supported between instances of 'tuple' and 'list'
```

**Root cause**: `add_request()` pushes `(priority, request_id)` tuples onto the heap, but JSON serialization (used by Redis) converts tuples to lists. When `get_queue()` retrieves the heap from the cache, items are lists. The next `heapq.heappush()` call tries to compare a new tuple with an existing list, which Python does not support.

## Changes

In `get_queue()`, after retrieving the queue from cache, convert any inner list items back to tuples using a list comprehension. This ensures `heapq` always compares items of the same type.

## Test plan

- Deploy with Redis caching enabled
- Send concurrent requests to `/queue/chat/completions` with the same priority
- Verify no `TypeError` about tuple/list comparison
- Single-request queuing behavior remains unchanged
