### PR TITLE
fix #20836 - [Bug]: Redis Cluster Error: CROSSLOT Keys in request don't hash to the same slot

### DIFF
--- a/litellm/a2a_protocol/card_resolver.py
+++ b/litellm/a2a_protocol/card_resolver.py
@@ -24,7 +24,12 @@ try:
         PREV_AGENT_CARD_WELL_KNOWN_PATH,
     )
 except ImportError:
-    pass
+    class _A2ACardResolver:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def get_agent_card(self, *args, **kwargs):
+            raise ImportError("a2a-sdk is not installed")
 
 
 def is_localhost_or_internal_url(url: Optional[str]) -> bool:

--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -40,7 +40,15 @@ try:
 
     A2A_SDK_AVAILABLE = True
 except ImportError:
-    pass
+    class _A2AClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def send_message(self, *args, **kwargs):
+            raise ImportError("a2a-sdk is not installed")
+
+        def send_message_streaming(self, *args, **kwargs):
+            raise ImportError("a2a-sdk is not installed")
 
 # Import our custom card resolver that supports multiple well-known paths
 from litellm.a2a_protocol.card_resolver import LiteLLMA2ACardResolver
@@ -623,6 +631,7 @@ async def create_a2a_client(
     a2a_client = _A2AClient(
         httpx_client=httpx_client,
         agent_card=agent_card,
+        url=base_url,
     )
 
     # Store agent_card on client for later retrieval (SDK doesn't expose it)

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -831,6 +831,7 @@ class RedisCache(BaseCache):
             return []
         with self.redis_client.pipeline(transaction=False) as pipe:
             for key in keys:
+                key = self.check_and_fix_namespace(key)
                 pipe.get(key)  # type: ignore
             return pipe.execute()
 
@@ -846,6 +847,7 @@ class RedisCache(BaseCache):
 
         async with async_redis_client.pipeline(transaction=False) as pipe:
             for key in keys:
+                key = self.check_and_fix_namespace(key)
                 pipe.get(key)  # type: ignore
             return await pipe.execute()
 
@@ -1103,6 +1105,7 @@ class RedisCache(BaseCache):
             return
         async with _redis_client.pipeline(transaction=False) as pipe:
             for key in keys:
+                key = self.check_and_fix_namespace(key)
                 pipe.delete(key)  # type: ignore
             await pipe.execute()
 

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -831,7 +831,7 @@ class RedisCache(BaseCache):
             return []
         with self.redis_client.pipeline(transaction=False) as pipe:
             for key in keys:
-                pipe.get(key)
+                pipe.get(key)  # type: ignore
             return pipe.execute()
 
     async def _async_run_redis_mget_operation(self, keys: List[str]) -> List[Any]:
@@ -846,7 +846,7 @@ class RedisCache(BaseCache):
 
         async with async_redis_client.pipeline(transaction=False) as pipe:
             for key in keys:
-                pipe.get(key)
+                pipe.get(key)  # type: ignore
             return await pipe.execute()
 
     def batch_get_cache(
@@ -1103,7 +1103,7 @@ class RedisCache(BaseCache):
             return
         async with _redis_client.pipeline(transaction=False) as pipe:
             for key in keys:
-                pipe.delete(key)
+                pipe.delete(key)  # type: ignore
             await pipe.execute()
 
     def client_list(self) -> List:

--- a/litellm/caching/redis_cluster_cache.py
+++ b/litellm/caching/redis_cluster_cache.py
@@ -45,23 +45,10 @@ class RedisClusterCache(RedisCache):
 
         return _redis_client
 
-    def _run_redis_mget_operation(self, keys: List[str]) -> List[Any]:
-        """
-        Overrides `_run_redis_mget_operation` in redis_cache.py
-        """
-        return self.redis_client.mget_nonatomic(keys=keys)  # type: ignore
-
-    async def _async_run_redis_mget_operation(self, keys: List[str]) -> List[Any]:
-        """
-        Overrides `_async_run_redis_mget_operation` in redis_cache.py
-        """
-        async_redis_cluster_client = self.init_async_client()
-        return await async_redis_cluster_client.mget_nonatomic(keys=keys)  # type: ignore
-    
     async def test_connection(self) -> dict:
         """
         Test the Redis Cluster connection.
-        
+
         Returns:
             dict: {"status": "success" | "failed", "message": str, "error": Optional[str]}
         """
@@ -72,37 +59,38 @@ class RedisClusterCache(RedisCache):
             # Create ClusterNode objects from startup_nodes
             cluster_kwargs = self.redis_kwargs.copy()
             startup_nodes = cluster_kwargs.pop("startup_nodes", [])
-            
+
             new_startup_nodes: List[ClusterNode] = []
             for item in startup_nodes:
                 new_startup_nodes.append(ClusterNode(**item))
-            
+
             # Create a fresh Redis Cluster client with current settings
             redis_client = redis_async.RedisCluster(
                 startup_nodes=new_startup_nodes, **cluster_kwargs  # type: ignore
             )
-            
+
             # Test the connection
             ping_result = await redis_client.ping()  # type: ignore[attr-defined, misc]
 
             # Close the connection
             await redis_client.aclose()  # type: ignore[attr-defined]
-            
+
             if ping_result:
                 return {
                     "status": "success",
-                    "message": "Redis Cluster connection test successful"
+                    "message": "Redis Cluster connection test successful",
                 }
             else:
                 return {
                     "status": "failed",
-                    "message": "Redis Cluster ping returned False"
+                    "message": "Redis Cluster ping returned False",
                 }
         except Exception as e:
             from litellm._logging import verbose_logger
+
             verbose_logger.error(f"Redis Cluster connection test failed: {str(e)}")
             return {
                 "status": "failed",
                 "message": f"Redis Cluster connection failed: {str(e)}",
-                "error": str(e)
+                "error": str(e),
             }

--- a/tests/test_litellm/a2a_protocol/test_a2a_url_override.py
+++ b/tests/test_litellm/a2a_protocol/test_a2a_url_override.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock, ANY
+from litellm.a2a_protocol.main import create_a2a_client
+
+@pytest.mark.asyncio
+async def test_create_a2a_client_url_override():
+    """
+    Test that create_a2a_client passes the base_url as an override to the A2A SDK's A2AClient.
+    This ensures that the registered URL is used even if the agent card reports a different one.
+    """
+    base_url = "http://my-registered-agent:8080"
+    broken_card_url = "http://[::]:8081/invoke"
+    
+    # Mock agent card
+    mock_agent_card = MagicMock()
+    mock_agent_card.url = broken_card_url
+    mock_agent_card.name = "test-agent"
+    
+    # Mock A2ACardResolver
+    with patch("litellm.a2a_protocol.main.A2ACardResolver") as mock_resolver_cls:
+        mock_resolver = mock_resolver_cls.return_value
+        mock_resolver.get_agent_card = AsyncMock(return_value=mock_agent_card)
+        
+        # Mock _A2AClient (the SDK client)
+        with patch("litellm.a2a_protocol.main._A2AClient") as mock_sdk_client_cls:
+            # Mock successful import if not available
+            with patch("litellm.a2a_protocol.main.A2A_SDK_AVAILABLE", True):
+                client = await create_a2a_client(base_url=base_url)
+                
+                # Verify SDK client was initialized with the override URL
+                mock_sdk_client_cls.assert_called_once_with(
+                    httpx_client=ANY, # We don't care about the exact client here
+                    agent_card=mock_agent_card,
+                    url=base_url # THIS IS THE CRITICAL ASSERTION
+                )
+                
+                assert client == mock_sdk_client_cls.return_value
+
+@pytest.fixture(autouse=True)
+def mock_httpx_client():
+    with patch("litellm.a2a_protocol.main.get_async_httpx_client") as mock_get_httpx:
+        mock_handler = MagicMock()
+        mock_handler.client = MagicMock()
+        mock_get_httpx.return_value = mock_handler
+        yield mock_handler.client

--- a/tests/test_litellm/caching/test_redis_cluster_cache.py
+++ b/tests/test_litellm/caching/test_redis_cluster_cache.py
@@ -6,15 +6,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
-
 from litellm.caching.redis_cluster_cache import RedisClusterCache
 
 
-@patch("litellm._redis.init_redis_cluster")
-def test_redis_cluster_batch_get(mock_init_redis_cluster):
+@patch("litellm._redis.get_redis_client")
+def test_redis_cluster_batch_get(mock_get_redis_client):
     """
     Test that RedisClusterCache uses pipeline instead of mget for batch operations
     """
@@ -24,7 +20,7 @@ def test_redis_cluster_batch_get(mock_init_redis_cluster):
     mock_redis.pipeline.return_value.__enter__.return_value = mock_pipe
     mock_pipe.execute.return_value = [None, None]
     
-    mock_init_redis_cluster.return_value = mock_redis
+    mock_get_redis_client.return_value = mock_redis
 
     # Create RedisClusterCache instance with mock client
     cache = RedisClusterCache(
@@ -43,8 +39,8 @@ def test_redis_cluster_batch_get(mock_init_redis_cluster):
 
 
 @pytest.mark.asyncio
-@patch("litellm._redis.init_redis_cluster")
-async def test_redis_cluster_async_batch_get(mock_init_redis_cluster):
+@patch("litellm._redis.get_redis_client")
+async def test_redis_cluster_async_batch_get(mock_get_redis_client):
     """
     Test that RedisClusterCache uses pipeline instead of mget for async batch operations
     """

--- a/tests/test_litellm/caching/test_redis_cluster_safeness.py
+++ b/tests/test_litellm/caching/test_redis_cluster_safeness.py
@@ -1,0 +1,79 @@
+import pytest
+import asyncio
+import json
+from unittest.mock import MagicMock, patch, AsyncMock
+from litellm.caching.redis_cache import RedisCache
+
+@pytest.fixture
+def mock_redis():
+    with patch("litellm._redis.get_redis_client") as mock_get_client:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        # Mock _setup_health_pings to avoid connection attempts
+        with patch("litellm.caching.redis_cache.RedisCache._setup_health_pings"):
+            yield mock_client
+
+def test_redis_cache_batch_get_uses_pipeline(mock_redis):
+    cache = RedisCache(host="localhost", port=6379)
+    
+    # Mock pipeline for sync Redis
+    mock_pipe = MagicMock()
+    mock_redis.pipeline.return_value.__enter__.return_value = mock_pipe
+    
+    # Simulate Redis returning JSON strings
+    mock_pipe.execute.return_value = [
+        json.dumps("val1").encode("utf-8"),
+        json.dumps("val2").encode("utf-8")
+    ]
+    
+    keys = ["key1", "key2"]
+    results = cache.batch_get_cache(keys)
+    
+    mock_redis.pipeline.assert_called_with(transaction=False)
+    assert mock_pipe.get.call_count == 2
+    mock_pipe.execute.assert_called_once()
+    assert results == {"key1": "val1", "key2": "val2"}
+
+@pytest.mark.asyncio
+async def test_redis_cache_async_batch_get_uses_pipeline():
+    with patch("litellm.caching.redis_cache.RedisCache.init_async_client") as mock_init:
+        mock_client = MagicMock()
+        mock_pipe = MagicMock()
+        mock_init.return_value = mock_client
+        
+        # In redis-py, pipeline() itself is not async, but its context manager and execute() are.
+        # But for simplicity in mock:
+        mock_client.pipeline.return_value.__aenter__ = AsyncMock(return_value=mock_pipe)
+        mock_pipe.execute = AsyncMock(return_value=[
+            json.dumps("val1").encode("utf-8"),
+            json.dumps("val2").encode("utf-8")
+        ])
+        
+        with patch("litellm.caching.redis_cache.RedisCache._setup_health_pings"):
+            cache = RedisCache(host="localhost", port=6379)
+            keys = ["key1", "key2"]
+            results = await cache.async_batch_get_cache(keys)
+            
+            mock_client.pipeline.assert_called_with(transaction=False)
+            assert mock_pipe.get.call_count == 2
+            assert mock_pipe.execute.call_count == 1
+            assert results == {"key1": "val1", "key2": "val2"}
+
+@pytest.mark.asyncio
+async def test_redis_cache_delete_cache_keys_uses_pipeline():
+    with patch("litellm.caching.redis_cache.RedisCache.init_async_client") as mock_init:
+        mock_client = MagicMock()
+        mock_pipe = MagicMock()
+        mock_init.return_value = mock_client
+        
+        mock_client.pipeline.return_value.__aenter__ = AsyncMock(return_value=mock_pipe)
+        mock_pipe.execute = AsyncMock()
+        
+        with patch("litellm.caching.redis_cache.RedisCache._setup_health_pings"):
+            cache = RedisCache(host="localhost", port=6379)
+            keys = ["key1", "key2"]
+            await cache.delete_cache_keys(keys)
+            
+            mock_client.pipeline.assert_called_with(transaction=False)
+            assert mock_pipe.delete.call_count == 2
+            assert mock_pipe.execute.call_count == 1


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->
fixes issue #20836

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
