### PR TITLE
Fix: Moonshot provider removes image content from list of messages

### DIFF
--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -310,3 +310,27 @@ class TestMoonshotConfig:
             # Check that no extra message was added
             assert len(result["messages"]) == 1
             assert result["messages"][0]["content"] == "What's the weather?"
+
+
+class TestMoonshotVisionModel:
+    """Test class for Moonshot AI Vision model functionality."""
+
+    def test_image_content_is_preserved(self):
+        """Test that image content lists are not converted to strings."""
+        config = MoonshotChatConfig()
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+                    {"type": "text", "text": "Describe this"}
+                ]
+            }
+        ]
+
+        result = config._transform_messages(messages, "kimi-k2.5")
+
+        # Image content should remain as a list
+        assert isinstance(result[0]["content"], list)
+        assert result[0]["content"][0]["type"] == "image_url"


### PR DESCRIPTION
## Relevant issues

Fixes #20862 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

According to [Moonshot documentation](https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart#image-understanding-code-example, images should be preserved in base64 list of messages:
```
completion = client.chat.completions.create(
    model="kimi-k2.5",
    messages=[
        {"role": "system", "content": "You are Kimi."},
        {
            "role": "user",
            # Note: content is changed from str type to a list containing multiple content parts.
            # Image (image_url) is one part, and text is another part.
            "content": [
                {
                    "type": "image_url",  # <-- Use image_url type to upload images, with content as base64-encoded image data
                    "image_url": {
                        "url": image_url,
                    },
                },
                {
                    "type": "text",
                    "text": "Please describe the content of the image.",  # <-- Use text type to provide text instructions
                },
            ],
        },
    ],
)
``` 

This PR handles that in similar manner as AzureAI provider.


Tested by building docker compose, with config.yaml:
```
model_list:
  - model_name: main
    litellm_params:
      model: moonshot/kimi-k2.5
      api_key: os.environ/MOONSHOT_API_KEY

general_settings:
  master_key: test
```

Curl command for testing:
```
curl 'http://localhost:4000/v1/chat/completions' \
  -X POST \
  -H "Content-Type: application/json" \
  -H 'x-litellm-api-key: test' \
  --data-binary '{
    "model": "main",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "What is in this image?"
          },
          {
            "type": "image_url",
            "image_url": {
              "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
            }
          }
        ]
      }
    ],
    "temperature": 1.0,
    "max_tokens": 32768,
    "top_p": 0.95,
    "stream": false
  }'
```

Response (😍 emoji was uploaded)
```
{"id":"chatcmpl-698b2c653293fbed63e45e97","created":1770728549,"model":"main","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I cannot see actual image files or attachments. However, based on the text \"[HEART EYES EMOJI]\" that appears in your message, you may be referring to the **😍 emoji** (also known as \"Face with Heart-Eyes\" or \"Heart Eyes\").\n\nThis emoji depicts a smiling face with heart-shaped eyes and typically expresses:\n- **Love or adoration** (romantic or platonic)\n- **Being starstruck** or infatuated\n- **Excitement** about something you really like (food, celebrities, cute animals, etc.)\n- **Attraction** or finding something beautiful\n\nIf you meant to upload an actual photograph or different image that isn't displaying properly, please describe what you see in the image or try uploading it again, and I'll do my best to help identify it!","role":"assistant","reasoning_content":"The user is asking me to identify what is in an image. However, looking at the input, I see the text \"[HEART EYES EMOJI]\" which appears to be a description or alt-text of an emoji, rather than an actual image file or image data that I can analyze.\n\nWait, let me look more carefully. The user wrote \"What is in this image?\" and then there appears to be some content. But in the message, I see \"[HEART EYES EMOJI]\" which suggests that either:\n1. An image failed to load and was replaced with alt-text\n2. The user is referring to the emoji itself\n3. There's a formatting issue\n\nActually, looking at the raw input, it seems like there might have been an image that didn't render properly, or the user is asking about the emoji 😍 (heart eyes emoji).\n\nGiven that the text shows \"[HEART EYES EMOJI]\" or similar, and the user is asking what is in the image, I should explain that I cannot see the actual image, but if they're referring to the heart eyes emoji (😍), I can describe that.\n\nHowever, looking more carefully at the context, it appears the user might have tried to upload an image but it didn't come through properly, or they're referring to an emoji that was rendered as text.\n\nLet me assume the user is showing me the \"😍\" emoji (face with heart-shaped eyes). This emoji typically represents:\n- Love or adoration\n- Attraction\n- Being starstruck\n- Really liking something\n\nBut I should be careful - I need to state that I cannot actually see images, but if they're referring to the heart-eyes emoji, I can describe it.\n\nActually, wait. In some interfaces, when an image fails to load, it shows alt text. The user might see an emoji while I see \"[HEART EYES EMOJI]\" as alt text.\n\nI should respond by saying that I cannot view images directly, but if they are referring to the heart-eyes emoji (😍), I can describe what that emoji represents.\n\nOr, it's possible the user literally typed \"[HEART EYES EMOJI]\" as text and is asking what that means.\n\nGiven the ambiguity, I should:\n1. Clarify that I cannot see images \n2. Note that if they're referring to the heart-eyes emoji (😍), it shows a face with hearts for eyes\n3. Ask them to describe the image if it's something else\n\nBut looking at the format again, it seems like there might have been an image attachment that was converted to text. The most helpful response is to acknowledge that I see a reference to a heart-eyes emoji and describe it, while noting my limitations with images.\n\nLet me provide a helpful response about the heart-eyes emoji while clarifying my capabilities.","provider_specific_fields":{"reasoning_content":"The user is asking me to identify what is in an image. However, looking at the input, I see the text \"[HEART EYES EMOJI]\" which appears to be a description or alt-text of an emoji, rather than an actual image file or image data that I can analyze.\n\nWait, let me look more carefully. The user wrote \"What is in this image?\" and then there appears to be some content. But in the message, I see \"[HEART EYES EMOJI]\" which suggests that either:\n1. An image failed to load and was replaced with alt-text\n2. The user is referring to the emoji itself\n3. There's a formatting issue\n\nActually, looking at the raw input, it seems like there might have been an image that didn't render properly, or the user is asking about the emoji 😍 (heart eyes emoji).\n\nGiven that the text shows \"[HEART EYES EMOJI]\" or similar, and the user is asking what is in the image, I should explain that I cannot see the actual image, but if they're referring to the heart eyes emoji (😍), I can describe that.\n\nHowever, looking more carefully at the context, it appears the user might have tried to upload an image but it didn't come through properly, or they're referring to an emoji that was rendered as text.\n\nLet me assume the user is showing me the \"😍\" emoji (face with heart-shaped eyes). This emoji typically represents:\n- Love or adoration\n- Attraction\n- Being starstruck\n- Really liking something\n\nBut I should be careful - I need to state that I cannot actually see images, but if they're referring to the heart-eyes emoji, I can describe it.\n\nActually, wait. In some interfaces, when an image fails to load, it shows alt text. The user might see an emoji while I see \"[HEART EYES EMOJI]\" as alt text.\n\nI should respond by saying that I cannot view images directly, but if they are referring to the heart-eyes emoji (😍), I can describe what that emoji represents.\n\nOr, it's possible the user literally typed \"[HEART EYES EMOJI]\" as text and is asking what that means.\n\nGiven the ambiguity, I should:\n1. Clarify that I cannot see images \n2. Note that if they're referring to the heart-eyes emoji (😍), it shows a face with hearts for eyes\n3. Ask them to describe the image if it's something else\n\nBut looking at the format again, it seems like there might have been an image attachment that was converted to text. The most helpful response is to acknowledge that I see a reference to a heart-eyes emoji and describe it, while noting my limitations with images.\n\nLet me provide a helpful response about the heart-eyes emoji while clarifying my capabilities."}}}],"usage":{"completion_tokens":753,"prompt_tokens":28,"total_tokens":781}}
```