### PR TITLE
fix: prevent health check timeout from cancelling all asyncio tasks

### DIFF
--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -67,16 +67,6 @@ async def run_with_timeout(task, timeout):
     try:
         return await asyncio.wait_for(task, timeout)
     except asyncio.TimeoutError:
-        task.cancel()
-        # Only cancel child tasks of the current task
-        current_task = asyncio.current_task()
-        for t in asyncio.all_tasks():
-            if t != current_task:
-                t.cancel()
-        try:
-            await asyncio.wait_for(task, 0.1)  # Give 100ms for cleanup
-        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
-            pass
         return {"error": "Timeout exceeded"}
 
 


### PR DESCRIPTION
## Summary

Fixes #19541

When a single model health check timed out in `run_with_timeout()`, the function iterated over **all** tasks in the asyncio event loop via `asyncio.all_tasks()` and cancelled every one of them. This caused all other concurrent health checks (running in parallel via `asyncio.gather`) to be aborted, resulting in every model being reported as unhealthy — even when only one endpoint was slow or unreachable.

## Root Cause

```python
# Before — cancels ALL tasks in the event loop
async def run_with_timeout(task, timeout):
    try:
        return await asyncio.wait_for(task, timeout)
    except asyncio.TimeoutError:
        task.cancel()  # task is a coroutine, not a Task — raises AttributeError
        current_task = asyncio.current_task()
        for t in asyncio.all_tasks():
            if t != current_task:
                t.cancel()  # CRITICAL: kills all sibling health checks
        ...
```

Three issues:
1. `asyncio.all_tasks()` returns **every** running task, including sibling health checks and background proxy tasks
2. `task.cancel()` is called on a coroutine object (not an `asyncio.Task`), which raises `AttributeError`
3. `asyncio.wait_for()` already handles task cancellation internally on timeout — no manual cleanup is needed

## Fix

```python
# After — only the timed-out coroutine is affected
async def run_with_timeout(task, timeout):
    try:
        return await asyncio.wait_for(task, timeout)
    except asyncio.TimeoutError:
        return {"error": "Timeout exceeded"}
```

`asyncio.wait_for()` wraps the coroutine in an internal `Task` and cancels it when the timeout expires. No additional cancellation is needed. The function simply returns the error dict, allowing `asyncio.gather` to collect results from all health checks independently.

## Test Plan

- [x] When one model times out, other models still return correct healthy/unhealthy status
- [x] The `/health` endpoint no longer reports all models as unhealthy due to a single timeout
- [x] No `AttributeError` from calling `.cancel()` on a coroutine
- [x] Background proxy tasks (logging, spend tracking, etc.) are not disrupted