### PR TITLE
fix(proxy): avoid in-place mutation in SpendUpdateQueue aggregation

### DIFF
--- a/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
@@ -109,7 +109,8 @@ class SpendUpdateQueue(BaseUpdateQueue):
         for update in updates:
             _key = f"{update.get('entity_type')}:{update.get('entity_id')}"
             if _key not in _in_memory_map:
-                _in_memory_map[_key] = update
+                # avoid mutating caller-owned dicts while aggregating queue entries
+                _in_memory_map[_key] = update.copy()
             else:
                 current_cost = _in_memory_map[_key].get("response_cost", 0) or 0
                 update_cost = update.get("response_cost", 0) or 0

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py
@@ -242,10 +242,20 @@ def test_get_aggregated_spend_update_queue_item_does_not_mutate_original_updates
     aggregated_updates = spend_queue._get_aggregated_spend_update_queue_item(
         [original_update, duplicate_key_update]
     )
+    user1_aggregated_update = next(
+        (
+            update
+            for update in aggregated_updates
+            if update.get("entity_type") == Litellm_EntityType.USER
+            and update.get("entity_id") == "user1"
+        ),
+        None,
+    )
 
     assert original_update["response_cost"] == 10.0
-    assert aggregated_updates[0]["response_cost"] == 30.0
-    assert aggregated_updates[0] is not original_update
+    assert user1_aggregated_update is not None
+    assert user1_aggregated_update["response_cost"] == 30.0
+    assert user1_aggregated_update is not original_update
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py
@@ -225,6 +225,29 @@ async def test_aggregate_queue_updates_accuracy(spend_queue):
     assert aggregated["team_list_transactions"]["team1"] == 5.0
 
 
+def test_get_aggregated_spend_update_queue_item_does_not_mutate_original_updates(
+    spend_queue,
+):
+    original_update: SpendUpdateQueueItem = {
+        "entity_type": Litellm_EntityType.USER,
+        "entity_id": "user1",
+        "response_cost": 10.0,
+    }
+    duplicate_key_update: SpendUpdateQueueItem = {
+        "entity_type": Litellm_EntityType.USER,
+        "entity_id": "user1",
+        "response_cost": 20.0,
+    }
+
+    aggregated_updates = spend_queue._get_aggregated_spend_update_queue_item(
+        [original_update, duplicate_key_update]
+    )
+
+    assert original_update["response_cost"] == 10.0
+    assert aggregated_updates[0]["response_cost"] == 30.0
+    assert aggregated_updates[0] is not original_update
+
+
 @pytest.mark.asyncio
 async def test_queue_size_reduction_with_large_volume(monkeypatch, spend_queue):
     """Test that queue size is actually reduced when dealing with many items"""


### PR DESCRIPTION
## Summary
This PR fixes in-place mutation in `SpendUpdateQueue._get_aggregated_spend_update_queue_item()`.

Previously, aggregation stored a direct reference to the first `SpendUpdateQueueItem` seen for a key and then mutated that dict when combining costs. If any caller retained a reference to the original update object, its `response_cost` would be overwritten during queue aggregation.

## Changes
- In `litellm/proxy/db/db_transaction_queue/spend_update_queue.py`:
  - Copy the first update per entity key (`update.copy()`) before storing it in the aggregation map.
  - Continue aggregating into the copied object, preserving original caller-owned dicts.
- In `tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py`:
  - Added regression test `test_get_aggregated_spend_update_queue_item_does_not_mutate_original_updates`.
  - Verifies:
    - original input update remains unchanged (`10.0`)
    - aggregated result is correct (`30.0`)
    - aggregated object is not the same instance as the original input.

## Validation
- `poetry run pytest -q tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py`
  - Result: `11 passed`

Closes #20875
