### PR TITLE
feat: keep prompts only in s3 bucket aws

### DIFF
--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -62,6 +62,11 @@ class S3Logger:
                 s3_use_team_prefix = bool(
                     litellm.s3_callback_params.get("s3_use_team_prefix", False)
                 )
+                self.s3_log_prompts_only = bool(
+                    litellm.s3_callback_params.get("s3_log_prompts_only", False)
+                )
+            else:
+                self.s3_log_prompts_only = False
             self.s3_use_team_prefix = s3_use_team_prefix
             self.bucket_name = s3_bucket_name
             self.s3_path = s3_path
@@ -156,7 +161,13 @@ class S3Logger:
 
             from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
-            payload_str = safe_dumps(payload)
+            payload_dict = dict(payload)
+            if self.s3_log_prompts_only:
+                # Store only prompt content when prompts-only logging is enabled.
+                payload_dict = {
+                    "messages": payload_dict.get("messages") or [],
+                }
+            payload_str = safe_dumps(payload_dict)
 
             print_verbose(f"\ns3 Logger - Logging payload = {payload_str}")
 

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -51,6 +51,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         s3_use_team_prefix: bool = False,
         s3_strip_base64_files: bool = False,
         s3_use_key_prefix: bool = False,
+        s3_log_prompts_only: bool = False,
         **kwargs,
     ):
         try:
@@ -78,7 +79,8 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 s3_path=s3_path,
                 s3_use_team_prefix=s3_use_team_prefix,
                 s3_strip_base64_files=s3_strip_base64_files,
-                s3_use_key_prefix=s3_use_key_prefix
+                s3_use_key_prefix=s3_use_key_prefix,
+                s3_log_prompts_only=s3_log_prompts_only,
             )
             verbose_logger.debug(f"s3 logger using endpoint url {s3_endpoint_url}")
 
@@ -89,7 +91,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             )
             self.async_httpx_client = get_async_httpx_client(
                 llm_provider=httpxSpecialProvider.LoggingCallback,
-                params={"ssl_verify": self.s3_verify}
+                params={"ssl_verify": self.s3_verify},
             )
 
             asyncio.create_task(self.periodic_flush())
@@ -135,6 +137,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         s3_use_team_prefix: bool = False,
         s3_strip_base64_files: bool = False,
         s3_use_key_prefix: bool = False,
+        s3_log_prompts_only: bool = False,
     ):
         """
         Initialize the s3 params for this logging callback
@@ -155,10 +158,14 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             litellm.s3_callback_params.get("s3_api_version") or s3_api_version
         )
         self.s3_use_ssl = (
-            litellm.s3_callback_params.get("s3_use_ssl", True) if litellm.s3_callback_params.get("s3_use_ssl") is not None else s3_use_ssl
+            litellm.s3_callback_params.get("s3_use_ssl", True)
+            if litellm.s3_callback_params.get("s3_use_ssl") is not None
+            else s3_use_ssl
         )
         self.s3_verify = (
-            litellm.s3_callback_params.get("s3_verify") if litellm.s3_callback_params.get("s3_verify") is not None else s3_verify
+            litellm.s3_callback_params.get("s3_verify")
+            if litellm.s3_callback_params.get("s3_verify") is not None
+            else s3_verify
         )
         self.s3_endpoint_url = (
             litellm.s3_callback_params.get("s3_endpoint_url") or s3_endpoint_url
@@ -208,13 +215,18 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         )
 
         self.s3_use_key_prefix = (
-                bool(litellm.s3_callback_params.get("s3_use_key_prefix", False))
-                or s3_use_key_prefix
+            bool(litellm.s3_callback_params.get("s3_use_key_prefix", False))
+            or s3_use_key_prefix
         )
 
         self.s3_strip_base64_files = (
             bool(litellm.s3_callback_params.get("s3_strip_base64_files", False))
             or s3_strip_base64_files
+        )
+
+        self.s3_log_prompts_only = (
+            bool(litellm.s3_callback_params.get("s3_log_prompts_only", False))
+            or s3_log_prompts_only
         )
 
         return
@@ -294,9 +306,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             verbose_logger.debug(
                 f"s3_v2 logger - uploading data to s3 - {batch_logging_element.s3_object_key}"
             )
-            verbose_logger.debug(
-                f"s3_v2 logger - s3_verify setting: {self.s3_verify}"
-            )
+            verbose_logger.debug(f"s3_v2 logger - s3_verify setting: {self.s3_verify}")
 
             # Prepare the URL
             url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{batch_logging_element.s3_object_key}"
@@ -392,19 +402,24 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             return None
 
         if self.s3_strip_base64_files:
-            standard_logging_payload = self._strip_base64_from_messages_sync(standard_logging_payload)
+            standard_logging_payload = self._strip_base64_from_messages_sync(
+                standard_logging_payload
+            )
 
         # Base prefix (default empty)
         prefix_components = []
         if self.s3_use_team_prefix:
-            team_alias = standard_logging_payload.get("metadata", {}).get("user_api_key_team_alias", None)
+            team_alias = standard_logging_payload.get("metadata", {}).get(
+                "user_api_key_team_alias", None
+            )
             if team_alias:
                 prefix_components.append(team_alias)
         if self.s3_use_key_prefix:
-            user_api_key_alias = standard_logging_payload.get("metadata", {}).get("user_api_key_alias", None)
+            user_api_key_alias = standard_logging_payload.get("metadata", {}).get(
+                "user_api_key_alias", None
+            )
             if user_api_key_alias:
                 prefix_components.append(user_api_key_alias)
-
 
         # Construct full prefix path
         prefix_path = "/".join(prefix_components)
@@ -414,7 +429,9 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         s3_file_name = (
             litellm.utils.get_logging_id(start_time, standard_logging_payload) or ""
         )
-        verbose_logger.debug(f"Creating s3 file with prefix_components={prefix_components},prefix_path={prefix_path} and {s3_file_name}")
+        verbose_logger.debug(
+            f"Creating s3 file with prefix_components={prefix_components},prefix_path={prefix_path} and {s3_file_name}"
+        )
         s3_object_key = get_s3_object_key(
             s3_path=cast(Optional[str], self.s3_path) or "",
             prefix=prefix_path,
@@ -425,8 +442,15 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
 
         s3_object_download_filename = f"time-{start_time.strftime('%Y-%m-%dT%H-%M-%S-%f')}_{standard_logging_payload['id']}.json"
 
+        payload_dict = dict(standard_logging_payload)
+        if self.s3_log_prompts_only:
+            # Store only prompt content when prompts-only logging is enabled.
+            payload_dict = {
+                "messages": payload_dict.get("messages") or [],
+            }
+
         return s3BatchLoggingElement(
-            payload=dict(standard_logging_payload),
+            payload=payload_dict,
             s3_object_key=s3_object_key,
             s3_object_download_filename=s3_object_download_filename,
         )
@@ -497,7 +521,9 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             signed_headers = dict(aws_request.headers.items())
 
             httpx_client = _get_httpx_client(
-                params={"ssl_verify": self.s3_verify} if self.s3_verify is not None else None
+                params={"ssl_verify": self.s3_verify}
+                if self.s3_verify is not None
+                else None
             )
             # Make the request
             response = httpx_client.put(url, data=json_string, headers=signed_headers)

--- a/tests/test_litellm/integrations/test_s3.py
+++ b/tests/test_litellm/integrations/test_s3.py
@@ -1,0 +1,47 @@
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import litellm
+
+from litellm.integrations.s3 import S3Logger
+
+
+def test_s3_prompts_only_payload():
+    mock_client = MagicMock()
+    mock_client.put_object.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    with patch("boto3.client", return_value=mock_client):
+        litellm.s3_callback_params = {
+            "s3_bucket_name": "test-bucket",
+            "s3_region_name": "us-east-1",
+            "s3_log_prompts_only": True,
+        }
+
+        logger = S3Logger()
+
+        kwargs = {
+            "standard_logging_object": {
+                "id": "test-id",
+                "metadata": {},
+                "messages": [{"role": "user", "content": "hello"}],
+                "response": {"id": "resp"},
+            }
+        }
+
+        logger.log_event(
+            kwargs=kwargs,
+            response_obj={},
+            start_time=datetime(2026, 2, 10, 15, 0, 0),
+            end_time=datetime(2026, 2, 10, 15, 0, 1),
+            print_verbose=lambda *args, **kwargs: None,
+        )
+
+    call_args = mock_client.put_object.call_args
+    assert call_args is not None
+    payload_str = call_args.kwargs["Body"]
+    payload = json.loads(payload_str)
+
+    assert payload == {"messages": [{"role": "user", "content": "hello"}]}
+
+    litellm.s3_callback_params = None


### PR DESCRIPTION
## Relevant issues

LIT-1899

## Pre-Submission checklist

- [x] I have Added testing in the tests/litellm/ directory, Adding at least 1 test is a hard requirement
- [x] My PR passes all unit tests on make test-unit
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [ ] Branch creation CI run  
       Link: 

- [ ] CI run for the last commit  
       Link: 

- [ ] Merge / cherry-pick CI run  
       Links: 

## Type

🆕 New Feature  
✅ Test

## Changes


<img width="1200" height="650" alt="image" src="https://github.com/user-attachments/assets/77d2d351-0190-4277-a9bd-d3d037bd25ae" />


- Add `s3_log_prompts_only` behavior to store only prompt messages (no response/metadata) in S3 logs.
- Add regression tests for prompts-only payloads in both `s3_v2` and legacy `s3` loggers.