### PR TITLE
fix(usage): map OpenAI cached_tokens to _cache_read_input_tokens

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1556,6 +1556,15 @@ class Usage(SafeAttributeModel, CompletionUsage):
         ):
             self._cache_read_input_tokens = params["prompt_cache_hit_tokens"]
 
+        ## OPENAI MAPPING - populate _cache_read_input_tokens from prompt_tokens_details.cached_tokens ##
+        if (
+            self._cache_read_input_tokens == 0
+            and _prompt_tokens_details is not None
+            and _prompt_tokens_details.cached_tokens is not None
+            and _prompt_tokens_details.cached_tokens > 0
+        ):
+            self._cache_read_input_tokens = _prompt_tokens_details.cached_tokens
+
         for k, v in params.items():
             setattr(self, k, v)
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1561,7 +1561,6 @@ class Usage(SafeAttributeModel, CompletionUsage):
             self._cache_read_input_tokens == 0
             and _prompt_tokens_details is not None
             and _prompt_tokens_details.cached_tokens is not None
-            and _prompt_tokens_details.cached_tokens > 0
         ):
             self._cache_read_input_tokens = _prompt_tokens_details.cached_tokens
 

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -193,15 +193,16 @@ def test_usage_anthropic_cache_read_not_overwritten_by_prompt_details():
     from litellm.types.utils import Usage
 
     # Anthropic passes cache_read_input_tokens explicitly in **params
+    # Use different values to verify the explicit param wins over prompt_tokens_details
     usage = Usage(
         prompt_tokens=1000,
         completion_tokens=50,
         total_tokens=1050,
-        prompt_tokens_details={"cached_tokens": 500},
+        prompt_tokens_details={"cached_tokens": 300},
         cache_read_input_tokens=500,
     )
 
-    # Should use the explicit Anthropic value, not overwrite it
+    # Should use the explicit Anthropic value (500), not the prompt_tokens_details value (300)
     assert usage._cache_read_input_tokens == 500
     assert usage.prompt_tokens_details.cached_tokens == 500
 


### PR DESCRIPTION
## Relevant issues

Fixes #19684

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

OpenAI models return cached token counts in `usage.prompt_tokens_details.cached_tokens`, but LiteLLM was not mapping this value to the internal `_cache_read_input_tokens` private attribute on the `Usage` class.

This caused the admin UI to display "Cache Read Tokens: 0" for OpenAI/Azure requests even when prompt caching was active (visible in response metadata). Cost calculation was unaffected since it reads directly from `prompt_tokens_details.cached_tokens`.

**Root cause**: Anthropic and Bedrock explicitly pass `cache_read_input_tokens` when constructing `Usage`, which sets the private attr. OpenAI's usage dict only contains `prompt_tokens_details.cached_tokens`, and no mapping existed from that field to `_cache_read_input_tokens`.

**Fix**: In `Usage.__init__`, after all provider-specific mappings (Anthropic, DeepSeek), populate `_cache_read_input_tokens` from `prompt_tokens_details.cached_tokens` if it hasn't already been set. This is safe because the `== 0` guard prevents overwriting values set by other providers.

**Files changed**:
- `litellm/types/utils.py` - Added fallback mapping in `Usage.__init__`
- `tests/test_litellm/types/test_types_utils.py` - Added 4 unit tests covering OpenAI cached tokens mapping, zero value, Anthropic non-overwrite, and no prompt_tokens_details