### PR TITLE
fix: await Redis increment pipeline before budget sync reads

### DIFF
--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -353,13 +353,7 @@ class RouterBudgetLimiting(CustomLogger):
             self.redis_increment_operation_queue.append(increment_op)
 
     def _get_redis_increment_queue_lock(self) -> asyncio.Lock:
-        queue_lock: Optional[asyncio.Lock] = getattr(
-            self, "_redis_increment_queue_lock", None
-        )
-        if queue_lock is None:
-            queue_lock = asyncio.Lock()
-            self._redis_increment_queue_lock = queue_lock
-        return queue_lock
+        return self._redis_increment_queue_lock
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         """Original method now uses helper functions"""

--- a/tests/test_litellm/router_strategy/test_budget_limiter.py
+++ b/tests/test_litellm/router_strategy/test_budget_limiter.py
@@ -1,0 +1,94 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from litellm.router_strategy.budget_limiter import RouterBudgetLimiting
+from litellm.types.utils import BudgetConfig
+
+
+class _MockRedisCache:
+    def __init__(self, initial_values):
+        self.values = initial_values
+        self.events = []
+
+    async def async_increment_pipeline(self, increment_list, **kwargs):
+        self.events.append("increment_pipeline:start")
+        await asyncio.sleep(0.05)
+        for op in increment_list:
+            key = op["key"]
+            current = float(self.values.get(key, 0.0) or 0.0)
+            self.values[key] = current + float(op["increment_value"])
+        self.events.append("increment_pipeline:done")
+
+    async def async_batch_get_cache(self, key_list, **kwargs):
+        self.events.append("batch_get")
+        return {key: self.values.get(key) for key in key_list}
+
+
+class _MockInMemoryCache:
+    def __init__(self, initial_values):
+        self.values = initial_values
+
+    async def async_set_cache(self, key, value, **kwargs):
+        self.values[key] = float(value)
+
+
+@pytest.mark.asyncio
+async def test_should_await_redis_pipeline_before_sync_reads():
+    spend_key = "provider_spend:openai:1d"
+    redis_cache = _MockRedisCache(initial_values={spend_key: 100.0})
+    in_memory_cache = _MockInMemoryCache(initial_values={spend_key: 160.0})
+
+    budget_limiter = RouterBudgetLimiting.__new__(RouterBudgetLimiting)
+    budget_limiter.dual_cache = SimpleNamespace(
+        redis_cache=redis_cache,
+        in_memory_cache=in_memory_cache,
+    )
+    budget_limiter.provider_budget_config = {
+        "openai": BudgetConfig(time_period="1d", budget_limit=500.0)
+    }
+    budget_limiter.deployment_budget_config = None
+    budget_limiter.tag_budget_config = None
+    budget_limiter.redis_increment_operation_queue = [
+        {
+            "key": spend_key,
+            "increment_value": 60.0,
+            "ttl": 86400,
+        }
+    ]
+
+    await budget_limiter._sync_in_memory_spend_with_redis()
+
+    assert redis_cache.values[spend_key] == 160.0
+    assert in_memory_cache.values[spend_key] == 160.0
+    assert budget_limiter.redis_increment_operation_queue == []
+    assert redis_cache.events == [
+        "increment_pipeline:start",
+        "increment_pipeline:done",
+        "batch_get",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_should_requeue_increments_when_redis_pipeline_fails():
+    spend_key = "provider_spend:openai:1d"
+
+    class _FailingRedisCache:
+        async def async_increment_pipeline(self, increment_list, **kwargs):
+            raise RuntimeError("redis down")
+
+    budget_limiter = RouterBudgetLimiting.__new__(RouterBudgetLimiting)
+    budget_limiter.dual_cache = SimpleNamespace(
+        redis_cache=_FailingRedisCache(),
+        in_memory_cache=SimpleNamespace(),
+    )
+    budget_limiter.redis_increment_operation_queue = [
+        {"key": spend_key, "increment_value": 10.0, "ttl": 86400}
+    ]
+
+    await budget_limiter._push_in_memory_increments_to_redis()
+
+    assert budget_limiter.redis_increment_operation_queue == [
+        {"key": spend_key, "increment_value": 10.0, "ttl": 86400}
+    ]

--- a/tests/test_litellm/router_strategy/test_budget_limiter.py
+++ b/tests/test_litellm/router_strategy/test_budget_limiter.py
@@ -1,5 +1,6 @@
 import asyncio
 from types import SimpleNamespace
+from typing import Optional
 
 import pytest
 
@@ -8,13 +9,27 @@ from litellm.types.utils import BudgetConfig
 
 
 class _MockRedisCache:
-    def __init__(self, initial_values):
+    def __init__(
+        self,
+        initial_values,
+        pipeline_started: Optional[asyncio.Event] = None,
+        allow_pipeline_to_complete: Optional[asyncio.Event] = None,
+        should_fail_pipeline: bool = False,
+    ):
         self.values = initial_values
         self.events = []
+        self.pipeline_started = pipeline_started
+        self.allow_pipeline_to_complete = allow_pipeline_to_complete
+        self.should_fail_pipeline = should_fail_pipeline
 
     async def async_increment_pipeline(self, increment_list, **kwargs):
         self.events.append("increment_pipeline:start")
-        await asyncio.sleep(0.05)
+        if self.pipeline_started is not None:
+            self.pipeline_started.set()
+        if self.allow_pipeline_to_complete is not None:
+            await self.allow_pipeline_to_complete.wait()
+        if self.should_fail_pipeline:
+            raise RuntimeError("redis down")
         for op in increment_list:
             key = op["key"]
             current = float(self.values.get(key, 0.0) or 0.0)
@@ -30,6 +45,11 @@ class _MockInMemoryCache:
     def __init__(self, initial_values):
         self.values = initial_values
 
+    async def async_increment(self, key, value, ttl, **kwargs):
+        current = float(self.values.get(key, 0.0) or 0.0)
+        self.values[key] = current + float(value)
+        return self.values[key]
+
     async def async_set_cache(self, key, value, **kwargs):
         self.values[key] = float(value)
 
@@ -37,7 +57,13 @@ class _MockInMemoryCache:
 @pytest.mark.asyncio
 async def test_should_await_redis_pipeline_before_sync_reads():
     spend_key = "provider_spend:openai:1d"
-    redis_cache = _MockRedisCache(initial_values={spend_key: 100.0})
+    pipeline_started = asyncio.Event()
+    allow_pipeline_to_complete = asyncio.Event()
+    redis_cache = _MockRedisCache(
+        initial_values={spend_key: 100.0},
+        pipeline_started=pipeline_started,
+        allow_pipeline_to_complete=allow_pipeline_to_complete,
+    )
     in_memory_cache = _MockInMemoryCache(initial_values={spend_key: 160.0})
 
     budget_limiter = RouterBudgetLimiting.__new__(RouterBudgetLimiting)
@@ -57,8 +83,13 @@ async def test_should_await_redis_pipeline_before_sync_reads():
             "ttl": 86400,
         }
     ]
+    budget_limiter._redis_increment_queue_lock = asyncio.Lock()
 
-    await budget_limiter._sync_in_memory_spend_with_redis()
+    sync_task = asyncio.create_task(budget_limiter._sync_in_memory_spend_with_redis())
+    await asyncio.wait_for(pipeline_started.wait(), timeout=1)
+    assert "batch_get" not in redis_cache.events
+    allow_pipeline_to_complete.set()
+    await sync_task
 
     assert redis_cache.values[spend_key] == 160.0
     assert in_memory_cache.values[spend_key] == 160.0
@@ -73,22 +104,58 @@ async def test_should_await_redis_pipeline_before_sync_reads():
 @pytest.mark.asyncio
 async def test_should_requeue_increments_when_redis_pipeline_fails():
     spend_key = "provider_spend:openai:1d"
-
-    class _FailingRedisCache:
-        async def async_increment_pipeline(self, increment_list, **kwargs):
-            raise RuntimeError("redis down")
-
+    redis_cache = _MockRedisCache(
+        initial_values={},
+        should_fail_pipeline=True,
+    )
     budget_limiter = RouterBudgetLimiting.__new__(RouterBudgetLimiting)
     budget_limiter.dual_cache = SimpleNamespace(
-        redis_cache=_FailingRedisCache(),
+        redis_cache=redis_cache,
         in_memory_cache=SimpleNamespace(),
     )
     budget_limiter.redis_increment_operation_queue = [
         {"key": spend_key, "increment_value": 10.0, "ttl": 86400}
     ]
+    budget_limiter._redis_increment_queue_lock = asyncio.Lock()
 
     await budget_limiter._push_in_memory_increments_to_redis()
 
     assert budget_limiter.redis_increment_operation_queue == [
         {"key": spend_key, "increment_value": 10.0, "ttl": 86400}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_should_keep_new_increments_when_pipeline_flush_fails():
+    spend_key = "provider_spend:openai:1d"
+    pipeline_started = asyncio.Event()
+    allow_pipeline_to_complete = asyncio.Event()
+    redis_cache = _MockRedisCache(
+        initial_values={},
+        pipeline_started=pipeline_started,
+        allow_pipeline_to_complete=allow_pipeline_to_complete,
+        should_fail_pipeline=True,
+    )
+    in_memory_cache = _MockInMemoryCache(initial_values={spend_key: 0.0})
+    budget_limiter = RouterBudgetLimiting.__new__(RouterBudgetLimiting)
+    budget_limiter.dual_cache = SimpleNamespace(
+        redis_cache=redis_cache,
+        in_memory_cache=in_memory_cache,
+    )
+    budget_limiter.redis_increment_operation_queue = [
+        {"key": spend_key, "increment_value": 10.0, "ttl": 86400}
+    ]
+    budget_limiter._redis_increment_queue_lock = asyncio.Lock()
+
+    push_task = asyncio.create_task(budget_limiter._push_in_memory_increments_to_redis())
+    await asyncio.wait_for(pipeline_started.wait(), timeout=1)
+    await budget_limiter._increment_spend_in_current_window(
+        spend_key=spend_key, response_cost=20.0, ttl=86400
+    )
+    allow_pipeline_to_complete.set()
+    await push_task
+
+    assert budget_limiter.redis_increment_operation_queue == [
+        {"key": spend_key, "increment_value": 10.0, "ttl": 86400},
+        {"key": spend_key, "increment_value": 20.0, "ttl": 86400},
     ]


### PR DESCRIPTION
## Relevant issues

Fixes #20886

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

- Fixes a race in `RouterBudgetLimiting._push_in_memory_increments_to_redis()` where Redis increment pipeline writes were scheduled via `asyncio.create_task(...)` and not awaited.
- Uses an atomic queue snapshot + swap before awaiting Redis flush:
  - snapshot current queue to `increment_operations_to_flush`
  - reset live queue immediately so new increments are queued for next cycle
  - await `async_increment_pipeline(...)` for the snapshot before continuing
- Adds defensive behavior: if Redis flush fails, re-queue the flushed increments to avoid dropping spend updates.
- Adds regression tests in `tests/test_litellm/router_strategy/test_budget_limiter.py`:
  - verifies `_sync_in_memory_spend_with_redis()` waits for Redis pipeline completion before Redis reads
  - verifies increments are re-queued when Redis pipeline write fails

## Validation

Ran locally:

- `pytest -q tests/test_litellm/router_strategy/test_budget_limiter.py`
- `pytest -q tests/test_litellm/router_strategy`

Both passed.
