### PR TITLE
feat(helm): add bearer token authentication to ServiceMonitor

### DIFF
--- a/deploy/charts/litellm-helm/templates/secret-servicemonitor-token.yaml
+++ b/deploy/charts/litellm-helm/templates/secret-servicemonitor-token.yaml
@@ -1,0 +1,11 @@
+{{- if and (eq .Values.serviceMonitor.enabled true) (eq .Values.serviceMonitor.secret.create true) .Values.serviceMonitor.secret.value }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "litellm.fullname" . }}-servicemonitor-token
+  labels:
+    {{- include "litellm.labels" . | nindent 4 }}
+data:
+  token: {{ .Values.serviceMonitor.secret.value | b64enc }}
+type: Opaque
+{{- end }}

--- a/deploy/charts/litellm-helm/templates/servicemonitor.yaml
+++ b/deploy/charts/litellm-helm/templates/servicemonitor.yaml
@@ -31,6 +31,18 @@ spec:
     interval: {{ .interval }}
     scrapeTimeout: {{ .scrapeTimeout }}
     scheme: http
+  {{- /*
+    Render bearerTokenSecret block if either chart creates the secret (secret.create=true) or
+    user explicitly sets all three fields (name, key, optional).
+  */ -}}
+  {{- if or (eq .secret.create true) (and .bearerTokenSecret.name .bearerTokenSecret.key }}
+    bearerTokenSecret:
+      name: {{ .bearerTokenSecret.name | default (print (include "litellm.fullname" $) "-servicemonitor-token") }}
+      key: {{ .bearerTokenSecret.key | default "token" }}
+      {{- if hasKey .bearerTokenSecret "optional" }}
+      optional: {{ .bearerTokenSecret.optional }}
+      {{- end }}
+  {{- end }}
   {{- if .relabelings }}
     relabelings:
 {{- toYaml .relabelings | nindent 4 }}

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -339,3 +339,18 @@ serviceMonitor:
   namespaceSelector:
     matchNames: []
     # - test-namespace
+  # Bearer token authentication for metrics endpoint
+
+  # Creates a K8s secret with the API key you want to use. With that you do not need to specify
+  # bearerTokenSecret manually.
+  secret:
+    create: false        # Set to true to have the chart create the secret
+    value: ""            # Token value (required if create: true)
+
+  # Use this if you want to configure the bearerTokenSecret manually.
+  bearerTokenSecret: {}
+  #   name: ""           # Secret name. Defaults to: {{ include "litellm.fullname" . }}-servicemonitor-token
+  #   key: "token"       # Secret key. Defaults to: "token"
+  #   optional: false    # Mark secret as optional. Defaults to: false
+
+


### PR DESCRIPTION
## Relevant issues                                                                                                                                                                                    
                 
  <!-- e.g. "Fixes #000" -->                                                                                                                                                                            
  N/A - Enhancement to Helm chart security           

Allows the ServiceMonitor, with which we tell Prometheus how to scrape the LiteLLM metrics, to use a bearer token authentication. This is needed for setups where the /metrics endpoint is secured with the API key, otherwise we would not be able to scrape metrics in such a scenario.                                                                                                                                                   

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] ~~I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement**~~
    - Only helm chart changes
  - [x] ~~My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)~~
    - Only helm chart changes
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## CI (LiteLLM team)

  > **CI status guideline:**
  >
  > - 50-55 passing tests: main is stable with minor issues.
  > - 45-49 passing tests: acceptable but needs attention
  > - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

  - [ ] **Branch creation CI run**
         Link:

  - [ ] **CI run for the last commit**
         Link:

  - [ ] **Merge / cherry-pick CI run**
         Links:

  ## Type

 🆕 New Feature
 🚄 Infrastructure

  ## Changes

  ### Summary
  Adds bearer token authentication support to the ServiceMonitor resource in the LiteLLM Helm chart, enabling secure Prometheus metrics scraping.

  ### What Changed
  - **values.yaml**: Added `serviceMonitor.bearerTokenSecret` and `serviceMonitor.secret` configuration options
  - **templates/servicemonitor.yaml**: Added `bearerTokenSecret` block with smart defaults and conditional rendering
  - **templates/secret-servicemonitor-token.yaml**: New template for optional chart-managed secret creation

  ### Features
  - **Two usage patterns**:
    1. **Chart-managed secret**: Set `serviceMonitor.secret.create: true` with a token value
    2. **External secret**: Reference existing secrets via `serviceMonitor.bearerTokenSecret.name`
  - **Smart defaults**: When chart creates secret, ServiceMonitor automatically references it
  - **Fully backward compatible**: Feature is opt-in, defaults to no authentication (empty `{}`)
  - **Decoupled design**: Secret creation is independent of ServiceMonitor configuration

  ### Testing
  Verified Helm template rendering with multiple configurations:
  - ✅ Default (no authentication) - backward compatible
  - ✅ Chart-created secret - automatic configuration
  - ✅ External secret reference - custom configuration
  - ✅ Optional flag handling - explicit control

  ### Example Usage
  ```yaml
  # Pattern 1: Chart creates secret
  serviceMonitor:
    enabled: true
    secret:
      create: true
      value: "my-bearer-token"

  # Pattern 2: Use existing secret
  serviceMonitor:
    enabled: true
    bearerTokenSecret:
      name: my-external-secret
      key: bearer-token
      optional: false