### PR TITLE
[Fix] UI - Usage: Request Chart stack variant

### DIFF
--- a/ui/litellm-dashboard/src/components/activity_metrics.tsx
+++ b/ui/litellm-dashboard/src/components/activity_metrics.tsx
@@ -148,7 +148,6 @@ const ModelSection = ({
             categories={["metrics.successful_requests", "metrics.failed_requests"]}
             colors={["green", "red"]}
             valueFormatter={valueFormatter}
-            stack
             customTooltip={CustomTooltip}
             showLegend={false}
           />


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

Removes the `stack` prop from the Success vs Failed Requests chart in the activity metrics model section (`ModelSection` in `activity_metrics.tsx`). The chart no longer renders as a stacked area chart.

Adds unit tests for `ActivityMetrics`: display of model sections (Spend per day, Requests per day, Success vs Failed Requests, Model Usage, Top Virtual Keys), collapse order for empty model keys, and for `processActivityData` (empty results, `top_models` from api_key breakdown) and `formatKeyLabel` (key label when teams array is empty).

## Screenshots
<img width="806" height="469" alt="image" src="https://github.com/user-attachments/assets/c5e870ef-25cc-4cd7-96f0-4bbd2355619a" />


BEFORE FIX:
<img width="843" height="489" alt="image" src="https://github.com/user-attachments/assets/576fa842-ef97-4c87-9362-7ca9c6b1ca7d" />


Tests:
<img width="832" height="409" alt="image" src="https://github.com/user-attachments/assets/456fc3d9-cd60-47d7-b4b1-cc2ae9a635ef" />
