### PR TITLE
perf: shallow copy messages in Logging.__init__ 

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -334,7 +334,11 @@ class Logging(LiteLLMLoggingBaseClass):
                 messages = new_messages
 
         self.model = model
-        self.messages = copy.deepcopy(messages) if messages is not None else None
+        self.messages = (
+            [msg.copy() if isinstance(msg, dict) else msg for msg in messages]
+            if isinstance(messages, list)
+            else messages
+        ) if messages is not None else None
         self.stream = stream
         self.start_time = start_time  # log the call start time
         self.call_type = call_type


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring
✅ Test
Performance 

## Changes

Replace copy.deepcopy(messages) with shallow dict copy. Safe because proxy's update_messages() overwrites self.messages before reads, and no code mutates nested message objects in-place.

I profiled the before and after of this change only with this message

[{"role": "user", "content": "Hey"}]

In real world scenarios, this would end up being much more useful when messages ends up being much longer. In the benchmark I ran it ended up being a 20% speed increase for the construction of Logging objects. 

Tested these edge cases locally

<img width="1018" height="186" alt="Screenshot 2026-02-10 at 3 02 18 PM" src="https://github.com/user-attachments/assets/385f7b01-5243-4e9e-bee6-0fa6de9c3765" />

Before 

<img width="989" height="91" alt="Screenshot 2026-02-10 at 3 08 00 PM" src="https://github.com/user-attachments/assets/79b20934-bf20-4f76-93c0-c4b02dda348d" />

After

<img width="942" height="154" alt="Screenshot 2026-02-10 at 3 08 10 PM" src="https://github.com/user-attachments/assets/0415e7c9-e6af-4b76-bf92-e2f52cc93326" />


