### PR TITLE
[Feature] UI - Login: New Login With SSO Button

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -395,7 +395,7 @@ router_settings:
 | ATHINA_API_KEY | API key for Athina service
 | ATHINA_BASE_URL | Base URL for Athina service (defaults to `https://log.athina.ai`)
 | AUTH_STRATEGY | Strategy used for authentication (e.g., OAuth, API key)
-| AUTO_REDIRECT_UI_LOGIN_TO_SSO | Flag to enable automatic redirect of UI login page to SSO when SSO is configured. Default is **true**
+| AUTO_REDIRECT_UI_LOGIN_TO_SSO | Flag to enable automatic redirect of UI login page to SSO when SSO is configured. Default is **false**
 | AUDIO_SPEECH_CHUNK_SIZE | Chunk size for audio speech processing. Default is 1024
 | ANTHROPIC_API_KEY | API key for Anthropic service
 | ANTHROPIC_API_BASE | Base URL for Anthropic API. Default is https://api.anthropic.com

--- a/litellm/proxy/discovery_endpoints/ui_discovery_endpoints.py
+++ b/litellm/proxy/discovery_endpoints/ui_discovery_endpoints.py
@@ -19,13 +19,15 @@ async def get_ui_config():
     from litellm.proxy.utils import get_proxy_base_url, get_server_root_path
 
     auto_redirect_ui_login_to_sso = (
-        os.getenv("AUTO_REDIRECT_UI_LOGIN_TO_SSO", "true").lower() == "true"
+        os.getenv("AUTO_REDIRECT_UI_LOGIN_TO_SSO", "false").lower() == "true"
     )
     admin_ui_disabled = os.getenv("DISABLE_ADMIN_UI", "false").lower() == "true"
 
+    sso_configured = _has_user_setup_sso()
     return UiDiscoveryEndpoints(
         server_root_path=get_server_root_path(),
         proxy_base_url=get_proxy_base_url(),
-        auto_redirect_to_sso=_has_user_setup_sso() and auto_redirect_ui_login_to_sso,
+        auto_redirect_to_sso=sso_configured and auto_redirect_ui_login_to_sso,
         admin_ui_disabled=admin_ui_disabled,
+        sso_configured=sso_configured,
     )

--- a/litellm/types/proxy/discovery_endpoints/ui_discovery_endpoints.py
+++ b/litellm/types/proxy/discovery_endpoints/ui_discovery_endpoints.py
@@ -8,3 +8,4 @@ class UiDiscoveryEndpoints(BaseModel):
     proxy_base_url: Optional[str]
     auto_redirect_to_sso: bool
     admin_ui_disabled: bool
+    sso_configured: bool

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/uiConfig/useUIConfig.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/uiConfig/useUIConfig.test.ts
@@ -23,6 +23,7 @@ vi.mock("../common/queryKeysFactory", () => ({
 
 // Mock data
 const mockUIConfig: LiteLLMWellKnownUiConfig = {
+  sso_configured: true,
   server_root_path: "/api",
   proxy_base_url: "https://proxy.example.com",
   auto_redirect_to_sso: true,
@@ -99,6 +100,7 @@ describe("useUIConfig", () => {
       server_root_path: "/v1",
       proxy_base_url: null,
       auto_redirect_to_sso: false,
+      sso_configured: false,
       admin_ui_disabled: true,
     };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
@@ -90,6 +90,7 @@ describe("useAuthorized", () => {
       proxy_base_url: null,
       auto_redirect_to_sso: false,
       admin_ui_disabled: false,
+      sso_configured: false,
     });
     
     const decodedPayload = {
@@ -131,6 +132,7 @@ describe("useAuthorized", () => {
       proxy_base_url: null,
       auto_redirect_to_sso: false,
       admin_ui_disabled: false,
+      sso_configured: false,
     });
 
     decodeTokenMock.mockReturnValue(null);
@@ -155,6 +157,7 @@ describe("useAuthorized", () => {
       proxy_base_url: null,
       auto_redirect_to_sso: false,
       admin_ui_disabled: true,
+      sso_configured: false,
     });
 
     const decodedPayload = {
@@ -190,6 +193,7 @@ describe("useAuthorized", () => {
       proxy_base_url: null,
       auto_redirect_to_sso: false,
       admin_ui_disabled: false,
+      sso_configured: false,
     });
 
     decodeTokenMock.mockReturnValue(null);
@@ -212,6 +216,7 @@ describe("useAuthorized", () => {
       proxy_base_url: null,
       auto_redirect_to_sso: false,
       admin_ui_disabled: false,
+      sso_configured: false,
     });
 
     const decodedPayload = {

--- a/ui/litellm-dashboard/src/app/login/LoginPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.test.tsx
@@ -64,7 +64,12 @@ describe("LoginPage", () => {
 
   it("should render", async () => {
     (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
-      data: { auto_redirect_to_sso: false, server_root_path: "/", proxy_base_url: null },
+      data: {
+        auto_redirect_to_sso: false,
+        server_root_path: "/",
+        proxy_base_url: null,
+        sso_configured: false,
+      },
       isLoading: false,
     });
     (getCookie as ReturnType<typeof vi.fn>).mockReturnValue(null);
@@ -84,7 +89,12 @@ describe("LoginPage", () => {
   it("should call router.replace to dashboard when jwt is valid", async () => {
     const validToken = "valid-token";
     (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
-      data: { auto_redirect_to_sso: false, server_root_path: "/", proxy_base_url: null },
+      data: {
+        auto_redirect_to_sso: false,
+        server_root_path: "/",
+        proxy_base_url: null,
+        sso_configured: false,
+      },
       isLoading: false,
     });
     (getCookie as ReturnType<typeof vi.fn>).mockReturnValue(validToken);
@@ -105,7 +115,12 @@ describe("LoginPage", () => {
   it("should call router.push to SSO when jwt is invalid and auto_redirect_to_sso is true", async () => {
     const invalidToken = "invalid-token";
     (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
-      data: { auto_redirect_to_sso: true, server_root_path: "/", proxy_base_url: null },
+      data: {
+        auto_redirect_to_sso: true,
+        server_root_path: "/",
+        proxy_base_url: null,
+        sso_configured: true,
+      },
       isLoading: false,
     });
     (getCookie as ReturnType<typeof vi.fn>).mockReturnValue(invalidToken);
@@ -126,7 +141,12 @@ describe("LoginPage", () => {
   it("should not call router when jwt is invalid and auto_redirect_to_sso is false", async () => {
     const invalidToken = "invalid-token";
     (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
-      data: { auto_redirect_to_sso: false, server_root_path: "/", proxy_base_url: null },
+      data: {
+        auto_redirect_to_sso: false,
+        server_root_path: "/",
+        proxy_base_url: null,
+        sso_configured: false,
+      },
       isLoading: false,
     });
     (getCookie as ReturnType<typeof vi.fn>).mockReturnValue(invalidToken);
@@ -150,7 +170,12 @@ describe("LoginPage", () => {
   it("should send user to dashboard when jwt is valid even if auto_redirect_to_sso is true", async () => {
     const validToken = "valid-token";
     (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
-      data: { auto_redirect_to_sso: true, server_root_path: "/", proxy_base_url: null },
+      data: {
+        auto_redirect_to_sso: true,
+        server_root_path: "/",
+        proxy_base_url: null,
+        sso_configured: true,
+      },
       isLoading: false,
     });
     (getCookie as ReturnType<typeof vi.fn>).mockReturnValue(validToken);
@@ -172,7 +197,12 @@ describe("LoginPage", () => {
 
   it("should show alert when admin_ui_disabled is true", async () => {
     (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
-      data: { admin_ui_disabled: true, server_root_path: "/", proxy_base_url: null },
+      data: {
+        admin_ui_disabled: true,
+        server_root_path: "/",
+        proxy_base_url: null,
+        sso_configured: false,
+      },
       isLoading: false,
     });
     (getCookie as ReturnType<typeof vi.fn>).mockReturnValue(null);
@@ -191,5 +221,61 @@ describe("LoginPage", () => {
 
     expect(mockPush).not.toHaveBeenCalled();
     expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("should show Login with SSO button when sso_configured is true", async () => {
+    (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        auto_redirect_to_sso: false,
+        server_root_path: "/",
+        proxy_base_url: null,
+        sso_configured: true,
+      },
+      isLoading: false,
+    });
+    (getCookie as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    (isJwtExpired as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <LoginPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Login" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: "Login with SSO" })).toBeInTheDocument();
+  });
+
+  it("should show disabled Login with SSO button with popover when sso_configured is false", async () => {
+    (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        auto_redirect_to_sso: false,
+        server_root_path: "/",
+        proxy_base_url: null,
+        sso_configured: false,
+      },
+      isLoading: false,
+    });
+    (getCookie as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    (isJwtExpired as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <LoginPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Login" })).toBeInTheDocument();
+    });
+
+    const ssoButton = screen.getByRole("button", { name: "Login with SSO" });
+    expect(ssoButton).toBeInTheDocument();
+    expect(ssoButton).toBeDisabled();
   });
 });

--- a/ui/litellm-dashboard/src/app/login/LoginPage.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.tsx
@@ -8,7 +8,7 @@ import { getCookie } from "@/utils/cookieUtils";
 import { isJwtExpired } from "@/utils/jwtUtils";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Alert, Button, Card, Form, Input, Space, Typography } from "antd";
+import { Alert, Button, Card, Form, Input, Popover, Space, Typography } from "antd";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
@@ -179,7 +179,31 @@ function LoginPageContent() {
                 {isLoginLoading ? "Logging in..." : "Login"}
               </Button>
             </Form.Item>
+            <Form.Item>
+              {!uiConfig?.sso_configured ? (
+                <Popover
+                  content="Please configure SSO to log in with SSO."
+                  trigger="hover"
+                >
+                  <Button disabled block size="large">
+                    Login with SSO
+                  </Button>
+                </Popover>
+              ) : (
+                <Button
+                  disabled={isLoginLoading}
+                  onClick={() =>
+                    router.push(`${getProxyBaseUrl()}/sso/key/generate`)
+                  }
+                  block
+                  size="large"
+                >
+                  Login with SSO
+                </Button>
+              )}
+            </Form.Item>
           </Form>
+
         </Space>
       </Card>
     </div>

--- a/ui/litellm-dashboard/src/app/login/LoginPage.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.tsx
@@ -203,8 +203,15 @@ function LoginPageContent() {
               )}
             </Form.Item>
           </Form>
-
         </Space>
+        {uiConfig?.sso_configured && (
+          <Alert
+            type="info"
+            showIcon
+            closable
+            message={<Text>Single Sign-On (SSO) is enabled. LiteLLM no longer automatically redirects to the SSO login flow upon loading this page. To re-enable auto-redirect-to-SSO, set <Text code>AUTO_REDIRECT_UI_LOGIN_TO_SSO=true</Text> in your environment configuration.</Text>}
+          />
+        )}
       </Card>
     </div>
   );

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.test.tsx
@@ -71,6 +71,7 @@ describe("ModelHubTable", () => {
       proxy_base_url: "http://localhost:4000",
       auto_redirect_to_sso: false,
       admin_ui_disabled: false,
+      sso_configured: false,
     });
     vi.mocked(networking.modelHubPublicModelsCall).mockResolvedValue([]);
     vi.mocked(networking.getUiSettings).mockResolvedValue({
@@ -140,6 +141,7 @@ describe("ModelHubTable", () => {
       proxy_base_url: "http://localhost:4000",
       auto_redirect_to_sso: false,
       admin_ui_disabled: false,
+      sso_configured: false,
     });
     modelHubPublicModelsCallMock.mockResolvedValue([]);
     vi.mocked(networking.getUiSettings).mockResolvedValue({

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -259,6 +259,7 @@ export interface LiteLLMWellKnownUiConfig {
   proxy_base_url: string | null;
   auto_redirect_to_sso: boolean;
   admin_ui_disabled: boolean;
+  sso_configured: boolean;
 }
 
 export interface CredentialsResponse {


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature  
✅ Test

## Changes

- **Default behavior**: `AUTO_REDIRECT_UI_LOGIN_TO_SSO` now defaults to `false` instead of `true`. When SSO is configured, users see the login form by default instead of being automatically redirected to SSO.
- **Login with SSO button**: Added a "Login with SSO" button on the login page. When SSO is configured, the button navigates to the SSO flow. When SSO is not configured, the button is disabled and shows a popover prompting the user to configure SSO.
- **Discovery endpoint**: The `/.well-known/litellm-ui-config` endpoint now includes `sso_configured` so the UI can conditionally render the SSO button.
- Tests added for the new default and the Login with SSO button behavior.

## Screenshots
<img width="643" height="802" alt="image" src="https://github.com/user-attachments/assets/3e975d8f-77a3-4872-8bef-5869c1a72c84" />
<img width="675" height="175" alt="image" src="https://github.com/user-attachments/assets/34f4c175-12eb-4b19-83db-36f959419ca6" />
<img width="816" height="179" alt="image" src="https://github.com/user-attachments/assets/ca64b7af-86c0-4d7c-9c2e-667cdac8ea9c" />
