### PR TITLE
fix(ui): remove duplicate URL in tagsSpendLogsCall query string

### DIFF
--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2424,7 +2424,7 @@ export const tagsSpendLogsCall = async (
 
     // if tags, convert the list to a comma separated string
     if (tags) {
-      url += `${url}&tags=${tags.join(",")}`;
+      url += `&tags=${tags.join(",")}`;
     }
 
     console.log("in tagsSpendLogsCall:", url);


### PR DESCRIPTION
## Relevant issues

Supersedes #8793 (original fix by @Mte90, now stale due to age).

The `tagsSpendLogsCall` function in `networking.tsx` constructs a malformed URL when tags are provided. The `+=` operator combined with `${url}` inside the template literal causes the entire URL to be doubled:

```javascript
// Bug (line 2427): url is duplicated via += and ${url}
url += `${url}&tags=${tags.join(",")}`;
// Result: "/global/spend/tags?start_date=...&end_date=.../global/spend/tags?start_date=...&end_date=...&tags=foo,bar"

// Fix: remove ${url} from the template literal
url += `&tags=${tags.join(",")}`;
// Result: "/global/spend/tags?start_date=...&end_date=...&tags=foo,bar"
```

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

- Removed `${url}` from the template literal in `tagsSpendLogsCall` (line 2427 of `networking.tsx`), which was causing the full URL to be duplicated when tags were appended via `+=`.