### PR TITLE
fix: output_cost_per_token missing for azure/gpt-image-1.5

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4318,6 +4318,7 @@
         "input_cost_per_image_token": 8e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
+        "output_cost_per_token": 1e-05,
         "output_cost_per_image_token": 3.2e-05,
         "supported_endpoints": [
             "/v1/images/generations",
@@ -4331,6 +4332,7 @@
         "input_cost_per_image_token": 8e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
+        "output_cost_per_token": 1e-05,
         "output_cost_per_image_token": 3.2e-05,
         "supported_endpoints": [
             "/v1/images/generations",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4318,6 +4318,7 @@
         "input_cost_per_image_token": 8e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
+        "output_cost_per_token": 1e-05,
         "output_cost_per_image_token": 3.2e-05,
         "supported_endpoints": [
             "/v1/images/generations",
@@ -4331,6 +4332,7 @@
         "input_cost_per_image_token": 8e-06,
         "litellm_provider": "azure",
         "mode": "image_generation",
+        "output_cost_per_token": 1e-05,
         "output_cost_per_image_token": 3.2e-05,
         "supported_endpoints": [
             "/v1/images/generations",

--- a/tests/test_litellm/test_gpt_image_cost_calculator.py
+++ b/tests/test_litellm/test_gpt_image_cost_calculator.py
@@ -273,6 +273,8 @@ class TestGPTImage15OutputImageTokens:
         """
         Test that output tokens are correctly calculated in cost calculation for Azure.
         """
+        # Set environment variable to use local model cost map
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
         # Simulate gpt-image-1.5 response with output_tokens_details
         usage = Usage(
             prompt_tokens=200,

--- a/tests/test_litellm/test_gpt_image_cost_calculator.py
+++ b/tests/test_litellm/test_gpt_image_cost_calculator.py
@@ -269,9 +269,9 @@ class TestGPTImage15OutputImageTokens:
             f"Image tokens may not be included in cost calculation."
         )
     
-    def test_azure_gpt_image_15_output_image_tokens_cost(self):
+    def test_azure_gpt_image_15_output_tokens_cost(self):
         """
-        Test that output image tokens are correctly included in cost calculation for Azure.
+        Test that output tokens are correctly calculated in cost calculation for Azure.
         """
         # Simulate gpt-image-1.5 response with output_tokens_details
         usage = Usage(
@@ -316,7 +316,7 @@ class TestGPTImage15OutputImageTokens:
 
         assert abs(cost - expected_cost) < 1e-6, (
             f"Expected {expected_cost}, got {cost}. "
-            f"Image tokens may not be included in cost calculation."
+            f"Output tokens may be calculated in a wrong rate for Azure."
         )
 
 

--- a/tests/test_litellm/test_gpt_image_cost_calculator.py
+++ b/tests/test_litellm/test_gpt_image_cost_calculator.py
@@ -268,6 +268,56 @@ class TestGPTImage15OutputImageTokens:
             f"Expected {expected_cost}, got {cost}. "
             f"Image tokens may not be included in cost calculation."
         )
+    
+    def test_azure_gpt_image_15_output_image_tokens_cost(self):
+        """
+        Test that output image tokens are correctly included in cost calculation for Azure.
+        """
+        # Simulate gpt-image-1.5 response with output_tokens_details
+        usage = Usage(
+            prompt_tokens=200,
+            completion_tokens=4800,
+            total_tokens=5000,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                text_tokens=200,
+                image_tokens=0,
+            ),
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                text_tokens=600,
+                image_tokens=4200,
+            ),
+        )
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(b64_json="test")],
+        )
+        image_response.usage = usage
+        image_response._hidden_params = {"custom_llm_provider": "azure"}
+
+        cost = litellm.completion_cost(
+            completion_response=image_response,
+            model="gpt-image-1.5",
+            call_type="image_generation",
+            custom_llm_provider="azure",
+        )
+
+        # Azure gpt-image-1.5 pricing:
+        # - input_cost_per_token: 5e-06 ($5/1M for text input)
+        # - output_cost_per_token: 1e-05 ($10/1M for text output)
+        # - output_cost_per_image_token: 3.2e-05 ($32/1M for image output)
+        #
+        # Expected cost:
+        # Input text: 200 * $5/1M = $0.001
+        # Output text: 600 * $10/1M = $0.006
+        # Output image: 4200 * $32/1M = $0.1344
+        # Total: $0.1414
+        expected_cost = 200 * 5e-06 + 600 * 1e-05 + 4200 * 3.2e-05
+
+        assert abs(cost - expected_cost) < 1e-6, (
+            f"Expected {expected_cost}, got {cost}. "
+            f"Image tokens may not be included in cost calculation."
+        )
 
 
 class TestCompletionCostIntegration:


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes #21902 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

Add output_cost_per_tokens for 'azure/gpt-image-1.5'