### PR TITLE
Add provider_specific_fields to StreamingChoices to fix Pydantic serialization warnings

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1577,6 +1577,8 @@ class Usage(SafeAttributeModel, CompletionUsage):
 
 
 class StreamingChoices(OpenAIObject):
+    provider_specific_fields: Optional[Dict[str, Any]] = Field(default=None)
+
     def __init__(
         self,
         finish_reason=None,
@@ -1584,12 +1586,14 @@ class StreamingChoices(OpenAIObject):
         delta: Optional[Delta] = None,
         logprobs=None,
         enhancements=None,
+        provider_specific_fields: Optional[Dict[str, Any]] = None,
         **params,
     ):
         # Fix Perplexity return both delta and message cause OpenWebUI repect text
         # https://github.com/BerriAI/litellm/issues/8455
         params.pop("message", None)
         super(StreamingChoices, self).__init__(**params)
+        add_provider_specific_fields(self, provider_specific_fields)
         if finish_reason:
             self.finish_reason = map_finish_reason(finish_reason)
         else:


### PR DESCRIPTION
## Superseded

This PR is superseded by #20945, which addresses both #17631 and #18801 in a single commit (both issues share the same root cause: undeclared Pydantic fields on `StreamingChoices`).