### PR TITLE
fix(vertex_ai): forward extra_body to completion transformation handler

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -681,6 +681,7 @@ def responses(
                 _is_async=_is_async,
                 stream=stream,
                 extra_headers=extra_headers,
+                extra_body=extra_body,
                 **kwargs,
             )
 

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -352,3 +353,34 @@ class TestResponsesAPIProviderSpecificParams:
         # Should not raise any exception
         result = ResponsesAPIRequestUtils.get_requested_response_api_optional_param(params)
         assert "temperature" in result
+
+
+def test_responses_extra_body_forwarded_to_completion_transformation_handler():
+    """
+    Regression test: extra_body must be forwarded to response_api_handler
+    when responses_api_provider_config is None (completion transformation path).
+
+    Before the fix, extra_body was a named parameter of responses() but was
+    not passed to litellm_completion_transformation_handler.response_api_handler(),
+    so it was silently dropped.
+    """
+    with patch(
+        "litellm.responses.main.ProviderConfigManager.get_provider_responses_api_config",
+        return_value=None,
+    ), patch(
+        "litellm.responses.main.litellm_completion_transformation_handler.response_api_handler",
+    ) as mock_handler:
+        mock_handler.return_value = MagicMock()
+
+        litellm.responses(
+            model="openai/gpt-4o",
+            input="Hello",
+            extra_body={"custom_key": "custom_value"},
+        )
+
+        mock_handler.assert_called_once()
+        call_kwargs = mock_handler.call_args
+        # extra_body can be a positional or keyword arg; check both
+        assert call_kwargs.kwargs.get("extra_body") == {
+            "custom_key": "custom_value"
+        }


### PR DESCRIPTION
 ## Summary
  - **Responses API**: `responses()` accepted `extra_body` as a parameter but did not pass it to
  `response_api_handler` when `responses_api_provider_config` is `None` (completion transformation path), silently
  dropping it.
  - **Vertex AI Gemini**: Added deep-merge support for `extra_body` in `_transform_request_body`, so dict values
  like `generationConfig` are merged rather than replaced—preserving both normal params and `extra_body` additions
  (e.g. `responseModalities`, `imageConfig`).

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
