### PR TITLE
fix: export PermissionDeniedError from litellm.__init__

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1155,6 +1155,7 @@ from .exceptions import (
     BadRequestError,
     ImageFetchError,
     NotFoundError,
+    PermissionDeniedError,
     RateLimitError,
     ServiceUnavailableError,
     BadGatewayError,

--- a/tests/test_litellm/test_exception_exports.py
+++ b/tests/test_litellm/test_exception_exports.py
@@ -1,0 +1,31 @@
+"""
+Test that all standard HTTP error exceptions are exported from litellm.__init__.
+"""
+
+import litellm
+
+
+def test_permission_denied_error_is_exported():
+    """PermissionDeniedError (403) should be accessible as litellm.PermissionDeniedError."""
+    assert hasattr(litellm, "PermissionDeniedError")
+    assert litellm.PermissionDeniedError is not None
+
+
+def test_all_http_error_exceptions_exported():
+    """All standard HTTP error exceptions should be accessible at module level."""
+    expected_exceptions = [
+        "BadRequestError",           # 400
+        "AuthenticationError",       # 401
+        "PermissionDeniedError",     # 403
+        "NotFoundError",             # 404
+        "Timeout",                   # 408
+        "UnprocessableEntityError",  # 422
+        "RateLimitError",            # 429
+        "InternalServerError",       # 500
+        "BadGatewayError",           # 502
+        "ServiceUnavailableError",   # 503
+    ]
+    for exc_name in expected_exceptions:
+        assert hasattr(litellm, exc_name), (
+            f"litellm.{exc_name} is not exported from litellm.__init__"
+        )


### PR DESCRIPTION
## Summary

`PermissionDeniedError` (403) is defined in `litellm/exceptions.py` but was never added to the `from .exceptions import (...)` block in `litellm/__init__.py`. This makes it the only standard HTTP error exception not accessible at module level.

```python
import litellm

# Works for every other HTTP error:
litellm.AuthenticationError      # 401 ✅
litellm.NotFoundError            # 404 ✅
litellm.RateLimitError           # 429 ✅

# But not this one:
litellm.PermissionDeniedError    # 403 ❌ AttributeError
```

## Changes

- **`litellm/__init__.py`**: Add `PermissionDeniedError` to the exception imports (1 line)
- **`tests/test_litellm/test_exception_exports.py`**: Add tests verifying all standard HTTP error exceptions are exported

Fixes #20959