### PR TITLE
Fix LoggingWorker RuntimeError when event loop changes

### DIFF
--- a/tests/test_litellm/litellm_core_utils/test_logging_worker.py
+++ b/tests/test_litellm/litellm_core_utils/test_logging_worker.py
@@ -5,6 +5,7 @@ Tests for the LoggingWorker class to ensure graceful shutdown handling.
 import asyncio
 import contextvars
 from unittest.mock import AsyncMock, patch
+import unittest.mock as mock
 
 import pytest
 
@@ -380,7 +381,6 @@ class TestLoggingWorker:
         # RuntimeError about a stale queue and exits instead of crashing.
         # We test this by directly calling _worker_loop with a queue bound
         # to a *different* loop (mock).
-        import unittest.mock as mock
 
         old_queue = worker._queue
         fake_old_loop = mock.MagicMock()
@@ -416,8 +416,6 @@ class TestLoggingWorker:
 
         This tests the fix for GitHub issue #14521.
         """
-        import unittest.mock as mock
-
         worker = LoggingWorker(timeout=1.0, max_queue_size=10)
 
         # Start the worker


### PR DESCRIPTION
## Summary

Fixes #14521 
Fixes #16518

When `pytest-asyncio` (or any framework) creates a new event loop per test, the `GLOBAL_LOGGING_WORKER` singleton retains a `Queue` bound to the old (now-closed) loop. This causes `RuntimeError: Queue is bound to a different event loop` in the worker loop, which surfaces as `Task exception was never retrieved` warnings. On Python <= 3.11, the use of `asyncio.get_event_loop()` in `clear_queue()` can also cause hangs.

## Root cause

The existing `_ensure_queue()` already detects event loop changes and reinitializes state, but:

1. **It does not suppress exceptions on the old done tasks** before dropping their references. When Python's GC collects these tasks, it reports "Task exception was never retrieved."
2. **`_worker_loop()` only catches `CancelledError`**, not the `RuntimeError` from stale queue operations. When the old loop closes, `await self._queue.get()` raises `RuntimeError` which propagates unhandled.
3. **`clear_queue()` uses the deprecated `asyncio.get_event_loop()`** instead of `asyncio.get_running_loop()`, which can cause hangs on Python <= 3.11 when no running loop exists.

## Fix

- `_ensure_queue()`: Before dropping old task references, call `.exception()` on done tasks to mark their exceptions as retrieved, preventing GC warnings.
- `_worker_loop()`: Add `except RuntimeError` handler for the "bound to a different event loop" error, exiting the loop gracefully instead of leaving an unhandled exception.
- `clear_queue()`: Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()`.

## Test plan

Added three focused regression tests:
- `test_worker_loop_handles_stale_event_loop_gracefully` — verifies the worker loop exits cleanly when the queue raises a stale-loop `RuntimeError`
- `test_ensure_queue_suppresses_old_task_exceptions` — verifies old done tasks have their exceptions retrieved before reference is dropped
- `test_clear_queue_uses_get_running_loop` — verifies `clear_queue` works correctly (uses `get_running_loop()` internally)

All 13 tests in `test_logging_worker.py` pass (10 existing + 3 new).