### PR TITLE
Add bounds checking for deployment index lookups in Router

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6523,15 +6523,18 @@ class Router:
         # O(1) lookup in model_name index
         if model_group_name in self.model_name_to_deployment_indices:
             indices = self.model_name_to_deployment_indices[model_group_name]
-            if indices and indices[0] < len(self.model_list):
-                # Return first deployment for this model_name
-                model = self.model_list[indices[0]]
+            for idx in indices:
+                if idx >= len(self.model_list):
+                    continue
+                model = self.model_list[idx]
                 if isinstance(model, dict):
                     return Deployment(**model)
                 elif isinstance(model, Deployment):
                     return model
                 else:
-                    raise Exception("Model Name invalid - {}".format(type(model)))
+                    raise Exception(
+                        "Model Name invalid - {}".format(type(model))
+                    )
         return None
 
     def get_deployment_credentials_with_provider(


### PR DESCRIPTION
## Summary

Fixes #15521.

When a deployment is deleted from a model group (via `/model/delete`) while another request is in-flight, there is a brief race condition window between `model_list.pop()` and `_update_deployment_indices_after_removal()` where the cached indices in `model_name_to_deployment_indices` (and `model_id_to_deployment_index_map`) point beyond the end of `model_list`. Accessing `model_list[idx]` with a stale index raises `IndexError: list index out of range`, crashing the request with a 500.

## Root cause

The `delete_deployment` method first pops the deployment from `model_list` (shrinking it), then calls `_update_deployment_indices_after_removal()` to adjust all stored indices. Between these two operations, any concurrent reader that looks up a deployment by model name or model ID will use the old (now out-of-bounds) index, causing the `IndexError`.

## Fix

Added bounds checking (`idx >= len(self.model_list)`) to all five index-based lookup paths in the Router:

- `_get_all_deployments()` — used by `get_model_list()`
- `get_deployment()` — returns `None` for stale index
- `get_deployment_by_model()` — raw dict lookup, returns `None`
- `get_deployment_by_model_group_name()` — returns `None`
- `get_model_ids()` — skips stale index

When a stale index is encountered, the lookup silently skips it or returns `None`, which is correct since the deployment no longer exists. This is a defensive guard that prevents crashes without masking the underlying race — the index update still runs immediately after.

## Test plan

Added `test_stale_index_after_deployment_deletion_does_not_crash`:
1. Creates a router with two deployments under the same model name
2. Deletes one deployment and verifies the other remains accessible
3. Artificially injects stale indices (simulating the race window)
4. Verifies `get_model_list()` and `get_deployment()` handle stale indices gracefully without `IndexError`