### PR TITLE
fix: daily activity endpoints return incomplete data for long date range

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -624,7 +624,7 @@ class CustomGuardrail(CustomLogger):
         This gets logged on downsteam Langfuse, DataDog, etc.
         """
         # Convert None to empty dict to satisfy type requirements
-        guardrail_response = {} if response is None else response
+        guardrail_response: Union[Dict, str] = {} if response is None else response
 
         # For apply_guardrail functions in custom_code_guardrail scenario,
         # simplify the logged response to "allow", "deny", or "mask"

--- a/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 import httpx
 
-from litellm.anthropic_beta_headers_manager import filter_and_transform_beta_headers
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
     AmazonInvokeConfig,

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -12,9 +12,6 @@ from typing import (
 
 import httpx
 
-from litellm.anthropic_beta_headers_manager import (
-    filter_and_transform_beta_headers,
-)
 from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,

--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -24,7 +24,10 @@ from litellm.types.agents import (
     PatchAgentRequest,
 )
 
-from litellm.proxy.management_endpoints.common_daily_activity import get_daily_activity
+from litellm.proxy.management_endpoints.common_daily_activity import (
+    get_daily_activity,
+    get_daily_activity_aggregated,
+)
 from litellm.types.proxy.management_endpoints.common_daily_activity import (
     SpendAnalyticsPaginatedResponse,
 )
@@ -768,4 +771,65 @@ async def get_agent_daily_activity(
         api_key=api_key,
         page=page,
         page_size=page_size,
+    )
+
+
+@router.get(
+    "/agent/daily/activity/aggregated",
+    tags=["Agent Management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=SpendAnalyticsPaginatedResponse,
+)
+async def get_agent_daily_activity_aggregated(
+    agent_ids: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    exclude_agent_ids: Optional[str] = None,
+    timezone: Optional[int] = None,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Get aggregated daily activity for specific agents or all accessible agents (no pagination).
+    Returns the full date range in a single response.
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
+
+    agent_ids_list = agent_ids.split(",") if agent_ids else None
+    exclude_agent_ids_list: Optional[List[str]] = None
+    if exclude_agent_ids:
+        exclude_agent_ids_list = (
+            exclude_agent_ids.split(",") if exclude_agent_ids else None
+        )
+
+    where_condition = {}
+    if agent_ids_list:
+        where_condition["agent_id"] = {"in": list(agent_ids_list)}
+
+    agent_records = await prisma_client.db.litellm_agentstable.find_many(
+        where=where_condition
+    )
+    agent_metadata = {
+        agent.agent_id: {"agent_name": agent.agent_name} for agent in agent_records
+    }
+
+    return await get_daily_activity_aggregated(
+        prisma_client=prisma_client,
+        table_name="litellm_dailyagentspend",
+        entity_id_field="agent_id",
+        entity_id=agent_ids_list,
+        entity_metadata_field=agent_metadata,
+        exclude_entity_ids=exclude_agent_ids_list,
+        start_date=start_date,
+        end_date=end_date,
+        model=model,
+        api_key=api_key,
+        timezone_offset_minutes=timezone,
     )

--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
@@ -330,6 +330,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         end_time: Optional[float] = None,
         duration: Optional[float] = None,
         event_type: Optional[GuardrailEventHooks] = None,
+        original_inputs: Optional[Dict] = None,
     ):
         """
         Override to store only the Model Armor API response, not the entire data dict.

--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -588,7 +588,7 @@ async def get_daily_activity_aggregated(
     start_date: Optional[str],
     end_date: Optional[str],
     model: Optional[str],
-    api_key: Optional[str],
+    api_key: Optional[Union[str, List[str]]],
     exclude_entity_ids: Optional[List[str]] = None,
     timezone_offset_minutes: Optional[int] = None,
 ) -> SpendAnalyticsPaginatedResponse:

--- a/litellm/proxy/management_endpoints/customer_endpoints.py
+++ b/litellm/proxy/management_endpoints/customer_endpoints.py
@@ -23,7 +23,10 @@ from litellm.proxy.utils import handle_exception_on_proxy
 from litellm.types.proxy.management_endpoints.common_daily_activity import (
     SpendAnalyticsPaginatedResponse,
 )
-from litellm.proxy.management_endpoints.common_daily_activity import get_daily_activity
+from litellm.proxy.management_endpoints.common_daily_activity import (
+    get_daily_activity,
+    get_daily_activity_aggregated,
+)
 
 router = APIRouter()
 
@@ -751,4 +754,73 @@ async def get_customer_daily_activity(
         api_key=api_key,
         page=page,
         page_size=page_size,
+    )
+
+
+@router.get(
+    "/customer/daily/activity/aggregated",
+    tags=["Customer Management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=SpendAnalyticsPaginatedResponse,
+)
+@router.get(
+    "/end_user/daily/activity/aggregated",
+    tags=["Customer Management"],
+    include_in_schema=False,
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def get_customer_daily_activity_aggregated(
+    end_user_ids: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    exclude_end_user_ids: Optional[str] = None,
+    timezone: Optional[int] = None,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Get aggregated daily activity for specific customers or all customers (no pagination).
+    Returns the full date range in a single response.
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
+
+    # Parse comma-separated ids
+    end_user_ids_list = end_user_ids.split(",") if end_user_ids else None
+    exclude_end_user_ids_list: Optional[List[str]] = None
+    if exclude_end_user_ids:
+        exclude_end_user_ids_list = (
+            exclude_end_user_ids.split(",") if exclude_end_user_ids else None
+        )
+
+    # Fetch end user aliases for metadata
+    where_condition = {}
+    if end_user_ids_list:
+        where_condition["user_id"] = {"in": list(end_user_ids_list)}
+    end_user_aliases = await prisma_client.db.litellm_endusertable.find_many(
+        where=where_condition
+    )
+    end_user_alias_metadata = {
+        e.user_id: {"alias": e.alias}
+        for e in end_user_aliases
+    }
+
+    return await get_daily_activity_aggregated(
+        prisma_client=prisma_client,
+        table_name="litellm_dailyenduserspend",
+        entity_id_field="end_user_id",
+        entity_id=end_user_ids_list,
+        entity_metadata_field=end_user_alias_metadata,
+        exclude_entity_ids=exclude_end_user_ids_list,
+        start_date=start_date,
+        end_date=end_date,
+        model=model,
+        api_key=api_key,
+        timezone_offset_minutes=timezone,
     )

--- a/litellm/proxy/management_endpoints/tag_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tag_management_endpoints.py
@@ -577,7 +577,14 @@ async def get_tag_daily_activity_aggregated(
     Get aggregated daily activity for specific tags or all tags (no pagination).
     Returns the full date range in a single response.
     """
+    from litellm.proxy._types import CommonProxyErrors
     from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
 
     # Convert comma-separated tags string to list if provided
     tag_list = tags.split(",") if tags else None

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -79,6 +79,9 @@ from litellm.proxy.management_endpoints.common_utils import (
 from litellm.proxy.management_endpoints.tag_management_endpoints import (
     get_daily_activity,
 )
+from litellm.proxy.management_endpoints.common_daily_activity import (
+    get_daily_activity_aggregated,
+)
 from litellm.proxy.management_helpers.object_permission_utils import (
     _set_object_permission,
     handle_update_object_permission_common,
@@ -4012,4 +4015,133 @@ async def get_team_daily_activity(
         api_key=final_api_key_filter,
         page=page,
         page_size=page_size,
+    )
+
+
+@router.get(
+    "/team/daily/activity/aggregated",
+    response_model=SpendAnalyticsPaginatedResponse,
+    tags=["team management"],
+)
+async def get_team_daily_activity_aggregated(
+    team_ids: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    exclude_team_ids: Optional[str] = None,
+    timezone: Optional[int] = None,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Get aggregated daily activity for specific teams or all teams (no pagination).
+    Returns the full date range in a single response.
+    """
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
+
+    # Convert comma-separated tags string to list if provided
+    team_ids_list = team_ids.split(",") if team_ids else None
+    exclude_team_ids_list: Optional[List[str]] = None
+
+    if exclude_team_ids:
+        exclude_team_ids_list = (
+            exclude_team_ids.split(",") if exclude_team_ids else None
+        )
+
+    if not _user_has_admin_view(user_api_key_dict):
+        user_info = await get_user_object(
+            user_id=user_api_key_dict.user_id,
+            prisma_client=prisma_client,
+            user_id_upsert=False,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=user_api_key_dict.parent_otel_span,
+            proxy_logging_obj=proxy_logging_obj,
+            check_db_only=True,
+        )
+        if user_info is None:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": "User= {} not found".format(user_api_key_dict.user_id)
+                },
+            )
+
+        if team_ids_list is None:
+            team_ids_list = user_info.teams
+        else:
+            # check if all team_ids are in user_info.teams
+            for team_id in team_ids_list:
+                if team_id not in user_info.teams:
+                    raise HTTPException(
+                        status_code=404,
+                        detail={
+                            "error": "User does not belong to Team= {}. Call `/user/info` to see user's teams".format(
+                                team_id
+                            )
+                        },
+                    )
+
+    ## Fetch team aliases and check team admin status
+    where_condition = {}
+    if team_ids_list:
+        where_condition["team_id"] = {"in": list(team_ids_list)}
+    team_aliases = await prisma_client.db.litellm_teamtable.find_many(
+        where=where_condition
+    )
+    team_alias_metadata = {
+        t.team_id: {"team_alias": t.team_alias} for t in team_aliases
+    }
+
+    # Check if user is team admin for any requested teams
+    # If not, filter by user's API keys
+    user_api_keys: Optional[List[str]] = None
+    if not _user_has_admin_view(user_api_key_dict) and team_ids_list and team_aliases:
+        # Check if user is team admin for any of the teams
+        is_team_admin_for_any = False
+        for team_alias in team_aliases:
+            team_obj = LiteLLM_TeamTable(**team_alias.model_dump())
+            if _is_user_team_admin(
+                user_api_key_dict=user_api_key_dict, team_obj=team_obj
+            ):
+                is_team_admin_for_any = True
+                break
+
+        # If user is not a team admin for any team, filter by their API keys
+        if not is_team_admin_for_any:
+            # Get all API keys for this user
+            user_keys = await prisma_client.db.litellm_verificationtoken.find_many(
+                where={"user_id": user_api_key_dict.user_id}
+            )
+            user_api_keys = [key.token for key in user_keys if key.token]
+            # If user has no API keys, return empty result
+            if not user_api_keys:
+                user_api_keys = [""]  # Use empty string to ensure no matches
+
+    # If api_key parameter is provided, use it; otherwise use user_api_keys if set
+    final_api_key_filter: Optional[Union[str, List[str]]] = api_key
+    if final_api_key_filter is None and user_api_keys is not None:
+        final_api_key_filter = user_api_keys
+
+    return await get_daily_activity_aggregated(
+        prisma_client=prisma_client,
+        table_name="litellm_dailyteamspend",
+        entity_id_field="team_id",
+        entity_id=team_ids_list,
+        entity_metadata_field=team_alias_metadata,
+        exclude_entity_ids=exclude_team_ids_list,
+        start_date=start_date,
+        end_date=end_date,
+        model=model,
+        api_key=final_api_key_filter,
+        timezone_offset_minutes=timezone,
     )

--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
@@ -27,11 +27,11 @@ import { ActivityMetrics, processActivityData } from "../../../activity_metrics"
 import { UsageExportHeader } from "../../../EntityUsageExport";
 import type { EntityType } from "../../../EntityUsageExport/types";
 import {
-  agentDailyActivityCall,
-  customerDailyActivityCall,
-  organizationDailyActivityCall,
-  tagDailyActivityCall,
-  teamDailyActivityCall,
+  agentDailyActivityAggregatedCall,
+  customerDailyActivityAggregatedCall,
+  organizationDailyActivityAggregatedCall,
+  tagDailyActivityAggregatedCall,
+  teamDailyActivityAggregatedCall,
 } from "../../../networking";
 import { getProviderLogoAndName } from "../../../provider_info_helpers";
 import { BreakdownMetrics, DailyData, EntityMetricWithMetadata, KeyMetricWithMetadata, TagUsage } from "../../types";
@@ -112,47 +112,42 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
     const endTime = new Date(dateValue.to);
 
     if (entityType === "tag") {
-      const data = await tagDailyActivityCall(
+      const data = await tagDailyActivityAggregatedCall(
         accessToken,
         startTime,
         endTime,
-        1,
         selectedTags.length > 0 ? selectedTags : null,
       );
       setSpendData(data);
     } else if (entityType === "team") {
-      const data = await teamDailyActivityCall(
+      const data = await teamDailyActivityAggregatedCall(
         accessToken,
         startTime,
         endTime,
-        1,
         selectedTags.length > 0 ? selectedTags : null,
       );
       setSpendData(data);
     } else if (entityType === "organization") {
-      const data = await organizationDailyActivityCall(
+      const data = await organizationDailyActivityAggregatedCall(
         accessToken,
         startTime,
         endTime,
-        1,
         selectedTags.length > 0 ? selectedTags : null,
       );
       setSpendData(data);
     } else if (entityType === "customer") {
-      const data = await customerDailyActivityCall(
+      const data = await customerDailyActivityAggregatedCall(
         accessToken,
         startTime,
         endTime,
-        1,
         selectedTags.length > 0 ? selectedTags : null,
       );
       setSpendData(data);
     } else if (entityType === "agent") {
-      const data = await agentDailyActivityCall(
+      const data = await agentDailyActivityAggregatedCall(
         accessToken,
         startTime,
         endTime,
-        1,
         selectedTags.length > 0 ? selectedTags : null,
       );
       setSpendData(data);

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1841,6 +1841,92 @@ export const agentDailyActivityCall = async (
   });
 };
 
+export const tagDailyActivityAggregatedCall = async (
+  accessToken: string,
+  startTime: Date,
+  endTime: Date,
+  tags: string[] | null = null,
+) => {
+  return fetchDailyActivity({
+    accessToken,
+    endpoint: "/tag/daily/activity/aggregated",
+    startTime,
+    endTime,
+    extraQueryParams: {
+      tags,
+    },
+  });
+};
+
+export const teamDailyActivityAggregatedCall = async (
+  accessToken: string,
+  startTime: Date,
+  endTime: Date,
+  teamIds: string[] | null = null,
+) => {
+  return fetchDailyActivity({
+    accessToken,
+    endpoint: "/team/daily/activity/aggregated",
+    startTime,
+    endTime,
+    extraQueryParams: {
+      team_ids: teamIds,
+      exclude_team_ids: "litellm-dashboard",
+    },
+  });
+};
+
+export const organizationDailyActivityAggregatedCall = async (
+  accessToken: string,
+  startTime: Date,
+  endTime: Date,
+  organizationIds: string[] | null = null,
+) => {
+  return fetchDailyActivity({
+    accessToken,
+    endpoint: "/organization/daily/activity/aggregated",
+    startTime,
+    endTime,
+    extraQueryParams: {
+      organization_ids: organizationIds,
+    },
+  });
+};
+
+export const customerDailyActivityAggregatedCall = async (
+  accessToken: string,
+  startTime: Date,
+  endTime: Date,
+  customerIds: string[] | null = null,
+) => {
+  return fetchDailyActivity({
+    accessToken,
+    endpoint: "/customer/daily/activity/aggregated",
+    startTime,
+    endTime,
+    extraQueryParams: {
+      end_user_ids: customerIds,
+    },
+  });
+};
+
+export const agentDailyActivityAggregatedCall = async (
+  accessToken: string,
+  startTime: Date,
+  endTime: Date,
+  agentIds: string[] | null = null,
+) => {
+  return fetchDailyActivity({
+    accessToken,
+    endpoint: "/agent/daily/activity/aggregated",
+    startTime,
+    endTime,
+    extraQueryParams: {
+      agent_ids: agentIds,
+    },
+  });
+};
+
 export const getTotalSpendCall = async (accessToken: string) => {
   /**
    * Get all models on proxy


### PR DESCRIPTION
Add aggregated endpoints for team, organization, customer, tag, and agent daily activity that return the full date range in a single response instead of paginating at the database record level.

- Add /X/daily/activity/aggregated endpoints to 5 backend files
- Update frontend EntityUsage component to use aggregated endpoints
- Add test verifying all days are returned for large datasets

The original endpoints paginated at the record level (e.g., 324k records = 324 pages), causing the frontend to only display ~1 day of data when fetching page 1. The aggregated endpoints group by date first, then return all days at once.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
