### PR TITLE
fix: login error when database is not connected

### DIFF
--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -163,15 +163,16 @@ async def authenticate_user(  # noqa: PLR0915
         # Admin is Authe'd in - generate key for the UI to access Proxy
 
         # ensure this user is set as the proxy admin, in this route there is no sso, we can assume this user is only the admin
-        await user_update(
-            data=UpdateUserRequest(
-                user_id=key_user_id,
-                user_role=user_role,
-            ),
-            user_api_key_dict=UserAPIKeyAuth(
-                user_role=LitellmUserRoles.PROXY_ADMIN,
-            ),
-        )
+        if prisma_client is not None:
+            await user_update(
+                data=UpdateUserRequest(
+                    user_id=key_user_id,
+                    user_role=user_role,
+                ),
+                user_api_key_dict=UserAPIKeyAuth(
+                    user_role=LitellmUserRoles.PROXY_ADMIN,
+                ),
+            )
 
         if os.getenv("DATABASE_URL") is not None:
             response = await generate_key_helper_fn(


### PR DESCRIPTION
fix: #20918

- fixes UI login failure when database is not connected

- previously, attempting to login to the UI with UI_USERNAME/UI_PASSWORD would fail with "Not connected to DB!" error even when credentials were correct. 
- This happened because authenticate_user() was calling user_update() without first checking if a database connection exists.

- the fix adds a simple guard check to only call user_update() when prisma_client is available, 
- preventing the premature exception and allowing the login flow to proceed properly.