### PR TITLE
fix(logging): avoid shared callback list references

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3127,7 +3127,7 @@ class Logging(LiteLLMLoggingBaseClass):
         self, dynamic_success_callbacks: Optional[List], global_callbacks: List
     ) -> List:
         if dynamic_success_callbacks is None:
-            return global_callbacks
+            return list(global_callbacks)
         return list(set(dynamic_success_callbacks + global_callbacks))
 
     def _remove_internal_litellm_callbacks(self, callbacks: List) -> List:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -740,7 +740,7 @@ class ProxyLogging:
         self, dynamic_success_callbacks: Optional[List], global_callbacks: List
     ) -> List:
         if dynamic_success_callbacks is None:
-            return global_callbacks
+            return list(global_callbacks)
         return list(set(dynamic_success_callbacks + global_callbacks))
 
     def _parse_pre_mcp_call_hook_response(

--- a/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
+++ b/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
@@ -293,3 +293,29 @@ def test_get_combined_callback_list():
     assert "lago" in _logging.get_combined_callback_list(
         dynamic_success_callbacks=["langfuse"], global_callbacks=["lago"]
     )
+
+
+def test_get_combined_callback_list_returns_copy_when_dynamic_is_none():
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+    _logging = LiteLLMLoggingObj(
+        model="claude-3-opus-20240229",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.now(),
+        litellm_call_id="123",
+        function_id="456",
+    )
+
+    global_callbacks = ["langfuse"]
+    combined_callbacks = _logging.get_combined_callback_list(
+        dynamic_success_callbacks=None, global_callbacks=global_callbacks
+    )
+
+    assert combined_callbacks == ["langfuse"]
+    assert combined_callbacks is not global_callbacks
+
+    combined_callbacks.append("new_callback")
+
+    assert global_callbacks == ["langfuse"]


### PR DESCRIPTION
## Relevant issues

Fixes #20983

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix  
✅ Test

## Changes

- Return a copy of `global_callbacks` in `get_combined_callback_list()` when `dynamic_success_callbacks` is `None`.
- This prevents request-local callback iteration from sharing/mutating the same list object used by global callback state.
- Added a regression test to verify the combined callback list is not the same object as the source global list and that mutating the returned list does not mutate the original.
- Applied the same copy-on-return safety in `litellm/proxy/utils.py` to keep callback combining semantics consistent in proxy utilities.

## Local validation

- Ran:
  - `poetry run pytest tests/logging_callback_tests/test_unit_tests_init_callbacks.py -k "combined_callback_list"`
- Result:
  - `2 passed, 1 deselected`
