### PR TITLE
[Fix] exempt /models and /v1/models from DISABLE_LLM_API_ENDPOINTS so admin UI works

### DIFF
--- a/enterprise/litellm_enterprise/proxy/auth/route_checks.py
+++ b/enterprise/litellm_enterprise/proxy/auth/route_checks.py
@@ -41,6 +41,10 @@ class EnterpriseRouteChecks:
 
         return get_secret_bool("DISABLE_ADMIN_ENDPOINTS") is True
 
+    # Routes that should remain accessible even when LLM API endpoints are disabled.
+    # These are read-only model listing routes needed by the Admin UI.
+    LLM_API_EXEMPT_ROUTES = ["/models", "/v1/models"]
+
     @staticmethod
     def should_call_route(route: str):
         """
@@ -58,6 +62,7 @@ class EnterpriseRouteChecks:
             )
         elif (
             RouteChecks.is_llm_api_route(route=route)
+            and route not in EnterpriseRouteChecks.LLM_API_EXEMPT_ROUTES
             and EnterpriseRouteChecks.is_llm_api_route_disabled()
         ):
             raise HTTPException(

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -906,6 +906,109 @@ def test_proxy_admin_viewer_can_access_global_spend_tags():
         )
 
 
+class TestModelsRouteExemptFromDisableLLMEndpoints:
+    """
+    Test that /models and /v1/models are exempt from DISABLE_LLM_API_ENDPOINTS.
+
+    When DISABLE_LLM_API_ENDPOINTS is set, inference routes like /v1/chat/completions
+    should be blocked, but /models and /v1/models should remain accessible because
+    they are read-only model listing routes needed by the Admin UI.
+
+    Relevant issue: https://github.com/BerriAI/litellm/issues/new (UI breaks with DISABLE_LLM_ENDPOINTS)
+    """
+
+    def _get_enterprise_route_checks(self):
+        """Import EnterpriseRouteChecks from the local enterprise source file."""
+        import importlib.util
+
+        local_file = os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..", "enterprise",
+            "litellm_enterprise", "proxy", "auth", "route_checks.py",
+        )
+        local_file = os.path.abspath(local_file)
+
+        spec = importlib.util.spec_from_file_location(
+            "local_enterprise_route_checks", local_file
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.EnterpriseRouteChecks
+
+    @patch("litellm.proxy.proxy_server.premium_user", True)
+    def test_should_models_route_allowed_when_llm_api_disabled(self):
+        """Test that /models is allowed even when LLM API routes are disabled"""
+        EnterpriseRouteChecks = self._get_enterprise_route_checks()
+
+        with patch.object(
+            EnterpriseRouteChecks, "is_llm_api_route_disabled", return_value=True
+        ), patch.object(
+            EnterpriseRouteChecks, "is_management_routes_disabled", return_value=False
+        ):
+            # /models should NOT raise - it's exempt
+            EnterpriseRouteChecks.should_call_route("/models")
+
+    @patch("litellm.proxy.proxy_server.premium_user", True)
+    def test_should_v1_models_route_allowed_when_llm_api_disabled(self):
+        """Test that /v1/models is allowed even when LLM API routes are disabled"""
+        EnterpriseRouteChecks = self._get_enterprise_route_checks()
+
+        with patch.object(
+            EnterpriseRouteChecks, "is_llm_api_route_disabled", return_value=True
+        ), patch.object(
+            EnterpriseRouteChecks, "is_management_routes_disabled", return_value=False
+        ):
+            # /v1/models should NOT raise - it's exempt
+            EnterpriseRouteChecks.should_call_route("/v1/models")
+
+    @patch("litellm.proxy.proxy_server.premium_user", True)
+    def test_should_chat_completions_still_blocked_when_llm_api_disabled(self):
+        """Test that non-exempt LLM routes like /v1/chat/completions are still blocked"""
+        EnterpriseRouteChecks = self._get_enterprise_route_checks()
+
+        with patch.object(
+            EnterpriseRouteChecks, "is_llm_api_route_disabled", return_value=True
+        ), patch.object(
+            EnterpriseRouteChecks, "is_management_routes_disabled", return_value=False
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                EnterpriseRouteChecks.should_call_route("/v1/chat/completions")
+
+            assert exc_info.value.status_code == 403
+            assert "LLM API routes are disabled for this instance." in str(
+                exc_info.value.detail
+            )
+
+    @patch("litellm.proxy.proxy_server.premium_user", True)
+    def test_should_embeddings_still_blocked_when_llm_api_disabled(self):
+        """Test that /v1/embeddings is still blocked when LLM API routes are disabled"""
+        EnterpriseRouteChecks = self._get_enterprise_route_checks()
+
+        with patch.object(
+            EnterpriseRouteChecks, "is_llm_api_route_disabled", return_value=True
+        ), patch.object(
+            EnterpriseRouteChecks, "is_management_routes_disabled", return_value=False
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                EnterpriseRouteChecks.should_call_route("/v1/embeddings")
+
+            assert exc_info.value.status_code == 403
+
+    @patch("litellm.proxy.proxy_server.premium_user", True)
+    def test_should_models_route_allowed_when_llm_api_not_disabled(self):
+        """Test that /models works normally when LLM API routes are not disabled"""
+        EnterpriseRouteChecks = self._get_enterprise_route_checks()
+
+        with patch.object(
+            EnterpriseRouteChecks, "is_llm_api_route_disabled", return_value=False
+        ), patch.object(
+            EnterpriseRouteChecks, "is_management_routes_disabled", return_value=False
+        ):
+            # Should not raise
+            EnterpriseRouteChecks.should_call_route("/models")
+            EnterpriseRouteChecks.should_call_route("/v1/models")
+
+
 def test_route_in_additional_public_routes_wildcard_match():
     """
     Test that route_in_additonal_public_routes supports wildcard patterns.


### PR DESCRIPTION
## Relevant issues
When running LiteLLM with DISABLE_LLM_API_ENDPOINTS for an admin-only setup, the Admin UI returns 403 on GET /models, breaking model listing. The UI needs /models to show available models, but the endpoint is treated as an LLM API route and is blocked along with inference endpoints.

Cause: /models and /v1/models are in LiteLLMRoutes.openai_routes, so EnterpriseRouteChecks.should_call_route() blocks them when DISABLE_LLM_API_ENDPOINTS is set, even though they only return read-only metadata and do not perform inference.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes
Added LLM_API_EXEMPT_ROUTES = ["/models", "/v1/models"] in enterprise/litellm_enterprise/proxy/auth/route_checks.py and updated should_call_route() so these routes are not blocked when LLM API endpoints are disabled. Inference routes (chat completions, embeddings, etc.) remain blocked; only the read-only model-listing endpoints are exempt.