### PR TITLE
feat(bedrock): extend model support

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -22611,6 +22611,19 @@
         "output_cost_per_token": 2.3e-07,
         "supports_system_messages": true
     },
+    "nvidia.nemotron-nano-3-30b": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "o1": {
         "cache_read_input_token_cost": 7.5e-06,
         "input_cost_per_token": 1.5e-05,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5859,6 +5859,7 @@
         "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/kimi-k2-5-now-in-microsoft-foundry/4492321",
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_video_input": true,
         "supports_vision": true
     },
     "azure_ai/ministral-3b": {
@@ -6134,8 +6135,11 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 3.03e-06,
+        "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
-        "supports_reasoning": true
+        "supports_reasoning": true,
+        "supports_video_input": true,
+        "supports_vision": true
     },
     "bedrock/ap-south-1/meta.llama3-70b-instruct-v1:0": {
         "input_cost_per_token": 3.18e-06,
@@ -22147,9 +22151,10 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 3e-06,
-        "source": "https://platform.moonshot.ai/docs/pricing/chat",
+        "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_video_input": true,
         "supports_vision": true
     },
     "moonshot/kimi-latest": {
@@ -24502,6 +24507,7 @@
         "source": "https://openrouter.ai/moonshotai/kimi-k2.5",
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_video_input": true,
         "supports_vision": true
     },
     "openrouter/nousresearch/nous-hermes-llama2-13b": {

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -32315,6 +32315,20 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "zai.glm-4.7": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "zai/glm-4.7": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 1.1e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -22611,6 +22611,19 @@
         "output_cost_per_token": 2.3e-07,
         "supports_system_messages": true
     },
+    "nvidia.nemotron-nano-3-30b": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "o1": {
         "cache_read_input_token_cost": 7.5e-06,
         "input_cost_per_token": 1.5e-05,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5859,6 +5859,7 @@
         "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/kimi-k2-5-now-in-microsoft-foundry/4492321",
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_video_input": true,
         "supports_vision": true
     },
     "azure_ai/ministral-3b": {
@@ -6134,8 +6135,11 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 3.03e-06,
+        "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
-        "supports_reasoning": true
+        "supports_reasoning": true,
+        "supports_video_input": true,
+        "supports_vision": true
     },
     "bedrock/ap-south-1/meta.llama3-70b-instruct-v1:0": {
         "input_cost_per_token": 3.18e-06,
@@ -22147,9 +22151,10 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 3e-06,
-        "source": "https://platform.moonshot.ai/docs/pricing/chat",
+        "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_video_input": true,
         "supports_vision": true
     },
     "moonshot/kimi-latest": {
@@ -24502,6 +24507,7 @@
         "source": "https://openrouter.ai/moonshotai/kimi-k2.5",
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_video_input": true,
         "supports_vision": true
     },
     "openrouter/nousresearch/nous-hermes-llama2-13b": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -32315,6 +32315,20 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "zai.glm-4.7": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "zai/glm-4.7": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 1.1e-07,


### PR DESCRIPTION
<!-- e.g. "Fixes NA"-->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link:

- [x] **CI run for the last commit**  
       Link:

- [x] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

### Model database updates

**1. Added NVIDIA Nemotron Nano 3 30B (Bedrock)**
- Added `nvidia.nemotron-nano-3-30b` to both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`
- Pricing: $0.06 input, $0.24 output per 1M tokens (US regions)
- Context: 262K input, 8K output
- Flags: `supports_function_calling`, `supports_system_messages`, `supports_tool_choice`
- Source: [AWS Bedrock pricing](https://aws.amazon.com/bedrock/pricing/)

**2. Added Z AI GLM 4.7 (Bedrock)**
- Added `zai.glm-4.7` to both JSON files
- Pricing: $0.60 input, $2.20 output per 1M tokens (US regions)
- Context: 200K input, 128K output
- Flags: `supports_function_calling`, `supports_reasoning`, `supports_system_messages`, `supports_tool_choice`
- Source: [AWS Bedrock pricing](https://aws.amazon.com/bedrock/pricing/)

**3. Added Kimi K2.5 video input support**
- Added `supports_video_input: true` (and `supports_vision: true` where missing) to all Kimi K2.5 entries per [Moonshot AI docs](https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart)
- Updated: `moonshot/kimi-k2.5`, `bedrock/moonshotai.kimi-k2.5`, `openrouter/moonshotai/kimi-k2.5`, `azure_ai/kimi-k2.5`

### Local validation

Ran the following commands successfully before submission:

```bash
poetry run python ci_cd/check_files_match.py
poetry run python -m json.tool model_prices_and_context_window.json
poetry run python -m json.tool litellm/model_prices_and_context_window_backup.json
```
