### PR TITLE
feat(vertex_ai): add Vertex GLM-5 model support

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -30799,6 +30799,21 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "vertex_ai/zai-org/glm-5-maas": {
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "vertex_ai-zai_models",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3.2e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#glm-models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "vertex_ai/mistral-medium-3": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "vertex_ai-mistral_models",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -30799,6 +30799,21 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "vertex_ai/zai-org/glm-5-maas": {
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "vertex_ai-zai_models",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3.2e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#glm-models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "vertex_ai/mistral-medium-3": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "vertex_ai-mistral_models",


### PR DESCRIPTION
## Summary
- add `vertex_ai/zai-org/glm-5-maas` to the model map
- include pricing from Vertex GLM models page:
  - input: `$1 / 1M` (`1e-06`)
  - output: `$3.2 / 1M` (`3.2e-06`)
  - cache hit: `$0.1 / 1M` (`cache_read_input_token_cost=1e-07`)
- mark model as reasoning + prompt-caching capable
- mirror the entry in both main and backup model maps

## Validation
- `python -m json.tool model_prices_and_context_window.json`
- `python -m json.tool litellm/model_prices_and_context_window_backup.json`

Fixes #21052
