### PR TITLE
fix(typing): resolve MyPy type errors in guardrail and aiohttp code

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -624,7 +624,10 @@ class CustomGuardrail(CustomLogger):
         This gets logged on downsteam Langfuse, DataDog, etc.
         """
         # Convert None to empty dict to satisfy type requirements
-        guardrail_response = {} if response is None else response
+        # Type can be dict or str (simplified to "allow", "deny", or "mask")
+        guardrail_response: Union[Dict[Any, Any], str] = (
+            {} if response is None else response
+        )
 
         # For apply_guardrail functions in custom_code_guardrail scenario,
         # simplify the logged response to "allow", "deny", or "mask"

--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -252,6 +252,8 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
         if ssl_verify is not None:
             ssl_kwargs["ssl"] = ssl_verify
 
+        # Type ignore needed because MyPy cannot infer that ssl_kwargs only contains
+        # the 'ssl' key with appropriate type when unpacked
         response = await client_session.request(
             method=request.method,
             url=YarlURL(str(request.url), encoded=True),
@@ -266,7 +268,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
             ),
             proxy=proxy,
             server_hostname=sni_hostname,
-            **ssl_kwargs,
+            **ssl_kwargs,  # type: ignore[arg-type]
         ).__aenter__()
 
         return response

--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
@@ -330,6 +330,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         end_time: Optional[float] = None,
         duration: Optional[float] = None,
         event_type: Optional[GuardrailEventHooks] = None,
+        original_inputs: Optional[dict] = None,
     ):
         """
         Override to store only the Model Armor API response, not the entire data dict.


### PR DESCRIPTION
## Summary
Fix three MyPy type errors that were causing lint check failures in CI. These are pre-existing issues in the main branch unrelated to any specific feature PR, but they block the lint checks for all PRs (e.g., PR #19611).

## Changes

### 1. litellm/integrations/custom_guardrail.py (lines 634, 636)
**Issue**: Variable `guardrail_response` was initialized as `dict` but then reassigned to strings `"mask"` and `"allow"`, causing type incompatibility errors.

**Fix**: Added explicit `Union[Dict[Any, Any], str]` type annotation to properly type the variable that can hold either dict or str values.

```python
# Before:
guardrail_response = {} if response is None else response
guardrail_response = "mask"  # Type error!

# After:
guardrail_response: Union[Dict[Any, Any], str] = {} if response is None else response
guardrail_response = "mask"  # Now valid
```

### 2. litellm/llms/custom_httpx/aiohttp_transport.py (line 269)
**Issue**: MyPy could not infer the type of `**ssl_kwargs` unpacking, reporting 13 different incompatible type errors for the `ssl` parameter.

**Fix**: Added `# type: ignore[arg-type]` comment with explanation. The dict only contains the `ssl` key with the correct type, but MyPy's type narrowing doesn't handle this pattern.

### 3. litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py (line 325)
**Issue**: Method signature of `_process_response` was incompatible with parent class `CustomGuardrail` - missing `original_inputs` parameter.

**Fix**: Added missing `original_inputs: Optional[dict] = None` parameter to match parent class signature.

## Testing
- ✅ Ran `mypy` on all three fixed files - no errors remain (except unrelated import-untyped warnings)
- ✅ Verified fixes address the exact errors from failing CI lint checks

## Impact
This PR resolves blocking lint failures and should allow other PRs (like #19611) to pass their lint checks.

## Related Issues
- Blocks: #19611 (and potentially other PRs with failing lint checks)