### PR TITLE
fix: remove unused MCP_NPM_CACHE_DIR import

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -31,7 +31,6 @@ from pydantic import AnyUrl
 
 import litellm
 from litellm._logging import verbose_logger
-from litellm.constants import MCP_NPM_CACHE_DIR
 from litellm.exceptions import BlockedPiiEntityError, GuardrailRaisedException
 from litellm.experimental_mcp_client.client import MCPClient
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client


### PR DESCRIPTION
## Summary

Fixes a Ruff F401 lint error in `mcp_server_manager.py`:
```
proxy/_experimental/mcp_server/mcp_server_manager.py:34:31: F401 [*] `litellm.constants.MCP_NPM_CACHE_DIR` imported but unused
```

## Changes

- Removed the unused top-level import of `MCP_NPM_CACHE_DIR` on line 34
- The constant is already imported locally on line 899 where it's actually used

## Test Plan

- ✅ Verified with `ruff check` - no lint errors
- ✅ Confirmed the local import at line 899 is still present and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)