### PR TITLE
fix: improve Langfuse test isolation to prevent flaky failures

### DIFF
--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -256,22 +256,21 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         Test that _log_langfuse_v2 correctly handles None values in the usage object
         by converting them to 0, preventing validation errors.
         """
-        # Create fresh mocks for this test to avoid state pollution from setUp's side_effect
-        # The setUp configures trace.side_effect which can interfere with return_value
-        mock_trace = MagicMock()
-        mock_generation = MagicMock()
-        mock_generation.trace_id = "test-trace-id"
+        # Reset the mock to ensure clean state
+        self.mock_langfuse_client.reset_mock()
+        self.mock_langfuse_trace.reset_mock()
+        self.mock_langfuse_generation.reset_mock()
+
+        # Re-setup the trace and generation chain with clean state
+        self.mock_langfuse_generation.trace_id = "test-trace-id"
         mock_span = MagicMock()
         mock_span.end = MagicMock()
-        
-        mock_trace.generation.return_value = mock_generation
-        mock_trace.span.return_value = mock_span
-        
-        mock_client = MagicMock()
-        mock_client.trace.return_value = mock_trace
-        
-        # Use our fresh mock client
-        self.logger.Langfuse = mock_client
+        self.mock_langfuse_trace.span.return_value = mock_span
+        self.mock_langfuse_trace.generation.return_value = self.mock_langfuse_generation
+
+        # Ensure trace returns our mock
+        self.mock_langfuse_client.trace.return_value = self.mock_langfuse_trace
+        self.logger.Langfuse = self.mock_langfuse_client
         
         with patch(
             "litellm.integrations.langfuse.langfuse._add_prompt_to_generation_params",
@@ -325,13 +324,13 @@ class TestLangfuseUsageDetails(unittest.TestCase):
                 )
             except Exception as e:
                 self.fail(f"_log_langfuse_v2 raised an exception: {e}")
-            
+
             # Verify that trace was called first
-            mock_client.trace.assert_called()
-            
+            self.mock_langfuse_client.trace.assert_called()
+
             #  Check the arguments passed to the mocked langfuse generation call
-            mock_trace.generation.assert_called_once()
-            call_args, call_kwargs = mock_trace.generation.call_args
+            self.mock_langfuse_trace.generation.assert_called_once()
+            call_args, call_kwargs = self.mock_langfuse_trace.generation.call_args
 
             #  Inspect the usage and usage_details dictionaries
             usage_arg = call_kwargs.get("usage")


### PR DESCRIPTION
## Problem
The `test_log_langfuse_v2_handles_null_usage_values` test was intermittently failing in CI with:
```
AssertionError: Expected 'generation' to have been called once. Called 0 times.
```

The test passed consistently locally but failed randomly in CI, blocking builds.

## Root Cause
The test was creating fresh mocks to avoid state pollution, but this didn't fully isolate from the `setUp` method's mock configuration, leading to inconsistent behavior in CI.

## Fix
Instead of creating entirely new mocks, properly reset the existing `setUp` mocks using `.reset_mock()`:
```python
self.mock_langfuse_client.reset_mock()
self.mock_langfuse_trace.reset_mock()
self.mock_langfuse_generation.reset_mock()
```

This ensures clean mock state while maintaining proper mock chain configuration.

## Testing
```bash
poetry run pytest tests/test_litellm/integrations/test_langfuse.py::TestLangfuseUsageDetails::test_log_langfuse_v2_handles_null_usage_values -v
```
✅ Test passes consistently

## Note
This is a clean version of PR #21073, which accidentally included unrelated changes from other branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)