### PR TITLE
fix(anthropic): filter numeric constraints from output JSON schema

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -206,26 +206,36 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
     def filter_anthropic_output_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
         """
         Filter out unsupported fields from JSON schema for Anthropic's output_format API.
-        
+
         Anthropic's output_format doesn't support certain JSON schema properties:
-        - maxItems: Not supported for array types
-        - minItems: Not supported for array types
-        
+        - maxItems/minItems: Not supported for array types
+        - minimum/maximum: Not supported for integer/number types
+        - exclusiveMinimum/exclusiveMaximum: Not supported for integer/number types
+
         This function recursively removes these unsupported fields while preserving
         all other valid schema properties.
-        
+
         Args:
             schema: The JSON schema dictionary to filter
-            
+
         Returns:
             A new dictionary with unsupported fields removed
-            
-        Related issue: https://github.com/BerriAI/litellm/issues/19444
+
+        Related issues:
+            https://github.com/BerriAI/litellm/issues/19444
+            https://github.com/BerriAI/litellm/issues/21016
         """
         if not isinstance(schema, dict):
             return schema
 
-        unsupported_fields = {"maxItems", "minItems"}
+        unsupported_fields = {
+            "maxItems",
+            "minItems",
+            "minimum",
+            "maximum",
+            "exclusiveMinimum",
+            "exclusiveMaximum",
+        }
 
         result: Dict[str, Any] = {}
         for key, value in schema.items():


### PR DESCRIPTION
## Summary

When using Pydantic models with numeric constraints (`ge`, `le`, `gt`, `lt`) in `response_format` for Anthropic, the generated JSON schema included `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum` fields that Anthropic's API rejects with a validation error.

Extended `filter_anthropic_output_schema()` to also strip these numeric constraint fields, similar to how it already strips `maxItems`/`minItems` for array types.

## Changes
- `litellm/llms/anthropic/chat/transformation.py` - added numeric constraint fields to unsupported_fields set
- Updated existing test and added new tests for ge/le and gt/lt constraint filtering

## Test plan
- [x] All 6 structured output tests pass
- [x] Verified Pydantic ge/le generates minimum/maximum in raw schema (confirmed in test)
- [x] Verified these are stripped after transformation
- [x] String constraints (maxLength, minLength) are still preserved
- [x] `make test-unit` passes

Fixes #21016