### PR TITLE
fix: default supports_native_streaming to True for unknown models

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2372,6 +2372,9 @@ def supports_native_streaming(model: str, custom_llm_provider: Optional[str]) ->
         verbose_logger.debug(
             f"Model not found or error in checking supports_native_streaming support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {str(e)}"
         )
+        # Default to True: a false positive (attempting native streaming on an
+        # unsupported model) produces an explicit backend error, while a false
+        # negative silently drops function_call events via MockResponsesAPI.
         return True
 
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2372,7 +2372,7 @@ def supports_native_streaming(model: str, custom_llm_provider: Optional[str]) ->
         verbose_logger.debug(
             f"Model not found or error in checking supports_native_streaming support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {str(e)}"
         )
-        return False
+        return True
 
 
 def supports_response_schema(

--- a/tests/test_litellm/test_supports_native_streaming.py
+++ b/tests/test_litellm/test_supports_native_streaming.py
@@ -1,0 +1,52 @@
+"""
+Test supports_native_streaming() behavior for custom/unknown models.
+
+Related issue: https://github.com/BerriAI/litellm/issues/21090
+"""
+
+import pytest
+
+from litellm.utils import supports_native_streaming
+
+
+class TestSupportsNativeStreaming:
+    """Test that supports_native_streaming defaults correctly for unknown models."""
+
+    def test_unknown_model_defaults_to_true(self):
+        """
+        Custom models not in model_prices_and_context_window.json should default
+        to True (supports native streaming), not False.
+
+        When returning False, the Responses API falls back to
+        MockResponsesAPIStreamingIterator which silently drops
+        function_call_arguments.delta events.
+        """
+        result = supports_native_streaming(
+            model="openai/my-custom-vllm-model",
+            custom_llm_provider="openai",
+        )
+        assert result is True
+
+    def test_known_model_returns_correct_value(self):
+        """
+        Known models that are registered in the DB should return their
+        actual supports_native_streaming value.
+        """
+        # gpt-4o is a known model that supports streaming
+        result = supports_native_streaming(
+            model="gpt-4o",
+            custom_llm_provider="openai",
+        )
+        assert result is True
+
+    def test_completely_unknown_model_defaults_to_true(self):
+        """
+        Even completely unknown models (no provider match) should default
+        to True so that real streaming is attempted rather than silently
+        dropping events with fake streaming.
+        """
+        result = supports_native_streaming(
+            model="some-random-model-xyz-123",
+            custom_llm_provider="openai",
+        )
+        assert result is True


### PR DESCRIPTION
## Summary

Custom models not registered in `model_prices_and_context_window.json` (e.g., models served by vLLM, TGI) were defaulting to `supports_native_streaming=False` when the lookup threw an exception. This caused the Responses API to use `MockResponsesAPIStreamingIterator` which silently drops `function_call_arguments.delta` events - pretty bad for tool calling workflows.

Only 4 models in the DB actually have `supports_native_streaming: false` (gpt-5-pro, o1-pro variants), and they're properly registered so they never hit the except block. Every model that reaches the except path is a custom model that almost certainly supports streaming. If one doesn't, the backend will return an explicit error - way better than silently eating events.

## Changes
- `litellm/utils.py` - changed `return False` to `return True` in the except block of `supports_native_streaming()`
- Added 3 tests verifying the default behavior

## Test plan
- [x] Tests confirm unknown models return True
- [x] Tests confirm known models still return their actual value
- [x] `make test-unit` passes

Fixes #21090