### PR TITLE
fix(vertex_ai): pass through native Gemini imageConfig params

### DIFF
--- a/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
@@ -10,10 +10,7 @@ from litellm.llms.base_llm.image_generation.transformation import (
 from litellm.llms.vertex_ai.common_utils import get_vertex_base_url
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexLLM
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.llms.openai import (
-    AllMessageValues,
-    OpenAIImageGenerationOptionalParams,
-)
+from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import (
     ImageObject,
     ImageResponse,
@@ -43,7 +40,7 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
     
     def get_supported_openai_params(
         self, model: str
-    ) -> List[OpenAIImageGenerationOptionalParams]:
+    ) -> List[str]:
         """
         Gemini image generation supported parameters.
 

--- a/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
@@ -45,11 +45,19 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
         self, model: str
     ) -> List[OpenAIImageGenerationOptionalParams]:
         """
-        Gemini image generation supported parameters
+        Gemini image generation supported parameters.
+
+        Includes both OpenAI-compatible params (n, size) and native Gemini
+        image config params (aspectRatio, imageSize) so they pass through
+        to transform_image_generation_request() instead of being dropped.
         """
         return [
             "n",
             "size",
+            "aspectRatio",
+            "aspect_ratio",
+            "imageSize",
+            "image_size",
         ]
     
     def map_openai_params(
@@ -61,7 +69,7 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
     ) -> dict:
         supported_params = self.get_supported_openai_params(model)
         mapped_params = {}
-        
+
         for k, v in non_default_params.items():
             if k not in optional_params.keys():
                 if k in supported_params:
@@ -72,8 +80,10 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
                         # Map OpenAI size format to Gemini aspectRatio
                         mapped_params["aspectRatio"] = self._map_size_to_aspect_ratio(v)
                     else:
+                        # Native Gemini params (aspectRatio, imageSize, etc.)
+                        # pass through directly
                         mapped_params[k] = v
-        
+
         return mapped_params
     
     def _map_size_to_aspect_ratio(self, size: str) -> str:

--- a/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
@@ -38,7 +38,7 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
         BaseImageGenerationConfig.__init__(self)
         VertexLLM.__init__(self)
     
-    def get_supported_openai_params(
+    def get_supported_openai_params(  # type: ignore[override]
         self, model: str
     ) -> List[str]:
         """

--- a/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
@@ -28,6 +28,11 @@ class TestVertexAIGeminiImageGenerationConfig:
         supported = self.config.get_supported_openai_params("gemini-2.5-flash-image")
         assert "n" in supported
         assert "size" in supported
+        # Native Gemini image config params should also be supported
+        assert "aspectRatio" in supported
+        assert "aspect_ratio" in supported
+        assert "imageSize" in supported
+        assert "image_size" in supported
 
     def test_map_openai_params_n(self):
         """Test mapping n parameter to candidate_count"""
@@ -55,6 +60,48 @@ class TestVertexAIGeminiImageGenerationConfig:
             non_default_params, optional_params, "gemini-2.5-flash-image", False
         )
         assert result.get("aspectRatio") == "16:9"
+
+    def test_map_openai_params_native_aspect_ratio(self):
+        """Test that native aspectRatio param passes through to optional_params.
+
+        Related issue: https://github.com/BerriAI/litellm/issues/21070
+        """
+        non_default_params = {"aspectRatio": "16:9"}
+        optional_params = {}
+        result = self.config.map_openai_params(
+            non_default_params, optional_params, "gemini-2.5-flash-image", False
+        )
+        assert result.get("aspectRatio") == "16:9"
+
+    def test_map_openai_params_native_aspect_ratio_snake_case(self):
+        """Test that native aspect_ratio (snake_case) param passes through."""
+        non_default_params = {"aspect_ratio": "9:16"}
+        optional_params = {}
+        result = self.config.map_openai_params(
+            non_default_params, optional_params, "gemini-2.5-flash-image", False
+        )
+        assert result.get("aspect_ratio") == "9:16"
+
+    def test_map_openai_params_native_image_size(self):
+        """Test that native imageSize param passes through to optional_params.
+
+        Related issue: https://github.com/BerriAI/litellm/issues/21070
+        """
+        non_default_params = {"imageSize": "4K"}
+        optional_params = {}
+        result = self.config.map_openai_params(
+            non_default_params, optional_params, "gemini-3-pro-image-preview", False
+        )
+        assert result.get("imageSize") == "4K"
+
+    def test_map_openai_params_native_image_size_snake_case(self):
+        """Test that native image_size (snake_case) param passes through."""
+        non_default_params = {"image_size": "4K"}
+        optional_params = {}
+        result = self.config.map_openai_params(
+            non_default_params, optional_params, "gemini-3-pro-image-preview", False
+        )
+        assert result.get("image_size") == "4K"
 
     def test_map_size_to_aspect_ratio(self):
         """Test size to aspect ratio mapping"""


### PR DESCRIPTION
## Summary

When using Vertex AI Gemini image generation models (gemini-2.5-flash-image, gemini-3-pro-image-preview), native params like `aspectRatio` and `imageSize` were silently dropped because they weren't in `get_supported_openai_params()`. The param validation step would either raise `UnsupportedParamsError` or drop them before they reached `transform_image_generation_request()`, which already had the correct handling code.

Added the native Gemini image config params to the supported list so they pass through validation. Both camelCase and snake_case variants are supported.

## Changes
- `litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py` - added aspectRatio, aspect_ratio, imageSize, image_size to supported params
- Added 4 tests for native param mapping, updated existing test

## Test plan
- [x] All 30 image generation tests pass (2 skipped - no Vertex AI creds)
- [x] Native params correctly pass through map_openai_params
- [x] transform_image_generation_request correctly includes imageConfig
- [x] `make test-unit` passes

Fixes #21070