### PR TITLE
chore: add .claude directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .venv
 .venv_policy_test
 .env
+.claude
 .newenv
 newenv/*
 litellm/proxy/myenv/*


### PR DESCRIPTION
## Summary
- Add `.claude` directory to `.gitignore`

The `.claude` directory contains Claude Code's project-specific memory and configuration files, which are session-specific and should not be tracked in version control.

## Test plan
- [x] Verify `.gitignore` correctly excludes `.claude` directory
- [x] Ensure no other gitignore patterns are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)