### PR TITLE
fix: remove duplicate PerplexityResponsesConfig from LLM_CONFIG_NAMES

### DIFF
--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -275,7 +275,6 @@ LLM_CONFIG_NAMES = (
     "LmStudioEmbeddingConfig",
     "NscaleConfig",
     "PerplexityChatConfig",
-    "PerplexityResponsesConfig",
     "AzureOpenAIO1Config",
     "IBMWatsonXAIConfig",
     "IBMWatsonXChatConfig",


### PR DESCRIPTION
## Summary
- Remove duplicate entry of `PerplexityResponsesConfig` in `LLM_CONFIG_NAMES` tuple

## Issue
Ruff linting was failing with error:
```
_lazy_imports_registry.py:1042:5: F601 Dictionary key literal `"PerplexityResponsesConfig"` repeated
```

The config name appeared twice in the `LLM_CONFIG_NAMES` tuple (lines 229 and 278), causing a linting error.

## Changes
- Removed the duplicate entry at line 278
- Kept the entry at line 229 (grouped with other ResponsesConfig entries)

## Test plan
- [x] Verify `poetry run ruff check litellm/_lazy_imports_registry.py` passes without errors
- [x] Confirm `PerplexityResponsesConfig` still appears once in the tuple and once in the import map

🤖 Generated with [Claude Code](https://claude.com/claude-code)