### PR TITLE
fix: enforce user deactivation via scim_active metadata

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -208,6 +208,17 @@ async def common_checks(
             f"Team={team_object.team_id} is blocked. Update via `/team/unblock` if your admin."
         )
 
+    # 1.1. If user is deactivated via SCIM
+    if user_object is not None and user_object.metadata is not None:
+        scim_active = user_object.metadata.get("scim_active")
+        if scim_active is False:
+            raise ProxyException(
+                message="User account is deactivated.",
+                type=ProxyErrorTypes.auth_error,
+                param="user_id",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
+
     # 2. If team can call model
     if _model and team_object:
         if not can_team_access_model(


### PR DESCRIPTION
Fixes issue where SCIM PATCH to set active=false updates metadata but doesn't prevent authentication.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Add check in common_checks() to block users with scim_active=False
- Add unit tests for scim_active validation
- Raises ProxyException with 401 when deactivated user attempts to authenticate