### PR TITLE
fix(aiohttp): prevent closing shared ClientSession in AiohttpTransport

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -119,8 +119,13 @@ class AiohttpResponseStream(httpx.AsyncByteStream):
 
 
 class AiohttpTransport(httpx.AsyncBaseTransport):
-    def __init__(self, client: Union[ClientSession, Callable[[], ClientSession]]) -> None:
+    def __init__(
+        self,
+        client: Union[ClientSession, Callable[[], ClientSession]],
+        owns_session: bool = True,
+    ) -> None:
         self.client = client
+        self._owns_session = owns_session
 
         #########################################################
         # Class variables for proxy settings
@@ -128,7 +133,7 @@ class AiohttpTransport(httpx.AsyncBaseTransport):
         self.proxy_cache: Dict[str, Optional[str]] = {}
 
     async def aclose(self) -> None:
-        if isinstance(self.client, ClientSession):
+        if self._owns_session and isinstance(self.client, ClientSession):
             await self.client.close()
 
 
@@ -144,10 +149,11 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
         self,
         client: Union[ClientSession, Callable[[], ClientSession]],
         ssl_verify: Optional[Union[bool, ssl.SSLContext]] = None,
+        owns_session: bool = True,
     ):
         self.client = client
         self._ssl_verify = ssl_verify  # Store for per-request SSL override
-        super().__init__(client=client)
+        super().__init__(client=client, owns_session=owns_session)
         # Store the client factory for recreating sessions when needed
         if callable(client):
             self._client_factory = client

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -866,6 +866,7 @@ class AsyncHTTPHandler:
             return LiteLLMAiohttpTransport(
                 client=shared_session,
                 ssl_verify=ssl_for_transport,
+                owns_session=False,
             )
 
         # Create new session only if none provided or existing one is invalid


### PR DESCRIPTION
## Relevant issues

Fixes #21116

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`AiohttpTransport.aclose()` unconditionally closes any `ClientSession` it holds. When a shared session is passed via `_create_aiohttp_transport()`, this closes the session for all other clients still using it.

Add `owns_session` parameter (default `True`) to `AiohttpTransport` and `LiteLLMAiohttpTransport`. Pass `owns_session=False` when creating transport with a shared session.

Aligns with the `_owns_session` pattern already used in `AiohttpHandler` (#19190).

**Files**:
- `litellm/llms/custom_httpx/aiohttp_transport.py`
- `litellm/llms/custom_httpx/http_handler.py`
- `tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py`