### PR TITLE
Fix Gemini functionCall casing and propagate thoughtSignature across parallel tool calls

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1394,7 +1394,8 @@ def convert_to_gemini_tool_call_invoke(
                     )
                     if gemini_function_call is not None:
                         part_dict: VertexPartType = {
-                            "function_call": gemini_function_call
+                            # Gemini request payloads should use camelCase functionCall.
+                            "functionCall": gemini_function_call
                         }
                         thought_signature = _get_thought_signature_from_tool(
                             dict(tool), model=model
@@ -1415,7 +1416,8 @@ def convert_to_gemini_tool_call_invoke(
             )
             if gemini_function_call is not None:
                 part_dict_function: VertexPartType = {
-                    "function_call": gemini_function_call
+                    # Gemini request payloads should use camelCase functionCall.
+                    "functionCall": gemini_function_call
                 }
 
                 # Extract thought signature from function_call's provider_specific_fields

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -994,10 +994,6 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                         if (
                             isinstance(existing_part, dict)
                             and existing_part.get("thoughtSignature")
-                            and (
-                                existing_part.get("functionCall") is not None
-                                or existing_part.get("function_call") is not None
-                            )
                         ):
                             turn_thought_signature = existing_part.get(
                                 "thoughtSignature"

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -991,9 +991,8 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                     # copy it to parallel function calls missing thoughtSignature.
                     turn_thought_signature = None
                     for existing_part in assistant_content:
-                        if (
-                            isinstance(existing_part, dict)
-                            and existing_part.get("thoughtSignature")
+                        if isinstance(existing_part, dict) and existing_part.get(
+                            "thoughtSignature"
                         ):
                             turn_thought_signature = existing_part.get(
                                 "thoughtSignature"

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -985,8 +985,36 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                     gemini_tool_call_parts = convert_to_gemini_tool_call_invoke(
                         assistant_msg, model=model
                     )
+
+                    # Gemini validates thought signatures on function-call turns.
+                    # If a signature exists for this assistant turn (e.g. from thinking_blocks),
+                    # copy it to parallel function calls missing thoughtSignature.
+                    turn_thought_signature = None
+                    for existing_part in assistant_content:
+                        if (
+                            isinstance(existing_part, dict)
+                            and existing_part.get("thoughtSignature")
+                            and (
+                                existing_part.get("functionCall") is not None
+                                or existing_part.get("function_call") is not None
+                            )
+                        ):
+                            turn_thought_signature = existing_part.get(
+                                "thoughtSignature"
+                            )
+                            break
+
                     ## check if gemini_tool_call already exists in assistant_content
                     for gemini_tool_call_part in gemini_tool_call_parts:
+                        if (
+                            turn_thought_signature is not None
+                            and isinstance(gemini_tool_call_part, dict)
+                            and gemini_tool_call_part.get("thoughtSignature") is None
+                        ):
+                            gemini_tool_call_part["thoughtSignature"] = (
+                                turn_thought_signature
+                            )
+
                         if not check_if_part_exists_in_parts(
                             assistant_content,
                             gemini_tool_call_part,

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -39,6 +39,7 @@ class PartType(TypedDict, total=False):
     inline_data: BlobType
     file_data: FileDataType
     function_call: FunctionCall
+    functionCall: FunctionCall
     function_response: FunctionResponse
     thought: bool
     thoughtSignature: str

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_thought_signature_in_tool_call_id.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_thought_signature_in_tool_call_id.py
@@ -11,7 +11,6 @@ enable_preview_features=True to be enabled.
 
 import pytest
 
-import litellm
 from litellm.litellm_core_utils.prompt_templates.factory import (
     THOUGHT_SIGNATURE_SEPARATOR,
     _encode_tool_call_id_with_signature,

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_thought_signature_in_tool_call_id.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_thought_signature_in_tool_call_id.py
@@ -176,7 +176,7 @@ def test_convert_to_gemini_with_embedded_signature():
 
     # Verify thought signature is extracted and sent to Gemini
     assert len(gemini_parts) == 1
-    assert "function_call" in gemini_parts[0]
+    assert "functionCall" in gemini_parts[0]
     assert "thoughtSignature" in gemini_parts[0]
     assert gemini_parts[0]["thoughtSignature"] == test_signature
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -453,12 +453,12 @@ def test_thought_signature_preservation_in_conversion():
 
     # Verify thought signature is preserved in first function call part
     assert len(gemini_parts) == 2
-    assert "function_call" in gemini_parts[0]
+    assert "functionCall" in gemini_parts[0]
     assert "thoughtSignature" in gemini_parts[0]
     assert gemini_parts[0]["thoughtSignature"] == test_signature
 
     # Verify second function call part does not have thought signature
-    assert "function_call" in gemini_parts[1]
+    assert "functionCall" in gemini_parts[1]
     assert "thoughtSignature" not in gemini_parts[1]
 
 
@@ -520,6 +520,53 @@ def test_thought_signature_sequential_function_calls():
 
     assert len(gemini_parts_step2) == 1
     assert gemini_parts_step2[0]["thoughtSignature"] == signature_2
+
+
+def test_parallel_tool_calls_copy_thought_signature_from_thinking_block():
+    """Test that parallel tool calls inherit turn thought signature from thinking_blocks."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": '{"functionCall":{"name":"get_current_temperature","args":{"location":"Paris"}}}',
+                    "signature": "sig-turn-123",
+                }
+            ],
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_current_temperature",
+                        "arguments": '{"location": "Paris"}',
+                    },
+                    "index": 0,
+                },
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {
+                        "name": "get_current_temperature",
+                        "arguments": '{"location": "London"}',
+                    },
+                    "index": 1,
+                },
+            ],
+        }
+    ]
+
+    contents = _gemini_convert_messages_with_history(messages, model="gemini-2.5-flash")
+
+    assert len(contents) == 1
+    model_parts = contents[0]["parts"]
+    function_parts = [
+        p for p in model_parts if p.get("functionCall") is not None or p.get("function_call") is not None
+    ]
+    assert len(function_parts) == 2
+    assert all(p.get("thoughtSignature") == "sig-turn-123" for p in function_parts)
 
 
 def test_thought_signature_with_function_call_mode():
@@ -589,7 +636,7 @@ def test_dummy_signature_added_for_gemini_3_conversation_history():
 
     # Verify dummy signature is added
     assert len(gemini_parts) == 1
-    assert "function_call" in gemini_parts[0]
+    assert "functionCall" in gemini_parts[0]
     assert "thoughtSignature" in gemini_parts[0]
 
     # Verify it's the expected dummy signature (base64 encoded "skip_thought_signature_validator")
@@ -630,7 +677,7 @@ def test_dummy_signature_not_added_for_gemini_2_5():
 
     # Verify no dummy signature is added for non-gemini-3 models
     assert len(gemini_parts) == 1
-    assert "function_call" in gemini_parts[0]
+    assert "functionCall" in gemini_parts[0]
     assert "thoughtSignature" not in gemini_parts[0]
 
 
@@ -669,7 +716,7 @@ def test_dummy_signature_not_added_when_signature_exists():
 
     # Verify real signature is preserved, not replaced with dummy
     assert len(gemini_parts) == 1
-    assert "function_call" in gemini_parts[0]
+    assert "functionCall" in gemini_parts[0]
     assert "thoughtSignature" in gemini_parts[0]
     assert gemini_parts[0]["thoughtSignature"] == real_signature
 
@@ -700,7 +747,7 @@ def test_dummy_signature_with_function_call_mode():
 
     # Verify dummy signature is added
     assert len(gemini_parts) == 1
-    assert "function_call" in gemini_parts[0]
+    assert "functionCall" in gemini_parts[0]
     assert "thoughtSignature" in gemini_parts[0]
 
     # Verify it's the expected dummy signature
@@ -1938,7 +1985,7 @@ def test_function_response_has_user_role():
 
     assert contents[0]["role"] == "user"
     assert contents[1]["role"] == "model"
-    assert "function_call" in contents[1]["parts"][0]
+    assert "functionCall" in contents[1]["parts"][0]
 
     # The critical assertion: function response must have role="user"
     assert contents[2]["role"] == "user"

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -569,6 +569,55 @@ def test_parallel_tool_calls_copy_thought_signature_from_thinking_block():
     assert all(p.get("thoughtSignature") == "sig-turn-123" for p in function_parts)
 
 
+def test_parallel_tool_calls_copy_thought_signature_from_text_thinking_block():
+    """Text-fallback thinking blocks still carry the turn signature."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": "I need to call both tools.",
+                    "signature": "sig-text-thinking",
+                }
+            ],
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_current_temperature",
+                        "arguments": '{"location": "Paris"}',
+                    },
+                    "index": 0,
+                },
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {
+                        "name": "get_current_temperature",
+                        "arguments": '{"location": "London"}',
+                    },
+                    "index": 1,
+                },
+            ],
+        }
+    ]
+
+    contents = _gemini_convert_messages_with_history(messages, model="gemini-2.5-flash")
+
+    function_parts = [
+        p
+        for p in contents[0]["parts"]
+        if p.get("functionCall") is not None or p.get("function_call") is not None
+    ]
+    assert len(function_parts) == 2
+    assert all(
+        p.get("thoughtSignature") == "sig-text-thinking" for p in function_parts
+    )
+
+
 def test_thought_signature_with_function_call_mode():
     """Test thought signature extraction in function_call mode (is_function_call=True)"""
     from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -1384,8 +1384,6 @@ def test_file_data_field_order():
 
 def test_file_data_field_order_gcs_urls():
     """Test that GCS URLs also maintain correct field order."""
-    import json
-
     from litellm.llms.vertex_ai.gemini.transformation import _process_gemini_media
 
     # Test with GCS URL

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -563,7 +563,9 @@ def test_parallel_tool_calls_copy_thought_signature_from_thinking_block():
     assert len(contents) == 1
     model_parts = contents[0]["parts"]
     function_parts = [
-        p for p in model_parts if p.get("functionCall") is not None or p.get("function_call") is not None
+        p
+        for p in model_parts
+        if p.get("functionCall") is not None or p.get("function_call") is not None
     ]
     assert len(function_parts) == 2
     assert all(p.get("thoughtSignature") == "sig-turn-123" for p in function_parts)
@@ -613,9 +615,7 @@ def test_parallel_tool_calls_copy_thought_signature_from_text_thinking_block():
         if p.get("functionCall") is not None or p.get("function_call") is not None
     ]
     assert len(function_parts) == 2
-    assert all(
-        p.get("thoughtSignature") == "sig-text-thinking" for p in function_parts
-    )
+    assert all(p.get("thoughtSignature") == "sig-text-thinking" for p in function_parts)
 
 
 def test_thought_signature_with_function_call_mode():

--- a/tests/test_litellm/llms/vertex_ai/test_vertex.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex.py
@@ -393,8 +393,8 @@ def test_multiple_function_call():
                     "role": "model",
                     "parts": [
                         {"text": "test"},
-                        {"function_call": {"name": "test", "args": {"arg": "test"}}},
-                        {"function_call": {"name": "test2", "args": {"arg": "test2"}}},
+                        {"functionCall": {"name": "test", "args": {"arg": "test"}}},
+                        {"functionCall": {"name": "test2", "args": {"arg": "test2"}}},
                     ],
                 },
                 {
@@ -502,8 +502,8 @@ def test_multiple_function_call_changed_text_pos():
                 "role": "model",
                 "parts": [
                     {"text": "test"},
-                    {"function_call": {"name": "test", "args": {"arg": "test"}}},
-                    {"function_call": {"name": "test2", "args": {"arg": "test2"}}},
+                    {"functionCall": {"name": "test", "args": {"arg": "test"}}},
+                    {"functionCall": {"name": "test2", "args": {"arg": "test2"}}},
                 ],
             },
             {
@@ -1280,7 +1280,6 @@ def test_process_gemini_media():
     print("base64_result", base64_result)
     assert base64_result["inline_data"]["mime_type"] == "image/jpeg"
     assert base64_result["inline_data"]["data"] == "/9j/4AAQSkZJRg..."
-
 
 
 def test_get_image_mime_type_from_url():


### PR DESCRIPTION
## Summary
- use camelCase `functionCall` when serializing Gemini tool invoke parts
- propagate assistant turn thoughtSignature from thinking blocks to parallel tool-call parts missing signatures
- update Gemini transformation tests for functionCall casing and parallel signature inheritance

## Validation
- attempted to run targeted `poetry run pytest` for Gemini transformation tests, but local env is missing dependencies and poetry install is blocked by lock mismatch on this branch
- ran `poetry run ruff check` on touched files; branch has pre-existing F401 warnings in test files