### PR TITLE
fix: shared health check serialization

### DIFF
--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -45,7 +45,6 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
             return result
         elif isinstance(obj, BaseModel):
             dumped = obj.model_dump()
-            seen.add(id(obj))
             result = _serialize(dumped, seen, depth + 1)
             seen.remove(id(obj))
             return result

--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -1,6 +1,8 @@
 import json
 from typing import Any, Union
 
+from pydantic import BaseModel
+
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
 
 
@@ -39,6 +41,12 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
             return result
         elif isinstance(obj, set):
             result = sorted([_serialize(item, seen, depth + 1) for item in obj])
+            seen.remove(id(obj))
+            return result
+        elif isinstance(obj, BaseModel):
+            dumped = obj.model_dump()
+            seen.add(id(obj))
+            result = _serialize(dumped, seen, depth + 1)
             seen.remove(id(obj))
             return result
         else:

--- a/litellm/proxy/health_check_utils/shared_health_check_manager.py
+++ b/litellm/proxy/health_check_utils/shared_health_check_manager.py
@@ -4,6 +4,7 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.caching.redis_cache import RedisCache
 from litellm.constants import (
     DEFAULT_SHARED_HEALTH_CHECK_TTL,
@@ -177,7 +178,7 @@ class SharedHealthCheckManager:
             cache_key = self.get_health_check_cache_key()
             await self.redis_cache.async_set_cache(
                 cache_key,
-                json.dumps(cache_data),
+                safe_dumps(cache_data),
                 ttl=self.health_check_ttl,
             )
             


### PR DESCRIPTION
## Relevant issues

As we use shared health check on our team, we've noticed that it hasn't actually been caching any of our health check results.

Calling `/cache/ping` got us:
<img width="1440" height="247" alt="image" src="https://github.com/user-attachments/assets/61b379a5-7e15-4056-a077-de6fa2fe7500" />

When we actually checked our shared health check, we got:
<img width="312" height="233" alt="image" src="https://github.com/user-attachments/assets/cacd092f-c8b7-49f2-9f79-11a42083b867" />
indicating that the results were not being cached.

This was corroborated by a message we received on load of each LiteLLM pod:
<img width="1278" height="27" alt="image" src="https://github.com/user-attachments/assets/bc769958-3b97-4eb9-8b58-74132a785ac6" />
followed by a message from other pods indicating that there was no cache and that they would fall back on local health checks.'

I found that the issue lies in that the Pydantic model `UserAPIKeyAuth` ends up in the `healthy_endpoint` and `unhealthy_endpoint` metadata. As it is a Pydantic model, it cannot be serialized via `json.dumps()` and thus throws an error, not saving in the redis cache.

This PR moves the redis cache json dumping to use the `safe_dumps` function and adds the ability for that function to process Pydantic-based models recursively. 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
* Added Pydantic models to `safe_dumps`
* Changed shared_health_check to use `safe_dumps` rather than `json.dumps()`