### PR TITLE
fix(router): avoid O(n) alias scan for non-alias get_model_list lookups

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7600,9 +7600,16 @@ class Router:
         Used by `.get_model_list` to get model list from model alias.
         """
         returned_models: List[DeploymentTypedDict] = []
-        for model_alias, model_value in self.model_group_alias.items():
-            if model_name is not None and model_alias != model_name:
-                continue
+
+        if model_name is not None:
+            # Fast path: direct dict lookup avoids scanning all aliases for non-alias model names.
+            if model_name not in self.model_group_alias:
+                return returned_models
+            alias_items = [(model_name, self.model_group_alias[model_name])]
+        else:
+            alias_items = self.model_group_alias.items()
+
+        for model_alias, model_value in alias_items:
             if isinstance(model_value, str):
                 _router_model_name: str = model_value
             elif isinstance(model_value, dict):
@@ -9099,4 +9106,3 @@ class Router:
         litellm._async_failure_callback = []
         self.retry_policy = None
         self.flush_cache()
-

--- a/tests/router_unit_tests/test_get_model_list_alias_optimization.py
+++ b/tests/router_unit_tests/test_get_model_list_alias_optimization.py
@@ -1,0 +1,50 @@
+from litellm import Router
+
+
+class NoItemsAliasDict(dict):
+    def items(self):
+        raise AssertionError("Unexpected full alias iteration via items()")
+
+
+def test_get_model_list_from_model_alias_should_not_iterate_for_non_alias_lookup():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo"},
+            }
+        ],
+        model_group_alias={"alias-1": "gpt-4"},
+    )
+    router.model_group_alias = NoItemsAliasDict(
+        {f"alias-{idx}": "gpt-4" for idx in range(200)}
+    )
+
+    model_alias_list = router.get_model_list_from_model_alias(
+        model_name="gpt-3.5-turbo"
+    )
+    assert model_alias_list == []
+
+
+def test_map_team_model_should_not_iterate_aliases_for_non_alias_team_model_name():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo"},
+                "model_info": {
+                    "team_id": "team-1",
+                    "team_public_model_name": "team-model",
+                },
+            }
+        ],
+        model_group_alias={"alias-1": "gpt-4"},
+    )
+    router.model_group_alias = NoItemsAliasDict(
+        {f"alias-{idx}": "gpt-4" for idx in range(200)}
+    )
+
+    assert (
+        router.map_team_model(team_model_name="team-model", team_id="team-1")
+        == "gpt-3.5-turbo"
+    )


### PR DESCRIPTION
## Relevant issues

Fixes #21134

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/` directory, **Adding at least 1 test is a hard requirement**
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix  
✅ Test

## Changes

- Added a fast path in `Router.get_model_list_from_model_alias()` for `model_name` lookups:
  - If `model_name` is not in `model_group_alias`, return immediately.
  - If present, resolve only that one alias via direct dict lookup.
- Preserved existing full alias iteration behavior when `model_name is None`.
- Added regression tests in `tests/router_unit_tests/test_get_model_list_alias_optimization.py` to ensure non-alias lookups do not iterate `model_group_alias.items()`:
  - `test_get_model_list_from_model_alias_should_not_iterate_for_non_alias_lookup`
  - `test_map_team_model_should_not_iterate_aliases_for_non_alias_team_model_name`

## Verification

Ran locally:

- `poetry run pytest tests/router_unit_tests/test_get_model_list_alias_optimization.py -q`
- `poetry run pytest tests/test_litellm/test_router.py -k "test_arouter_test_team_model" -q`
- `poetry run pytest tests/local_testing/test_router.py -k "test_router_get_model_list_from_model_alias" -q`
