### PR TITLE
docs: fix Claude Code MCP tutorial

### DIFF
--- a/docs/my-website/docs/tutorials/claude_mcp.md
+++ b/docs/my-website/docs/tutorials/claude_mcp.md
@@ -9,7 +9,7 @@ Note: LiteLLM supports OAuth for MCP servers as well. [Learn more](https://docs.
 
 ## Connecting MCP Servers
 
-You can also connect MCP servers to Claude Code via LiteLLM Proxy.
+You can connect MCP servers to Claude Code via LiteLLM Proxy.
 
 
 1. Add the MCP server to your `config.yaml`
@@ -23,6 +23,7 @@ In this example, we'll add the Github MCP server to our `config.yaml`
 mcp_servers:
   github_mcp:
     url: "https://api.githubcopilot.com/mcp"
+    transport: "http"
     auth_type: oauth2
     client_id: os.environ/GITHUB_OAUTH_CLIENT_ID
     client_secret: os.environ/GITHUB_OAUTH_CLIENT_SECRET
@@ -34,17 +35,23 @@ mcp_servers:
 In this example, we'll add the Atlassian MCP server to our `config.yaml`
 
 ```yaml title="config.yaml" showLineNumbers
-atlassian_mcp:
-  server_id: atlassian_mcp_id
-  url: "https://mcp.atlassian.com/v1/sse"
-  transport: "sse"
-  auth_type: oauth2
+mcp_servers:
+  atlassian_mcp:
+    url: "https://mcp.atlassian.com/v1/mcp"
+    transport: "http"
+    auth_type: oauth2
 ```
 
 </TabItem>
 </Tabs>
 
+:::important
+The server name under `mcp_servers:` (e.g. `atlassian_mcp`, `github_mcp`) **must match** the name used in the Claude Code URL path (`/mcp/<server_name>`). A mismatch will cause a 404 error during OAuth.
+:::
+
 2. Start LiteLLM Proxy
+
+Since Claude Code needs a publicly accessible URL for the OAuth callback, expose your proxy via ngrok or a similar tool.
 
 ```bash
 litellm --config /path/to/config.yaml
@@ -52,13 +59,46 @@ litellm --config /path/to/config.yaml
 # RUNNING on http://0.0.0.0:4000
 ```
 
-3. Use the MCP server in Claude Code
-
 ```bash
-claude mcp add --transport http litellm_proxy http://0.0.0.0:4000/github_mcp/mcp --header "Authorization: Bearer sk-LITELLM_VIRTUAL_KEY"
+# In a separate terminal — expose proxy for OAuth callbacks
+ngrok http 4000
 ```
 
-For MCP servers that require dynamic client registration (such as Atlassian), please set `x-litellm-api-key: Bearer sk-LITELLM_VIRTUAL_KEY` instead of using `Authorization: Bearer LITELLM_VIRTUAL_KEY`.
+3. Add the MCP server to Claude Code
+
+<Tabs>
+<TabItem value="github" label="GitHub MCP">
+
+```bash
+claude mcp add --transport http litellm-github https://your-ngrok-url.ngrok-free.dev/mcp/github_mcp \
+  --header "x-litellm-api-key: Bearer sk-1234"
+```
+
+</TabItem>
+<TabItem value="atlassian" label="Atlassian MCP">
+
+```bash
+claude mcp add --transport http litellm-atlassian https://your-ngrok-url.ngrok-free.dev/mcp/atlassian_mcp \
+  --header "x-litellm-api-key: Bearer sk-1234"
+```
+
+</TabItem>
+</Tabs>
+
+**Parameter breakdown:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `--transport http` | Use HTTP transport for the MCP connection |
+| `litellm-atlassian` | The name for this MCP server **on Claude Code** — can be anything you choose |
+| `https://your-ngrok-url.ngrok-free.dev/mcp/atlassian_mcp` | The LiteLLM proxy URL. Format: `<PROXY_URL>/mcp/<server_name_on_litellm>`. The `atlassian_mcp` part **must match** the key under `mcp_servers:` in your LiteLLM proxy config |
+| `--header "x-litellm-api-key: Bearer sk-1234"` | Your LiteLLM virtual key for authentication to the proxy |
+
+You can also add the MCP server directly to your `~/.claude.json` file instead of using `claude mcp add`. [See Claude Code docs](https://docs.anthropic.com/en/docs/claude-code/mcp).
+
+:::note
+For MCP servers that require OAuth (such as Atlassian), use `x-litellm-api-key` instead of `Authorization` for the LiteLLM virtual key. The `Authorization` header is reserved for the OAuth flow.
+:::
 
 4. Authenticate via Claude Code
 
@@ -68,24 +108,20 @@ a. Start Claude Code
 claude
 ```
 
-b. Authenticate via Claude Code
+b. Open the MCP menu
 
 ```bash
 /mcp
 ```
 
-c. Select the MCP server
+c. Select the MCP server (e.g. `litellm-atlassian`)
 
-```bash
-> litellm_proxy
-```
-
-d. Start Oauth flow via Claude Code
+d. Start the OAuth flow
 
 ```bash
 > 1. Authenticate
  2. Reconnect
- 3. Disable             
+ 3. Disable
 ```
 
 e. Once completed, you should see this success message:


### PR DESCRIPTION
## Summary
- Fixed Atlassian MCP config example: was using `sse` transport and wrong URL (`/v1/sse`), corrected to `http` transport and `/v1/mcp`
- Fixed URL pattern in `claude mcp add` command: was using legacy `/{server_name}/mcp`, corrected to standard `/mcp/{server_name}`
- Added parameter breakdown table explaining each `claude mcp add` argument
- Added callout warning that server name in proxy config must match the name in the Claude Code URL path (mismatch causes 404 during OAuth)
- Added ngrok step since OAuth callbacks require a publicly accessible URL
- Added `~/.claude.json` config option as alternative to `claude mcp add`
- Fixed auth header: use `x-litellm-api-key` instead of `Authorization` for OAuth MCP servers

## Test plan
- [ ] Verify docs render correctly on Vercel preview
- [ ] Confirm Atlassian MCP OAuth flow works end-to-end with the documented config