### PR TITLE
[Fix] UI - Spend Logs: Reset Filters Resets Custom Date Range

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
@@ -1,8 +1,45 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { RequestViewer } from "./index";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SpendLogsTable, { RequestViewer } from "./index";
 import type { LogEntry } from "./columns";
 import type { Row } from "@tanstack/react-table";
+import type { Team } from "../key_team_helpers/key_list";
+import { renderWithProviders } from "../../../tests/test-utils";
+
+const mockHandleFilterResetFromHook = vi.fn();
+vi.mock("./log_filter_logic", () => ({
+  useLogFilterLogic: vi.fn(() => ({
+    filters: {},
+    filteredLogs: { data: [], total: 0, page: 1, page_size: 50, total_pages: 1 },
+    allTeams: [],
+    allKeyAliases: [],
+    handleFilterChange: vi.fn(),
+    handleFilterReset: mockHandleFilterResetFromHook,
+  })),
+}));
+
+vi.mock("../networking", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../networking")>();
+  return {
+    ...actual,
+    uiSpendLogsCall: vi.fn().mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      page_size: 50,
+      total_pages: 0,
+    }),
+    keyListCall: vi.fn().mockResolvedValue({ keys: [] }),
+    keyInfoV1Call: vi.fn().mockResolvedValue({ info: {} }),
+    allEndUsersCall: vi.fn().mockResolvedValue([]),
+  };
+});
+
+vi.mock("../key_team_helpers/filter_helpers", () => ({
+  fetchAllKeyAliases: vi.fn().mockResolvedValue([]),
+  fetchAllTeams: vi.fn().mockResolvedValue([]),
+}));
 
 const baseLogEntry: LogEntry = {
   request_id: "chatcmpl-test-id",
@@ -85,5 +122,65 @@ describe("Request Viewer", () => {
     render(<RequestViewer row={createRow()} />);
 
     expect(screen.queryByText("LiteLLM Overhead:")).not.toBeInTheDocument();
+  });
+});
+
+describe("SpendLogsTable", () => {
+  const defaultProps = {
+    accessToken: "test-token",
+    token: "test-token",
+    userRole: "Admin",
+    userID: "user-1",
+    allTeams: [] as Team[],
+    premiumUser: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear sessionStorage to avoid isLiveTail state from previous tests
+    sessionStorage.clear();
+  });
+
+  it("should call handleFilterResetFromHook when Reset Filters is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SpendLogsTable {...defaultProps} />);
+
+    const resetButton = screen.getByRole("button", { name: "Reset Filters" });
+    await user.click(resetButton);
+
+    await waitFor(() => {
+      expect(mockHandleFilterResetFromHook).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("should reset custom date range to default when Reset Filters is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SpendLogsTable {...defaultProps} />);
+
+    // Open the time range quick select dropdown (button shows current range like "Last 24 Hours")
+    const quickSelectButton = screen.getByRole("button", { name: /Last 24 Hours|Last 15 Minutes|Last Hour|Last 4 Hours|Last 7 Days/i });
+    await user.click(quickSelectButton);
+
+    // Click "Custom Range" to enable custom date selection
+    const customRangeButton = await screen.findByRole("button", { name: "Custom Range" });
+    await user.click(customRangeButton);
+
+    // Custom date inputs should now be visible (start and end datetime-local inputs)
+    const datetimeInputs = document.querySelectorAll('input[type="datetime-local"]');
+    expect(datetimeInputs.length).toBeGreaterThanOrEqual(2);
+
+    // Click Reset Filters - this should reset the custom date range and hide custom inputs
+    const resetButton = screen.getByRole("button", { name: "Reset Filters" });
+    await user.click(resetButton);
+
+    await waitFor(() => {
+      expect(mockHandleFilterResetFromHook).toHaveBeenCalled();
+    });
+
+    // After reset, custom date inputs should be hidden (isCustomDate reset to false)
+    await waitFor(() => {
+      const inputsAfterReset = document.querySelectorAll('input[type="datetime-local"]');
+      expect(inputsAfterReset.length).toBe(0);
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -239,7 +239,7 @@ export default function SpendLogsTable({
     allTeams: hookAllTeams,
     allKeyAliases,
     handleFilterChange,
-    handleFilterReset,
+    handleFilterReset: handleFilterResetFromHook,
   } = useLogFilterLogic({
     logs: logsData,
     accessToken,
@@ -273,6 +273,16 @@ export default function SpendLogsTable({
     },
     [accessToken, currentPage, pageSize],
   );
+
+  const handleFilterReset = useCallback(() => {
+    handleFilterResetFromHook();
+    // Reset custom time range to default (last 24 hours)
+    setStartTime(moment().subtract(24, "hours").format("YYYY-MM-DDTHH:mm"));
+    setEndTime(moment().format("YYYY-MM-DDTHH:mm"));
+    setIsCustomDate(false);
+    setSelectedTimeInterval({ value: 24, unit: "hours" });
+    setCurrentPage(1);
+  }, [handleFilterResetFromHook]);
 
   // Add this effect to update selected filters when filter changes
   useEffect(() => {


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

Clicking "Reset Filters" in the spend logs view did not reset the custom time range. The custom date inputs remained visible and the selected date range persisted. This PR updates `handleFilterReset` to also reset the time range to the default (last 24 hours), clear `isCustomDate`, and reset the page. Adds unit tests for `SpendLogsTable` that verify the Reset Filters button calls the filter reset handler and that the custom date range is cleared when Reset Filters is clicked.

## Screenshots
<img width="1005" height="257" alt="image" src="https://github.com/user-attachments/assets/61b9b367-b30e-408a-8de7-b98439b6caab" />
<img width="872" height="247" alt="image" src="https://github.com/user-attachments/assets/57c490e5-7459-4425-847c-9c2f166f6f5a" />
