### PR TITLE
fix: update db_health_cache on failure and add LITELLM_READINESS_FAIL_ON_DB_DISCONNECT

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -31,7 +31,7 @@ from litellm.proxy.health_check import (
     perform_health_check,
     run_with_timeout,
 )
-from litellm.secret_managers.main import get_secret
+from litellm.secret_managers.main import get_secret, get_secret_bool
 from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
 
 #### Health ENDPOINTS ####
@@ -110,26 +110,31 @@ def _resolve_os_environ_variables(params: dict) -> dict:
 def get_callback_identifier(callback):
     """
     Get the callback identifier string, handling both strings and objects.
-    
+
     This function extracts a string identifier from a callback, which can be:
     - A string (returned as-is)
     - An object with a callback_name attribute
     - An object registered in CustomLoggerRegistry
     - Falls back to callback_name() helper function
-    
+
     Args:
         callback: The callback to identify (can be str or object)
-        
+
     Returns:
         str: The callback identifier string
     """
     if isinstance(callback, str):
         return callback
-    if hasattr(callback, 'callback_name') and callback.callback_name:
+    if hasattr(callback, "callback_name") and callback.callback_name:
         return callback.callback_name
-    if hasattr(callback, '__class__'):
-        callback_strs = CustomLoggerRegistry.get_all_callback_strs_from_class_type(callback.__class__)
-        if hasattr(callback, 'callback_name') and callback.callback_name in callback_strs:
+    if hasattr(callback, "__class__"):
+        callback_strs = CustomLoggerRegistry.get_all_callback_strs_from_class_type(
+            callback.__class__
+        )
+        if (
+            hasattr(callback, "callback_name")
+            and callback.callback_name in callback_strs
+        ):
             return callback.callback_name
         if callback_strs:
             return callback_strs[0]
@@ -151,7 +156,7 @@ services = Union[
         "datadog_llm_observability",
         "generic_api",
         "arize",
-        "sqs"
+        "sqs",
     ],
     str,
 ]
@@ -224,7 +229,7 @@ async def health_services_endpoint(  # noqa: PLR0915
             "datadog_llm_observability",
             "generic_api",
             "arize",
-            "sqs"
+            "sqs",
         ]:
             raise HTTPException(
                 status_code=400,
@@ -238,14 +243,14 @@ async def health_services_endpoint(  # noqa: PLR0915
             service_in_success_callbacks = True
         else:
             for cb in litellm.success_callback:
-                if hasattr(cb, 'callback_name') and cb.callback_name == service:
+                if hasattr(cb, "callback_name") and cb.callback_name == service:
                     service_in_success_callbacks = True
                     break
                 cb_id = get_callback_identifier(cb)
                 if cb_id == service:
                     service_in_success_callbacks = True
                     break
-        
+
         if (
             service == "openmeter"
             or service == "braintrust"
@@ -320,6 +325,7 @@ async def health_services_endpoint(  # noqa: PLR0915
             )
         elif service == "sqs":
             from litellm.integrations.sqs import SQSLogger
+
             sqs_logger = SQSLogger()
             response = await sqs_logger.async_health_check()
             return {
@@ -518,12 +524,12 @@ async def _save_health_check_to_db(
 def _build_model_param_to_info_mapping(model_list: list) -> dict:
     """
     Build a mapping from model parameter to model info (model_name, model_id).
-    
+
     Multiple models might share the same model parameter, so we use a list.
-    
+
     Args:
         model_list: List of model configurations
-        
+
     Returns:
         Dictionary mapping model parameter to list of model info dicts
     """
@@ -534,14 +540,16 @@ def _build_model_param_to_info_mapping(model_list: list) -> dict:
         model_id = model_info.get("id")
         litellm_params = model.get("litellm_params", {})
         model_param = litellm_params.get("model")
-        
+
         if model_param and model_name:
             if model_param not in model_param_to_info:
                 model_param_to_info[model_param] = []
-            model_param_to_info[model_param].append({
-                "model_name": model_name,
-                "model_id": model_id,
-            })
+            model_param_to_info[model_param].append(
+                {
+                    "model_name": model_name,
+                    "model_id": model_id,
+                }
+            )
     return model_param_to_info
 
 
@@ -552,19 +560,19 @@ def _aggregate_health_check_results(
 ) -> dict:
     """
     Aggregate health check results per unique model.
-    
+
     Uses (model_id, model_name) as key, or (None, model_name) if model_id is None.
-    
+
     Args:
         model_param_to_info: Mapping from model parameter to model info
         healthy_endpoints: List of healthy endpoint results
         unhealthy_endpoints: List of unhealthy endpoint results
-        
+
     Returns:
         Dictionary mapping (model_id, model_name) to aggregated health check results
     """
     model_results = {}
-    
+
     # Process healthy endpoints
     for endpoint in healthy_endpoints:
         model_param = endpoint.get("model")
@@ -580,7 +588,7 @@ def _aggregate_health_check_results(
                         "error_message": None,
                     }
                 model_results[key]["healthy_count"] += 1
-    
+
     # Process unhealthy endpoints
     for endpoint in unhealthy_endpoints:
         model_param = endpoint.get("model")
@@ -600,7 +608,7 @@ def _aggregate_health_check_results(
                 # Use the first error message encountered
                 if not model_results[key]["error_message"] and error_message:
                     model_results[key]["error_message"] = str(error_message)[:500]
-    
+
     return model_results
 
 
@@ -613,14 +621,14 @@ async def _save_health_check_results_if_changed(
 ):
     """
     Save health check results to database, but only if status changed or >1 hour since last save.
-    
+
     OPTIMIZATION: Only saves to database if the status has changed from the last saved check.
     This dramatically reduces database writes when health status remains stable.
-    
+
     - Stable systems: ~1 write/hour per model (instead of 12 writes/hour with 5-min intervals)
     - Status changes: Immediate write (no delay)
     - Result: ~92% reduction in DB writes for stable systems, while maintaining real-time updates on changes
-    
+
     Args:
         prisma_client: Database client
         model_results: Dictionary of aggregated health check results per model
@@ -630,7 +638,7 @@ async def _save_health_check_results_if_changed(
     """
     for result in model_results.values():
         new_status = "healthy" if result["healthy_count"] > 0 else "unhealthy"
-        
+
         # Check if we should save this result
         should_save = True
         lookup_key = result["model_id"] if result["model_id"] else result["model_name"]
@@ -641,6 +649,7 @@ async def _save_health_check_results_if_changed(
                 # Check if last check was recent (within 1 hour)
                 if last_check.checked_at:
                     from datetime import datetime, timezone
+
                     time_since_last_check = (
                         datetime.now(timezone.utc) - last_check.checked_at
                     ).total_seconds()
@@ -648,7 +657,7 @@ async def _save_health_check_results_if_changed(
                     # This ensures we still get periodic updates even if status is stable
                     if time_since_last_check < 3600:  # 1 hour threshold
                         should_save = False
-        
+
         if should_save:
             asyncio.create_task(
                 prisma_client.save_health_check_result(
@@ -675,27 +684,27 @@ async def _save_background_health_checks_to_db(
 ):
     """
     Save background health check results to database for each model.
-    
+
     Maps health check endpoints back to their original models to get model_name and model_id.
     Aggregates results per unique model (by model_id if available, otherwise model_name).
-    
+
     OPTIMIZATION: Only saves to database if the status has changed from the last saved check.
     This dramatically reduces database writes when health status remains stable.
     """
     if prisma_client is None:
         return
-    
+
     try:
         # Step 1: Build mapping from model parameter to model info
         model_param_to_info = _build_model_param_to_info_mapping(model_list)
-        
+
         # Step 2: Aggregate health check results per unique model
         model_results = _aggregate_health_check_results(
             model_param_to_info,
             healthy_endpoints,
             unhealthy_endpoints,
         )
-        
+
         # Step 3: Get latest health checks for all models in one query to compare status
         latest_checks = await prisma_client.get_all_latest_health_checks()
         latest_checks_map = {}
@@ -704,7 +713,7 @@ async def _save_background_health_checks_to_db(
             key = check.model_id if check.model_id else check.model_name
             if key not in latest_checks_map:
                 latest_checks_map[key] = check
-        
+
         # Step 4: Save aggregated results, but only if status changed
         await _save_health_check_results_if_changed(
             prisma_client,
@@ -1114,6 +1123,7 @@ async def _db_health_readiness_check():
         db_health_cache = {"status": "connected", "last_updated": datetime.now()}
         return db_health_cache
     except Exception as e:
+        db_health_cache = {"status": "disconnected", "last_updated": datetime.now()}
         PrismaDBExceptionHandler.handle_db_exception(e)
         return db_health_cache
 
@@ -1254,14 +1264,20 @@ async def health_readiness():
         # check DB
         if prisma_client is not None:  # if db passed in, check if it's connected
             db_health_status = await _db_health_readiness_check()
+            if db_health_status.get("status") == "disconnected" and get_secret_bool(
+                "LITELLM_READINESS_FAIL_ON_DB_DISCONNECT", False
+            ):
+                raise HTTPException(
+                    status_code=503,
+                    detail="Service Unhealthy (DB disconnected)",
+                )
             return {
                 "status": "healthy",
-                "db": "connected",
+                "db": db_health_status.get("status", "connected"),
                 "cache": cache_type,
                 "litellm_version": version,
                 "success_callbacks": success_callback_names,
                 "use_aiohttp_transport": AsyncHTTPHandler._should_use_aiohttp_transport(),
-                **db_health_status,
             }
         else:
             return {
@@ -1272,6 +1288,8 @@ async def health_readiness():
                 "success_callbacks": success_callback_names,
                 "use_aiohttp_transport": AsyncHTTPHandler._should_use_aiohttp_transport(),
             }
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=503, detail=f"Service Unhealthy ({str(e)})")
 
@@ -1420,11 +1438,11 @@ async def test_model_connection(
                 status_code=500,
                 detail={"error": CommonProxyErrors.db_not_connected_error.value},
             )
-        
+
         # Get model name from litellm_params
         request_litellm_params = litellm_params or {}
         model_name = request_litellm_params.get("model")
-        
+
         # Look up model configuration from router if model name is provided
         # This gets the litellm_params from proxy config (with resolved env vars)
         config_litellm_params: dict = {}
@@ -1432,34 +1450,39 @@ async def test_model_connection(
             try:
                 # First try to find by proxy model_name (e.g., "gpt-4o")
                 deployments = llm_router.get_model_list(model_name=model_name)
-                
+
                 # If not found, try to find by litellm model name (e.g., "azure/gpt-4o")
                 if not deployments or len(deployments) == 0:
                     all_deployments = llm_router.get_model_list(model_name=None)
                     if all_deployments:
                         for deployment in all_deployments:
-                            if deployment.get("litellm_params", {}).get("model") == model_name:
+                            if (
+                                deployment.get("litellm_params", {}).get("model")
+                                == model_name
+                            ):
                                 deployments = [deployment]
                                 break
-                
+
                 if deployments and len(deployments) > 0:
                     # Use the first deployment's litellm_params as base config
                     # These already have resolved environment variables from proxy config
-                    config_litellm_params = dict(deployments[0].get("litellm_params", {}))
+                    config_litellm_params = dict(
+                        deployments[0].get("litellm_params", {})
+                    )
             except Exception as e:
                 verbose_proxy_logger.debug(
                     f"Could not find model {model_name} in router: {e}. "
                     "Proceeding with request params only."
                 )
-        
+
         # Merge: config params (from proxy config) as base, request params override
         # This allows users to override specific params while using config for credentials
         merged_litellm_params = {**config_litellm_params, **request_litellm_params}
-        
+
         # Resolve os.environ/ environment variables in any remaining request params
         # This handles cases where user explicitly passes os.environ/ values to override config
         litellm_params = _resolve_os_environ_variables(merged_litellm_params)
-        
+
         ## Auth check
         await ModelManagementAuthChecks.can_user_make_model_call(
             model_params=Deployment(

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -10,14 +10,15 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 import pytest
+from fastapi import HTTPException
 from prisma.errors import ClientNotConnectedError, HTTPClientClosedError, PrismaError
 
 import litellm.proxy.health_endpoints._health_endpoints as _health_endpoints_module
 from litellm.proxy.health_endpoints._health_endpoints import (
     _db_health_readiness_check,
-    db_health_cache,
     get_callback_identifier,
     health_license_endpoint,
+    health_readiness,
     health_services_endpoint,
 )
 from litellm.proxy.health_endpoints._health_endpoints import (
@@ -50,7 +51,7 @@ async def test_db_health_readiness_check_with_prisma_error(prisma_error):
     # Reset the health cache in the source module so _db_health_readiness_check
     # sees the updated value (assigning to a test-module global doesn't work).
     _health_endpoints_module.db_health_cache = {
-        "status": "unknown",
+        "status": "connected",
         "last_updated": datetime.now() - timedelta(minutes=5),
     }
 
@@ -67,7 +68,9 @@ async def test_db_health_readiness_check_with_prisma_error(prisma_error):
 
         # Verify that the function returned the cache
         assert result is not None
-        assert result["status"] == "unknown"  # Should retain the status from the cache
+        assert (
+            result["status"] == "disconnected"
+        )  # Cache must update to reflect actual disconnected state
 
 
 @pytest.mark.asyncio
@@ -204,15 +207,15 @@ async def test_test_model_connection_loads_config_from_router():
     """
     # Mock request
     mock_request = MagicMock()
-    
+
     # Mock user_api_key_dict
     mock_user_api_key_dict = MagicMock()
     mock_user_api_key_dict.user_id = "test-user"
     mock_user_api_key_dict.token = "test-token"
-    
+
     # Mock prisma_client
     mock_prisma_client = MagicMock()
-    
+
     # Mock router with model configuration
     mock_router = MagicMock()
     mock_deployment = {
@@ -226,31 +229,31 @@ async def test_test_model_connection_loads_config_from_router():
         "model_info": {},
     }
     mock_router.get_model_list.return_value = [mock_deployment]
-    
+
     # Mock ModelManagementAuthChecks - patch at the source module since it's imported inside the function
     mock_can_user_make_model_call = AsyncMock()
-    
+
     # Mock litellm.ahealth_check
     mock_health_check_result = {
         "status": "healthy",
         "response_time_ms": 100,
     }
     mock_ahealth_check = AsyncMock(return_value=mock_health_check_result)
-    
+
     # Mock run_with_timeout
     mock_run_with_timeout = AsyncMock(return_value=mock_health_check_result)
-    
+
     # Mock _update_litellm_params_for_health_check
     def mock_update_params(model_info, litellm_params):
         # Just return params with messages added
         params = litellm_params.copy()
         params["messages"] = [{"role": "user", "content": "test"}]
         return params
-    
+
     # Mock _resolve_os_environ_variables
     def mock_resolve_os_environ(params):
         return params
-    
+
     with patch(
         "litellm.proxy.proxy_server.prisma_client",
         mock_prisma_client,
@@ -284,30 +287,35 @@ async def test_test_model_connection_loads_config_from_router():
             model_info={},
             user_api_key_dict=mock_user_api_key_dict,
         )
-        
+
         # Verify router.get_model_list was called with the model name
         mock_router.get_model_list.assert_called_once_with(model_name="gpt-4o")
-        
+
         # Verify that run_with_timeout was called (which wraps ahealth_check)
         assert mock_run_with_timeout.called
-        
+
         # Get the call args to verify merged params
         call_args = mock_run_with_timeout.call_args
         assert call_args is not None
-        
+
         # The first arg should be the coroutine from ahealth_check
         # We need to check what was passed to ahealth_check
         ahealth_check_call_args = mock_ahealth_check.call_args
         assert ahealth_check_call_args is not None
         model_params = ahealth_check_call_args.kwargs.get("model_params", {})
-        
+
         # Verify that config params were loaded and merged
         # Note: request params override config params, so model from request is used
         assert model_params.get("api_key") == "resolved-api-key-from-env"
-        assert model_params.get("api_base") == "https://resolved-endpoint.openai.azure.com/"
+        assert (
+            model_params.get("api_base")
+            == "https://resolved-endpoint.openai.azure.com/"
+        )
         assert model_params.get("api_version") == "2024-10-21"
-        assert model_params.get("model") == "gpt-4o"  # Request param overrides config param
-        
+        assert (
+            model_params.get("model") == "gpt-4o"
+        )  # Request param overrides config param
+
         # Verify result
         assert result["status"] == "success"
         assert "result" in result
@@ -328,9 +336,7 @@ async def test_health_services_endpoint_datadog_llm_observability():
 
     # Mock datadog_llm_observability to be in success_callback so the generic branch handles it
     with patch("litellm.success_callback", ["datadog_llm_observability"]):
-        result = await health_services_endpoint(
-            service="datadog_llm_observability"
-        )
+        result = await health_services_endpoint(service="datadog_llm_observability")
 
     # Should not raise HTTPException(400) and should return success
     assert result["status"] == "success"
@@ -345,9 +351,7 @@ async def test_health_services_endpoint_rejects_unknown_service():
     from litellm.proxy._types import ProxyException
 
     with pytest.raises(ProxyException):
-        await health_services_endpoint(
-            service="totally_unknown_service_xyz"
-        )
+        await health_services_endpoint(service="totally_unknown_service_xyz")
 
 
 @pytest.fixture(scope="function")
@@ -355,16 +359,16 @@ def proxy_client(monkeypatch):
     """
     Fixture that starts a proxy server instance for testing.
     Uses the actual FastAPI app from proxy_server which includes all routers.
-    
+
     Note: TestClient doesn't start a real HTTP server - it runs the FastAPI app
     in-process. However, it DOES trigger FastAPI's lifespan events (startup/shutdown)
     when used as a context manager, which initializes the proxy server components.
-    
+
     Database access:
     - If DATABASE_URL is set in environment, the proxy will automatically connect
     - Database connection happens during lifespan startup events
     - To enable database access, set DATABASE_URL environment variable before running tests
-    
+
     Redis cache:
     - If REDIS_HOST is set in environment, Redis cache will be automatically configured
     - Cache configuration is included in /health/readiness endpoint response
@@ -381,23 +385,29 @@ def test_health_liveliness_endpoint(proxy_client):
     """
     # Measure the time taken for the health check call
     start_time = time.perf_counter()
-    
+
     # Make GET request to /health/liveliness
     response = proxy_client.get("/health/liveliness")
-    
+
     end_time = time.perf_counter()
     duration_ms = (end_time - start_time) * 1000
-    
+
     # Assert response status
-    assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}: {response.text}"
-    
+    assert (
+        response.status_code == 200
+    ), f"Expected 200 OK, got {response.status_code}: {response.text}"
+
     # Assert response content (FastAPI JSON-encodes the string)
-    assert response.json() == "I'm alive!", f"Expected 'I'm alive!' message, got: {response.json()}"
-    
+    assert (
+        response.json() == "I'm alive!"
+    ), f"Expected 'I'm alive!' message, got: {response.json()}"
+
     # Verify response is fast (should be < 100ms for a simple endpoint)
     # This is critical for orchestration systems that poll frequently
-    assert duration_ms < 100, f"Health check took {duration_ms:.2f}ms, expected < 100ms for a simple endpoint"
-    
+    assert (
+        duration_ms < 100
+    ), f"Health check took {duration_ms:.2f}ms, expected < 100ms for a simple endpoint"
+
     # Log the duration for visibility (useful for CI/CD monitoring)
     print(f"\n/health/liveliness response time: {duration_ms:.2f}ms")
 
@@ -408,22 +418,28 @@ def test_health_liveness_endpoint(proxy_client):
     """
     # Measure the time taken for the health check call
     start_time = time.perf_counter()
-    
+
     # Make GET request to /health/liveness
     response = proxy_client.get("/health/liveness")
-    
+
     end_time = time.perf_counter()
     duration_ms = (end_time - start_time) * 1000
-    
+
     # Assert response status
-    assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}: {response.text}"
-    
+    assert (
+        response.status_code == 200
+    ), f"Expected 200 OK, got {response.status_code}: {response.text}"
+
     # Assert response content (FastAPI JSON-encodes the string)
-    assert response.json() == "I'm alive!", f"Expected 'I'm alive!' message, got: {response.json()}"
-    
+    assert (
+        response.json() == "I'm alive!"
+    ), f"Expected 'I'm alive!' message, got: {response.json()}"
+
     # Verify response is fast (should be < 100ms for a simple endpoint)
-    assert duration_ms < 100, f"Health check took {duration_ms:.2f}ms, expected < 100ms for a simple endpoint"
-    
+    assert (
+        duration_ms < 100
+    ), f"Health check took {duration_ms:.2f}ms, expected < 100ms for a simple endpoint"
+
     # Log the duration for visibility (useful for CI/CD monitoring)
     print(f"\n/health/liveness response time: {duration_ms:.2f}ms")
 
@@ -432,59 +448,71 @@ def test_health_readiness(proxy_client):
     """
     Test /health/readiness endpoint.
     Database and Redis are optional - the endpoint should work whether they're available or not.
-    
+
     If DATABASE_URL is set, the endpoint will check database connectivity.
     If REDIS_HOST is set, the endpoint will report cache status.
     If neither is set, the endpoint should still return a valid health status.
     """
     # Measure the time taken for the health check call
     start_time = time.perf_counter()
-    
+
     # Make GET request to /health/readiness
     response = proxy_client.get("/health/readiness")
-    
+
     end_time = time.perf_counter()
     duration_ms = (end_time - start_time) * 1000
-    
+
     # Assert response status
-    assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}: {response.text}"
-    
+    assert (
+        response.status_code == 200
+    ), f"Expected 200 OK, got {response.status_code}: {response.text}"
+
     # Verify response is fast (readiness may include DB check if available, so < 500ms is reasonable)
     # This is critical for orchestration systems (Kubernetes) that poll frequently
-    assert duration_ms < 500, f"Health check took {duration_ms:.2f}ms, expected < 500ms for readiness endpoint"
-    
+    assert (
+        duration_ms < 500
+    ), f"Health check took {duration_ms:.2f}ms, expected < 500ms for readiness endpoint"
+
     # Assert response contains expected fields
     response_data = response.json()
     assert "status" in response_data, "Response should contain 'status' field"
-    assert "litellm_version" in response_data, "Response should contain 'litellm_version' field"
-    
+    assert (
+        "litellm_version" in response_data
+    ), "Response should contain 'litellm_version' field"
+
     # Display all health endpoint response fields (matches what /health/readiness returns)
-    print("\n" + "-"*60)
+    print("\n" + "-" * 60)
     print("HEALTH ENDPOINT RESPONSE")
-    print("-"*60)
+    print("-" * 60)
     print(f"Status: {response_data.get('status', 'unknown')}")
     print(f"Database: {response_data.get('db', 'not reported')}")
     print(f"LiteLLM Version: {response_data.get('litellm_version', 'unknown')}")
     print(f"Success Callbacks: {response_data.get('success_callbacks', [])}")
     print(f"Cache: {response_data.get('cache', 'none')}")
-    print(f"Use AioHTTP Transport: {response_data.get('use_aiohttp_transport', 'unknown')}")
+    print(
+        f"Use AioHTTP Transport: {response_data.get('use_aiohttp_transport', 'unknown')}"
+    )
     print(f"Response time: {duration_ms:.2f}ms")
-    
+
     # If database status is reported, verify it's a valid status
     # Database may be "connected", "disconnected", "unknown", or "Not connected" (when prisma_client is None)
     if "db" in response_data:
         db_status = response_data["db"]
         # Database status can be any of these valid states
-        assert db_status in ["connected", "disconnected", "unknown", "Not connected"], \
-            f"Unexpected db status: {db_status}"
-    
-    print("="*60 + "\n")
+        assert db_status in [
+            "connected",
+            "disconnected",
+            "unknown",
+            "Not connected",
+        ], f"Unexpected db status: {db_status}"
+
+    print("=" * 60 + "\n")
 
 
 def test_get_callback_identifier_string_and_object_with_callback_name():
     """
     Test get_callback_identifier with string callbacks and objects with callback_name attribute.
-    
+
     Covers:
     - String callback (returned as-is)
     - Object with callback_name attribute
@@ -495,15 +523,15 @@ def test_get_callback_identifier_string_and_object_with_callback_name():
     # Test 1: String callback should be returned as-is
     assert get_callback_identifier("datadog") == "datadog"
     assert get_callback_identifier("langfuse") == "langfuse"
-    
+
     # Test 2: Object with callback_name attribute
     class MockCallbackWithName:
         def __init__(self, name):
             self.callback_name = name
-    
+
     callback_obj = MockCallbackWithName("custom_callback")
     assert get_callback_identifier(callback_obj) == "custom_callback"
-    
+
     # Test 3: Object with empty callback_name should fall through
     callback_obj_empty = MockCallbackWithName("")
     # This should fall through to CustomLoggerRegistry or callback_name() fallback
@@ -516,98 +544,191 @@ def test_get_callback_identifier_string_and_object_with_callback_name():
 def test_get_callback_identifier_custom_logger_registry_and_fallback():
     """
     Test get_callback_identifier with CustomLoggerRegistry lookup and fallback scenarios.
-    
+
     Covers:
     - Object registered in CustomLoggerRegistry
     - Object with callback_name that matches registry entry
     - Fallback to callback_name() helper function
     """
     from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
-    from litellm.proxy.health_endpoints._health_endpoints import get_callback_identifier
+
 
     # Test 1: Object registered in CustomLoggerRegistry (without callback_name attribute)
     # Mock a class that's registered in the registry
     class MockRegisteredLogger:
         pass
-    
+
     # Mock the registry to return callback strings for our mock class
     with patch.object(
         CustomLoggerRegistry,
-        'get_all_callback_strs_from_class_type',
-        return_value=['mock_logger']
+        "get_all_callback_strs_from_class_type",
+        return_value=["mock_logger"],
     ):
         mock_instance = MockRegisteredLogger()
         result = get_callback_identifier(mock_instance)
         assert result == "mock_logger"
-    
+
     # Test 2: Object with callback_name that matches registry entry
     class MockCallbackWithMatchingName:
         def __init__(self):
             self.callback_name = "matched_name"
-    
+
     callback_with_matching = MockCallbackWithMatchingName()
     # Mock registry to return list containing the matching name
     with patch.object(
         CustomLoggerRegistry,
-        'get_all_callback_strs_from_class_type',
-        return_value=['matched_name', 'other_name']
+        "get_all_callback_strs_from_class_type",
+        return_value=["matched_name", "other_name"],
     ):
         result = get_callback_identifier(callback_with_matching)
         assert result == "matched_name"
-    
+
     # Test 3: Object with falsy callback_name (empty string), should use registry
     class MockCallbackWithEmptyName:
         def __init__(self):
             self.callback_name = ""  # Empty string is falsy
-    
+
     callback_empty = MockCallbackWithEmptyName()
     # Mock registry to return list - should use first registry entry since callback_name is falsy
     with patch.object(
         CustomLoggerRegistry,
-        'get_all_callback_strs_from_class_type',
-        return_value=['registry_name']
+        "get_all_callback_strs_from_class_type",
+        return_value=["registry_name"],
     ):
         result = get_callback_identifier(callback_empty)
         assert result == "registry_name"
-    
+
     # Test 3b: Object with truthy callback_name not in registry - returns callback_name immediately
     # (This tests that truthy callback_name takes precedence over registry)
     class MockCallbackWithNonMatchingName:
         def __init__(self):
             self.callback_name = "non_matching"
-    
+
     callback_non_matching = MockCallbackWithNonMatchingName()
     # Even if registry has different values, truthy callback_name is returned first
     with patch.object(
         CustomLoggerRegistry,
-        'get_all_callback_strs_from_class_type',
-        return_value=['registry_name']
+        "get_all_callback_strs_from_class_type",
+        return_value=["registry_name"],
     ):
         result = get_callback_identifier(callback_non_matching)
         # Should return callback_name because it's truthy (checked before registry)
         assert result == "non_matching"
-    
+
     # Test 4: Object not in registry, falls back to callback_name() helper
     class UnregisteredCallback:
         def __init__(self):
             pass
-    
+
     unregistered = UnregisteredCallback()
     # Mock registry to return empty list (not registered)
     with patch.object(
-        CustomLoggerRegistry,
-        'get_all_callback_strs_from_class_type',
-        return_value=[]
+        CustomLoggerRegistry, "get_all_callback_strs_from_class_type", return_value=[]
     ):
         result = get_callback_identifier(unregistered)
         # Should fall back to callback_name() which returns __class__.__name__
         assert result == "UnregisteredCallback"
-    
+
     # Test 5: Function callback (not a class instance)
     def my_callback_function():
         pass
-    
+
     # Function won't have __class__, so it will skip registry check and go to callback_name()
     result = get_callback_identifier(my_callback_function)
     # Should fall back to callback_name() which returns __name__
     assert result == "my_callback_function"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "prisma_error",
+    [
+        PrismaError(),
+        ClientNotConnectedError(),
+        HTTPClientClosedError(),
+    ],
+)
+async def test_db_health_readiness_cache_updates_from_connected_to_disconnected(
+    prisma_error,
+):
+    """
+    Test that when DB was previously connected but health check fails,
+    the cache updates from 'connected' to 'disconnected'.
+    This is the core zombie-state fix: after a CNPG outage, the cache
+    must reflect the actual disconnected state.
+    """
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.health_check.side_effect = prisma_error
+
+    _health_endpoints_module.db_health_cache = {
+        "status": "connected",
+        "last_updated": datetime.now() - timedelta(minutes=5),
+    }
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client), patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"allow_requests_on_db_unavailable": True},
+    ):
+        result = await _db_health_readiness_check()
+
+        mock_prisma_client.health_check.assert_called_once()
+        assert result["status"] == "disconnected"
+        assert _health_endpoints_module.db_health_cache["status"] == "disconnected"
+
+
+@pytest.mark.asyncio
+async def test_health_readiness_returns_503_when_flag_enabled():
+    """
+    Test that /health/readiness returns 503 when DB is disconnected
+    and LITELLM_READINESS_FAIL_ON_DB_DISCONNECT is enabled.
+    """
+    mock_db_health = AsyncMock(
+        return_value={"status": "disconnected", "last_updated": datetime.now()}
+    )
+
+    with patch(
+        "litellm.proxy.health_endpoints._health_endpoints._db_health_readiness_check",
+        mock_db_health,
+    ), patch(
+        "litellm.proxy.proxy_server.prisma_client",
+        MagicMock(),
+    ), patch(
+        "litellm.proxy.health_endpoints._health_endpoints.get_secret_bool",
+        return_value=True,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await health_readiness()
+
+        assert exc_info.value.status_code == 503
+        assert "DB disconnected" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_health_readiness_returns_200_when_flag_disabled_disconnected():
+    """
+    Test that /health/readiness returns 200 when DB is disconnected
+    but LITELLM_READINESS_FAIL_ON_DB_DISCONNECT is disabled (default).
+    This preserves backward-compatible behavior.
+    """
+    mock_db_health = AsyncMock(
+        return_value={"status": "disconnected", "last_updated": datetime.now()}
+    )
+
+    with patch(
+        "litellm.proxy.health_endpoints._health_endpoints._db_health_readiness_check",
+        mock_db_health,
+    ), patch(
+        "litellm.proxy.proxy_server.prisma_client",
+        MagicMock(),
+    ), patch(
+        "litellm.proxy.health_endpoints._health_endpoints.get_secret_bool",
+        return_value=False,
+    ):
+        result = await health_readiness()
+
+        # Top-level status stays "healthy" (HTTP 200 signals overall health);
+        # the "db" field carries the actual DB state.
+        assert result["status"] == "healthy"
+        assert result["db"] == "disconnected"
+        # No HTTPException was raised — response is still 200
+        assert isinstance(result, dict)


### PR DESCRIPTION
## Relevant issues

#14739
#18415

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm)
directory, **Adding at least 1 test is a hard requirement** - [see
details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least
4/5** before requesting a maintainer review

## Type

Bug Fix / New Feature (opt-in feature flag)

## Changes

### Problem

After brief DB outages (e.g., CNPG failovers), LiteLLM pods enter a zombie state: Prisma fails to reconnect but
`/health/readiness` continues returning HTTP 200. All DB-dependent operations (auth, spend tracking, budgets) fail
silently. Requires manual pod restart to recover.

Two compounding bugs:

1. **Readiness cache never updates on failure** - the `except` block in `_db_health_readiness_check()` returns the
stale cached value (e.g., `"connected"`) instead of updating to reflect the actual disconnected state.
2. **Readiness always returns HTTP 200** - even if the cache were correct, K8s probes only check status codes, not
response bodies. There's no mechanism to make readiness return 503 on DB failure when
`allow_requests_on_db_unavailable=True`.
3. **Response body leaked internal state** - `**db_health_status` was spread into the response dict, overwriting
`"status": "healthy"` and leaking `"last_updated"` datetime into the API response.

### Fix

**Change 1: Always update cache on failure** (`_health_endpoints.py:1127`)

The `except` block now sets `db_health_cache = {"status": "disconnected", ...}` before calling
`handle_db_exception`:
- If `allow_requests_on_db_unavailable=False` (default): handler re-raises -> 503 via outer handler (same as
today), but cache is now correct
- If `allow_requests_on_db_unavailable=True`: handler returns None -> function returns accurate `"disconnected"`
  instead of stale `"connected"`

**Change 2: Derive `db` field from health check result** (`_health_endpoints.py:1276-1277`)

The `"db"` field in the readiness response now uses `db_health_status.get("status", "connected")` instead of the
previously hardcoded `"connected"`. The `**db_health_status` spread has been removed to prevent overwriting the
top-level `"status": "healthy"` and leaking `"last_updated"` into the API response.

**Change 3: Opt-in feature flag** (`_health_endpoints.py:1268-1274`)

New env var `LITELLM_READINESS_FAIL_ON_DB_DISCONNECT` (default: `False`). When enabled, `/health/readiness` returns
  HTTP 503 when DB health status is `"disconnected"`, allowing K8s readiness probes to detect the failure and
stop routing traffic.

### Behavior matrix

| `allow_requests_on_db_unavailable` | `LITELLM_READINESS_FAIL_ON_DB_DISCONNECT` | DB down | Result |
|---|---|---|---|
| `False` (default) | any | yes | **503** (exception propagates - same as today) |
| `True` | `False` (default) | yes | **200** with `"status": "healthy"`, `"db": "disconnected"` (was: stale
`"db": "connected"`) |
| `True` | `True` | yes | **503** (new behavior, opt-in) |
| any | any | no | **200** with `"status": "healthy"`, `"db": "connected"` (unchanged) |

The only row that changes default behavior is row 2: the HTTP status code stays 200, `"status"` stays `"healthy"`,
but the `"db"` field now accurately reports `"disconnected"` instead of the stale `"connected"`.

### Tests added

- `test_db_health_readiness_cache_updates_from_connected_to_disconnected` - verifies cache updates from
`"connected"` -> `"disconnected"` on health check failure (parametrized across PrismaError types)
- `test_health_readiness_returns_503_when_flag_enabled` - verifies 503 when feature flag is on
- `test_health_readiness_returns_200_when_flag_disabled_disconnected` - verifies backward-compatible 200 with
`"status": "healthy"` and `"db": "disconnected"` when flag is off
- Updated existing `test_db_health_readiness_check_with_prisma_error` to assert `"disconnected"` (the fix)
instead of stale cache value
- Fixed test isolation: pre-existing tests now properly reset the module-level `db_health_cache` instead of only
rebinding the test module's variable