### PR TITLE
fix: prevent double-counting of litellm_proxy_total_requests_metric

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -450,18 +450,32 @@ class ProxyLogging:
     def _init_litellm_callbacks(self, llm_router: Optional[Router] = None):
         self._add_proxy_hooks(llm_router)
         litellm.logging_callback_manager.add_litellm_callback(self.service_logging_obj)  # type: ignore
-        for callback in litellm.callbacks:
+
+        # Track string callbacks and their initialized instances so we can
+        # replace them in-place, preventing duplicates (string + instance) in
+        # litellm.callbacks which caused double-counting of metrics.
+        string_callbacks_to_replace: Dict[int, CustomLogger] = {}
+
+        for idx, callback in enumerate(litellm.callbacks):
             if isinstance(callback, str):
-                callback = litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class(  # type: ignore
+                initialized_callback = litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class(
                     cast(_custom_logger_compatible_callbacks_literal, callback),
                     internal_usage_cache=self.internal_usage_cache.dual_cache,
                     llm_router=llm_router,
                 )
 
-                if callback is None:
-                    continue
+                if initialized_callback is not None:
+                    string_callbacks_to_replace[idx] = initialized_callback
+            else:
+                # Only add non-string callbacks to the manager; string
+                # callbacks will be replaced in-place below and are already
+                # present in litellm.callbacks, so adding them to the manager
+                # (which appends to litellm.callbacks) would create duplicates.
+                litellm.logging_callback_manager.add_litellm_callback(callback)
 
-            litellm.logging_callback_manager.add_litellm_callback(callback)
+        # Replace string entries in litellm.callbacks with initialized instances
+        for idx, initialized_callback in string_callbacks_to_replace.items():
+            litellm.callbacks[idx] = initialized_callback
 
     async def update_request_status(
         self, litellm_call_id: str, status: Literal["success", "fail"]

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -464,18 +464,10 @@ class ProxyLogging:
                     llm_router=llm_router,
                 )
 
-                if initialized_callback is not None:
-                    string_callbacks_to_replace[idx] = initialized_callback
-            else:
-                # Only add non-string callbacks to the manager; string
-                # callbacks will be replaced in-place below and are already
-                # present in litellm.callbacks, so adding them to the manager
-                # (which appends to litellm.callbacks) would create duplicates.
-                litellm.logging_callback_manager.add_litellm_callback(callback)
-
         # Replace string entries in litellm.callbacks with initialized instances
         for idx, initialized_callback in string_callbacks_to_replace.items():
             litellm.callbacks[idx] = initialized_callback
+            litellm.logging_callback_manager.add_litellm_callback(initialized_callback)
 
     async def update_request_status(
         self, litellm_call_id: str, status: Literal["success", "fail"]

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -464,11 +464,19 @@ class ProxyLogging:
                     llm_router=llm_router,
                 )
 
+                if initialized_callback is not None:
+                    string_callbacks_to_replace[idx] = initialized_callback
+            else:
+                # Only add non-string callbacks to the manager; string
+                # callbacks will be replaced in-place below and are already
+                # present in litellm.callbacks, so adding them to the manager
+                # (which appends to litellm.callbacks) would create duplicates.
+                litellm.logging_callback_manager.add_litellm_callback(callback)
+
         # Replace string entries in litellm.callbacks with initialized instances
         for idx, initialized_callback in string_callbacks_to_replace.items():
-            litellm.callbacks[idx] = initialized_callback
-            litellm.logging_callback_manager.add_litellm_callback(initialized_callback)
-
+            litellm.callbacks[idx] = initialized_callback        
+            
     async def update_request_status(
         self, litellm_call_id: str, status: Literal["success", "fail"]
     ):

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -466,12 +466,6 @@ class ProxyLogging:
 
                 if initialized_callback is not None:
                     string_callbacks_to_replace[idx] = initialized_callback
-            else:
-                # Only add non-string callbacks to the manager; string
-                # callbacks will be replaced in-place below and are already
-                # present in litellm.callbacks, so adding them to the manager
-                # (which appends to litellm.callbacks) would create duplicates.
-                litellm.logging_callback_manager.add_litellm_callback(callback)
 
         # Replace string entries in litellm.callbacks with initialized instances
         for idx, initialized_callback in string_callbacks_to_replace.items():

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -475,8 +475,8 @@ class ProxyLogging:
 
         # Replace string entries in litellm.callbacks with initialized instances
         for idx, initialized_callback in string_callbacks_to_replace.items():
-            litellm.callbacks[idx] = initialized_callback        
-            
+            litellm.callbacks[idx] = initialized_callback
+
     async def update_request_status(
         self, litellm_call_id: str, status: Literal["success", "fail"]
     ):

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
@@ -792,7 +792,8 @@ async def test_async_post_call_success_hook(prometheus_logger):
     """
     Test for the async_post_call_success_hook method
 
-    it should increment the litellm_proxy_total_requests_metric
+    litellm_proxy_total_requests_metric is NOT incremented here to avoid double-counting.
+    It is incremented in async_log_success_event instead.
     """
     # Mock the prometheus metric
     prometheus_logger.litellm_proxy_total_requests_metric = MagicMock()
@@ -817,23 +818,8 @@ async def test_async_post_call_success_hook(prometheus_logger):
         data=data, user_api_key_dict=user_api_key_dict, response=response
     )
 
-    # Assert total requests metric was incremented with correct labels
-    prometheus_logger.litellm_proxy_total_requests_metric.labels.assert_called_once_with(
-        end_user=None,
-        hashed_api_key="test_key",
-        api_key_alias="test_alias",
-        requested_model="gpt-3.5-turbo",
-        team="test_team",
-        team_alias="test_team_alias",
-        user="test_user",
-        status_code="200",
-        user_email=None,
-        route=user_api_key_dict.request_route,
-        model_id=None,
-        client_ip=None,
-        user_agent=None,
-    )
-    prometheus_logger.litellm_proxy_total_requests_metric.labels().inc.assert_called_once()
+    # Assert total requests metric was NOT incremented (moved to async_log_success_event)
+    prometheus_logger.litellm_proxy_total_requests_metric.labels.assert_not_called()
 
 
 def test_set_llm_deployment_success_metrics(prometheus_logger):

--- a/tests/litellm/proxy/test_init_litellm_callbacks.py
+++ b/tests/litellm/proxy/test_init_litellm_callbacks.py
@@ -1,0 +1,175 @@
+"""
+Unit tests for ProxyLogging._init_litellm_callbacks.
+
+Validates that string callbacks in litellm.callbacks are replaced in-place
+with their initialized instances, preventing duplicate entries (string + instance)
+that caused double-counting of metrics like litellm_proxy_total_requests_metric.
+"""
+
+from typing import List, Union
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import litellm
+from litellm.integrations.custom_logger import CustomLogger
+
+
+class FakeCustomLogger(CustomLogger):
+    """A minimal CustomLogger subclass for testing."""
+
+    pass
+
+
+class TestInitLitellmCallbacks:
+    """Tests for ProxyLogging._init_litellm_callbacks."""
+
+    def _make_proxy_logging(self):
+        """Create a ProxyLogging instance with mocked dependencies."""
+        from litellm.proxy.utils import ProxyLogging
+
+        mock_cache = MagicMock()
+        proxy_logging = ProxyLogging(user_api_key_cache=mock_cache)
+        return proxy_logging
+
+    @patch(
+        "litellm.proxy.utils.ProxyLogging._add_proxy_hooks",
+        new_callable=lambda: lambda self, *a, **kw: None,
+    )
+    def test_should_replace_string_callback_with_instance(self, _mock_hooks):
+        """
+        When litellm.callbacks contains a string callback (e.g. "lago"),
+        _init_litellm_callbacks should replace the string with the initialized
+        CustomLogger instance, not leave both the string and instance in the list.
+        """
+        fake_logger = FakeCustomLogger()
+
+        # Start with a string callback in litellm.callbacks
+        litellm.callbacks = ["lago"]  # type: ignore
+
+        proxy_logging = self._make_proxy_logging()
+
+        with patch(
+            "litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class",
+            return_value=fake_logger,
+        ):
+            proxy_logging._init_litellm_callbacks(llm_router=None)
+
+        # The string "lago" should be replaced by the instance, not appended
+        string_entries = [c for c in litellm.callbacks if isinstance(c, str)]
+        instance_entries = [
+            c for c in litellm.callbacks if isinstance(c, FakeCustomLogger)
+        ]
+
+        assert len(string_entries) == 0, (
+            f"String callbacks should have been replaced, but found: {string_entries}"
+        )
+        assert len(instance_entries) == 1, (
+            f"Expected exactly one FakeCustomLogger instance, found {len(instance_entries)}"
+        )
+        assert instance_entries[0] is fake_logger
+
+        # Clean up
+        litellm.callbacks = []  # type: ignore
+
+    @patch(
+        "litellm.proxy.utils.ProxyLogging._add_proxy_hooks",
+        new_callable=lambda: lambda self, *a, **kw: None,
+    )
+    def test_should_not_duplicate_existing_instance_callbacks(self, _mock_hooks):
+        """
+        When litellm.callbacks already contains a CustomLogger instance (not a string),
+        _init_litellm_callbacks should not create a duplicate.
+        """
+        existing_logger = FakeCustomLogger()
+
+        litellm.callbacks = [existing_logger]  # type: ignore
+
+        proxy_logging = self._make_proxy_logging()
+
+        proxy_logging._init_litellm_callbacks(llm_router=None)
+
+        # Count how many FakeCustomLogger instances are in litellm.callbacks
+        instance_count = sum(
+            1 for c in litellm.callbacks if isinstance(c, FakeCustomLogger)
+        )
+        assert instance_count == 1, (
+            f"Expected exactly 1 FakeCustomLogger instance, found {instance_count}. "
+            f"litellm.callbacks = {litellm.callbacks}"
+        )
+
+        # Clean up
+        litellm.callbacks = []  # type: ignore
+
+    @patch(
+        "litellm.proxy.utils.ProxyLogging._add_proxy_hooks",
+        new_callable=lambda: lambda self, *a, **kw: None,
+    )
+    def test_should_handle_unrecognized_string_callback(self, _mock_hooks):
+        """
+        When _init_custom_logger_compatible_class returns None for a string callback,
+        the string should remain in litellm.callbacks (not crash).
+        """
+        litellm.callbacks = ["unknown_callback"]  # type: ignore
+
+        proxy_logging = self._make_proxy_logging()
+
+        with patch(
+            "litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class",
+            return_value=None,
+        ):
+            proxy_logging._init_litellm_callbacks(llm_router=None)
+
+        # The unknown string callback should still be there (not replaced, not crashed)
+        assert "unknown_callback" in litellm.callbacks
+
+        # Clean up
+        litellm.callbacks = []  # type: ignore
+
+    @patch(
+        "litellm.proxy.utils.ProxyLogging._add_proxy_hooks",
+        new_callable=lambda: lambda self, *a, **kw: None,
+    )
+    def test_should_replace_multiple_string_callbacks(self, _mock_hooks):
+        """
+        When litellm.callbacks contains multiple string callbacks,
+        each should be replaced with its corresponding initialized instance.
+        """
+        fake_logger_a = FakeCustomLogger()
+        fake_logger_b = FakeCustomLogger()
+
+        litellm.callbacks = ["callback_a", "callback_b"]  # type: ignore
+
+        proxy_logging = self._make_proxy_logging()
+
+        call_count = 0
+
+        def mock_init_class(callback_name, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return fake_logger_a
+            return fake_logger_b
+
+        with patch(
+            "litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class",
+            side_effect=mock_init_class,
+        ):
+            proxy_logging._init_litellm_callbacks(llm_router=None)
+
+        string_entries = [c for c in litellm.callbacks if isinstance(c, str)]
+        instance_entries = [
+            c for c in litellm.callbacks if isinstance(c, FakeCustomLogger)
+        ]
+
+        assert len(string_entries) == 0, (
+            f"All string callbacks should have been replaced: {string_entries}"
+        )
+        assert len(instance_entries) == 2, (
+            f"Expected 2 FakeCustomLogger instances, found {len(instance_entries)}"
+        )
+        assert instance_entries[0] is fake_logger_a
+        assert instance_entries[1] is fake_logger_b
+
+        # Clean up
+        litellm.callbacks = []  # type: ignore


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**
Root cause
When "prometheus" was added as a string to litellm.callbacks, _init_litellm_callbacks() converted it to a PrometheusLogger instance and added it via add_litellm_callback() without removing the original string. Both the string and the instance stayed in litellm.callbacks. post_call_success_hook() iterated over both entries, so async_post_call_success_hook() ran twice per request and incremented litellm_proxy_total_requests_metric twice.

The metric after one non-streaming request.
Before:
<img width="1492" height="46" alt="Screenshot 2026-02-13 at 6 43 06 PM" src="https://github.com/user-attachments/assets/54f9b7bf-0adb-469e-b4eb-638601191f50" />

After:
<img width="1496" height="75" alt="Screenshot 2026-02-13 at 6 36 39 PM" src="https://github.com/user-attachments/assets/bfe81507-5778-4c07-b532-7c325a2b53c0" />

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
Fixes
litellm/proxy/utils.py – In _init_litellm_callbacks(), string callbacks are now replaced in-place with their initialized instances instead of appending them, so each callback appears only once in litellm.callbacks.

litellm/integrations/prometheus.py – The metric is incremented only in async_log_success_event (for both streaming and non-streaming). The increment was removed from async_post_call_success_hook to avoid double-counting. Dead code in _increment_token_metrics was removed.
