### PR TITLE
fix: populate identity fields in proxy admin JWT early-return path

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -585,7 +585,20 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
                 if is_proxy_admin:
                     return UserAPIKeyAuth(
+                        api_key=None,
                         user_role=LitellmUserRoles.PROXY_ADMIN,
+                        user_id=user_id,
+                        team_id=team_id,
+                        team_alias=(
+                            team_object.team_alias
+                            if team_object is not None
+                            else None
+                        ),
+                        team_metadata=team_object.metadata
+                        if team_object is not None
+                        else None,
+                        org_id=org_id,
+                        end_user_id=end_user_id,
                         parent_otel_span=parent_otel_span,
                     )
 


### PR DESCRIPTION
## Summary
- When `is_proxy_admin` is True during JWT auth, the `UserAPIKeyAuth` early-return now includes `user_id`, `team_id`, `team_alias`, `team_metadata`, `org_id`, and `end_user_id` resolved from the JWT
- Previously only `user_role` and `parent_otel_span` were set, causing blank Team Name and Internal User in the Request Logs UI for JWT-authenticated proxy admins

## Test plan
- [x] Added `test_proxy_admin_jwt_auth_includes_identity_fields` — verifies all identity fields are populated
- [x] Added `test_proxy_admin_jwt_auth_handles_no_team_object` — verifies None team_object is handled correctly
- [x] All existing tests pass (`make test-unit`)