### PR TITLE
Fix Bedrock service_tier cost propagation

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -446,7 +446,9 @@ def cost_per_token(  # noqa: PLR0915
     elif custom_llm_provider == "anthropic":
         return anthropic_cost_per_token(model=model, usage=usage_block)
     elif custom_llm_provider == "bedrock":
-        return bedrock_cost_per_token(model=model, usage=usage_block)
+        return bedrock_cost_per_token(
+            model=model, usage=usage_block, service_tier=service_tier
+        )
     elif custom_llm_provider == "openai":
         return openai_cost_per_token(
             model=model, usage=usage_block, service_tier=service_tier
@@ -2133,5 +2135,4 @@ def handle_realtime_stream_cost_calculation(
     total_cost = input_cost_per_token + output_cost_per_token
 
     return total_cost
-
 

--- a/litellm/llms/bedrock/cost_calculation.py
+++ b/litellm/llms/bedrock/cost_calculation.py
@@ -3,7 +3,7 @@ Helper util for handling bedrock-specific cost calculation
 - e.g.: prompt caching
 """
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 
@@ -11,12 +11,17 @@ if TYPE_CHECKING:
     from litellm.types.utils import Usage
 
 
-def cost_per_token(model: str, usage: "Usage") -> Tuple[float, float]:
+def cost_per_token(
+    model: str, usage: "Usage", service_tier: Optional[str] = None
+) -> Tuple[float, float]:
     """
     Calculates the cost per token for a given model, prompt tokens, and completion tokens.
 
     Follows the same logic as Anthropic's cost per token calculation.
     """
     return generic_cost_per_token(
-        model=model, usage=usage, custom_llm_provider="bedrock"
+        model=model,
+        usage=usage,
+        custom_llm_provider="bedrock",
+        service_tier=service_tier,
     )


### PR DESCRIPTION
## Summary
Fix Bedrock `service_tier` cost propagation so tier-specific rates are applied during `completion_cost` / `response_cost_calculator`.

## Root Cause
`completion_cost` extracts `service_tier`, but the Bedrock branch in `cost_per_token` did not forward it:
- `litellm/cost_calculator.py` called `bedrock_cost_per_token(model, usage)` without tier.
- `litellm/llms/bedrock/cost_calculation.py` did not accept/pass `service_tier` to `generic_cost_per_token`.

## Changes
1. `litellm/cost_calculator.py`
- Pass `service_tier` to `bedrock_cost_per_token(...)`.

2. `litellm/llms/bedrock/cost_calculation.py`
- Add optional `service_tier` arg.
- Forward `service_tier` to `generic_cost_per_token(...)`.

3. `tests/test_litellm/test_cost_calculator.py`
- Add regression test `test_completion_cost_service_tier_for_bedrock`.
- Registers a temporary Bedrock model with distinct `default` / `priority` / `flex` rates and asserts:
  - `priority_cost > default_cost > flex_cost > 0`.

## Validation
Ran:
- `poetry run pytest tests/test_litellm/test_cost_calculator.py -k "service_tier"`
- `poetry run pytest tests/test_litellm/llms/bedrock/chat/test_service_tier.py`

Both passed.

## Note on `supports_service_tier`
This fix intentionally does not gate cost calculation on `supports_service_tier`. The current cost engine uses tier-specific price keys (e.g. `input_cost_per_token_priority`, `..._flex`) and falls back to base pricing when tier keys are absent.

Closes #21171
