### PR TITLE
fix(ci): add claude-sonnet-4-5-20250929 to anthropic E2E test config

### DIFF
--- a/tests/proxy_e2e_anthropic_messages_tests/test_config.yaml
+++ b/tests/proxy_e2e_anthropic_messages_tests/test_config.yaml
@@ -1,4 +1,9 @@
 model_list:
+  - model_name: claude-sonnet-4-5-20250929
+    litellm_params:
+      model: "anthropic/claude-sonnet-4-5-20250929"
+      api_key: os.environ/ANTHROPIC_API_KEY
+
   - model_name: bedrock-claude-sonnet-3.5
     litellm_params:
       model: "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0"


### PR DESCRIPTION
## Summary
- Add `claude-sonnet-4-5-20250929` model entry to `tests/proxy_e2e_anthropic_messages_tests/test_config.yaml`
- The `test_anthropic_messages_with_all_beta_headers` test parametrizes with this model but it was missing from the proxy config, causing a 400 "Invalid model name" error

## Test plan
- [ ] `proxy_e2e_anthropic_messages_tests` job should pass with the `claude-sonnet-4-5-20250929-anthropic` parameter