### PR TITLE
Add pipeline flow builder UI for guardrail policies

### DIFF
--- a/litellm/proxy/policy_engine/pipeline_executor.py
+++ b/litellm/proxy/policy_engine/pipeline_executor.py
@@ -148,6 +148,11 @@ class PipelineExecutor:
             return ("error", None, f"Guardrail '{step.guardrail}' not found")
 
         try:
+            # Inject guardrail name into metadata so should_run_guardrail() allows it
+            if "metadata" not in data:
+                data["metadata"] = {}
+            data["metadata"]["guardrails"] = [step.guardrail]
+
             # Use unified_guardrail path if callback implements apply_guardrail
             target = callback
             use_unified = "apply_guardrail" in type(callback).__dict__

--- a/litellm/proxy/policy_engine/policy_endpoints.py
+++ b/litellm/proxy/policy_engine/policy_endpoints.py
@@ -10,8 +10,11 @@ from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.policy_engine.attachment_registry import get_attachment_registry
+from litellm.proxy.policy_engine.pipeline_executor import PipelineExecutor
 from litellm.proxy.policy_engine.policy_registry import get_policy_registry
 from litellm.types.proxy.policy_engine import (
+    GuardrailPipeline,
+    PipelineTestRequest,
     PolicyAttachmentCreateRequest,
     PolicyAttachmentDBResponse,
     PolicyAttachmentListResponse,
@@ -346,6 +349,68 @@ async def get_resolved_guardrails(policy_id: str):
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         verbose_proxy_logger.exception(f"Error resolving guardrails: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pipeline Test Endpoint
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/policies/test-pipeline",
+    tags=["Policies"],
+)
+async def test_pipeline(
+    request: PipelineTestRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Test a guardrail pipeline with sample messages.
+
+    Executes the pipeline steps against the provided test messages and returns
+    step-by-step results showing which guardrails passed/failed, actions taken,
+    and timing information.
+
+    Example Request:
+    ```bash
+    curl -X POST "http://localhost:4000/policies/test-pipeline" \\
+        -H "Authorization: Bearer <your_api_key>" \\
+        -H "Content-Type: application/json" \\
+        -d '{
+            "pipeline": {
+                "mode": "pre_call",
+                "steps": [
+                    {"guardrail": "pii-guard", "on_pass": "next", "on_fail": "block"}
+                ]
+            },
+            "test_messages": [{"role": "user", "content": "My SSN is 123-45-6789"}]
+        }'
+    ```
+    """
+    try:
+        validated_pipeline = GuardrailPipeline(**request.pipeline)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid pipeline: {e}")
+
+    data = {
+        "messages": request.test_messages,
+        "model": "test",
+        "metadata": {},
+    }
+
+    try:
+        result = await PipelineExecutor.execute_steps(
+            steps=validated_pipeline.steps,
+            mode=validated_pipeline.mode,
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            call_type="completion",
+            policy_name="test-pipeline",
+        )
+        return result.model_dump()
+    except Exception as e:
+        verbose_proxy_logger.exception(f"Error testing pipeline: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -917,6 +917,7 @@ model LiteLLM_PolicyTable {
   guardrails_add   String[]  @default([])
   guardrails_remove String[] @default([])
   condition        Json?     @default("{}")  // Policy conditions (e.g., model matching)
+  pipeline         Json?     // Optional guardrail pipeline (mode + steps[])
   created_at       DateTime  @default(now())
   created_by       String?
   updated_at       DateTime  @default(now()) @updatedAt

--- a/litellm/types/proxy/policy_engine/__init__.py
+++ b/litellm/types/proxy/policy_engine/__init__.py
@@ -26,6 +26,7 @@ from litellm.types.proxy.policy_engine.policy_types import (
 )
 from litellm.types.proxy.policy_engine.resolver_types import (
     AttachmentImpactResponse,
+    PipelineTestRequest,
     PolicyAttachmentCreateRequest,
     PolicyAttachmentDBResponse,
     PolicyAttachmentListResponse,
@@ -90,6 +91,8 @@ __all__ = [
     "PolicyAttachmentCreateRequest",
     "PolicyAttachmentDBResponse",
     "PolicyAttachmentListResponse",
+    # Pipeline test types
+    "PipelineTestRequest",
     # Resolve types
     "PolicyResolveRequest",
     "PolicyResolveResponse",

--- a/litellm/types/proxy/policy_engine/resolver_types.py
+++ b/litellm/types/proxy/policy_engine/resolver_types.py
@@ -302,6 +302,17 @@ class PolicyAttachmentListResponse(BaseModel):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+class PipelineTestRequest(BaseModel):
+    """Request body for testing a guardrail pipeline with sample messages."""
+
+    pipeline: Dict[str, Any] = Field(
+        description="Pipeline definition with 'mode' and 'steps'.",
+    )
+    test_messages: List[Dict[str, str]] = Field(
+        description="Test messages to run through the pipeline, e.g. [{'role': 'user', 'content': '...'}].",
+    )
+
+
 class PolicyResolveRequest(BaseModel):
     """Request body for resolving effective policies/guardrails for a context."""
 

--- a/litellm/types/proxy/policy_engine/resolver_types.py
+++ b/litellm/types/proxy/policy_engine/resolver_types.py
@@ -154,6 +154,10 @@ class PolicyCreateRequest(BaseModel):
         default=None,
         description="Condition for when this policy applies.",
     )
+    pipeline: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Optional guardrail pipeline for ordered execution. Contains 'mode' and 'steps'.",
+    )
 
 
 class PolicyUpdateRequest(BaseModel):
@@ -183,6 +187,10 @@ class PolicyUpdateRequest(BaseModel):
         default=None,
         description="Condition for when this policy applies.",
     )
+    pipeline: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Optional guardrail pipeline for ordered execution. Contains 'mode' and 'steps'.",
+    )
 
 
 class PolicyDBResponse(BaseModel):
@@ -200,6 +208,9 @@ class PolicyDBResponse(BaseModel):
     )
     condition: Optional[Dict[str, Any]] = Field(
         default=None, description="Policy condition."
+    )
+    pipeline: Optional[Dict[str, Any]] = Field(
+        default=None, description="Optional guardrail pipeline."
     )
     created_at: Optional[datetime] = Field(
         default=None, description="When the policy was created."

--- a/tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py
+++ b/tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py
@@ -1,0 +1,102 @@
+"""
+Tests for pipeline field on policy CRUD types (resolver_types.py).
+"""
+
+import pytest
+
+from litellm.types.proxy.policy_engine.resolver_types import (
+    PolicyCreateRequest,
+    PolicyDBResponse,
+    PolicyUpdateRequest,
+)
+
+
+def test_policy_create_request_with_pipeline():
+    pipeline_data = {
+        "mode": "pre_call",
+        "steps": [
+            {"guardrail": "g1", "on_fail": "next", "on_pass": "allow"},
+            {"guardrail": "g2", "on_fail": "block", "on_pass": "allow"},
+        ],
+    }
+    req = PolicyCreateRequest(
+        policy_name="test-policy",
+        guardrails_add=["g1", "g2"],
+        pipeline=pipeline_data,
+    )
+    assert req.pipeline is not None
+    assert req.pipeline["mode"] == "pre_call"
+    assert len(req.pipeline["steps"]) == 2
+
+
+def test_policy_create_request_without_pipeline():
+    req = PolicyCreateRequest(
+        policy_name="test-policy",
+        guardrails_add=["g1"],
+    )
+    assert req.pipeline is None
+
+
+def test_policy_update_request_with_pipeline():
+    pipeline_data = {
+        "mode": "pre_call",
+        "steps": [
+            {"guardrail": "g1", "on_fail": "block", "on_pass": "allow"},
+        ],
+    }
+    req = PolicyUpdateRequest(pipeline=pipeline_data)
+    assert req.pipeline is not None
+    assert req.pipeline["steps"][0]["guardrail"] == "g1"
+
+
+def test_policy_db_response_with_pipeline():
+    pipeline_data = {
+        "mode": "pre_call",
+        "steps": [
+            {"guardrail": "g1", "on_fail": "next", "on_pass": "allow"},
+            {"guardrail": "g2", "on_fail": "block", "on_pass": "allow"},
+        ],
+    }
+    resp = PolicyDBResponse(
+        policy_id="test-id",
+        policy_name="test-policy",
+        guardrails_add=["g1", "g2"],
+        pipeline=pipeline_data,
+    )
+    assert resp.pipeline is not None
+    assert resp.pipeline["mode"] == "pre_call"
+    dumped = resp.model_dump()
+    assert dumped["pipeline"]["steps"][0]["guardrail"] == "g1"
+
+
+def test_policy_db_response_without_pipeline():
+    resp = PolicyDBResponse(
+        policy_id="test-id",
+        policy_name="test-policy",
+    )
+    assert resp.pipeline is None
+    dumped = resp.model_dump()
+    assert dumped["pipeline"] is None
+
+
+def test_policy_create_request_roundtrip():
+    pipeline_data = {
+        "mode": "post_call",
+        "steps": [
+            {
+                "guardrail": "g1",
+                "on_fail": "modify_response",
+                "on_pass": "next",
+                "pass_data": True,
+                "modify_response_message": "custom msg",
+            },
+        ],
+    }
+    req = PolicyCreateRequest(
+        policy_name="roundtrip-test",
+        guardrails_add=["g1"],
+        pipeline=pipeline_data,
+    )
+    dumped = req.model_dump()
+    restored = PolicyCreateRequest(**dumped)
+    assert restored.pipeline == pipeline_data

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -5673,6 +5673,37 @@ export const deletePolicyAttachmentCall = async (accessToken: string, attachment
   }
 };
 
+export const testPipelineCall = async (
+  accessToken: string,
+  pipeline: any,
+  testMessages: Array<{role: string, content: string}>
+) => {
+  try {
+    const url = proxyBaseUrl ? `${proxyBaseUrl}/policies/test-pipeline` : `/policies/test-pipeline`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ pipeline, test_messages: testMessages }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Failed to test pipeline:", error);
+    throw error;
+  }
+};
+
 export const getResolvedGuardrails = async (accessToken: string, policyId: string) => {
   try {
     const url = proxyBaseUrl

--- a/ui/litellm-dashboard/src/components/policies/index.tsx
+++ b/ui/litellm-dashboard/src/components/policies/index.tsx
@@ -6,6 +6,7 @@ import { isAdminRole } from "@/utils/roles";
 import PolicyTable from "./policy_table";
 import PolicyInfoView from "./policy_info";
 import AddPolicyForm from "./add_policy_form";
+import { FlowBuilderPage } from "./pipeline_flow_builder";
 import AttachmentTable from "./attachment_table";
 import AddAttachmentForm from "./add_attachment_form";
 import PolicyTestPanel from "./policy_test_panel";
@@ -56,6 +57,7 @@ const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
   const [selectedTemplate, setSelectedTemplate] = useState<any>(null);
   const [existingGuardrailNames, setExistingGuardrailNames] = useState<Set<string>>(new Set());
   const [isCreatingGuardrails, setIsCreatingGuardrails] = useState(false);
+  const [showFlowBuilder, setShowFlowBuilder] = useState(false);
 
   const isAdmin = userRole ? isAdminRole(userRole) : false;
 
@@ -349,8 +351,12 @@ const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
                 onClose={() => setSelectedPolicyId(null)}
                 onEdit={(policy) => {
                   setEditingPolicy(policy);
-                  setIsAddPolicyModalVisible(true);
                   setSelectedPolicyId(null);
+                  if (policy.pipeline) {
+                    setShowFlowBuilder(true);
+                  } else {
+                    setIsAddPolicyModalVisible(true);
+                  }
                 }}
                 accessToken={accessToken}
                 isAdmin={isAdmin}
@@ -363,7 +369,11 @@ const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
                 onDeleteClick={handleDeleteClick}
                 onEditClick={(policy) => {
                   setEditingPolicy(policy);
-                  setIsAddPolicyModalVisible(true);
+                  if (policy.pipeline) {
+                    setShowFlowBuilder(true);
+                  } else {
+                    setIsAddPolicyModalVisible(true);
+                  }
                 }}
                 onViewClick={(policyId) => setSelectedPolicyId(policyId)}
                 isAdmin={isAdmin}
@@ -374,6 +384,10 @@ const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
               visible={isAddPolicyModalVisible}
               onClose={handleCloseModal}
               onSuccess={handleSuccess}
+              onOpenFlowBuilder={() => {
+                setIsAddPolicyModalVisible(false);
+                setShowFlowBuilder(true);
+              }}
               accessToken={accessToken}
               editingPolicy={editingPolicy}
               existingPolicies={policiesList}
@@ -473,6 +487,24 @@ const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
           </TabPanel>
         </TabPanels>
       </TabGroup>
+
+      {showFlowBuilder && (
+        <FlowBuilderPage
+          onBack={() => {
+            setShowFlowBuilder(false);
+            setEditingPolicy(null);
+          }}
+          onSuccess={() => {
+            fetchPolicies();
+            setEditingPolicy(null);
+          }}
+          accessToken={accessToken}
+          editingPolicy={editingPolicy}
+          availableGuardrails={guardrailsList}
+          createPolicy={createPolicyCall}
+          updatePolicy={updatePolicyCall}
+        />
+      )}
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/components/policies/pipeline_flow_builder.tsx
+++ b/ui/litellm-dashboard/src/components/policies/pipeline_flow_builder.tsx
@@ -181,14 +181,17 @@ const StepCard: React.FC<StepCardProps> = ({
       style={{
         border: "1px solid #e5e7eb",
         borderRadius: 10,
-        padding: "16px 20px",
         backgroundColor: "#fff",
         maxWidth: 720,
         width: "100%",
+        overflow: "hidden",
       }}
     >
-      {/* Header row: icon + GUARDRAIL label ... Step N + menu */}
-      <div className="flex items-center justify-between" style={{ marginBottom: 12 }}>
+      {/* Header row */}
+      <div
+        className="flex items-center justify-between"
+        style={{ padding: "14px 20px 0 20px" }}
+      >
         <div className="flex items-center gap-2">
           <GuardrailIcon />
           <span
@@ -226,8 +229,11 @@ const StepCard: React.FC<StepCardProps> = ({
         </div>
       </div>
 
-      {/* Guardrail name / selector */}
-      <div style={{ marginBottom: 12 }}>
+      {/* Guardrail selector */}
+      <div style={{ padding: "12px 20px 16px 20px" }}>
+        <label style={{ fontSize: 12, fontWeight: 500, color: "#6b7280", display: "block", marginBottom: 6 }}>
+          Guardrail
+        </label>
         <Select
           showSearch
           style={{ width: "100%" }}
@@ -241,47 +247,63 @@ const StepCard: React.FC<StepCardProps> = ({
         />
       </div>
 
-      {/* Divider */}
-      <div style={{ borderTop: "1px solid #f3f4f6", marginBottom: 12 }} />
-
-      {/* Pass / Fail row */}
-      <div className="flex items-center gap-6" style={{ flexWrap: "wrap" }}>
-        <div className="flex items-center gap-2">
+      {/* ON PASS section */}
+      <div style={{ borderTop: "1px solid #f0f0f0", padding: "14px 20px" }}>
+        <div className="flex items-center gap-2" style={{ marginBottom: 8 }}>
           <PassIcon />
-          <span style={{ fontSize: 13, color: "#374151" }}>Pass</span>
-          <span style={{ fontSize: 13, color: "#9ca3af" }}>&#8594;</span>
-          <Select
-            size="small"
-            style={{ minWidth: 140 }}
-            value={step.on_pass}
-            onChange={(value) => onChange({ on_pass: value as PipelineStep["on_pass"] })}
-            options={ACTION_OPTIONS}
-          />
+          <span style={{ fontSize: 13, fontWeight: 600, color: "#374151" }}>ON PASS</span>
         </div>
-        <div className="flex items-center gap-2">
-          <FailIcon />
-          <span style={{ fontSize: 13, color: "#374151" }}>Fail</span>
-          <span style={{ fontSize: 13, color: "#9ca3af" }}>&#8594;</span>
-          <Select
-            size="small"
-            style={{ minWidth: 140 }}
-            value={step.on_fail}
-            onChange={(value) => onChange({ on_fail: value as PipelineStep["on_fail"] })}
-            options={ACTION_OPTIONS}
-          />
-        </div>
+        <label style={{ fontSize: 12, fontWeight: 500, color: "#6b7280", display: "block", marginBottom: 6 }}>
+          Action
+        </label>
+        <Select
+          style={{ width: "100%" }}
+          value={step.on_pass}
+          onChange={(value) => onChange({ on_pass: value as PipelineStep["on_pass"] })}
+          options={ACTION_OPTIONS}
+        />
+        {step.on_pass === "modify_response" && (
+          <div style={{ marginTop: 8 }}>
+            <label style={{ fontSize: 12, fontWeight: 500, color: "#6b7280", display: "block", marginBottom: 6 }}>
+              Custom Response Message
+            </label>
+            <TextInput
+              placeholder="Enter custom response..."
+              value={step.modify_response_message || ""}
+              onChange={(e) => onChange({ modify_response_message: e.target.value || null })}
+            />
+          </div>
+        )}
       </div>
 
-      {/* Custom response input */}
-      {(step.on_pass === "modify_response" || step.on_fail === "modify_response") && (
-        <div style={{ marginTop: 10 }}>
-          <TextInput
-            placeholder="Custom response message"
-            value={step.modify_response_message || ""}
-            onChange={(e) => onChange({ modify_response_message: e.target.value || null })}
-          />
+      {/* ON FAIL section */}
+      <div style={{ borderTop: "1px solid #f0f0f0", padding: "14px 20px" }}>
+        <div className="flex items-center gap-2" style={{ marginBottom: 8 }}>
+          <FailIcon />
+          <span style={{ fontSize: 13, fontWeight: 600, color: "#374151" }}>ON FAIL</span>
         </div>
-      )}
+        <label style={{ fontSize: 12, fontWeight: 500, color: "#6b7280", display: "block", marginBottom: 6 }}>
+          Action
+        </label>
+        <Select
+          style={{ width: "100%" }}
+          value={step.on_fail}
+          onChange={(value) => onChange({ on_fail: value as PipelineStep["on_fail"] })}
+          options={ACTION_OPTIONS}
+        />
+        {step.on_fail === "modify_response" && (
+          <div style={{ marginTop: 8 }}>
+            <label style={{ fontSize: 12, fontWeight: 500, color: "#6b7280", display: "block", marginBottom: 6 }}>
+              Custom Response Message
+            </label>
+            <TextInput
+              placeholder="Enter custom response..."
+              value={step.modify_response_message || ""}
+              onChange={(e) => onChange({ modify_response_message: e.target.value || null })}
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/components/policies/pipeline_flow_builder.tsx
+++ b/ui/litellm-dashboard/src/components/policies/pipeline_flow_builder.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Select, Typography, Tag, message } from "antd";
+import { Select, Typography, message } from "antd";
 import { Button, TextInput } from "@tremor/react";
 import { ArrowLeftIcon, PlusIcon, TrashIcon } from "@heroicons/react/outline";
 import { GuardrailPipeline, PipelineStep, PolicyCreateRequest, PolicyUpdateRequest, Policy } from "./types";
@@ -55,39 +55,36 @@ interface ConnectorProps {
 }
 
 const Connector: React.FC<ConnectorProps> = ({ onInsert }) => (
-  <div className="flex flex-col items-center" style={{ height: 48 }}>
-    <div
-      style={{
-        width: 2,
-        flex: 1,
-        backgroundColor: "#d9d9d9",
-      }}
-    />
+  <div className="flex flex-col items-center" style={{ height: 28 }}>
+    <div style={{ width: 1, flex: 1, backgroundColor: "#e5e7eb" }} />
     <button
       onClick={onInsert}
       className="flex items-center justify-center"
       style={{
-        width: 28,
-        height: 28,
+        width: 20,
+        height: 20,
         borderRadius: "50%",
-        border: "2px solid #d9d9d9",
+        border: "1px solid #e5e7eb",
         backgroundColor: "#fff",
         cursor: "pointer",
         zIndex: 1,
-        marginTop: -4,
-        marginBottom: -4,
+        marginTop: -2,
+        marginBottom: -2,
+        transition: "all 0.15s ease",
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.borderColor = "#9ca3af";
+        e.currentTarget.style.backgroundColor = "#f9fafb";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.borderColor = "#e5e7eb";
+        e.currentTarget.style.backgroundColor = "#fff";
       }}
       title="Insert step"
     >
-      <PlusIcon style={{ width: 14, height: 14, color: "#8c8c8c" }} />
+      <PlusIcon style={{ width: 10, height: 10, color: "#9ca3af" }} />
     </button>
-    <div
-      style={{
-        width: 2,
-        flex: 1,
-        backgroundColor: "#d9d9d9",
-      }}
-    />
+    <div style={{ width: 1, flex: 1, backgroundColor: "#e5e7eb" }} />
   </div>
 );
 
@@ -116,52 +113,32 @@ const StepCard: React.FC<StepCardProps> = ({
   return (
     <div
       style={{
-        border: "1px solid #e8e8e8",
-        borderRadius: 12,
-        padding: 20,
+        border: "1px solid #e5e7eb",
+        borderRadius: 6,
+        padding: "10px 14px",
         backgroundColor: "#fff",
-        boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
         maxWidth: 680,
         width: "100%",
       }}
     >
-      {/* Header */}
-      <div className="flex justify-between items-center" style={{ marginBottom: 16 }}>
-        <div className="flex items-center gap-2">
-          <Tag color="purple" style={{ margin: 0, fontWeight: 600, fontSize: 11 }}>
-            GUARDRAIL
-          </Tag>
-          <Text strong>{step.guardrail || "Select guardrail..."}</Text>
-        </div>
-        <div className="flex items-center gap-2">
-          <Text type="secondary" style={{ fontSize: 12 }}>
-            Step {stepIndex + 1}
-          </Text>
-          <button
-            onClick={onDelete}
-            disabled={totalSteps <= 1}
-            style={{
-              background: "none",
-              border: "none",
-              cursor: totalSteps <= 1 ? "not-allowed" : "pointer",
-              opacity: totalSteps <= 1 ? 0.3 : 1,
-              padding: 4,
-            }}
-            title="Delete step"
-          >
-            <TrashIcon style={{ width: 16, height: 16, color: "#ff4d4f" }} />
-          </button>
-        </div>
-      </div>
-
-      {/* Guardrail Selector */}
-      <div style={{ marginBottom: 12 }}>
-        <Text type="secondary" style={{ fontSize: 12, display: "block", marginBottom: 4 }}>
-          Guardrail
-        </Text>
+      {/* Row 1: GUARDRAIL label + selector + step number + delete */}
+      <div className="flex items-center gap-2" style={{ marginBottom: 8 }}>
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            textTransform: "uppercase",
+            color: "#9ca3af",
+            letterSpacing: "0.05em",
+            flexShrink: 0,
+          }}
+        >
+          GUARDRAIL
+        </span>
         <Select
           showSearch
-          style={{ width: "100%" }}
+          size="small"
+          style={{ flex: 1 }}
           placeholder="Select a guardrail"
           value={step.guardrail || undefined}
           onChange={(value) => onChange({ guardrail: value })}
@@ -170,66 +147,95 @@ const StepCard: React.FC<StepCardProps> = ({
             (option?.label ?? "").toString().toLowerCase().includes(input.toLowerCase())
           }
         />
+        <span style={{ fontSize: 11, color: "#9ca3af", flexShrink: 0 }}>
+          Step {stepIndex + 1}
+        </span>
+        <button
+          onClick={onDelete}
+          disabled={totalSteps <= 1}
+          style={{
+            background: "none",
+            border: "none",
+            cursor: totalSteps <= 1 ? "not-allowed" : "pointer",
+            opacity: totalSteps <= 1 ? 0.3 : 1,
+            padding: 2,
+            display: "flex",
+            alignItems: "center",
+            transition: "all 0.15s ease",
+          }}
+          onMouseEnter={(e) => {
+            if (totalSteps > 1) {
+              const icon = e.currentTarget.querySelector("svg");
+              if (icon) (icon as SVGElement).style.color = "#ef4444";
+            }
+          }}
+          onMouseLeave={(e) => {
+            const icon = e.currentTarget.querySelector("svg");
+            if (icon) (icon as SVGElement).style.color = "#9ca3af";
+          }}
+          title="Delete step"
+        >
+          <TrashIcon style={{ width: 14, height: 14, color: "#9ca3af", transition: "color 0.15s ease" }} />
+        </button>
       </div>
 
-      {/* ON PASS */}
-      <div
-        style={{
-          backgroundColor: "#f6ffed",
-          border: "1px solid #b7eb8f",
-          borderRadius: 8,
-          padding: 12,
-          marginBottom: 8,
-        }}
-      >
-        <Text style={{ fontSize: 12, fontWeight: 600, color: "#52c41a" }}>
-          ON PASS
-        </Text>
-        <Select
-          style={{ width: "100%", marginTop: 4 }}
-          value={step.on_pass}
-          onChange={(value) => onChange({ on_pass: value as PipelineStep["on_pass"] })}
-          options={ACTION_OPTIONS}
-        />
-        {step.on_pass === "modify_response" && (
-          <div style={{ marginTop: 8 }}>
-            <TextInput
-              placeholder="Custom response message"
-              value={step.modify_response_message || ""}
-              onChange={(e) => onChange({ modify_response_message: e.target.value || null })}
-            />
-          </div>
-        )}
+      {/* Row 2: ON PASS + ON FAIL inline */}
+      <div className="flex items-center gap-4" style={{ flexWrap: "wrap" }}>
+        <div className="flex items-center gap-2" style={{ flex: 1, minWidth: 200 }}>
+          <span
+            style={{
+              fontSize: 10,
+              fontWeight: 600,
+              textTransform: "uppercase",
+              color: "#16a34a",
+              letterSpacing: "0.05em",
+              flexShrink: 0,
+            }}
+          >
+            ON PASS
+          </span>
+          <Select
+            size="small"
+            style={{ flex: 1 }}
+            value={step.on_pass}
+            onChange={(value) => onChange({ on_pass: value as PipelineStep["on_pass"] })}
+            options={ACTION_OPTIONS}
+          />
+        </div>
+        <div className="flex items-center gap-2" style={{ flex: 1, minWidth: 200 }}>
+          <span
+            style={{
+              fontSize: 10,
+              fontWeight: 600,
+              textTransform: "uppercase",
+              color: "#dc2626",
+              letterSpacing: "0.05em",
+              flexShrink: 0,
+            }}
+          >
+            ON FAIL
+          </span>
+          <Select
+            size="small"
+            style={{ flex: 1 }}
+            value={step.on_fail}
+            onChange={(value) => onChange({ on_fail: value as PipelineStep["on_fail"] })}
+            options={ACTION_OPTIONS}
+          />
+        </div>
       </div>
 
-      {/* ON FAIL */}
-      <div
-        style={{
-          backgroundColor: "#fff2f0",
-          border: "1px solid #ffccc7",
-          borderRadius: 8,
-          padding: 12,
-        }}
-      >
-        <Text style={{ fontSize: 12, fontWeight: 600, color: "#ff4d4f" }}>
-          ON FAIL
-        </Text>
-        <Select
-          style={{ width: "100%", marginTop: 4 }}
-          value={step.on_fail}
-          onChange={(value) => onChange({ on_fail: value as PipelineStep["on_fail"] })}
-          options={ACTION_OPTIONS}
-        />
-        {step.on_fail === "modify_response" && (
-          <div style={{ marginTop: 8 }}>
-            <TextInput
-              placeholder="Custom response message"
-              value={step.modify_response_message || ""}
-              onChange={(e) => onChange({ modify_response_message: e.target.value || null })}
-            />
-          </div>
-        )}
-      </div>
+      {/* Custom response input (shown only when modify_response is selected) */}
+      {(step.on_pass === "modify_response" || step.on_fail === "modify_response") && (
+        <div style={{ marginTop: 6 }}>
+          <TextInput
+            placeholder="Custom response message"
+            value={step.modify_response_message || ""}
+            onChange={(e) => onChange({ modify_response_message: e.target.value || null })}
+            style={{ fontSize: 13 }}
+          />
+        </div>
+      )}
     </div>
   );
 };
@@ -265,41 +271,37 @@ const PipelineFlowBuilder: React.FC<PipelineFlowBuilderProps> = ({
   };
 
   return (
-    <div className="flex flex-col items-center" style={{ padding: "16px 0" }}>
+    <div className="flex flex-col items-center" style={{ padding: "8px 0" }}>
       {/* Trigger Card */}
       <div
         style={{
-          border: "1px solid #d9d9d9",
-          borderRadius: 12,
-          padding: "16px 24px",
+          border: "1px solid #e5e7eb",
+          borderRadius: 6,
+          padding: "10px 14px",
           backgroundColor: "#fafafa",
           maxWidth: 680,
           width: "100%",
         }}
       >
-        <div className="flex items-center gap-3">
-          <div
-            style={{
-              width: 32,
-              height: 32,
-              borderRadius: "50%",
-              backgroundColor: "#f0f0f0",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <span style={{ fontSize: 16 }}>&#9654;</span>
-          </div>
+        <div className="flex items-center gap-2">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="#9ca3af" stroke="none">
+            <polygon points="5,3 19,12 5,21" />
+          </svg>
           <div>
-            <Text type="secondary" style={{ fontSize: 11, fontWeight: 600, display: "block" }}>
+            <span
+              style={{
+                fontSize: 10,
+                fontWeight: 600,
+                textTransform: "uppercase",
+                color: "#9ca3af",
+                letterSpacing: "0.05em",
+              }}
+            >
               TRIGGER
-            </Text>
-            <Text strong>Incoming LLM Request</Text>
-            <br />
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              This flow runs when a request matches this policy
-            </Text>
+            </span>
+            <span style={{ fontSize: 13, fontWeight: 500, marginLeft: 8 }}>
+              Incoming LLM Request
+            </span>
           </div>
         </div>
       </div>
@@ -329,13 +331,6 @@ const PipelineFlowBuilder: React.FC<PipelineFlowBuilderProps> = ({
 // Read-only display for policy info view
 // ─────────────────────────────────────────────────────────────────────────────
 
-const ACTION_COLORS: Record<string, string> = {
-  allow: "green",
-  block: "red",
-  next: "blue",
-  modify_response: "orange",
-};
-
 const ACTION_LABELS: Record<string, string> = {
   allow: "Allow",
   block: "Block",
@@ -348,67 +343,63 @@ interface PipelineInfoDisplayProps {
 }
 
 export const PipelineInfoDisplay: React.FC<PipelineInfoDisplayProps> = ({ pipeline }) => (
-  <div className="flex flex-col items-center" style={{ padding: "16px 0" }}>
+  <div className="flex flex-col items-center" style={{ padding: "8px 0" }}>
     {/* Trigger */}
     <div
       style={{
-        border: "1px solid #d9d9d9",
-        borderRadius: 12,
-        padding: "12px 20px",
+        border: "1px solid #e5e7eb",
+        borderRadius: 6,
+        padding: "8px 14px",
         backgroundColor: "#fafafa",
         maxWidth: 680,
         width: "100%",
       }}
     >
-      <div className="flex items-center gap-3">
-        <span style={{ fontSize: 16 }}>&#9654;</span>
-        <div>
-          <Text type="secondary" style={{ fontSize: 11, fontWeight: 600 }}>TRIGGER</Text>
-          <br />
-          <Text strong>Incoming LLM Request</Text>
-        </div>
+      <div className="flex items-center gap-2">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="#9ca3af" stroke="none">
+          <polygon points="5,3 19,12 5,21" />
+        </svg>
+        <span style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", color: "#9ca3af", letterSpacing: "0.05em" }}>
+          TRIGGER
+        </span>
+        <span style={{ fontSize: 13, fontWeight: 500 }}>
+          Incoming LLM Request
+        </span>
       </div>
     </div>
 
     {/* Steps */}
     {pipeline.steps.map((step, index) => (
       <React.Fragment key={index}>
-        {/* Connector line */}
-        <div style={{ width: 2, height: 32, backgroundColor: "#d9d9d9" }} />
-
-        {/* Step card */}
+        <div style={{ width: 1, height: 20, backgroundColor: "#e5e7eb" }} />
         <div
           style={{
-            border: "1px solid #e8e8e8",
-            borderRadius: 12,
-            padding: "12px 20px",
+            border: "1px solid #e5e7eb",
+            borderRadius: 6,
+            padding: "8px 14px",
             backgroundColor: "#fff",
             maxWidth: 680,
             width: "100%",
           }}
         >
-          <div className="flex justify-between items-center" style={{ marginBottom: 8 }}>
-            <div className="flex items-center gap-2">
-              <Tag color="purple" style={{ margin: 0, fontSize: 11, fontWeight: 600 }}>
-                GUARDRAIL
-              </Tag>
-              <Text strong>{step.guardrail}</Text>
-            </div>
-            <Text type="secondary" style={{ fontSize: 12 }}>Step {index + 1}</Text>
+          <div className="flex items-center gap-2" style={{ marginBottom: 4 }}>
+            <span style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", color: "#9ca3af", letterSpacing: "0.05em" }}>
+              GUARDRAIL
+            </span>
+            <span style={{ fontSize: 13, fontWeight: 500 }}>{step.guardrail}</span>
+            <span style={{ fontSize: 11, color: "#9ca3af", marginLeft: "auto" }}>Step {index + 1}</span>
           </div>
-          <div className="flex gap-3">
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              Pass →{" "}
-              <Tag color={ACTION_COLORS[step.on_pass]} style={{ fontSize: 11 }}>
-                {ACTION_LABELS[step.on_pass] || step.on_pass}
-              </Tag>
-            </Text>
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              Fail →{" "}
-              <Tag color={ACTION_COLORS[step.on_fail]} style={{ fontSize: 11 }}>
-                {ACTION_LABELS[step.on_fail] || step.on_fail}
-              </Tag>
-            </Text>
+          <div className="flex gap-4" style={{ fontSize: 12, color: "#6b7280" }}>
+            <span>
+              <span style={{ fontSize: 10, fontWeight: 600, color: "#16a34a", textTransform: "uppercase" }}>Pass</span>
+              {" "}
+              {ACTION_LABELS[step.on_pass] || step.on_pass}
+            </span>
+            <span>
+              <span style={{ fontSize: 10, fontWeight: 600, color: "#dc2626", textTransform: "uppercase" }}>Fail</span>
+              {" "}
+              {ACTION_LABELS[step.on_fail] || step.on_fail}
+            </span>
           </div>
         </div>
       </React.Fragment>
@@ -506,7 +497,7 @@ export const FlowBuilderPage: React.FC<FlowBuilderPageProps> = ({
         left: 0,
         right: 0,
         bottom: 0,
-        backgroundColor: "#f8f9fa",
+        backgroundColor: "#fafafa",
         zIndex: 1000,
         display: "flex",
         flexDirection: "column",
@@ -518,14 +509,14 @@ export const FlowBuilderPage: React.FC<FlowBuilderPageProps> = ({
         style={{
           borderBottom: "1px solid #e5e7eb",
           backgroundColor: "#fff",
-          padding: "12px 24px",
+          padding: "10px 24px",
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
           flexShrink: 0,
         }}
       >
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           <button
             onClick={onBack}
             style={{
@@ -537,33 +528,40 @@ export const FlowBuilderPage: React.FC<FlowBuilderPageProps> = ({
               alignItems: "center",
             }}
           >
-            <ArrowLeftIcon style={{ width: 20, height: 20, color: "#6b7280" }} />
+            <ArrowLeftIcon style={{ width: 16, height: 16, color: "#9ca3af" }} />
           </button>
-          <Text type="secondary">Policies</Text>
-          <Text type="secondary">/</Text>
+          <span style={{ fontSize: 13, color: "#9ca3af" }}>Policies</span>
+          <span style={{ fontSize: 13, color: "#d1d5db" }}>/</span>
           <TextInput
             placeholder="Policy name..."
             value={policyName}
             onChange={(e) => setPolicyName(e.target.value)}
             disabled={isEditing}
-            style={{ width: 240 }}
+            style={{ width: 220, fontSize: 13 }}
           />
-          <Tag color="purple" style={{ margin: 0, fontSize: 11, fontWeight: 600 }}>
+          <span
+            style={{
+              fontSize: 10,
+              fontWeight: 600,
+              backgroundColor: "#f3f4f6",
+              color: "#6b7280",
+              padding: "2px 6px",
+              borderRadius: 3,
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+            }}
+          >
             Flow
-          </Tag>
+          </span>
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="secondary" onClick={onBack}>
+          <Button variant="secondary" onClick={onBack} style={{ fontSize: 13 }}>
             Cancel
           </Button>
           <Button
             onClick={handleSave}
             loading={isSubmitting}
-            style={{
-              backgroundColor: "#4f46e5",
-              color: "#fff",
-              border: "none",
-            }}
+            style={{ fontSize: 13 }}
           >
             {isEditing ? "Update Policy" : "Save Policy"}
           </Button>
@@ -573,7 +571,7 @@ export const FlowBuilderPage: React.FC<FlowBuilderPageProps> = ({
       {/* Description bar */}
       <div
         style={{
-          padding: "8px 24px",
+          padding: "6px 24px",
           backgroundColor: "#fff",
           borderBottom: "1px solid #e5e7eb",
           flexShrink: 0,
@@ -583,21 +581,21 @@ export const FlowBuilderPage: React.FC<FlowBuilderPageProps> = ({
           placeholder="Add a description (optional)..."
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          style={{ maxWidth: 500 }}
+          style={{ maxWidth: 480, fontSize: 13 }}
         />
       </div>
 
-      {/* Flow builder canvas - scrollable */}
+      {/* Flow builder canvas */}
       <div
         style={{
           flex: 1,
           overflowY: "auto",
           display: "flex",
           justifyContent: "center",
-          padding: "40px 24px",
+          padding: "24px 24px",
         }}
       >
-        <div style={{ maxWidth: 760, width: "100%" }}>
+        <div style={{ maxWidth: 720, width: "100%" }}>
           <PipelineFlowBuilder
             pipeline={pipeline}
             onChange={setPipeline}

--- a/ui/litellm-dashboard/src/components/policies/pipeline_flow_builder.tsx
+++ b/ui/litellm-dashboard/src/components/policies/pipeline_flow_builder.tsx
@@ -1,0 +1,419 @@
+import React from "react";
+import { Select, Typography, Tag } from "antd";
+import { TextInput } from "@tremor/react";
+import { PlusIcon, TrashIcon } from "@heroicons/react/outline";
+import { GuardrailPipeline, PipelineStep } from "./types";
+import { Guardrail } from "../guardrails/types";
+
+const { Text } = Typography;
+
+const ACTION_OPTIONS = [
+  { label: "Continue to next step", value: "next" },
+  { label: "Allow (end flow)", value: "allow" },
+  { label: "Block with error response", value: "block" },
+  { label: "Return custom response", value: "modify_response" },
+];
+
+function createDefaultStep(): PipelineStep {
+  return {
+    guardrail: "",
+    on_pass: "next",
+    on_fail: "block",
+    pass_data: false,
+    modify_response_message: null,
+  };
+}
+
+function insertStep(steps: PipelineStep[], atIndex: number): PipelineStep[] {
+  const newSteps = [...steps];
+  newSteps.splice(atIndex, 0, createDefaultStep());
+  return newSteps;
+}
+
+function removeStep(steps: PipelineStep[], index: number): PipelineStep[] {
+  if (steps.length <= 1) return steps;
+  const newSteps = [...steps];
+  newSteps.splice(index, 1);
+  return newSteps;
+}
+
+function updateStepAtIndex(
+  steps: PipelineStep[],
+  index: number,
+  updated: Partial<PipelineStep>
+): PipelineStep[] {
+  return steps.map((s, i) => (i === index ? { ...s, ...updated } : s));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-components
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ConnectorProps {
+  onInsert: () => void;
+}
+
+const Connector: React.FC<ConnectorProps> = ({ onInsert }) => (
+  <div className="flex flex-col items-center" style={{ height: 48 }}>
+    <div
+      style={{
+        width: 2,
+        flex: 1,
+        backgroundColor: "#d9d9d9",
+      }}
+    />
+    <button
+      onClick={onInsert}
+      className="flex items-center justify-center"
+      style={{
+        width: 28,
+        height: 28,
+        borderRadius: "50%",
+        border: "2px solid #d9d9d9",
+        backgroundColor: "#fff",
+        cursor: "pointer",
+        zIndex: 1,
+        marginTop: -4,
+        marginBottom: -4,
+      }}
+      title="Insert step"
+    >
+      <PlusIcon style={{ width: 14, height: 14, color: "#8c8c8c" }} />
+    </button>
+    <div
+      style={{
+        width: 2,
+        flex: 1,
+        backgroundColor: "#d9d9d9",
+      }}
+    />
+  </div>
+);
+
+interface StepCardProps {
+  step: PipelineStep;
+  stepIndex: number;
+  totalSteps: number;
+  onChange: (updated: Partial<PipelineStep>) => void;
+  onDelete: () => void;
+  availableGuardrails: Guardrail[];
+}
+
+const StepCard: React.FC<StepCardProps> = ({
+  step,
+  stepIndex,
+  totalSteps,
+  onChange,
+  onDelete,
+  availableGuardrails,
+}) => {
+  const guardrailOptions = availableGuardrails.map((g) => ({
+    label: g.guardrail_name || g.guardrail_id,
+    value: g.guardrail_name || g.guardrail_id,
+  }));
+
+  return (
+    <div
+      style={{
+        border: "1px solid #e8e8e8",
+        borderRadius: 12,
+        padding: 20,
+        backgroundColor: "#fff",
+        boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+        maxWidth: 520,
+        width: "100%",
+      }}
+    >
+      {/* Header */}
+      <div className="flex justify-between items-center" style={{ marginBottom: 16 }}>
+        <div className="flex items-center gap-2">
+          <Tag color="purple" style={{ margin: 0, fontWeight: 600, fontSize: 11 }}>
+            GUARDRAIL
+          </Tag>
+          <Text strong>{step.guardrail || "Select guardrail..."}</Text>
+        </div>
+        <div className="flex items-center gap-2">
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            Step {stepIndex + 1}
+          </Text>
+          <button
+            onClick={onDelete}
+            disabled={totalSteps <= 1}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: totalSteps <= 1 ? "not-allowed" : "pointer",
+              opacity: totalSteps <= 1 ? 0.3 : 1,
+              padding: 4,
+            }}
+            title="Delete step"
+          >
+            <TrashIcon style={{ width: 16, height: 16, color: "#ff4d4f" }} />
+          </button>
+        </div>
+      </div>
+
+      {/* Guardrail Selector */}
+      <div style={{ marginBottom: 12 }}>
+        <Text type="secondary" style={{ fontSize: 12, display: "block", marginBottom: 4 }}>
+          Guardrail
+        </Text>
+        <Select
+          showSearch
+          style={{ width: "100%" }}
+          placeholder="Select a guardrail"
+          value={step.guardrail || undefined}
+          onChange={(value) => onChange({ guardrail: value })}
+          options={guardrailOptions}
+          filterOption={(input, option) =>
+            (option?.label ?? "").toString().toLowerCase().includes(input.toLowerCase())
+          }
+        />
+      </div>
+
+      {/* ON PASS */}
+      <div
+        style={{
+          backgroundColor: "#f6ffed",
+          border: "1px solid #b7eb8f",
+          borderRadius: 8,
+          padding: 12,
+          marginBottom: 8,
+        }}
+      >
+        <Text style={{ fontSize: 12, fontWeight: 600, color: "#52c41a" }}>
+          ON PASS
+        </Text>
+        <Select
+          style={{ width: "100%", marginTop: 4 }}
+          value={step.on_pass}
+          onChange={(value) => onChange({ on_pass: value as PipelineStep["on_pass"] })}
+          options={ACTION_OPTIONS}
+        />
+        {step.on_pass === "modify_response" && (
+          <div style={{ marginTop: 8 }}>
+            <TextInput
+              placeholder="Custom response message"
+              value={step.modify_response_message || ""}
+              onChange={(e) => onChange({ modify_response_message: e.target.value || null })}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* ON FAIL */}
+      <div
+        style={{
+          backgroundColor: "#fff2f0",
+          border: "1px solid #ffccc7",
+          borderRadius: 8,
+          padding: 12,
+        }}
+      >
+        <Text style={{ fontSize: 12, fontWeight: 600, color: "#ff4d4f" }}>
+          ON FAIL
+        </Text>
+        <Select
+          style={{ width: "100%", marginTop: 4 }}
+          value={step.on_fail}
+          onChange={(value) => onChange({ on_fail: value as PipelineStep["on_fail"] })}
+          options={ACTION_OPTIONS}
+        />
+        {step.on_fail === "modify_response" && (
+          <div style={{ marginTop: 8 }}>
+            <TextInput
+              placeholder="Custom response message"
+              value={step.modify_response_message || ""}
+              onChange={(e) => onChange({ modify_response_message: e.target.value || null })}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main Component
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface PipelineFlowBuilderProps {
+  pipeline: GuardrailPipeline;
+  onChange: (pipeline: GuardrailPipeline) => void;
+  availableGuardrails: Guardrail[];
+}
+
+const PipelineFlowBuilder: React.FC<PipelineFlowBuilderProps> = ({
+  pipeline,
+  onChange,
+  availableGuardrails,
+}) => {
+  const handleInsertStep = (atIndex: number) => {
+    onChange({ ...pipeline, steps: insertStep(pipeline.steps, atIndex) });
+  };
+
+  const handleRemoveStep = (index: number) => {
+    onChange({ ...pipeline, steps: removeStep(pipeline.steps, index) });
+  };
+
+  const handleUpdateStep = (index: number, updated: Partial<PipelineStep>) => {
+    onChange({
+      ...pipeline,
+      steps: updateStepAtIndex(pipeline.steps, index, updated),
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-center" style={{ padding: "16px 0" }}>
+      {/* Trigger Card */}
+      <div
+        style={{
+          border: "1px solid #d9d9d9",
+          borderRadius: 12,
+          padding: "16px 24px",
+          backgroundColor: "#fafafa",
+          maxWidth: 520,
+          width: "100%",
+        }}
+      >
+        <div className="flex items-center gap-3">
+          <div
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: "50%",
+              backgroundColor: "#f0f0f0",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <span style={{ fontSize: 16 }}>&#9654;</span>
+          </div>
+          <div>
+            <Text type="secondary" style={{ fontSize: 11, fontWeight: 600, display: "block" }}>
+              TRIGGER
+            </Text>
+            <Text strong>Incoming LLM Request</Text>
+            <br />
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              This flow runs when a request matches this policy
+            </Text>
+          </div>
+        </div>
+      </div>
+
+      {/* Steps */}
+      {pipeline.steps.map((step, index) => (
+        <React.Fragment key={index}>
+          <Connector onInsert={() => handleInsertStep(index)} />
+          <StepCard
+            step={step}
+            stepIndex={index}
+            totalSteps={pipeline.steps.length}
+            onChange={(updated) => handleUpdateStep(index, updated)}
+            onDelete={() => handleRemoveStep(index)}
+            availableGuardrails={availableGuardrails}
+          />
+        </React.Fragment>
+      ))}
+
+      {/* Bottom add button */}
+      <Connector onInsert={() => handleInsertStep(pipeline.steps.length)} />
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Read-only display for policy info view
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ACTION_COLORS: Record<string, string> = {
+  allow: "green",
+  block: "red",
+  next: "blue",
+  modify_response: "orange",
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  allow: "Allow",
+  block: "Block",
+  next: "Next Step",
+  modify_response: "Custom Response",
+};
+
+interface PipelineInfoDisplayProps {
+  pipeline: GuardrailPipeline;
+}
+
+export const PipelineInfoDisplay: React.FC<PipelineInfoDisplayProps> = ({ pipeline }) => (
+  <div className="flex flex-col items-center" style={{ padding: "16px 0" }}>
+    {/* Trigger */}
+    <div
+      style={{
+        border: "1px solid #d9d9d9",
+        borderRadius: 12,
+        padding: "12px 20px",
+        backgroundColor: "#fafafa",
+        maxWidth: 520,
+        width: "100%",
+      }}
+    >
+      <div className="flex items-center gap-3">
+        <span style={{ fontSize: 16 }}>&#9654;</span>
+        <div>
+          <Text type="secondary" style={{ fontSize: 11, fontWeight: 600 }}>TRIGGER</Text>
+          <br />
+          <Text strong>Incoming LLM Request</Text>
+        </div>
+      </div>
+    </div>
+
+    {/* Steps */}
+    {pipeline.steps.map((step, index) => (
+      <React.Fragment key={index}>
+        {/* Connector line */}
+        <div style={{ width: 2, height: 32, backgroundColor: "#d9d9d9" }} />
+
+        {/* Step card */}
+        <div
+          style={{
+            border: "1px solid #e8e8e8",
+            borderRadius: 12,
+            padding: "12px 20px",
+            backgroundColor: "#fff",
+            maxWidth: 520,
+            width: "100%",
+          }}
+        >
+          <div className="flex justify-between items-center" style={{ marginBottom: 8 }}>
+            <div className="flex items-center gap-2">
+              <Tag color="purple" style={{ margin: 0, fontSize: 11, fontWeight: 600 }}>
+                GUARDRAIL
+              </Tag>
+              <Text strong>{step.guardrail}</Text>
+            </div>
+            <Text type="secondary" style={{ fontSize: 12 }}>Step {index + 1}</Text>
+          </div>
+          <div className="flex gap-3">
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              Pass →{" "}
+              <Tag color={ACTION_COLORS[step.on_pass]} style={{ fontSize: 11 }}>
+                {ACTION_LABELS[step.on_pass] || step.on_pass}
+              </Tag>
+            </Text>
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              Fail →{" "}
+              <Tag color={ACTION_COLORS[step.on_fail]} style={{ fontSize: 11 }}>
+                {ACTION_LABELS[step.on_fail] || step.on_fail}
+              </Tag>
+            </Text>
+          </div>
+        </div>
+      </React.Fragment>
+    ))}
+  </div>
+);
+
+export { createDefaultStep };
+export default PipelineFlowBuilder;

--- a/ui/litellm-dashboard/src/components/policies/pipeline_flow_builder.tsx
+++ b/ui/litellm-dashboard/src/components/policies/pipeline_flow_builder.tsx
@@ -394,6 +394,59 @@ const PipelineFlowBuilder: React.FC<PipelineFlowBuilderProps> = ({
 
       {/* Bottom connector */}
       <Connector onInsert={() => handleInsertStep(pipeline.steps.length)} />
+
+      {/* End card */}
+      <div
+        style={{
+          border: "1px solid #e5e7eb",
+          borderRadius: 10,
+          padding: "14px 20px",
+          backgroundColor: "#fff",
+          maxWidth: 720,
+          width: "100%",
+        }}
+      >
+        <div className="flex items-center gap-3">
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: "50%",
+              backgroundColor: "#f3f4f6",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+            }}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#6b7280" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="3" y="3" width="18" height="18" rx="2" />
+              <line x1="8" y1="12" x2="16" y2="12" />
+            </svg>
+          </div>
+          <div>
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: 700,
+                textTransform: "uppercase",
+                color: "#6b7280",
+                letterSpacing: "0.06em",
+                display: "block",
+                marginBottom: 2,
+              }}
+            >
+              END
+            </span>
+            <span style={{ fontSize: 14, fontWeight: 600, color: "#111827", display: "block" }}>
+              Continue to LLM
+            </span>
+            <span style={{ fontSize: 13, color: "#9ca3af" }}>
+              Request proceeds to the model
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/components/policies/policy_info.tsx
+++ b/ui/litellm-dashboard/src/components/policies/policy_info.tsx
@@ -3,6 +3,7 @@ import { Card, Badge, Button } from "@tremor/react";
 import { ArrowLeftIcon, PencilIcon } from "@heroicons/react/outline";
 import { Descriptions, Tag, Spin, Divider, Typography, Alert } from "antd";
 import { Policy } from "./types";
+import { PipelineInfoDisplay } from "./pipeline_flow_builder";
 import { getResolvedGuardrails } from "../networking";
 
 const { Title, Text } = Typography;
@@ -126,6 +127,21 @@ const PolicyInfoView: React.FC<PolicyInfoViewProps> = ({
               : "-"}
           </Descriptions.Item>
         </Descriptions>
+
+        {policy.pipeline && (
+          <>
+            <Divider orientation="left">
+              <Text strong>Pipeline Flow</Text>
+            </Divider>
+            <Alert
+              message={`Pipeline (${policy.pipeline.mode} mode, ${policy.pipeline.steps.length} step${policy.pipeline.steps.length !== 1 ? "s" : ""})`}
+              type="info"
+              showIcon
+              style={{ marginBottom: 16 }}
+            />
+            <PipelineInfoDisplay pipeline={policy.pipeline} />
+          </>
+        )}
 
         <Divider orientation="left">
           <Text strong>Guardrails Configuration</Text>

--- a/ui/litellm-dashboard/src/components/policies/types.ts
+++ b/ui/litellm-dashboard/src/components/policies/types.ts
@@ -82,3 +82,20 @@ export interface PolicyAttachmentListResponse {
   attachments: PolicyAttachment[];
   total_count: number;
 }
+
+export interface PipelineStepResult {
+  guardrail_name: string;
+  outcome: "pass" | "fail" | "error";
+  action_taken: string;
+  modified_data: Record<string, any> | null;
+  error_detail: string | null;
+  duration_seconds: number | null;
+}
+
+export interface PipelineTestResult {
+  terminal_action: string;
+  step_results: PipelineStepResult[];
+  modified_data: Record<string, any> | null;
+  error_message: string | null;
+  modify_response_message: string | null;
+}

--- a/ui/litellm-dashboard/src/components/policies/types.ts
+++ b/ui/litellm-dashboard/src/components/policies/types.ts
@@ -6,6 +6,7 @@ export interface Policy {
   guardrails_add: string[];
   guardrails_remove: string[];
   condition: PolicyCondition | null;
+  pipeline?: GuardrailPipeline | null;
   created_at?: string;
   updated_at?: string;
   created_by?: string;
@@ -14,6 +15,19 @@ export interface Policy {
 
 export interface PolicyCondition {
   model?: string;
+}
+
+export interface PipelineStep {
+  guardrail: string;
+  on_fail: "block" | "allow" | "next" | "modify_response";
+  on_pass: "allow" | "block" | "next" | "modify_response";
+  pass_data?: boolean;
+  modify_response_message?: string | null;
+}
+
+export interface GuardrailPipeline {
+  mode: "pre_call" | "post_call";
+  steps: PipelineStep[];
 }
 
 export interface PolicyAttachment {
@@ -37,6 +51,7 @@ export interface PolicyCreateRequest {
   guardrails_add?: string[];
   guardrails_remove?: string[];
   condition?: PolicyCondition;
+  pipeline?: GuardrailPipeline | null;
 }
 
 export interface PolicyUpdateRequest {
@@ -46,6 +61,7 @@ export interface PolicyUpdateRequest {
   guardrails_add?: string[];
   guardrails_remove?: string[];
   condition?: PolicyCondition;
+  pipeline?: GuardrailPipeline | null;
 }
 
 export interface PolicyAttachmentCreateRequest {


### PR DESCRIPTION
## Summary
- Add `pipeline` column to `LiteLLM_PolicyTable` Prisma schema for storing guardrail pipeline data
- Add pipeline field to policy CRUD request/response types (create, update, DB response)
- Wire pipeline through all policy registry DB methods (add, update, get, list, sync, resolve) with PrismaJson wrapping
- Add Zapier-style visual flow builder UI component (`pipeline_flow_builder.tsx`) with trigger card, step cards, connector lines, and insert buttons
- Integrate flow builder into policy form with Simple Mode / Flow Builder mode toggle
- Add pipeline display section in policy info view


<img width="2200" height="1450" alt="Xnapper-2026-02-13-19 48 42" src="https://github.com/user-attachments/assets/ca349fa5-7491-4865-b3ce-e92619ca286a" />


## Test plan
- [x] Unit tests pass (`test_resolver_types.py` - 6 tests)
- [ ] Manual E2E: create policy with pipeline via API, verify persistence and retrieval
- [ ] Manual UI: toggle to flow builder mode, add steps, save, verify in policy info view