### PR TITLE
perf(proxy): remove duplicate daily agent transaction computation

### DIFF
--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -1725,13 +1725,6 @@ class DBSpendUpdateWriter:
                 "prisma_client is None. Skipping writing spend logs to db."
             )
             return
-        base_daily_transaction = (
-            await self._common_add_spend_log_transaction_to_daily_transaction(
-                payload, prisma_client, "agent"
-            )
-        )
-        if base_daily_transaction is None:
-            return
         if payload["agent_id"] is None:
             verbose_proxy_logger.debug(
                 "agent_id is None for request. Skipping incrementing agent spend."


### PR DESCRIPTION
## Summary
This PR removes duplicate work in `add_spend_log_transaction_to_daily_agent_transaction()`.

Before:
- `_common_add_spend_log_transaction_to_daily_transaction(...)` was called once before `agent_id` checks and then called a second time again for the same request.

After:
- Validate `agent_id` first.
- Build `payload_with_agent_id` once.
- Call `_common_add_spend_log_transaction_to_daily_transaction(...)` only once.

This eliminates redundant metadata parsing/status computation in the daily agent spend path.

## Files Changed
- `litellm/proxy/db/db_spend_update_writer.py`
- `tests/test_litellm/proxy/db/test_db_spend_update_writer.py`

## Issue
Closes #21181

## Validation
- `timeout 120s poetry run pytest -q tests/test_litellm/proxy/db/test_db_spend_update_writer.py::test_add_spend_log_transaction_to_daily_agent_transaction_injects_agent_id_and_queues_update tests/test_litellm/proxy/db/test_db_spend_update_writer.py::test_add_spend_log_transaction_to_daily_agent_transaction_calls_common_helper_once tests/test_litellm/proxy/db/test_db_spend_update_writer.py::test_add_spend_log_transaction_to_daily_agent_transaction_skips_when_agent_id_missing`

