### PR TITLE
fix(redis): add SSL, password and shared SSLContext support for Sentinel

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -12,6 +12,8 @@ import json
 
 # s/o [@Frank Colson](https://www.linkedin.com/in/frank-colson-422b9b183/) for this redis implementation
 import os
+import ssl as _ssl_module
+import threading
 from typing import Callable, List, Optional, Union
 
 import redis  # type: ignore
@@ -318,10 +320,175 @@ def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
     return redis.RedisCluster(startup_nodes=new_startup_nodes, **cluster_kwargs)  # type: ignore
 
 
+def _remove_sentinel_kwargs(redis_kwargs: dict) -> dict:
+    """
+    Remove Sentinel-specific kwargs that are not supported by standard Redis client.
+    """
+    sentinel_specific_keys = ["sentinel_nodes", "sentinel_password", "service_name"]
+    cleaned_kwargs = redis_kwargs.copy()
+    for key in sentinel_specific_keys:
+        cleaned_kwargs.pop(key, None)
+    return cleaned_kwargs
+
+
+def _get_redis_ssl_context(ssl_cert_reqs=None) -> _ssl_module.SSLContext:
+    """
+    Create a new SSLContext configured for Redis connections.
+
+    redis-py 5.2 creates a NEW ssl.SSLContext per connection via
+    ssl.create_default_context(), which calls set_default_verify_paths()
+    and parses ALL system CA certs into C-level structures each time.
+    With 100+ connections in a Sentinel pool this causes 700+ MB memory
+    spikes.
+
+    One shared context eliminates this overhead entirely.
+    """
+    ctx = _ssl_module.create_default_context()
+    if ssl_cert_reqs is not None:
+        req_str = str(ssl_cert_reqs).lower()
+        if req_str == "none":
+            ctx.check_hostname = False
+            ctx.verify_mode = _ssl_module.CERT_NONE
+        elif req_str == "optional":
+            ctx.check_hostname = False
+            ctx.verify_mode = _ssl_module.CERT_OPTIONAL
+    return ctx
+
+
+# Process-wide caches — at most ~6 entries (3 cert_reqs variants × sync/async).
+# Tests must call .clear() on these in setup_method for isolation.
+_redis_ssl_context_cache: dict = {}
+_redis_ssl_class_cache: dict = {}
+_redis_ssl_context_lock = threading.RLock()
+
+
+def _get_cached_redis_ssl_context(ssl_cert_reqs=None) -> _ssl_module.SSLContext:
+    key = str(ssl_cert_reqs).lower() if ssl_cert_reqs is not None else "required"
+    with _redis_ssl_context_lock:
+        if key not in _redis_ssl_context_cache:
+            _redis_ssl_context_cache[key] = _get_redis_ssl_context(ssl_cert_reqs)
+        return _redis_ssl_context_cache[key]
+
+
+def _make_shared_ssl_connection_class(base_cls, ssl_cert_reqs=None):
+    """
+    Create (or return cached) a connection class that reuses a shared SSLContext
+    instead of creating a new one per connection.
+
+    Sync SSLConnection._wrap_socket_with_ssl() calls ssl.create_default_context()
+    every time.  We override it to use a cached context.
+
+    Async SSLConnection stores self.ssl_context = RedisSSLContext(...) which
+    creates context lazily.  We replace it after __init__ with a pre-built one.
+    """
+    cert_key = str(ssl_cert_reqs).lower() if ssl_cert_reqs is not None else "required"
+    cache_key = (base_cls, cert_key)
+    with _redis_ssl_context_lock:
+        if cache_key in _redis_ssl_class_cache:
+            return _redis_ssl_class_cache[cache_key]
+
+        shared_ctx = _get_cached_redis_ssl_context(ssl_cert_reqs)
+
+        class SharedSSLConnection(base_cls):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                # Async path: replace RedisSSLContext lazy context with shared one.
+                # Inject shared SSLContext into RedisSSLContext.context so that
+                # .get() returns it instead of calling create_default_context().
+                # Tested against redis-py 5.2.1 and 7.1.1. If redis-py changes
+                # RedisSSLContext internals, the guard below will skip
+                # injection and fall back to per-connection creation.
+                if hasattr(self, "ssl_context") and hasattr(self.ssl_context, "get"):
+                    sc = self.ssl_context
+                    has_custom = (
+                        getattr(sc, "certfile", None)
+                        or getattr(sc, "keyfile", None)
+                        or getattr(sc, "ca_certs", None)
+                        or getattr(sc, "ca_data", None)
+                        or getattr(sc, "min_version", None)
+                        or getattr(sc, "ciphers", None)
+                        or getattr(sc, "include_verify_flags", None)
+                        or getattr(sc, "exclude_verify_flags", None)
+                    )
+                    if not has_custom:
+                        sc.context = shared_ctx
+
+            # Sync path: use shared SSLContext for vanilla TLS (server-cert only).
+            # For any per-connection customization (client certs, custom CA, OCSP,
+            # min_version, ciphers) fall back to the original redis-py method.
+            def _wrap_socket_with_ssl(self, sock):
+                has_custom = (
+                    getattr(self, "certfile", None)
+                    or getattr(self, "keyfile", None)
+                    or getattr(self, "ca_certs", None)
+                    or getattr(self, "ca_path", None)
+                    or getattr(self, "ca_data", None)
+                    or getattr(self, "ssl_validate_ocsp", False)
+                    or getattr(self, "ssl_validate_ocsp_stapled", False)
+                    or getattr(self, "ssl_min_version", None)
+                    or getattr(self, "ssl_ciphers", None)
+                    or getattr(self, "ssl_include_verify_flags", None)
+                    or getattr(self, "ssl_exclude_verify_flags", None)
+                )
+                if has_custom:
+                    return super()._wrap_socket_with_ssl(sock)
+                return shared_ctx.wrap_socket(sock, server_hostname=self.host)
+
+        SharedSSLConnection.__name__ = f"Shared{base_cls.__name__}"
+        SharedSSLConnection.__qualname__ = f"Shared{base_cls.__qualname__}"
+        _redis_ssl_class_cache[cache_key] = SharedSSLConnection
+        return SharedSSLConnection
+
+
+def _build_sentinel_master_kwargs(redis_kwargs: dict) -> dict:
+    """
+    Build kwargs for sentinel.master_for() from redis_kwargs.
+    Forwards connection-relevant params, skips sentinel-specific ones.
+    """
+    master_kwargs = {}
+    # NOTE: max_connections intentionally excluded — SentinelConnectionPool
+    # should use its default (unlimited).  The max_connections value from
+    # Helm/redis_kwargs is meant for BlockingConnectionPool, not Sentinel.
+    # Passing it here caused "Too many connections" errors under burst load.
+    # NOTE: ssl_certfile, ssl_keyfile, ssl_ca_certs etc. are intentionally
+    # excluded — they reach connection instances through the connection_class
+    # kwargs set by sentinel.master_for(). Only top-level ssl and ssl_cert_reqs
+    # are needed to select SSL vs plain connection class.
+    forward_keys = [
+        "username",
+        "password",
+        "db",
+        "socket_timeout",
+        "socket_connect_timeout",
+        "socket_keepalive",
+        "socket_keepalive_options",
+        "retry_on_timeout",
+        "decode_responses",
+        "encoding",
+        "encoding_errors",
+        "health_check_interval",
+        "ssl",
+        "ssl_cert_reqs",
+    ]
+    for key in forward_keys:
+        if key in redis_kwargs and redis_kwargs[key] is not None:
+            master_kwargs[key] = redis_kwargs[key]
+    master_kwargs.setdefault("socket_timeout", REDIS_SOCKET_TIMEOUT)
+    # Backward compatibility: if no explicit master password is set but
+    # sentinel_password is provided, use it for master auth too.  The old
+    # code passed sentinel_password as the positional `password` arg to
+    # redis.Sentinel(), which redis-py treated as the default master auth.
+    if "password" not in master_kwargs and redis_kwargs.get("sentinel_password"):
+        master_kwargs["password"] = redis_kwargs["sentinel_password"]
+    return master_kwargs
+
+
 def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     sentinel_nodes = redis_kwargs.get("sentinel_nodes")
     sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
+    ssl_enabled = redis_kwargs.get("ssl", False)
+    ssl_cert_reqs = redis_kwargs.get("ssl_cert_reqs")
 
     if not sentinel_nodes or not service_name:
         raise ValueError(
@@ -330,22 +497,45 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
 
     verbose_logger.debug("init_redis_sentinel: sentinel nodes are being initialized.")
 
-    # Set up the Sentinel client
+    sentinel_kwargs_dict = {}
+    if sentinel_password:
+        sentinel_kwargs_dict["password"] = sentinel_password
+    if ssl_enabled:
+        sentinel_kwargs_dict["ssl"] = True
+        if ssl_cert_reqs is not None:
+            sentinel_kwargs_dict["ssl_cert_reqs"] = ssl_cert_reqs
+
     sentinel = redis.Sentinel(
         sentinel_nodes,
         socket_timeout=REDIS_SOCKET_TIMEOUT,
-        password=sentinel_password,
+        sentinel_kwargs=sentinel_kwargs_dict,
     )
 
-    # Return the master instance for the given service
+    master_kwargs = _build_sentinel_master_kwargs(redis_kwargs)
+    if ssl_enabled:
+        master_kwargs["connection_class"] = _make_shared_ssl_connection_class(
+            redis.sentinel.SentinelManagedSSLConnection, ssl_cert_reqs
+        )
+        master_kwargs.pop("ssl", None)
+        # Patch sentinel connection pools to reuse shared SSLContext.
+        # Redis.__init__ creates SSLConnection per connection; we replace
+        # connection_class on already-created pools before any connections
+        # are established (pools start empty).
+        _shared_sentinel_cls = _make_shared_ssl_connection_class(
+            redis.connection.SSLConnection, ssl_cert_reqs
+        )
+        for s in sentinel.sentinels:
+            s.connection_pool.connection_class = _shared_sentinel_cls
 
-    return sentinel.master_for(service_name)
+    return sentinel.master_for(service_name, **master_kwargs)
 
 
 def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     sentinel_nodes = redis_kwargs.get("sentinel_nodes")
     sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
+    ssl_enabled = redis_kwargs.get("ssl", False)
+    ssl_cert_reqs = redis_kwargs.get("ssl_cert_reqs")
 
     if not sentinel_nodes or not service_name:
         raise ValueError(
@@ -354,16 +544,34 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
 
     verbose_logger.debug("init_redis_sentinel: sentinel nodes are being initialized.")
 
-    # Set up the Sentinel client
+    sentinel_kwargs_dict = {}
+    if sentinel_password:
+        sentinel_kwargs_dict["password"] = sentinel_password
+    if ssl_enabled:
+        sentinel_kwargs_dict["ssl"] = True
+        if ssl_cert_reqs is not None:
+            sentinel_kwargs_dict["ssl_cert_reqs"] = ssl_cert_reqs
+
     sentinel = async_redis.Sentinel(
         sentinel_nodes,
         socket_timeout=REDIS_SOCKET_TIMEOUT,
-        password=sentinel_password,
+        sentinel_kwargs=sentinel_kwargs_dict,
     )
 
-    # Return the master instance for the given service
+    master_kwargs = _build_sentinel_master_kwargs(redis_kwargs)
+    if ssl_enabled:
+        master_kwargs["connection_class"] = _make_shared_ssl_connection_class(
+            async_redis.sentinel.SentinelManagedSSLConnection, ssl_cert_reqs
+        )
+        master_kwargs.pop("ssl", None)
+        # Patch sentinel connection pools to reuse shared SSLContext
+        _shared_sentinel_cls = _make_shared_ssl_connection_class(
+            async_redis.connection.SSLConnection, ssl_cert_reqs
+        )
+        for s in sentinel.sentinels:
+            s.connection_pool.connection_class = _shared_sentinel_cls
 
-    return sentinel.master_for(service_name)
+    return sentinel.master_for(service_name, **master_kwargs)
 
 
 def get_redis_client(**env_overrides):
@@ -384,7 +592,7 @@ def get_redis_client(**env_overrides):
     if "sentinel_nodes" in redis_kwargs and "service_name" in redis_kwargs:
         return _init_redis_sentinel(redis_kwargs)
 
-    return redis.Redis(**redis_kwargs)
+    return redis.Redis(**_remove_sentinel_kwargs(redis_kwargs))
 
 
 def get_redis_async_client(
@@ -477,12 +685,16 @@ def get_redis_async_client(
     if connection_pool is not None:
         redis_kwargs["connection_pool"] = connection_pool
 
+    redis_kwargs = _remove_sentinel_kwargs(redis_kwargs)
     return async_redis.Redis(
         **redis_kwargs,
     )
 
 
 def get_redis_connection_pool(**env_overrides):
+    # NOTE: This pool is unused when Sentinel is configured —
+    # get_redis_async_client() detects sentinel_nodes and creates its own
+    # client via _init_async_redis_sentinel(), ignoring connection_pool.
     redis_kwargs = _get_redis_client_logic(**env_overrides)
     verbose_logger.debug("get_redis_connection_pool: redis_kwargs", redis_kwargs)
     if "url" in redis_kwargs and redis_kwargs["url"] is not None:
@@ -505,6 +717,7 @@ def get_redis_connection_pool(**env_overrides):
         redis_kwargs.pop("ssl", None)
         redis_kwargs["connection_class"] = connection_class
     redis_kwargs.pop("startup_nodes", None)
+    redis_kwargs = _remove_sentinel_kwargs(redis_kwargs)
     return async_redis.BlockingConnectionPool(
         timeout=REDIS_CONNECTION_POOL_TIMEOUT, **redis_kwargs
     )

--- a/tests/test_litellm/test_redis_sentinel.py
+++ b/tests/test_litellm/test_redis_sentinel.py
@@ -1,0 +1,261 @@
+"""
+Tests for Redis Sentinel SSL and password support.
+"""
+
+import ssl
+from unittest.mock import MagicMock, patch
+
+from litellm._redis import (
+    _build_sentinel_master_kwargs,
+    _get_cached_redis_ssl_context,
+    _get_redis_ssl_context,
+    _make_shared_ssl_connection_class,
+    _remove_sentinel_kwargs,
+    _redis_ssl_context_cache,
+    _redis_ssl_class_cache,
+)
+
+
+class TestRemoveSentinelKwargs:
+    def test_removes_sentinel_keys(self):
+        kwargs = {
+            "host": "localhost",
+            "sentinel_nodes": [("host", 26379)],
+            "sentinel_password": "pass",
+            "service_name": "mymaster",
+            "password": "redis_pass",
+        }
+        result = _remove_sentinel_kwargs(kwargs)
+        assert "sentinel_nodes" not in result
+        assert "sentinel_password" not in result
+        assert "service_name" not in result
+        assert result["host"] == "localhost"
+        assert result["password"] == "redis_pass"
+
+    def test_does_not_modify_original(self):
+        kwargs = {"sentinel_nodes": [("host", 26379)], "host": "localhost"}
+        _remove_sentinel_kwargs(kwargs)
+        assert "sentinel_nodes" in kwargs
+
+
+class TestBuildSentinelMasterKwargs:
+    def test_forwards_password_and_ssl(self):
+        kwargs = {
+            "password": "secret",
+            "ssl": True,
+            "ssl_cert_reqs": "none",
+            "db": 0,
+            "sentinel_nodes": [("h", 26379)],
+        }
+        result = _build_sentinel_master_kwargs(kwargs)
+        assert result["password"] == "secret"
+        assert result["ssl"] is True
+        assert result["ssl_cert_reqs"] == "none"
+        assert result["db"] == 0
+        assert "sentinel_nodes" not in result
+
+    def test_excludes_max_connections(self):
+        kwargs = {"max_connections": 100, "password": "secret"}
+        result = _build_sentinel_master_kwargs(kwargs)
+        assert "max_connections" not in result
+
+    def test_sets_default_socket_timeout(self):
+        result = _build_sentinel_master_kwargs({})
+        assert "socket_timeout" in result
+
+    def test_sentinel_password_fallback_when_no_password(self):
+        kwargs = {"sentinel_password": "sent_pass"}
+        result = _build_sentinel_master_kwargs(kwargs)
+        assert result["password"] == "sent_pass"
+
+    def test_explicit_password_not_overridden_by_sentinel_password(self):
+        kwargs = {"password": "master_pass", "sentinel_password": "sent_pass"}
+        result = _build_sentinel_master_kwargs(kwargs)
+        assert result["password"] == "master_pass"
+
+
+class TestGetRedisSslContext:
+    def test_default_verifies_certs(self):
+        ctx = _get_redis_ssl_context()
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+    def test_none_disables_verification(self):
+        ctx = _get_redis_ssl_context(ssl_cert_reqs="none")
+        assert ctx.verify_mode == ssl.CERT_NONE
+        assert ctx.check_hostname is False
+
+    def test_optional_mode(self):
+        ctx = _get_redis_ssl_context(ssl_cert_reqs="optional")
+        assert ctx.verify_mode == ssl.CERT_OPTIONAL
+        assert ctx.check_hostname is False
+
+
+class TestCachedSslContext:
+    def setup_method(self):
+        _redis_ssl_context_cache.clear()
+        _redis_ssl_class_cache.clear()
+
+    def test_returns_same_context(self):
+        ctx1 = _get_cached_redis_ssl_context("none")
+        ctx2 = _get_cached_redis_ssl_context("none")
+        assert ctx1 is ctx2
+
+    def test_different_reqs_different_context(self):
+        ctx_none = _get_cached_redis_ssl_context("none")
+        ctx_req = _get_cached_redis_ssl_context(None)
+        assert ctx_none is not ctx_req
+
+
+class TestMakeSharedSslConnectionClass:
+    def setup_method(self):
+        _redis_ssl_context_cache.clear()
+        _redis_ssl_class_cache.clear()
+
+    def test_overrides_wrap_socket(self):
+        base_cls = type(
+            "FakeSSL",
+            (),
+            {
+                "__init__": lambda self, *a, **kw: None,
+            },
+        )
+        cls = _make_shared_ssl_connection_class(base_cls, "none")
+        assert cls.__name__.startswith("Shared")
+        assert hasattr(cls, "_wrap_socket_with_ssl")
+
+    def test_shared_ctx_reused_for_vanilla_ssl(self):
+        """Vanilla SSL (no client certs) should use the shared context."""
+        shared_ctx = _get_cached_redis_ssl_context("none")
+        mock_sock = MagicMock()
+
+        base_cls = type(
+            "FakeSSL",
+            (),
+            {
+                "__init__": lambda self, *a, **kw: None,
+                "_wrap_socket_with_ssl": lambda self, sock: None,
+            },
+        )
+        cls = _make_shared_ssl_connection_class(base_cls, "none")
+        instance = cls()
+        instance.host = "redis.example.com"
+        # No certfile/keyfile/ca — vanilla case
+        with patch.object(
+            shared_ctx, "wrap_socket", return_value=mock_sock
+        ) as mock_wrap:
+            instance._wrap_socket_with_ssl(MagicMock())
+            mock_wrap.assert_called_once()
+            assert mock_wrap.call_args[1]["server_hostname"] == "redis.example.com"
+
+    def test_falls_back_to_super_with_client_certs(self):
+        """Client certs should trigger fallback to original redis-py method."""
+        parent_called = []
+
+        class FakeSSL:
+            def __init__(self, *a, **kw):
+                pass
+
+            def _wrap_socket_with_ssl(self, sock):
+                parent_called.append(True)
+                return sock
+
+        cls = _make_shared_ssl_connection_class(FakeSSL, "none")
+        instance = cls()
+        instance.certfile = "/path/to/cert.pem"
+        instance.keyfile = None
+        instance._wrap_socket_with_ssl(MagicMock())
+        assert len(parent_called) == 1
+
+
+class TestInitRedisSentinelSsl:
+    @patch("litellm._redis.redis.Sentinel")
+    def test_sentinel_receives_ssl_kwargs(self, mock_sentinel_cls):
+        """Sentinel constructor should get sentinel_kwargs with ssl and password."""
+        mock_sentinel = MagicMock()
+        mock_sentinel_cls.return_value = mock_sentinel
+        mock_sentinel.sentinels = []
+        mock_sentinel.master_for.return_value = MagicMock()
+
+        from litellm._redis import _init_redis_sentinel
+
+        kwargs = {
+            "sentinel_nodes": [("host1", 26379)],
+            "sentinel_password": "sent_pass",
+            "service_name": "mymaster",
+            "password": "redis_pass",
+            "ssl": True,
+            "ssl_cert_reqs": "none",
+        }
+        _init_redis_sentinel(kwargs)
+
+        # Check sentinel_kwargs was passed
+        sentinel_call_kwargs = mock_sentinel_cls.call_args[1]
+        assert "sentinel_kwargs" in sentinel_call_kwargs
+        sk = sentinel_call_kwargs["sentinel_kwargs"]
+        assert sk["password"] == "sent_pass"
+        assert sk["ssl"] is True
+
+        # Check master_for got password and connection_class (not raw ssl=True)
+        master_call_kwargs = mock_sentinel.master_for.call_args[1]
+        assert master_call_kwargs["password"] == "redis_pass"
+        assert "ssl" not in master_call_kwargs  # replaced by connection_class
+        assert "connection_class" in master_call_kwargs
+
+    @patch("litellm._redis.redis.Sentinel")
+    def test_non_ssl_sentinel_no_connection_class(self, mock_sentinel_cls):
+        """Non-SSL sentinel should not set connection_class or patch pools."""
+        mock_sentinel = MagicMock()
+        mock_sentinel_cls.return_value = mock_sentinel
+        mock_sentinel.sentinels = [MagicMock()]
+        mock_sentinel.master_for.return_value = MagicMock()
+
+        from litellm._redis import _init_redis_sentinel
+
+        kwargs = {
+            "sentinel_nodes": [("host1", 26379)],
+            "sentinel_password": "sent_pass",
+            "service_name": "mymaster",
+        }
+        _init_redis_sentinel(kwargs)
+
+        # sentinel_kwargs should have password but no ssl
+        sentinel_call_kwargs = mock_sentinel_cls.call_args[1]
+        sk = sentinel_call_kwargs["sentinel_kwargs"]
+        assert sk["password"] == "sent_pass"
+        assert "ssl" not in sk
+
+        # master_for should not get connection_class
+        master_call_kwargs = mock_sentinel.master_for.call_args[1]
+        assert "connection_class" not in master_call_kwargs
+        # sentinel_password fallback: master gets password
+        assert master_call_kwargs["password"] == "sent_pass"
+
+        # sentinel pool connection_class should NOT be patched
+        original_cls = mock_sentinel.sentinels[0].connection_pool.connection_class
+        assert not str(type(original_cls).__name__).startswith("Shared")
+
+    @patch("litellm._redis.async_redis.Sentinel")
+    def test_async_sentinel_receives_ssl_kwargs(self, mock_sentinel_cls):
+        """Async sentinel should also get sentinel_kwargs with ssl and password."""
+        mock_sentinel = MagicMock()
+        mock_sentinel_cls.return_value = mock_sentinel
+        mock_sentinel.sentinels = []
+        mock_sentinel.master_for.return_value = MagicMock()
+
+        from litellm._redis import _init_async_redis_sentinel
+
+        kwargs = {
+            "sentinel_nodes": [("host1", 26379)],
+            "sentinel_password": "sent_pass",
+            "service_name": "mymaster",
+            "password": "redis_pass",
+            "ssl": True,
+            "ssl_cert_reqs": "none",
+        }
+        _init_async_redis_sentinel(kwargs)
+
+        sentinel_call_kwargs = mock_sentinel_cls.call_args[1]
+        assert "sentinel_kwargs" in sentinel_call_kwargs
+        sk = sentinel_call_kwargs["sentinel_kwargs"]
+        assert sk["password"] == "sent_pass"
+        assert sk["ssl"] is True


### PR DESCRIPTION
Fixes #21197

## Summary

- **SSL support for Sentinel connections**: Pass `ssl` and `ssl_cert_reqs` to both sentinel nodes and master via `sentinel_kwargs` and `connection_class`
- **Proper password propagation**: Forward `sentinel_password` to sentinel nodes, `password` to master (with backward-compatible fallback to `sentinel_password` when `password` is not set)
- **Connection kwargs forwarding**: Forward `db`, `username`, `socket_timeout`, `socket_connect_timeout`, `encoding`, `decode_responses`, `health_check_interval` etc. to `master_for()`
- **Shared SSLContext to prevent OOM**: redis-py 5.2 creates a new `ssl.SSLContext` per connection via `ssl.create_default_context()`, parsing all system CA certs each time. With 100+ Sentinel pool connections this causes 700+ MB memory spikes. A process-wide cached SSLContext eliminates this, with automatic fallback to original redis-py method when per-connection customization (client certs, OCSP, custom CA, ciphers) is needed
- **Clean up sentinel-specific kwargs**: Prevent `sentinel_nodes`, `sentinel_password`, `service_name` from leaking into `redis.Redis()` / `async_redis.Redis()` constructors

## Changes

- `_remove_sentinel_kwargs()` — strips sentinel-specific keys before passing to standard Redis client
- `_get_redis_ssl_context()` / `_get_cached_redis_ssl_context()` — cached SSLContext creation under `threading.RLock()`
- `_make_shared_ssl_connection_class()` — creates (and caches) connection subclass that reuses shared SSLContext for vanilla TLS, falls back to `super()._wrap_socket_with_ssl()` for any customization
- `_build_sentinel_master_kwargs()` — builds kwargs for `sentinel.master_for()` with explicit forward list
- Updated `_init_redis_sentinel()` / `_init_async_redis_sentinel()` to use above helpers
- Updated `get_redis_client()`, `get_redis_async_client()`, `get_redis_connection_pool()` to call `_remove_sentinel_kwargs()`

## Test plan

- [x] 18 unit tests in `tests/test_litellm/test_redis_sentinel.py`
- [x] Tests cover: SSL and non-SSL Sentinel paths, password forwarding, sentinel_password fallback, SSLContext caching, shared connection class, client cert fallback, kwargs cleanup
- [x] Tested in production with Redis Sentinel + SSL (3 sentinel nodes, TLS required)