### PR TITLE
fix: support read-only type env

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 echo $(pwd)
 
+# Copy pre-cached Prisma binaries to writable location for read-only filesystem environments (AKS, etc.)
+if [ -d "/app/.cache/prisma-python/binaries" ] && [ ! -d "/tmp/.cache/prisma-python/binaries" ]; then
+    echo "Copying pre-cached Prisma binaries to /tmp for read-only filesystem compatibility..."
+    mkdir -p /tmp/.cache/prisma-python
+    cp -r /app/.cache/prisma-python/binaries /tmp/.cache/prisma-python/
+    echo "Prisma binaries copied successfully"
+fi
+
+# Set runtime cache locations to /tmp (writable even in read-only root filesystem)
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/tmp/.cache}"
+export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-/tmp/npm-cache}"
+export PRISMA_BINARY_CACHE_DIR="${PRISMA_BINARY_CACHE_DIR:-/tmp/.cache/prisma-python/binaries}"
+
 # Run the Python migration script
 python3 litellm/proxy/prisma_migration.py
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,10 +9,19 @@ if [ -d "/app/.cache/prisma-python/binaries" ] && [ ! -d "/tmp/.cache/prisma-pyt
     echo "Prisma binaries copied successfully"
 fi
 
-# Set runtime cache locations to /tmp (writable even in read-only root filesystem)
-export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/tmp/.cache}"
-export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-/tmp/npm-cache}"
-export PRISMA_BINARY_CACHE_DIR="${PRISMA_BINARY_CACHE_DIR:-/tmp/.cache/prisma-python/binaries}"
+# Override Dockerfile ENV defaults that point to read-only /app/.cache,
+# but respect user-provided overrides (e.g. via K8s pod spec, docker-compose).
+# The Dockerfile.non_root sets these to /app/.cache/... at build time, but at
+# runtime /app is read-only, so we redirect to /tmp which is always writable.
+if [ "$XDG_CACHE_HOME" = "/app/.cache" ] || [ -z "$XDG_CACHE_HOME" ]; then
+    export XDG_CACHE_HOME="/tmp/.cache"
+fi
+if [ "$NPM_CONFIG_CACHE" = "/app/.cache/npm" ] || [ -z "$NPM_CONFIG_CACHE" ]; then
+    export NPM_CONFIG_CACHE="/tmp/npm-cache"
+fi
+if [ "$PRISMA_BINARY_CACHE_DIR" = "/app/.cache/prisma-python/binaries" ] || [ -z "$PRISMA_BINARY_CACHE_DIR" ]; then
+    export PRISMA_BINARY_CACHE_DIR="/tmp/.cache/prisma-python/binaries"
+fi
 
 # Run the Python migration script
 python3 litellm/proxy/prisma_migration.py

--- a/docker/prod_entrypoint.sh
+++ b/docker/prod_entrypoint.sh
@@ -1,5 +1,18 @@
 #!/bin/sh
 
+# Copy pre-cached Prisma binaries to writable location for read-only filesystem environments (AKS, etc.)
+if [ -d "/app/.cache/prisma-python/binaries" ] && [ ! -d "/tmp/.cache/prisma-python/binaries" ]; then
+    echo "Copying pre-cached Prisma binaries to /tmp for read-only filesystem compatibility..."
+    mkdir -p /tmp/.cache/prisma-python
+    cp -r /app/.cache/prisma-python/binaries /tmp/.cache/prisma-python/
+    echo "Prisma binaries copied successfully"
+fi
+
+# Set runtime cache locations to /tmp (writable even in read-only root filesystem)
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/tmp/.cache}"
+export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-/tmp/npm-cache}"
+export PRISMA_BINARY_CACHE_DIR="${PRISMA_BINARY_CACHE_DIR:-/tmp/.cache/prisma-python/binaries}"
+
 if [ "$SEPARATE_HEALTH_APP" = "1" ]; then
     export LITELLM_ARGS="$@"
     export SUPERVISORD_STOPWAITSECS="${SUPERVISORD_STOPWAITSECS:-3600}"

--- a/docker/prod_entrypoint.sh
+++ b/docker/prod_entrypoint.sh
@@ -8,10 +8,19 @@ if [ -d "/app/.cache/prisma-python/binaries" ] && [ ! -d "/tmp/.cache/prisma-pyt
     echo "Prisma binaries copied successfully"
 fi
 
-# Set runtime cache locations to /tmp (writable even in read-only root filesystem)
-export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/tmp/.cache}"
-export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-/tmp/npm-cache}"
-export PRISMA_BINARY_CACHE_DIR="${PRISMA_BINARY_CACHE_DIR:-/tmp/.cache/prisma-python/binaries}"
+# Override Dockerfile ENV defaults that point to read-only /app/.cache,
+# but respect user-provided overrides (e.g. via K8s pod spec, docker-compose).
+# The Dockerfile.non_root sets these to /app/.cache/... at build time, but at
+# runtime /app is read-only, so we redirect to /tmp which is always writable.
+if [ "$XDG_CACHE_HOME" = "/app/.cache" ] || [ -z "$XDG_CACHE_HOME" ]; then
+    export XDG_CACHE_HOME="/tmp/.cache"
+fi
+if [ "$NPM_CONFIG_CACHE" = "/app/.cache/npm" ] || [ -z "$NPM_CONFIG_CACHE" ]; then
+    export NPM_CONFIG_CACHE="/tmp/npm-cache"
+fi
+if [ "$PRISMA_BINARY_CACHE_DIR" = "/app/.cache/prisma-python/binaries" ] || [ -z "$PRISMA_BINARY_CACHE_DIR" ]; then
+    export PRISMA_BINARY_CACHE_DIR="/tmp/.cache/prisma-python/binaries"
+fi
 
 if [ "$SEPARATE_HEALTH_APP" = "1" ]; then
     export LITELLM_ARGS="$@"


### PR DESCRIPTION
## Relevant issues

make non-root handle read-only env like k8, VKS

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:
- [ ] **CI run for the last commit**  
       Link:
- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes

<img width="1691" height="923" alt="image" src="https://github.com/user-attachments/assets/5df86a46-6ef3-4491-9e48-fa8d3156dd95" />


docker/entrypoint.sh
docker/prod_entrypoint.sh
