### PR TITLE
fix: remove unused variable original_guardrails in pipeline_executor

### DIFF
--- a/litellm/proxy/policy_engine/pipeline_executor.py
+++ b/litellm/proxy/policy_engine/pipeline_executor.py
@@ -154,7 +154,6 @@ class PipelineExecutor:
             # Inject guardrail name into metadata so should_run_guardrail() allows it
             if "metadata" not in data:
                 data["metadata"] = {}
-            original_guardrails = data["metadata"].get("guardrails")
             data["metadata"]["guardrails"] = [step.guardrail]
 
             # Use unified_guardrail path if callback implements apply_guardrail


### PR DESCRIPTION
## Summary
Fixes Ruff F841 linting error by removing unused local variable.

## Changes
- Remove unused `original_guardrails` variable in `_execute_guardrail_step` method
- Variable was assigned but never used

## Testing
- Linting passes
- No functional changes

Fixes linting error:
```
proxy/policy_engine/pipeline_executor.py:157:13: F841 Local variable `original_guardrails` is assigned to but never used
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)