### PR TITLE
Fix: Refactor content filter to reduce statement count (PLR0915)

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1084,7 +1084,7 @@ class ContentFilterGuardrail(CustomGuardrail):
         self,
         keyword: str,
         action: ContentFilterAction,
-        description: str,
+        description: Optional[str],
         text: str,
         detections: Optional[List[ContentFilterDetection]],
     ) -> str:


### PR DESCRIPTION
## Summary
Fixes linting error PLR0915 in `content_filter.py` where `_filter_single_text` method had 64 statements (exceeding the 50 limit).

## Changes
Extracted repeated logic from `_filter_single_text` into four focused helper methods:
- `_handle_conditional_match` - handles conditional category matches
- `_handle_category_keyword_match` - handles category keyword matches  
- `_handle_pattern_match` - handles regex pattern matches
- `_handle_blocked_word_match` - handles blocked word matches

## Benefits
- Reduces statement count in `_filter_single_text` from 64 to well below 50
- Improves code organization and readability
- Makes the code more maintainable
- Eliminates code duplication

## Testing
✅ All 43 content filter tests pass
✅ Ruff linting passes with no errors

## Related Issue
Fixes linting error:
```
proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py:979:9: PLR0915 Too many statements (64 > 50)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)