### PR TITLE
Fix/21193 chatgpt codex unsupported params

### DIFF
--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -73,10 +73,6 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             litellm_params,
             headers,
         )
-        request.pop("max_output_tokens", None)
-        request.pop("max_tokens", None)
-        request.pop("max_completion_tokens", None)
-        request.pop("metadata", None)
         base_instructions = get_chatgpt_default_instructions()
         existing_instructions = request.get("instructions")
         if existing_instructions:
@@ -92,7 +88,22 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         if "reasoning.encrypted_content" not in include:
             include.append("reasoning.encrypted_content")
         request["include"] = include
-        return request
+
+        allowed_keys = {
+            "model",
+            "input",
+            "instructions",
+            "stream",
+            "store",
+            "include",
+            "tools",
+            "tool_choice",
+            "reasoning",
+            "previous_response_id",
+            "truncation",
+        }
+
+        return {k: v for k, v in request.items() if k in allowed_keys}
 
     def transform_response_api_response(
         self,


### PR DESCRIPTION
Summary
Fixes ChatGPT Codex (chatgpt/gpt-5.2-codex, etc.) failures where the Responses API bridge forwards unsupported params (like user, temperature, context_management) and the API rejects the request.

What changed
Updated ChatGPTResponsesAPIConfig.transform_responses_api_request() to use an allowlist of supported Responses API keys and drop everything else.
Keeps required ChatGPT defaults (streaming enabled + reasoning.encrypted_content included).

Why this works
Codex’s Responses endpoint is strict about accepted parameters. By only sending known-supported keys, we prevent “Unsupported parameter: …” errors without needing to chase every new unsupported param via pop().

Tests
Added/updated unit test in tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py to assert unsupported keys are removed and supported keys remain.

Fixes #21193 