### PR TITLE
perf(router): avoid O(n^2) membership scans in team deployment filter

### DIFF
--- a/litellm/router_utils/common_utils.py
+++ b/litellm/router_utils/common_utils.py
@@ -58,7 +58,7 @@ def filter_team_based_models(
     request_team_id = metadata.get("user_api_key_team_id") or litellm_metadata.get(
         "user_api_key_team_id"
     )
-    ids_to_remove = []
+    ids_to_remove = set()
     if isinstance(healthy_deployments, dict):
         return healthy_deployments
     for deployment in healthy_deployments:
@@ -67,7 +67,7 @@ def filter_team_based_models(
         if model_team_id is None:
             continue
         if model_team_id != request_team_id:
-            ids_to_remove.append(deployment.get("model_info", {}).get("id"))
+            ids_to_remove.add(_model_info.get("id"))
 
     return [
         deployment
@@ -125,4 +125,3 @@ def filter_web_search_deployments(
     if len(healthy_deployments) > 0 and len(final_deployments) == 0:
         verbose_logger.warning("No deployments support web search for request")
     return final_deployments
-


### PR DESCRIPTION
## Summary
This PR fixes a performance hotspot in `filter_team_based_models` by switching `ids_to_remove` from a list to a set.

- File changed: `litellm/router_utils/common_utils.py`
- Scope: request-time healthy deployment filtering in router path

## Issue Rationale (Detailed)
`filter_team_based_models` runs during router deployment selection (`Router.async_get_healthy_deployments`).
The previous implementation built `ids_to_remove` as a list and then checked membership with `not in` inside a list comprehension.

That creates an avoidable quadratic pattern:

1. First pass over `healthy_deployments` builds `ids_to_remove` (O(n)).
2. Second pass checks `id not in ids_to_remove` for each deployment.
3. With a list, each membership check is O(k) (linear scan), so the second pass becomes O(n * k), worst-case O(n^2).

For large deployment pools (common in gateway setups with many model variants/team-specific configs), this adds avoidable CPU overhead on a request path.

### Observed impact (pre-fix benchmark from bug validation)
On this code path, measured median per-call time (current vs set-based variant):

- 100 deployments: `0.0736 ms` vs `0.0280 ms` (`2.63x` faster)
- 500 deployments: `1.5689 ms` vs `0.1850 ms` (`8.48x` faster)
- 1000 deployments: `6.0891 ms` vs `0.3196 ms` (`19.05x` faster)

Repeated 1000-deployment trials remained in the same range (`~20x–30x` faster).

## Fix Rationale
Change `ids_to_remove` from `list` to `set` and use `add()` instead of `append()`.

- Before: list membership lookup O(n)
- After: set membership lookup O(1) average
- Result: filtering phase drops from quadratic to linear behavior in practice

The change is minimal and localized:

- `ids_to_remove = []` -> `ids_to_remove = set()`
- `ids_to_remove.append(...)` -> `ids_to_remove.add(...)`

## Correctness / Behavior Safety
This change preserves behavior for filtering semantics:

- `ids_to_remove` is only used for membership tests.
- Ordering of `ids_to_remove` is irrelevant.
- Duplicate IDs do not change semantics (membership-only check).
- Output ordering remains unchanged because we still iterate `healthy_deployments` in original order for the returned list.

## Validation
Ran existing team-filter test suite:

```bash
poetry run pytest -q tests/test_litellm/router_utils/test_router_utils_common_utils.py -k filter_team_based_models
```

Result: `12 passed, 18 deselected`.

## Related report
- `BUG_CONFIRMED-PERF-LIST-LOOKUP-FILTER-TEAM.md`
