### PR TITLE
fix(test): resolve merge conflict and fix bedrock thinking test flakiness

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1051,7 +1051,7 @@ class OpenTelemetry(CustomLogger):
         # See: https://github.com/open-telemetry/opentelemetry-python/pull/4676
         # TODO: Refactor to use the proper OTEL Logs API instead of directly creating SDK LogRecords
 
-        from opentelemetry._logs import SeverityNumber, get_logger, get_logger_provider
+        from opentelemetry._logs import SeverityNumber, get_logger
         try:
             from opentelemetry.sdk._logs import (  # type: ignore[attr-defined]  # OTEL < 1.39.0
                 LogRecord as SdkLogRecord,

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1051,23 +1051,15 @@ class OpenTelemetry(CustomLogger):
         # See: https://github.com/open-telemetry/opentelemetry-python/pull/4676
         # TODO: Refactor to use the proper OTEL Logs API instead of directly creating SDK LogRecords
 
-        from opentelemetry._logs import (
-            SeverityNumber,
-            get_logger,
-        )
-
-        # MyPy evaluates both branches of try/except imports and can fail when
-        # newer OTEL stubs remove/relocate symbols. Gate the typing import so
-        # only the canonical location is type-checked.
-        if TYPE_CHECKING:
-            from opentelemetry.sdk._logs._internal import LogRecord as SdkLogRecord
-        else:
-            try:
-                from opentelemetry.sdk._logs import (
-                    LogRecord as SdkLogRecord,  # type: ignore[attr-defined]
-                )
-            except ImportError:
-                from opentelemetry.sdk._logs._internal import LogRecord as SdkLogRecord
+        from opentelemetry._logs import SeverityNumber, get_logger, get_logger_provider
+        try:
+            from opentelemetry.sdk._logs import (  # type: ignore[attr-defined]  # OTEL < 1.39.0
+                LogRecord as SdkLogRecord,
+            )
+        except ImportError:
+            from opentelemetry.sdk._logs._internal import (
+                LogRecord as SdkLogRecord,  # type: ignore[attr-defined]  # OTEL >= 1.39.0
+            )
 
         otel_logger = get_logger(LITELLM_LOGGER_NAME)
 


### PR DESCRIPTION
## Summary
- Resolved merge conflict in `litellm/integrations/opentelemetry.py` blocking imports
- Fixed flaky `test_bedrock_converse_budget_tokens_preserved` that was intermittently failing in CI

## Problem
The test was failing in CI with:
```
AssertionError: Expected 'post' to have been called once. Called 0 times.
```

Additionally, there were RuntimeWarnings about unawaited coroutines:
```
RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    response.raise_for_status()
```

## Root Cause
1. **Merge conflict**: The opentelemetry.py file had unresolved merge markers preventing module imports
2. **Mock setup issue**: Using `AsyncMock()` for the response object caused child methods like `raise_for_status()` and `json()` to auto-create as async, returning unawaited coroutines. This behavior was unreliable across Python versions and test environments.

## Solution
1. Resolved merge conflict by keeping the simpler import structure that includes all needed symbols
2. Fixed mock setup:
   - Created response as `MagicMock()` instead of `AsyncMock()`
   - Explicitly set `raise_for_status` and `json` as `MagicMock` instances
   - Used `AsyncMock` only for the `post()` method via `patch.object(..., new=AsyncMock())`

## Test Results
**Before fix:**
- Test passed locally but with RuntimeWarnings
- Failed intermittently in CI
- 18 warnings total (including 2 RuntimeWarnings)

**After fix:**
- ✅ Test passes consistently across 5 consecutive runs
- ✅ No RuntimeWarnings about unawaited coroutines
- ✅ Only 16 warnings (removed 2 RuntimeWarnings)
- ✅ Request JSON verification shows budget_tokens correctly preserved

## Test plan
- [x] Run test 5 times locally - all passed
- [x] Verified RuntimeWarnings eliminated
- [x] Confirmed budget_tokens preservation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)