### PR TITLE
Fix SSO test flakiness by correctly mocking premium_user

### DIFF
--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -262,6 +262,11 @@ def test_sso_key_generate_shows_deprecation_banner(client_no_auth, monkeypatch):
         "litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler.should_use_sso_handler",
         lambda *args, **kwargs: False,
     )
+    # Mock premium_user to bypass enterprise check (prevents 403 Forbidden)
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.premium_user",
+        True,
+    )
     monkeypatch.setenv("UI_USERNAME", "admin")
 
     response = client_no_auth.get("/sso/key/generate")


### PR DESCRIPTION
## Summary
- Fixes intermittent test failure in `test_sso_key_generate_shows_deprecation_banner`
- Test was failing in CI with 403 Forbidden instead of expected 200 status

## Root Cause
The SSO endpoint `/sso/key/generate` checks for `premium_user` at line 297 in `litellm/proxy/management_endpoints/ui_sso.py` and returns 403 if it's not True. The test was missing this monkeypatch, causing the enterprise check to fail intermittently.

## Changes
- Added `monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)` to bypass the enterprise check during testing
- Monkeypatch targets the correct import location (`litellm.proxy.proxy_server.premium_user`)

## Test plan
- [x] Test passes locally: `poetry run pytest tests/test_litellm/proxy/test_proxy_server.py::test_sso_key_generate_shows_deprecation_banner -v`
- [x] Verified the endpoint implementation to confirm premium_user check location
- [x] Tested with proper monkeypatch path

🤖 Generated with [Claude Code](https://claude.com/claude-code)