### PR TITLE
[Fix] UI - E2E Tests: Injecting localStorage Values to Hide Usage Indicator

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/tests/navigation/sidebar.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/navigation/sidebar.spec.ts
@@ -26,6 +26,11 @@ for (const { role, storage } of roles) {
 
     test("should navigate to correct URL when clicking sidebar menu items from homepage", async ({ page }) => {
       await page.goto("/ui");
+      await page.evaluate(() => {
+        window.localStorage.setItem("disableUsageIndicator", "true");
+        window.localStorage.setItem("disableShowPrompts", "true");
+        window.localStorage.setItem("disableShowNewBadge", "true");
+      });
 
       for (const buttonLabel of sidebarButtons[role as keyof typeof sidebarButtons]) {
         const expectedPage = menuLabelToPage[buttonLabel];
@@ -45,6 +50,13 @@ for (const { role, storage } of roles) {
     });
 
     test("should navigate directly to page using navigation helper", async ({ page }) => {
+      await page.goto("/ui");
+      await page.evaluate(() => {
+        window.localStorage.setItem("disableUsageIndicator", "true");
+        window.localStorage.setItem("disableShowPrompts", "true");
+        window.localStorage.setItem("disableShowNewBadge", "true");
+      });
+
       // Test direct navigation to verify the helper function works
       await navigateToPage(page, Page.ApiKeys);
       await expect(page).toHaveURL(new RegExp(`[?&]page=${Page.ApiKeys}(&|$)`));


### PR DESCRIPTION


## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure

## Changes
