### PR TITLE
feat: support per-request enable_json_schema_validation for thread safety

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -416,6 +416,8 @@ async def acompletion(  # noqa: PLR0915
     web_search_options: Optional[OpenAIWebSearchOptions] = None,
     # Session management
     shared_session: Optional["ClientSession"] = None,
+    # Per-request JSON schema validation (overrides litellm.enable_json_schema_validation)
+    enable_json_schema_validation: Optional[bool] = None,
     **kwargs,
 ) -> Union[ModelResponse, CustomStreamWrapper]:
     """
@@ -560,6 +562,7 @@ async def acompletion(  # noqa: PLR0915
         "thinking": thinking,
         "web_search_options": web_search_options,
         "shared_session": shared_session,
+        "enable_json_schema_validation": enable_json_schema_validation,
     }
     if custom_llm_provider is None:
         _, custom_llm_provider, _, _ = get_llm_provider(
@@ -1045,6 +1048,8 @@ def completion(  # type: ignore # noqa: PLR0915
     thinking: Optional[AnthropicThinkingParam] = None,
     # Session management
     shared_session: Optional["ClientSession"] = None,
+    # Per-request JSON schema validation (overrides litellm.enable_json_schema_validation)
+    enable_json_schema_validation: Optional[bool] = None,
     **kwargs,
 ) -> Union[ModelResponse, CustomStreamWrapper]:
     """

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1170,6 +1170,7 @@ def completion(  # type: ignore # noqa: PLR0915
                 thinking=thinking,
                 web_search_options=web_search_options,
                 shared_session=shared_session,
+                enable_json_schema_validation=enable_json_schema_validation,
                 **kwargs,
             )
     api_base = kwargs.get("api_base", None)

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2939,6 +2939,7 @@ all_litellm_params = (
         "shared_session",
         "search_tool_name",
         "order",
+        "enable_json_schema_validation",
     ]
     + list(StandardCallbackDynamicParams.__annotations__.keys())
     + list(CustomPricingLiteLLMParams.model_fields.keys())

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1318,7 +1318,18 @@ def post_call_processing(
                             ### POST-CALL RULES ###
                             rules_obj.post_call_rules(input=model_response, model=model)
                             ### JSON SCHEMA VALIDATION ###
-                            if litellm.enable_json_schema_validation is True:
+                            # Per-request flag takes priority over global flag
+                            _per_request_validation = (
+                                optional_params.get("enable_json_schema_validation")
+                                if optional_params is not None
+                                else None
+                            )
+                            _enable_json_schema_validation = (
+                                _per_request_validation
+                                if _per_request_validation is not None
+                                else litellm.enable_json_schema_validation
+                            )
+                            if _enable_json_schema_validation is True:
                                 try:
                                     if (
                                         optional_params is not None

--- a/tests/litellm/litellm_core_utils/test_json_schema_validation.py
+++ b/tests/litellm/litellm_core_utils/test_json_schema_validation.py
@@ -1,0 +1,139 @@
+"""
+Tests for per-request enable_json_schema_validation parameter.
+
+Ensures the per-request flag overrides the global litellm.enable_json_schema_validation,
+making JSON schema validation thread-safe for concurrent usage.
+
+Related issue: https://github.com/BerriAI/litellm/issues/XXXX
+"""
+
+import json
+
+import pytest
+
+import litellm
+from litellm.types.utils import ModelResponse
+from litellm.utils import Rules, post_call_processing
+
+
+def _make_response(content: dict) -> ModelResponse:
+    """Create a ModelResponse with the given content as JSON string."""
+    response = ModelResponse()
+    response.choices[0].message.content = json.dumps(content)
+    return response
+
+
+def _mock_completion():
+    """Mock function with __name__ == 'completion' for post_call_processing."""
+    pass
+
+
+_mock_completion.__name__ = "completion"
+
+# Schema that requires 'title' (string) and 'rating' (integer)
+STRICT_SCHEMA = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "MovieReview",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "rating": {"type": "integer"},
+            },
+            "required": ["title", "rating"],
+        },
+    },
+}
+
+# Response that does NOT match the schema (wrong field names)
+INVALID_RESPONSE = _make_response({"name": "test", "age": 25})
+
+# Response that matches the schema
+VALID_RESPONSE = _make_response({"title": "Inception", "rating": 9})
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_flag():
+    """Reset the global flag before and after each test."""
+    original = litellm.enable_json_schema_validation
+    litellm.enable_json_schema_validation = False
+    yield
+    litellm.enable_json_schema_validation = original
+
+
+class TestPerRequestJsonSchemaValidation:
+    """Test that per-request enable_json_schema_validation overrides the global flag."""
+
+    def test_global_off_no_per_request_skips_validation(self):
+        """Global OFF + no per-request flag -> no validation (default behavior)."""
+        litellm.enable_json_schema_validation = False
+        # Should NOT raise even though response doesn't match schema
+        post_call_processing(
+            INVALID_RESPONSE,
+            "test-model",
+            {"response_format": STRICT_SCHEMA},
+            _mock_completion,
+            Rules(),
+        )
+
+    def test_per_request_on_overrides_global_off(self):
+        """Global OFF + per-request ON -> validation runs and catches invalid response."""
+        litellm.enable_json_schema_validation = False
+        with pytest.raises(litellm.JSONSchemaValidationError):
+            post_call_processing(
+                INVALID_RESPONSE,
+                "test-model",
+                {
+                    "response_format": STRICT_SCHEMA,
+                    "enable_json_schema_validation": True,
+                },
+                _mock_completion,
+                Rules(),
+            )
+
+    def test_per_request_off_overrides_global_on(self):
+        """Global ON + per-request OFF -> validation skipped (per-request wins)."""
+        litellm.enable_json_schema_validation = True
+        # Should NOT raise because per-request says False
+        post_call_processing(
+            INVALID_RESPONSE,
+            "test-model",
+            {
+                "response_format": STRICT_SCHEMA,
+                "enable_json_schema_validation": False,
+            },
+            _mock_completion,
+            Rules(),
+        )
+
+    def test_global_on_no_per_request_validates(self):
+        """Global ON + no per-request flag -> validation runs (backward compatible)."""
+        litellm.enable_json_schema_validation = True
+        with pytest.raises(litellm.JSONSchemaValidationError):
+            post_call_processing(
+                INVALID_RESPONSE,
+                "test-model",
+                {"response_format": STRICT_SCHEMA},
+                _mock_completion,
+                Rules(),
+            )
+
+    def test_valid_response_passes_with_per_request_on(self):
+        """Per-request ON + valid response -> no error raised."""
+        post_call_processing(
+            VALID_RESPONSE,
+            "test-model",
+            {
+                "response_format": STRICT_SCHEMA,
+                "enable_json_schema_validation": True,
+            },
+            _mock_completion,
+            Rules(),
+        )
+
+    def test_per_request_flag_is_in_all_litellm_params(self):
+        """Ensure the param is registered so it doesn't leak to provider APIs."""
+        from litellm.types.utils import all_litellm_params
+
+        assert "enable_json_schema_validation" in all_litellm_params

--- a/tests/litellm/litellm_core_utils/test_json_schema_validation.py
+++ b/tests/litellm/litellm_core_utils/test_json_schema_validation.py
@@ -46,11 +46,8 @@ STRICT_SCHEMA = {
     },
 }
 
-# Response that does NOT match the schema (wrong field names)
-INVALID_RESPONSE = _make_response({"name": "test", "age": 25})
-
-# Response that matches the schema
-VALID_RESPONSE = _make_response({"title": "Inception", "rating": 9})
+INVALID_CONTENT = {"name": "test", "age": 25}  # Does NOT match the schema
+VALID_CONTENT = {"title": "Inception", "rating": 9}  # Matches the schema
 
 
 @pytest.fixture(autouse=True)
@@ -70,7 +67,7 @@ class TestPerRequestJsonSchemaValidation:
         litellm.enable_json_schema_validation = False
         # Should NOT raise even though response doesn't match schema
         post_call_processing(
-            INVALID_RESPONSE,
+            _make_response(INVALID_CONTENT),
             "test-model",
             {"response_format": STRICT_SCHEMA},
             _mock_completion,
@@ -82,7 +79,7 @@ class TestPerRequestJsonSchemaValidation:
         litellm.enable_json_schema_validation = False
         with pytest.raises(litellm.JSONSchemaValidationError):
             post_call_processing(
-                INVALID_RESPONSE,
+                _make_response(INVALID_CONTENT),
                 "test-model",
                 {
                     "response_format": STRICT_SCHEMA,
@@ -97,7 +94,7 @@ class TestPerRequestJsonSchemaValidation:
         litellm.enable_json_schema_validation = True
         # Should NOT raise because per-request says False
         post_call_processing(
-            INVALID_RESPONSE,
+            _make_response(INVALID_CONTENT),
             "test-model",
             {
                 "response_format": STRICT_SCHEMA,
@@ -112,7 +109,7 @@ class TestPerRequestJsonSchemaValidation:
         litellm.enable_json_schema_validation = True
         with pytest.raises(litellm.JSONSchemaValidationError):
             post_call_processing(
-                INVALID_RESPONSE,
+                _make_response(INVALID_CONTENT),
                 "test-model",
                 {"response_format": STRICT_SCHEMA},
                 _mock_completion,
@@ -122,7 +119,7 @@ class TestPerRequestJsonSchemaValidation:
     def test_valid_response_passes_with_per_request_on(self):
         """Per-request ON + valid response -> no error raised."""
         post_call_processing(
-            VALID_RESPONSE,
+            _make_response(VALID_CONTENT),
             "test-model",
             {
                 "response_format": STRICT_SCHEMA,


### PR DESCRIPTION
## Relevant issues

Fixes thread-safety issue with `litellm.enable_json_schema_validation` global flag in concurrent environments (FastAPI, multi-threaded services).

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Allow passing `enable_json_schema_validation` as a per-request parameter to `completion()` and `acompletion()`, instead of only relying on the global `litellm.enable_json_schema_validation` flag.

The global flag isn't thread-safe. In a FastAPI service with concurrent users, one request can change the flag while another is mid-execution:

```python
# Thread A sets it to True
litellm.enable_json_schema_validation = True
# Thread B sets it to False  
litellm.enable_json_schema_validation = False
# Thread A calls completion() — gets False instead of True
```

**Solution:** Pass the flag dynamically per-request:

```python
# Thread-safe: each request controls its own validation
completion(..., enable_json_schema_validation=True)
completion(..., enable_json_schema_validation=False)
```

**Priority:** per-request value > global value. If not passed, falls back to the global (fully backward compatible).

**Files changed:**
- `litellm/main.py` — added `enable_json_schema_validation` param to `completion()` and `acompletion()`
- `litellm/types/utils.py` — registered in `all_litellm_params` so it doesn't leak to provider APIs
- `litellm/utils.py` — `post_call_processing()` checks per-request value first, falls back to global
- `tests/litellm/litellm_core_utils/test_json_schema_validation.py` — 6 tests covering the full matrix