### PR TITLE
fix: handle stricter aws typing from transitive stubs

### DIFF
--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -573,6 +573,8 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 url=prepped.url,
                 headers=prepped.headers,
             )
+            if self.s3_region_name is None:
+                raise ValueError("S3 region name is required for SigV4 signing")
             SigV4Auth(credentials, "s3", self.s3_region_name).add_auth(aws_request)
 
             # Prepare the signed headers

--- a/litellm/integrations/sqs.py
+++ b/litellm/integrations/sqs.py
@@ -341,6 +341,8 @@ class SQSLogger(CustomBatchLogger, BaseAWSLLM):
                 data=prepped.body,
                 headers=prepped.headers,
             )
+            if self.sqs_region_name is None:
+                raise ValueError("SQS region name is required for SigV4 signing")
             SigV4Auth(credentials, "sqs", self.sqs_region_name).add_auth(
                 aws_request
             )

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -714,7 +714,12 @@ class BaseAWSLLM:
         with tracer.trace("boto3.Session(**iam_creds_dict)"):
             session = boto3.Session(**iam_creds_dict)
 
-        iam_creds = cast(Credentials, session.get_credentials())
+        iam_creds = session.get_credentials()
+        if iam_creds is None:
+            raise AwsAuthError(
+                message="Could not resolve AWS credentials from web identity session.",
+                status_code=401,
+            )
         return iam_creds, self._get_default_ttl_for_boto3_credentials()
 
     def _handle_irsa_cross_account(
@@ -1012,7 +1017,13 @@ class BaseAWSLLM:
         # uses auth values from AWS profile usually stored in ~/.aws/credentials
         with tracer.trace("boto3.Session(profile_name=aws_profile_name)"):
             client = boto3.Session(profile_name=aws_profile_name)
-            return cast(Credentials, client.get_credentials()), None
+            credentials = client.get_credentials()
+            if credentials is None:
+                raise AwsAuthError(
+                    message=f"Could not resolve AWS credentials for profile '{aws_profile_name}'.",
+                    status_code=401,
+                )
+            return credentials, None
 
     @tracer.wrap()
     def _auth_with_aws_session_token(
@@ -1057,7 +1068,12 @@ class BaseAWSLLM:
                 region_name=aws_region_name,
             )
 
-        credentials = cast(Credentials, session.get_credentials())
+        credentials = session.get_credentials()
+        if credentials is None:
+            raise AwsAuthError(
+                message="Could not resolve AWS credentials from access key/secret key session.",
+                status_code=401,
+            )
         return credentials, self._get_default_ttl_for_boto3_credentials()
 
     @tracer.wrap()
@@ -1069,7 +1085,12 @@ class BaseAWSLLM:
 
         with tracer.trace("boto3.Session()"):
             session = boto3.Session()
-            credentials = cast(Credentials, session.get_credentials())
+            credentials = session.get_credentials()
+            if credentials is None:
+                raise AwsAuthError(
+                    message="Could not resolve AWS credentials from environment/session.",
+                    status_code=401,
+                )
             return credentials, None
 
     @tracer.wrap()
@@ -1369,4 +1390,15 @@ class BaseAWSLLM:
         ):  # prevent sigv4 from overwriting the auth header
             request_headers_dict["Authorization"] = headers["Authorization"]
 
-        return request_headers_dict, cast(Optional[bytes], request.body)
+        request_body = request.body
+        normalized_body: Optional[bytes]
+        if request_body is None:
+            normalized_body = None
+        elif isinstance(request_body, bytes):
+            normalized_body = request_body
+        elif isinstance(request_body, str):
+            normalized_body = request_body.encode("utf-8")
+        else:
+            normalized_body = bytes(request_body)
+
+        return request_headers_dict, normalized_body

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -715,6 +715,11 @@ class BaseAWSLLM:
             session = boto3.Session(**iam_creds_dict)
 
         iam_creds = session.get_credentials()
+        if iam_creds is None:
+            raise AwsAuthError(
+                message="Unable to load AWS credentials from web identity session.",
+                status_code=401,
+            )
         return iam_creds, self._get_default_ttl_for_boto3_credentials()
 
     def _handle_irsa_cross_account(
@@ -1012,7 +1017,13 @@ class BaseAWSLLM:
         # uses auth values from AWS profile usually stored in ~/.aws/credentials
         with tracer.trace("boto3.Session(profile_name=aws_profile_name)"):
             client = boto3.Session(profile_name=aws_profile_name)
-            return client.get_credentials(), None
+            credentials = client.get_credentials()
+            if credentials is None:
+                raise AwsAuthError(
+                    message="Unable to load AWS credentials from profile.",
+                    status_code=401,
+                )
+            return credentials, None
 
     @tracer.wrap()
     def _auth_with_aws_session_token(
@@ -1058,6 +1069,11 @@ class BaseAWSLLM:
             )
 
         credentials = session.get_credentials()
+        if credentials is None:
+            raise AwsAuthError(
+                message="Unable to load AWS credentials from access key/secret key.",
+                status_code=401,
+            )
         return credentials, self._get_default_ttl_for_boto3_credentials()
 
     @tracer.wrap()
@@ -1070,6 +1086,11 @@ class BaseAWSLLM:
         with tracer.trace("boto3.Session()"):
             session = boto3.Session()
             credentials = session.get_credentials()
+            if credentials is None:
+                raise AwsAuthError(
+                    message="Unable to load AWS credentials from environment variables.",
+                    status_code=401,
+                )
             return credentials, None
 
     @tracer.wrap()
@@ -1369,4 +1390,13 @@ class BaseAWSLLM:
         ):  # prevent sigv4 from overwriting the auth header
             request_headers_dict["Authorization"] = headers["Authorization"]
 
-        return request_headers_dict, request.body
+        raw_request_body = request.body
+        request_body: Optional[bytes]
+        if isinstance(raw_request_body, bytes):
+            request_body = raw_request_body
+        elif isinstance(raw_request_body, str):
+            request_body = raw_request_body.encode()
+        else:
+            request_body = None
+
+        return request_headers_dict, request_body

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -668,9 +668,10 @@ class BedrockEmbedding(BaseAWSLLM):
 
         # Make the GET request
         client = get_async_httpx_client(llm_provider=LlmProviders.BEDROCK)
+        request_headers = dict(prepped.headers)
         response = await client.get(
             url=prepped.url,
-            headers=prepped.headers,
+            headers=request_headers,
         )
 
         # LOGGING

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -5,7 +5,7 @@ Handles embedding calls to Bedrock's `/invoke` endpoint
 import copy
 import json
 import urllib.parse
-from typing import Any, Callable, List, Optional, Tuple, Union, get_args
+from typing import Any, Callable, List, Optional, Tuple, Union, cast, get_args
 
 import httpx
 
@@ -668,10 +668,9 @@ class BedrockEmbedding(BaseAWSLLM):
 
         # Make the GET request
         client = get_async_httpx_client(llm_provider=LlmProviders.BEDROCK)
-        request_headers = dict(prepped.headers)
         response = await client.get(
             url=prepped.url,
-            headers=request_headers,
+            headers=cast(dict[Any, Any], prepped.headers),
         )
 
         # LOGGING

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -670,7 +670,7 @@ class BedrockEmbedding(BaseAWSLLM):
         client = get_async_httpx_client(llm_provider=LlmProviders.BEDROCK)
         response = await client.get(
             url=prepped.url,
-            headers=cast(dict[Any, Any], prepped.headers),
+            headers=cast(Dict[Any, Any], prepped.headers),
         )
 
         # LOGGING

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -670,7 +670,7 @@ class BedrockEmbedding(BaseAWSLLM):
         client = get_async_httpx_client(llm_provider=LlmProviders.BEDROCK)
         response = await client.get(
             url=prepped.url,
-            headers=cast(Dict[Any, Any], prepped.headers),
+            headers=cast(dict, prepped.headers),
         )
 
         # LOGGING

--- a/litellm/rag/ingestion/bedrock_ingestion.py
+++ b/litellm/rag/ingestion/bedrock_ingestion.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 from litellm._logging import verbose_logger
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
@@ -578,7 +578,8 @@ class BedrockRAGIngestion(BaseRAGIngestion, BaseAWSLLM):
             region_name=self.aws_region_name,
         )
 
-        return session.client(service_name)
+        session_any = cast(Any, session)
+        return session_any.client(service_name)
 
     async def embed(
         self,
@@ -682,4 +683,3 @@ class BedrockRAGIngestion(BaseRAGIngestion, BaseAWSLLM):
                     break
 
         return str(self.knowledge_base_id) if self.knowledge_base_id else None, s3_key
-


### PR DESCRIPTION
## Summary
This PR contains typing fixes that were discovered when making changes in [#21232](https://github.com/BerriAI/litellm/pull/21232). Some tests were failing and needed remediating.

## What changed
- `litellm/llms/bedrock/base_aws_llm.py`
  - Added explicit credential null-guards for stricter boto typing.
  - Normalized request body typing for signed requests.
- `litellm/rag/ingestion/bedrock_ingestion.py`
  - Added safe cast around dynamic `session.client(service_name)` usage to satisfy strict overload checks.
- `litellm/integrations/sqs.py`
  - Added explicit region guard before SigV4 signing.
- `litellm/integrations/s3_v2.py`
  - Added explicit region guard before SigV4 signing.
- `litellm/llms/bedrock/embed/embedding.py`
  - Normalized headers type passed to async HTTP client.

## Notes
- This PR should be merged prior to `#21232` can be rebased/updated to remove duplicate lint blockers.
