### PR TITLE
fix(proxy): handle missing DATABASE_URL in append_query_params

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -45,6 +45,7 @@ def append_query_params(url: Optional[str], params: dict) -> str:
     if not isinstance(url, str) or url == "":
         # Preserve previous startup behavior when DATABASE_URL is absent.
         # Returning an empty string avoids urlparse type errors in test/dev flows.
+        verbose_proxy_logger.warning("append_query_params received empty or non-string URL, returning empty string")
         return ""
     parsed_url = urlparse.urlparse(url)
     parsed_query = urlparse.parse_qs(parsed_url.query)

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -37,11 +37,15 @@ class LiteLLMDatabaseConnectionPool(Enum):
     database_connection_pool_timeout = 60
 
 
-def append_query_params(url, params) -> str:
+def append_query_params(url: Optional[str], params: dict) -> str:
     from litellm._logging import verbose_proxy_logger
 
     verbose_proxy_logger.debug(f"url: {url}")
     verbose_proxy_logger.debug(f"params: {params}")
+    if not isinstance(url, str) or url == "":
+        # Preserve previous startup behavior when DATABASE_URL is absent.
+        # Returning an empty string avoids urlparse type errors in test/dev flows.
+        return ""
     parsed_url = urlparse.urlparse(url)
     parsed_query = urlparse.parse_qs(parsed_url.query)
     parsed_query.update(params)

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -218,6 +218,12 @@ class TestProxyInitializationHelpers:
             assert "connection_limit=10" in modified_url
             assert "pool_timeout=60" in modified_url
 
+    def test_append_query_params_handles_missing_url(self):
+        from litellm.proxy.proxy_cli import append_query_params
+
+        modified_url = append_query_params(None, {"connection_limit": 10})
+        assert modified_url == ""
+
     @patch("uvicorn.run")
     @patch("atexit.register")  # 🔥 critical
     def test_skip_server_startup(self, mock_atexit_register, mock_uvicorn_run):


### PR DESCRIPTION
## Summary
This PR fixes a deterministic proxy test/setup failure path where `append_query_params()` is called with `url=None` and crashes in `urllib.parse` with: `TypeError: Cannot mix str and non-str arguments`

## Changes
- Update `append_query_params(url, params)` in `litellm/proxy/proxy_cli.py` to gracefully handle missing/empty URL input.
- If `url` is not a non-empty string, return `""` instead of calling `urlparse`.
- Add a unit test in `tests/test_litellm/proxy/test_proxy_cli.py`:
  - `test_append_query_params_handles_missing_url`
