### PR TITLE
Fix: Exclude tool params for models without function calling support (#21125)

### DIFF
--- a/litellm/llms/openai_like/dynamic_config.py
+++ b/litellm/llms/openai_like/dynamic_config.py
@@ -4,6 +4,7 @@ Dynamic configuration class generator for JSON-based providers.
 
 from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
 
+from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     handle_messages_with_content_list_to_str_conversion,
 )
@@ -98,17 +99,13 @@ def create_config_class(provider: SimpleProviderConfig):
         def get_supported_openai_params(self, model: str) -> list:
             """Get supported OpenAI params, excluding tool-related params for models
             that don't support function calling."""
-            from litellm._logging import verbose_logger
             from litellm.utils import supports_function_calling
 
             supported_params = super().get_supported_openai_params(model=model)
 
-            try:
-                _supports_fc = supports_function_calling(
-                    model=model, custom_llm_provider=provider.slug
-                )
-            except Exception:
-                _supports_fc = False
+            _supports_fc = supports_function_calling(
+                model=model, custom_llm_provider=provider.slug
+            )
 
             if not _supports_fc:
                 tool_params = ["tools", "tool_choice", "function_call", "functions", "parallel_tool_calls"]


### PR DESCRIPTION
## Summary

Fixes #21125

JSON-configured providers (like PublicAI/EuroLLM) inherit `get_supported_openai_params` from `OpenAIGPTConfig`, which always includes tool-related parameters (`tools`, `tool_choice`, `function_call`, `functions`, `parallel_tool_calls`). This causes issues when models on these providers don't actually support function calling — the params are incorrectly advertised as supported, leading to API errors.

## Changes

- **`litellm/llms/openai_like/dynamic_config.py`**: Override `get_supported_openai_params` in the dynamically generated `JSONProviderConfig` class to check `supports_function_calling()` and remove tool-related params when the model doesn't support it.
- **`tests/test_litellm/llms/openai_like/test_json_providers.py`**: Added 2 regression tests — one verifying tool params are excluded when function calling is not supported, another verifying they're included when it is.

## Approach

Follows the same pattern already used by **OVHCloud** (`litellm/llms/ovhcloud/chat/transformation.py`) and **Fireworks AI** (`litellm/llms/fireworks_ai/chat/transformation.py`) — both check `supports_function_calling()` before including tool params.

## Test Plan

- [x] `test_tool_params_excluded_when_function_calling_not_supported` — mocks `supports_function_calling` → `False`, asserts tool params removed
- [x] `test_tool_params_included_when_function_calling_supported` — mocks `supports_function_calling` → `True`, asserts tool params present
- [x] All 8 existing JSON provider tests pass
- [x] No regressions

## Future Suggestion

Currently, the supported params list in `OpenAIGPTConfig` is hardcoded — every time OpenAI adds or changes a parameter, the base class needs a manual update. A potential improvement could be to allow JSON-configured providers to define their own `supported_params` list directly in `providers.json`, making each provider's capabilities fully data-driven instead of relying on inheritance from a hardcoded base class. This would also allow per-provider param customization without needing code changes. Happy to help with this if it's something the team is interested in!

**Note:** Open to any feedback or changes!
