### PR TITLE
Generic Guardrails: Add a configurable fallback to handle generic guardrail endpoint connection failures

### DIFF
--- a/docs/my-website/docs/adding_provider/generic_guardrail_api.md
+++ b/docs/my-website/docs/adding_provider/generic_guardrail_api.md
@@ -237,6 +237,7 @@ litellm_settings:
         mode: pre_call  # or post_call, during_call
         api_base: https://your-guardrail-api.com
         api_key: os.environ/YOUR_GUARDRAIL_API_KEY  # optional
+        unreachable_fallback: fail_closed  # default: fail_closed. Set to fail_open to proceed if the guardrail endpoint is unreachable (network errors).
         additional_provider_specific_params:
           # your custom parameters
           threshold: 0.8

--- a/docs/my-website/docs/adding_provider/generic_guardrail_api.md
+++ b/docs/my-website/docs/adding_provider/generic_guardrail_api.md
@@ -237,7 +237,7 @@ litellm_settings:
         mode: pre_call  # or post_call, during_call
         api_base: https://your-guardrail-api.com
         api_key: os.environ/YOUR_GUARDRAIL_API_KEY  # optional
-        unreachable_fallback: fail_closed  # default: fail_closed. Set to fail_open to proceed if the guardrail endpoint is unreachable (network errors).
+        unreachable_fallback: fail_closed  # default: fail_closed. Set to fail_open to proceed if the guardrail endpoint is unreachable (network errors, or HTTP 502/503/504 from an upstream proxy/LB).
         additional_provider_specific_params:
           # your custom parameters
           threshold: 0.8

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/__init__.py
@@ -18,6 +18,9 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
         additional_provider_specific_params=getattr(
             litellm_params, "additional_provider_specific_params", {}
         ),
+        unreachable_fallback=getattr(
+            litellm_params, "unreachable_fallback", "fail_closed"
+        ),
         guardrail_name=guardrail.get("guardrail_name", ""),
         event_hook=litellm_params.mode,
         default_on=litellm_params.default_on,

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/example_config.yaml
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/example_config.yaml
@@ -14,7 +14,7 @@ litellm_settings:
         mode: pre_call  # Options: pre_call, post_call, during_call, [pre_call, post_call]
         api_key: os.environ/GENERIC_GUARDRAIL_API_KEY  # Optional if using Bearer auth
         api_base: http://localhost:8080  # Required. Endpoint /beta/litellm_basic_guardrail_api is automatically appended
-        unreachable_fallback: fail_closed  # Options: fail_closed (default, raise), fail_open (proceed if endpoint unreachable)
+        unreachable_fallback: fail_closed  # Options: fail_closed (default, raise), fail_open (proceed if endpoint unreachable or upstream returns 502/503/504)
         default_on: false  # Set to true to apply to all requests by default
         additional_provider_specific_params:
           # Any additional parameters your guardrail API needs

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/example_config.yaml
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/example_config.yaml
@@ -14,6 +14,7 @@ litellm_settings:
         mode: pre_call  # Options: pre_call, post_call, during_call, [pre_call, post_call]
         api_key: os.environ/GENERIC_GUARDRAIL_API_KEY  # Optional if using Bearer auth
         api_base: http://localhost:8080  # Required. Endpoint /beta/litellm_basic_guardrail_api is automatically appended
+        unreachable_fallback: fail_closed  # Options: fail_closed (default, raise), fail_open (proceed if endpoint unreachable)
         default_on: false  # Set to true to apply to all requests by default
         additional_provider_specific_params:
           # Any additional parameters your guardrail API needs

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -655,6 +655,7 @@ class BaseLitellmParams(
         default="fail_closed",
         description=(
             "Behavior when a guardrail endpoint is unreachable due to network errors. "
+            "NOTE: This is currently only implemented by guardrail='generic_guardrail_api'. "
             "'fail_closed' raises an error (default). 'fail_open' logs a critical error and allows the request to proceed."
         ),
     )

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -651,6 +651,14 @@ class BaseLitellmParams(
         description="Additional provider-specific parameters for generic guardrail APIs",
     )
 
+    unreachable_fallback: Literal["fail_closed", "fail_open"] = Field(
+        default="fail_closed",
+        description=(
+            "Behavior when a guardrail endpoint is unreachable due to network errors. "
+            "'fail_closed' raises an error (default). 'fail_open' logs a critical error and allows the request to proceed."
+        ),
+    )
+
     # Custom code guardrail params
     custom_code: Optional[str] = Field(
         default=None,
@@ -692,6 +700,7 @@ class LitellmParams(
         "mode",
         "default_action",
         "on_disallowed_action",
+        "unreachable_fallback",
         mode="before",
         check_fields=False,
     )

--- a/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
@@ -31,6 +31,14 @@ class GenericGuardrailAPIOptionalParams(BaseModel):
         description="Additional provider-specific parameters to send with the guardrail request",
     )
 
+    unreachable_fallback: Optional[Literal["fail_closed", "fail_open"]] = Field(
+        default="fail_closed",
+        description=(
+            "Behavior when the guardrail endpoint is unreachable due to network errors. "
+            "'fail_closed' raises an error (default). 'fail_open' logs a critical error and allows the request to proceed."
+        ),
+    )
+
 
 class GenericGuardrailAPIConfigModel(
     GuardrailConfigModel[GenericGuardrailAPIOptionalParams],
@@ -52,9 +60,9 @@ class GenericGuardrailAPIRequest(BaseModel):
 
     input_type: Literal["request", "response"]
     litellm_call_id: Optional[str] = None  # the call id of the individual LLM call
-    litellm_trace_id: Optional[
-        str
-    ] = None  # the trace id of the LLM call - useful if there are multiple LLM calls for the same conversation
+    litellm_trace_id: Optional[str] = (
+        None  # the trace id of the LLM call - useful if there are multiple LLM calls for the same conversation
+    )
     structured_messages: Optional[List[AllMessageValues]] = None
     images: Optional[List[str]] = None
     tools: Optional[List[ChatCompletionToolParam]] = None


### PR DESCRIPTION
Add a configurable fallback to handle generic guardrail endpoint connection failures
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
📖 Documentation
✅ Test

## Changes
- Add `unreachable_fallback` config option for `generic_guardrail_api` (fail_closed default, fail_open on network/unreachable errors).
- Log CRITICAL and proceed when fail_open is enabled and guardrail endpoint is unreachable.
- Add unit tests + docs/example config updates.

When `fail_closed` (same like before):
<img width="756" height="65" alt="image" src="https://github.com/user-attachments/assets/10c7d696-99a1-4c36-b1db-c7711da5efa9" />

When `fail_open` (log critical, but continue the flow):
<img width="758" height="79" alt="image" src="https://github.com/user-attachments/assets/d2b0af0e-e7ef-4132-9c86-a183ab3c9649" />
