### PR TITLE
fix: remove unused Reasoning import from transformation.py

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -31,7 +31,6 @@ from litellm.types.llms.openai import (
     OpenAIWebSearchOptions,
     OpenAIWebSearchUserLocation,
     OutputTokensDetails,
-    Reasoning,
     ResponseAPIUsage,
     ResponseInputParam,
     ResponsesAPIOptionalRequestParams,


### PR DESCRIPTION
## Summary
Removes unused `Reasoning` import from `litellm/responses/litellm_completion_transformation/transformation.py` that was causing a Ruff F401 linting error.

## Root Cause
PR #21103 changed `reasoning=dict(Reasoning())` to `reasoning=None`, which removed the only usage of the `Reasoning` import, but the import statement was not cleaned up.

## Changes
- Removed `Reasoning` from the import list in `litellm.types.llms.openai`

## Linting Error Fixed
```
responses/litellm_completion_transformation/transformation.py:34:5: F401 [*] `litellm.types.llms.openai.Reasoning` imported but unused
```

## Testing
✅ Ruff linting passes without errors
✅ No functional changes - purely removing dead code

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)