### PR TITLE
refactor: remove dead code from Langfuse test cleanup

### DIFF
--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -77,19 +77,12 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         sys.modules["langfuse"].Langfuse = self.mock_langfuse_class
 
         # Create a fresh logger instance for each test
-        # Force a clean state by clearing any class-level cached state
-        if hasattr(LangFuseLogger, '_langfuse_clients'):
-            LangFuseLogger._langfuse_clients = {}
-
         self.logger = LangFuseLogger()
 
         # Explicitly set the Langfuse client to our mock
         self.logger.Langfuse = self.mock_langfuse_client
         # Ensure langfuse_sdk_version is set correctly for _supports_* methods
         self.logger.langfuse_sdk_version = "3.0.0"
-        # Reset any cached client instances
-        if hasattr(self.logger, '_langfuse_client_cache'):
-            self.logger._langfuse_client_cache = None
 
         # Add the log_event_on_langfuse method to the instance
         def log_event_on_langfuse(
@@ -132,11 +125,9 @@ class TestLangfuseUsageDetails(unittest.TestCase):
     def tearDown(self):
         # Clean up logger instance to prevent state leakage
         if hasattr(self, 'logger'):
-            # Reset logger's Langfuse client
+            # Reset logger's Langfuse client to break any references
             self.logger.Langfuse = None
-            # Clear any cached state
-            if hasattr(self.logger, '_langfuse_client_cache'):
-                self.logger._langfuse_client_cache = None
+            # Delete logger instance to ensure complete cleanup
             del self.logger
 
         self.env_patcher.stop()


### PR DESCRIPTION
## Summary
Follow-up to PR #21248 addressing greptile code review feedback that was identified after the PR merged.

Removes `hasattr` checks for non-existent attributes that were flagged as dead code by greptile's automated code review.

## Background
PR #21248 improved Langfuse test isolation by adding cleanup in `setUp` and `tearDown`. However, it included defensive `hasattr` checks for attributes that don't actually exist on the `LangFuseLogger` class:
- `LangFuseLogger._langfuse_clients` (class-level)
- `self.logger._langfuse_client_cache` (instance-level)

Greptile correctly identified these as dead code, but the PR was merged before the cleanup could be applied.

## Changes
### Removed from setUp:
- ❌ `if hasattr(LangFuseLogger, '_langfuse_clients'): ...` (no-op)
- ❌ `if hasattr(self.logger, '_langfuse_client_cache'): ...` (no-op)

### Removed from tearDown:
- ❌ `if hasattr(self.logger, '_langfuse_client_cache'): ...` (no-op)

### Kept (effective fixes):
- ✅ `self.logger.Langfuse = None` (breaks references)
- ✅ `del self.logger` (ensures cleanup)

## Testing
✅ All 7 tests in `TestLangfuseUsageDetails` pass  
✅ No functional change - only removing dead code  
✅ Core test isolation fix from #21248 remains intact  

## Impact
- Makes code clearer by removing misleading defensive checks
- No change to test behavior or effectiveness
- Addresses technical debt identified in code review

## Related
- Follow-up to: #21248
- Greptile feedback: https://github.com/BerriAI/litellm/pull/21248#issuecomment

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)