### PR TITLE
fix(test): restore Langfuse client counter in test cleanup

### DIFF
--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -21,6 +21,9 @@ from litellm.types.integrations.langfuse import *
 
 class TestLangfuseUsageDetails(unittest.TestCase):
     def setUp(self):
+        # Save global Langfuse client counter to restore after test
+        self._original_langfuse_clients_count = litellm.initialized_langfuse_clients
+
         # Set up environment variables for testing
         self.env_patcher = patch.dict(
             "os.environ",
@@ -129,6 +132,9 @@ class TestLangfuseUsageDetails(unittest.TestCase):
             self.logger.Langfuse = None
             # Delete logger instance to ensure complete cleanup
             del self.logger
+
+        # Restore global Langfuse client counter to prevent cross-test pollution
+        litellm.initialized_langfuse_clients = self._original_langfuse_clients_count
 
         self.env_patcher.stop()
         self.langfuse_module_patcher.stop()  # patch.dict automatically restores sys.modules


### PR DESCRIPTION
## Summary
Completes the Langfuse test isolation fix from PR #21248 by also saving and restoring the global `litellm.initialized_langfuse_clients` counter.

## Root Cause
PR #21248 fixed logger instance cleanup but missed a critical piece: the global client counter.

Each time `LangFuseLogger()` is created, it increments `litellm.initialized_langfuse_clients`. Our test class creates a logger in `setUp` for each of 7 tests, so the counter accumulates: 1, 2, 3, 4, 5, 6, 7.

When other tests run before/after this test class, the accumulated counter state can cause unpredictable behavior, leading to:
- **Symptom**: `AssertionError: Expected 'generation' to have been called once. Called 0 times.`
- **When**: Test passes in isolation, fails when run with other tests
- **Why**: Global state pollution from counter accumulation

## Changes
- **setUp**: Save `litellm.initialized_langfuse_clients` before test
- **tearDown**: Restore original counter value after test

## Testing
✅ All 7 tests in `TestLangfuseUsageDetails` pass  
✅ Counter properly reset between tests  
✅ No state accumulation across test runs  

## Related
- Completes: #21248 (added logger cleanup, missed counter)
- Addresses: Greptile's observation about counter never being reset
- Follow-up to: #21253 (removed dead code)

## Impact
This should **finally** resolve the persistent `test_log_langfuse_v2_handles_null_usage_values` flakiness that has survived multiple fix attempts.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)