### PR TITLE
fix(test): flush client cache before test_extra_body_with_fallback

### DIFF
--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -427,6 +427,12 @@ async def test_extra_body_with_fallback(
     original_disable_aiohttp = litellm.disable_aiohttp_transport
 
     try:
+        # Clear cache to ensure no cached clients from previous tests interfere
+        # This prevents cache pollution where a previous test cached a client with
+        # aiohttp transport, which would bypass respx mocks
+        if hasattr(litellm, "in_memory_llm_clients_cache"):
+            litellm.in_memory_llm_clients_cache.flush_cache()
+
         # since this uses respx, we need to set use_aiohttp_transport to False
         litellm.disable_aiohttp_transport = True
         # Set up test parameters


### PR DESCRIPTION
## Summary
Fixes test isolation issue in `test_extra_body_with_fallback` by flushing the client cache before the test runs.

## Problem
- Previous tests may cache HTTP clients with aiohttp transport enabled
- When `test_extra_body_with_fallback` runs, even though it sets `disable_aiohttp_transport = True`, the cached client is still used
- Cached aiohttp clients bypass respx mocks, causing real API calls that fail
- This causes "All fallback attempts failed" errors in CI when run with other tests

## Solution
- Flush `in_memory_llm_clients_cache` before setting `disable_aiohttp_transport`
- Ensures a fresh client is created that respects the flag setting
- Follows the same pattern as `test_openai_env_base` which also uses respx

## Testing
- Test passes locally in isolation ✅
- Should now pass in CI with other tests

Related to #8425

🤖 Generated with [Claude Code](https://claude.com/claude-code)