### PR TITLE
refactor(test): remove redundant cache flush from test_openai_env_base

### DIFF
--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -497,12 +497,6 @@ async def test_openai_env_base(
     respx_mock: respx.MockRouter, env_base, openai_api_response, monkeypatch
 ):
     "This tests OpenAI env variables are honored, including legacy OPENAI_API_BASE"
-    # Clear cache to ensure no cached clients from previous tests interfere
-    # This prevents cache pollution where a previous test cached a client with
-    # aiohttp transport, which would bypass respx mocks
-    if hasattr(litellm, "in_memory_llm_clients_cache"):
-        litellm.in_memory_llm_clients_cache.flush_cache()
-    
     # Ensure aiohttp transport is disabled to use httpx which respx can mock
     litellm.disable_aiohttp_transport = True
 


### PR DESCRIPTION
## Summary
Removes redundant manual cache flush from `test_openai_env_base` since the `clear_client_cache` autouse fixture already handles this.

## Background
The manual cache flush was added on **Jan 26, 2026** to fix test flakiness. However, 5 days later on **Jan 31, 2026**, an `autouse=True` fixture was added (lines 21-32) that automatically flushes the cache before and after every test in the module.

This made the manual flush redundant.

## Changes
- Removed 6 lines of redundant cache flush code from `test_openai_env_base`
- Test still passes (verified locally)
- No functional changes - the autouse fixture already does this work

## Why Now?
This cleanup was identified by greptile during review of PR #21255, which was attempting to add the same redundant pattern to another test.

## Test Results
```
tests/test_litellm/test_main.py::test_openai_env_base[OPENAI_API_BASE] PASSED
tests/test_litellm/test_main.py::test_openai_env_base[OPENAI_BASE_URL] PASSED
```

Related: #21255 (closed as redundant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)