### PR TITLE
fix(test): add environment cleanup for Vertex AI rerank tests

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_transformation.py
@@ -15,8 +15,29 @@ from litellm.types.rerank import RerankResponse
 
 class TestVertexAIRerankTransform:
     def setup_method(self):
+        # Save and clear Google/Vertex AI environment variables to prevent
+        # test isolation issues where previous tests leave credentials set
+        self._saved_env = {}
+        env_vars_to_clear = [
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "GOOGLE_CLOUD_PROJECT",
+            "VERTEXAI_PROJECT",
+            "VERTEX_PROJECT",
+            "VERTEX_LOCATION",
+            "VERTEX_AI_PROJECT",
+        ]
+        for var in env_vars_to_clear:
+            if var in os.environ:
+                self._saved_env[var] = os.environ[var]
+                del os.environ[var]
+
         self.config = VertexAIRerankConfig()
         self.model = "semantic-ranker-default@latest"
+
+    def teardown_method(self):
+        # Restore saved environment variables
+        for var, value in self._saved_env.items():
+            os.environ[var] = value
 
     @patch('litellm.llms.vertex_ai.rerank.transformation.VertexAIRerankConfig._ensure_access_token')
     def test_get_complete_url(self, mock_ensure_access_token):


### PR DESCRIPTION
## Summary
Fixes test isolation issue in `test_vertex_ai_rerank_transformation.py` by adding proper environment variable cleanup.

## Problem
- Test passes in isolation ✅
- Test fails in CI with `DefaultCredentialsError: Your default credentials were not found` ❌
- Previous tests set Google/Vertex AI environment variables (`GOOGLE_APPLICATION_CREDENTIALS`, `VERTEXAI_PROJECT`, etc.) and don't clean them up
- When this test runs, it attempts real Google authentication instead of using mocks
- This causes authentication failures in CI

## Root Cause
Environment variable pollution from other tests that use Vertex AI/Google Cloud credentials:
- `tests/litellm_utils_tests/test_secret_manager.py`
- `tests/pass_through_tests/test_vertex_ai.py`
- `tests/unified_google_tests/base_google_test.py`
- `tests/pass_through_unit_tests/test_unit_test_passthrough_router.py`
- etc.

## Solution
Added `setup_method` and `teardown_method` to:
1. **setup_method**: Save and clear all Google/Vertex AI environment variables before each test
2. **teardown_method**: Restore saved environment variables after each test

This ensures each test starts with a clean environment regardless of what previous tests did.

## Testing
```bash
# All 17 tests pass locally
pytest tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_transformation.py -v
======================= 17 passed in 0.17s ========================
```

## Related
This is another test isolation issue affecting PR #21217 (Anthropic structured output test). NOT caused by PR #21217 - that PR only modifies Anthropic test expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)