### PR TITLE
fix(test): update reasoning_effort test to expect dict format

### DIFF
--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -176,8 +176,12 @@ def test_openai_model_with_thinking_converts_to_reasoning_effort():
         
         # Verify reasoning_effort is set (converted from thinking)
         assert "reasoning_effort" in call_kwargs, "reasoning_effort should be passed to completion"
-        assert call_kwargs["reasoning_effort"] == "minimal", f"reasoning_effort should be 'minimal' for budget_tokens=1024, got {call_kwargs.get('reasoning_effort')}"
-        
+
+        # reasoning_effort is transformed into a dict with effort and summary fields
+        expected_reasoning_effort = {"effort": "minimal", "summary": "detailed"}
+        assert call_kwargs["reasoning_effort"] == expected_reasoning_effort, \
+            f"reasoning_effort should be {expected_reasoning_effort} for budget_tokens=1024, got {call_kwargs.get('reasoning_effort')}"
+
         # Verify thinking is NOT passed (non-Claude model)
         assert "thinking" not in call_kwargs, "thinking should NOT be passed for non-Claude models"
 


### PR DESCRIPTION
## Summary
Fixes broken test that was expecting `reasoning_effort` to be a string, but the code now returns a dict format.

## Problem
Test `test_openai_model_with_thinking_converts_to_reasoning_effort` was failing with:
```
AssertionError: reasoning_effort should be 'minimal' for budget_tokens=1024, 
got {'effort': 'minimal', 'summary': 'detailed'}
```

**Test fails on main branch** ❌ - This is a pre-existing broken test, not a regression.

## Root Cause
Code in `litellm/llms/anthropic/experimental_pass_through/adapters/handler.py` (lines 72-74) transforms `reasoning_effort` from a string to a dict:

```python
completion_kwargs["reasoning_effort"] = {
    "effort": reasoning_effort,  # "minimal"
    "summary": "detailed",
}
```

The test was never updated to expect this dict format.

## Solution
Updated test expectations from:
```python
assert call_kwargs["reasoning_effort"] == "minimal"
```

To:
```python
expected_reasoning_effort = {"effort": "minimal", "summary": "detailed"}
assert call_kwargs["reasoning_effort"] == expected_reasoning_effort
```

## Testing
```bash
pytest tests/.../test_anthropic_experimental_pass_through_messages_handler.py::test_openai_model_with_thinking_converts_to_reasoning_effort -v
======================== 1 passed in 0.14s ========================
```

## Related
This test failure was reported on PR #21217, but **NOT caused by PR #21217** (which only modifies `test_anthropic_structured_output.py`). This is a pre-existing bug that also fails on the main branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)