### PR TITLE
fix(test): add environment cleanup for Vertex AI GPT-OSS tests

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/gpt_oss/test_vertex_ai_gpt_oss_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/gpt_oss/test_vertex_ai_gpt_oss_transformation.py
@@ -16,6 +16,30 @@ from litellm.llms.vertex_ai.vertex_ai_partner_models.gpt_oss.transformation impo
 )
 
 
+@pytest.fixture(autouse=True)
+def clean_vertex_env():
+    """Clear Google/Vertex AI environment variables before each test to prevent test isolation issues."""
+    saved_env = {}
+    env_vars_to_clear = [
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "VERTEXAI_PROJECT",
+        "VERTEX_PROJECT",
+        "VERTEX_LOCATION",
+        "VERTEX_AI_PROJECT",
+    ]
+    for var in env_vars_to_clear:
+        if var in os.environ:
+            saved_env[var] = os.environ[var]
+            del os.environ[var]
+
+    yield
+
+    # Restore saved environment variables
+    for var, value in saved_env.items():
+        os.environ[var] = value
+
+
 class TestVertexAIGPTOSSTransformation:
     """Test class for VertexAI GPT-OSS transformation functionality."""
 

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/gpt_oss/test_vertex_ai_gpt_oss_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/gpt_oss/test_vertex_ai_gpt_oss_transformation.py
@@ -24,6 +24,8 @@ def clean_vertex_env():
         "GOOGLE_APPLICATION_CREDENTIALS",
         "GOOGLE_CLOUD_PROJECT",
         "VERTEXAI_PROJECT",
+        "VERTEXAI_LOCATION",
+        "VERTEXAI_CREDENTIALS",
         "VERTEX_PROJECT",
         "VERTEX_LOCATION",
         "VERTEX_AI_PROJECT",


### PR DESCRIPTION
## Summary
Fixes test isolation issue in Vertex AI GPT-OSS tests by adding environment variable cleanup.

## Problem
Test `test_vertex_ai_gpt_oss_reasoning_effort` was failing in CI with:
```
litellm.exceptions.AuthenticationError: Vertex_aiException - {
  "error": {
    "code": 401,
    "message": "Request had invalid authentication credentials..."
  }
}
```

Previous tests set Google/Vertex AI environment variables (`GOOGLE_APPLICATION_CREDENTIALS`, `VERTEXAI_PROJECT`, etc.) and don't clean them up, causing this test to attempt real Google authentication instead of using mocks.

## Root Cause
Environment variable pollution from other Vertex AI tests that don't clean up after themselves.

## Solution
Added `clean_vertex_env` pytest fixture with `autouse=True` to:
1. Save and clear all Google/Vertex AI environment variables before each test
2. Restore them after each test completes

This ensures each test starts with a clean environment.

## Testing
**Locally** (without vertexai SDK):
- Test fails with `ModuleNotFoundError: No module named 'vertexai'` (expected)
- Does NOT try to authenticate ✅

**In CI** (with vertexai SDK):
- Should no longer attempt real API calls
- Mocks will be used correctly

## Related
This test failure was reported on PR #21217, but **NOT caused by PR #21217** (which only modifies Anthropic structured output tests). This is another test isolation issue affecting multiple Vertex AI tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)