### PR TITLE
fix(test): add environment cleanup for Vertex AI Qwen tests

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/qwen/test_vertex_ai_qwen_global_endpoint.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/qwen/test_vertex_ai_qwen_global_endpoint.py
@@ -24,6 +24,30 @@ from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 from litellm.types.llms.vertex_ai import VertexPartnerProvider
 
 
+@pytest.fixture(autouse=True)
+def clean_vertex_env():
+    """Clear Google/Vertex AI environment variables before each test to prevent test isolation issues."""
+    saved_env = {}
+    env_vars_to_clear = [
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "VERTEXAI_PROJECT",
+        "VERTEX_PROJECT",
+        "VERTEX_LOCATION",
+        "VERTEX_AI_PROJECT",
+    ]
+    for var in env_vars_to_clear:
+        if var in os.environ:
+            saved_env[var] = os.environ[var]
+            del os.environ[var]
+
+    yield
+
+    # Restore saved environment variables
+    for var, value in saved_env.items():
+        os.environ[var] = value
+
+
 class TestQwenGlobalOnlyDetection:
     """Test that Qwen models are correctly identified as global-only."""
 


### PR DESCRIPTION
## Summary
Fixes test isolation issue in Vertex AI Qwen tests by adding environment variable cleanup.

## Problem
Test `test_vertex_ai_qwen_global_endpoint_url` was failing in CI with:
```
litellm.exceptions.AuthenticationError: Vertex_aiException - {
  "error": {
    "code": 401,
    "message": "Request had invalid authentication credentials..."
  }
}
```

Previous tests set Google/Vertex AI environment variables and don't clean them up, causing this test to attempt real Google authentication instead of using mocks.

## Solution
Added `clean_vertex_env` pytest fixture with `autouse=True` to:
1. Save and clear all Google/Vertex AI environment variables before each test
2. Restore them after each test completes

Same fix pattern as:
- PR #21268 (Vertex AI rerank tests)
- PR #21272 (Vertex AI GPT-OSS tests)

## Testing
Prevents real API calls by ensuring clean environment for all tests in this file.

## Related
This test failure was reported on PR #21217, but **NOT caused by PR #21217** (which only modifies Anthropic structured output tests). This is part of a broader test isolation issue affecting multiple Vertex AI test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)