### PR TITLE
fix(test): mock vertexai module in GPT-OSS tests to prevent authentication

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/gpt_oss/test_vertex_ai_gpt_oss_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/gpt_oss/test_vertex_ai_gpt_oss_transformation.py
@@ -73,7 +73,7 @@ class TestVertexAIGPTOSSTransformation:
 @pytest.mark.asyncio
 async def test_vertex_ai_gpt_oss_simple_request():
     """
-    Test that a simple request to vertex_ai/openai/gpt-oss-20b-maas lands at the correct URL 
+    Test that a simple request to vertex_ai/openai/gpt-oss-20b-maas lands at the correct URL
     with the correct request body.
     """
     from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
@@ -106,14 +106,20 @@ async def test_vertex_ai_gpt_oss_simple_request():
             "total_tokens": 70
         }
     }
-    
+
     client = AsyncHTTPHandler()
-    
+
     async def mock_post_func(*args, **kwargs):
         return mock_response
-    
+
+    # Mock vertexai module to prevent import from triggering authentication
+    mock_vertexai = MagicMock()
+    mock_vertexai.preview = MagicMock()
+    mock_vertexai.preview.language_models = MagicMock()
+
     with patch.object(client, "post", side_effect=mock_post_func) as mock_post, \
-         patch.object(VertexLLM, "_ensure_access_token", return_value=("fake-token", "pathrise-convert-1606954137718")):
+         patch.object(VertexLLM, "_ensure_access_token", return_value=("fake-token", "pathrise-convert-1606954137718")), \
+         patch.dict('sys.modules', {'vertexai': mock_vertexai, 'vertexai.preview': mock_vertexai.preview}):
         response = await litellm.acompletion(
             model="vertex_ai/openai/gpt-oss-20b-maas",
             messages=[
@@ -122,7 +128,7 @@ async def test_vertex_ai_gpt_oss_simple_request():
                     "content": "Your name is Litellm Bot, you are a helpful assistant"
                 },
                 {
-                    "role": "user", 
+                    "role": "user",
                     "content": "Hello, what is your name and can you tell me the weather?"
                 }
             ],
@@ -170,7 +176,7 @@ async def test_vertex_ai_gpt_oss_simple_request():
 @pytest.mark.asyncio
 async def test_vertex_ai_gpt_oss_reasoning_effort():
     """
-    Test that reasoning_effort parameter is correctly passed in the request body 
+    Test that reasoning_effort parameter is correctly passed in the request body
     for GPT-OSS models.
     """
     from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
@@ -184,7 +190,7 @@ async def test_vertex_ai_gpt_oss_reasoning_effort():
     mock_response.headers = {}
     mock_response.json.return_value = {
         "id": "chatcmpl-test456",
-        "object": "chat.completion", 
+        "object": "chat.completion",
         "created": 1234567890,
         "model": "openai/gpt-oss-20b-maas",
         "choices": [
@@ -203,14 +209,20 @@ async def test_vertex_ai_gpt_oss_reasoning_effort():
             "total_tokens": 67
         }
     }
-    
+
     client = AsyncHTTPHandler()
-    
+
     async def mock_post_func(*args, **kwargs):
         return mock_response
-    
+
+    # Mock vertexai module to prevent import from triggering authentication
+    mock_vertexai = MagicMock()
+    mock_vertexai.preview = MagicMock()
+    mock_vertexai.preview.language_models = MagicMock()
+
     with patch.object(client, "post", side_effect=mock_post_func) as mock_post, \
-         patch.object(VertexLLM, "_ensure_access_token", return_value=("fake-token", "pathrise-convert-1606954137718")):
+         patch.object(VertexLLM, "_ensure_access_token", return_value=("fake-token", "pathrise-convert-1606954137718")), \
+         patch.dict('sys.modules', {'vertexai': mock_vertexai, 'vertexai.preview': mock_vertexai.preview}):
         response = await litellm.acompletion(
             model="vertex_ai/openai/gpt-oss-20b-maas",
             messages=[


### PR DESCRIPTION
## Summary
Fixes 401 authentication errors in `test_vertex_ai_gpt_oss_simple_request` and `test_vertex_ai_gpt_oss_reasoning_effort` tests.

## Root Cause
The tests were mocking `VertexLLM._ensure_access_token` but not the `vertexai` module import. When the code executed `import vertexai` in `vertex_ai_partner_models/main.py`, it triggered authentication attempts even with mocked tokens. This caused the tests to make real API calls with the fake token, resulting in 401 errors in CI.

## Changes
- Added `patch.dict('sys.modules', {'vertexai': mock_vertexai, 'vertexai.preview': mock_vertexai.preview})` to both async tests
- This mocks the entire vertexai module, preventing import-time authentication
- Works in combination with the existing autouse fixture (PR #21272) that clears environment variables

## Testing
- All 4 tests in the file pass: `poetry run pytest tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/gpt_oss/test_vertex_ai_gpt_oss_transformation.py -v`
- Tests now fully isolated and won't attempt real API calls

## Related Issues
This is **not** related to PR #21217 (which only modifies Anthropic tests). This is a pre-existing issue in the Vertex AI GPT-OSS tests that manifests in CI due to the vertexai module being installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)