### PR TITLE
fix(test): correct async mock for video generation logging test

### DIFF
--- a/tests/test_litellm/test_video_generation.py
+++ b/tests/test_litellm/test_video_generation.py
@@ -735,8 +735,6 @@ class TestVideoLogging:
 
         Note: Uses AsyncMock with side_effect pattern for reliable parallel execution.
         """
-        import litellm.videos.main as videos_main
-
         custom_logger = self.TestVideoLogger()
         litellm.logging_callback_manager._reset_all_callbacks()
         litellm.callbacks = [custom_logger]

--- a/tests/test_litellm/test_video_generation.py
+++ b/tests/test_litellm/test_video_generation.py
@@ -731,50 +731,58 @@ class TestVideoLogging:
     
     @pytest.mark.asyncio
     async def test_video_generation_logging(self):
-        """Test that video generation creates proper logging payload with cost tracking."""
+        """Test that video generation creates proper logging payload with cost tracking.
+
+        Note: Uses AsyncMock with side_effect pattern for reliable parallel execution.
+        """
+        import litellm.videos.main as videos_main
+
         custom_logger = self.TestVideoLogger()
         litellm.logging_callback_manager._reset_all_callbacks()
         litellm.callbacks = [custom_logger]
-        
+
         # Mock video generation response
         mock_response = VideoObject(
             id="video_test_123",
-            object="video", 
+            object="video",
             status="queued",
             created_at=1712697600,
             model="sora-2",
             size="720x1280",
             seconds="8"
         )
-        
-        with patch('litellm.videos.main.base_llm_http_handler') as mock_handler:
-            mock_handler.video_generation_handler.return_value = mock_response
-            
+
+        # Create async mock function to return the mock_response
+        async def mock_async_handler(*args, **kwargs):
+            return mock_response
+
+        # Patch the async_video_generation_handler method on base_llm_http_handler
+        with patch.object(videos_main.base_llm_http_handler, 'async_video_generation_handler', side_effect=mock_async_handler):
             response = await litellm.avideo_generation(
                 prompt="A cat running in a garden",
                 model="sora-2",
                 seconds="8",
                 size="720x1280"
             )
-            
+
             await asyncio.sleep(1)  # Allow logging to complete
-            
+
             # Verify logging payload was created
             assert custom_logger.standard_logging_payload is not None
-            
+
             payload = custom_logger.standard_logging_payload
-            
+
             # Verify basic logging fields
             assert payload["call_type"] == "avideo_generation"
             assert payload["status"] == "success"
             assert payload["model"] == "sora-2"
             assert payload["custom_llm_provider"] == "openai"
-            
+
             # Verify response object is recognized for logging
             assert payload["response"] is not None
             assert payload["response"]["id"] == "video_test_123"
             assert payload["response"]["object"] == "video"
-            
+
             # Verify cost tracking is present (may be 0 in test environment)
             assert payload["response_cost"] is not None
             # Note: Cost calculation may not work in test environment due to mocking


### PR DESCRIPTION
## Summary

Fixes `test_video_generation_logging` failure when running with pytest-xdist parallel execution (`--dist=loadscope`).

## Problem

The test was failing with:
```
litellm.exceptions.AuthenticationError: AuthenticationError: OpenAIException - 
Incorrect API key provided: None
```

Root cause: The mock wasn't intercepting the HTTP handler calls, causing real API requests with no API key.

The test was incorrectly patching:
- Using string path `patch('litellm.videos.main.base_llm_http_handler')` instead of `patch.object`
- Mocking `video_generation_handler` (sync) instead of `async_video_generation_handler` (async)

## Solution

Fixed the mock setup to match the pattern used in `test_video_generation_async()`:
- Use `patch.object` on the actual handler instance
- Mock the correct async method: `async_video_generation_handler`
- Use `side_effect` with async function instead of `return_value`

```python
async def mock_async_handler(*args, **kwargs):
    return mock_response

with patch.object(videos_main.base_llm_http_handler, 'async_video_generation_handler', side_effect=mock_async_handler):
    response = await litellm.avideo_generation(...)
```

## Testing

- Tested locally: `pytest tests/test_litellm/test_video_generation.py::TestVideoLogging::test_video_generation_logging -v`
- Verified mock is called and no real API requests are made

## Related

- Fixes test failure exposed by PR #21277 (CI improvements)
- Not caused by PR #21277, but exposed by better test isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)