### PR TITLE
fix(test): add cleanup fixture and no_parallel mark for MCP tests

### DIFF
--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -16,6 +16,28 @@ from litellm.proxy._types import (
 from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
 
+@pytest.fixture(autouse=True)
+def cleanup_mcp_global_state():
+    """Clean up MCP global state before and after each test.
+
+    This fixture ensures test isolation when running with pytest-xdist
+    parallel execution. Without this, global_mcp_server_manager state
+    can leak between tests causing mock assertion failures.
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+        # Clear before test
+        global_mcp_server_manager.registry.clear()
+        yield
+        # Clear after test
+        global_mcp_server_manager.registry.clear()
+    except ImportError:
+        # MCP not available, skip cleanup
+        yield
+
+
 @pytest.mark.asyncio
 async def test_mcp_server_tool_call_body_contains_request_data():
     """Test that proxy_server_request body contains name and arguments"""
@@ -756,6 +778,7 @@ async def test_concurrent_initialize_session_managers():
 
 
 @pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_mcp_routing_with_conflicting_alias_and_group_name():
     """
     Tests (GH #14536) where an MCP server alias (e.g., "group/id")
@@ -839,6 +862,7 @@ async def test_mcp_routing_with_conflicting_alias_and_group_name():
 
 
 @pytest.mark.asyncio
+@pytest.mark.no_parallel
 async def test_oauth2_headers_passed_to_mcp_client():
     """Test that OAuth2 headers are properly passed through to the MCP client for OAuth2 servers like github_mcp"""
     try:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -30,9 +30,11 @@ def cleanup_mcp_global_state():
         )
         # Clear before test
         global_mcp_server_manager.registry.clear()
+        global_mcp_server_manager.tool_name_to_mcp_server_name_mapping.clear()
         yield
         # Clear after test
         global_mcp_server_manager.registry.clear()
+        global_mcp_server_manager.tool_name_to_mcp_server_name_mapping.clear()
     except ImportError:
         # MCP not available, skip cleanup
         yield


### PR DESCRIPTION
## Summary

Fixes two MCP server test failures when running with pytest-xdist parallel execution (`--dist=loadscope`):
- `test_mcp_routing_with_conflicting_alias_and_group_name`
- `test_oauth2_headers_passed_to_mcp_client`

## Problem

Both tests were failing with:
```
AssertionError: Should have resolved to exactly one server. (got 0 servers)
AssertionError: Expected _create_mcp_client to be called once (call_count was 0)
```

Root cause: These tests rely on `global_mcp_server_manager` singleton state and complex async mocking patterns. When running with parallel execution:
- Each worker process may have different singleton instances
- Patches applied in one worker don't affect code running in another
- Global state can leak between tests running in the same worker

## Solution

Two-pronged approach:

### 1. Added autouse fixture for state cleanup
```python
@pytest.fixture(autouse=True)
def cleanup_mcp_global_state():
    """Clean up MCP global state before and after each test."""
    global_mcp_server_manager.registry.clear()
    yield
    global_mcp_server_manager.registry.clear()
```

This ensures proper isolation even when tests run sequentially in the same worker.

### 2. Added @pytest.mark.no_parallel
Marked these specific tests to run sequentially rather than in parallel:
```python
@pytest.mark.no_parallel
async def test_mcp_routing_with_conflicting_alias_and_group_name():
```

This prevents the parallel execution issues while still allowing other tests in the file to benefit from parallelization.

## Testing

- Tested locally with serial execution: `pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py -v`
- Verified tests pass with fixture but without no_parallel mark (when run individually)
- Confirmed that global state cleanup prevents test pollution

## Related

- Fixes test failures exposed by PR #21277 (CI improvements with better test isolation)
- Not caused by PR #21277, but exposed by improved test distribution with `--dist=loadscope`

🤖 Generated with [Claude Code](https://claude.com/claude-code)