### PR TITLE
fix(test): mock enterprise license check in JWT test

### DIFF
--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -1044,8 +1044,13 @@ async def test_jwt_non_admin_team_route_access(monkeypatch):
         litellm.proxy.proxy_server, "general_settings", {"enable_jwt_auth": True}
     )
 
-    # Mock JWTAuthManager.auth_builder
+    # Mock enterprise license check and JWTAuthManager.auth_builder
+    # License check must be mocked to avoid environment variable pollution
+    # in parallel test execution
     with patch(
+        "litellm.proxy.auth.handle_jwt.JWTAuthManager._is_jwt_auth_available",
+        return_value=True,
+    ), patch(
         "litellm.proxy.auth.handle_jwt.JWTAuthManager.auth_builder",
         return_value=mock_jwt_response,
     ):

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -1048,8 +1048,8 @@ async def test_jwt_non_admin_team_route_access(monkeypatch):
     # License check must be mocked to avoid environment variable pollution
     # in parallel test execution
     with patch(
-        "litellm.proxy.auth.handle_jwt.JWTAuthManager._is_jwt_auth_available",
-        return_value=True,
+        "litellm.proxy.proxy_server.premium_user",
+        True,
     ), patch(
         "litellm.proxy.auth.handle_jwt.JWTAuthManager.auth_builder",
         return_value=mock_jwt_response,


### PR DESCRIPTION
## Summary

Fixes `test_jwt_non_admin_team_route_access` failure when running with pytest-xdist parallel execution (`--dist=loadscope`).

## Problem

The test was failing with:
```
AssertionError: assert 'Only proxy admin can be used to generate' in 
'Authentication Error, JWT Auth is an enterprise only feature. 
You must be a LiteLLM Enterprise user to use this feature. 
If you have a license please set `LITELLM_LICENSE` in your env...'
```

Root cause: The test was hitting the enterprise license validation check before reaching the proxy admin authorization logic. In parallel execution:
- Different worker processes may have different environment variables
- `LITELLM_LICENSE` env var may be unset or vary between workers
- This causes the test to fail at license check instead of testing authorization

## Solution

Mock `JWTAuthManager._is_jwt_auth_available` to return `True`, bypassing the license validation:

```python
with patch(
    "litellm.proxy.auth.handle_jwt.JWTAuthManager._is_jwt_auth_available",
    return_value=True,
), patch(
    "litellm.proxy.auth.handle_jwt.JWTAuthManager.auth_builder",
    return_value=mock_jwt_response,
):
    # Test code...
```

This approach:
- Avoids environment variable pollution between parallel tests
- Ensures the test reaches the actual authorization logic being tested
- Makes the test deterministic regardless of environment setup

## Testing

- Tested locally: `pytest tests/proxy_unit_tests/test_user_api_key_auth.py::test_jwt_non_admin_team_route_access -v`
- Verified correct error message is now caught

## Related

- Fixes test failure exposed by PR #21277 (CI improvements with better test isolation)
- Not caused by PR #21277, but exposed by parallel execution environment differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)