### PR TITLE
fix(test): mock environment variables for callback validation test

### DIFF
--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -1170,16 +1170,24 @@ def test_team_callback_metadata_none_values(none_key):
     assert none_key not in resp
 
 
-def test_proxy_config_state_post_init_callback_call():
+def test_proxy_config_state_post_init_callback_call(monkeypatch):
     """
     Ensures team_id is still in config, after callback is called
 
     Addresses issue: https://github.com/BerriAI/litellm/issues/6787
 
     Where team_id was being popped from config, after callback was called
+
+    Note: Environment variables are mocked to avoid validation errors
+    in parallel execution where env vars may not be set.
     """
     from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
     from litellm.proxy.proxy_server import ProxyConfig
+
+    # Mock environment variables to avoid Pydantic validation errors
+    # when env vars are resolved to None in parallel execution
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "test_public_key")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "test_secret_key")
 
     pc = ProxyConfig()
 


### PR DESCRIPTION
## Summary

Fixes `test_proxy_config_state_post_init_callback_call` failure when running with pytest-xdist parallel execution (`--dist=loadscope`).

## Problem

The test was failing with Pydantic validation error:
```
ValidationError: 2 validation errors for TeamCallbackMetadata
callback_vars.langfuse_public_key
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
callback_vars.langfuse_secret
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

Root cause: The test configures callback settings with environment variable references:
```python
"langfuse_public_key": "os.environ/LANGFUSE_PUBLIC_KEY",
"langfuse_secret": "os.environ/LANGFUSE_SECRET_KEY",
```

These get resolved at runtime. In parallel execution:
- Different worker processes may have different environment variables
- Required env vars (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`) may not be set
- Resolution returns `None` instead of a string
- Pydantic validation fails expecting string type

## Solution

Use `monkeypatch` to set the required environment variables before test execution:

```python
def test_proxy_config_state_post_init_callback_call(monkeypatch):
    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "test_public_key")
    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "test_secret_key")
    # ... rest of test
```

This ensures:
- Consistent behavior across all execution environments (local, CI, parallel workers)
- Environment variable resolution always produces valid strings
- Pydantic validation passes
- No pollution between tests (monkeypatch auto-cleans up)

## Testing

- Tested locally: `pytest tests/proxy_unit_tests/test_proxy_utils.py::test_proxy_config_state_post_init_callback_call -v`
- Verified Pydantic validation passes with mocked env vars

## Related

- Fixes test failure exposed by PR #21277 (CI improvements with better test isolation)
- Not caused by PR #21277, but exposed by parallel execution environment differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)