### PR TITLE
fix(spend): remove duplicate _common_add_spend_log_transaction call in agent spend path

### DIFF
--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -1737,22 +1737,9 @@ class DBSpendUpdateWriter:
                 "agent_id is None for request. Skipping incrementing agent spend."
             )
             return
-        payload_with_agent_id = cast(
-            SpendLogsPayload,
-            {
-                **payload,
-                "agent_id": payload["agent_id"],
-            },
-        )
-        base_daily_transaction = (
-            await self._common_add_spend_log_transaction_to_daily_transaction(
-                payload_with_agent_id, prisma_client, "agent"
-            )
-        )
-        if base_daily_transaction is None:
-            return
+
         endpoint_str = base_daily_transaction.get("endpoint") or ""
-        daily_transaction_key = f"{payload['agent_id']}_{base_daily_transaction['date']}_{payload_with_agent_id['api_key']}_{payload_with_agent_id['model']}_{payload_with_agent_id['custom_llm_provider']}_{endpoint_str}"
+        daily_transaction_key = f"{payload['agent_id']}_{base_daily_transaction['date']}_{payload['api_key']}_{payload['model']}_{payload['custom_llm_provider']}_{endpoint_str}"
         daily_transaction = DailyAgentSpendTransaction(
             agent_id=payload['agent_id'], **base_daily_transaction
         )


### PR DESCRIPTION
Fixes #21181

`add_spend_log_transaction_to_daily_agent_transaction()` calls `_common_add_spend_log_transaction_to_daily_transaction()` **twice** for the same request when `agent_id` is present. The second call uses `payload_with_agent_id`, which is just `{**payload, "agent_id": payload["agent_id"]}` — identical to `payload` since `agent_id` is already present. This duplicates JSON metadata parsing and status computation work on every agent spend log.

**Fix:** Remove the redundant second call and the unnecessary `payload_with_agent_id` construction. Reuse `base_daily_transaction` from the first call, matching the pattern already used by the `team`, `user`, `org`, and `end_user` variants of this function.

**Changed files:**
- `litellm/proxy/db/db_spend_update_writer.py` — removed 13 lines of redundant code
- `tests/test_litellm/proxy/db/test_db_spend_update_writer.py` — added regression test verifying the common helper is called exactly once