### PR TITLE
fix(ui): fetch all session logs instead of only first 50

### DIFF
--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -7026,15 +7026,17 @@ export const teamPermissionsUpdateCall = async (accessToken: string, teamId: str
  */
 export const sessionSpendLogsCall = async (accessToken: string, session_id: string) => {
   const pageSize = 100; // backend maximum
+  const maxPages = 50;  // safety limit — caps at 5,000 logs
   let currentPage = 1;
   let allData: any[] = [];
   let total = 0;
 
+  const baseUrl = proxyBaseUrl
+    ? `${proxyBaseUrl}/spend/logs/session/ui`
+    : `/spend/logs/session/ui`;
+
   try {
-    while (true) {
-      const baseUrl = proxyBaseUrl
-        ? `${proxyBaseUrl}/spend/logs/session/ui`
-        : `/spend/logs/session/ui`;
+    while (currentPage <= maxPages) {
       const url = `${baseUrl}?session_id=${encodeURIComponent(session_id)}&page=${currentPage}&page_size=${pageSize}`;
 
       const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- The session logs drawer on the `/ui/?page=logs` page only showed 50 results when clicking on a session, even if there were more logs
- Root cause: `sessionSpendLogsCall` in `networking.tsx` didn't pass `page` or `page_size` params to the `/spend/logs/session/ui` backend endpoint, which defaults to `page_size=50`
- Fix: the function now fetches all pages (using `page_size=100`, the backend max) and merges them into a single response so the session sidebar displays every log entry

## Test plan
- [ ] Open the logs page (`/ui/?page=logs`)
- [ ] Click on a session that has more than 50 log entries
- [ ] Verify all log entries are now displayed in the session drawer sidebar
- [ ] Verify sessions with fewer than 50 entries still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)