### PR TITLE
fix: propagate per-model guardrails from deployment litellm_params into request metadata

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -3,7 +3,7 @@ import copy
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 from starlette.datastructures import Headers
 
 import litellm
@@ -1550,6 +1550,8 @@ def move_guardrails_to_metadata(
                     else:
                         _merged = list(_all_deployment_guardrails)
                     data[_metadata_variable_name]["guardrails"] = _merged
+    except HTTPException:
+        raise
     except Exception as e:
         verbose_proxy_logger.debug(
             "Failed to read guardrails from model deployment: %s", str(e)

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1539,6 +1539,9 @@ def move_guardrails_to_metadata(
                     if isinstance(_dep_guardrails, list):
                         _all_deployment_guardrails.update(_dep_guardrails)
                 if _all_deployment_guardrails:
+                    from litellm.proxy.utils import _premium_user_check
+
+                    _premium_user_check()
                     if _metadata_variable_name not in data:
                         data[_metadata_variable_name] = {}
                     _existing = data[_metadata_variable_name].get("guardrails", [])

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -1634,8 +1634,8 @@ class TestMoveGuardrailsFromModelDeployment:
         ]
 
         with patch(
-            "litellm.proxy.litellm_pre_call_utils.llm_router", mock_router
-        ):
+            "litellm.proxy.proxy_server.llm_router", mock_router
+        ), patch("litellm.proxy.utils._premium_user_check"):
             move_guardrails_to_metadata(
                 data=data,
                 _metadata_variable_name="metadata",
@@ -1674,8 +1674,8 @@ class TestMoveGuardrailsFromModelDeployment:
         ]
 
         with patch(
-            "litellm.proxy.litellm_pre_call_utils.llm_router", mock_router
-        ):
+            "litellm.proxy.proxy_server.llm_router", mock_router
+        ), patch("litellm.proxy.utils._premium_user_check"):
             move_guardrails_to_metadata(
                 data=data,
                 _metadata_variable_name="metadata",
@@ -1712,7 +1712,7 @@ class TestMoveGuardrailsFromModelDeployment:
         ]
 
         with patch(
-            "litellm.proxy.litellm_pre_call_utils.llm_router", mock_router
+            "litellm.proxy.proxy_server.llm_router", mock_router
         ):
             move_guardrails_to_metadata(
                 data=data,
@@ -1739,7 +1739,7 @@ class TestMoveGuardrailsFromModelDeployment:
         user_api_key_dict = UserAPIKeyAuth(api_key="test-key", metadata={})
 
         with patch(
-            "litellm.proxy.litellm_pre_call_utils.llm_router", None
+            "litellm.proxy.proxy_server.llm_router", None
         ):
             move_guardrails_to_metadata(
                 data=data,
@@ -1793,8 +1793,8 @@ class TestMoveGuardrailsFromModelDeployment:
         ]
 
         with patch(
-            "litellm.proxy.litellm_pre_call_utils.llm_router", mock_router
-        ):
+            "litellm.proxy.proxy_server.llm_router", mock_router
+        ), patch("litellm.proxy.utils._premium_user_check"):
             move_guardrails_to_metadata(
                 data=data,
                 _metadata_variable_name="metadata",


### PR DESCRIPTION
## Relevant issues

Fixes a dead feature: the "Guardrails" field on model settings in the LiteLLM admin UI is non-functional because no code reads the stored values at request time.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Problem

The LiteLLM admin UI has a "Guardrails" field on each model's settings page (Model Management → Edit Model → Guardrails). Users can assign guardrails like `["presidio"]` to specific model deployments. This data is saved to the database in `LiteLLM_ProxyModelTable` under `litellm_params.guardrails`.

However, the `move_guardrails_to_metadata()` function in `litellm_pre_call_utils.py` only reads guardrails from:
1. API key metadata
2. Team metadata
3. Request body
4. Policy engine

It **never** reads from the model deployment's `litellm_params.guardrails`. This makes the per-model guardrail UI field completely non-functional — the UI lets you set it, the DB stores it, but the values are never used during request processing.

### Fix

Added a new section at the end of `move_guardrails_to_metadata()` that:
1. Looks up the requested model in `llm_router.get_model_list()`
2. Reads `guardrails` from the deployment's `litellm_params`
3. Merges them (set union, no duplicates) into the request metadata's guardrails list

The code is wrapped in a try/except to ensure request processing is never broken by guardrail lookup failures.

### Use case

This enables per-model guardrail scoping — for example, applying PII masking (Presidio) only to Anthropic models while excluding it from OpenAI/Gemini models, all configured through the existing UI.

### Tests

Added 4 tests in `tests/test_litellm/proxy/test_litellm_pre_call_utils.py`:
- Model deployment guardrails are added to metadata
- Model deployment guardrails are merged with existing guardrails (no duplicates)
- No guardrails added when deployment has none
- No crash when `llm_router` is None (startup scenario)