### PR TITLE
fix(responses): use output_index for parallel tool call streaming indices

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -960,9 +960,10 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                         provider_specific_fields
                     )
 
+                tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(
                     id=output_item.get("call_id"),
-                    index=0,
+                    index=tool_call_index,
                     type="function",
                     function=function_chunk,
                 )
@@ -983,6 +984,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
         elif event_type == "response.function_call_arguments.delta":
             content_part: Optional[str] = parsed_chunk.get("delta", None)
             if content_part:
+                tool_call_index = parsed_chunk.get("output_index", 0)
                 return ModelResponseStream(
                     choices=[
                         StreamingChoices(
@@ -991,7 +993,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                                 tool_calls=[
                                     ChatCompletionToolCallChunk(
                                         id=None,
-                                        index=0,
+                                        index=tool_call_index,
                                         type="function",
                                         function=ChatCompletionToolCallFunctionChunk(
                                             name=None, arguments=content_part
@@ -1033,9 +1035,10 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                         provider_specific_fields
                     )
 
+                tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(
                     id=output_item.get("call_id"),
-                    index=0,
+                    index=tool_call_index,
                     type="function",
                     function=function_chunk,
                 )


### PR DESCRIPTION
## Relevant issues

Fixes #21331

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

The Responses API streaming bridge (`translate_responses_chunk_to_openai_stream`) hardcoded `index=0` for all `ChatCompletionToolCallChunk` objects, ignoring the `output_index` field from Responses API streaming chunks. This made parallel tool calls indistinguishable in the Chat Completions output format.

### Before fix — tool calls emitted with `index: 0`

```json
// chunk for tool call 1 (output_index=0) — OK
{"choices": [{"delta": {"tool_calls": [{"index": 0, "id": "call_abc", "function": {"name": "get_weather", "arguments": "{\"city\": \"SF\"}"}}]}}]}

// chunk for tool call 2 (output_index=1) — BUG: index is 0 instead of 1
{"choices": [{"delta": {"tool_calls": [{"index": 0, "id": "call_def", "function": {"name": "get_weather", "arguments": "{\"city\": \"NY\"}"}}]}}]}
```

Consumers that rely on `index` to distinguish parallel tool calls (standard Chat Completions behavior) would merge both calls into one malformed tool invocation.

### After fix — `index` matches `output_index` from Responses API

```json
// chunk for tool call 1 (output_index=0)
{"choices": [{"delta": {"tool_calls": [{"index": 0, "id": "call_abc", "function": {"name": "get_weather", "arguments": "{\"city\": \"SF\"}"}}]}}]}

// chunk for tool call 2 (output_index=1) — CORRECT
{"choices": [{"delta": {"tool_calls": [{"index": 1, "id": "call_def", "function": {"name": "get_weather", "arguments": "{\"city\": \"NY\"}"}}]}}]}
```

### What changed

Read `parsed_chunk.get("output_index", 0)` instead of hardcoding `0` in three event handlers:
- `response.output_item.added`
- `response.function_call_arguments.delta`
- `response.output_item.done`

### Test

Added `test_streaming_parallel_tool_calls_have_distinct_indices` — simulates two parallel tool calls with `output_index` 0 and 1, verifying each gets the correct index in the Chat Completions output.