### PR TITLE
docs(anthropic): add OAuth token SDK usage for Pro/Max subscriptions

### DIFF
--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -165,6 +165,56 @@ os.environ["ANTHROPIC_API_KEY"] = "your-api-key"
 # os.environ["LITELLM_ANTHROPIC_DISABLE_URL_SUFFIX"] = "true" # [OPTIONAL] Disable automatic URL suffix appending
 ```
 
+### OAuth Token (Claude Pro/Max Subscription)
+
+If you have a Claude Pro or Max subscription, you can use your OAuth token instead of an API key. LiteLLM automatically detects OAuth tokens (prefixed with `sk-ant-oat`) and sends them via `Authorization: Bearer` instead of `x-api-key`.
+
+**1. Generate your OAuth token**
+
+```bash
+claude setup-token
+```
+
+This generates a token in the format `sk-ant-oat01-...`. The token expires every 8 hours but can be refreshed automatically.
+
+**2. Use it in LiteLLM**
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+
+response = completion(
+    model="anthropic/claude-sonnet-4-5-20250929",
+    api_key="sk-ant-oat01-...",  # OAuth token works here
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+Or via environment variable:
+
+```python
+import os
+
+os.environ["ANTHROPIC_API_KEY"] = "sk-ant-oat01-..."  # OAuth token
+```
+
+</TabItem>
+<TabItem value="proxy" label="Proxy">
+
+For routing Claude Pro/Max subscription traffic through LiteLLM Proxy with cost tracking and budgets, see the [Claude Code Max Subscription tutorial](/docs/tutorials/claude_code_max_subscription).
+
+</TabItem>
+</Tabs>
+
+:::info How it works
+LiteLLM detects the `sk-ant-oat` prefix and automatically:
+- Sends the token via `Authorization: Bearer` header (instead of `x-api-key`)
+- Adds the required `anthropic-beta: oauth-2025-04-20` header
+- Adds the `anthropic-dangerous-direct-browser-access: true` header
+:::
+
 :::tip Azure Foundry Support
 
 Claude models are also available via Microsoft Azure Foundry. Use the `azure/` prefix instead of `anthropic/` and configure Azure authentication. See the [Azure Anthropic documentation](../providers/azure/azure_anthropic) for details.

--- a/docs/my-website/docs/tutorials/claude_code_max_subscription.md
+++ b/docs/my-website/docs/tutorials/claude_code_max_subscription.md
@@ -349,8 +349,25 @@ curl "http://localhost:4000/v1/models" \
   -H "Authorization: Bearer sk-otsclFlEblQ-6D60ua2IZg"
 ```
 
+## SDK Direct Usage
+
+If you don't need the proxy and just want to use your Claude Pro/Max OAuth token directly with the LiteLLM SDK, you can pass it as the `api_key` parameter. LiteLLM automatically detects OAuth tokens and handles the correct authentication headers.
+
+```python
+from litellm import completion
+
+response = completion(
+    model="anthropic/claude-sonnet-4-5-20250929",
+    api_key="sk-ant-oat01-...",  # Your OAuth token
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+See the [Anthropic provider docs](/docs/providers/anthropic#oauth-token-claude-promax-subscription) for more details.
+
 ## Related Documentation
 
+- [Anthropic Provider - OAuth Token Support](/docs/providers/anthropic#oauth-token-claude-promax-subscription) - Direct SDK usage with OAuth tokens
 - [Forward Client Headers](/docs/proxy/forward_client_headers) - Detailed header forwarding configuration
 - [Claude Code Quickstart](/docs/tutorials/claude_responses_api) - Basic Claude Code + LiteLLM setup
 - [Virtual Keys](/docs/proxy/virtual_keys) - Creating and managing API keys


### PR DESCRIPTION
## Relevant issues

Related to #21039 (OAuth token handling fix)

## Pre-Submission checklist

- [x] I have Added testing — N/A, docs-only change
- [x] My PR passes all unit tests on `make test-unit` — N/A, docs-only change
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

- **`docs/providers/anthropic.md`**: Add "OAuth Token (Claude Pro/Max Subscription)" section under API Keys, documenting how to use `sk-ant-oat*` tokens directly with `litellm.completion()` via the `api_key` parameter. Includes how to generate the token (`claude setup-token`), SDK and Proxy usage tabs, and how LiteLLM handles the authentication headers automatically.
- **`docs/tutorials/claude_code_max_subscription.md`**: Add "SDK Direct Usage" section with cross-reference to the Anthropic provider OAuth docs.

### Context

PR #21039 added support for Anthropic OAuth tokens (`sk-ant-oat*`) in the SDK by automatically detecting the token prefix and sending it via `Authorization: Bearer` instead of `x-api-key`. However, the documentation only covered the proxy flow (`forward_client_headers_to_llm_api`). This PR documents the SDK direct usage path.