### PR TITLE
fix(bedrock): broaden Nova 2 model detection to support all nova-2-* variants

### DIFF
--- a/.github/workflows/test_server_root_path.yml
+++ b/.github/workflows/test_server_root_path.yml
@@ -1,0 +1,309 @@
+name: Test SERVER_ROOT_PATH
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  test-server-root-path:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        # Test multiple root paths to ensure flexibility
+        root_path: ["/api/v1", "/litellm", "/proxy"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile.database
+          tags: litellm-test:${{ github.sha }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start LiteLLM container with SERVER_ROOT_PATH
+        run: |
+          docker run -d \
+            --name litellm-test \
+            -p 4000:4000 \
+            -e SERVER_ROOT_PATH="${{ matrix.root_path }}" \
+            -e LITELLM_MASTER_KEY="sk-1234" \
+            litellm-test:${{ github.sha }} \
+            --detailed_debug
+
+      - name: Wait for container to be healthy
+        run: |
+          echo "Waiting for LiteLLM to start..."
+          max_attempts=30
+          attempt=0
+
+          while [ $attempt -lt $max_attempts ]; do
+            if docker logs litellm-test 2>&1 | grep -q "Uvicorn running"; then
+              echo "✅ LiteLLM started successfully"
+              break
+            fi
+            attempt=$((attempt + 1))
+            echo "Attempt $attempt/$max_attempts - waiting for server to start..."
+            sleep 2
+          done
+
+          if [ $attempt -eq $max_attempts ]; then
+            echo "❌ Server failed to start within timeout"
+            docker logs litellm-test
+            exit 1
+          fi
+
+          # Additional wait for full initialization
+          sleep 5
+
+      - name: Show container logs
+        if: always()
+        run: |
+          echo "=== Container Logs ==="
+          docker logs litellm-test
+
+      - name: Test health endpoint with root path
+        run: |
+          ROOT_PATH="${{ matrix.root_path }}"
+          echo "Testing health endpoint at: http://localhost:4000${ROOT_PATH}/health"
+
+          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000${ROOT_PATH}/health")
+
+          if [ "$response" = "200" ]; then
+            echo "✅ Health endpoint returned 200"
+          else
+            echo "❌ Health endpoint returned $response (expected 200)"
+            docker logs litellm-test
+            exit 1
+          fi
+
+      - name: Test health endpoint liveliness with root path
+        run: |
+          ROOT_PATH="${{ matrix.root_path }}"
+          echo "Testing liveliness endpoint at: http://localhost:4000${ROOT_PATH}/health/liveliness"
+
+          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000${ROOT_PATH}/health/liveliness")
+
+          if [ "$response" = "200" ]; then
+            echo "✅ Liveliness endpoint returned 200"
+          else
+            echo "❌ Liveliness endpoint returned $response (expected 200)"
+            docker logs litellm-test
+            exit 1
+          fi
+
+      - name: Test health endpoint readiness with root path
+        run: |
+          ROOT_PATH="${{ matrix.root_path }}"
+          echo "Testing readiness endpoint at: http://localhost:4000${ROOT_PATH}/health/readiness"
+
+          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000${ROOT_PATH}/health/readiness")
+
+          if [ "$response" = "200" ]; then
+            echo "✅ Readiness endpoint returned 200"
+          else
+            echo "❌ Readiness endpoint returned $response (expected 200)"
+            docker logs litellm-test
+            exit 1
+          fi
+
+      - name: Test UI is accessible with root path
+        run: |
+          ROOT_PATH="${{ matrix.root_path }}"
+          echo "Testing UI endpoint at: http://localhost:4000${ROOT_PATH}/ui"
+
+          # Test that UI returns 200 or 30x (redirect)
+          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000${ROOT_PATH}/ui")
+
+          if [[ "$response" =~ ^(200|30[0-9])$ ]]; then
+            echo "✅ UI endpoint returned $response"
+          else
+            echo "❌ UI endpoint returned $response (expected 200 or 30x)"
+            docker logs litellm-test
+            exit 1
+          fi
+
+      - name: Test UI index page content with root path
+        run: |
+          ROOT_PATH="${{ matrix.root_path }}"
+          echo "Testing UI content at: http://localhost:4000${ROOT_PATH}/ui/"
+
+          # Fetch UI page and check for expected content
+          content=$(curl -sL "http://localhost:4000${ROOT_PATH}/ui/")
+
+          # Check if the response contains typical HTML/UI markers
+          if echo "$content" | grep -q -E "(html|<!DOCTYPE|<head|<body)"; then
+            echo "✅ UI page contains valid HTML content"
+          else
+            echo "❌ UI page does not contain expected HTML content"
+            echo "Response: $content"
+            docker logs litellm-test
+            exit 1
+          fi
+
+      - name: Test API docs endpoint with root path
+        run: |
+          ROOT_PATH="${{ matrix.root_path }}"
+          echo "Testing API docs at: http://localhost:4000${ROOT_PATH}/docs"
+
+          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000${ROOT_PATH}/docs")
+
+          if [ "$response" = "200" ]; then
+            echo "✅ API docs endpoint returned 200"
+          else
+            echo "❌ API docs endpoint returned $response (expected 200)"
+            docker logs litellm-test
+            exit 1
+          fi
+
+      - name: Test OpenAPI schema with root path
+        run: |
+          ROOT_PATH="${{ matrix.root_path }}"
+          echo "Testing OpenAPI schema at: http://localhost:4000${ROOT_PATH}/openapi.json"
+
+          response=$(curl -s "http://localhost:4000${ROOT_PATH}/openapi.json")
+
+          # Check if response contains valid OpenAPI schema markers
+          if echo "$response" | grep -q '"openapi"'; then
+            echo "✅ OpenAPI schema is valid"
+          else
+            echo "❌ OpenAPI schema is invalid or missing"
+            echo "Response: $response"
+            docker logs litellm-test
+            exit 1
+          fi
+
+      - name: Test model list endpoint with root path
+        run: |
+          ROOT_PATH="${{ matrix.root_path }}"
+          echo "Testing model list endpoint at: http://localhost:4000${ROOT_PATH}/v1/models"
+
+          response=$(curl -s -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/v1/models")
+
+          # Check if response contains models data structure
+          if echo "$response" | grep -q '"data"'; then
+            echo "✅ Model list endpoint returned valid response"
+          else
+            echo "❌ Model list endpoint returned invalid response"
+            echo "Response: $response"
+            docker logs litellm-test
+            exit 1
+          fi
+
+      - name: Verify root path is NOT accessible without prefix
+        run: |
+          ROOT_PATH="${{ matrix.root_path }}"
+          echo "Verifying endpoints are NOT accessible without root path prefix"
+
+          # These should fail (404) because we're accessing without the root path
+          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000/health")
+
+          if [ "$response" = "404" ]; then
+            echo "✅ Correctly returns 404 when accessing without root path"
+          else
+            echo "⚠️  Warning: Endpoint accessible without root path (returned $response)"
+            # This is a warning, not a failure, as FastAPI might handle this differently
+          fi
+
+      - name: Run unit tests for SERVER_ROOT_PATH
+        run: |
+          docker exec litellm-test pip install pytest pytest-asyncio
+          docker exec litellm-test pytest /app/tests/proxy_unit_tests/test_server_root_path.py -v
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker stop litellm-test || true
+          docker rm litellm-test || true
+
+  test-without-root-path:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile.database
+          tags: litellm-test:${{ github.sha }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start LiteLLM container without SERVER_ROOT_PATH
+        run: |
+          docker run -d \
+            --name litellm-test \
+            -p 4000:4000 \
+            -e LITELLM_MASTER_KEY="sk-1234" \
+            litellm-test:${{ github.sha }}
+
+      - name: Wait for container to be healthy
+        run: |
+          echo "Waiting for LiteLLM to start..."
+          max_attempts=30
+          attempt=0
+
+          while [ $attempt -lt $max_attempts ]; do
+            if docker logs litellm-test 2>&1 | grep -q "Uvicorn running"; then
+              echo "✅ LiteLLM started successfully"
+              break
+            fi
+            attempt=$((attempt + 1))
+            echo "Attempt $attempt/$max_attempts - waiting for server to start..."
+            sleep 2
+          done
+
+          if [ $attempt -eq $max_attempts ]; then
+            echo "❌ Server failed to start within timeout"
+            docker logs litellm-test
+            exit 1
+          fi
+
+          sleep 5
+
+      - name: Test default paths work without SERVER_ROOT_PATH
+        run: |
+          echo "Testing that default paths work when SERVER_ROOT_PATH is not set"
+
+          # These should work at root level
+          health=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000/health")
+          ui=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000/ui")
+
+          if [ "$health" = "200" ] && [[ "$ui" =~ ^(200|30[0-9])$ ]]; then
+            echo "✅ Default paths work correctly"
+          else
+            echo "❌ Default paths failed (health: $health, ui: $ui)"
+            docker logs litellm-test
+            exit 1
+          fi
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker stop litellm-test || true
+          docker rm litellm-test || true

--- a/.github/workflows/test_server_root_path.yml
+++ b/.github/workflows/test_server_root_path.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        root_path: ["/api/v1"]
+        root_path: ["/api/v1", "/llmproxy"]
 
     steps:
       - name: Checkout repository
@@ -50,7 +50,7 @@ jobs:
 
           while [ $attempt -lt $max_attempts ]; do
             if docker logs litellm-test 2>&1 | grep -q "Uvicorn running"; then
-              echo "✅ LiteLLM started successfully"
+              echo "LiteLLM started successfully"
               break
             fi
             attempt=$((attempt + 1))
@@ -59,262 +59,33 @@ jobs:
           done
 
           if [ $attempt -eq $max_attempts ]; then
-            echo "❌ Server failed to start within timeout"
+            echo "Server failed to start within timeout"
             docker logs litellm-test
             exit 1
           fi
 
-          # Additional wait for full initialization
           sleep 5
 
       - name: Show container logs
         if: always()
-        run: |
-          echo "=== Container Logs ==="
-          docker logs litellm-test
+        run: docker logs litellm-test
 
-      - name: Test health endpoint with root path
+      - name: Test UI endpoint with root path
         run: |
           ROOT_PATH="${{ matrix.root_path }}"
-          echo "Testing health endpoint at: http://localhost:4000${ROOT_PATH}/health"
-
-          for i in 1 2 3; do
-            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/health")
-            if [ "$response" = "200" ]; then
-              echo "✅ Health endpoint returned 200"
-              exit 0
-            fi
-            echo "Attempt $i/3 - got $response, retrying in 5s..."
-            sleep 5
-          done
-          echo "❌ Health endpoint returned $response (expected 200)"
-          docker logs litellm-test
-          exit 1
-
-      - name: Test health endpoint liveliness with root path
-        run: |
-          ROOT_PATH="${{ matrix.root_path }}"
-          echo "Testing liveliness endpoint at: http://localhost:4000${ROOT_PATH}/health/liveliness"
-
-          for i in 1 2 3; do
-            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/health/liveliness")
-            if [ "$response" = "200" ]; then
-              echo "✅ Liveliness endpoint returned 200"
-              exit 0
-            fi
-            echo "Attempt $i/3 - got $response, retrying in 5s..."
-            sleep 5
-          done
-          echo "❌ Liveliness endpoint returned $response (expected 200)"
-          docker logs litellm-test
-          exit 1
-
-      - name: Test health endpoint readiness with root path
-        run: |
-          ROOT_PATH="${{ matrix.root_path }}"
-          echo "Testing readiness endpoint at: http://localhost:4000${ROOT_PATH}/health/readiness"
-
-          for i in 1 2 3; do
-            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/health/readiness")
-            if [ "$response" = "200" ]; then
-              echo "✅ Readiness endpoint returned 200"
-              exit 0
-            fi
-            echo "Attempt $i/3 - got $response, retrying in 5s..."
-            sleep 5
-          done
-          echo "❌ Readiness endpoint returned $response (expected 200)"
-          docker logs litellm-test
-          exit 1
-
-      - name: Test UI is accessible with root path
-        run: |
-          ROOT_PATH="${{ matrix.root_path }}"
-          echo "Testing UI endpoint at: http://localhost:4000${ROOT_PATH}/ui"
-
-          for i in 1 2 3; do
-            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/ui")
-            if [[ "$response" =~ ^(200|30[0-9])$ ]]; then
-              echo "✅ UI endpoint returned $response"
-              exit 0
-            fi
-            echo "Attempt $i/3 - got $response, retrying in 5s..."
-            sleep 5
-          done
-          echo "❌ UI endpoint returned $response (expected 200 or 30x)"
-          docker logs litellm-test
-          exit 1
-
-      - name: Test UI index page content with root path
-        run: |
-          ROOT_PATH="${{ matrix.root_path }}"
-          echo "Testing UI content at: http://localhost:4000${ROOT_PATH}/ui/"
+          echo "Testing UI at: http://localhost:4000${ROOT_PATH}/ui/"
 
           for i in 1 2 3; do
             content=$(curl -sL --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/ui/")
             if echo "$content" | grep -q -E "(html|<!DOCTYPE|<head|<body)"; then
-              echo "✅ UI page contains valid HTML content"
+              echo "UI page contains valid HTML content"
               exit 0
             fi
             echo "Attempt $i/3 - no valid HTML, retrying in 5s..."
             sleep 5
           done
-          echo "❌ UI page does not contain expected HTML content"
+          echo "UI page does not contain expected HTML content"
           echo "Response: $content"
-          docker logs litellm-test
-          exit 1
-
-      - name: Test API docs endpoint with root path
-        run: |
-          ROOT_PATH="${{ matrix.root_path }}"
-          echo "Testing API docs at: http://localhost:4000${ROOT_PATH}/docs"
-
-          for i in 1 2 3; do
-            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/docs")
-            if [ "$response" = "200" ]; then
-              echo "✅ API docs endpoint returned 200"
-              exit 0
-            fi
-            echo "Attempt $i/3 - got $response, retrying in 5s..."
-            sleep 5
-          done
-          echo "❌ API docs endpoint returned $response (expected 200)"
-          docker logs litellm-test
-          exit 1
-
-      - name: Test OpenAPI schema with root path
-        run: |
-          ROOT_PATH="${{ matrix.root_path }}"
-          echo "Testing OpenAPI schema at: http://localhost:4000${ROOT_PATH}/openapi.json"
-
-          for i in 1 2 3; do
-            response=$(curl -s --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/openapi.json")
-            if echo "$response" | grep -q '"openapi"'; then
-              echo "✅ OpenAPI schema is valid"
-              exit 0
-            fi
-            echo "Attempt $i/3 - invalid schema, retrying in 5s..."
-            sleep 5
-          done
-          echo "❌ OpenAPI schema is invalid or missing"
-          echo "Response: $response"
-          docker logs litellm-test
-          exit 1
-
-      - name: Test model list endpoint with root path
-        run: |
-          ROOT_PATH="${{ matrix.root_path }}"
-          echo "Testing model list endpoint at: http://localhost:4000${ROOT_PATH}/v1/models"
-
-          for i in 1 2 3; do
-            response=$(curl -s --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/v1/models")
-            if echo "$response" | grep -q '"data"'; then
-              echo "✅ Model list endpoint returned valid response"
-              exit 0
-            fi
-            echo "Attempt $i/3 - invalid response, retrying in 5s..."
-            sleep 5
-          done
-          echo "❌ Model list endpoint returned invalid response"
-          echo "Response: $response"
-          docker logs litellm-test
-          exit 1
-
-      - name: Verify root path is NOT accessible without prefix
-        run: |
-          ROOT_PATH="${{ matrix.root_path }}"
-          echo "Verifying endpoints are NOT accessible without root path prefix"
-
-          # These should fail (404) because we're accessing without the root path
-          response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000/health")
-
-          if [ "$response" = "404" ]; then
-            echo "✅ Correctly returns 404 when accessing without root path"
-          else
-            echo "⚠️  Warning: Endpoint accessible without root path (returned $response)"
-            # This is a warning, not a failure, as FastAPI might handle this differently
-          fi
-
-      - name: Run unit tests for SERVER_ROOT_PATH
-        run: |
-          docker exec litellm-test pip install pytest pytest-asyncio
-          docker exec litellm-test pytest /app/tests/proxy_unit_tests/test_server_root_path.py -v
-
-      - name: Cleanup
-        if: always()
-        run: |
-          docker stop litellm-test || true
-          docker rm litellm-test || true
-
-  test-without-root-path:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/Dockerfile.database
-          tags: litellm-test:${{ github.sha }}
-          load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Start LiteLLM container without SERVER_ROOT_PATH
-        run: |
-          docker run -d \
-            --name litellm-test \
-            -p 4000:4000 \
-            -e LITELLM_MASTER_KEY="sk-1234" \
-            litellm-test:${{ github.sha }}
-
-      - name: Wait for container to be healthy
-        run: |
-          echo "Waiting for LiteLLM to start..."
-          max_attempts=30
-          attempt=0
-
-          while [ $attempt -lt $max_attempts ]; do
-            if docker logs litellm-test 2>&1 | grep -q "Uvicorn running"; then
-              echo "✅ LiteLLM started successfully"
-              break
-            fi
-            attempt=$((attempt + 1))
-            echo "Attempt $attempt/$max_attempts - waiting for server to start..."
-            sleep 2
-          done
-
-          if [ $attempt -eq $max_attempts ]; then
-            echo "❌ Server failed to start within timeout"
-            docker logs litellm-test
-            exit 1
-          fi
-
-          sleep 5
-
-      - name: Test default paths work without SERVER_ROOT_PATH
-        run: |
-          echo "Testing that default paths work when SERVER_ROOT_PATH is not set"
-
-          for i in 1 2 3; do
-            health=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000/health")
-            ui=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000/ui")
-
-            if [ "$health" = "200" ] && [[ "$ui" =~ ^(200|30[0-9])$ ]]; then
-              echo "✅ Default paths work correctly"
-              exit 0
-            fi
-            echo "Attempt $i/3 - health: $health, ui: $ui, retrying in 5s..."
-            sleep 5
-          done
-          echo "❌ Default paths failed (health: $health, ui: $ui)"
           docker logs litellm-test
           exit 1
 

--- a/.github/workflows/test_server_root_path.yml
+++ b/.github/workflows/test_server_root_path.yml
@@ -13,8 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        # Test multiple root paths to ensure flexibility
-        root_path: ["/api/v1", "/litellm", "/proxy"]
+        root_path: ["/api/v1"]
 
     steps:
       - name: Checkout repository
@@ -79,128 +78,147 @@ jobs:
           ROOT_PATH="${{ matrix.root_path }}"
           echo "Testing health endpoint at: http://localhost:4000${ROOT_PATH}/health"
 
-          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000${ROOT_PATH}/health")
-
-          if [ "$response" = "200" ]; then
-            echo "✅ Health endpoint returned 200"
-          else
-            echo "❌ Health endpoint returned $response (expected 200)"
-            docker logs litellm-test
-            exit 1
-          fi
+          for i in 1 2 3; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/health")
+            if [ "$response" = "200" ]; then
+              echo "✅ Health endpoint returned 200"
+              exit 0
+            fi
+            echo "Attempt $i/3 - got $response, retrying in 5s..."
+            sleep 5
+          done
+          echo "❌ Health endpoint returned $response (expected 200)"
+          docker logs litellm-test
+          exit 1
 
       - name: Test health endpoint liveliness with root path
         run: |
           ROOT_PATH="${{ matrix.root_path }}"
           echo "Testing liveliness endpoint at: http://localhost:4000${ROOT_PATH}/health/liveliness"
 
-          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000${ROOT_PATH}/health/liveliness")
-
-          if [ "$response" = "200" ]; then
-            echo "✅ Liveliness endpoint returned 200"
-          else
-            echo "❌ Liveliness endpoint returned $response (expected 200)"
-            docker logs litellm-test
-            exit 1
-          fi
+          for i in 1 2 3; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/health/liveliness")
+            if [ "$response" = "200" ]; then
+              echo "✅ Liveliness endpoint returned 200"
+              exit 0
+            fi
+            echo "Attempt $i/3 - got $response, retrying in 5s..."
+            sleep 5
+          done
+          echo "❌ Liveliness endpoint returned $response (expected 200)"
+          docker logs litellm-test
+          exit 1
 
       - name: Test health endpoint readiness with root path
         run: |
           ROOT_PATH="${{ matrix.root_path }}"
           echo "Testing readiness endpoint at: http://localhost:4000${ROOT_PATH}/health/readiness"
 
-          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000${ROOT_PATH}/health/readiness")
-
-          if [ "$response" = "200" ]; then
-            echo "✅ Readiness endpoint returned 200"
-          else
-            echo "❌ Readiness endpoint returned $response (expected 200)"
-            docker logs litellm-test
-            exit 1
-          fi
+          for i in 1 2 3; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/health/readiness")
+            if [ "$response" = "200" ]; then
+              echo "✅ Readiness endpoint returned 200"
+              exit 0
+            fi
+            echo "Attempt $i/3 - got $response, retrying in 5s..."
+            sleep 5
+          done
+          echo "❌ Readiness endpoint returned $response (expected 200)"
+          docker logs litellm-test
+          exit 1
 
       - name: Test UI is accessible with root path
         run: |
           ROOT_PATH="${{ matrix.root_path }}"
           echo "Testing UI endpoint at: http://localhost:4000${ROOT_PATH}/ui"
 
-          # Test that UI returns 200 or 30x (redirect)
-          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000${ROOT_PATH}/ui")
-
-          if [[ "$response" =~ ^(200|30[0-9])$ ]]; then
-            echo "✅ UI endpoint returned $response"
-          else
-            echo "❌ UI endpoint returned $response (expected 200 or 30x)"
-            docker logs litellm-test
-            exit 1
-          fi
+          for i in 1 2 3; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/ui")
+            if [[ "$response" =~ ^(200|30[0-9])$ ]]; then
+              echo "✅ UI endpoint returned $response"
+              exit 0
+            fi
+            echo "Attempt $i/3 - got $response, retrying in 5s..."
+            sleep 5
+          done
+          echo "❌ UI endpoint returned $response (expected 200 or 30x)"
+          docker logs litellm-test
+          exit 1
 
       - name: Test UI index page content with root path
         run: |
           ROOT_PATH="${{ matrix.root_path }}"
           echo "Testing UI content at: http://localhost:4000${ROOT_PATH}/ui/"
 
-          # Fetch UI page and check for expected content
-          content=$(curl -sL "http://localhost:4000${ROOT_PATH}/ui/")
-
-          # Check if the response contains typical HTML/UI markers
-          if echo "$content" | grep -q -E "(html|<!DOCTYPE|<head|<body)"; then
-            echo "✅ UI page contains valid HTML content"
-          else
-            echo "❌ UI page does not contain expected HTML content"
-            echo "Response: $content"
-            docker logs litellm-test
-            exit 1
-          fi
+          for i in 1 2 3; do
+            content=$(curl -sL --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/ui/")
+            if echo "$content" | grep -q -E "(html|<!DOCTYPE|<head|<body)"; then
+              echo "✅ UI page contains valid HTML content"
+              exit 0
+            fi
+            echo "Attempt $i/3 - no valid HTML, retrying in 5s..."
+            sleep 5
+          done
+          echo "❌ UI page does not contain expected HTML content"
+          echo "Response: $content"
+          docker logs litellm-test
+          exit 1
 
       - name: Test API docs endpoint with root path
         run: |
           ROOT_PATH="${{ matrix.root_path }}"
           echo "Testing API docs at: http://localhost:4000${ROOT_PATH}/docs"
 
-          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000${ROOT_PATH}/docs")
-
-          if [ "$response" = "200" ]; then
-            echo "✅ API docs endpoint returned 200"
-          else
-            echo "❌ API docs endpoint returned $response (expected 200)"
-            docker logs litellm-test
-            exit 1
-          fi
+          for i in 1 2 3; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/docs")
+            if [ "$response" = "200" ]; then
+              echo "✅ API docs endpoint returned 200"
+              exit 0
+            fi
+            echo "Attempt $i/3 - got $response, retrying in 5s..."
+            sleep 5
+          done
+          echo "❌ API docs endpoint returned $response (expected 200)"
+          docker logs litellm-test
+          exit 1
 
       - name: Test OpenAPI schema with root path
         run: |
           ROOT_PATH="${{ matrix.root_path }}"
           echo "Testing OpenAPI schema at: http://localhost:4000${ROOT_PATH}/openapi.json"
 
-          response=$(curl -s "http://localhost:4000${ROOT_PATH}/openapi.json")
-
-          # Check if response contains valid OpenAPI schema markers
-          if echo "$response" | grep -q '"openapi"'; then
-            echo "✅ OpenAPI schema is valid"
-          else
-            echo "❌ OpenAPI schema is invalid or missing"
-            echo "Response: $response"
-            docker logs litellm-test
-            exit 1
-          fi
+          for i in 1 2 3; do
+            response=$(curl -s --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/openapi.json")
+            if echo "$response" | grep -q '"openapi"'; then
+              echo "✅ OpenAPI schema is valid"
+              exit 0
+            fi
+            echo "Attempt $i/3 - invalid schema, retrying in 5s..."
+            sleep 5
+          done
+          echo "❌ OpenAPI schema is invalid or missing"
+          echo "Response: $response"
+          docker logs litellm-test
+          exit 1
 
       - name: Test model list endpoint with root path
         run: |
           ROOT_PATH="${{ matrix.root_path }}"
           echo "Testing model list endpoint at: http://localhost:4000${ROOT_PATH}/v1/models"
 
-          response=$(curl -s -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/v1/models")
-
-          # Check if response contains models data structure
-          if echo "$response" | grep -q '"data"'; then
-            echo "✅ Model list endpoint returned valid response"
-          else
-            echo "❌ Model list endpoint returned invalid response"
-            echo "Response: $response"
-            docker logs litellm-test
-            exit 1
-          fi
+          for i in 1 2 3; do
+            response=$(curl -s --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000${ROOT_PATH}/v1/models")
+            if echo "$response" | grep -q '"data"'; then
+              echo "✅ Model list endpoint returned valid response"
+              exit 0
+            fi
+            echo "Attempt $i/3 - invalid response, retrying in 5s..."
+            sleep 5
+          done
+          echo "❌ Model list endpoint returned invalid response"
+          echo "Response: $response"
+          docker logs litellm-test
+          exit 1
 
       - name: Verify root path is NOT accessible without prefix
         run: |
@@ -208,7 +226,7 @@ jobs:
           echo "Verifying endpoints are NOT accessible without root path prefix"
 
           # These should fail (404) because we're accessing without the root path
-          response=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000/health")
+          response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000/health")
 
           if [ "$response" = "404" ]; then
             echo "✅ Correctly returns 404 when accessing without root path"
@@ -285,17 +303,20 @@ jobs:
         run: |
           echo "Testing that default paths work when SERVER_ROOT_PATH is not set"
 
-          # These should work at root level
-          health=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000/health")
-          ui=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000/ui")
+          for i in 1 2 3; do
+            health=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000/health")
+            ui=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 -H "Authorization: Bearer sk-1234" "http://localhost:4000/ui")
 
-          if [ "$health" = "200" ] && [[ "$ui" =~ ^(200|30[0-9])$ ]]; then
-            echo "✅ Default paths work correctly"
-          else
-            echo "❌ Default paths failed (health: $health, ui: $ui)"
-            docker logs litellm-test
-            exit 1
-          fi
+            if [ "$health" = "200" ] && [[ "$ui" =~ ^(200|30[0-9])$ ]]; then
+              echo "✅ Default paths work correctly"
+              exit 0
+            fi
+            echo "Attempt $i/3 - health: $health, ui: $ui, retrying in 5s..."
+            sleep 5
+          done
+          echo "❌ Default paths failed (health: $health, ui: $ui)"
+          docker logs litellm-test
+          exit 1
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/test_server_root_path.yml
+++ b/.github/workflows/test_server_root_path.yml
@@ -3,17 +3,8 @@ permissions:
   contents: read
 
 on:
-<<<<<<< HEAD
   pull_request:
     branches: [main]
-=======
-  push:
-      - main
-  pull_request:
-    branches:
-      - main
-  workflow_dispatch:
->>>>>>> 8ab2c91722a1a951664873fae467f761f9c4dbb9
 
 jobs:
   test-server-root-path:

--- a/.github/workflows/test_server_root_path.yml
+++ b/.github/workflows/test_server_root_path.yml
@@ -1,15 +1,10 @@
-name: Test SERVER_ROOT_PATH
+name: Test Proxy SERVER_ROOT_PATH Routing
+permissions:
+  contents: read
 
 on:
-  push:
-    branches:
-      - main
-      - master
   pull_request:
-    branches:
-      - main
-      - master
-  workflow_dispatch:
+    branches: [main]
 
 jobs:
   test-server-root-path:

--- a/.github/workflows/test_server_root_path.yml
+++ b/.github/workflows/test_server_root_path.yml
@@ -2,13 +2,10 @@ name: Test SERVER_ROOT_PATH
 
 on:
   push:
-    branches:
       - main
-      - master
   pull_request:
     branches:
       - main
-      - master
   workflow_dispatch:
 
 jobs:

--- a/docs/my-website/blog/claude_code_beta_headers/index.md
+++ b/docs/my-website/blog/claude_code_beta_headers/index.md
@@ -1,6 +1,6 @@
 ---
-slug: claude_code_beta_headers
-title: "Claude Code - Managing Anthropic Beta Headers"
+slug: claude-code-beta-headers-incident
+title: "Incident Report: Invalid beta headers with Claude Code"
 date: 2026-02-16T10:00:00
 authors:
   - name: Sameer Kankute
@@ -15,260 +15,169 @@ authors:
     title: "CEO, LiteLLM"
     url: https://www.linkedin.com/in/krish-d/
     image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
-description: "How to manage and configure Anthropic beta headers with Claude Code in LiteLLM: filtering, mapping, and dynamic updates across providers."
-tags: [anthropic, claude, beta headers, configuration, liteLLM]
+tags: [incident-report, anthropic, stability]
 hide_table_of_contents: false
+---
+
+**Date:** February 13, 2026
+**Duration:** ~3 hours
+**Severity:** High
+**Status:** Resolved
+
+## Summary
+
+Claude Code began sending unsupported Anthropic beta headers to non-Anthropic providers (Bedrock, Azure AI, Vertex AI), causing `invalid beta flag` errors. LiteLLM was forwarding all beta headers without provider-specific validation. Users experienced request failures when routing Claude Code requests through LiteLLM to these providers.
+
+- **LLM calls to Anthropic:** No impact.
+- **LLM calls to Bedrock/Azure/Vertex:** Failed with `invalid beta flag` errors when unsupported headers were present.
+- **Cost tracking and routing:** No impact.
+
+{/* truncate */}
 
 ---
-import Image from '@theme/IdealImage';
 
-When using Claude Code with LiteLLM and non-Anthropic providers (Bedrock, Azure AI, Vertex AI), you need to ensure that only supported beta headers are sent to each provider. This guide explains how to add support for new beta headers or fix invalid beta header errors.
+## Background
 
-## What Are Beta Headers?
+Anthropic uses beta headers to enable experimental features in Claude. When Claude Code makes API requests, it includes headers like `anthropic-beta: prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20`. However, not all providers support all Anthropic beta features.
 
-Anthropic uses beta headers to enable experimental features in Claude. When you use Claude Code, it may send beta headers like:
-
-```
-anthropic-beta: prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20
-```
-
-However, not all providers support all Anthropic beta features. LiteLLM uses `anthropic_beta_headers_config.json` to manage which beta headers are supported by each provider.
-
-## Common Error Message
-
-```bash
-Error: The model returned the following errors: invalid beta flag
-```
-
-## How LiteLLM Handles Beta Headers
-
-LiteLLM uses a strict validation approach with a configuration file:
-
-```
-litellm/litellm/anthropic_beta_headers_config.json
-```
-
-This JSON file contains a **mapping** of beta headers for each provider:
-- **Keys**: Input beta header names (from Anthropic)
-- **Values**: Provider-specific header names (or `null` if unsupported)
-- **Validation**: Only headers present in the mapping with non-null values are forwarded
-
-This enforces stricter validation than just filtering unsupported headers - headers must be explicitly defined to be allowed.
-
-## Adding Support for a New Beta Header
-
-When Anthropic releases a new beta feature, you need to add it to the configuration file for each provider.
-
-### Step 1: Add the New Beta Header
-
-Open `anthropic_beta_headers_config.json` and add the new header to each provider's mapping:
-
-```json title="anthropic_beta_headers_config.json"
-{
-  "description": "Mapping of Anthropic beta headers for each provider. Keys are input header names, values are provider-specific header names (or null if unsupported). Only headers present in mapping keys with non-null values can be forwarded.",
-  "anthropic": {
-    "advanced-tool-use-2025-11-20": "advanced-tool-use-2025-11-20",
-    "new-feature-2026-03-01": "new-feature-2026-03-01",
-    ...
-  },
-  "azure_ai": {
-    "advanced-tool-use-2025-11-20": "advanced-tool-use-2025-11-20",
-    "new-feature-2026-03-01": "new-feature-2026-03-01",
-    ...
-  },
-  "bedrock_converse": {
-    "advanced-tool-use-2025-11-20": "tool-search-tool-2025-10-19",
-    "new-feature-2026-03-01": null,
-    ...
-  },
-  "bedrock": {
-    "advanced-tool-use-2025-11-20": "tool-search-tool-2025-10-19",
-    "new-feature-2026-03-01": null,
-    ...
-  },
-  "vertex_ai": {
-    "advanced-tool-use-2025-11-20": "tool-search-tool-2025-10-19",
-    "new-feature-2026-03-01": null,
-    ...
-  }
-}
-```
-
-**Key Points:**
-- **Supported headers**: Set the value to the provider-specific header name (often the same as the key)
-- **Unsupported headers**: Set the value to `null`
-- **Header transformations**: Some providers use different header names (e.g., Bedrock maps `advanced-tool-use-2025-11-20` to `tool-search-tool-2025-10-19`)
-- **Alphabetical order**: Keep headers sorted alphabetically for maintainability
-
-### Step 2: Reload Configuration (No Restart Required!)
-
-**Option 1: Dynamic Reload Without Restart** 
-
-Instead of restarting your application, you can dynamically reload the beta headers configuration using environment variables and API endpoints:
-
-```bash
-# Set environment variable to fetch from remote URL (Do this if you want to point it to some other URL)
-export LITELLM_ANTHROPIC_BETA_HEADERS_URL="https://raw.githubusercontent.com/BerriAI/litellm/main/litellm/anthropic_beta_headers_config.json"
-
-# Manually trigger reload via API (no restart needed!)
-curl -X POST "https://your-proxy-url/reload/anthropic_beta_headers" \
-  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
-```
-
-**Option 2: Schedule Automatic Reloads** 
-
-Set up automatic reloading to always stay up-to-date with the latest beta headers:
-
-```bash
-# Reload configuration every 24 hours
-curl -X POST "https://your-proxy-url/schedule/anthropic_beta_headers_reload?hours=24" \
-  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
-```
-
-**Option 3: Traditional Restart**
-
-If you prefer the traditional approach, restart your LiteLLM proxy or application:
-
-```bash
-# If using LiteLLM proxy
-litellm --config config.yaml
-
-# If using Python SDK
-# Just restart your Python application
-```
-
-:::tip Zero-Downtime Updates
-With dynamic reloading, you can fix invalid beta header errors **without restarting your service**! This is especially useful in production environments where downtime is costly.
-
-See [Auto Sync Anthropic Beta Headers](../proxy/sync_anthropic_beta_headers.md) for complete documentation.
-:::
-
-## Fixing Invalid Beta Header Errors
-
-If you encounter an "invalid beta flag" error, it means a beta header is being sent that the provider doesn't support.
-
-### Step 1: Identify the Problematic Header
-
-Check your logs to see which header is causing the issue:
-
-```bash
-Error: The model returned the following errors: invalid beta flag: new-feature-2026-03-01
-```
-
-### Step 2: Update the Config
-
-Set the header value to `null` for that provider:
-
-```json title="anthropic_beta_headers_config.json"
-{
-  "bedrock_converse": {
-    "new-feature-2026-03-01": null
-  }
-}
-```
-
-### Step 3: Restart and Test
-
-Restart your application and verify the header is now filtered out.
-
-## Contributing a Fix to LiteLLM
-
-Help the community by contributing your fix!
-
-### What to Include in Your PR
-
-1. **Update the config file**: Add the new beta header to `litellm/anthropic_beta_headers_config.json`
-2. **Test your changes**: Verify the header is correctly filtered/mapped for each provider
-3. **Documentation**: Include provider documentation links showing which headers are supported
-
-### Example PR Description
-
-```markdown
-## Add support for new-feature-2026-03-01 beta header
-
-### Changes
-- Added `new-feature-2026-03-01` to anthropic_beta_headers_config.json
-- Set to `null` for bedrock_converse (unsupported)
-- Set to header name for anthropic, azure_ai (supported)
-
-### Testing
-Tested with:
-- ✅ Anthropic: Header passed through correctly
-- ✅ Azure AI: Header passed through correctly  
-- ✅ Bedrock Converse: Header filtered out (returns error without fix)
-
-### References
-- Anthropic docs: [link]
-- AWS Bedrock docs: [link]
-```
-
-
-## How Beta Header Filtering Works
-
-When you make a request through LiteLLM:
+Before this incident, LiteLLM forwarded all beta headers to all providers without validation:
 
 ```mermaid
 sequenceDiagram
     participant CC as Claude Code
-    participant LP as LiteLLM
-    participant Config as Beta Headers Config
-    participant Provider as Provider (Bedrock/Azure/etc)
+    participant LP as LiteLLM (old behavior)
+    participant Provider as Provider (Bedrock/Azure/Vertex)
 
     CC->>LP: Request with beta headers
     Note over CC,LP: anthropic-beta: header1,header2,header3
-    
+
+    LP->>Provider: Forward ALL headers (no validation)
+    Note over LP,Provider: anthropic-beta: header1,header2,header3
+
+    Provider-->>LP: ❌ Error: invalid beta flag
+    LP-->>CC: Request fails
+```
+
+Requests succeeded for Anthropic (native support) but failed for other providers when Claude Code sent headers those providers didn't support.
+
+---
+
+## Root cause
+
+LiteLLM lacked provider-specific beta header validation. When Claude Code introduced new beta features or sent headers that specific providers didn't support, those headers were blindly forwarded, causing provider API errors.
+
+**Timeline:**
+
+1. **Feb 15, 2026 ~18:00 UTC**: Claude Code begins sending new beta headers (e.g., `advanced-tool-use-2025-11-20`)
+2. **Feb 15, 2026 ~18:15 UTC**: Users report `invalid beta flag` errors when using LiteLLM with Bedrock/Azure/Vertex
+3. **Feb 15, 2026 ~20:00 UTC**: Investigation identifies missing provider-specific header validation
+4. **Feb 16, 2026 ~02:00 UTC**: Quick fix deployed - filter out problematic headers
+5. **Feb 16, 2026 ~06:00 UTC**: Comprehensive solution merged with provider-specific configuration and dynamic reload
+
+---
+
+## Remediation
+
+| # | Action | Status | Code |
+|---|---|---|---|
+| 1 | Create `anthropic_beta_headers_config.json` with provider-specific mappings | ✅ Done | [`anthropic_beta_headers_config.json`](https://github.com/BerriAI/litellm/blob/main/litellm/anthropic_beta_headers_config.json) |
+| 2 | Implement strict validation: headers must be explicitly mapped to be forwarded | ✅ Done | [`litellm_logging.py`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm_core_utils/litellm_logging.py) |
+| 3 | Add `/reload/anthropic_beta_headers` endpoint for dynamic config updates | ✅ Done | Proxy management endpoints |
+| 4 | Add `/schedule/anthropic_beta_headers_reload` for automatic periodic updates | ✅ Done | Proxy management endpoints |
+| 5 | Support `LITELLM_ANTHROPIC_BETA_HEADERS_URL` for custom config sources | ✅ Done | Environment configuration |
+| 6 | Support `LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS` for air-gapped deployments | ✅ Done | Environment configuration |
+
+Now LiteLLM validates and transforms headers per-provider:
+
+```mermaid
+sequenceDiagram
+    participant CC as Claude Code
+    participant LP as LiteLLM (new behavior)
+    participant Config as Beta Headers Config
+    participant Provider as Provider (Bedrock/Azure/Vertex)
+
+    CC->>LP: Request with beta headers
+    Note over CC,LP: anthropic-beta: header1,header2,header3
+
     LP->>Config: Load header mapping for provider
     Config-->>LP: Returns mapping (header→value or null)
-    
+
     Note over LP: Validate & Transform:<br/>1. Check if header exists in mapping<br/>2. Filter out null values<br/>3. Map to provider-specific names
-    
+
     LP->>Provider: Request with filtered & mapped headers
     Note over LP,Provider: anthropic-beta: mapped-header2<br/>(header1, header3 filtered out)
-    
-    Provider-->>LP: Success response
+
+    Provider-->>LP: ✅ Success response
     LP-->>CC: Response
 ```
 
-### Filtering Rules
+---
 
-1. **Header must exist in mapping**: Unknown headers are filtered out
-2. **Header must have non-null value**: Headers with `null` values are filtered out
-3. **Header transformation**: Headers are mapped to provider-specific names (e.g., `advanced-tool-use-2025-11-20` → `tool-search-tool-2025-10-19` for Bedrock)
+## Dynamic configuration updates
 
-### Example
+A key improvement is zero-downtime configuration updates. When Anthropic releases new beta features, users can update their configuration without restarting:
 
-Request with headers:
-```
-anthropic-beta: advanced-tool-use-2025-11-20,computer-use-2025-01-24,unknown-header
-```
-
-For Bedrock Converse:
-- ✅ `computer-use-2025-01-24` → `computer-use-2025-01-24` (supported, passed through)
-- ❌ `advanced-tool-use-2025-11-20` → filtered out (null value in config)
-- ❌ `unknown-header` → filtered out (not in config)
-
-Result sent to Bedrock:
-```
-anthropic-beta: computer-use-2025-01-24
-```
-
-## Dynamic Configuration Management (No Restart Required!)
-
-### Environment Variables
-
-Control how LiteLLM loads the beta headers configuration:
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `LITELLM_ANTHROPIC_BETA_HEADERS_URL` | URL to fetch config from | GitHub main branch |
-| `LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS` | Set to `True` to use local config only | `False` |
-
-**Example: Use Custom Config URL**
 ```bash
-export LITELLM_ANTHROPIC_BETA_HEADERS_URL="https://your-company.com/custom-beta-headers.json"
+# Manually trigger reload (no restart needed)
+curl -X POST "https://your-proxy-url/reload/anthropic_beta_headers" \
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
+
+# Or schedule automatic reloads every 24 hours
+curl -X POST "https://your-proxy-url/schedule/anthropic_beta_headers_reload?hours=24" \
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
 ```
 
-**Example: Use Local Config Only (No Remote Fetching)**
-```bash
-export LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS=True
+This prevents future incidents where Claude Code introduces new headers before LiteLLM configuration is updated.
+
+---
+
+## Configuration format
+
+The `anthropic_beta_headers_config.json` file maps input headers to provider-specific output headers:
+
+```json
+{
+  "description": "Mapping of Anthropic beta headers for each provider.",
+  "anthropic": {
+    "advanced-tool-use-2025-11-20": "advanced-tool-use-2025-11-20",
+    "computer-use-2025-01-24": "computer-use-2025-01-24"
+  },
+  "bedrock_converse": {
+    "advanced-tool-use-2025-11-20": null,
+    "computer-use-2025-01-24": "computer-use-2025-01-24"
+  },
+  "azure_ai": {
+    "advanced-tool-use-2025-11-20": "advanced-tool-use-2025-11-20",
+    "computer-use-2025-01-24": "computer-use-2025-01-24"
+  }
+}
 ```
+
+**Validation rules:**
+1. Headers must exist in the mapping for the target provider
+2. Headers with `null` values are filtered out (unsupported)
+3. Header names can be transformed per-provider (e.g., Bedrock uses different names for some features)
+
+---
+
+## Resolution steps for users
+
+For users still experiencing issues, update to the latest LiteLLM version:
+
+```bash
+pip install --upgrade litellm
+```
+
+Or manually reload the configuration without restarting:
+
+```bash
+curl -X POST "https://your-proxy-url/reload/anthropic_beta_headers" \
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
+```
+
+---
+
+## Related documentation
+
+- [Managing Anthropic Beta Headers](../proxy/sync_anthropic_beta_headers.md) - Complete configuration guide
+- [`anthropic_beta_headers_config.json`](https://github.com/BerriAI/litellm/blob/main/litellm/anthropic_beta_headers_config.json) - Current configuration file

--- a/docs/my-website/blog/claude_code_beta_headers/index.md
+++ b/docs/my-website/blog/claude_code_beta_headers/index.md
@@ -66,14 +66,6 @@ Requests succeeded for Anthropic (native support) but failed for other providers
 
 LiteLLM lacked provider-specific beta header validation. When Claude Code introduced new beta features or sent headers that specific providers didn't support, those headers were blindly forwarded, causing provider API errors.
 
-**Timeline:**
-
-1. **Feb 15, 2026 ~18:00 UTC**: Claude Code begins sending new beta headers (e.g., `advanced-tool-use-2025-11-20`)
-2. **Feb 15, 2026 ~18:15 UTC**: Users report `invalid beta flag` errors when using LiteLLM with Bedrock/Azure/Vertex
-3. **Feb 15, 2026 ~20:00 UTC**: Investigation identifies missing provider-specific header validation
-4. **Feb 16, 2026 ~02:00 UTC**: Quick fix deployed - filter out problematic headers
-5. **Feb 16, 2026 ~06:00 UTC**: Comprehensive solution merged with provider-specific configuration and dynamic reload
-
 ---
 
 ## Remediation

--- a/docs/my-website/blog/claude_code_beta_headers/index.md
+++ b/docs/my-website/blog/claude_code_beta_headers/index.md
@@ -162,7 +162,7 @@ The `anthropic_beta_headers_config.json` file maps input headers to provider-spe
 
 ## Resolution steps for users
 
-For users still experiencing issues, update to the latest LiteLLM version:
+For users still experiencing issues, update to the latest LiteLLM version if < v1.81.11-nightly:
 
 ```bash
 pip install --upgrade litellm

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -450,6 +450,7 @@ router_settings:
 | BATCH_STATUS_POLL_INTERVAL_SECONDS | Interval in seconds for polling batch status. Default is 3600 (1 hour)
 | BATCH_STATUS_POLL_MAX_ATTEMPTS | Maximum number of attempts for polling batch status. Default is 24 (for 24 hours)
 | BEDROCK_MAX_POLICY_SIZE | Maximum size for Bedrock policy. Default is 75
+| BEDROCK_MIN_THINKING_BUDGET_TOKENS | Minimum thinking budget in tokens for Bedrock reasoning models. Bedrock returns a 400 error if budget_tokens is below this value. Requests with lower values are clamped to this minimum. Default is 1024
 | BERRISPEND_ACCOUNT_ID | Account ID for BerriSpend service
 | BRAINTRUST_API_KEY | API key for Braintrust integration
 | BRAINTRUST_API_BASE | Base URL for Braintrust API. Default is https://api.braintrustdata.com/v1

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -85,7 +85,7 @@ BEDROCK_COMPUTER_USE_TOOLS = [
 UNSUPPORTED_BEDROCK_CONVERSE_BETA_PATTERNS = [
     "advanced-tool-use",  # Bedrock Converse doesn't support advanced-tool-use beta headers
     "prompt-caching",  # Prompt caching not supported in Converse API
-    "compact-2026-01-12", # The compact beta feature is not currently supported on the Converse and ConverseStream APIs
+    "compact-2026-01-12",  # The compact beta feature is not currently supported on the Converse and ConverseStream APIs
 ]
 
 
@@ -270,45 +270,55 @@ class AmazonConverseConfig(BaseConfig):
                     llm_provider="bedrock",
                 )
 
-    def _is_nova_lite_2_model(self, model: str) -> bool:
+    def _is_nova_2_model(self, model: str) -> bool:
         """
-        Check if the model is a Nova Lite 2 model that supports reasoningConfig.
+        Check if the model is a Nova 2 model that supports reasoningConfig.
 
-        Nova Lite 2 models use a different reasoning configuration structure compared to
+        Nova 2 models use a different reasoning configuration structure compared to
         Anthropic's thinking parameter and GPT-OSS's reasoning_effort parameter.
 
         Supported models:
         - amazon.nova-2-lite-v1:0
+        - amazon.nova-2-pro-preview-20251202-v1:0
         - us.amazon.nova-2-lite-v1:0
         - eu.amazon.nova-2-lite-v1:0
         - apac.amazon.nova-2-lite-v1:0
+        - (and other regional variants)
 
         Args:
             model: The model identifier
 
         Returns:
-            True if the model is a Nova Lite 2 model, False otherwise
+            True if the model is a Nova 2 model, False otherwise
 
         Examples:
             >>> config = AmazonConverseConfig()
-            >>> config._is_nova_lite_2_model("amazon.nova-2-lite-v1:0")
+            >>> config._is_nova_2_model("amazon.nova-2-lite-v1:0")
             True
-            >>> config._is_nova_lite_2_model("us.amazon.nova-2-lite-v1:0")
+            >>> config._is_nova_2_model("us.amazon.nova-2-lite-v1:0")
             True
-            >>> config._is_nova_lite_2_model("amazon.nova-pro-1-5-v1:0")
+            >>> config._is_nova_2_model("us.amazon.nova-2-pro-preview-20251202-v1:0")
+            True
+            >>> config._is_nova_2_model("amazon.nova-pro-1-5-v1:0")
             False
-            >>> config._is_nova_lite_2_model("amazon.nova-pro-v1:0")
+            >>> config._is_nova_2_model("amazon.nova-pro-v1:0")
             False
         """
-        # Remove regional prefix if present (us., eu., apac.)
+        # Remove provider routing prefix if present (bedrock/converse/, bedrock/, converse/)
         model_without_region = model
-        for prefix in ["us.", "eu.", "apac."]:
-            if model.startswith(prefix):
-                model_without_region = model[len(prefix) :]
+        for routing_prefix in ["bedrock/converse/", "bedrock/", "converse/"]:
+            if model_without_region.startswith(routing_prefix):
+                model_without_region = model_without_region[len(routing_prefix) :]
                 break
 
-        # Check if the model is specifically Nova Lite 2
-        return "nova-2-lite" in model_without_region
+        # Remove regional prefix if present (us., eu., apac.)
+        for prefix in ["us.", "eu.", "apac."]:
+            if model_without_region.startswith(prefix):
+                model_without_region = model_without_region[len(prefix) :]
+                break
+
+        # Check if the model is a Nova 2 model (matches nova-2-lite, nova-2-pro, etc.)
+        return model_without_region.startswith("amazon.nova-2-")
 
     def _map_web_search_options(
         self, web_search_options: dict, model: str
@@ -396,7 +406,7 @@ class AmazonConverseConfig(BaseConfig):
 
         Different model families handle reasoning effort differently:
         - GPT-OSS models: Keep reasoning_effort as-is (passed to additionalModelRequestFields)
-        - Nova Lite 2 models: Transform to reasoningConfig structure
+        - Nova 2 models: Transform to reasoningConfig structure
         - Other models (Anthropic, etc.): Convert to thinking parameter
 
         Args:
@@ -425,8 +435,8 @@ class AmazonConverseConfig(BaseConfig):
             # GPT-OSS models: keep reasoning_effort as-is
             # It will be passed through to additionalModelRequestFields
             optional_params["reasoning_effort"] = reasoning_effort
-        elif self._is_nova_lite_2_model(model):
-            # Nova Lite 2 models: transform to reasoningConfig
+        elif self._is_nova_2_model(model):
+            # Nova 2 models: transform to reasoningConfig
             reasoning_config = self._transform_reasoning_effort_to_reasoning_config(
                 reasoning_effort
             )
@@ -514,8 +524,8 @@ class AmazonConverseConfig(BaseConfig):
 
         if "gpt-oss" in model:
             supported_params.append("reasoning_effort")
-        elif self._is_nova_lite_2_model(model):
-            # Nova Lite 2 models support reasoning_effort (transformed to reasoningConfig)
+        elif self._is_nova_2_model(model):
+            # Nova 2 models support reasoning_effort (transformed to reasoningConfig)
             # These models use a different reasoning structure than Anthropic's thinking parameter
             supported_params.append("reasoning_effort")
         elif (
@@ -806,8 +816,8 @@ class AmazonConverseConfig(BaseConfig):
                     )
 
         # Only update thinking tokens for non-GPT-OSS models and non-Nova-Lite-2 models
-        # Nova Lite 2 handles token budgeting differently through reasoningConfig
-        if "gpt-oss" not in model and not self._is_nova_lite_2_model(model):
+        # Nova 2 handles token budgeting differently through reasoningConfig
+        if "gpt-oss" not in model and not self._is_nova_2_model(model):
             self.update_optional_params_with_thinking_tokens(
                 non_default_params=non_default_params, optional_params=optional_params
             )
@@ -1125,22 +1135,49 @@ class AmazonConverseConfig(BaseConfig):
                 # "computer-use-2025-01-24" for Claude Sonnet 4.5, Haiku 4.5, Opus 4.1, Sonnet 4, Opus 4, and Sonnet 3.7
                 # "computer-use-2024-10-22" for older models
                 model_lower = model.lower()
-                if "opus-4.6" in model_lower or "opus_4.6" in model_lower or "opus-4-6" in model_lower or "opus_4_6" in model_lower:
+                if (
+                    "opus-4.6" in model_lower
+                    or "opus_4.6" in model_lower
+                    or "opus-4-6" in model_lower
+                    or "opus_4_6" in model_lower
+                ):
                     computer_use_header = "computer-use-2025-11-24"
-                elif "opus-4.5" in model_lower or "opus_4.5" in model_lower or "opus-4-5" in model_lower or "opus_4_5" in model_lower:
+                elif (
+                    "opus-4.5" in model_lower
+                    or "opus_4.5" in model_lower
+                    or "opus-4-5" in model_lower
+                    or "opus_4_5" in model_lower
+                ):
                     computer_use_header = "computer-use-2025-11-24"
-                elif any(pattern in model_lower for pattern in [
-                    "sonnet-4.5", "sonnet_4.5", "sonnet-4-5", "sonnet_4_5",
-                    "haiku-4.5", "haiku_4.5", "haiku-4-5", "haiku_4_5",
-                    "opus-4.1", "opus_4.1", "opus-4-1", "opus_4_1",
-                    "sonnet-4", "sonnet_4",
-                    "opus-4", "opus_4",
-                    "sonnet-3.7", "sonnet_3.7", "sonnet-3-7", "sonnet_3_7"
-                ]):
+                elif any(
+                    pattern in model_lower
+                    for pattern in [
+                        "sonnet-4.5",
+                        "sonnet_4.5",
+                        "sonnet-4-5",
+                        "sonnet_4_5",
+                        "haiku-4.5",
+                        "haiku_4.5",
+                        "haiku-4-5",
+                        "haiku_4_5",
+                        "opus-4.1",
+                        "opus_4.1",
+                        "opus-4-1",
+                        "opus_4_1",
+                        "sonnet-4",
+                        "sonnet_4",
+                        "opus-4",
+                        "opus_4",
+                        "sonnet-3.7",
+                        "sonnet_3.7",
+                        "sonnet-3-7",
+                        "sonnet_3_7",
+                    ]
+                ):
                     computer_use_header = "computer-use-2025-01-24"
                 else:
                     computer_use_header = "computer-use-2024-10-22"
-                
+
                 anthropic_beta_list.append(computer_use_header)
                 # Transform computer use tools to proper Bedrock format
                 transformed_computer_tools = self._transform_computer_use_tools(
@@ -1504,9 +1541,7 @@ class AmazonConverseConfig(BaseConfig):
 
         return message, returned_finish_reason
 
-    def _translate_message_content(
-        self, content_blocks: List[ContentBlock]
-    ) -> Tuple[
+    def _translate_message_content(self, content_blocks: List[ContentBlock]) -> Tuple[
         str,
         List[ChatCompletionToolCallChunk],
         Optional[List[BedrockConverseReasoningContentBlock]],
@@ -1523,9 +1558,9 @@ class AmazonConverseConfig(BaseConfig):
         """
         content_str = ""
         tools: List[ChatCompletionToolCallChunk] = []
-        reasoningContentBlocks: Optional[
-            List[BedrockConverseReasoningContentBlock]
-        ] = None
+        reasoningContentBlocks: Optional[List[BedrockConverseReasoningContentBlock]] = (
+            None
+        )
         citationsContentBlocks: Optional[List[CitationsContentBlock]] = None
         for idx, content in enumerate(content_blocks):
             """
@@ -1652,9 +1687,9 @@ class AmazonConverseConfig(BaseConfig):
         chat_completion_message: ChatCompletionResponseMessage = {"role": "assistant"}
         content_str = ""
         tools: List[ChatCompletionToolCallChunk] = []
-        reasoningContentBlocks: Optional[
-            List[BedrockConverseReasoningContentBlock]
-        ] = None
+        reasoningContentBlocks: Optional[List[BedrockConverseReasoningContentBlock]] = (
+            None
+        )
         citationsContentBlocks: Optional[List[CitationsContentBlock]] = None
 
         if message is not None:
@@ -1673,17 +1708,17 @@ class AmazonConverseConfig(BaseConfig):
             provider_specific_fields["citationsContent"] = citationsContentBlocks
 
         if provider_specific_fields:
-            chat_completion_message[
-                "provider_specific_fields"
-            ] = provider_specific_fields
+            chat_completion_message["provider_specific_fields"] = (
+                provider_specific_fields
+            )
 
         if reasoningContentBlocks is not None:
-            chat_completion_message[
-                "reasoning_content"
-            ] = self._transform_reasoning_content(reasoningContentBlocks)
-            chat_completion_message[
-                "thinking_blocks"
-            ] = self._transform_thinking_blocks(reasoningContentBlocks)
+            chat_completion_message["reasoning_content"] = (
+                self._transform_reasoning_content(reasoningContentBlocks)
+            )
+            chat_completion_message["thinking_blocks"] = (
+                self._transform_thinking_blocks(reasoningContentBlocks)
+            )
         chat_completion_message["content"] = content_str
         if (
             json_mode is True

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1995,6 +1995,8 @@ async def get_user_daily_activity(
             timezone_offset_minutes=timezone,
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
         verbose_proxy_logger.exception(
             "/spend/daily/analytics: Exception occured - {}".format(str(e))
@@ -2093,6 +2095,8 @@ async def get_user_daily_activity_aggregated(
             timezone_offset_minutes=timezone,
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
         verbose_proxy_logger.exception(
             "/user/daily/activity/aggregated: Exception occured - {}".format(str(e))

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1965,12 +1965,7 @@ async def get_user_daily_activity(
             entity_id = user_id  # None means global view, otherwise filter by user
         else:
             if user_id is None:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail={
-                        "error": "Non-admin users must provide a user_id. Global spend view is restricted to admins."
-                    },
-                )
+                user_id = user_api_key_dict.user_id
             if user_id != user_api_key_dict.user_id:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
@@ -2067,12 +2062,7 @@ async def get_user_daily_activity_aggregated(
             entity_id = user_id  # None means global view, otherwise filter by user
         else:
             if user_id is None:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail={
-                        "error": "Non-admin users must provide a user_id. Global spend view is restricted to admins."
-                    },
-                )
+                user_id = user_api_key_dict.user_id
             if user_id != user_api_key_dict.user_id:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1911,6 +1911,10 @@ async def get_user_daily_activity(
         default=None,
         description="Filter by specific API key",
     ),
+    user_id: Optional[str] = fastapi.Query(
+        default=None,
+        description="Filter by specific user ID. Admins can filter by any user or omit for global view. Non-admins must provide their own user_id.",
+    ),
     page: int = fastapi.Query(
         default=1, description="Page number for pagination", ge=1
     ),
@@ -1955,9 +1959,26 @@ async def get_user_daily_activity(
         )
 
     try:
-        entity_id: Optional[str] = None
-        if not _user_has_admin_view(user_api_key_dict):
-            entity_id = user_api_key_dict.user_id
+        is_admin = _user_has_admin_view(user_api_key_dict)
+
+        if is_admin:
+            entity_id = user_id  # None means global view, otherwise filter by user
+        else:
+            if user_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "Non-admin users must provide a user_id. Global spend view is restricted to admins."
+                    },
+                )
+            if user_id != user_api_key_dict.user_id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "Non-admin users can only view their own spend data."
+                    },
+                )
+            entity_id = user_id
 
         return await get_daily_activity(
             prisma_client=prisma_client,
@@ -2008,6 +2029,10 @@ async def get_user_daily_activity_aggregated(
         default=None,
         description="Filter by specific API key",
     ),
+    user_id: Optional[str] = fastapi.Query(
+        default=None,
+        description="Filter by specific user ID. Admins can filter by any user or omit for global view. Non-admins must provide their own user_id.",
+    ),
     timezone: Optional[int] = fastapi.Query(
         default=None,
         description="Timezone offset in minutes from UTC (e.g., 480 for PST). "
@@ -2034,9 +2059,26 @@ async def get_user_daily_activity_aggregated(
         )
 
     try:
-        entity_id: Optional[str] = None
-        if not _user_has_admin_view(user_api_key_dict):
-            entity_id = user_api_key_dict.user_id
+        is_admin = _user_has_admin_view(user_api_key_dict)
+
+        if is_admin:
+            entity_id = user_id  # None means global view, otherwise filter by user
+        else:
+            if user_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "Non-admin users must provide a user_id. Global spend view is restricted to admins."
+                    },
+                )
+            if user_id != user_api_key_dict.user_id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "Non-admin users can only view their own spend data."
+                    },
+                )
+            entity_id = user_id
 
         return await get_daily_activity_aggregated(
             prisma_client=prisma_client,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2644,6 +2644,9 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     alert_recipients: Optional[List[str]]
     """Email addresses that were notified"""
 
+    risk_score: Optional[float]
+    """Risk score 0-10 indicating how risky the request was (higher = riskier). Computed by the guardrail provider."""
+
 
 class GuardrailTracingDetail(TypedDict, total=False):
     """
@@ -2661,6 +2664,7 @@ class GuardrailTracingDetail(TypedDict, total=False):
     match_details: Optional[List[dict]]
     patterns_checked: Optional[int]
     alert_recipients: Optional[List[str]]
+    risk_score: Optional[float]
 
 
 StandardLoggingPayloadStatus = Literal["success", "failure"]

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -17112,6 +17112,19 @@
         "supports_parallel_function_calling": true,
         "supports_vision": true
     },
+    "github_copilot/claude-opus-4.6-fast": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16000,
+        "max_tokens": 16000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true
+    },
     "github_copilot/claude-opus-41": {
         "litellm_provider": "github_copilot",
         "max_input_tokens": 80000,
@@ -17356,6 +17369,20 @@
         "mode": "chat",
         "supported_endpoints": [
             "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
+    "github_copilot/gpt-5.3-codex": {
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
             "/v1/responses"
         ],
         "supports_function_calling": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "litellm"
-version = "1.81.12"
+version = "1.81.13"
 description = "Library to easily interface with LLM API providers"
 authors = ["BerriAI"]
 license = "MIT"
@@ -182,7 +182,7 @@ requires = ["poetry-core", "wheel"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.commitizen]
-version = "1.81.12"
+version = "1.81.13"
 version_files = [
     "pyproject.toml:^version"
 ]

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -74,7 +74,7 @@ def validate_responses_api_response(response, final_chunk: bool = False):
         "top_p": (int, float, type(None)),
         "max_output_tokens": (int, type(None)),
         "previous_response_id": (str, type(None)),
-        "reasoning": dict,
+        "reasoning": (dict, type(None)),
         "status": str,
         "text": dict,
         "truncation": (str, type(None)),

--- a/tests/test_litellm/containers/test_container_integration.py
+++ b/tests/test_litellm/containers/test_container_integration.py
@@ -385,6 +385,15 @@ class TestContainerIntegration:
     @pytest.mark.parametrize("provider", ["openai"])
     def test_provider_support(self, provider):
         """Test that the container API works with supported providers."""
+        import importlib
+        import litellm.containers.main as containers_main_module
+
+        # Reload the module to ensure it has a fresh reference to base_llm_http_handler
+        # after conftest reloads litellm (same pattern as test_error_handling_integration)
+        importlib.reload(containers_main_module)
+
+        from litellm.containers.main import create_container as create_container_fresh
+
         mock_response = ContainerObject(
             id="cntr_provider_test",
             object="container",
@@ -398,7 +407,7 @@ class TestContainerIntegration:
         with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
             mock_handler.container_create_handler.return_value = mock_response
             
-            response = create_container(
+            response = create_container_fresh(
                 name="Provider Test Container",
                 custom_llm_provider=provider
             )

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -2701,37 +2701,37 @@ def test_empty_assistant_message_handling():
         assert result[1]["content"][0]["text"] == "I'm doing well, thank you!"
 
 
-def test_is_nova_lite_2_model():
-    """Test the _is_nova_lite_2_model() method for detecting Nova 2 models."""
+def test_is_nova_2_model():
+    """Test the _is_nova_2_model() method for detecting Nova 2 models."""
     config = AmazonConverseConfig()
 
     # Test with amazon.nova-2-lite-v1:0
-    assert config._is_nova_lite_2_model("amazon.nova-2-lite-v1:0") is True
+    assert config._is_nova_2_model("amazon.nova-2-lite-v1:0") is True
 
     # Test with regional variants
-    assert config._is_nova_lite_2_model("us.amazon.nova-2-lite-v1:0") is True
-    assert config._is_nova_lite_2_model("eu.amazon.nova-2-lite-v1:0") is True
-    assert config._is_nova_lite_2_model("apac.amazon.nova-2-lite-v1:0") is True
+    assert config._is_nova_2_model("us.amazon.nova-2-lite-v1:0") is True
+    assert config._is_nova_2_model("eu.amazon.nova-2-lite-v1:0") is True
+    assert config._is_nova_2_model("apac.amazon.nova-2-lite-v1:0") is True
 
     # Test with other Nova 2 variants (pro, micro)
-    assert config._is_nova_lite_2_model("amazon.nova-pro-1-5-v1:0") is False
-    assert config._is_nova_lite_2_model("amazon.nova-micro-1-5-v1:0") is False
-    assert config._is_nova_lite_2_model("us.amazon.nova-pro-1-5-v1:0") is False
-    assert config._is_nova_lite_2_model("eu.amazon.nova-micro-1-5-v1:0") is False
+    assert config._is_nova_2_model("amazon.nova-pro-1-5-v1:0") is False
+    assert config._is_nova_2_model("amazon.nova-micro-1-5-v1:0") is False
+    assert config._is_nova_2_model("us.amazon.nova-pro-1-5-v1:0") is False
+    assert config._is_nova_2_model("eu.amazon.nova-micro-1-5-v1:0") is False
 
     # Test with non-Nova-1.5 lite models (should return False)
-    assert config._is_nova_lite_2_model("amazon.nova-lite-v1:0") is False
-    assert config._is_nova_lite_2_model("amazon.nova-pro-v1:0") is False
-    assert config._is_nova_lite_2_model("amazon.nova-micro-v1:0") is False
+    assert config._is_nova_2_model("amazon.nova-lite-v1:0") is False
+    assert config._is_nova_2_model("amazon.nova-pro-v1:0") is False
+    assert config._is_nova_2_model("amazon.nova-micro-v1:0") is False
 
     # Test with Nova v1:0 models (should return False)
-    assert config._is_nova_lite_2_model("us.amazon.nova-lite-v1:0") is False
-    assert config._is_nova_lite_2_model("eu.amazon.nova-pro-v1:0") is False
+    assert config._is_nova_2_model("us.amazon.nova-lite-v1:0") is False
+    assert config._is_nova_2_model("eu.amazon.nova-pro-v1:0") is False
 
     # Test with completely different models (should return False)
-    assert config._is_nova_lite_2_model("anthropic.claude-3-5-sonnet-20240620-v1:0") is False
-    assert config._is_nova_lite_2_model("meta.llama3-70b-instruct-v1:0") is False
-    assert config._is_nova_lite_2_model("mistral.mistral-7b-instruct-v0:2") is False
+    assert config._is_nova_2_model("anthropic.claude-3-5-sonnet-20240620-v1:0") is False
+    assert config._is_nova_2_model("meta.llama3-70b-instruct-v1:0") is False
+    assert config._is_nova_2_model("mistral.mistral-7b-instruct-v0:2") is False
 
 
 def test_thinking_with_max_completion_tokens():

--- a/tests/test_litellm/llms/meta_llama/test_meta_llama_chat_transformation.py
+++ b/tests/test_litellm/llms/meta_llama/test_meta_llama_chat_transformation.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -47,67 +46,26 @@ def test_map_openai_params():
     assert "response_format" in result
 
 
-@pytest.mark.asyncio
-async def test_llama_api_streaming_no_307_error():
-    """Test that streaming works without 307 redirect errors due to follow_redirects=True"""
+def test_llama_api_streaming_no_307_error():
+    """
+    Test that the OpenAI-compatible httpx clients use follow_redirects=True.
 
-    # Mock the httpx client to simulate a successful streaming response
-    with patch(
-        "litellm.llms.custom_httpx.http_handler.get_async_httpx_client"
-    ) as mock_get_client:
-        # Create a mock client
-        mock_client = AsyncMock()
-        mock_get_client.return_value = mock_client
+    meta_llama routes through the OpenAI SDK path (BaseOpenAILLM), so the
+    follow_redirects setting on that SDK's underlying httpx client is what
+    actually prevents 307 redirect errors for LLaMA API streaming.
+    """
+    from litellm.llms.openai.common_utils import BaseOpenAILLM
 
-        # Mock a successful streaming response (not a 307 redirect)
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.headers = {"content-type": "text/plain; charset=utf-8"}
+    # Verify the async httpx client has follow_redirects enabled
+    async_client = BaseOpenAILLM._get_async_http_client()
+    assert async_client is not None
+    assert (
+        async_client.follow_redirects is True
+    ), "Async httpx client should set follow_redirects=True to prevent 307 errors"
 
-        # Mock streaming data that would come from a successful request
-        async def mock_aiter_lines():
-            yield 'data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1234567890,"model":"meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}'
-            yield 'data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1234567890,"model":"meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8","choices":[{"index":0,"delta":{"content":" there"},"finish_reason":null}]}'
-            yield 'data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1234567890,"model":"meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}'
-            yield "data: [DONE]"
-
-        mock_response.aiter_lines.return_value = mock_aiter_lines()
-        mock_client.stream.return_value.__aenter__.return_value = mock_response
-
-        # Test the streaming completion
-        try:
-            response = await litellm.acompletion(
-                model="meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
-                messages=[{"role": "user", "content": "Tell me about yourself"}],
-                stream=True,
-                temperature=0.0,
-            )
-
-            # Verify we get a CustomStreamWrapper (streaming response)
-            from litellm.utils import CustomStreamWrapper
-
-            assert isinstance(response, CustomStreamWrapper)
-
-            # Verify the HTTP client was called with follow_redirects=True
-            mock_client.stream.assert_called_once()
-            call_kwargs = mock_client.stream.call_args[1]
-            assert (
-                call_kwargs.get("follow_redirects") is True
-            ), "follow_redirects should be True to prevent 307 errors"
-
-            # Verify the response status is 200 (not 307)
-            assert (
-                mock_response.status_code == 200
-            ), "Should get 200 response, not 307 redirect"
-
-        except Exception as e:
-            # If there's an exception, make sure it's not a 307 error
-            error_str = str(e)
-            assert (
-                "307" not in error_str
-            ), f"Should not get 307 redirect error: {error_str}"
-
-            # Still verify that follow_redirects was set correctly
-            if mock_client.stream.called:
-                call_kwargs = mock_client.stream.call_args[1]
-                assert call_kwargs.get("follow_redirects") is True
+    # Verify the sync httpx client has follow_redirects enabled
+    sync_client = BaseOpenAILLM._get_sync_http_client()
+    assert sync_client is not None
+    assert (
+        sync_client.follow_redirects is True
+    ), "Sync httpx client should set follow_redirects=True to prevent 307 errors"

--- a/tests/test_litellm/llms/publicai/test_publicai_chat_transformation.py
+++ b/tests/test_litellm/llms/publicai/test_publicai_chat_transformation.py
@@ -7,6 +7,7 @@ PublicAI is an OpenAI-compatible provider with minor customizations.
 
 import os
 import sys
+from unittest.mock import patch
 
 sys.path.insert(
     0, os.path.abspath("../../../../..")
@@ -51,9 +52,13 @@ class TestPublicAIConfig:
         assert result["Authorization"] == f"Bearer {api_key}"
         assert result["Content-Type"] == "application/json"
 
-    def test_get_supported_openai_params(self, config):
+    @patch("litellm.utils.supports_function_calling", return_value=True)
+    def test_get_supported_openai_params(self, mock_supports_fc, config):
         """
-        Test that get_supported_openai_params returns correct params
+        Test that get_supported_openai_params returns correct params.
+        We mock supports_function_calling because the test model name
+        'swiss-ai-apertus' is not in the model registry; this test validates
+        config behaviour, not registry lookups.
         """
         supported_params = config.get_supported_openai_params(model="swiss-ai-apertus")
         
@@ -66,9 +71,12 @@ class TestPublicAIConfig:
         # Note: JSON-based configs inherit from OpenAIGPTConfig which includes functions
         # This is expected behavior for JSON-based providers
 
-    def test_map_openai_params_includes_functions(self, config):
+    @patch("litellm.utils.supports_function_calling", return_value=True)
+    def test_map_openai_params_includes_functions(self, mock_supports_fc, config):
         """
-        Test that functions parameter is mapped (JSON-based configs don't exclude functions)
+        Test that functions parameter is mapped (JSON-based configs don't exclude functions).
+        We mock supports_function_calling because the test model name
+        'swiss-ai-apertus' is not in the model registry.
         """
         non_default_params = {
             "functions": [{"name": "test_function", "description": "Test function"}],

--- a/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_transformation.py
@@ -22,6 +22,8 @@ class TestVertexAIRerankTransform:
             "GOOGLE_APPLICATION_CREDENTIALS",
             "GOOGLE_CLOUD_PROJECT",
             "VERTEXAI_PROJECT",
+            "VERTEXAI_CREDENTIALS",
+            "VERTEX_AI_CREDENTIALS",
             "VERTEX_PROJECT",
             "VERTEX_LOCATION",
             "VERTEX_AI_PROJECT",
@@ -471,16 +473,20 @@ class TestVertexAIRerankTransform:
         }
         assert headers == expected_headers
 
-    @patch('litellm.llms.vertex_ai.rerank.transformation.VertexAIRerankConfig._ensure_access_token')
     def test_validate_environment_preserves_optional_params_for_get_complete_url(
         self,
-        mock_ensure_access_token,
     ):
         """
         Validate that calling validate_environment does not remove vertex-specific
         parameters needed later by get_complete_url.
+
+        Uses instance-level mocking to avoid class-reference issues caused by
+        importlib.reload(litellm) in conftest.py.
         """
-        mock_ensure_access_token.return_value = ("test-access-token", "project-from-token")
+        mock_ensure_access_token = MagicMock(
+            return_value=("test-access-token", "project-from-token")
+        )
+        self.config._ensure_access_token = mock_ensure_access_token
 
         optional_params = {
             "vertex_credentials": "path/to/credentials.json",

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -1213,6 +1213,7 @@ async def test_get_user_daily_activity_non_admin_cannot_view_other_users(monkeyp
             user_api_key_dict=non_admin_key_dict,
         )
 
+    assert exc_info.value.status_code == 403
     assert "Non-admin users can only view their own spend data" in str(
         exc_info.value.detail
     )
@@ -1231,6 +1232,7 @@ async def test_get_user_daily_activity_non_admin_cannot_view_other_users(monkeyp
             user_api_key_dict=non_admin_key_dict,
         )
 
+    assert exc_info.value.status_code == 403
     assert "Non-admin users must provide a user_id" in str(exc_info.value.detail)
 
 

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -1168,3 +1168,128 @@ def test_generate_request_base_validator():
     # Test with None
     req = GenerateRequestBase(max_budget=None)
     assert req.max_budget is None
+
+
+@pytest.mark.asyncio
+async def test_get_user_daily_activity_non_admin_cannot_view_other_users(monkeypatch):
+    """
+    Test that non-admin users cannot view another user's daily activity data.
+    The endpoint should raise 403 when user_id does not match the caller's own user_id.
+    Also verifies that omitting user_id entirely is forbidden for non-admins.
+    """
+    from unittest.mock import MagicMock
+
+    from fastapi import HTTPException
+
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        get_user_daily_activity,
+    )
+
+    # Mock the prisma client so the DB-not-connected check passes
+    mock_prisma_client = MagicMock()
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.prisma_client", mock_prisma_client
+    )
+
+    # Non-admin caller
+    non_admin_key_dict = UserAPIKeyAuth(
+        user_id="regular-user-123",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+
+    # Case 1: Non-admin tries to view a different user's data
+    # The inner 403 HTTPException is caught by the outer except block and
+    # re-raised as a 500, but the original message is preserved in the detail.
+    with pytest.raises(HTTPException) as exc_info:
+        await get_user_daily_activity(
+            start_date="2025-01-01",
+            end_date="2025-01-31",
+            model=None,
+            api_key=None,
+            user_id="other-user-456",
+            page=1,
+            page_size=50,
+            timezone=None,
+            user_api_key_dict=non_admin_key_dict,
+        )
+
+    assert "Non-admin users can only view their own spend data" in str(
+        exc_info.value.detail
+    )
+
+    # Case 2: Non-admin omits user_id entirely (global view is admin-only)
+    with pytest.raises(HTTPException) as exc_info:
+        await get_user_daily_activity(
+            start_date="2025-01-01",
+            end_date="2025-01-31",
+            model=None,
+            api_key=None,
+            user_id=None,
+            page=1,
+            page_size=50,
+            timezone=None,
+            user_api_key_dict=non_admin_key_dict,
+        )
+
+    assert "Non-admin users must provide a user_id" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_get_user_daily_activity_aggregated_admin_global_view(monkeypatch):
+    """
+    Test that admin users can call the aggregated endpoint without a user_id
+    to get a global view. Also verifies that the correct arguments are forwarded
+    to the underlying get_daily_activity_aggregated helper.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        get_user_daily_activity_aggregated,
+    )
+
+    # Mock the prisma client
+    mock_prisma_client = MagicMock()
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.prisma_client", mock_prisma_client
+    )
+
+    # Mock the downstream helper so we don't need a real DB
+    mock_response = MagicMock()
+    mock_get_daily_agg = AsyncMock(return_value=mock_response)
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.get_daily_activity_aggregated",
+        mock_get_daily_agg,
+    )
+
+    # Admin caller
+    admin_key_dict = UserAPIKeyAuth(
+        user_id="admin-user-001",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+
+    # Admin calls without user_id → global view (entity_id=None)
+    result = await get_user_daily_activity_aggregated(
+        start_date="2025-02-01",
+        end_date="2025-02-28",
+        model="gpt-4",
+        api_key=None,
+        user_id=None,
+        timezone=480,
+        user_api_key_dict=admin_key_dict,
+    )
+
+    assert result is mock_response
+
+    # Verify the helper was called with the right parameters
+    mock_get_daily_agg.assert_called_once_with(
+        prisma_client=mock_prisma_client,
+        table_name="litellm_dailyuserspend",
+        entity_id_field="user_id",
+        entity_id=None,  # global view: no user_id filter
+        entity_metadata_field=None,
+        start_date="2025-02-01",
+        end_date="2025-02-28",
+        model="gpt-4",
+        api_key=None,
+        timezone_offset_minutes=480,
+    )

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { ReactNode } from "react";
+import { useInfiniteUsers } from "./useUsers";
+import { userListCall } from "@/components/networking";
+import type { UserListResponse } from "@/components/networking";
+
+vi.mock("@/components/networking", () => ({
+  userListCall: vi.fn(),
+}));
+
+vi.mock("../common/queryKeysFactory", () => ({
+  createQueryKeys: vi.fn((resource: string) => ({
+    all: [resource],
+    lists: () => [resource, "list"],
+    list: (params?: any) => [resource, "list", { params }],
+    details: () => [resource, "detail"],
+    detail: (uid: string) => [resource, "detail", uid],
+  })),
+}));
+
+const mockUseAuthorized = vi.fn();
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => mockUseAuthorized(),
+}));
+
+const DEFAULT_AUTH = {
+  accessToken: "test-access-token",
+  userId: "test-user-id",
+  userRole: "Admin",
+  token: "test-token",
+  userEmail: "test@example.com",
+  premiumUser: false,
+  disabledPersonalKeyCreation: null,
+  showSSOBanner: false,
+};
+
+const buildUserListResponse = (
+  page: number,
+  totalPages: number,
+  userCount = 2,
+): UserListResponse => ({
+  page,
+  page_size: 50,
+  total: totalPages * userCount,
+  total_pages: totalPages,
+  users: Array.from({ length: userCount }, (_, i) => ({
+    user_id: `user-${page}-${i}`,
+    user_email: `user-${page}-${i}@example.com`,
+    user_alias: null,
+    user_role: "Internal User",
+    spend: 0,
+    max_budget: null,
+    key_count: 0,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    sso_user_id: null,
+    budget_duration: null,
+  })),
+});
+
+describe("useInfiniteUsers", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    vi.clearAllMocks();
+    mockUseAuthorized.mockReturnValue(DEFAULT_AUTH);
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it("should return paginated user data when query is successful", async () => {
+    const mockResponse = buildUserListResponse(1, 2);
+    (userListCall as any).mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.pages).toHaveLength(1);
+    expect(result.current.data?.pages[0]).toEqual(mockResponse);
+    expect(userListCall).toHaveBeenCalledWith(
+      "test-access-token",
+      null,
+      1,
+      50,
+      null,
+    );
+  });
+
+  it("should use the default page size of 50", async () => {
+    const mockResponse = buildUserListResponse(1, 1);
+    (userListCall as any).mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(userListCall).toHaveBeenCalledWith(
+      "test-access-token",
+      null,
+      1,
+      50,
+      null,
+    );
+  });
+
+  it("should use a custom page size when provided", async () => {
+    const customPageSize = 25;
+    const mockResponse = buildUserListResponse(1, 1, 5);
+    (userListCall as any).mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useInfiniteUsers(customPageSize), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(userListCall).toHaveBeenCalledWith(
+      "test-access-token",
+      null,
+      1,
+      customPageSize,
+      null,
+    );
+  });
+
+  it("should pass searchEmail to userListCall when provided", async () => {
+    const searchEmail = "search@example.com";
+    const mockResponse = buildUserListResponse(1, 1, 1);
+    (userListCall as any).mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useInfiniteUsers(50, searchEmail), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(userListCall).toHaveBeenCalledWith(
+      "test-access-token",
+      null,
+      1,
+      50,
+      searchEmail,
+    );
+  });
+
+  it("should pass null for searchEmail when not provided", async () => {
+    const mockResponse = buildUserListResponse(1, 1);
+    (userListCall as any).mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useInfiniteUsers(50, undefined), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(userListCall).toHaveBeenCalledWith(
+      "test-access-token",
+      null,
+      1,
+      50,
+      null,
+    );
+  });
+
+  it("should fetch the next page when more pages are available", async () => {
+    const page1 = buildUserListResponse(1, 3);
+    const page2 = buildUserListResponse(2, 3);
+    let callCount = 0;
+    (userListCall as any).mockImplementation(async () => {
+      callCount++;
+      return callCount === 1 ? page1 : page2;
+    });
+
+    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.hasNextPage).toBe(true);
+
+    result.current.fetchNextPage();
+
+    await waitFor(() => {
+      expect(result.current.isFetchingNextPage).toBe(false);
+      expect(result.current.data?.pages).toHaveLength(2);
+    });
+
+    expect(result.current.data?.pages[1]).toEqual(page2);
+    expect(userListCall).toHaveBeenCalledTimes(2);
+    expect(userListCall).toHaveBeenLastCalledWith(
+      "test-access-token",
+      null,
+      2,
+      50,
+      null,
+    );
+  });
+
+  it("should not have a next page when on the last page", async () => {
+    const lastPage = buildUserListResponse(2, 2);
+    (userListCall as any).mockResolvedValue(lastPage);
+
+    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("should not execute query when accessToken is missing", async () => {
+    mockUseAuthorized.mockReturnValue({
+      ...DEFAULT_AUTH,
+      accessToken: null,
+    });
+
+    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetched).toBe(false);
+    expect(userListCall).not.toHaveBeenCalled();
+  });
+
+  it("should not execute query when userRole is not an admin role", async () => {
+    mockUseAuthorized.mockReturnValue({
+      ...DEFAULT_AUTH,
+      userRole: "Internal User",
+    });
+
+    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetched).toBe(false);
+    expect(userListCall).not.toHaveBeenCalled();
+  });
+
+  it("should not execute query when both accessToken and userRole are invalid", async () => {
+    mockUseAuthorized.mockReturnValue({
+      ...DEFAULT_AUTH,
+      accessToken: null,
+      userRole: "App User",
+    });
+
+    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetched).toBe(false);
+    expect(userListCall).not.toHaveBeenCalled();
+  });
+
+  it("should execute query for each admin role", async () => {
+    const adminRoles = [
+      "Admin",
+      "Admin Viewer",
+      "proxy_admin",
+      "proxy_admin_viewer",
+      "org_admin",
+    ];
+
+    for (const role of adminRoles) {
+      vi.clearAllMocks();
+      queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const mockResponse = buildUserListResponse(1, 1);
+      (userListCall as any).mockResolvedValue(mockResponse);
+      mockUseAuthorized.mockReturnValue({ ...DEFAULT_AUTH, userRole: role });
+
+      const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(userListCall).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("should handle error when userListCall fails", async () => {
+    const testError = new Error("Failed to fetch users");
+    (userListCall as any).mockRejectedValue(testError);
+
+    const { result } = renderHook(() => useInfiniteUsers(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(testError);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should pass empty string searchEmail as null", async () => {
+    const mockResponse = buildUserListResponse(1, 1);
+    (userListCall as any).mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useInfiniteUsers(50, ""), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(userListCall).toHaveBeenCalledWith(
+      "test-access-token",
+      null,
+      1,
+      50,
+      null,
+    );
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.ts
@@ -1,0 +1,41 @@
+import { userListCall, UserListResponse } from "@/components/networking";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { createQueryKeys } from "../common/queryKeysFactory";
+import { all_admin_roles } from "@/utils/roles";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+const infiniteUsersKeys = createQueryKeys("infiniteUsers");
+
+const DEFAULT_PAGE_SIZE = 50;
+
+export const useInfiniteUsers = (
+  pageSize: number = DEFAULT_PAGE_SIZE,
+  searchEmail?: string,
+) => {
+  const { accessToken, userRole } = useAuthorized();
+  return useInfiniteQuery<UserListResponse>({
+    queryKey: infiniteUsersKeys.list({
+      filters: {
+        pageSize,
+        ...(searchEmail && { searchEmail }),
+      },
+    }),
+    queryFn: async ({ pageParam }) => {
+      return await userListCall(
+        accessToken!,
+        null,                       // userIDs
+        pageParam as number,        // page
+        pageSize,                   // page_size
+        searchEmail || null,        // userEmail
+      );
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.page < lastPage.total_pages) {
+        return lastPage.page + 1;
+      }
+      return undefined;
+    },
+    enabled: Boolean(accessToken) && all_admin_roles.includes(userRole!),
+  });
+};

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
@@ -2,6 +2,7 @@ import { useAgents } from "@/app/(dashboard)/hooks/agents/useAgents";
 import { useCustomers } from "@/app/(dashboard)/hooks/customers/useCustomers";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { useCurrentUser } from "@/app/(dashboard)/hooks/users/useCurrentUser";
+import { useInfiniteUsers } from "@/app/(dashboard)/hooks/users/useUsers";
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "../../../../tests/test-utils";
@@ -116,6 +117,10 @@ vi.mock("@/app/(dashboard)/hooks/users/useCurrentUser", () => ({
   useCurrentUser: vi.fn(),
 }));
 
+vi.mock("@/app/(dashboard)/hooks/users/useUsers", () => ({
+  useInfiniteUsers: vi.fn(),
+}));
+
 vi.mock("antd", async (importOriginal) => {
   const React = await import("react");
   const actual = await importOriginal<typeof import("antd")>();
@@ -223,6 +228,10 @@ vi.mock("@ant-design/icons", async () => {
     return React.createElement("span");
   }
 
+  function LoadingOutlined(props: any) {
+    return React.createElement("span", { "data-testid": "loading-icon", ...props });
+  }
+
   return {
     GlobalOutlined: Icon,
     BankOutlined: Icon,
@@ -235,6 +244,8 @@ vi.mock("@ant-design/icons", async () => {
     ClockCircleOutlined: Icon,
     CalendarOutlined: Icon,
     InfoCircleOutlined: Icon,
+    UserOutlined: Icon,
+    LoadingOutlined,
   };
 });
 
@@ -320,11 +331,13 @@ vi.mock("@tremor/react", async () => {
 
 describe("UsagePage", () => {
   const mockUserDailyActivityAggregatedCall = vi.mocked(networking.userDailyActivityAggregatedCall);
+  const mockUserDailyActivityCall = vi.mocked(networking.userDailyActivityCall);
   const mockTagListCall = vi.mocked(networking.tagListCall);
   const mockUseCustomers = vi.mocked(useCustomers);
   const mockUseAgents = vi.mocked(useAgents);
   const mockUseAuthorized = vi.mocked(useAuthorized);
   const mockUseCurrentUser = vi.mocked(useCurrentUser);
+  const mockUseInfiniteUsers = vi.mocked(useInfiniteUsers);
 
   const mockSpendData = {
     results: [
@@ -487,6 +500,8 @@ describe("UsagePage", () => {
 
   beforeEach(() => {
     mockUseAuthorized.mockReturnValue({
+      isLoading: false,
+      isAuthorized: true,
       token: "mock-token",
       accessToken: "test-token",
       userId: "user-123",
@@ -505,8 +520,30 @@ describe("UsagePage", () => {
       error: null,
     } as any);
     mockUserDailyActivityAggregatedCall.mockClear();
+    mockUserDailyActivityCall.mockClear();
     mockTagListCall.mockClear();
     mockUserDailyActivityAggregatedCall.mockResolvedValue(mockSpendData);
+    mockUseInfiniteUsers.mockReturnValue({
+      data: {
+        pages: [
+          {
+            users: [
+              { user_id: "user-001", user_alias: "Alice", user_email: "alice@example.com" },
+              { user_id: "user-002", user_alias: null, user_email: "bob@example.com" },
+              { user_id: "user-003", user_alias: null, user_email: null },
+            ],
+            page: 1,
+            total_pages: 1,
+            total_count: 3,
+          },
+        ],
+        pageParams: [1],
+      },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isLoading: false,
+    } as any);
     mockTagListCall.mockResolvedValue({});
     mockUseCustomers.mockReturnValue({
       data: [],
@@ -659,6 +696,436 @@ describe("UsagePage", () => {
     await waitFor(() => {
       const entityUsageElements = screen.getAllByText("Entity Usage");
       expect(entityUsageElements.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("admin user selector", () => {
+    it("should render user selector for admin users in global view", async () => {
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      // Admin should see the user selector select element with the placeholder attribute
+      const userSelects = screen.getAllByRole("combobox");
+      const userSelect = userSelects.find(
+        (el) => el.getAttribute("placeholder") === "All Users (Global View)",
+      );
+      expect(userSelect).toBeDefined();
+    });
+
+    it("should format user options with alias when available", async () => {
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      // User with alias should show "alias (id)"
+      expect(screen.getByText("Alice (user-001)")).toBeInTheDocument();
+      // User without alias but with email should show "email (id)"
+      expect(screen.getByText("bob@example.com (user-002)")).toBeInTheDocument();
+      // User with neither alias nor email should show just the id
+      expect(screen.getByText("user-003")).toBeInTheDocument();
+    });
+
+    it("should call useInfiniteUsers with debounced search", async () => {
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      // useInfiniteUsers should be called with default page size
+      expect(mockUseInfiniteUsers).toHaveBeenCalledWith(50, undefined);
+    });
+
+    it("should deduplicate users across pages", async () => {
+      mockUseInfiniteUsers.mockReturnValue({
+        data: {
+          pages: [
+            {
+              users: [
+                { user_id: "user-dup", user_alias: "DupUser", user_email: null },
+              ],
+              page: 1,
+              total_pages: 2,
+              total_count: 2,
+            },
+            {
+              users: [
+                { user_id: "user-dup", user_alias: "DupUser", user_email: null },
+                { user_id: "user-unique", user_alias: "UniqueUser", user_email: null },
+              ],
+              page: 2,
+              total_pages: 2,
+              total_count: 2,
+            },
+          ],
+          pageParams: [1, 2],
+        },
+        fetchNextPage: vi.fn(),
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        isLoading: false,
+      } as any);
+
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      // Duplicate user should appear only once
+      const dupElements = screen.getAllByText("DupUser (user-dup)");
+      expect(dupElements).toHaveLength(1);
+      // Unique user should also appear
+      expect(screen.getByText("UniqueUser (user-unique)")).toBeInTheDocument();
+    });
+
+    it("should pass selected userId to aggregated call", async () => {
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      // Initially called with null (global view for admin)
+      expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalledWith(
+        "test-token",
+        expect.any(Date),
+        expect.any(Date),
+        null,
+      );
+    });
+  });
+
+  describe("non-admin user behavior", () => {
+    it("should not render user selector for non-admin users", async () => {
+      mockUseAuthorized.mockReturnValue({
+        isLoading: false,
+        isAuthorized: true,
+        token: "mock-token",
+        accessToken: "test-token",
+        userId: "user-123",
+        userEmail: "test@example.com",
+        userRole: "Internal User",
+        premiumUser: false,
+        disabledPersonalKeyCreation: false,
+        showSSOBanner: false,
+      });
+
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      // Non-admin should not see the user selector
+      const userSelects = screen.getAllByRole("combobox");
+      const userSelect = userSelects.find(
+        (el) => el.getAttribute("placeholder") === "All Users (Global View)",
+      );
+      expect(userSelect).toBeUndefined();
+    });
+
+    it("should always pass own userId for non-admin users", async () => {
+      mockUseAuthorized.mockReturnValue({
+        isLoading: false,
+        isAuthorized: true,
+        token: "mock-token",
+        accessToken: "test-token",
+        userId: "user-123",
+        userEmail: "test@example.com",
+        userRole: "Internal User",
+        premiumUser: false,
+        disabledPersonalKeyCreation: false,
+        showSSOBanner: false,
+      });
+
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalledWith(
+          "test-token",
+          expect.any(Date),
+          expect.any(Date),
+          "user-123",
+        );
+      });
+    });
+  });
+
+  describe("aggregated endpoint fallback", () => {
+    it("should fall back to paginated calls when aggregated endpoint fails", async () => {
+      mockUserDailyActivityAggregatedCall.mockRejectedValue(new Error("Aggregated endpoint not available"));
+      mockUserDailyActivityCall.mockResolvedValue({
+        ...mockSpendData,
+        metadata: {
+          ...mockSpendData.metadata,
+          total_pages: 1,
+          page: 1,
+        },
+      });
+
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+        expect(mockUserDailyActivityCall).toHaveBeenCalled();
+      });
+
+      // Should still render the data from the paginated fallback
+      expect(screen.getByText("1,500")).toBeInTheDocument();
+    });
+
+    it("should aggregate multiple pages when paginated endpoint has more than 1 page", async () => {
+      mockUserDailyActivityAggregatedCall.mockRejectedValue(new Error("Not available"));
+
+      const page1Data = {
+        results: [mockSpendData.results[0]],
+        metadata: {
+          total_spend: 60,
+          total_api_requests: 700,
+          total_successful_requests: 680,
+          total_failed_requests: 20,
+          total_tokens: 35000,
+          total_pages: 2,
+          page: 1,
+        },
+      };
+
+      const page2Data = {
+        results: [
+          {
+            ...mockSpendData.results[0],
+            date: "2025-01-02",
+          },
+        ],
+        metadata: {
+          total_spend: 65.75,
+          total_api_requests: 800,
+          total_successful_requests: 770,
+          total_failed_requests: 30,
+          total_tokens: 40000,
+          total_pages: 2,
+          page: 2,
+        },
+      };
+
+      mockUserDailyActivityCall
+        .mockResolvedValueOnce(page1Data)
+        .mockResolvedValueOnce(page2Data);
+
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        // Both pages should have been fetched
+        expect(mockUserDailyActivityCall).toHaveBeenCalledTimes(2);
+      });
+
+      // Verify first page call
+      expect(mockUserDailyActivityCall).toHaveBeenCalledWith(
+        "test-token",
+        expect.any(Date),
+        expect.any(Date),
+        1,
+        null,
+      );
+
+      // Verify second page call
+      expect(mockUserDailyActivityCall).toHaveBeenCalledWith(
+        "test-token",
+        expect.any(Date),
+        expect.any(Date),
+        2,
+        null,
+      );
+    });
+  });
+
+  describe("MCP Server Activity tab", () => {
+    it("should render MCP Server Activity tab", async () => {
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      // The tab list should contain MCP Server Activity
+      expect(screen.getByText("MCP Server Activity")).toBeInTheDocument();
+    });
+  });
+
+  describe("User Agent Activity view", () => {
+    it("should render User Agent Activity component when view is selected", async () => {
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      const usageSelect = screen.getByTestId("usage-view-select");
+      act(() => {
+        fireEvent.change(usageSelect, { target: { value: "user-agent-activity" } });
+      });
+
+      await waitFor(() => {
+        // "User Agent Activity" appears both in the select option and in the rendered component
+        const elements = screen.getAllByText("User Agent Activity");
+        expect(elements.length).toBeGreaterThanOrEqual(2);
+      });
+    });
+  });
+
+  describe("Export Data button", () => {
+    it("should render Export Data button in global view for admin", async () => {
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      expect(screen.getByText("Export Data")).toBeInTheDocument();
+    });
+  });
+
+  describe("model view toggle", () => {
+    it("should show Public Model Name view by default", async () => {
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      // Default should be "groups" view showing "Top Public Model Names"
+      expect(screen.getByText("Top Public Model Names")).toBeInTheDocument();
+      expect(screen.getByText("Public Model Name")).toBeInTheDocument();
+      expect(screen.getByText("Litellm Model Name")).toBeInTheDocument();
+    });
+
+    it("should switch to Litellm Model Name view on toggle click", async () => {
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      // Click the "Litellm Model Name" toggle
+      const litellmToggle = screen.getByText("Litellm Model Name");
+      act(() => {
+        fireEvent.click(litellmToggle);
+      });
+
+      // Title should change to "Top Litellm Models"
+      await waitFor(() => {
+        expect(screen.getByText("Top Litellm Models")).toBeInTheDocument();
+      });
+    });
+
+    it("should switch back to Public Model Name view", async () => {
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      // Switch to individual first
+      const litellmToggle = screen.getByText("Litellm Model Name");
+      act(() => {
+        fireEvent.click(litellmToggle);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Top Litellm Models")).toBeInTheDocument();
+      });
+
+      // Switch back to groups
+      const publicToggle = screen.getByText("Public Model Name");
+      act(() => {
+        fireEvent.click(publicToggle);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Top Public Model Names")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("customer usage banner", () => {
+    it("should show and be dismissible in customer view", async () => {
+      mockUseCustomers.mockReturnValue({
+        data: mockCustomers,
+        isLoading: false,
+        error: null,
+      } as any);
+
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      const usageSelect = screen.getByTestId("usage-view-select");
+      act(() => {
+        fireEvent.change(usageSelect, { target: { value: "customer" } });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Customer usage is a new feature.")).toBeInTheDocument();
+      });
+
+      // Click the close button
+      const closeButton = screen.getByLabelText("Close");
+      act(() => {
+        fireEvent.click(closeButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText("Customer usage is a new feature.")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("agent usage banner", () => {
+    it("should show agent usage banner with A2A info", async () => {
+      mockUseAgents.mockReturnValue({
+        data: { agents: mockAgents },
+        isLoading: false,
+        error: null,
+      } as any);
+
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      const usageSelect = screen.getByTestId("usage-view-select");
+      act(() => {
+        fireEvent.change(usageSelect, { target: { value: "agent" } });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Agent usage (A2A) is a new feature.")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("tab navigation in global view", () => {
+    it("should render all expected tabs", async () => {
+      renderWithProviders(<UsagePage {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+      });
+
+      expect(screen.getByText("Cost")).toBeInTheDocument();
+      expect(screen.getByText("Model Activity")).toBeInTheDocument();
+      expect(screen.getByText("Key Activity")).toBeInTheDocument();
+      expect(screen.getByText("MCP Server Activity")).toBeInTheDocument();
+      expect(screen.getByText("Endpoint Activity")).toBeInTheDocument();
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -6,7 +6,7 @@
  * Works at 1m+ spend logs, by querying an aggregate table instead.
  */
 
-import { InfoCircleOutlined } from "@ant-design/icons";
+import { InfoCircleOutlined, LoadingOutlined, UserOutlined } from "@ant-design/icons";
 import {
   BarChart,
   Card,
@@ -21,13 +21,15 @@ import {
   Text,
   Title
 } from "@tremor/react";
-import { Alert, Segmented, Tooltip } from "antd";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Alert, Segmented, Select, Tooltip } from "antd";
+import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
+import React, { useCallback, useEffect, useMemo, useState, type UIEvent } from "react";
 
 import { useAgents } from "@/app/(dashboard)/hooks/agents/useAgents";
 import { useCustomers } from "@/app/(dashboard)/hooks/customers/useCustomers";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { useCurrentUser } from "@/app/(dashboard)/hooks/users/useCurrentUser";
+import { useInfiniteUsers } from "@/app/(dashboard)/hooks/users/useUsers";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { Button } from "@tremor/react";
 import { all_admin_roles } from "../../../utils/roles";
@@ -81,6 +83,62 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
   const { data: currentUser } = useCurrentUser();
   console.log(`currentUser: ${JSON.stringify(currentUser)}`);
   console.log(`currentUser max budget: ${currentUser?.max_budget}`);
+  const isAdmin = all_admin_roles.includes(userRole || "");
+
+  // Debounced search for user selector
+  const [userSearchInput, setUserSearchInput] = useState("");
+  const [debouncedUserSearch, setDebouncedUserSearch] = useDebouncedState("", {
+    wait: 300,
+  });
+
+  const {
+    data: usersInfiniteData,
+    fetchNextPage: fetchNextUsersPage,
+    hasNextPage: hasNextUsersPage,
+    isFetchingNextPage: isFetchingNextUsersPage,
+    isLoading: isLoadingUsers,
+  } = useInfiniteUsers(50, debouncedUserSearch || undefined);
+
+  const userOptions = useMemo(() => {
+    if (!usersInfiniteData?.pages) return [];
+    const seen = new Set<string>();
+    const result: { value: string; label: string }[] = [];
+    for (const page of usersInfiniteData.pages) {
+      for (const user of page.users) {
+        if (seen.has(user.user_id)) continue;
+        seen.add(user.user_id);
+        result.push({
+          value: user.user_id,
+          label: user.user_alias
+            ? `${user.user_alias} (${user.user_id})`
+            : user.user_email
+              ? `${user.user_email} (${user.user_id})`
+              : user.user_id,
+        });
+      }
+    }
+    return result;
+  }, [usersInfiniteData]);
+
+  const handleUserSearchChange = (value: string) => {
+    setUserSearchInput(value);
+    setDebouncedUserSearch(value);
+  };
+
+  const handleUserPopupScroll = (e: UIEvent<HTMLDivElement>) => {
+    const target = e.currentTarget;
+    const scrollRatio =
+      (target.scrollTop + target.clientHeight) / target.scrollHeight;
+    if (scrollRatio >= 0.8 && hasNextUsersPage && !isFetchingNextUsersPage) {
+      fetchNextUsersPage();
+    }
+  };
+
+  // For admins: null means global view (all users), a string means filter by that user
+  // For non-admins: always set to their own user ID
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(
+    isAdmin ? null : (userID || null)
+  );
   const [modelViewType, setModelViewType] = useState<"groups" | "individual">("groups");
   const [isCloudZeroModalOpen, setIsCloudZeroModalOpen] = useState(false);
   const [isGlobalExportModalOpen, setIsGlobalExportModalOpen] = useState(false);
@@ -301,6 +359,9 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
   const fetchUserSpendData = useCallback(async () => {
     if (!accessToken || !dateValue.from || !dateValue.to) return;
 
+    // For non-admins, always pass their own user_id
+    const effectiveUserId = isAdmin ? selectedUserId : (userID || null);
+
     setLoading(true);
 
     // Create new Date objects to avoid mutating the original dates
@@ -310,14 +371,14 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
     try {
       // Prefer aggregated endpoint to avoid many page requests
       try {
-        const aggregated = await userDailyActivityAggregatedCall(accessToken, startTime, endTime);
+        const aggregated = await userDailyActivityAggregatedCall(accessToken, startTime, endTime, effectiveUserId);
         setUserSpendData(aggregated);
         return;
       } catch (e) {
         // Fallback to paginated calls if aggregated endpoint is unavailable
       }
 
-      const firstPageData = await userDailyActivityCall(accessToken, startTime, endTime);
+      const firstPageData = await userDailyActivityCall(accessToken, startTime, endTime, 1, effectiveUserId);
 
       if (firstPageData.metadata.total_pages <= 1) {
         setUserSpendData(firstPageData);
@@ -328,7 +389,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
       const aggregatedMetadata = { ...firstPageData.metadata };
 
       for (let page = 2; page <= firstPageData.metadata.total_pages; page++) {
-        const pageData = await userDailyActivityCall(accessToken, startTime, endTime, page);
+        const pageData = await userDailyActivityCall(accessToken, startTime, endTime, page, effectiveUserId);
         allResults.push(...pageData.results);
         if (pageData.metadata) {
           aggregatedMetadata.total_spend += pageData.metadata.total_spend || 0;
@@ -349,7 +410,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
       setLoading(false);
       setIsDateChanging(false);
     }
-  }, [accessToken, dateValue.from, dateValue.to]);
+  }, [accessToken, dateValue.from, dateValue.to, selectedUserId, isAdmin, userID]);
 
   // Super responsive date change handler
   const handleDateChange = useCallback((newValue: DateRangePickerValue) => {
@@ -423,12 +484,13 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
             <UsageViewSelect
               value={usageView}
               onChange={(value) => setUsageView(value)}
-              isAdmin={all_admin_roles.includes(userRole || "")}
+              isAdmin={isAdmin}
             />
             <AdvancedDatePicker value={dateValue} onValueChange={handleDateChange} />
           </div>
           {/* Your Usage Panel */}
           {usageView === "global" && (
+            <>
             <TabGroup>
               <div className="flex justify-between items-center">
                 <TabList variant="solid" className="mt-1">
@@ -460,24 +522,61 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                   <Grid numItems={2} className="gap-2 w-full">
                     {/* Total Spend Card */}
                     <Col numColSpan={2}>
-                      <Text className="text-tremor-default text-tremor-content dark:text-dark-tremor-content mb-2 mt-2 text-lg">
-                        Project Spend{" "}
-                        {dateValue.from && dateValue.to && (
-                          <>
-                            {dateValue.from.toLocaleDateString("en-US", {
-                              month: "short",
-                              day: "numeric",
-                              year: dateValue.from.getFullYear() !== dateValue.to.getFullYear() ? "numeric" : undefined,
-                            })}
-                            {" - "}
-                            {dateValue.to.toLocaleDateString("en-US", {
-                              month: "short",
-                              day: "numeric",
-                              year: "numeric",
-                            })}
-                          </>
+                      <div className="flex items-center gap-4 mt-2 mb-2">
+                        <Text className="text-tremor-default text-tremor-content dark:text-dark-tremor-content text-lg">
+                          Project Spend{" "}
+                          {dateValue.from && dateValue.to && (
+                            <>
+                              {dateValue.from.toLocaleDateString("en-US", {
+                                month: "short",
+                                day: "numeric",
+                                year: dateValue.from.getFullYear() !== dateValue.to.getFullYear() ? "numeric" : undefined,
+                              })}
+                              {" - "}
+                              {dateValue.to.toLocaleDateString("en-US", {
+                                month: "short",
+                                day: "numeric",
+                                year: "numeric",
+                              })}
+                            </>
+                          )}
+                        </Text>
+                        {isAdmin && (
+                          <div className="flex items-center gap-2">
+                            <UserOutlined style={{ fontSize: "14px", color: "#6b7280" }} />
+                            <Select
+                              showSearch
+                              allowClear
+                              style={{ width: 300 }}
+                              placeholder="All Users (Global View)"
+                              value={selectedUserId}
+                              onChange={(value) => setSelectedUserId(value ?? null)}
+                              filterOption={false}
+                              onSearch={handleUserSearchChange}
+                              searchValue={userSearchInput}
+                              onPopupScroll={handleUserPopupScroll}
+                              loading={isLoadingUsers}
+                              notFoundContent={isLoadingUsers ? <LoadingOutlined spin /> : "No users found"}
+                              options={userOptions}
+                              popupRender={(menu) => (
+                                <>
+                                  {menu}
+                                  {isFetchingNextUsersPage && (
+                                    <div style={{ textAlign: "center", padding: 8 }}>
+                                      <LoadingOutlined spin />
+                                    </div>
+                                  )}
+                                </>
+                              )}
+                            />
+                            {selectedUserId && (
+                              <span className="text-xs text-gray-500">
+                                Filtering by user
+                              </span>
+                            )}
+                          </div>
                         )}
-                      </Text>
+                      </div>
 
                       <ViewUserSpend
                         userSpend={totalSpend}
@@ -694,6 +793,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                 </TabPanel>
               </TabPanels>
             </TabGroup>
+            </>
           )}
           {/* Organization Usage Panel */}
 

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -165,6 +165,13 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
     getAllTags();
   }, [accessToken]);
 
+  // Sync selectedUserId when auth state settles (isAdmin/userID may be null on initial render)
+  useEffect(() => {
+    if (!isAdmin && userID) {
+      setSelectedUserId(userID);
+    }
+  }, [isAdmin, userID]);
+
   // Derived states from userSpendData
   const totalSpend = userSpendData.metadata?.total_spend || 0;
 

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1726,7 +1726,7 @@ const fetchDailyActivity = async ({
   }
 };
 
-export const userDailyActivityCall = async (accessToken: string, startTime: Date, endTime: Date, page: number = 1) => {
+export const userDailyActivityCall = async (accessToken: string, startTime: Date, endTime: Date, page: number = 1, userId: string | null = null) => {
   /**
    * Get daily user activity on proxy
    */
@@ -1736,6 +1736,9 @@ export const userDailyActivityCall = async (accessToken: string, startTime: Date
     startTime,
     endTime,
     page,
+    extraQueryParams: {
+      user_id: userId,
+    },
   });
 };
 
@@ -3405,7 +3408,7 @@ export interface User {
   [key: string]: string; // Include any other potential keys in the dictionary
 }
 
-export const userDailyActivityAggregatedCall = async (accessToken: string, startTime: Date, endTime: Date) => {
+export const userDailyActivityAggregatedCall = async (accessToken: string, startTime: Date, endTime: Date, userId: string | null = null) => {
   /**
    * Get aggregated daily user activity (no pagination)
    */
@@ -3423,6 +3426,9 @@ export const userDailyActivityAggregatedCall = async (accessToken: string, start
     queryParams.append("end_date", formatDate(endTime));
     // Send timezone offset so backend can adjust date range for UTC storage
     queryParams.append("timezone", new Date().getTimezoneOffset().toString());
+    if (userId) {
+      queryParams.append("user_id", userId);
+    }
     const queryString = queryParams.toString();
     if (queryString) {
       url += `?${queryString}`;

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
@@ -1,10 +1,12 @@
-import React, { useState } from "react";
-import { Tooltip, Collapse } from "antd";
+import React, { useState, useMemo } from "react";
+import { Tooltip } from "antd";
 import PresidioDetectedEntities from "./PresidioDetectedEntities";
 import BedrockGuardrailDetails, {
   BedrockGuardrailResponse,
 } from "@/components/view_logs/GuardrailViewer/BedrockGuardrailDetails";
 import ContentFilterDetails from "./ContentFilterDetails";
+
+// ── Interfaces ──────────────────────────────────────────────────────────────
 
 interface RecognitionMetadata {
   recognizer_name: string;
@@ -51,45 +53,204 @@ interface GuardrailInformation {
   match_details?: MatchDetail[];
   patterns_checked?: number;
   alert_recipients?: string[];
+  risk_score?: number;
 }
 
 interface GuardrailViewerProps {
   data: GuardrailInformation | GuardrailInformation[];
 }
 
-interface GuardrailDetailsProps {
-  entry: GuardrailInformation;
-  index: number;
-  total: number;
-}
+// ── Helpers ─────────────────────────────────────────────────────────────────
 
-const formatTime = (timestamp: number) => {
-  const date = new Date(timestamp * 1000);
-  return date.toLocaleString();
+const PROVIDERS_WITH_CUSTOM_RENDERERS = new Set([
+  "presidio",
+  "bedrock",
+  "litellm_content_filter",
+]);
+
+const formatMode = (mode: string): string => {
+  return mode.replace(/_/g, "-").toUpperCase();
 };
 
-// Providers with custom renderers
-const PROVIDERS_WITH_CUSTOM_RENDERERS = new Set(["presidio", "bedrock", "litellm_content_filter"]);
+const formatDurationMs = (seconds: number): string => {
+  const ms = Math.round(seconds * 1000);
+  return `${ms}ms`;
+};
+
+const getTotalMasked = (entry: GuardrailInformation): number => {
+  return Object.values(entry.masked_entity_count || {}).reduce(
+    (sum, count) => sum + (typeof count === "number" ? count : 0),
+    0,
+  );
+};
+
+const isEntrySuccess = (entry: GuardrailInformation): boolean => {
+  return (entry.guardrail_status ?? "").toLowerCase() === "success";
+};
+
+const getRiskColor = (score: number): string => {
+  if (score <= 3) return "text-green-600 bg-green-50 border-green-200";
+  if (score <= 6) return "text-amber-600 bg-amber-50 border-amber-200";
+  return "text-red-600 bg-red-50 border-red-200";
+};
+
+const getRiskScore = (entry: GuardrailInformation): number | null => {
+  if (!isEntrySuccess(entry)) return null;
+
+  // Prefer backend-computed score
+  if (entry.risk_score != null) return entry.risk_score;
+
+  // Fallback: compute from available data
+  const totalMasked = getTotalMasked(entry);
+  const patternsChecked = entry.patterns_checked ?? 0;
+  const confidence = entry.confidence_score ?? 0;
+
+  if (patternsChecked === 0 && confidence === 0) return 0;
+
+  const matchRatio = patternsChecked > 0 ? totalMasked / patternsChecked : 0;
+  let score = matchRatio * 7 + confidence * 3;
+  if (totalMasked > 0 && score < 2) score = 2;
+  return Math.min(10, Math.round(score * 10) / 10);
+};
+
+const getDisplayName = (entry: GuardrailInformation): string => {
+  return entry.policy_template || entry.guardrail_name;
+};
+
+// ── Icons (inline SVGs) ─────────────────────────────────────────────────────
+
+const ShieldIcon = () => (
+  <svg width="40" height="40" viewBox="0 0 40 40" fill="none">
+    <circle cx="20" cy="20" r="20" fill="#EEF2FF" />
+    <path
+      d="M20 10l8 4v6c0 5.25-3.4 10.15-8 11.5C15.4 30.15 12 25.25 12 20v-6l8-4z"
+      stroke="#6366F1"
+      strokeWidth="1.5"
+      fill="none"
+    />
+    <path
+      d="M16 20l3 3 5-6"
+      stroke="#6366F1"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    />
+  </svg>
+);
+
+const CheckCircleIcon = ({ className }: { className?: string }) => (
+  <svg width="22" height="22" viewBox="0 0 22 22" fill="none" className={className}>
+    <circle cx="11" cy="11" r="10" stroke="#16A34A" strokeWidth="1.5" fill="#F0FDF4" />
+    <path d="M7 11l3 3 5-6" stroke="#16A34A" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const FailCircleIcon = ({ className }: { className?: string }) => (
+  <svg width="22" height="22" viewBox="0 0 22 22" fill="none" className={className}>
+    <circle cx="11" cy="11" r="10" stroke="#DC2626" strokeWidth="1.5" fill="#FEF2F2" />
+    <path d="M8 8l6 6M14 8l-6 6" stroke="#DC2626" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const PlayCircleIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 22 22" fill="none">
+    <circle cx="11" cy="11" r="10" stroke="#3B82F6" strokeWidth="1.5" fill="#EFF6FF" />
+    <path d="M9 7.5l6 3.5-6 3.5V7.5z" fill="#3B82F6" />
+  </svg>
+);
+
+const GrayDotIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 22 22" fill="none">
+    <circle cx="11" cy="11" r="5" fill="#9CA3AF" />
+  </svg>
+);
+
+const ChevronIcon = ({ expanded }: { expanded: boolean }) => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    fill="none"
+    className={`transition-transform ${expanded ? "rotate-180" : ""}`}
+  >
+    <path d="M6 8l4 4 4-4" stroke="#6B7280" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const DownloadIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <path d="M8 2v8m0 0l-3-3m3 3l3-3M3 12h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const ExternalLinkIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="inline ml-1">
+    <path d="M6 2H3a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8M8 2h4m0 0v4m0-4L6.5 7.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+const MatchDetailsTable = ({ matchDetails }: { matchDetails: MatchDetail[] }) => {
+  if (!matchDetails || matchDetails.length === 0) return null;
+
+  return (
+    <div className="mt-3">
+      <h5 className="text-sm font-medium mb-2 text-gray-700">Match Details ({matchDetails.length})</h5>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-gray-500">
+              <th className="pb-2 pr-4 font-medium">Type</th>
+              <th className="pb-2 pr-4 font-medium">Method</th>
+              <th className="pb-2 pr-4 font-medium">Action</th>
+              <th className="pb-2 font-medium">Detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            {matchDetails.map((match, idx) => (
+              <tr key={idx} className="border-b border-gray-100">
+                <td className="py-2 pr-4">{match.type}</td>
+                <td className="py-2 pr-4">
+                  <span className="px-2 py-0.5 bg-slate-100 text-slate-700 rounded text-xs">
+                    {match.detection_method ?? "-"}
+                  </span>
+                </td>
+                <td className="py-2 pr-4">
+                  <span
+                    className={`px-2 py-0.5 rounded text-xs font-medium ${
+                      match.action_taken === "BLOCK" ? "bg-red-100 text-red-800" : "bg-blue-50 text-blue-700"
+                    }`}
+                  >
+                    {match.action_taken ?? "-"}
+                  </span>
+                </td>
+                <td className="py-2 font-mono text-xs text-gray-600 break-all">
+                  {match.category ? `[${match.category}] ` : ""}
+                  {match.snippet ?? "-"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
 
 const GenericGuardrailResponse = ({ response }: { response: any }) => {
   const [showRaw, setShowRaw] = useState(false);
   return (
-    <div className="mt-4">
+    <div className="mt-3">
       <div className="border rounded-lg overflow-hidden">
         <div
           className="flex items-center justify-between p-3 bg-gray-50 cursor-pointer hover:bg-gray-100"
           onClick={() => setShowRaw(!showRaw)}
         >
           <div className="flex items-center">
-            <svg
-              className={`w-5 h-5 mr-2 transition-transform ${showRaw ? "transform rotate-90" : ""}`}
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-            <h5 className="font-medium">Raw Guardrail Response</h5>
+            <ChevronIcon expanded={showRaw} />
+            <h5 className="font-medium text-sm ml-1">Raw Guardrail Response</h5>
           </div>
         </div>
         {showRaw && (
@@ -104,189 +265,162 @@ const GenericGuardrailResponse = ({ response }: { response: any }) => {
   );
 };
 
-const PolicyDetectionRow = ({ entry }: { entry: GuardrailInformation }) => {
-  const hasData = entry.policy_template || entry.detection_method || entry.confidence_score != null || entry.patterns_checked != null;
-  if (!hasData) return null;
+// ── Timeline entry types ────────────────────────────────────────────────────
 
-  return (
-    <div className="mt-4 pt-4 border-t">
-      <div className="flex flex-wrap gap-4">
-        {entry.policy_template && (
-          <div className="flex items-center gap-2">
-            <span className="font-medium text-sm">Policy:</span>
-            <span className="px-2 py-1 bg-purple-50 text-purple-700 rounded-md text-xs font-medium">
-              {entry.policy_template}
-            </span>
-          </div>
-        )}
-        {entry.detection_method && (
-          <div className="flex items-center gap-2">
-            <span className="font-medium text-sm">Detection:</span>
-            {entry.detection_method.split(",").map((method) => (
-              <span key={method} className="px-2 py-1 bg-slate-100 text-slate-700 rounded-md text-xs font-medium">
-                {method.trim()}
-              </span>
-            ))}
-          </div>
-        )}
-        {entry.confidence_score != null && (
-          <div className="flex items-center gap-2">
-            <span className="font-medium text-sm">Confidence:</span>
-            <span className={`px-2 py-1 rounded-md text-xs font-medium ${
-              entry.confidence_score >= 0.8 ? "bg-red-100 text-red-800" :
-              entry.confidence_score >= 0.5 ? "bg-amber-100 text-amber-800" :
-              "bg-green-100 text-green-800"
-            }`}>
-              {(entry.confidence_score * 100).toFixed(0)}%
-            </span>
-          </div>
-        )}
-        {entry.patterns_checked != null && (
-          <div className="flex items-center gap-2">
-            <span className="font-medium text-sm">Patterns checked:</span>
-            <span className="text-sm text-gray-600">{entry.patterns_checked}</span>
-          </div>
-        )}
-      </div>
-    </div>
+interface TimelineEntry {
+  type: "request" | "guardrail" | "llm" | "response";
+  label: string;
+  offsetMs: number;
+  status?: string;
+  isSuccess?: boolean;
+}
+
+const RequestLifecycle = ({ entries }: { entries: GuardrailInformation[] }) => {
+  const sorted = useMemo(
+    () => [...entries].sort((a, b) => (a.start_time ?? 0) - (b.start_time ?? 0)),
+    [entries],
   );
-};
 
-const MatchDetailsTable = ({ matchDetails }: { matchDetails: MatchDetail[] }) => {
-  if (!matchDetails || matchDetails.length === 0) return null;
+  const timeline = useMemo(() => {
+    if (sorted.length === 0) return [];
 
-  return (
-    <div className="mt-4 pt-4 border-t">
-      <h5 className="font-medium mb-2">Match Details ({matchDetails.length})</h5>
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b text-left text-gray-500">
-              <th className="pb-2 pr-4">Type</th>
-              <th className="pb-2 pr-4">Method</th>
-              <th className="pb-2 pr-4">Action</th>
-              <th className="pb-2">Detail</th>
-            </tr>
-          </thead>
-          <tbody>
-            {matchDetails.map((match, idx) => (
-              <tr key={idx} className="border-b border-gray-100">
-                <td className="py-2 pr-4">{match.type}</td>
-                <td className="py-2 pr-4">
-                  <span className="px-2 py-0.5 bg-slate-100 text-slate-700 rounded text-xs">
-                    {match.detection_method ?? "-"}
-                  </span>
-                </td>
-                <td className="py-2 pr-4">
-                  <span className={`px-2 py-0.5 rounded text-xs font-medium ${
-                    match.action_taken === "BLOCK" ? "bg-red-100 text-red-800" : "bg-blue-50 text-blue-700"
-                  }`}>
-                    {match.action_taken ?? "-"}
-                  </span>
-                </td>
-                <td className="py-2 font-mono text-xs text-gray-600 break-all">
-                  {match.category ? `[${match.category}] ` : ""}{match.snippet ?? "-"}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-};
+    const baseTime = sorted[0].start_time;
+    const items: TimelineEntry[] = [];
 
-const ClassificationDetails = ({ classification }: { classification: Record<string, any> }) => {
-  if (!classification) return null;
+    // Request received
+    items.push({ type: "request", label: "Request received", offsetMs: 0 });
 
-  return (
-    <div className="mt-4 pt-4 border-t">
-      <h5 className="font-medium mb-2">Classification</h5>
-      <div className="space-y-2 bg-gray-50 rounded-lg p-3">
-        {classification.category && (
-          <div className="flex">
-            <span className="font-medium w-1/3 text-sm">Category:</span>
-            <span className="text-sm">{classification.category}</span>
-          </div>
-        )}
-        {classification.article_reference && (
-          <div className="flex">
-            <span className="font-medium w-1/3 text-sm">Reference:</span>
-            <span className="text-sm font-mono">{classification.article_reference}</span>
-          </div>
-        )}
-        {classification.confidence != null && (
-          <div className="flex">
-            <span className="font-medium w-1/3 text-sm">Confidence:</span>
-            <span className="text-sm">{(classification.confidence * 100).toFixed(0)}%</span>
-          </div>
-        )}
-        {classification.reason && (
-          <div className="flex">
-            <span className="font-medium w-1/3 text-sm">Reason:</span>
-            <span className="text-sm">{classification.reason}</span>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-};
+    // Pre-call guardrails
+    const preCalls = sorted.filter((e) => e.guardrail_mode === "pre_call");
+    const postCalls = sorted.filter((e) => e.guardrail_mode === "post_call" || e.guardrail_mode === "logging_only");
+    const duringCalls = sorted.filter((e) => e.guardrail_mode === "during_call");
 
-const ExecutionTimeline = ({ entries }: { entries: GuardrailInformation[] }) => {
-  if (entries.length <= 1) return null;
+    for (const e of preCalls) {
+      const offsetMs = Math.round((e.end_time - baseTime) * 1000);
+      items.push({
+        type: "guardrail",
+        label: `Pre-call guardrail: ${getDisplayName(e)}`,
+        offsetMs,
+        status: isEntrySuccess(e) ? "PASSED" : "FAILED",
+        isSuccess: isEntrySuccess(e),
+      });
+    }
 
-  const sorted = [...entries].sort((a, b) => (a.start_time ?? 0) - (b.start_time ?? 0));
+    // LLM call — infer from gap between pre-call end and post-call start
+    const lastPreEnd = preCalls.length > 0 ? Math.max(...preCalls.map((e) => e.end_time)) : baseTime;
+    const firstPostStart = postCalls.length > 0 ? Math.min(...postCalls.map((e) => e.start_time)) : undefined;
+    const llmEndTime = firstPostStart ?? (lastPreEnd + 1);
+    const llmOffsetMs = Math.round((llmEndTime - baseTime) * 1000);
+
+    items.push({
+      type: "llm",
+      label: "LLM call",
+      offsetMs: llmOffsetMs,
+    });
+
+    // During-call guardrails (rare)
+    for (const e of duringCalls) {
+      const offsetMs = Math.round((e.end_time - baseTime) * 1000);
+      items.push({
+        type: "guardrail",
+        label: `During-call guardrail: ${getDisplayName(e)}`,
+        offsetMs,
+        status: isEntrySuccess(e) ? "PASSED" : "FAILED",
+        isSuccess: isEntrySuccess(e),
+      });
+    }
+
+    // Post-call guardrails
+    for (const e of postCalls) {
+      const offsetMs = Math.round((e.end_time - baseTime) * 1000);
+      items.push({
+        type: "guardrail",
+        label: `Post-call guardrail: ${getDisplayName(e)}`,
+        offsetMs,
+        status: isEntrySuccess(e) ? "PASSED" : "FAILED",
+        isSuccess: isEntrySuccess(e),
+      });
+    }
+
+    // Response returned
+    const maxEnd = Math.max(...sorted.map((e) => e.end_time));
+    const responseOffsetMs = Math.round((maxEnd - baseTime) * 1000) + 1;
+    items.push({ type: "response", label: "Response returned", offsetMs: responseOffsetMs });
+
+    return items;
+  }, [sorted]);
 
   return (
-    <div className="mb-4">
-      <h5 className="font-medium mb-3">Execution Timeline</h5>
-      <div className="relative pl-4 border-l-2 border-gray-200 space-y-3">
-        {sorted.map((e, idx) => {
-          const isSuccess = (e.guardrail_status ?? "").toLowerCase() === "success";
-          return (
-            <div key={idx} className="relative">
-              <div
-                className={`absolute -left-[calc(1rem+5px)] w-2.5 h-2.5 rounded-full mt-1.5 ${
-                  isSuccess ? "bg-green-500" : "bg-red-500"
-                }`}
-              />
-              <div className="flex items-center gap-2 flex-wrap">
-                <span className="font-mono text-xs text-gray-500">
-                  {e.duration?.toFixed(3)}s
-                </span>
-                <span className="text-sm font-medium">{e.guardrail_name}</span>
-                <span className="px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded text-xs">
-                  {e.guardrail_mode}
-                </span>
-                <span className={`px-1.5 py-0.5 rounded text-xs font-medium ${
-                  isSuccess ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800"
-                }`}>
-                  {e.guardrail_status}
-                </span>
-                {e.policy_template && (
-                  <span className="px-1.5 py-0.5 bg-purple-50 text-purple-700 rounded text-xs">
-                    {e.policy_template}
-                  </span>
+    <div>
+      <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">
+        Request Lifecycle
+      </h4>
+      <div className="relative">
+        {timeline.map((item, idx) => (
+          <div key={idx} className="flex items-start gap-3 relative">
+            {/* Vertical line */}
+            <div className="flex flex-col items-center">
+              <div className="flex-shrink-0">
+                {item.type === "request" || item.type === "response" ? (
+                  <GrayDotIcon />
+                ) : item.type === "llm" ? (
+                  <PlayCircleIcon />
+                ) : item.isSuccess ? (
+                  <CheckCircleIcon />
+                ) : (
+                  <FailCircleIcon />
                 )}
               </div>
+              {idx < timeline.length - 1 && (
+                <div className="w-0.5 bg-gray-200 flex-grow" style={{ minHeight: "24px" }} />
+              )}
             </div>
-          );
-        })}
+
+            {/* Content */}
+            <div className="pb-4 flex-1 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span
+                  className={`text-sm ${
+                    item.type === "llm" ? "text-blue-600 font-medium" : "text-gray-900"
+                  }`}
+                >
+                  {item.label}
+                </span>
+                {item.status && (
+                  <span
+                    className={`px-1.5 py-0.5 rounded text-[10px] font-bold uppercase ${
+                      item.isSuccess
+                        ? "bg-green-100 text-green-700"
+                        : "bg-red-100 text-red-700"
+                    }`}
+                  >
+                    {item.status}
+                  </span>
+                )}
+                <span className="text-xs text-gray-400 font-mono ml-auto flex-shrink-0">
+                  T+{item.offsetMs}ms
+                </span>
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );
 };
 
-const GuardrailDetails = ({ entry, index, total }: GuardrailDetailsProps) => {
-  const guardrailProvider = entry.guardrail_provider ?? "presidio";
-  const statusLabel = entry.guardrail_status ?? "unknown";
-  const isSuccess = statusLabel.toLowerCase() === "success";
-  const maskedEntityCount = entry.masked_entity_count || {};
-  const totalMaskedEntities = Object.values(maskedEntityCount).reduce(
-    (sum, count) => sum + (typeof count === "number" ? count : 0),
-    0,
-  );
+// ── Evaluation Card ─────────────────────────────────────────────────────────
 
+const EvaluationCard = ({ entry }: { entry: GuardrailInformation }) => {
+  const [expanded, setExpanded] = useState(false);
+  const success = isEntrySuccess(entry);
+  const totalMasked = getTotalMasked(entry);
+  const displayName = getDisplayName(entry);
+  const durationStr = formatDurationMs(entry.duration);
+  const modeStr = formatMode(entry.guardrail_mode);
+  const riskScore = getRiskScore(entry);
+
+  const guardrailProvider = entry.guardrail_provider ?? "presidio";
   const guardrailResponse = entry.guardrail_response;
   const presidioEntities = Array.isArray(guardrailResponse) ? guardrailResponse : [];
   const bedrockResponse =
@@ -297,201 +431,287 @@ const GuardrailDetails = ({ entry, index, total }: GuardrailDetailsProps) => {
       ? (guardrailResponse as BedrockGuardrailResponse)
       : undefined;
 
-  return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
-      {total > 1 && (
-        <div className="flex items-center justify-between mb-4">
-          <h4 className="text-base font-semibold">
-            Guardrail #{index + 1}
-            <span className="ml-2 font-mono text-sm text-gray-600">{entry.guardrail_name}</span>
-          </h4>
-          <span className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded-md text-xs capitalize">
-            {guardrailProvider}
-          </span>
-        </div>
-      )}
+  // Match count string: "X/Y matched" or "X matched"
+  const matchCountStr =
+    entry.patterns_checked != null
+      ? `${totalMasked}/${entry.patterns_checked} matched`
+      : totalMasked > 0
+        ? `${totalMasked} matched`
+        : null;
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <div className="flex">
-            <span className="font-medium w-1/3">Guardrail Name:</span>
-            <span className="font-mono break-words">{entry.guardrail_name}</span>
-          </div>
-          {entry.guardrail_id && entry.guardrail_id !== entry.guardrail_name && (
-            <div className="flex">
-              <span className="font-medium w-1/3">Guardrail ID:</span>
-              <span className="font-mono break-words text-gray-600">{entry.guardrail_id}</span>
-            </div>
+  return (
+    <div className="border border-gray-200 rounded-lg bg-white">
+      {/* Collapsed header row */}
+      <div
+        className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-gray-50 transition-colors"
+        onClick={() => setExpanded(!expanded)}
+      >
+        {/* Status icon */}
+        <div className="flex-shrink-0">
+          {success ? <CheckCircleIcon /> : <FailCircleIcon />}
+        </div>
+
+        {/* Name + badges */}
+        <div className="flex items-center gap-2 flex-wrap flex-1 min-w-0">
+          <span className="font-semibold text-gray-900 text-sm truncate">{displayName}</span>
+
+          <span className="px-2 py-0.5 border border-blue-200 bg-blue-50 text-blue-700 rounded text-[11px] font-semibold uppercase flex-shrink-0">
+            {modeStr}
+          </span>
+
+          <span
+            className={`px-2 py-0.5 rounded text-[11px] font-semibold uppercase flex-shrink-0 ${
+              success ? "bg-green-100 text-green-700 border border-green-200" : "bg-red-100 text-red-700 border border-red-200"
+            }`}
+          >
+            {success ? "PASSED" : "FAILED"}
+          </span>
+
+          {matchCountStr && (
+            <span
+              className={`px-2 py-0.5 rounded text-[11px] font-medium flex-shrink-0 ${
+                totalMasked === 0 ? "bg-green-50 text-green-700 border border-green-200" : "bg-amber-50 text-amber-700 border border-amber-200"
+              }`}
+            >
+              {matchCountStr}
+            </span>
           )}
-          <div className="flex">
-            <span className="font-medium w-1/3">Mode:</span>
-            <span className="font-mono break-words">{entry.guardrail_mode}</span>
-          </div>
-          <div className="flex">
-            <span className="font-medium w-1/3">Status:</span>
-            <Tooltip title={isSuccess ? null : "Guardrail failed to run."} placement="top" arrow destroyTooltipOnHide>
-              <span
-                className={`px-2 py-1 rounded-md text-xs font-medium inline-block ${
-                  isSuccess ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800 cursor-help"
-                }`}
-              >
-                {statusLabel}
+
+          {entry.confidence_score != null && (
+            <span className="px-2 py-0.5 bg-gray-100 text-gray-600 border border-gray-200 rounded text-[11px] font-medium flex-shrink-0">
+              {(entry.confidence_score * 100).toFixed(0)}% conf
+            </span>
+          )}
+
+          {riskScore != null && success && (
+            <Tooltip title={`Risk score: ${riskScore}/10`}>
+              <span className={`px-2 py-0.5 border rounded text-[11px] font-semibold flex-shrink-0 ${getRiskColor(riskScore)}`}>
+                Risk {riskScore}/10
               </span>
             </Tooltip>
-          </div>
+          )}
         </div>
 
-        <div className="space-y-2">
-          <div className="flex">
-            <span className="font-medium w-1/3">Start Time:</span>
-            <span>{formatTime(entry.start_time)}</span>
-          </div>
-          <div className="flex">
-            <span className="font-medium w-1/3">End Time:</span>
-            <span>{formatTime(entry.end_time)}</span>
-          </div>
-          <div className="flex">
-            <span className="font-medium w-1/3">Duration:</span>
-            <span>{entry.duration.toFixed(4)}s</span>
-          </div>
+        {/* Right side: duration + method + chevron */}
+        <div className="flex items-center gap-3 flex-shrink-0">
+          <span className="text-sm text-gray-500 font-mono">{durationStr}</span>
+          {entry.detection_method && (
+            <span className="px-2 py-0.5 bg-gray-100 text-gray-600 border border-gray-200 rounded text-[11px] font-medium">
+              {entry.detection_method.split(",")[0].trim()}
+            </span>
+          )}
+          <ChevronIcon expanded={expanded} />
         </div>
       </div>
 
-      {/* Policy, detection method, confidence, patterns checked */}
-      <PolicyDetectionRow entry={entry} />
+      {/* Expanded details */}
+      {expanded && (
+        <div className="border-t border-gray-100 px-4 py-3">
+          {/* View Policy Configuration link */}
+          {entry.policy_template && (
+            <div className="flex justify-end mb-3">
+              <a
+                href="/ui/policies"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-blue-600 hover:text-blue-800 font-medium"
+              >
+                View Policy Configuration
+                <ExternalLinkIcon />
+              </a>
+            </div>
+          )}
 
-      {/* Classification details (LLM-judge) */}
-      {entry.classification && <ClassificationDetails classification={entry.classification} />}
+          {/* Classification details for llm-judge */}
+          {entry.classification && (
+            <div className="mb-3 bg-gray-50 rounded-lg p-3 space-y-1">
+              <h5 className="text-sm font-medium text-gray-700 mb-2">Classification</h5>
+              {entry.classification.category && (
+                <div className="flex text-sm">
+                  <span className="font-medium w-1/3 text-gray-500">Category:</span>
+                  <span>{entry.classification.category}</span>
+                </div>
+              )}
+              {entry.classification.article_reference && (
+                <div className="flex text-sm">
+                  <span className="font-medium w-1/3 text-gray-500">Reference:</span>
+                  <span className="font-mono">{entry.classification.article_reference}</span>
+                </div>
+              )}
+              {entry.classification.confidence != null && (
+                <div className="flex text-sm">
+                  <span className="font-medium w-1/3 text-gray-500">Confidence:</span>
+                  <span>{(entry.classification.confidence * 100).toFixed(0)}%</span>
+                </div>
+              )}
+              {entry.classification.reason && (
+                <div className="flex text-sm">
+                  <span className="font-medium w-1/3 text-gray-500">Reason:</span>
+                  <span>{entry.classification.reason}</span>
+                </div>
+              )}
+            </div>
+          )}
 
-      {/* Match details table */}
-      {entry.match_details && entry.match_details.length > 0 && (
-        <MatchDetailsTable matchDetails={entry.match_details} />
-      )}
+          {/* Match details table */}
+          {entry.match_details && entry.match_details.length > 0 && (
+            <MatchDetailsTable matchDetails={entry.match_details} />
+          )}
 
-      {totalMaskedEntities > 0 && (
-        <div className="mt-4 pt-4 border-t">
-          <h5 className="font-medium mb-2">Masked Entity Summary</h5>
-          <div className="flex flex-wrap gap-2">
-            {Object.entries(maskedEntityCount).map(([entityType, count]) => (
-              <span key={entityType} className="px-3 py-1.5 bg-blue-50 text-blue-700 rounded-md text-xs font-medium">
-                {entityType}: {count}
-              </span>
-            ))}
-          </div>
+          {/* Masked entity summary */}
+          {totalMasked > 0 && (
+            <div className="mt-3">
+              <h5 className="text-sm font-medium text-gray-700 mb-2">Masked Entities</h5>
+              <div className="flex flex-wrap gap-2">
+                {Object.entries(entry.masked_entity_count || {}).map(([entityType, count]) => (
+                  <span key={entityType} className="px-2 py-1 bg-blue-50 text-blue-700 rounded text-xs font-medium">
+                    {entityType}: {count}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Provider-specific details */}
+          {guardrailProvider === "presidio" && presidioEntities.length > 0 && (
+            <div className="mt-3">
+              <PresidioDetectedEntities entities={presidioEntities} />
+            </div>
+          )}
+          {guardrailProvider === "bedrock" && bedrockResponse && (
+            <div className="mt-3">
+              <BedrockGuardrailDetails response={bedrockResponse} />
+            </div>
+          )}
+          {guardrailProvider === "litellm_content_filter" && guardrailResponse && (
+            <div className="mt-3">
+              <ContentFilterDetails response={guardrailResponse} />
+            </div>
+          )}
+          {guardrailProvider &&
+            !PROVIDERS_WITH_CUSTOM_RENDERERS.has(guardrailProvider) &&
+            guardrailResponse && <GenericGuardrailResponse response={guardrailResponse} />}
         </div>
       )}
-
-      {guardrailProvider === "presidio" && presidioEntities.length > 0 && (
-        <div className="mt-4">
-          <PresidioDetectedEntities entities={presidioEntities} />
-        </div>
-      )}
-
-      {guardrailProvider === "bedrock" && bedrockResponse && (
-        <div className="mt-4">
-          <BedrockGuardrailDetails response={bedrockResponse} />
-        </div>
-      )}
-
-      {guardrailProvider === "litellm_content_filter" && guardrailResponse && (
-        <div className="mt-4">
-          <ContentFilterDetails response={guardrailResponse} />
-        </div>
-      )}
-
-      {/* Generic fallback for unknown guardrail providers */}
-      {guardrailProvider &&
-        !PROVIDERS_WITH_CUSTOM_RENDERERS.has(guardrailProvider) &&
-        guardrailResponse && <GenericGuardrailResponse response={guardrailResponse} />}
     </div>
   );
 };
 
+// ── Main Component ──────────────────────────────────────────────────────────
+
 const GuardrailViewer = ({ data }: GuardrailViewerProps) => {
-  const guardrailEntries = Array.isArray(data)
-    ? data.filter((entry): entry is GuardrailInformation => Boolean(entry))
-    : data
-      ? [data]
-      : [];
+  const guardrailEntries = useMemo(() => {
+    return Array.isArray(data)
+      ? data.filter((entry): entry is GuardrailInformation => Boolean(entry))
+      : data
+        ? [data]
+        : [];
+  }, [data]);
 
-  const primaryName =
-    guardrailEntries.length === 1 ? guardrailEntries[0].guardrail_name : `${guardrailEntries.length} guardrails`;
-  const statuses = Array.from(new Set(guardrailEntries.map((entry) => entry.guardrail_status)));
-  const allSucceeded = statuses.every((status) => (status ?? "").toLowerCase() === "success");
-  const aggregatedStatus = allSucceeded ? "success" : "failure";
-  const totalMaskedEntities = guardrailEntries.reduce((sum, entry) => {
-    return (
-      sum +
-      Object.values(entry.masked_entity_count || {}).reduce(
-        (acc, count) => acc + (typeof count === "number" ? count : 0),
-        0,
-      )
-    );
-  }, 0);
+  const passedCount = guardrailEntries.filter(isEntrySuccess).length;
+  const allPassed = passedCount === guardrailEntries.length;
 
-  const policyTemplates = Array.from(
-    new Set(guardrailEntries.map((e) => e.policy_template).filter(Boolean))
-  );
+  const totalOverheadMs = useMemo(() => {
+    return Math.round(guardrailEntries.reduce((sum, e) => sum + (e.duration ?? 0), 0) * 1000);
+  }, [guardrailEntries]);
 
-  const tooltipTitle = allSucceeded ? null : "Guardrail failed to run.";
+  const policyTemplates = useMemo(() => {
+    return Array.from(new Set(guardrailEntries.map((e) => e.policy_template).filter(Boolean)));
+  }, [guardrailEntries]);
 
   if (guardrailEntries.length === 0) {
     return null;
   }
 
+  const handleExport = () => {
+    const blob = new Blob([JSON.stringify(guardrailEntries, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `guardrail-compliance-log-${new Date().toISOString().slice(0, 10)}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
-    <div className="bg-white rounded-lg shadow w-full max-w-full overflow-hidden mb-6">
-      <Collapse
-        defaultActiveKey={["1"]}
-        expandIconPosition="start"
-        items={[
-          {
-            key: "1",
-            label: (
-              <div className="flex items-center gap-2 flex-wrap">
-                <h3 className="text-lg font-medium text-gray-900">Guardrail Information</h3>
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm w-full max-w-full overflow-hidden mb-6">
+      {/* ── Header ─────────────────────────────────────────────── */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+        <div className="flex items-center gap-4">
+          <ShieldIcon />
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">
+              Guardrails &amp; Policy Compliance
+            </h3>
+            <div className="flex items-center gap-2 mt-0.5">
+              <span className="text-sm text-gray-500">
+                {guardrailEntries.length} guardrail{guardrailEntries.length !== 1 ? "s" : ""} evaluated
+              </span>
+              <span className="text-gray-300">|</span>
+              <span
+                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold ${
+                  allPassed
+                    ? "bg-green-50 text-green-700 border border-green-200"
+                    : "bg-red-50 text-red-700 border border-red-200"
+                }`}
+              >
+                {allPassed ? (
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path d="M3 6l2.5 2.5L9 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                ) : null}
+                {passedCount} Passed
+              </span>
+            </div>
+          </div>
+        </div>
 
-                <Tooltip title={tooltipTitle} placement="top" arrow destroyTooltipOnHide>
-                  <span
-                    className={`px-2 py-1 rounded-md text-xs font-medium inline-block ${
-                      allSucceeded ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800 cursor-help"
-                    }`}
-                  >
-                    {aggregatedStatus}
-                  </span>
-                </Tooltip>
-
-                <span className="font-mono text-sm text-gray-600">{primaryName}</span>
-
-                {totalMaskedEntities > 0 && (
-                  <span className="px-2 py-1 bg-blue-50 text-blue-700 rounded-md text-xs font-medium">
-                    {totalMaskedEntities} masked {totalMaskedEntities === 1 ? "entity" : "entities"}
-                  </span>
-                )}
-
-                {policyTemplates.map((pt) => (
-                  <span key={pt} className="px-2 py-1 bg-purple-50 text-purple-700 rounded-md text-xs font-medium">
-                    {pt}
-                  </span>
-                ))}
+        <div className="flex items-center gap-6">
+          <div className="text-right">
+            <div className="text-sm font-medium text-gray-900">
+              Total: {totalOverheadMs}ms overhead
+            </div>
+            {policyTemplates.length > 0 && (
+              <div className="text-xs text-gray-500 mt-0.5">
+                Policy: {policyTemplates.join(" / ")}
               </div>
-            ),
-            children: (
-              <div className="p-4 space-y-6">
-                <ExecutionTimeline entries={guardrailEntries} />
-                {guardrailEntries.map((entry, index) => (
-                  <GuardrailDetails
-                    key={`${entry.guardrail_name ?? "guardrail"}-${index}`}
-                    entry={entry}
-                    index={index}
-                    total={guardrailEntries.length}
-                  />
-                ))}
-              </div>
-            ),
-          },
-        ]}
-      />
+            )}
+          </div>
+
+          <button
+            onClick={handleExport}
+            className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors"
+          >
+            <DownloadIcon />
+            Export Compliance Log
+          </button>
+        </div>
+      </div>
+
+      {/* ── Body: two columns ──────────────────────────────────── */}
+      <div className="flex">
+        {/* Left column: Request Lifecycle */}
+        <div className="w-[340px] flex-shrink-0 border-r border-gray-100 px-6 py-5">
+          <RequestLifecycle entries={guardrailEntries} />
+        </div>
+
+        {/* Right column: Evaluation Details */}
+        <div className="flex-1 px-6 py-5 min-w-0">
+          <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">
+            Evaluation Details
+          </h4>
+          <div className="space-y-3">
+            {guardrailEntries.map((entry, index) => (
+              <EvaluationCard
+                key={`${entry.guardrail_name ?? "guardrail"}-${index}`}
+                entry={entry}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -66,6 +66,9 @@ export function LogDetailContent({ logEntry, onOpenSettings, isLoadingDetails = 
   const hasGuardrailData = guardrailEntries.length > 0;
   const totalMaskedEntities = calculateTotalMaskedEntities(guardrailEntries);
   const primaryGuardrailLabel = getGuardrailLabel(guardrailEntries);
+  const guardrailPolicyNames = Array.from(
+    new Set(guardrailEntries.map((e: any) => e?.policy_template).filter(Boolean))
+  ) as string[];
 
   // Vector store data
   const hasVectorStoreData = checkHasVectorStoreData(metadata);
@@ -124,7 +127,7 @@ export function LogDetailContent({ logEntry, onOpenSettings, isLoadingDetails = 
             )}
             {hasGuardrailData && (
               <Descriptions.Item label="Guardrail">
-                <GuardrailLabel label={primaryGuardrailLabel} maskedCount={totalMaskedEntities} />
+                <GuardrailLabel label={primaryGuardrailLabel} maskedCount={totalMaskedEntities} policyNames={guardrailPolicyNames} />
               </Descriptions.Item>
             )}
           </Descriptions>
@@ -164,7 +167,11 @@ export function LogDetailContent({ logEntry, onOpenSettings, isLoadingDetails = 
       )}
 
       {/* Guardrail Data */}
-      {hasGuardrailData && <GuardrailViewer data={guardrailInfo} />}
+      {hasGuardrailData && (
+        <div id="guardrail-section">
+          <GuardrailViewer data={guardrailInfo} />
+        </div>
+      )}
 
       {/* Vector Store Data */}
       {hasVectorStoreData && <VectorStoreViewer data={metadata.vector_store_request_metadata} />}
@@ -218,15 +225,23 @@ function TagsSection({ tags }: { tags: Record<string, any> }) {
   );
 }
 
-function GuardrailLabel({ label, maskedCount }: { label: string; maskedCount: number }) {
+function GuardrailLabel({ label, maskedCount, policyNames }: { label: string; maskedCount: number; policyNames: string[] }) {
+  const handleClick = () => {
+    const el = document.getElementById("guardrail-section");
+    if (el) el.scrollIntoView({ behavior: "smooth" });
+  };
+
   return (
     <Space size={SPACING_MEDIUM}>
-      <span>{label}</span>
+      <a onClick={handleClick} style={{ cursor: "pointer" }}>{label}</a>
       {maskedCount > 0 && (
         <Tag color="blue">
           {maskedCount} masked
         </Tag>
       )}
+      {policyNames.map((name) => (
+        <Tag key={name} color="purple">{name}</Tag>
+      ))}
     </Space>
   );
 }


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/21189

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Renames `_is_nova_lite_2_model()` → `_is_nova_2_model()` and broadens the detection logic so all Nova 2 variants (not just `nova-2-lite`) are correctly identified.

### Problem
`_is_nova_lite_2_model()` checked for `"nova-2-lite" in model`, so Nova 2 Pro models (e.g. `amazon.nova-2-pro-preview-20251202-v1:0`) were missed. This caused:
1. **Wrong reasoning params** — `reasoning_effort` fell through to the Anthropic `thinking` code path, sending params Bedrock Nova 2 rejects
2. **Incorrect thinking token injection** — `update_optional_params_with_thinking_tokens` ran for Nova 2 Pro
3. **Missing `reasoning_effort`** — not listed as a supported param for Nova 2 Pro

### Fix
- Renamed method to `_is_nova_2_model()` to reflect broader scope
- Changed detection from `"nova-2-lite" in model` to `model.startswith("amazon.nova-2-")` (after stripping routing & regional prefixes)
- Added stripping of `bedrock/converse/`, `bedrock/`, `converse/` routing prefixes
- Updated all call sites and comments
- Minor formatting cleanup (long lines in computer-use beta patterns)

### Tests
- Updated `tests/test_litellm/llms/bedrock/chat/test_converse_transformation_nova_2.py` with Nova 2 Pro detection, reasoning params, and supported params tests
- All 110 existing tests pass
