### PR TITLE
fix: preserve multimodal messages in DashScopeChatConfig

### DIFF
--- a/litellm/llms/dashscope/chat/transformation.py
+++ b/litellm/llms/dashscope/chat/transformation.py
@@ -4,9 +4,6 @@ Translates from OpenAI's `/v1/chat/completions` to DashScope's `/v1/chat/complet
 
 from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
 
-from litellm.litellm_core_utils.prompt_templates.common_utils import (
-    handle_messages_with_content_list_to_str_conversion,
-)
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 
@@ -33,9 +30,11 @@ class DashScopeChatConfig(OpenAIGPTConfig):
         self, messages: List[AllMessageValues], model: str, is_async: bool = False
     ) -> Union[List[AllMessageValues], Coroutine[Any, Any, List[AllMessageValues]]]:
         """
-        DashScope does not support content in list format.
+        DashScope's OpenAI-compatible endpoint supports content in list format.
+        Use parent class transformation for proper handling of multimodal messages.
         """
-        messages = handle_messages_with_content_list_to_str_conversion(messages)
+        # Skip handle_messages_with_content_list_to_str_conversion to preserve
+        # image_url and other non-text content in multimodal messages
         if is_async:
             return super()._transform_messages(
                 messages=messages, model=model, is_async=True

--- a/litellm/llms/dashscope/chat/transformation.py
+++ b/litellm/llms/dashscope/chat/transformation.py
@@ -2,47 +2,19 @@
 Translates from OpenAI's `/v1/chat/completions` to DashScope's `/v1/chat/completions`
 """
 
-from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
+from typing import Optional, Tuple
 
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.llms.openai import AllMessageValues
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
 
 class DashScopeChatConfig(OpenAIGPTConfig):
-    @overload
-    def _transform_messages(
-        self, messages: List[AllMessageValues], model: str, is_async: Literal[True]
-    ) -> Coroutine[Any, Any, List[AllMessageValues]]:
-        ...
-
-    @overload
-    def _transform_messages(
-        self,
-        messages: List[AllMessageValues],
-        model: str,
-        is_async: Literal[False] = False,
-    ) -> List[AllMessageValues]:
-        ...
-
-    def _transform_messages(
-        self, messages: List[AllMessageValues], model: str, is_async: bool = False
-    ) -> Union[List[AllMessageValues], Coroutine[Any, Any, List[AllMessageValues]]]:
-        """
-        DashScope's OpenAI-compatible endpoint supports content in list format.
-        Use parent class transformation for proper handling of multimodal messages.
-        """
-        # Skip handle_messages_with_content_list_to_str_conversion to preserve
-        # image_url and other non-text content in multimodal messages
-        if is_async:
-            return super()._transform_messages(
-                messages=messages, model=model, is_async=True
-            )
-        else:
-            return super()._transform_messages(
-                messages=messages, model=model, is_async=False
-            )
+    """
+    DashScope's OpenAI-compatible endpoint supports content in list format.
+    Parent class transformation is used for proper handling of multimodal messages.
+    No need to call handle_messages_with_content_list_to_str_conversion.
+    """
 
     def _get_openai_compatible_provider_info(
         self, api_base: Optional[str], api_key: Optional[str]

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9140,7 +9140,8 @@
         "source": "https://www.alibabacloud.com/help/en/model-studio/models",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "dashscope/qwen-plus-2025-01-25": {
         "input_cost_per_token": 4e-07,
@@ -9153,7 +9154,8 @@
         "source": "https://www.alibabacloud.com/help/en/model-studio/models",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "dashscope/qwen-plus-2025-04-28": {
         "input_cost_per_token": 4e-07,
@@ -9167,7 +9169,8 @@
         "source": "https://www.alibabacloud.com/help/en/model-studio/models",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "dashscope/qwen-plus-2025-07-14": {
         "input_cost_per_token": 4e-07,
@@ -9181,7 +9184,8 @@
         "source": "https://www.alibabacloud.com/help/en/model-studio/models",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "dashscope/qwen-plus-2025-07-28": {
         "litellm_provider": "dashscope",
@@ -9212,7 +9216,8 @@
                     1000000.0
                 ]
             }
-        ]
+        ],
+        "supports_vision": true
     },
     "dashscope/qwen-plus-2025-09-11": {
         "litellm_provider": "dashscope",
@@ -9243,7 +9248,8 @@
                     1000000.0
                 ]
             }
-        ]
+        ],
+        "supports_vision": true
     },
     "dashscope/qwen-plus-latest": {
         "litellm_provider": "dashscope",
@@ -9274,7 +9280,8 @@
                     1000000.0
                 ]
             }
-        ]
+        ],
+        "supports_vision": true
     },
     "dashscope/qwen-turbo": {
         "input_cost_per_token": 5e-08,
@@ -36978,5 +36985,19 @@
         "supports_vision": true,
         "supports_web_search": true,
         "tpm": 8000000
+    },
+    "dashscope/qwen3.5-plus": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
     }
 }

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9140,8 +9140,7 @@
         "source": "https://www.alibabacloud.com/help/en/model-studio/models",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_tool_choice": true
     },
     "dashscope/qwen-plus-2025-01-25": {
         "input_cost_per_token": 4e-07,
@@ -9154,8 +9153,7 @@
         "source": "https://www.alibabacloud.com/help/en/model-studio/models",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_tool_choice": true
     },
     "dashscope/qwen-plus-2025-04-28": {
         "input_cost_per_token": 4e-07,
@@ -9169,8 +9167,7 @@
         "source": "https://www.alibabacloud.com/help/en/model-studio/models",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_tool_choice": true
     },
     "dashscope/qwen-plus-2025-07-14": {
         "input_cost_per_token": 4e-07,
@@ -9184,8 +9181,7 @@
         "source": "https://www.alibabacloud.com/help/en/model-studio/models",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_tool_choice": true
     },
     "dashscope/qwen-plus-2025-07-28": {
         "litellm_provider": "dashscope",
@@ -9216,8 +9212,7 @@
                     1000000.0
                 ]
             }
-        ],
-        "supports_vision": true
+        ]
     },
     "dashscope/qwen-plus-2025-09-11": {
         "litellm_provider": "dashscope",
@@ -9248,8 +9243,7 @@
                     1000000.0
                 ]
             }
-        ],
-        "supports_vision": true
+        ]
     },
     "dashscope/qwen-plus-latest": {
         "litellm_provider": "dashscope",
@@ -9280,8 +9274,7 @@
                     1000000.0
                 ]
             }
-        ],
-        "supports_vision": true
+        ]
     },
     "dashscope/qwen-turbo": {
         "input_cost_per_token": 5e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -36982,9 +36982,9 @@
     "dashscope/qwen3.5-plus": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "dashscope",
-        "max_input_tokens": 129024,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
+        "max_input_tokens": 991808,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
         "mode": "chat",
         "output_cost_per_token": 1.2e-06,
         "source": "https://www.alibabacloud.com/help/en/model-studio/models",

--- a/tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py
@@ -111,3 +111,61 @@ class TestDashScopeConfig:
         # Check for specific content in the response
         assert "```python" in response.choices[0].message.content
         assert "Hey from LiteLLM" in response.choices[0].message.content
+
+    def test_dashscope_transform_messages_preserves_multimodal_content(self):
+        """
+        Test that DashScopeChatConfig preserves multimodal content (image_url) in messages.
+        This is critical for vision models like qwen3-vl-plus.
+        """
+        config = DashScopeChatConfig()
+        
+        # Test multimodal message with image_url
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "https://example.com/image.jpg"
+                        }
+                    },
+                    {
+                        "type": "text",
+                        "text": "Describe this image"
+                    }
+                ]
+            }
+        ]
+        
+        # Transform messages synchronously
+        transformed = config._transform_messages(messages=messages, model="dashscope/qwen3-vl-plus", is_async=False)
+        
+        # Verify that image_url is preserved
+        assert isinstance(transformed, list)
+        assert len(transformed) == 1
+        assert transformed[0]["role"] == "user"
+        
+        content = transformed[0]["content"]
+        assert isinstance(content, list)
+        assert len(content) == 2
+        
+        # Check image_url item
+        assert content[0]["type"] == "image_url"
+        assert content[0]["image_url"]["url"] == "https://example.com/image.jpg"
+        
+        # Check text item
+        assert content[1]["type"] == "text"
+        assert content[1]["text"] == "Describe this image"
+        
+        # Test text-only message should also work
+        text_messages = [
+            {
+                "role": "user",
+                "content": "Hello, how are you?"
+            }
+        ]
+        
+        text_transformed = config._transform_messages(messages=text_messages, model="dashscope/qwen-turbo", is_async=False)
+        assert len(text_transformed) == 1
+        assert text_transformed[0]["content"] == "Hello, how are you?"


### PR DESCRIPTION
- Remove handle_messages_with_content_list_to_str_conversion call that was dropping image_url content
- Use parent OpenAIGPTConfig transformation logic to properly handle multimodal messages
- Add test to verify image_url and text content are preserved
- Fixes issue where dashscope/qwen3-vl-plus could not process images

## Relevant issues

[Bug]: LiteLL version 1.79.0 ignores images when using Dashscope (Qwen API) VL models with mixed text and image content #16007
https://github.com/BerriAI/litellm/issues/16007

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes
