### PR TITLE
Fix Pydantic numeric constraints failing with Anthropic tool-based structured output

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -800,11 +800,18 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         )
         if json_schema is None:
             return None
+
+        # Filter unsupported constraints (minimum, maximum, etc.) from the schema.
+        # The output_format path (newer models) already does this via
+        # map_response_format_to_anthropic_output_format, but the tool-based
+        # path for older models was missing it. See #21016.
+        json_schema = self.filter_anthropic_output_schema(json_schema)
+
         """
         When using tools in this way: - https://docs.anthropic.com/en/docs/build-with-claude/tool-use#json-mode
         - You usually want to provide a single tool
         - You should set tool_choice (see Forcing tool use) to instruct the model to explicitly use that tool
-        - Remember that the model will pass the input to the tool, so the name of the tool and description should be from the model’s perspective.
+        - Remember that the model will pass the input to the tool, so the name of the tool and description should be from the model's perspective.
         """
 
         _tool = self._create_json_tool_call_for_response_format(


### PR DESCRIPTION
Fixes #21016



## Summary

Pydantic models with numeric constraints (`ge`, `le`, `gt`, `lt`) fail when used with `response_format` on older Anthropic models. Anthropic's API rejects the schema with: `"For 'integer' type, properties maximum, minimum are not supported"`

## Root Cause

LiteLLM has two code paths for `response_format` with Anthropic:

1. **Newer models** (Sonnet 4.5+, Opus 4.1+) - uses `map_response_format_to_anthropic_output_format()` which calls `filter_anthropic_output_schema()` to strip unsupported constraints
2. **Older models** - uses `map_response_format_to_anthropic_tool()` which was **not** calling `filter_anthropic_output_schema()`, sending raw schemas with `minimum`/`maximum` properties to the API

## Fix

Added `filter_anthropic_output_schema()` call in `map_response_format_to_anthropic_tool()` so both code paths consistently strip unsupported JSON schema constraints before sending to Anthropic.

## Changes

- `litellm/llms/anthropic/chat/transformation.py` - Added schema filtering in the tool-based response_format path
- `tests/test_litellm/llms/anthropic/test_anthropic_structured_output.py` - Added 4 tests for tool-based path covering numeric, string, and array constraints

## Test plan

- [x] Numeric constraints (ge/le/gt/lt) stripped in tool path
- [x] Constraint info moved to description in tool path
- [x] String constraints (min_length/max_length) stripped in tool path
- [x] Array constraints (min_length/max_length on List) stripped in tool path
- [x] All 14 existing + new Anthropic schema tests pass
