### PR TITLE
feat(tts): true end-to-end streaming for /v1/audio/speech

### DIFF
--- a/litellm/llms/aws_polly/text_to_speech/transformation.py
+++ b/litellm/llms/aws_polly/text_to_speech/transformation.py
@@ -19,9 +19,11 @@ from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.types.llms.openai import HttpxBinaryResponseContent
+    from litellm.llms.custom_httpx.httpx_stream_handler import HttpxStreamHandler
 else:
     LiteLLMLoggingObj = Any
     HttpxBinaryResponseContent = Any
+    HttpxStreamHandler = Any
 
 
 class AWSPollyTextToSpeechConfig(BaseTextToSpeechConfig, BaseAWSLLM):
@@ -76,12 +78,14 @@ class AWSPollyTextToSpeechConfig(BaseTextToSpeechConfig, BaseAWSLLM):
         extra_headers: Optional[Dict[str, Any]],
         base_llm_http_handler: Any,
         aspeech: bool,
+        stream: Optional[bool],
         api_base: Optional[str],
         api_key: Optional[str],
         **kwargs: Any,
     ) -> Union[
         "HttpxBinaryResponseContent",
-        Coroutine[Any, Any, "HttpxBinaryResponseContent"],
+        "HttpxStreamHandler",
+        Coroutine[Any, Any, Union["HttpxBinaryResponseContent", "HttpxStreamHandler"]],
     ]:
         """
         Dispatch method to handle AWS Polly TTS requests
@@ -124,6 +128,7 @@ class AWSPollyTextToSpeechConfig(BaseTextToSpeechConfig, BaseAWSLLM):
             extra_headers=extra_headers,
             client=None,
             _is_async=aspeech,
+            stream=stream,
         )
 
         return response

--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -1,7 +1,10 @@
 import asyncio
 import json
 import time
-from typing import Any, Callable, Coroutine, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Optional, Union
+
+if TYPE_CHECKING:
+    from litellm.llms.custom_httpx.httpx_stream_handler import HttpxStreamHandler
 
 import httpx  # type: ignore
 from openai import (
@@ -1306,7 +1309,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         client=None,
         litellm_params: Optional[dict] = None,
         stream: Optional[bool] = None,
-    ) -> HttpxBinaryResponseContent:
+    ) -> Union[HttpxBinaryResponseContent, "HttpxStreamHandler"]:
         max_retries = optional_params.pop("max_retries", 2)
 
         if aspeech is not None and aspeech is True:
@@ -1378,7 +1381,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         client=None,
         litellm_params: Optional[dict] = None,
         stream: Optional[bool] = None,
-    ) -> HttpxBinaryResponseContent:
+    ) -> Union[HttpxBinaryResponseContent, "HttpxStreamHandler"]:
         azure_client: AsyncAzureOpenAI = self.get_azure_openai_client(
             api_base=api_base,
             api_version=api_version,

--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -1305,6 +1305,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         aspeech: Optional[bool] = None,
         client=None,
         litellm_params: Optional[dict] = None,
+        stream: Optional[bool] = None,
     ) -> HttpxBinaryResponseContent:
         max_retries = optional_params.pop("max_retries", 2)
 
@@ -1323,6 +1324,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 timeout=timeout,
                 client=client,
                 litellm_params=litellm_params,
+                stream=stream,
             )  # type: ignore
 
         azure_client: AzureOpenAI = self.get_azure_openai_client(
@@ -1334,6 +1336,23 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             client=client,
             litellm_params=litellm_params,
         )  # type: ignore
+
+        if stream is True:
+            from litellm.llms.custom_httpx.httpx_stream_handler import (
+                HttpxStreamHandler,
+            )
+
+            ctx = azure_client.audio.speech.with_streaming_response.create(
+                model=model,
+                voice=voice,  # type: ignore
+                input=input,
+                **optional_params,
+            )
+            streamed_response = ctx.__enter__()
+            return HttpxStreamHandler(
+                response=streamed_response.http_response,
+                cleanup=lambda: ctx.__exit__(None, None, None),
+            )  # type: ignore
 
         response = azure_client.audio.speech.create(
             model=model,
@@ -1358,6 +1377,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         timeout: Union[float, httpx.Timeout],
         client=None,
         litellm_params: Optional[dict] = None,
+        stream: Optional[bool] = None,
     ) -> HttpxBinaryResponseContent:
         azure_client: AsyncAzureOpenAI = self.get_azure_openai_client(
             api_base=api_base,
@@ -1368,6 +1388,23 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             client=client,
             litellm_params=litellm_params,
         )  # type: ignore
+
+        if stream is True:
+            from litellm.llms.custom_httpx.httpx_stream_handler import (
+                HttpxStreamHandler,
+            )
+
+            ctx = azure_client.audio.speech.with_streaming_response.create(
+                model=model,
+                voice=voice,  # type: ignore
+                input=input,
+                **optional_params,
+            )
+            streamed_response = await ctx.__aenter__()
+            return HttpxStreamHandler(
+                response=streamed_response.http_response,
+                cleanup=lambda: ctx.__aexit__(None, None, None),
+            )  # type: ignore
 
         azure_response = await azure_client.audio.speech.create(
             model=model,

--- a/litellm/llms/azure/text_to_speech/transformation.py
+++ b/litellm/llms/azure/text_to_speech/transformation.py
@@ -19,9 +19,11 @@ from litellm.secret_managers.main import get_secret_str
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.types.llms.openai import HttpxBinaryResponseContent
+    from litellm.llms.custom_httpx.httpx_stream_handler import HttpxStreamHandler
 else:
     LiteLLMLoggingObj = Any
     HttpxBinaryResponseContent = Any
+    HttpxStreamHandler = Any
 
 
 class AzureAVATextToSpeechConfig(BaseTextToSpeechConfig):
@@ -69,12 +71,14 @@ class AzureAVATextToSpeechConfig(BaseTextToSpeechConfig):
         extra_headers: Optional[Dict[str, Any]],
         base_llm_http_handler: Any,
         aspeech: bool,
+        stream: Optional[bool],
         api_base: Optional[str],
         api_key: Optional[str],
         **kwargs: Any,
     ) -> Union[
         "HttpxBinaryResponseContent",
-        Coroutine[Any, Any, "HttpxBinaryResponseContent"],
+        "HttpxStreamHandler",
+        Coroutine[Any, Any, Union["HttpxBinaryResponseContent", "HttpxStreamHandler"]],
     ]:
         """
         Dispatch method to handle Azure AVA TTS requests
@@ -128,6 +132,7 @@ class AzureAVATextToSpeechConfig(BaseTextToSpeechConfig):
             extra_headers=extra_headers,
             client=None,
             _is_async=aspeech,
+            stream=stream,
         )
         
         return response

--- a/litellm/llms/base_llm/text_to_speech/transformation.py
+++ b/litellm/llms/base_llm/text_to_speech/transformation.py
@@ -147,3 +147,13 @@ class BaseTextToSpeechConfig(ABC):
             headers=headers,
         )
 
+    @property
+    def supports_streaming(self) -> bool:
+        """
+        Whether this provider supports true streaming for TTS responses.
+
+        By default, this is True for most providers. Providers that don't support
+        streaming (e.g., Vertex AI which returns base64 JSON, RunwayML which uses
+        polling) should override this to return False.
+        """
+        return True

--- a/litellm/llms/custom_httpx/httpx_stream_handler.py
+++ b/litellm/llms/custom_httpx/httpx_stream_handler.py
@@ -1,0 +1,94 @@
+"""
+Streaming binary response wrapper for httpx.
+
+Analogous to ``AiohttpResponseStream`` in ``aiohttp_transport.py`` but for
+native httpx streaming responses.  Used by TTS / audio-speech endpoints when
+``stream=True`` to yield audio bytes as they arrive from the upstream
+provider without buffering the entire response in memory.
+"""
+
+import asyncio
+from typing import Any, Optional
+
+import httpx
+
+
+class HttpxStreamHandler:
+    """
+    A streaming binary response that yields bytes as they arrive from the
+    upstream provider, without buffering the entire response in memory.
+
+    Returned by speech/TTS endpoints when ``stream=True`` is passed.  The 
+    audio bytes are **not** available via a``.content`` property — they 
+    must be consumed through ``aiter_bytes()`` (async) or ``iter_bytes()`` (sync).
+
+    The caller is responsible for ensuring the stream is fully consumed or
+    explicitly closed so that the underlying HTTP connection is released.
+    ``aiter_bytes`` / ``iter_bytes`` handle this automatically via a
+    ``finally`` block that invokes the cleanup callback.
+    """
+
+    _hidden_params: dict
+
+    def __init__(
+        self,
+        response: httpx.Response,
+        cleanup: Any = None,
+    ) -> None:
+        self.response = response
+        self._hidden_params = {}
+        self._cleanup = cleanup
+        self._consumed = False
+
+    async def aiter_bytes(
+        self,
+        chunk_size: Optional[int] = None,
+    ) -> Any:  # AsyncIterator[bytes] — typed as Any for compatibility
+        """Yield bytes from the upstream response as they arrive."""
+        if self._consumed:
+            raise RuntimeError("HttpxStreamHandler has already been consumed.")
+        self._consumed = True
+        try:
+            async for chunk in self.response.aiter_bytes(chunk_size=chunk_size):
+                yield chunk
+        finally:
+            await self.aclose()
+
+    def iter_bytes(
+        self,
+        chunk_size: Optional[int] = None,
+    ) -> Any:  # Iterator[bytes] — typed as Any for compatibility
+        """Yield bytes from the upstream response as they arrive (sync)."""
+        if self._consumed:
+            raise RuntimeError("HttpxStreamHandler has already been consumed.")
+        self._consumed = True
+        try:
+            for chunk in self.response.iter_bytes(chunk_size=chunk_size):
+                yield chunk
+        finally:
+            self.close()
+
+    async def aclose(self) -> None:
+        """Release the underlying HTTP connection (async)."""
+        try:
+            await self.response.aclose()
+        except Exception:
+            pass
+        if self._cleanup is not None:
+            cleanup_result = self._cleanup()
+            if asyncio.iscoroutine(cleanup_result):
+                await cleanup_result
+
+    def close(self) -> None:
+        """Release the underlying HTTP connection (sync)."""
+        try:
+            self.response.close()
+        except Exception:
+            pass
+        if self._cleanup is not None:
+            result = self._cleanup()
+            # If cleanup returns a coroutine in a sync context we cannot
+            # await it — callers using sync streams should provide a sync
+            # cleanup callback or None.
+            if asyncio.iscoroutine(result):
+                result.close()  # discard to avoid RuntimeWarning

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -146,6 +146,7 @@ if TYPE_CHECKING:
         Run,
         RunDeleteResponse,
     )
+    from litellm.llms.custom_httpx.httpx_stream_handler import HttpxStreamHandler
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
@@ -8785,9 +8786,11 @@ class BaseLLMHTTPHandler:
         extra_headers: Optional[Dict[str, Any]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         _is_async: bool = False,
+        stream: Optional[bool] = None,
     ) -> Union[
         "HttpxBinaryResponseContent",
-        Coroutine[Any, Any, "HttpxBinaryResponseContent"],
+        "HttpxStreamHandler",
+        Coroutine[Any, Any, Union["HttpxBinaryResponseContent", "HttpxStreamHandler"]],
     ]:
         """
         Handles text-to-speech requests.
@@ -8806,6 +8809,7 @@ class BaseLLMHTTPHandler:
                 extra_headers=extra_headers,
                 timeout=timeout,
                 client=client if isinstance(client, AsyncHTTPHandler) else None,
+                stream=stream,
             )
 
         if client is None or not isinstance(client, HTTPHandler):
@@ -8863,6 +8867,7 @@ class BaseLLMHTTPHandler:
                     headers=headers,
                     json=request_data["dict_body"],
                     timeout=timeout,
+                    stream=True if stream and text_to_speech_provider_config.supports_streaming else False,
                 )
             elif "ssml_body" in request_data:
                 response = sync_httpx_client.post(
@@ -8870,6 +8875,7 @@ class BaseLLMHTTPHandler:
                     headers=headers,
                     data=request_data["ssml_body"],
                     timeout=timeout,
+                    stream=True if stream and text_to_speech_provider_config.supports_streaming else False,
                 )
             else:
                 raise ValueError(
@@ -8881,6 +8887,13 @@ class BaseLLMHTTPHandler:
                 e=e,
                 provider_config=text_to_speech_provider_config,
             )
+
+        if stream is True and text_to_speech_provider_config.supports_streaming:
+            from litellm.llms.custom_httpx.httpx_stream_handler import (
+                HttpxStreamHandler,
+            )
+
+            return HttpxStreamHandler(response=response)
 
         return text_to_speech_provider_config.transform_text_to_speech_response(
             model=model,
@@ -8901,7 +8914,8 @@ class BaseLLMHTTPHandler:
         timeout: Union[float, httpx.Timeout],
         extra_headers: Optional[Dict[str, Any]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
-    ) -> "HttpxBinaryResponseContent":
+        stream: Optional[bool] = None,
+    ) -> Union["HttpxBinaryResponseContent", "HttpxStreamHandler"]:
         """
         Async version of the text-to-speech handler.
         Uses async HTTP client to make requests.
@@ -8962,6 +8976,7 @@ class BaseLLMHTTPHandler:
                     headers=headers,
                     json=request_data["dict_body"],
                     timeout=timeout,
+                    stream=True if stream and text_to_speech_provider_config.supports_streaming else False,
                 )
             elif "ssml_body" in request_data:
                 response = await async_httpx_client.post(
@@ -8969,6 +8984,7 @@ class BaseLLMHTTPHandler:
                     headers=headers,
                     data=request_data["ssml_body"],
                     timeout=timeout,
+                    stream=True if stream and text_to_speech_provider_config.supports_streaming else False,
                 )
             else:
                 raise ValueError(
@@ -8980,6 +8996,13 @@ class BaseLLMHTTPHandler:
                 e=e,
                 provider_config=text_to_speech_provider_config,
             )
+
+        if stream is True and text_to_speech_provider_config.supports_streaming:
+            from litellm.llms.custom_httpx.httpx_stream_handler import (
+                HttpxStreamHandler,
+            )
+
+            return HttpxStreamHandler(response=response)
 
         return text_to_speech_provider_config.transform_text_to_speech_response(
             model=model,

--- a/litellm/llms/minimax/text_to_speech/transformation.py
+++ b/litellm/llms/minimax/text_to_speech/transformation.py
@@ -419,3 +419,12 @@ class MinimaxTextToSpeechConfig(BaseTextToSpeechConfig):
 
         return url
 
+    @property
+    def supports_streaming(self) -> bool:
+        """
+        MiniMax TTS does not support true streaming.
+
+        The API returns JSON containing hex/base64-encoded audio data,
+        which must be fully received and decoded before audio bytes are available.
+        """
+        return False

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1536,6 +1536,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         aspeech: Optional[bool] = None,
         client=None,
         shared_session: Optional["ClientSession"] = None,
+        stream: Optional[bool] = None,
     ) -> HttpxBinaryResponseContent:
         if aspeech is not None and aspeech is True:
             return self.async_audio_speech(
@@ -1551,6 +1552,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 timeout=timeout,
                 client=client,
                 shared_session=shared_session,
+                stream=stream,
             )  # type: ignore
 
         openai_client = self._get_openai_client(
@@ -1562,6 +1564,25 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             client=client,
             shared_session=shared_session,
         )
+
+        if stream is True:
+            from litellm.llms.custom_httpx.httpx_stream_handler import (
+                HttpxStreamHandler,
+            )
+
+            ctx = cast(
+                OpenAI, openai_client
+            ).audio.speech.with_streaming_response.create(
+                model=model,
+                voice=voice,  # type: ignore
+                input=input,
+                **optional_params,
+            )
+            streamed_response = ctx.__enter__()
+            return HttpxStreamHandler(
+                response=streamed_response.http_response,
+                cleanup=lambda: ctx.__exit__(None, None, None),
+            )  # type: ignore
 
         response = cast(OpenAI, openai_client).audio.speech.create(
             model=model,
@@ -1585,6 +1606,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         timeout: Union[float, httpx.Timeout],
         client=None,
         shared_session: Optional["ClientSession"] = None,
+        stream: Optional[bool] = None,
     ) -> HttpxBinaryResponseContent:
         openai_client = cast(
             AsyncOpenAI,
@@ -1598,6 +1620,23 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 shared_session=shared_session,
             ),
         )
+
+        if stream is True:
+            from litellm.llms.custom_httpx.httpx_stream_handler import (
+                HttpxStreamHandler,
+            )
+
+            ctx = openai_client.audio.speech.with_streaming_response.create(
+                model=model,
+                voice=voice,  # type: ignore
+                input=input,
+                **optional_params,
+            )
+            streamed_response = await ctx.__aenter__()
+            return HttpxStreamHandler(
+                response=streamed_response.http_response,
+                cleanup=lambda: ctx.__aexit__(None, None, None),
+            )  # type: ignore
 
         response = await openai_client.audio.speech.create(
             model=model,

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -20,6 +20,7 @@ import httpx
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession
+    from litellm.llms.custom_httpx.httpx_stream_handler import HttpxStreamHandler
 
 import openai
 from openai import AsyncOpenAI, OpenAI
@@ -1537,7 +1538,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         client=None,
         shared_session: Optional["ClientSession"] = None,
         stream: Optional[bool] = None,
-    ) -> HttpxBinaryResponseContent:
+    ) -> Union[HttpxBinaryResponseContent, "HttpxStreamHandler"]:
         if aspeech is not None and aspeech is True:
             return self.async_audio_speech(
                 model=model,
@@ -1607,7 +1608,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         client=None,
         shared_session: Optional["ClientSession"] = None,
         stream: Optional[bool] = None,
-    ) -> HttpxBinaryResponseContent:
+    ) -> Union[HttpxBinaryResponseContent, "HttpxStreamHandler"]:
         openai_client = cast(
             AsyncOpenAI,
             self._get_openai_client(

--- a/litellm/llms/runwayml/text_to_speech/transformation.py
+++ b/litellm/llms/runwayml/text_to_speech/transformation.py
@@ -589,3 +589,12 @@ class RunwayMLTextToSpeechConfig(BaseTextToSpeechConfig):
         # Return the audio data wrapped in HttpxBinaryResponseContent
         return HttpxBinaryResponseContent(audio_response)
 
+    @property
+    def supports_streaming(self) -> bool:
+        """
+        RunwayML TTS does not support true streaming.
+
+        The API uses an asynchronous polling pattern: the initial POST returns a
+        task ID, which must be polled until completion before downloading audio.
+        """
+        return False

--- a/litellm/llms/runwayml/text_to_speech/transformation.py
+++ b/litellm/llms/runwayml/text_to_speech/transformation.py
@@ -24,9 +24,11 @@ from litellm.secret_managers.main import get_secret_str
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.types.llms.openai import HttpxBinaryResponseContent
+    from litellm.llms.custom_httpx.httpx_stream_handler import HttpxStreamHandler
 else:
     LiteLLMLoggingObj = Any
     HttpxBinaryResponseContent = Any
+    HttpxStreamHandler = Any
 
 
 class RunwayMLTextToSpeechConfig(BaseTextToSpeechConfig):
@@ -65,12 +67,14 @@ class RunwayMLTextToSpeechConfig(BaseTextToSpeechConfig):
         extra_headers: Optional[Dict[str, Any]],
         base_llm_http_handler: Any,
         aspeech: bool,
+        stream: Optional[bool],
         api_base: Optional[str],
         api_key: Optional[str],
         **kwargs: Any,
     ) -> Union[
         "HttpxBinaryResponseContent",
-        Coroutine[Any, Any, "HttpxBinaryResponseContent"],
+        "HttpxStreamHandler",
+        Coroutine[Any, Any, Union["HttpxBinaryResponseContent", "HttpxStreamHandler"]],
     ]:
         """
         Dispatch method to handle RunwayML TTS requests
@@ -126,6 +130,7 @@ class RunwayMLTextToSpeechConfig(BaseTextToSpeechConfig):
             extra_headers=extra_headers,
             client=None,
             _is_async=aspeech,
+            stream=stream,
         )
         
         return response

--- a/litellm/llms/vertex_ai/text_to_speech/transformation.py
+++ b/litellm/llms/vertex_ai/text_to_speech/transformation.py
@@ -470,3 +470,13 @@ class VertexAITextToSpeechConfig(BaseTextToSpeechConfig, VertexBase):
 
         # Initialize the HttpxBinaryResponseContent instance
         return HttpxBinaryResponseContent(response)
+
+    @property
+    def supports_streaming(self) -> bool:
+        """
+        Vertex AI TTS does not support true streaming.
+
+        The API returns JSON with base64-encoded audio in the audioContent field,
+        which must be fully received and decoded before audio bytes are available.
+        """
+        return False

--- a/litellm/llms/vertex_ai/text_to_speech/transformation.py
+++ b/litellm/llms/vertex_ai/text_to_speech/transformation.py
@@ -25,9 +25,11 @@ from litellm.types.llms.vertex_ai_text_to_speech import (
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.types.llms.openai import HttpxBinaryResponseContent
+    from litellm.llms.custom_httpx.httpx_stream_handler import HttpxStreamHandler
 else:
     LiteLLMLoggingObj = Any
     HttpxBinaryResponseContent = Any
+    HttpxStreamHandler = Any
 
 
 class VertexAITextToSpeechConfig(BaseTextToSpeechConfig, VertexBase):
@@ -133,12 +135,14 @@ class VertexAITextToSpeechConfig(BaseTextToSpeechConfig, VertexBase):
         extra_headers: Optional[Dict[str, Any]],
         base_llm_http_handler: Any,
         aspeech: bool,
+        stream: Optional[bool],
         api_base: Optional[str],
         api_key: Optional[str],
         **kwargs: Any,
     ) -> Union[
         "HttpxBinaryResponseContent",
-        Coroutine[Any, Any, "HttpxBinaryResponseContent"],
+        "HttpxStreamHandler",
+        Coroutine[Any, Any, Union["HttpxBinaryResponseContent", "HttpxStreamHandler"]],
     ]:
         """
         Dispatch method to handle Vertex AI TTS requests
@@ -185,6 +189,7 @@ class VertexAITextToSpeechConfig(BaseTextToSpeechConfig, VertexBase):
             extra_headers=extra_headers,
             client=None,
             _is_async=aspeech,
+            stream=stream,
         )
 
         return response

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -64,6 +64,7 @@ from litellm.utils import exception_type, get_litellm_params, get_optional_param
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging
     from litellm.types.utils import TokenCountResponse
+    from litellm.llms.custom_httpx.httpx_stream_handler import HttpxStreamHandler
 
 from litellm.constants import (
     DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT,
@@ -6627,8 +6628,13 @@ def speech(  # noqa: PLR0915
     headers: Optional[dict] = None,
     custom_llm_provider: Optional[str] = None,
     aspeech: Optional[bool] = None,
+    stream: Optional[bool] = None,
     **kwargs,
-) -> Union[HttpxBinaryResponseContent, Coroutine[Any, Any, HttpxBinaryResponseContent]]:
+) -> Union[
+    HttpxBinaryResponseContent,
+    "HttpxStreamHandler",
+    Coroutine[Any, Any, Union[HttpxBinaryResponseContent, "HttpxStreamHandler"]],
+]:
     user = kwargs.get("user", None)
     litellm_call_id: Optional[str] = kwargs.get("litellm_call_id", None)
     proxy_server_request = kwargs.get("proxy_server_request", None)
@@ -6751,6 +6757,7 @@ def speech(  # noqa: PLR0915
             client=client,  # pass AsyncOpenAI, OpenAI client
             aspeech=aspeech,
             shared_session=shared_session,
+            stream=stream,
         )
     elif custom_llm_provider == "azure":
         # Check if this is Azure Speech Service (Cognitive Services TTS)
@@ -6783,6 +6790,7 @@ def speech(  # noqa: PLR0915
                 extra_headers=extra_headers,
                 base_llm_http_handler=base_llm_http_handler,
                 aspeech=aspeech or False,
+                stream=stream,
                 api_base=api_base,
                 api_key=api_key,
                 **kwargs,
@@ -6833,6 +6841,7 @@ def speech(  # noqa: PLR0915
                 client=client,  # pass AsyncOpenAI, OpenAI client
                 aspeech=aspeech,
                 litellm_params=litellm_params_dict,
+                stream=stream,
             )
     elif custom_llm_provider == "elevenlabs":
         from litellm.llms.elevenlabs.text_to_speech.transformation import (
@@ -6885,6 +6894,7 @@ def speech(  # noqa: PLR0915
             extra_headers=extra_headers,
             client=client,
             _is_async=aspeech or False,
+            stream=stream,
         )
     elif custom_llm_provider == "vertex_ai" or custom_llm_provider == "vertex_ai_beta":
         from litellm.llms.vertex_ai.text_to_speech.transformation import (
@@ -6937,6 +6947,7 @@ def speech(  # noqa: PLR0915
             extra_headers=headers,
             base_llm_http_handler=base_llm_http_handler,
             aspeech=aspeech or False,
+            stream=stream,
             api_base=generic_optional_params.api_base,
             api_key=None,  # Vertex AI uses OAuth, not API key
             **kwargs,
@@ -6985,6 +6996,7 @@ def speech(  # noqa: PLR0915
             extra_headers=extra_headers,
             base_llm_http_handler=base_llm_http_handler,
             aspeech=aspeech or False,
+            stream=stream,
             api_base=api_base,
             api_key=api_key,
             **kwargs,
@@ -7026,6 +7038,7 @@ def speech(  # noqa: PLR0915
             extra_headers=extra_headers,
             client=client,
             _is_async=aspeech or False,
+            stream=stream,
         )
     elif custom_llm_provider == "aws_polly":
         from litellm.llms.aws_polly.text_to_speech.transformation import (
@@ -7052,6 +7065,7 @@ def speech(  # noqa: PLR0915
             extra_headers=extra_headers,
             base_llm_http_handler=base_llm_http_handler,
             aspeech=aspeech or False,
+            stream=stream,
             api_base=api_base,
             api_key=api_key,
             **kwargs,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -537,6 +537,7 @@ from litellm.types.llms.anthropic import (
     AnthropicResponseUsageBlock,
 )
 from litellm.types.llms.openai import HttpxBinaryResponseContent
+from litellm.llms.custom_httpx.httpx_stream_handler import HttpxStreamHandler
 from litellm.types.proxy.management_endpoints.model_management_endpoints import (
     ModelGroupInfoProxy,
 )
@@ -7263,15 +7264,21 @@ async def moderations(
 
 
 async def _audio_speech_chunk_generator(
-    _response: HttpxBinaryResponseContent,
+    _response: Union[HttpxBinaryResponseContent, HttpxStreamHandler],
 ) -> AsyncGenerator[bytes, None]:
     # chunk_size has a big impact on latency, it can't be too small or too large
     # too small: latency is high
     # too large: latency is low, but memory usage is high
     # 8192 is a good compromise
-    _generator = await _response.aiter_bytes(chunk_size=AUDIO_SPEECH_CHUNK_SIZE)
-    async for chunk in _generator:
-        yield chunk
+    if isinstance(_response, HttpxStreamHandler):
+        # HttpxStreamHandler.aiter_bytes() is an async generator — iterate directly
+        async for chunk in _response.aiter_bytes(chunk_size=AUDIO_SPEECH_CHUNK_SIZE):
+            yield chunk
+    else:
+        # HttpxBinaryResponseContent.aiter_bytes() is a coroutine returning an iterator
+        _generator = await _response.aiter_bytes(chunk_size=AUDIO_SPEECH_CHUNK_SIZE)
+        async for chunk in _generator:
+            yield chunk
 
 
 @router.post(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3107,7 +3107,7 @@ class Router:
                 self.fail_calls[model_name] += 1
             raise e
 
-    async def aspeech(self, model: str, input: str, voice: str, **kwargs):
+    async def aspeech(self, model: str, input: str, voice: str, stream: Optional[bool] = None, **kwargs):
         """
         Example Usage:
 
@@ -3142,6 +3142,7 @@ class Router:
         try:
             kwargs["input"] = input
             kwargs["voice"] = voice
+            kwargs["stream"] = stream
 
             deployment = await self.async_get_available_deployment(
                 model=model,

--- a/tests/test_litellm/llms/custom_httpx/test_httpx_stream_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_httpx_stream_handler.py
@@ -1,0 +1,255 @@
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))  # Adds the parent directory to the system path
+
+from litellm.llms.custom_httpx.httpx_stream_handler import HttpxStreamHandler
+
+
+class MockHttpxResponse:
+    """Mock httpx.Response for testing streaming iteration."""
+
+    def __init__(self, chunks=None, exception_to_raise=None, exception_at_chunk=None):
+        self.chunks = chunks or [b"chunk1", b"chunk2", b"chunk3"]
+        self.exception_to_raise = exception_to_raise
+        self.exception_at_chunk = exception_at_chunk
+        self._closed = False
+
+    async def aiter_bytes(self, chunk_size=None):
+        for i, chunk in enumerate(self.chunks):
+            if self.exception_to_raise and i == self.exception_at_chunk:
+                raise self.exception_to_raise
+            yield chunk
+
+    def iter_bytes(self, chunk_size=None):
+        for i, chunk in enumerate(self.chunks):
+            if self.exception_to_raise and i == self.exception_at_chunk:
+                raise self.exception_to_raise
+            yield chunk
+
+    async def aclose(self):
+        self._closed = True
+
+    def close(self):
+        self._closed = True
+
+
+@pytest.mark.asyncio
+async def test_aiter_bytes_normal_flow():
+    """should yield all chunks from the upstream response via aiter_bytes"""
+    mock_response = MockHttpxResponse(chunks=[b"hello", b"world", b"test"])
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    chunks = []
+    async for chunk in handler.aiter_bytes():
+        chunks.append(chunk)
+
+    assert chunks == [b"hello", b"world", b"test"]
+
+
+def test_iter_bytes_normal_flow():
+    """should yield all chunks from the upstream response via iter_bytes"""
+    mock_response = MockHttpxResponse(chunks=[b"hello", b"world", b"test"])
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    chunks = []
+    for chunk in handler.iter_bytes():
+        chunks.append(chunk)
+
+    assert chunks == [b"hello", b"world", b"test"]
+
+
+@pytest.mark.asyncio
+async def test_aiter_bytes_with_chunk_size():
+    """should pass chunk_size through to the underlying response"""
+    captured = {}
+
+    class CapturingResponse(MockHttpxResponse):
+        async def aiter_bytes(self, chunk_size=None):
+            captured["chunk_size"] = chunk_size
+            async for chunk in super().aiter_bytes(chunk_size=chunk_size):
+                yield chunk
+
+    mock_response = CapturingResponse(chunks=[b"data"])
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    async for _ in handler.aiter_bytes(chunk_size=8192):
+        pass
+
+    assert captured["chunk_size"] == 8192
+
+
+@pytest.mark.asyncio
+async def test_aiter_bytes_consumed_once():
+    """should raise RuntimeError on second call to aiter_bytes"""
+    mock_response = MockHttpxResponse(chunks=[b"data"])
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    async for _ in handler.aiter_bytes():
+        pass
+
+    with pytest.raises(RuntimeError, match="already been consumed"):
+        async for _ in handler.aiter_bytes():
+            pass
+
+
+def test_iter_bytes_consumed_once():
+    """should raise RuntimeError on second call to iter_bytes"""
+    mock_response = MockHttpxResponse(chunks=[b"data"])
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    for _ in handler.iter_bytes():
+        pass
+
+    with pytest.raises(RuntimeError, match="already been consumed"):
+        for _ in handler.iter_bytes():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_aiter_bytes_closes_response():
+    """should call aclose on the response after async iteration completes"""
+    mock_response = MockHttpxResponse(chunks=[b"data"])
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    async for _ in handler.aiter_bytes():
+        pass
+
+    assert mock_response._closed is True
+
+
+def test_iter_bytes_closes_response():
+    """should call close on the response after sync iteration completes"""
+    mock_response = MockHttpxResponse(chunks=[b"data"])
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    for _ in handler.iter_bytes():
+        pass
+
+    assert mock_response._closed is True
+
+
+@pytest.mark.asyncio
+async def test_aiter_bytes_closes_response_on_error():
+    """should call aclose on the response even when iteration raises an error"""
+    mock_response = MockHttpxResponse(
+        chunks=[b"chunk1", b"chunk2"],
+        exception_to_raise=RuntimeError("upstream error"),
+        exception_at_chunk=1,
+    )
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    with pytest.raises(RuntimeError, match="upstream error"):
+        async for _ in handler.aiter_bytes():
+            pass
+
+    assert mock_response._closed is True
+
+
+def test_iter_bytes_closes_response_on_error():
+    """should call close on the response even when iteration raises an error"""
+    mock_response = MockHttpxResponse(
+        chunks=[b"chunk1", b"chunk2"],
+        exception_to_raise=RuntimeError("upstream error"),
+        exception_at_chunk=1,
+    )
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    with pytest.raises(RuntimeError, match="upstream error"):
+        for _ in handler.iter_bytes():
+            pass
+
+    assert mock_response._closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_cleanup_callback_invoked():
+    """should invoke the async cleanup callback after aiter_bytes completes"""
+    cleanup_called = False
+
+    async def async_cleanup():
+        nonlocal cleanup_called
+        cleanup_called = True
+
+    mock_response = MockHttpxResponse(chunks=[b"data"])
+    handler = HttpxStreamHandler(response=mock_response, cleanup=async_cleanup)  # type: ignore
+
+    async for _ in handler.aiter_bytes():
+        pass
+
+    assert cleanup_called is True
+
+
+def test_sync_cleanup_callback_invoked():
+    """should invoke the sync cleanup callback after iter_bytes completes"""
+    cleanup_called = False
+
+    def sync_cleanup():
+        nonlocal cleanup_called
+        cleanup_called = True
+
+    mock_response = MockHttpxResponse(chunks=[b"data"])
+    handler = HttpxStreamHandler(response=mock_response, cleanup=sync_cleanup)  # type: ignore
+
+    for _ in handler.iter_bytes():
+        pass
+
+    assert cleanup_called is True
+
+
+@pytest.mark.asyncio
+async def test_hidden_params_default_empty():
+    """should initialize _hidden_params as an empty dict"""
+    mock_response = MockHttpxResponse()
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    assert handler._hidden_params == {}
+
+
+@pytest.mark.asyncio
+async def test_hidden_params_can_be_set():
+    """should allow _hidden_params to be set for cost tracking metadata"""
+    mock_response = MockHttpxResponse()
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    handler._hidden_params = {
+        "model_id": "test-model",
+        "response_cost": 0.001,
+    }
+
+    assert handler._hidden_params["model_id"] == "test-model"
+    assert handler._hidden_params["response_cost"] == 0.001
+
+
+@pytest.mark.asyncio
+async def test_aclose_handles_response_close_error():
+    """should not raise when the underlying response.aclose() fails"""
+
+    class FailingCloseResponse(MockHttpxResponse):
+        async def aclose(self):
+            raise ConnectionError("connection already closed")
+
+    mock_response = FailingCloseResponse(chunks=[b"data"])
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    # Should not raise
+    await handler.aclose()
+
+
+def test_close_handles_response_close_error():
+    """should not raise when the underlying response.close() fails"""
+
+    class FailingCloseResponse(MockHttpxResponse):
+        def close(self):
+            raise ConnectionError("connection already closed")
+
+    mock_response = FailingCloseResponse(chunks=[b"data"])
+    handler = HttpxStreamHandler(response=mock_response)  # type: ignore
+
+    # Should not raise
+    handler.close()

--- a/tests/test_litellm/llms/custom_httpx/test_httpx_stream_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_httpx_stream_handler.py
@@ -1,9 +1,6 @@
-import asyncio
 import os
 import sys
-from unittest.mock import AsyncMock, MagicMock
 
-import httpx
 import pytest
 
 sys.path.insert(0, os.path.abspath("../../../.."))  # Adds the parent directory to the system path

--- a/tests/test_litellm/llms/test_tts_streaming.py
+++ b/tests/test_litellm/llms/test_tts_streaming.py
@@ -1,0 +1,257 @@
+"""
+Tests for TTS streaming (stream=True) through the public litellm.speech()/aspeech() API.
+
+Covers:
+- OpenAI sync/async: mock with_streaming_response, assert HttpxStreamHandler returned
+- httpx-based provider sync/async: mock HTTPHandler.post, assert stream=True forwarded
+- Non-streaming provider: stream=True on supports_streaming=False returns HttpxBinaryResponseContent
+- Default behavior: no stream param returns HttpxBinaryResponseContent
+"""
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+import litellm
+from litellm.llms.custom_httpx.httpx_stream_handler import HttpxStreamHandler
+
+
+def _make_fake_httpx_response(status_code: int = 200) -> httpx.Response:
+    """Create a minimal httpx.Response that can be used in tests."""
+    request = httpx.Request("POST", "https://fake.example.com/v1/audio/speech")
+    response = httpx.Response(
+        status_code=status_code,
+        request=request,
+        content=b"fake-audio-bytes",
+    )
+    return response
+
+
+# ---------------------------------------------------------------------------
+# OpenAI sync — stream=True
+# ---------------------------------------------------------------------------
+class TestOpenAISyncStreaming:
+    def test_openai_speech_stream_returns_handler(self):
+        """litellm.speech(stream=True) with OpenAI should return HttpxStreamHandler."""
+        from openai import OpenAI
+
+        openai_client = OpenAI(api_key="fake-key")
+
+        fake_response = _make_fake_httpx_response()
+
+        # Mock the with_streaming_response.create context manager
+        fake_streamed = MagicMock()
+        fake_streamed.http_response = fake_response
+
+        @contextmanager
+        def fake_ctx(*args, **kwargs):
+            yield fake_streamed
+
+        mock_create = MagicMock(side_effect=fake_ctx)
+
+        with patch.object(
+            openai_client.audio.speech.with_streaming_response,
+            "create",
+            mock_create,
+        ):
+            result = litellm.speech(
+                model="openai/tts-1",
+                input="Hello world",
+                voice="alloy",
+                client=openai_client,
+                stream=True,
+            )
+
+        assert isinstance(result, HttpxStreamHandler)
+        mock_create.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# OpenAI async — stream=True
+# ---------------------------------------------------------------------------
+class TestOpenAIAsyncStreaming:
+    @pytest.mark.asyncio
+    async def test_openai_aspeech_stream_returns_handler(self):
+        """litellm.aspeech(stream=True) with OpenAI should return HttpxStreamHandler."""
+        from openai import AsyncOpenAI
+
+        openai_client = AsyncOpenAI(api_key="fake-key")
+
+        fake_response = _make_fake_httpx_response()
+
+        fake_streamed = MagicMock()
+        fake_streamed.http_response = fake_response
+
+        # Build an async context manager mock
+        async_ctx = AsyncMock()
+        async_ctx.__aenter__ = AsyncMock(return_value=fake_streamed)
+        async_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_create = MagicMock(return_value=async_ctx)
+
+        with patch.object(
+            openai_client.audio.speech.with_streaming_response,
+            "create",
+            mock_create,
+        ):
+            result = await litellm.aspeech(
+                model="openai/tts-1",
+                input="Hello world",
+                voice="alloy",
+                client=openai_client,
+                stream=True,
+            )
+
+        assert isinstance(result, HttpxStreamHandler)
+        mock_create.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# httpx-based provider sync — stream=True (ElevenLabs)
+# ---------------------------------------------------------------------------
+class TestHttpxProviderSyncStreaming:
+    @patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post")
+    def test_elevenlabs_speech_stream_returns_handler(self, mock_post):
+        """litellm.speech(stream=True) with ElevenLabs should pass stream=True
+        to HTTPHandler.post and return HttpxStreamHandler."""
+        fake_response = _make_fake_httpx_response()
+        mock_post.return_value = fake_response
+
+        result = litellm.speech(
+            model="elevenlabs/eleven_multilingual_v2",
+            input="Hello world",
+            voice="test-voice-id",
+            api_key="fake-elevenlabs-key",
+            stream=True,
+        )
+
+        assert isinstance(result, HttpxStreamHandler)
+        # Verify stream=True was passed to the HTTP client
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs.kwargs.get("stream") is True or (
+            len(call_kwargs.args) > 0 and call_kwargs.kwargs.get("stream") is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# httpx-based provider async — stream=True (ElevenLabs)
+# ---------------------------------------------------------------------------
+class TestHttpxProviderAsyncStreaming:
+    @pytest.mark.asyncio
+    @patch("litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post")
+    async def test_elevenlabs_aspeech_stream_returns_handler(self, mock_post):
+        """litellm.aspeech(stream=True) with ElevenLabs should return HttpxStreamHandler."""
+        fake_response = _make_fake_httpx_response()
+        mock_post.return_value = fake_response
+
+        result = await litellm.aspeech(
+            model="elevenlabs/eleven_multilingual_v2",
+            input="Hello world",
+            voice="test-voice-id",
+            api_key="fake-elevenlabs-key",
+            stream=True,
+        )
+
+        assert isinstance(result, HttpxStreamHandler)
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs.kwargs.get("stream") is True
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming provider — stream=True on supports_streaming=False
+# ---------------------------------------------------------------------------
+class TestNonStreamingProvider:
+    @patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post")
+    def test_minimax_stream_true_returns_binary(self, mock_post):
+        """When supports_streaming=False (MiniMax), stream=True should be
+        ignored and return HttpxBinaryResponseContent."""
+        import json
+
+        from litellm.types.llms.openai import HttpxBinaryResponseContent
+
+        # MiniMax returns JSON with hex-encoded audio
+        minimax_response_body = json.dumps(
+            {
+                "status": 0,
+                "data": {"audio": "48454c4c4f"},  # hex for "HELLO"
+            }
+        ).encode()
+        request = httpx.Request("POST", "https://fake.example.com/v1/t2a_v2")
+        fake_response = httpx.Response(
+            status_code=200,
+            request=request,
+            content=minimax_response_body,
+        )
+        mock_post.return_value = fake_response
+
+        result = litellm.speech(
+            model="minimax/speech-02-hd",
+            input="Hello world",
+            voice="Wise_Woman",
+            api_key="fake-minimax-key",
+            stream=True,
+        )
+
+        assert isinstance(result, HttpxBinaryResponseContent)
+        # Verify stream was NOT passed as True to HTTPHandler.post
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs.kwargs.get("stream") is not True
+
+
+# ---------------------------------------------------------------------------
+# Default behavior — no stream param
+# ---------------------------------------------------------------------------
+class TestDefaultBehavior:
+    @patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post")
+    def test_elevenlabs_no_stream_returns_binary(self, mock_post):
+        """Without stream param, litellm.speech() should return HttpxBinaryResponseContent."""
+        from litellm.types.llms.openai import HttpxBinaryResponseContent
+
+        fake_response = _make_fake_httpx_response()
+        mock_post.return_value = fake_response
+
+        result = litellm.speech(
+            model="elevenlabs/eleven_multilingual_v2",
+            input="Hello world",
+            voice="test-voice-id",
+            api_key="fake-elevenlabs-key",
+        )
+
+        assert isinstance(result, HttpxBinaryResponseContent)
+
+    def test_openai_no_stream_returns_binary(self):
+        """Without stream param, litellm.speech() with OpenAI should return
+        HttpxBinaryResponseContent."""
+        from openai import OpenAI
+
+        from litellm.types.llms.openai import HttpxBinaryResponseContent
+
+        openai_client = OpenAI(api_key="fake-key")
+
+        fake_response = _make_fake_httpx_response()
+
+        # Mock the regular (non-streaming) create
+        fake_speech_response = MagicMock()
+        fake_speech_response.response = fake_response
+
+        mock_create = MagicMock(return_value=fake_speech_response)
+
+        with patch.object(
+            openai_client.audio.speech,
+            "create",
+            mock_create,
+        ):
+            result = litellm.speech(
+                model="openai/tts-1",
+                input="Hello world",
+                voice="alloy",
+                client=openai_client,
+            )
+
+        assert isinstance(result, HttpxBinaryResponseContent)
+        mock_create.assert_called_once()


### PR DESCRIPTION
## Summary

Add opt-in `stream=True` parameter to the TTS `/v1/audio/speech` endpoint so audio bytes are forwarded to the client as they arrive from the upstream provider, instead of buffering the entire response in memory first.

## Problem

The current `/v1/audio/speech` proxy endpoint buffers the **entire** audio response from upstream providers into memory before sending any bytes to the client. The `StreamingResponse` in the proxy only re-chunks already-buffered data in 8 KB pieces — it is not true streaming. This has been reported multiple times:

- #7254 — Audio speech streaming support
- #14891 — TTS streaming not working as expected
- #11320 — Audio speech streaming

## Approach

- **Opt-in**: `stream=True` parameter added to `litellm.speech()`, `litellm.aspeech()`, and `Router.aspeech()`. Default behavior (`stream` omitted or `False`) is completely unchanged — full backward compatibility
- **New class**: `HttpxStreamHandler` in `litellm/llms/custom_httpx/httpx_stream_handler.py` — wraps a streaming `httpx.Response` with `aiter_bytes()`/`iter_bytes()`, `_hidden_params`, and cleanup lifecycle management
- **Capability flag**: `supports_streaming` property on `BaseTextToSpeechConfig` (default `True`), overridden to `False` on providers where true streaming is not possible
- **Proxy**: `isinstance` branch in `_audio_speech_chunk_generator` to handle `HttpxStreamHandler` (async generator) vs `HttpxBinaryResponseContent` (coroutine returning iterator)

### Provider support

| Provider | Streaming supported | Notes |
|----------|-------------------|-------|
| OpenAI | Yes | Uses `with_streaming_response.create()` |
| Azure OpenAI | Yes | Uses `with_streaming_response.create()` |
| ElevenLabs | Yes | Passes `stream=True` to httpx |
| Azure Cognitive (AVA) | Yes | Passes `stream=True` to httpx |
| AWS Polly | Yes | Passes `stream=True` to httpx |
| MiniMax | No (`supports_streaming=False`) | Returns JSON with hex-encoded audio; must be fully received |
| Vertex AI | No (`supports_streaming=False`) | Returns JSON with base64-encoded audio |
| RunwayML | No (`supports_streaming=False`) | Uses async polling pattern |

When `stream=True` is passed to a provider with `supports_streaming=False`, the parameter is silently ignored and the buffered `HttpxBinaryResponseContent` response is returned as usual.

## Testing

22 tests total — 15 unit tests + 7 integration tests:

```bash
python -m pytest tests/test_litellm/llms/custom_httpx/test_httpx_stream_handler.py tests/test_litellm/llms/test_tts_streaming.py -v
# 22 passed
```

**Unit tests** (`test_httpx_stream_handler.py`): async/sync iteration, chunk_size passthrough, consumed-once guard, cleanup callbacks, error handling, response close on error, `_hidden_params`.

**Integration tests** (`test_tts_streaming.py`): OpenAI sync/async streaming, ElevenLabs sync/async streaming, MiniMax `supports_streaming=False` fallback, default (no stream) backward compatibility for ElevenLabs and OpenAI.

## Files changed

- `litellm/llms/custom_httpx/httpx_stream_handler.py` — **new** `HttpxStreamHandler` class
- `litellm/llms/base_llm/text_to_speech/transformation.py` — `supports_streaming` property
- `litellm/llms/minimax/text_to_speech/transformation.py` — override `supports_streaming=False`
- `litellm/llms/vertex_ai/text_to_speech/transformation.py` — override `supports_streaming=False` + dispatch stream param
- `litellm/llms/runwayml/text_to_speech/transformation.py` — override `supports_streaming=False` + dispatch stream param
- `litellm/llms/openai/openai.py` — streaming branch in `audio_speech()`/`async_audio_speech()`
- `litellm/llms/azure/azure.py` — streaming branch in `audio_speech()`/`async_audio_speech()`
- `litellm/llms/azure/text_to_speech/transformation.py` — dispatch stream param
- `litellm/llms/aws_polly/text_to_speech/transformation.py` — dispatch stream param
- `litellm/llms/custom_httpx/llm_http_handler.py` — stream param in `text_to_speech_handler()`/`async_text_to_speech_handler()`
- `litellm/main.py` — `stream` param in `speech()` + forwarding to all provider branches
- `litellm/router.py` — `stream` param in `Router.aspeech()`
- `litellm/proxy/proxy_server.py` — `isinstance` branch in `_audio_speech_chunk_generator`

Fixes #7254, #14891, #11320