### PR TITLE
fix: Allow NotFoundError retry with multiple deployments for order-based routing

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5278,8 +5278,8 @@ class Router:
 
         status_code = getattr(error, "status_code", None)
         if status_code is not None and not litellm._should_retry(status_code):
-            # 401/403 are special cases - allow retry if multiple deployments exist (handled below)
-            if status_code not in (401, 403):
+            # 401/403/404 are special cases - allow retry if multiple deployments exist (handled below)
+            if status_code not in (401, 403, 404):
                 raise error
 
         if isinstance(error, litellm.NotFoundError):

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5283,7 +5283,21 @@ class Router:
                 raise error
 
         if isinstance(error, litellm.NotFoundError):
-            raise error
+            """
+            - if other deployments available -> retry
+            - else -> raise error
+
+            NotFoundError can occur for reasons other than "model doesn't exist":
+            - Provider policy restrictions (e.g., OpenRouter privacy settings)
+            - Regional availability issues
+            - Temporary endpoint unavailability
+
+            Allow fallback to other deployments when multiple are configured.
+            """
+            if (
+                _num_all_deployments <= 1
+            ):  # if there is only 1 deployment for this model group then don't retry
+                raise error  # then raise error
         # Error we should only retry if there are other deployments
         if isinstance(error, openai.RateLimitError):
             if (


### PR DESCRIPTION
## Problem

When using order-based routing with `enable_pre_call_checks: true`, LiteLLM does not retry with the next deployment (order 2) when order 1 fails with a `NotFoundError` (404). Instead, it immediately raises the error to the client, bypassing the fallback mechanism.

**Expected behavior:** When deployment with `order: 1` fails, the router should try deployment with `order: 2` before returning an error to the client.

**Actual behavior:** Router immediately raises `NotFoundError` without attempting order 2 fallback.

## Root Cause

Lines 5285-5286 in `litellm/router.py` (from commit 19c3a82d1bc) unconditionally raise `NotFoundError`:

```python
if isinstance(error, litellm.NotFoundError):
    raise error
```

This was added in August 2024 to prevent retries on "model not found" errors. However, this is too aggressive because:

1. **Not all 404s mean the model doesn't exist** - Providers can return 404 for:
   - Policy restrictions (e.g., OpenRouter privacy settings blocking free models)
   - Regional availability issues
   - Temporary endpoint unavailability
2. **It breaks order-based routing** - Users configure fallbacks specifically to handle provider failures
3. **Inconsistent with other error handling** - `AuthenticationError` checks for healthy deployments before raising

## Solution

Modified `should_retry_this_error` to check if multiple deployments exist before raising `NotFoundError`, similar to how `AuthenticationError` is handled (lines 5296-5304).

```python
if isinstance(error, litellm.NotFoundError):
    """
    - if other deployments available -> retry
    - else -> raise error
    """
    if _num_all_deployments <= 1:
        raise error  # Only 1 deployment, so raise the error
    # Otherwise, allow retry with other deployments
```

## Changes Made

### 1. Modified `litellm/router.py`
- Updated `NotFoundError` handling to check for multiple deployments
- Added documentation explaining when NotFoundError should allow retry

### 2. Updated `tests/local_testing/test_router_retries.py`
- Updated existing test to pass `all_deployments` parameter for consistency
- Added new test `test_retry_for_not_found_error_404_with_multiple_deployments` to verify:
  - NotFoundError allows retry when multiple deployments exist
  - Covers real-world scenario (OpenRouter privacy policy 404)

## Testing

The new test simulates the exact scenario from the bug report:
- Model group with 2 deployments (order 1 and order 2)
- Order 1 fails with OpenRouter privacy policy 404
- Verifies that `should_retry_this_error` returns `True` to allow retry with order 2

## Backward Compatibility

This change maintains backward compatibility:
- ✅ Single deployment configs: NotFoundError still raises immediately (original behavior)
- ✅ Multiple deployments: Now allows fallback (fixes the bug)
- ✅ Existing test still passes with updated parameters

## Related Issue

Fixes #21377

## Checklist

- [x] Add at least 1 test in `tests/litellm/`
- [x] Ensure `make test-unit` passes (will be verified by CI)
- [x] Code follows Google Python Style Guide
- [x] Added descriptive commit message