### PR TITLE
add a new supports_structured_outputs flag

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8146,7 +8146,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "tool_use_system_prompt_tokens": 159,
+        "supports_structured_outputs": true
     },
     "claude-opus-4-1-20250805": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -8174,7 +8175,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "tool_use_system_prompt_tokens": 159,
+        "supports_structured_outputs": true
     },
     "claude-opus-4-20250514": {
         "cache_creation_input_token_cost": 1.875e-05,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -7759,7 +7759,8 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_structured_outputs": true
     },
     "claude-haiku-4-5": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -7780,7 +7781,8 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_structured_outputs": true
     },
     "claude-3-5-sonnet-20240620": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -8059,7 +8061,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "claude-sonnet-4-5-20250929": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -8090,7 +8093,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -8225,7 +8229,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "tool_use_system_prompt_tokens": 159,
+        "supports_structured_outputs": true
     },
     "claude-opus-4-5": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -8252,7 +8257,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "tool_use_system_prompt_tokens": 159,
+        "supports_structured_outputs": true
     },
     "claude-opus-4-6": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -8283,7 +8289,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "fast/claude-opus-4-6": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -8314,7 +8321,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "us/claude-opus-4-6": {
         "cache_creation_input_token_cost": 6.875e-06,
@@ -8345,7 +8353,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "fast/us/claude-opus-4-6": {
         "cache_creation_input_token_cost": 6.875e-06,
@@ -8376,7 +8385,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "claude-opus-4-6-20260205": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -8407,7 +8417,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "fast/claude-opus-4-6-20260205": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -8438,7 +8449,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "us/claude-opus-4-6-20260205": {
         "cache_creation_input_token_cost": 6.875e-06,
@@ -8469,7 +8481,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "claude-sonnet-4-20250514": {
         "deprecation_date": "2026-05-14",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -104,6 +104,7 @@ class ProviderField(TypedDict):
 class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_system_messages: Optional[bool]
     supports_response_schema: Optional[bool]
+    supports_structured_outputs: Optional[bool]
     supports_vision: Optional[bool]
     supports_function_calling: Optional[bool]
     supports_tool_choice: Optional[bool]

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2420,6 +2420,19 @@ def supports_response_schema(
     )
 
 
+def supports_structured_outputs(
+    model: str, custom_llm_provider: Optional[str] = None
+) -> bool:
+    """
+    Check if a model supports native structured outputs (e.g. Anthropic output_format).
+    """
+    return _supports_factory(
+        model=model,
+        custom_llm_provider=custom_llm_provider,
+        key="supports_structured_outputs",
+    )
+
+
 def supports_parallel_function_calling(
     model: str, custom_llm_provider: Optional[str] = None
 ) -> bool:
@@ -5677,6 +5690,9 @@ def _get_model_info_helper(  # noqa: PLR0915
                 ),
                 supports_response_schema=_model_info.get(
                     "supports_response_schema", None
+                ),
+                supports_structured_outputs=_model_info.get(
+                    "supports_structured_outputs", None
                 ),
                 supports_vision=_model_info.get("supports_vision", None),
                 supports_function_calling=_model_info.get(

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8146,7 +8146,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "tool_use_system_prompt_tokens": 159,
+        "supports_structured_outputs": true
     },
     "claude-opus-4-1-20250805": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -8174,7 +8175,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "tool_use_system_prompt_tokens": 159,
+        "supports_structured_outputs": true
     },
     "claude-opus-4-20250514": {
         "cache_creation_input_token_cost": 1.875e-05,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -7759,7 +7759,8 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_structured_outputs": true
     },
     "claude-haiku-4-5": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -7780,7 +7781,8 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_structured_outputs": true
     },
     "claude-3-5-sonnet-20240620": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -8059,7 +8061,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "claude-sonnet-4-5-20250929": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -8090,7 +8093,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -8225,7 +8229,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "tool_use_system_prompt_tokens": 159,
+        "supports_structured_outputs": true
     },
     "claude-opus-4-5": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -8252,7 +8257,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
+        "tool_use_system_prompt_tokens": 159,
+        "supports_structured_outputs": true
     },
     "claude-opus-4-6": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -8283,7 +8289,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "fast/claude-opus-4-6": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -8314,7 +8321,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "us/claude-opus-4-6": {
         "cache_creation_input_token_cost": 6.875e-06,
@@ -8345,7 +8353,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "fast/us/claude-opus-4-6": {
         "cache_creation_input_token_cost": 6.875e-06,
@@ -8376,7 +8385,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "claude-opus-4-6-20260205": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -8407,7 +8417,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "fast/claude-opus-4-6-20260205": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -8438,7 +8449,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "us/claude-opus-4-6-20260205": {
         "cache_creation_input_token_cost": 6.875e-06,
@@ -8469,7 +8481,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346
+        "tool_use_system_prompt_tokens": 346,
+        "supports_structured_outputs": true
     },
     "claude-sonnet-4-20250514": {
         "deprecation_date": "2026-05-14",

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -861,6 +861,8 @@ def test_anthropic_structured_output_beta_header():
         "claude-opus-4-6-20260205",
         "claude-opus-4-5",
         "claude-opus-4-5-20251101",
+        "claude-opus-4-1",
+        "claude-opus-4-1-20250805",
         "claude-sonnet-4-5",
         "claude-sonnet-4-5-20250929",
         "claude-haiku-4-5",


### PR DESCRIPTION
 ## Relevant issues

  Fixes hardcoded model substring checks for Anthropic structured output routing in `anthropic/chat/transformation.py`.

  ## Type

  🧹 Refactoring
  🆕 New Feature

  ## Changes

  Problem

  The Anthropic chat transformation code (litellm/llms/anthropic/chat/transformation.py) hardcoded model name substrings to decide whether to use Anthropic's native structured output
  (output_format) vs the tool-based fallback. Every new model release required a code change, and Haiku 4.5 was missing despite Anthropic supporting it.

  Fix

  Replaced the hardcoded model substring check with a data-driven lookup using a new supports_structured_outputs flag in the model cost map (model_prices_and_context_window.json).

  Before (hardcoded):
  if any(substring in model for substring in {"sonnet-4.5", "sonnet-4-5", "opus-4.1", "opus-4-1", ...}):

  After (model DB driven):
  if supports_structured_outputs(model=model, custom_llm_provider=self.custom_llm_provider):

  Adding support for a new model now requires a single JSON change — zero code changes.

  Models with supports_structured_outputs: true

  Per https://platform.claude.com/docs/en/build-with-claude/structured-outputs:
  1. Claude Opus 4.6 (7 variants)
  2. Claude Sonnet 4.5 (2 variants)
  3. Claude Opus 4.5 (2 variants)
  4. Claude Haiku 4.5 (2 variants) — was previously missing from the hardcoded list

  Files changed

  - litellm/types/utils.py — Added supports_structured_outputs to ProviderSpecificModelInfo TypedDict
  - litellm/utils.py — Added supports_structured_outputs() helper function + wired up in _get_model_info_helper
  - litellm/llms/anthropic/chat/transformation.py — Replaced hardcoded substring check with DB lookup
  - model_prices_and_context_window.json — Added flag to 13 model entries
  - litellm/model_prices_and_context_window_backup.json — Same
  - tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py — Updated tests for all 4 model families + old model fallback