### PR TITLE
feat: add Xinference image edit support

### DIFF
--- a/litellm/llms/xinference/image_edit/__init__.py
+++ b/litellm/llms/xinference/image_edit/__init__.py
@@ -1,0 +1,11 @@
+from litellm.llms.base_llm.image_edit.transformation import BaseImageEditConfig
+
+from .transformation import XInferenceImageEditConfig
+
+__all__ = [
+    "XInferenceImageEditConfig",
+]
+
+
+def get_xinference_image_edit_config(model: str) -> BaseImageEditConfig:
+    return XInferenceImageEditConfig()

--- a/litellm/llms/xinference/image_edit/transformation.py
+++ b/litellm/llms/xinference/image_edit/transformation.py
@@ -1,0 +1,212 @@
+from io import BufferedReader
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from httpx._types import RequestFiles
+
+import litellm
+from litellm.images.utils import ImageEditRequestUtils
+from litellm.llms.base_llm.image_edit.transformation import BaseImageEditConfig
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.images.main import (
+    ImageEditOptionalRequestParams,
+)
+from litellm.types.llms.openai import FileTypes
+from litellm.types.router import GenericLiteLLMParams
+from litellm.utils import ImageResponse
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
+
+
+class XInferenceImageEditConfig(BaseImageEditConfig):
+    """
+    Configuration for Xinference image edit API.
+
+    Xinference supports image-to-image transformation through its image editing API.
+    The API is OpenAI-compatible and uses the /v1/images/edits endpoint.
+
+    Reference: https://inference.readthedocs.io/
+    """
+
+    def get_supported_openai_params(self, model: str) -> list:
+        """
+        Supported OpenAI parameters for Xinference image edit.
+
+        Based on Xinference's OpenAI-compatible API, it supports:
+        - image: The image to edit (required)
+        - prompt: Text description of the desired edit (required)
+        - mask: An additional image whose fully transparent areas indicate where image should be edited
+        - n: Number of images to generate (1-10)
+        - size: Size of the generated images
+        - response_format: Format of the response (url or b64_json)
+        """
+        return [
+            "image",
+            "prompt",
+            "mask",
+            "n",
+            "size",
+            "response_format",
+        ]
+
+    def map_openai_params(
+        self,
+        image_edit_optional_params: ImageEditOptionalRequestParams,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        """
+        Map OpenAI image edit parameters to Xinference parameters.
+
+        Xinference uses OpenAI-compatible format, so no transformation is needed.
+        We just filter to supported parameters.
+        """
+        all_params = dict(image_edit_optional_params)
+        supported_params = self.get_supported_openai_params(model)
+
+        if drop_params:
+            # Only include supported parameters
+            filtered_params = {k: v for k, v in all_params.items() if k in supported_params}
+            return filtered_params
+        else:
+            # Return all parameters (will raise error if unsupported params are used)
+            return all_params
+
+    def _add_image_to_files(
+        self,
+        files_list: list[tuple[str, Any]],
+        image: Any,
+        field_name: str,
+    ) -> None:
+        """Add an image to the files list with appropriate content type"""
+        image_content_type = ImageEditRequestUtils.get_image_content_type(image)
+
+        if isinstance(image, BufferedReader):
+            files_list.append((field_name, (image.name, image, image_content_type)))
+        else:
+            files_list.append((field_name, ("image.png", image, image_content_type)))
+
+    def transform_image_edit_request(
+        self,
+        model: str,
+        prompt: str | None,
+        image: FileTypes | None,
+        image_edit_optional_request_params: dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> tuple[dict, RequestFiles]:
+        """
+        Transform image edit request to Xinference API format.
+
+        Xinference uses the same multipart/form-data format as OpenAI for image edits.
+        """
+        # Build request params, only including non-None values
+        request_dict: dict = {
+            "model": model,
+            **image_edit_optional_request_params,
+        }
+        if image is not None:
+            request_dict["image"] = image
+        if prompt is not None:
+            request_dict["prompt"] = prompt
+
+        #########################################################
+        # Separate images and masks as `files` and send other parameters as `data`
+        #########################################################
+        _image_list = request_dict.get("image")
+        _mask = request_dict.get("mask")
+        data_without_files = {k: v for k, v in request_dict.items() if k not in ["image", "mask"]}
+        files_list: list[tuple[str, Any]] = []
+
+        # Handle image parameter
+        if _image_list is not None:
+            image_list = [_image_list] if not isinstance(_image_list, list) else _image_list
+
+            for _image in image_list:
+                if _image is not None:
+                    self._add_image_to_files(
+                        files_list=files_list,
+                        image=_image,
+                        field_name="image",
+                    )
+
+        # Handle mask parameter if provided
+        if _mask is not None:
+            # Handle case where mask can be a list (extract first mask)
+            if isinstance(_mask, list):
+                _mask = _mask[0] if _mask else None
+
+            if _mask is not None:
+                mask_content_type: str = ImageEditRequestUtils.get_image_content_type(_mask)
+                if isinstance(_mask, BufferedReader):
+                    files_list.append(("mask", (_mask.name, _mask, mask_content_type)))
+                else:
+                    files_list.append(("mask", ("mask.png", _mask, mask_content_type)))
+
+        return data_without_files, files_list
+
+    def transform_image_edit_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> ImageResponse:
+        """
+        Transform Xinference image edit response to LiteLLM format.
+
+        Xinference returns OpenAI-compatible responses, so minimal transformation is needed.
+        """
+        try:
+            raw_response_json = raw_response.json()
+        except Exception:
+            raise self.get_error_class(
+                error_message=raw_response.text,
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+        return ImageResponse(**raw_response_json)
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        api_key: str | None = None,
+        litellm_params: dict | None = None,
+        api_base: str | None = None,
+    ) -> dict:
+        """
+        Validate environment and set up authentication headers for Xinference.
+
+        Xinference typically doesn't require authentication for local deployments,
+        but supports optional API keys.
+        """
+        final_api_key = api_key or litellm.api_key or get_secret_str("XINFERENCE_API_KEY")
+
+        # Only add Authorization header if API key is provided
+        if final_api_key and final_api_key != "stub-xinference-key":
+            headers["Authorization"] = f"Bearer {final_api_key}"
+
+        return headers
+
+    def get_complete_url(
+        self,
+        model: str,
+        api_base: str | None,
+        litellm_params: dict,
+    ) -> str:
+        """
+        Get the endpoint URL for Xinference image edits API.
+
+        Xinference uses OpenAI-compatible endpoints at /v1/images/edits
+        """
+        api_base = api_base or litellm.api_base or get_secret_str("XINFERENCE_API_BASE") or "http://127.0.0.1:9997/v1"
+
+        # Remove trailing slashes
+        api_base = api_base.rstrip("/")
+
+        return f"{api_base}/images/edits"

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8796,6 +8796,12 @@ class ProviderConfigManager:
             )
 
             return get_openrouter_image_edit_config(model)
+        elif LlmProviders.XINFERENCE == provider:
+            from litellm.llms.xinference.image_edit import (
+                get_xinference_image_edit_config,
+            )
+
+            return get_xinference_image_edit_config(model)
         return None
 
     @staticmethod

--- a/tests/test_litellm/llms/xinference/__init__.py
+++ b/tests/test_litellm/llms/xinference/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for Xinference tests."""

--- a/tests/test_litellm/llms/xinference/image_edit/__init__.py
+++ b/tests/test_litellm/llms/xinference/image_edit/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for Xinference image edit tests."""

--- a/tests/test_litellm/llms/xinference/image_edit/test_xinference_image_edit_transformation.py
+++ b/tests/test_litellm/llms/xinference/image_edit/test_xinference_image_edit_transformation.py
@@ -1,0 +1,327 @@
+"""Tests for Xinference image edit transformation."""
+
+import io
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+from litellm.llms.xinference.image_edit.transformation import (
+    XInferenceImageEditConfig,
+)
+from litellm.types.images.main import ImageEditOptionalRequestParams
+from litellm.types.router import GenericLiteLLMParams
+from litellm.utils import ImageResponse
+
+
+class TestXInferenceImageEditConfig:
+    """Test XInferenceImageEditConfig class."""
+
+    def test_get_supported_openai_params(self):
+        """Test that supported OpenAI params are correctly returned."""
+        config = XInferenceImageEditConfig()
+        supported_params = config.get_supported_openai_params(model="test-model")
+
+        expected_params = [
+            "image",
+            "prompt",
+            "mask",
+            "n",
+            "size",
+            "response_format",
+        ]
+
+        assert supported_params == expected_params
+
+    def test_map_openai_params_with_drop_params_true(self):
+        """Test parameter mapping with drop_params=True."""
+        config = XInferenceImageEditConfig()
+
+        optional_params = ImageEditOptionalRequestParams(
+            n=2,
+            size="1024x1024",
+            response_format="url",
+            quality="hd",  # Not supported by Xinference
+        )
+
+        mapped_params = config.map_openai_params(
+            image_edit_optional_params=optional_params,
+            model="test-model",
+            drop_params=True,
+        )
+
+        # Should filter out unsupported params when drop_params=True
+        assert "n" in mapped_params
+        assert "size" in mapped_params
+        assert "response_format" in mapped_params
+        assert "quality" not in mapped_params
+
+    def test_map_openai_params_with_drop_params_false(self):
+        """Test parameter mapping with drop_params=False."""
+        config = XInferenceImageEditConfig()
+
+        optional_params = ImageEditOptionalRequestParams(
+            n=2,
+            size="1024x1024",
+            response_format="url",
+        )
+
+        mapped_params = config.map_openai_params(
+            image_edit_optional_params=optional_params,
+            model="test-model",
+            drop_params=False,
+        )
+
+        # Should include all params when drop_params=False
+        assert "n" in mapped_params
+        assert "size" in mapped_params
+        assert "response_format" in mapped_params
+
+    def test_transform_image_edit_request(self):
+        """Test transformation of image edit request to Xinference format."""
+        config = XInferenceImageEditConfig()
+
+        # Create a mock image file
+        image_bytes = b"fake image data"
+        image_file = io.BytesIO(image_bytes)
+
+        # Create request parameters
+        image_edit_params = {
+            "n": 1,
+            "size": "1024x1024",
+            "response_format": "url",
+        }
+
+        litellm_params = GenericLiteLLMParams()
+        headers = {}
+
+        # Transform the request
+        data, files = config.transform_image_edit_request(
+            model="xinference/test-model",
+            prompt="Test prompt",
+            image=image_file,
+            image_edit_optional_request_params=image_edit_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+
+        # Verify data parameters
+        assert data["model"] == "xinference/test-model"
+        assert data["prompt"] == "Test prompt"
+        assert data["n"] == 1
+        assert data["size"] == "1024x1024"
+        assert data["response_format"] == "url"
+
+        # Verify files
+        assert len(files) == 1
+        assert files[0][0] == "image"
+
+    def test_transform_image_edit_request_with_mask(self):
+        """Test transformation of image edit request with mask."""
+        config = XInferenceImageEditConfig()
+
+        # Create mock image and mask files
+        image_bytes = b"fake image data"
+        mask_bytes = b"fake mask data"
+        image_file = io.BytesIO(image_bytes)
+        mask_file = io.BytesIO(mask_bytes)
+
+        # Create request parameters with mask
+        image_edit_params = {
+            "mask": mask_file,
+            "n": 1,
+        }
+
+        litellm_params = GenericLiteLLMParams()
+        headers = {}
+
+        # Transform the request
+        data, files = config.transform_image_edit_request(
+            model="xinference/test-model",
+            prompt="Test prompt with mask",
+            image=image_file,
+            image_edit_optional_request_params=image_edit_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+
+        # Verify files include both image and mask
+        assert len(files) == 2
+        file_names = [f[0] for f in files]
+        assert "image" in file_names
+        assert "mask" in file_names
+
+    def test_transform_image_edit_response_success(self):
+        """Test successful transformation of image edit response."""
+        config = XInferenceImageEditConfig()
+
+        # Create mock response
+        response_data = {
+            "created": 1234567890,
+            "data": [
+                {
+                    "url": "https://example.com/image1.png",
+                    "b64_json": None,
+                },
+                {
+                    "url": "https://example.com/image2.png",
+                    "b64_json": None,
+                },
+            ],
+        }
+
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.json.return_value = response_data
+        mock_response.status_code = 200
+
+        logging_obj = Mock()
+
+        # Transform the response
+        result = config.transform_image_edit_response(
+            model="test-model",
+            raw_response=mock_response,
+            logging_obj=logging_obj,
+        )
+
+        # Verify the result
+        assert isinstance(result, ImageResponse)
+        assert len(result.data) == 2
+        assert result.data[0].url == "https://example.com/image1.png"
+        assert result.data[1].url == "https://example.com/image2.png"
+
+    def test_transform_image_edit_response_error(self):
+        """Test error handling in response transformation."""
+        config = XInferenceImageEditConfig()
+
+        # Create mock error response
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.json.side_effect = Exception("Invalid JSON")
+        mock_response.text = "Error message"
+        mock_response.status_code = 400
+        mock_response.headers = {}
+
+        logging_obj = Mock()
+
+        # Should raise an error
+        with pytest.raises(Exception):
+            config.transform_image_edit_response(
+                model="test-model",
+                raw_response=mock_response,
+                logging_obj=logging_obj,
+            )
+
+    def test_validate_environment_with_api_key(self):
+        """Test environment validation with API key."""
+        config = XInferenceImageEditConfig()
+        headers = {}
+
+        validated_headers = config.validate_environment(
+            headers=headers,
+            model="test-model",
+            api_key="test-api-key",
+        )
+
+        assert "Authorization" in validated_headers
+        assert validated_headers["Authorization"] == "Bearer test-api-key"
+
+    def test_validate_environment_without_api_key(self):
+        """Test environment validation without API key."""
+        config = XInferenceImageEditConfig()
+        headers = {}
+
+        with (
+            patch("litellm.api_key", None),
+            patch(
+                "litellm.llms.xinference.image_edit.transformation.get_secret_str",
+                return_value=None,
+            ),
+        ):
+            validated_headers = config.validate_environment(
+                headers=headers,
+                model="test-model",
+                api_key=None,
+            )
+
+        # Should not add Authorization header if no API key
+        assert "Authorization" not in validated_headers
+
+    def test_validate_environment_with_stub_api_key(self):
+        """The Xinference stub placeholder key must not set an Authorization header."""
+        config = XInferenceImageEditConfig()
+        headers = {}
+
+        with (
+            patch("litellm.api_key", None),
+            patch(
+                "litellm.llms.xinference.image_edit.transformation.get_secret_str",
+                return_value=None,
+            ),
+        ):
+            validated_headers = config.validate_environment(
+                headers=headers,
+                model="test-model",
+                api_key="stub-xinference-key",
+            )
+
+        # The placeholder key is treated as "no auth"
+        assert "Authorization" not in validated_headers
+
+    def test_validate_environment_accepts_handler_kwargs(self):
+        """Regression: BaseLLMHTTPHandler.image_edit_handler calls validate_environment
+        with litellm_params and api_base keyword arguments. If this override drops them,
+        every real Xinference image edit raises TypeError at runtime."""
+        config = XInferenceImageEditConfig()
+
+        validated_headers = config.validate_environment(
+            headers={},
+            model="test-model",
+            api_key="test-api-key",
+            litellm_params={"api_base": "http://127.0.0.1:9997/v1"},
+            api_base="http://127.0.0.1:9997/v1",
+        )
+
+        assert validated_headers["Authorization"] == "Bearer test-api-key"
+
+    def test_get_complete_url_default(self):
+        """Test URL construction with default base."""
+        config = XInferenceImageEditConfig()
+
+        with (
+            patch("litellm.api_base", None),
+            patch(
+                "litellm.llms.xinference.image_edit.transformation.get_secret_str",
+                return_value=None,
+            ),
+        ):
+            url = config.get_complete_url(
+                model="test-model",
+                api_base=None,
+                litellm_params={},
+            )
+
+        assert url == "http://127.0.0.1:9997/v1/images/edits"
+
+    def test_get_complete_url_custom_base(self):
+        """Test URL construction with custom base."""
+        config = XInferenceImageEditConfig()
+
+        url = config.get_complete_url(
+            model="test-model",
+            api_base="http://custom-host:8000/v1",
+            litellm_params={},
+        )
+
+        assert url == "http://custom-host:8000/v1/images/edits"
+
+    def test_get_complete_url_trailing_slash(self):
+        """Test URL construction handles trailing slashes correctly."""
+        config = XInferenceImageEditConfig()
+
+        url = config.get_complete_url(
+            model="test-model",
+            api_base="http://custom-host:8000/v1/",
+            litellm_params={},
+        )
+
+        # Should remove trailing slash
+        assert url == "http://custom-host:8000/v1/images/edits"


### PR DESCRIPTION
## Relevant issues

Fixes #20961 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

Implements `/images/edits` support for Xinference provider