### PR TITLE
fix(pricing): update Perplexity Agent API models to current offerings

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25974,61 +25974,142 @@
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_preset": true
-    },
-    "perplexity/openai/gpt-4o": {
-        "litellm_provider": "perplexity",
-        "mode": "responses",
-        "supports_web_search": true,
-        "supports_reasoning": false
-    },
-    "perplexity/openai/gpt-4o-mini": {
-        "litellm_provider": "perplexity",
-        "mode": "responses",
-        "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_preset": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
     "perplexity/openai/gpt-5.2": {
         "litellm_provider": "perplexity",
         "mode": "responses",
+        "input_cost_per_token": 1.75e-06,
+        "output_cost_per_token": 1.4e-05,
         "supports_web_search": true,
-        "supports_reasoning": true
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
-    "perplexity/anthropic/claude-3-5-sonnet-20241022": {
+    "perplexity/openai/gpt-5.1": {
         "litellm_provider": "perplexity",
         "mode": "responses",
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 1e-05,
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
-    "perplexity/anthropic/claude-3-5-haiku-20241022": {
+    "perplexity/openai/gpt-5-mini": {
         "litellm_provider": "perplexity",
         "mode": "responses",
+        "input_cost_per_token": 2.5e-07,
+        "output_cost_per_token": 2e-06,
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
-    "perplexity/google/gemini-2.0-flash-exp": {
+    "perplexity/anthropic/claude-opus-4-6": {
         "litellm_provider": "perplexity",
         "mode": "responses",
+        "input_cost_per_token": 5e-06,
+        "output_cost_per_token": 2.5e-05,
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
-    "perplexity/google/gemini-2.0-flash-thinking-exp": {
+    "perplexity/anthropic/claude-opus-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
+        "input_cost_per_token": 5e-06,
+        "output_cost_per_token": 2.5e-05,
         "supports_web_search": true,
-        "supports_reasoning": true
+        "supports_reasoning": false,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
-    "perplexity/xai/grok-2-1212": {
+    "perplexity/anthropic/claude-sonnet-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
+        "input_cost_per_token": 3e-06,
+        "output_cost_per_token": 1.5e-05,
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
-    "perplexity/xai/grok-2-vision-1212": {
+    "perplexity/anthropic/claude-haiku-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 5e-06,
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
+    },
+    "perplexity/google/gemini-3-pro-preview": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "input_cost_per_token": 2e-06,
+        "output_cost_per_token": 1.2e-05,
+        "supports_web_search": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
+    },
+    "perplexity/google/gemini-3-flash-preview": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_token": 3e-06,
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
+    },
+    "perplexity/google/gemini-2.5-pro": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 1e-05,
+        "supports_web_search": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
+    },
+    "perplexity/google/gemini-2.5-flash": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 2.5e-06,
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
+    },
+    "perplexity/xai/grok-4-1-fast-non-reasoning": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 5e-07,
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
     "publicai/aisingapore/Qwen-SEA-LION-v4-32B-IT": {
         "input_cost_per_token": 0.0,


### PR DESCRIPTION
## Relevant issues

Fixes #20869

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory — N/A (JSON-only change, no code logic affected)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Update Perplexity Agent API (`/v1/responses`) model entries in the pricing JSON to match current Perplexity offerings. All models were verified via direct API calls.

### Removed (deprecated by Perplexity, return "model not supported")
- `perplexity/openai/gpt-4o`, `gpt-4o-mini`
- `perplexity/anthropic/claude-3-5-sonnet-20241022`, `claude-3-5-haiku-20241022`
- `perplexity/google/gemini-2.0-flash-exp`, `gemini-2.0-flash-thinking-exp`
- `perplexity/xai/grok-2-1212`, `grok-2-vision-1212`

### Added (with pricing from [Perplexity docs](https://docs.perplexity.ai/docs/agent-api/models))
- **Anthropic**: `claude-opus-4-6`, `claude-opus-4-5`, `claude-sonnet-4-5`, `claude-haiku-4-5`
- **OpenAI**: `gpt-5.1`, `gpt-5-mini`
- **Google**: `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`
- **xAI**: `grok-4-1-fast-non-reasoning`

### Also added to Agent API entries
- `supported_endpoints: ["/v1/responses"]`
- `input_cost_per_token` / `output_cost_per_token` from official docs