### PR TITLE
fix: use provider-reported usage tokens for OpenRouter streaming

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1053,6 +1053,11 @@ class CustomStreamWrapper:
             ):
                 if self.received_finish_reason is not None:
                     if "provider_specific_fields" not in chunk:
+                        # Skip empty, non-terminal chunks (e.g. SSE separator
+                        # lines) so that usage-only chunks sent after the
+                        # finish_reason chunk can still be processed.
+                        if not chunk.get("is_finished") and not chunk.get("text"):
+                            return
                         raise StopIteration
                 anthropic_response_obj: GChunk = cast(GChunk, chunk)
                 completion_obj["content"] = anthropic_response_obj["text"]
@@ -1479,6 +1484,15 @@ class CustomStreamWrapper:
                         and self.stream_options["include_usage"] is True
                     ):
                         return model_response
+                    # Some providers (e.g., OpenRouter) send usage in a
+                    # separate chunk after finish_reason with empty choices.
+                    # Append it to self.chunks so stream_chunk_builder and
+                    # calculate_total_usage can use provider-reported values.
+                    if (
+                        hasattr(model_response, "usage")
+                        and model_response.usage is not None
+                    ):
+                        self.chunks.append(model_response)
                     return
             print_verbose(
                 f"model_response.choices[0].delta: {model_response.choices[0].delta}; completion_obj: {completion_obj}"

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -277,8 +277,6 @@ class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
             for choice in chunk["choices"]:
                 choice["delta"]["reasoning_content"] = choice["delta"].get("reasoning")
                 new_choices.append(choice)
-            if chunk.get("usage") is not None:
-                print(f"Usage: {chunk.get('usage')}")
             return ModelResponseStream(
                 id=chunk["id"],
                 object="chat.completion.chunk",

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -277,6 +277,8 @@ class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
             for choice in chunk["choices"]:
                 choice["delta"]["reasoning_content"] = choice["delta"].get("reasoning")
                 new_choices.append(choice)
+            if chunk.get("usage") is not None:
+                print(f"Usage: {chunk.get('usage')}")
             return ModelResponseStream(
                 id=chunk["id"],
                 object="chat.completion.chunk",

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1202,7 +1202,6 @@ async def test_streaming_usage_after_finish_reason(sync_mode: bool):
     Without the fix, chunk #3 is discarded and litellm falls back to its own
     token estimation. With the fix, the provider-reported usage is used.
     """
-    import time
 
     # Chunk 1: content
     content_chunk = ModelResponseStream(


### PR DESCRIPTION
## Summary
- Empty SSE separator lines after the finish_reason chunk were triggering
  premature `StopIteration` in `chunk_creator`, preventing the usage-only
  chunk (containing provider-reported token counts and cost) from being processed
- `stream_chunk_builder` then fell back to `token_counter()` estimates instead
  of using the provider's actual values
- Skip empty, non-terminal `GenericStreamingChunks` so usage-only chunks can
  still be processed after the finish_reason chunk

## Test plan
- [ ] Verify streaming returns provider-reported `prompt_tokens`,
      `completion_tokens`, and `cost` (not litellm estimates)
- [ ] Verify non-streaming cost tracking still works
- [ ] Run tests `poetry run pytest tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py -v`