### PR TITLE
[Fix] /v1/models returning wildcard instead of expanded models for BYOK team keys

### DIFF
--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -1928,6 +1928,24 @@ def test_get_known_models_from_wildcard(
     assert all(model in wildcard_models for model in expected_models)
 
 
+def test_get_known_models_from_wildcard_without_litellm_params():
+    """
+    Test wildcard expansion without litellm_params (BYOK case - team has openai/*
+    but no deployment in router config).
+    """
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+
+    wildcard_models = get_known_models_from_wildcard(
+        wildcard_model="openai/*", litellm_params=None
+    )
+    # Should return expanded OpenAI models (gpt-4o, gpt-4o-mini, etc.)
+    assert len(wildcard_models) > 0
+    assert all(m.startswith("openai/") for m in wildcard_models)
+    # Check for common OpenAI models
+    model_ids = [m.split("/", 1)[1] for m in wildcard_models]
+    assert "gpt-4o" in model_ids or "gpt-3.5-turbo" in model_ids
+
+
 @pytest.mark.parametrize(
     "data, user_api_key_dict, expected_model",
     [


### PR DESCRIPTION
## Relevant issues
For a team with BYOK (Bring Your Own Key) and wildcard models like openai/*, keys created under that team receive {"data":[{"id":"openai/*",...}]} from GET /v1/models instead of the expanded list of OpenAI models (e.g. gpt-4o, gpt-3.5-turbo).

Two issues in litellm/proxy/auth/model_checks.py: (1) get_known_models_from_wildcard returned [] when litellm_params was None, because it always required litellm_params to derive the provider. (2) _get_wildcard_models only expanded wildcards when the router had a deployment for that model; for BYOK, openai/* is not in the router config, so llm_router.get_model_list(model_name="openai/*") returned None or [], and there was no fallback to expand using known provider models.
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
(1) Updated get_known_models_from_wildcard to use the wildcard prefix (e.g. "openai" from "openai/*") as the provider when litellm_params is None.
(2) In _get_wildcard_models, added a fallback when llm_router.get_model_list() returns None or an empty list: it now calls get_known_models_from_wildcard(wildcard_model=model, litellm_params=None) to expand the wildcard using known provider models.