### PR TITLE
fix: remove unused asyncio imports (linting errors)

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -822,7 +822,6 @@ def log_guardrail_information(func):
         - during_call
         - post_call
     """
-    import asyncio
     import functools
     import inspect
 

--- a/litellm/proxy/common_utils/performance_utils.py
+++ b/litellm/proxy/common_utils/performance_utils.py
@@ -8,7 +8,6 @@ for line-by-line profiling.
 See performance_utils.md for detailed usage examples and documentation.
 """
 
-import asyncio
 import atexit
 import cProfile
 import functools


### PR DESCRIPTION
## Problem

After PR #21396 replaced `asyncio.iscoroutinefunction()` with `inspect.iscoroutinefunction()`, the `asyncio` imports in two files became unused, causing linting errors:

```
integrations/custom_guardrail.py:825:12: F401 [*] asyncio imported but unused
proxy/common_utils/performance_utils.py:11:8: F401 [*] asyncio imported but unused
```

## Solution

Removed unused `asyncio` imports from both files.

## Files Changed

- `litellm/integrations/custom_guardrail.py` - Removed line 825: `import asyncio`
- `litellm/proxy/common_utils/performance_utils.py` - Removed line 11: `import asyncio`

## Testing

Linting should pass with these changes.

## Related

- Follow-up to PR #21396 (deprecation warnings fix)
- Resolves F401 linting errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)