### PR TITLE
Add EU AI Act Article 5 template to policy templates UI

### DIFF
--- a/litellm/policy_templates_backup.json
+++ b/litellm/policy_templates_backup.json
@@ -71,86 +71,22 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "us_ssn",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "us_ssn_no_dash",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "passport_us",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "passport_uk",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "passport_germany",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "passport_france",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "passport_netherlands",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "nl_bsn_contextual",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "passport_china",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "passport_india",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "passport_japan",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "passport_canada",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "br_cpf",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "br_cpf_unformatted",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "br_rg",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "br_cnpj",
-              "action": "MASK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "us_ssn", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "us_ssn_no_dash", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "passport_us", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "passport_uk", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "passport_germany", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "passport_france", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "passport_netherlands", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "nl_bsn_contextual", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "passport_china", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "passport_india", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "passport_japan", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "passport_canada", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "br_cpf", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "br_cpf_unformatted", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "br_rg", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "br_cnpj", "action": "MASK"}
           ],
           "pattern_redaction_format": "[{pattern_name}_REDACTED]"
         },
@@ -164,36 +100,12 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "email",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "us_phone",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "br_phone_landline",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "br_phone_mobile",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "street_address",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "br_cep",
-              "action": "MASK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "email", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "us_phone", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "br_phone_landline", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "br_phone_mobile", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "street_address", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "br_cep", "action": "MASK"}
           ],
           "pattern_redaction_format": "[{pattern_name}_REDACTED]"
         },
@@ -207,36 +119,12 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "visa",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "mastercard",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "amex",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "discover",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "credit_card",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "iban",
-              "action": "MASK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "visa", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "mastercard", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "amex", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "discover", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "credit_card", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "iban", "action": "MASK"}
           ],
           "pattern_redaction_format": "[{pattern_name}_REDACTED]"
         },
@@ -250,31 +138,11 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "aws_access_key",
-              "action": "BLOCK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "aws_secret_key",
-              "action": "BLOCK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "github_token",
-              "action": "BLOCK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "slack_token",
-              "action": "BLOCK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "generic_api_key",
-              "action": "BLOCK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "aws_access_key", "action": "BLOCK"},
+            {"pattern_type": "prebuilt", "pattern_name": "aws_secret_key", "action": "BLOCK"},
+            {"pattern_type": "prebuilt", "pattern_name": "github_token", "action": "BLOCK"},
+            {"pattern_type": "prebuilt", "pattern_name": "slack_token", "action": "BLOCK"},
+            {"pattern_type": "prebuilt", "pattern_name": "generic_api_key", "action": "BLOCK"}
           ],
           "pattern_redaction_format": "[{pattern_name}_REDACTED]"
         },
@@ -288,16 +156,8 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "ipv4",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "ipv6",
-              "action": "MASK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "ipv4", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "ipv6", "action": "MASK"}
           ],
           "pattern_redaction_format": "[INTERNAL_IP_REDACTED]"
         },
@@ -311,46 +171,14 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "gender_sexual_orientation",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "race_ethnicity_national_origin",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "religion",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "age_discrimination",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "disability",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "marital_family_status",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "military_status",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "public_assistance",
-              "action": "MASK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "gender_sexual_orientation", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "race_ethnicity_national_origin", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "religion", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "age_discrimination", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "disability", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "marital_family_status", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "military_status", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "public_assistance", "action": "MASK"}
           ],
           "pattern_redaction_format": "[PROTECTED_CLASS_INFO_REDACTED]"
         },
@@ -396,27 +224,13 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "au_tfn",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "au_abn",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "au_medicare",
-              "action": "MASK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "au_tfn", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "au_abn", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "au_medicare", "action": "MASK"}
           ],
           "pattern_redaction_format": "[{pattern_name}_REDACTED]"
         },
-        "guardrail_info": {
-          "description": "Masks Australian Tax File Numbers, Business Numbers, and Medicare Numbers"
-        }
+        "guardrail_info": {"description": "Masks Australian Tax File Numbers, Business Numbers, and Medicare Numbers"}
       },
       {
         "guardrail_name": "credentials-api-keys",
@@ -424,37 +238,15 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "aws_access_key",
-              "action": "BLOCK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "aws_secret_key",
-              "action": "BLOCK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "github_token",
-              "action": "BLOCK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "slack_token",
-              "action": "BLOCK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "generic_api_key",
-              "action": "BLOCK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "aws_access_key", "action": "BLOCK"},
+            {"pattern_type": "prebuilt", "pattern_name": "aws_secret_key", "action": "BLOCK"},
+            {"pattern_type": "prebuilt", "pattern_name": "github_token", "action": "BLOCK"},
+            {"pattern_type": "prebuilt", "pattern_name": "slack_token", "action": "BLOCK"},
+            {"pattern_type": "prebuilt", "pattern_name": "generic_api_key", "action": "BLOCK"}
           ],
           "pattern_redaction_format": "[{pattern_name}_REDACTED]"
         },
-        "guardrail_info": {
-          "description": "Blocks requests containing API keys and credentials (AWS, GitHub, Slack)"
-        }
+        "guardrail_info": {"description": "Blocks requests containing API keys and credentials (AWS, GitHub, Slack)"}
       },
       {
         "guardrail_name": "financial-pii",
@@ -462,42 +254,16 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "visa",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "mastercard",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "amex",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "discover",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "credit_card",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "iban",
-              "action": "MASK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "visa", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "mastercard", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "amex", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "discover", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "credit_card", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "iban", "action": "MASK"}
           ],
           "pattern_redaction_format": "[{pattern_name}_REDACTED]"
         },
-        "guardrail_info": {
-          "description": "Masks financial information including credit cards and bank account numbers"
-        }
+        "guardrail_info": {"description": "Masks financial information including credit cards and bank account numbers"}
       }
     ],
     "templateData": {
@@ -916,7 +682,7 @@
   },
   {
     "id": "gdpr-eu-pii-protection",
-    "title": "GDPR Art. 32 \u2014 EU PII Protection",
+    "title": "GDPR Art. 32 — EU PII Protection",
     "description": "GDPR Article 32 compliance for EU personal data protection. Masks French national IDs (NIR/INSEE), EU IBANs, French phone numbers, EU VAT numbers, EU passport numbers, and email addresses. Suitable for applications processing EU citizen data requiring GDPR compliance.",
     "region": "EU",
     "icon": "ShieldCheckIcon",
@@ -936,16 +702,8 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "fr_nir",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "eu_passport_generic",
-              "action": "MASK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "fr_nir", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "eu_passport_generic", "action": "MASK"}
           ],
           "pattern_redaction_format": "[{pattern_name}_REDACTED]"
         },
@@ -959,16 +717,8 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "eu_iban_enhanced",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "iban",
-              "action": "MASK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "eu_iban_enhanced", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "iban", "action": "MASK"}
           ],
           "pattern_redaction_format": "[IBAN_REDACTED]"
         },
@@ -982,21 +732,9 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "email",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "fr_phone",
-              "action": "MASK"
-            },
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "fr_postal_code",
-              "action": "MASK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "email", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "fr_phone", "action": "MASK"},
+            {"pattern_type": "prebuilt", "pattern_name": "fr_postal_code", "action": "MASK"}
           ],
           "pattern_redaction_format": "[{pattern_name}_REDACTED]"
         },
@@ -1010,11 +748,7 @@
           "guardrail": "litellm_content_filter",
           "mode": "pre_call",
           "patterns": [
-            {
-              "pattern_type": "prebuilt",
-              "pattern_name": "eu_vat",
-              "action": "MASK"
-            }
+            {"pattern_type": "prebuilt", "pattern_name": "eu_vat", "action": "MASK"}
           ],
           "pattern_redaction_format": "[VAT_NUMBER_REDACTED]"
         },
@@ -1031,6 +765,47 @@
         "gdpr-eu-financial-data",
         "gdpr-eu-contact-information",
         "gdpr-eu-business-identifiers"
+      ],
+      "guardrails_remove": []
+    }
+  },
+  {
+    "id": "eu-ai-act-article5",
+    "title": "EU AI Act Article 5 — Prohibited Practices",
+    "description": "EU AI Act Article 5 compliance for prohibited AI practices. Blocks requests related to social scoring, emotion recognition in workplace/education, biometric categorization, predictive profiling, manipulation, and vulnerability exploitation. Uses conditional matching (identifier word + context word).",
+    "region": "EU",
+    "icon": "ShieldExclamationIcon",
+    "iconColor": "text-red-500",
+    "iconBg": "bg-red-50",
+    "guardrails": [
+      "eu-ai-act-prohibited-practices"
+    ],
+    "complexity": "High",
+    "guardrailDefinitions": [
+      {
+        "guardrail_name": "eu-ai-act-prohibited-practices",
+        "litellm_params": {
+          "guardrail": "litellm_content_filter",
+          "mode": "pre_call",
+          "categories": [
+            {
+              "category": "eu_ai_act_article5_prohibited_practices",
+              "enabled": true,
+              "action": "BLOCK",
+              "severity_threshold": "medium"
+            }
+          ]
+        },
+        "guardrail_info": {
+          "description": "Blocks EU AI Act Article 5 prohibited practices: social scoring systems, emotion recognition in workplace/education, biometric categorization for sensitive attributes, predictive profiling, manipulation, and vulnerability exploitation"
+        }
+      }
+    ],
+    "templateData": {
+      "policy_name": "eu-ai-act-article5",
+      "description": "EU AI Act Article 5 compliance policy for prohibited AI practices. Blocks social scoring, emotion recognition in workplace/education, biometric categorization, predictive profiling, manipulation, and vulnerability exploitation.",
+      "guardrails_add": [
+        "eu-ai-act-prohibited-practices"
       ],
       "guardrails_remove": []
     }

--- a/policy_templates.json
+++ b/policy_templates.json
@@ -768,5 +768,46 @@
       ],
       "guardrails_remove": []
     }
+  },
+  {
+    "id": "eu-ai-act-article5",
+    "title": "EU AI Act Article 5 — Prohibited Practices",
+    "description": "EU AI Act Article 5 compliance for prohibited AI practices. Blocks requests related to social scoring, emotion recognition in workplace/education, biometric categorization, predictive profiling, manipulation, and vulnerability exploitation. Uses conditional matching (identifier word + context word).",
+    "region": "EU",
+    "icon": "ShieldExclamationIcon",
+    "iconColor": "text-red-500",
+    "iconBg": "bg-red-50",
+    "guardrails": [
+      "eu-ai-act-prohibited-practices"
+    ],
+    "complexity": "High",
+    "guardrailDefinitions": [
+      {
+        "guardrail_name": "eu-ai-act-prohibited-practices",
+        "litellm_params": {
+          "guardrail": "litellm_content_filter",
+          "mode": "pre_call",
+          "categories": [
+            {
+              "category": "eu_ai_act_article5_prohibited_practices",
+              "enabled": true,
+              "action": "BLOCK",
+              "severity_threshold": "medium"
+            }
+          ]
+        },
+        "guardrail_info": {
+          "description": "Blocks EU AI Act Article 5 prohibited practices: social scoring systems, emotion recognition in workplace/education, biometric categorization for sensitive attributes, predictive profiling, manipulation, and vulnerability exploitation"
+        }
+      }
+    ],
+    "templateData": {
+      "policy_name": "eu-ai-act-article5",
+      "description": "EU AI Act Article 5 compliance policy for prohibited AI practices. Blocks social scoring, emotion recognition in workplace/education, biometric categorization, predictive profiling, manipulation, and vulnerability exploitation.",
+      "guardrails_add": [
+        "eu-ai-act-prohibited-practices"
+      ],
+      "guardrails_remove": []
+    }
   }
 ]


### PR DESCRIPTION
## What's missing

PR #21342 added the EU AI Act Article 5 YAML category file but didn't add it to `policy_templates.json`, so it doesn't show up in the UI.

## What this fixes

Adds the template entry to both:
- `policy_templates.json` (main source)
- `litellm/policy_templates_backup.json` (fallback)

## What it does

The template shows up in the UI under **EU** region filter as:
- **EU AI Act Article 5 — Prohibited Practices**
- High complexity
- Red shield icon
- Uses the `eu_ai_act_article5_prohibited_practices` category

Blocks prompts for:
- Social scoring systems
- Emotion recognition in workplace/education
- Biometric categorization for sensitive attributes
- Predictive profiling and manipulation

## Before/After

**Before**: 6 templates, no EU AI Act template visible in UI  
**After**: 7 templates, EU AI Act shows under EU region filter