### PR TITLE
fix(deps): regenerate poetry.lock after pyproject.toml changes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1272,6 +1272,21 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"},
+    {file = "execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "fakeredis"
 version = "2.33.0"
 description = "Python implementation of redis API, can be used for testing purposes."
@@ -5541,22 +5556,25 @@ packaging = ">=17.1"
 pytest = ">=7.2"
 
 [[package]]
-name = "pytest-retry"
-version = "1.7.0"
-description = "Adds the ability to retry flaky tests in CI environments"
+name = "pytest-xdist"
+version = "3.8.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest_retry-1.7.0-py3-none-any.whl", hash = "sha256:a2dac85b79a4e2375943f1429479c65beb6c69553e7dae6b8332be47a60954f4"},
-    {file = "pytest_retry-1.7.0.tar.gz", hash = "sha256:f8d52339f01e949df47c11ba9ee8d5b362f5824dff580d3870ec9ae0057df80f"},
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
 ]
 
 [package.dependencies]
+execnet = ">=2.1"
 pytest = ">=7.0.0"
 
 [package.extras]
-dev = ["black", "flake8", "isort", "mypy"]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
 
 [[package]]
 name = "python-dateutil"
@@ -7950,4 +7968,4 @@ utils = ["numpydoc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "d99036fc86de60170dde4a1a9b3f9fdac6eb3610edb6177e70ca86133b71703e"
+content-hash = "808c804f4b78ac91fe6fa060b976b7d03e3ad5316f2ac33bad4976bd284aeef4"


### PR DESCRIPTION
## Summary

- `pyproject.toml` was updated in two commits merged into `main` without regenerating `poetry.lock`:
  - `48105e650b` replaced `pytest-retry` with `pytest-xdist` in dev dependencies
  - `e37befd5b4` added `asyncio_default_fixture_loop_scope` to pytest ini_options
- This caused **all CI jobs** to fail immediately at the "Install dependencies" step with:
  ```
  pyproject.toml changed significantly since poetry.lock was last generated. Run `poetry lock` to fix the lock file.
  Error: Process completed with exit code 1.
  ```
- Fix: ran `poetry lock` to regenerate the lock file in sync with the current `pyproject.toml`

## Changes

- `poetry.lock` only — replaces `pytest-retry 1.7.0` with `pytest-xdist 3.8.0` (+ its `execnet 2.1.2` dep), and updates the lock file hash

## Test plan
- [ ] All CI test jobs should pass the "Install dependencies" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)