### PR TITLE
fix(test): prevent flaky failure in test_log_langfuse_v2_handles_null_usage_values

### DIFF
--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -268,10 +268,10 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         Test that _log_langfuse_v2 correctly handles None values in the usage object
         by converting them to 0, preventing validation errors.
         """
-        # Reset the mock to ensure clean state
-        self.mock_langfuse_client.reset_mock()
-        self.mock_langfuse_trace.reset_mock()
-        self.mock_langfuse_generation.reset_mock()
+        # Reset the mock to ensure clean state; clear side_effect so return_value takes effect
+        self.mock_langfuse_client.reset_mock(side_effect=True)
+        self.mock_langfuse_trace.reset_mock(side_effect=True)
+        self.mock_langfuse_generation.reset_mock(side_effect=True)
 
         # Re-setup the trace and generation chain with clean state
         self.mock_langfuse_generation.trace_id = "test-trace-id"
@@ -283,12 +283,14 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         # Ensure trace returns our mock
         self.mock_langfuse_client.trace.return_value = self.mock_langfuse_trace
         self.logger.Langfuse = self.mock_langfuse_client
-        
+
         with patch(
             "litellm.integrations.langfuse.langfuse._add_prompt_to_generation_params",
             side_effect=lambda generation_params, **kwargs: generation_params,
             create=True,
-        ) as mock_add_prompt_params:
+        ) as mock_add_prompt_params, patch.object(
+            self.logger, "_supports_prompt", return_value=True
+        ):
             # Create a mock response object with usage information containing None values
             response_obj = MagicMock()
             response_obj.usage = MagicMock()


### PR DESCRIPTION
## Summary

This test has repeatedly failed in CI (previously fixed in #17599, #20475, #21093) with:
```
AssertionError: Expected '_add_prompt_to_generation_params' to have been called once. Called 0 times.
```

- `_add_prompt_to_generation_params` is only reached when `_supports_prompt()` returns `True`
- Under cross-test state contamination in CI (parallel workers running in the same process), `langfuse_sdk_version` can end up in an unexpected state
- `_supports_prompt()` then returns `False`, silently skipping the call (the outer `try/except Exception` in `_log_langfuse_v2` swallows any exception)
- The previous fix used `reset_mock()` without `side_effect=True`, so setUp's `trace.side_effect` persisted and overrode the `return_value` set afterward

**Fixes:**
- Use `reset_mock(side_effect=True)` to clear setUp's side effects so the explicit `return_value` assignments actually take effect
- Add `patch.object(self.logger, "_supports_prompt", return_value=True)` to make the `_add_prompt_to_generation_params` assertion fully independent of SDK version state contamination

## Test plan
- [ ] `poetry run pytest tests/test_litellm/integrations/test_langfuse.py::TestLangfuseUsageDetails -v` — all 7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)