### PR TITLE
fix(tests): mock prisma.Prisma in backoff retry tests to avoid 'prisma generate'

### DIFF
--- a/tests/proxy_unit_tests/test_prisma_client_backoff_retry.py
+++ b/tests/proxy_unit_tests/test_prisma_client_backoff_retry.py
@@ -22,6 +22,20 @@ import httpx
 import backoff
 
 
+@pytest.fixture(autouse=True)
+def mock_prisma_binary():
+    """Mock prisma.Prisma to avoid requiring 'prisma generate' in CI.
+
+    PrismaClient.__init__ does `from prisma import Prisma` inline, which raises
+    RuntimeError when the Prisma client hasn't been generated yet.  Replacing
+    sys.modules['prisma'] with a MagicMock lets the import succeed so tests can
+    instantiate a real PrismaClient and override client.db with their own mocks.
+    """
+    mock_module = MagicMock()
+    with patch.dict(sys.modules, {"prisma": mock_module}):
+        yield
+
+
 @pytest.fixture
 def mock_prisma_client():
     """Create a mock PrismaClient with necessary attributes"""


### PR DESCRIPTION
## Summary

Two tests in `tests/proxy_unit_tests/test_prisma_client_backoff_retry.py` were failing in CI with:

```
Exception: Unable to find Prisma binaries. Please run 'prisma generate' first.
```

**Root cause:** `PrismaClient.__init__` does `from prisma import Prisma` inline, which raises `RuntimeError` in environments where `prisma generate` hasn't been run (all CI test jobs — `prisma generate` is never called in the test workflow).

**Fix:** Add a single `autouse=True` fixture that replaces `sys.modules['prisma']` with a `MagicMock` for the duration of each test. This lets `PrismaClient(...)` be instantiated normally; individual tests then override `client.db` with their existing `AsyncMock` objects as before.

## Changes

- `tests/proxy_unit_tests/test_prisma_client_backoff_retry.py` only — 14 lines added (one `autouse` fixture)

## Test plan
- [ ] `poetry run pytest tests/proxy_unit_tests/test_prisma_client_backoff_retry.py -v` passes locally (after mocking)
- [ ] `test (proxy-unit-b)` CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)