### PR TITLE
fix(lakera-guardrail): avoid KeyError on missing LAKERA_API_KEY during initialization

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/lakera_ai.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lakera_ai.py
@@ -59,7 +59,7 @@ class lakeraAI_Moderation(CustomGuardrail):
         self.async_handler = get_async_httpx_client(
             llm_provider=httpxSpecialProvider.GuardrailCallback
         )
-        self.lakera_api_key = api_key or os.environ.get("LAKERA_API_KEY")
+        self.lakera_api_key = api_key or os.environ.get("LAKERA_API_KEY") or ""
         self.moderation_check = moderation_check
         self.category_thresholds = category_thresholds
         self.api_base = (

--- a/litellm/proxy/guardrails/guardrail_hooks/lakera_ai.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lakera_ai.py
@@ -59,7 +59,7 @@ class lakeraAI_Moderation(CustomGuardrail):
         self.async_handler = get_async_httpx_client(
             llm_provider=httpxSpecialProvider.GuardrailCallback
         )
-        self.lakera_api_key = api_key or os.environ["LAKERA_API_KEY"]
+        self.lakera_api_key = api_key or os.environ.get("LAKERA_API_KEY")
         self.moderation_check = moderation_check
         self.category_thresholds = category_thresholds
         self.api_base = (

--- a/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
@@ -54,7 +54,7 @@ class LakeraAIGuardrail(CustomGuardrail):
         self.async_handler = get_async_httpx_client(
             llm_provider=httpxSpecialProvider.GuardrailCallback
         )
-        self.lakera_api_key = api_key or os.environ.get("LAKERA_API_KEY")
+        self.lakera_api_key = api_key or os.environ.get("LAKERA_API_KEY") or ""
         self.project_id = project_id
         self.api_base = (
             api_base or get_secret_str("LAKERA_API_BASE") or "https://api.lakera.ai"

--- a/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
@@ -54,7 +54,7 @@ class LakeraAIGuardrail(CustomGuardrail):
         self.async_handler = get_async_httpx_client(
             llm_provider=httpxSpecialProvider.GuardrailCallback
         )
-        self.lakera_api_key = api_key or os.environ["LAKERA_API_KEY"]
+        self.lakera_api_key = api_key or os.environ.get("LAKERA_API_KEY")
         self.project_id = project_id
         self.api_base = (
             api_base or get_secret_str("LAKERA_API_BASE") or "https://api.lakera.ai"

--- a/tests/proxy_unit_tests/test_proxy_setting_guardrails.py
+++ b/tests/proxy_unit_tests/test_proxy_setting_guardrails.py
@@ -30,7 +30,8 @@ from litellm.proxy.proxy_server import (  # Replace with the actual module where
 def client():
     filepath = os.path.dirname(os.path.abspath(__file__))
     config_fp = f"{filepath}/test_configs/test_guardrails_config.yaml"
-    asyncio.run(initialize(config=config_fp))
+    with mock.patch("litellm.proxy.proxy_server.premium_user", True):
+        asyncio.run(initialize(config=config_fp))
     from litellm.proxy.proxy_server import app
 
     return TestClient(app)


### PR DESCRIPTION
## Summary

- `os.environ["LAKERA_API_KEY"]` in `lakera_ai.py` and `lakera_ai_v2.py` raises `KeyError` when the env var is not set, causing `test_active_callbacks` to ERROR during fixture setup
- Switch to `os.environ.get("LAKERA_API_KEY")` so guardrail initialization completes without the key present (actual API calls will fail naturally if the key is unset at runtime)
- Mock `premium_user=True` in the test fixture so the enterprise `hide_secrets` guardrail can initialize, matching the existing test assertions for `_ENTERPRISE_SecretDetection`

## Test plan
- [x] `poetry run pytest tests/proxy_unit_tests/test_proxy_setting_guardrails.py::test_active_callbacks -v` — previously ERROR, now PASSES

🤖 Generated with [Claude Code](https://claude.com/claude-code)