### PR TITLE
fix(token-counter): fix test isolation and encode() return type normalization

### DIFF
--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -582,14 +582,15 @@ class TestTokenizerSelection(unittest.TestCase):
 
     @patch("litellm.utils._return_huggingface_tokenizer")
     def test_disable_hf_tokenizer_download(self, mock_return_huggingface_tokenizer):
-        # Use pytest.MonkeyPatch() directly instead of fixture
         monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setattr(litellm, "disable_hf_tokenizer_download", True)
-
-        result = _select_tokenizer_helper("grok-32r22r")
-        mock_return_huggingface_tokenizer.assert_not_called()
-        assert result["type"] == "openai_tokenizer"
-        assert result["tokenizer"] == encoding
+        try:
+            result = _select_tokenizer_helper("grok-32r22r")
+            mock_return_huggingface_tokenizer.assert_not_called()
+            assert result["type"] == "openai_tokenizer"
+            assert result["tokenizer"] == encoding
+        finally:
+            monkeypatch.undo()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Two independent fixes for `test_token_counter.py` failures in CI (not related to PR #21422):

### 1. Monkeypatch leak causing `test_llama2/3_tokenizer_api_failure` to fail
`test_disable_hf_tokenizer_download` set `litellm.disable_hf_tokenizer_download = True` via `pytest.MonkeyPatch()` but **never called `undo()`**. Because tests run alphabetically, `test_llama2_tokenizer_api_failure` and `test_llama3_tokenizer_api_failure` ran after it with the flag still set — `_select_tokenizer_helper` short-circuited to the tiktoken fallback without ever calling `from_pretrained`, failing the `assert_called_once_with` assertion.

**Fix:** wrap the test body in `try/finally` and call `monkeypatch.undo()`.

### 2. `encode()` return type inconsistency causing `test_encoding_and_decoding` to fail
`encode()` returns a HuggingFace `Encoding` object when the HF tokenizer loads, but a plain `List[int]` (tiktoken) when the model hub is unreachable in CI. The test called `.ids` on the result, raising `AttributeError: 'list' object has no attribute 'ids'` on the fallback path.

**Fix:** normalize `encode()` to always return `List[int]` by extracting `.ids` when present, and remove the now-unnecessary `.ids` access in the test.

## Test plan
- [x] `poetry run pytest tests/test_litellm/litellm_core_utils/test_token_counter.py::test_encoding_and_decoding tests/test_litellm/litellm_core_utils/test_token_counter.py::TestTokenizerSelection::test_llama2_tokenizer_api_failure tests/test_litellm/litellm_core_utils/test_token_counter.py::TestTokenizerSelection::test_llama3_tokenizer_api_failure -v` — all 3 previously failing, now PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)