### PR TITLE
Fix EU AI Act template: add missing category_file path

### DIFF
--- a/litellm/policy_templates_backup.json
+++ b/litellm/policy_templates_backup.json
@@ -790,6 +790,7 @@
           "categories": [
             {
               "category": "eu_ai_act_article5_prohibited_practices",
+              "category_file": "litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/policy_templates/eu_ai_act_article5.yaml",
               "enabled": true,
               "action": "BLOCK",
               "severity_threshold": "medium"

--- a/policy_templates.json
+++ b/policy_templates.json
@@ -790,6 +790,7 @@
           "categories": [
             {
               "category": "eu_ai_act_article5_prohibited_practices",
+              "category_file": "litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/policy_templates/eu_ai_act_article5.yaml",
               "enabled": true,
               "action": "BLOCK",
               "severity_threshold": "medium"


### PR DESCRIPTION
## Problem

PR #21414 added the EU AI Act template, but the guardrail definition was missing the `category_file` path. This caused the guardrail to be created in the database but fail silently - it couldn't load the YAML file with the actual blocking rules.

## Test showing the bug

```bash
# Guardrail exists in DB but category_file is null
curl http://localhost:4000/v2/guardrails/list | grep -A 10 "eu-ai-act"
# Shows: "category_file": null

# Test prompt that should be blocked
curl -X POST http://localhost:4000/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -d '{
    "model": "gpt-4o",
    "messages": [{"role": "user", "content": "social credit system"}],
    "guardrails": ["eu-ai-act-prohibited-practices"]
  }'
# Returns 200 OK with LLM response (should be 403 blocked)
```

## Fix

Added the missing `category_file` path:

```json
"category_file": "litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/policy_templates/eu_ai_act_article5.yaml"
```
