### PR TITLE
fix: remove importlib.reload calls causing cross-test class-reference staleness

### DIFF
--- a/tests/test_litellm/llms/huggingface/embedding/test_huggingface_embedding_handler.py
+++ b/tests/test_litellm/llms/huggingface/embedding/test_huggingface_embedding_handler.py
@@ -1,4 +1,3 @@
-import importlib
 import json
 import os
 import sys
@@ -16,22 +15,7 @@ MOCK_EMBEDDING_RESPONSE = [[0.1, 0.2, 0.3, 0.4, 0.5]]
 
 
 @pytest.fixture
-def reload_huggingface_modules():
-    """
-    Reload modules to ensure fresh references after conftest reloads litellm.
-    This ensures the HTTPHandler class being patched is the same one used by
-    the embedding handler during parallel test execution.
-    """
-    import litellm.llms.custom_httpx.http_handler as http_handler_module
-    import litellm.llms.huggingface.embedding.handler as hf_embedding_handler_module
-
-    importlib.reload(http_handler_module)
-    importlib.reload(hf_embedding_handler_module)
-    yield
-
-
-@pytest.fixture
-def mock_embedding_http_handler(reload_huggingface_modules):
+def mock_embedding_http_handler():
     """Fixture to mock the HTTP handler for embedding tests"""
     with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post") as mock_post:
         mock_response = MagicMock()
@@ -43,7 +27,7 @@ def mock_embedding_http_handler(reload_huggingface_modules):
 
 
 @pytest.fixture
-def mock_embedding_async_http_handler(reload_huggingface_modules):
+def mock_embedding_async_http_handler():
     """Fixture to mock the async HTTP handler for embedding tests"""
     with patch("litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post", new_callable=AsyncMock) as mock_post:
         mock_response = MagicMock()

--- a/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_integration.py
+++ b/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_integration.py
@@ -2,7 +2,6 @@
 Integration tests for Vertex AI rerank functionality.
 These tests demonstrate end-to-end usage of the Vertex AI rerank feature.
 """
-import importlib
 import os
 from unittest.mock import MagicMock, patch
 
@@ -14,14 +13,7 @@ from litellm.llms.vertex_ai.rerank.transformation import VertexAIRerankConfig
 
 class TestVertexAIRerankIntegration:
     def setup_method(self):
-        # Reload modules to ensure fresh references after conftest reloads litellm.
-        # This ensures the class being patched is the same one used by the tests.
-        import litellm.llms.vertex_ai.rerank.transformation as rerank_transformation_module
-        importlib.reload(rerank_transformation_module)
-
-        # Re-import after reload to get the fresh class
-        from litellm.llms.vertex_ai.rerank.transformation import VertexAIRerankConfig as FreshConfig
-        self.config = FreshConfig()
+        self.config = VertexAIRerankConfig()
         self.model = "semantic-ranker-default@latest"
 
     @patch('litellm.llms.vertex_ai.rerank.transformation.VertexAIRerankConfig._ensure_access_token')


### PR DESCRIPTION
## Summary

Two test files were calling `importlib.reload()` on shared modules in their `setup_method`/fixtures, creating new class objects that broke `isinstance` checks and `@patch` targets for subsequent tests running in the same pytest-xdist worker.

**Issue 1: `test_huggingface_embedding_handler.py`**
- Reloaded `litellm.llms.custom_httpx.http_handler`, creating a new `HTTPHandler` class in the module
- Subsequent tests (e.g. `test_hosted_vllm_embedding_transformation.py`) imported `HTTPHandler` from the now-updated module (new class) and created `client = HTTPHandler()`
- `llm_http_handler.py` still held the original class reference (bound at module load time)
- `isinstance(client, HTTPHandler)` in `BaseLLMHTTPHandler.embedding()` returned `False`, so a new unpatched client was used instead of the passed one
- Result: `Expected 'post' to have been called once. Called 0 times.`

**Issue 2: `test_vertex_ai_rerank_integration.py`**
- Reloaded `litellm.llms.vertex_ai.rerank.transformation` in `setup_method`, creating a new `VertexAIRerankConfig` class
- `test_vertex_ai_rerank_transformation.py` had `from litellm.llms.vertex_ai.rerank.transformation import VertexAIRerankConfig` at module level (the old class)
- `@patch('litellm.llms.vertex_ai.rerank.transformation.VertexAIRerankConfig._ensure_access_token')` patched the new class, but `self.config = VertexAIRerankConfig()` used the old class
- Mock didn't apply → real Google credentials were attempted → `DefaultCredentialsError`

## Fix

Remove the `importlib.reload()` calls. The module-level class references are stable across tests within a worker process. The reloads were solving a non-existent problem while actively creating cross-test contamination.

## Test plan

- [x] `test_huggingface_embedding_handler.py` tests still pass
- [x] `test_hosted_vllm_embedding_transformation.py` tests pass after `test_huggingface_embedding_handler.py`
- [x] `test_vertex_ai_rerank_integration.py` tests still pass
- [x] `test_vertex_ai_rerank_transformation.py` tests pass after `test_vertex_ai_rerank_integration.py`
- [x] All 53 tests in the affected directories pass together

🤖 Generated with [Claude Code](https://claude.com/claude-code)