### PR TITLE
fix(tests): restore disable_aiohttp_transport and force_ipv4 in isolate_litellm_state

### DIFF
--- a/tests/test_litellm/conftest.py
+++ b/tests/test_litellm/conftest.py
@@ -49,6 +49,12 @@ def isolate_litellm_state():
     if hasattr(litellm, '_async_failure_callback'):
         original_state['_async_failure_callback'] = litellm._async_failure_callback.copy() if litellm._async_failure_callback else []
 
+    # Store transport/network globals — many tests set these without restoring,
+    # causing subsequent tests to get None from _create_async_transport()
+    for _attr in ('disable_aiohttp_transport', 'force_ipv4'):
+        if hasattr(litellm, _attr):
+            original_state[_attr] = getattr(litellm, _attr)
+
     # Flush cache before test (critical for respx mocks)
     if hasattr(litellm, "in_memory_llm_clients_cache"):
         litellm.in_memory_llm_clients_cache.flush_cache()


### PR DESCRIPTION
## Summary

- Fixes `test_session_reuse_chain` and `test_ssl_context_transport` flaky CI failures (`assert None is not None`)
- Extends the `isolate_litellm_state` autouse fixture in `conftest.py` to save and restore `litellm.disable_aiohttp_transport` and `litellm.force_ipv4`

## Root Cause

These tests call `AsyncHTTPHandler._create_async_transport()` and assert the result is not `None`. The method returns `None` when both:
- `litellm.disable_aiohttp_transport = True` (aiohttp disabled)
- `litellm.force_ipv4 = False` (httpx fallback skipped)

Many tests across the `llms` group set `litellm.disable_aiohttp_transport = True` without restoring it:
- `tests/test_litellm/llms/compactifai/test_compactifai.py` (7 occurrences)
- `tests/test_litellm/llms/sap/` (5 occurrences)
- `tests/test_litellm/llms/vercel_ai_gateway/` (4 occurrences)
- `tests/test_litellm/llms/mistral/` (3 occurrences)
- `tests/test_litellm/llms/zai/`, `tests/test_litellm/llms/heroku/` (2 each)

The existing `isolate_litellm_state` fixture only saved/restored callback lists, not transport globals. When one of the above tests runs before `test_ssl_context_transport` or `test_session_reuse_chain` in the same xdist worker, the contaminated state causes the transport to be `None`.

## Fix

Add `disable_aiohttp_transport` and `force_ipv4` to the list of litellm attributes that `isolate_litellm_state` saves before each test and restores after — exactly the same pattern already used for `callbacks`, `success_callback`, etc.

## Test plan

- [x] `test_ssl_context_transport` and `test_session_reuse_chain` pass after running `test_aiohttp_disabled_transport` first (which was the contaminating test)
- [x] Full `test_http_handler.py` (36 tests) passes
- [x] No production code changed — conftest-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)