### PR TITLE
fix(websearch_interception): fix pre_call_deployment_hook not triggering via proxy router

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -82,8 +82,7 @@ class WebSearchInterceptionLogger(CustomLogger):
         custom_llm_provider = kwargs.get("custom_llm_provider", "") or kwargs.get("litellm_params", {}).get("custom_llm_provider", "")
         if not custom_llm_provider:
             try:
-                from litellm import get_llm_provider
-                _, custom_llm_provider, _, _ = get_llm_provider(model=kwargs.get("model", ""))
+                _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=kwargs.get("model", ""))
             except Exception:
                 custom_llm_provider = ""
         if custom_llm_provider not in self.enabled_providers:

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -16,6 +16,7 @@ from litellm.constants import LITELLM_WEB_SEARCH_TOOL_NAME
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.websearch_interception.tools import (
     get_litellm_web_search_tool,
+    get_litellm_web_search_tool_openai,
     is_web_search_tool,
     is_web_search_tool_chat_completion,
 )
@@ -77,7 +78,14 @@ class WebSearchInterceptionLogger(CustomLogger):
         that we can intercept and execute ourselves.
         """
         # Check if this is for an enabled provider
-        custom_llm_provider = kwargs.get("litellm_params", {}).get("custom_llm_provider", "")
+        # Try top-level kwargs first, then nested litellm_params, then derive from model name
+        custom_llm_provider = kwargs.get("custom_llm_provider", "") or kwargs.get("litellm_params", {}).get("custom_llm_provider", "")
+        if not custom_llm_provider:
+            try:
+                from litellm import get_llm_provider
+                _, custom_llm_provider, _, _ = get_llm_provider(model=kwargs.get("model", ""))
+            except Exception:
+                custom_llm_provider = ""
         if custom_llm_provider not in self.enabled_providers:
             return None
 
@@ -101,7 +109,7 @@ class WebSearchInterceptionLogger(CustomLogger):
         for tool in tools:
             if is_web_search_tool(tool):
                 # Convert to LiteLLM standard web search tool
-                converted_tool = get_litellm_web_search_tool()
+                converted_tool = get_litellm_web_search_tool_openai()
                 converted_tools.append(converted_tool)
                 verbose_logger.debug(
                     f"WebSearchInterception: Converted {tool.get('name', 'unknown')} "
@@ -111,8 +119,9 @@ class WebSearchInterceptionLogger(CustomLogger):
                 # Keep other tools as-is
                 converted_tools.append(tool)
 
-        # Return modified kwargs with converted tools
-        return {"tools": converted_tools}
+        # Update tools in-place and return full kwargs
+        kwargs["tools"] = converted_tools
+        return kwargs
 
     @classmethod
     def from_config_yaml(

--- a/litellm/integrations/websearch_interception/tools.py
+++ b/litellm/integrations/websearch_interception/tools.py
@@ -49,6 +49,39 @@ def get_litellm_web_search_tool() -> Dict[str, Any]:
     }
 
 
+def get_litellm_web_search_tool_openai() -> Dict[str, Any]:
+    """
+    Get the standard LiteLLM web search tool definition in OpenAI format.
+
+    Used by async_pre_call_deployment_hook which runs in the chat completions
+    path where tools must be in OpenAI format (type: "function" with
+    function.parameters).
+
+    Returns:
+        Dict containing the OpenAI-style tool definition.
+    """
+    return {
+        "type": "function",
+        "function": {
+            "name": LITELLM_WEB_SEARCH_TOOL_NAME,
+            "description": (
+                "Search the web for information. Use this when you need current "
+                "information or answers to questions that require up-to-date data."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query to execute"
+                    }
+                },
+                "required": ["query"]
+            }
+        }
+    }
+
+
 def is_web_search_tool_chat_completion(tool: Dict[str, Any]) -> bool:
     """
     Check if a tool is a web search tool for Chat Completions API (strict check).


### PR DESCRIPTION
Fix provider lookup (check top-level kwargs + fallback to get_llm_provider), return full kwargs dict instead of partial, and use OpenAI-format tool definition.

## Relevant issues

Fixes websearch_interception `async_pre_call_deployment_hook` never triggering for `/chat/completions` requests through the proxy router.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

Three bugs in `WebSearchInterceptionLogger.async_pre_call_deployment_hook` prevented websearch interception from working through the standard proxy `/chat/completions` path:

1. **Provider lookup read wrong key path** — checked `kwargs["litellm_params"]["custom_llm_provider"]` but the router places it at the top level (or not at all in `_acompletion`). Fixed with a 3-level fallback: top-level kwargs → nested `litellm_params` → derived from model name via `get_llm_provider()`.

2. **Return value dropped all request data** — returned `{"tools": converted_tools}` instead of the full kwargs dict. The dispatcher does a full replacement (`modified_kwargs = result`), so `model`, `messages`, `api_key`, etc. were all lost. Fixed to mutate in-place and return full kwargs, matching `CustomGuardrail` and `async_pre_request_hook`.

3. **Wrong tool format** — used Anthropic-format tool (`input_schema`) but this hook runs in the chat completions path where OpenAI format (`type: "function"`) is required. Added `get_litellm_web_search_tool_openai()` and used it here.

**Files changed:**
- `litellm/integrations/websearch_interception/handler.py` — fixed provider lookup, return value, and tool format
- `litellm/integrations/websearch_interception/tools.py` — added `get_litellm_web_search_tool_openai()`
- `tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py` — 6 regression tests