### PR TITLE
fix: restore sys.modules after stub injection in langfuse otel test

### DIFF
--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -157,8 +157,12 @@ class TestLangfuseOtelIntegration:
 
         stub_module.LangFuseLogger = StubLFLogger  # type: ignore
 
-        # Register stub in sys.modules so import inside method succeeds
-        sys.modules["litellm.integrations.langfuse.langfuse"] = stub_module  # type: ignore
+        # Register stub in sys.modules so import inside method succeeds.
+        # Use monkeypatch so the real module is restored after the test runs,
+        # preventing sys.modules corruption that would break patch() targets in
+        # later tests (the patch would hit the stub while the real module's
+        # globals remain unpatch-ed).
+        monkeypatch.setitem(sys.modules, "litellm.integrations.langfuse.langfuse", stub_module)  # type: ignore
 
         kwargs = {"litellm_params": {"metadata": {"foo": "bar"}}}
         extracted = LangfuseOtelLogger._extract_langfuse_metadata(kwargs)


### PR DESCRIPTION
## Summary

- `test_extract_langfuse_metadata_with_header_enrichment` in `test_langfuse_otel.py` directly assigned `sys.modules["litellm.integrations.langfuse.langfuse"] = stub_module` but never restored it
- This caused subsequent tests that used `patch("litellm.integrations.langfuse.langfuse._add_prompt_to_generation_params")` to patch the stub module instead of the real one
- Meanwhile `_log_langfuse_v2` executed with the **real** module's `__globals__` (unpatched), calling the real `_add_prompt_to_generation_params`, which triggered `ModuleNotFoundError: No module named 'langfuse.model'; 'langfuse' is not a package` (since `sys.modules["langfuse"]` was a `MagicMock` during the failing test)
- This caused `TestLangfuseUsageDetails::test_log_langfuse_v2_handles_null_usage_values` to fail with `AssertionError: Expected '_add_prompt_to_generation_params' to have been called once. Called 0 times`

## Fix

Replace the direct `sys.modules` assignment with `monkeypatch.setitem()`, which pytest automatically reverses after the test completes. The `monkeypatch` fixture was already declared as a parameter in the test signature but unused for the sys.modules mutation.

## Test plan

- [x] `test_extract_langfuse_metadata_with_header_enrichment` still passes (functionality unchanged)
- [x] `test_log_langfuse_v2_handles_null_usage_values` now passes when run after the otel tests
- [x] Full `tests/test_litellm/integrations/` suite: target failure eliminated

Not related to PR #21423 (which only touches `test_token_counter.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)