### PR TITLE
fix: session grouping broken for dict rows from query_raw

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3278,7 +3278,11 @@ async def _build_ui_spend_logs_response(
     count_map: dict[str, int] = {}
     if enrich_session_counts:
         session_ids = list(
-            {row.session_id for row in data if getattr(row, "session_id", None)}
+            {
+                (row.get("session_id") if isinstance(row, dict) else getattr(row, "session_id", None))
+                for row in data
+                if (row.get("session_id") if isinstance(row, dict) else getattr(row, "session_id", None))
+            }
         )
         if session_ids:
             # NOTE: This GROUP BY runs on every v1/UI page load. The IN clause


### PR DESCRIPTION
## Relevant issues

Fixes session grouping in the UI logs table — rows with the same session_id were showing as separate rows instead of being grouped.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
      Link:

- [ ] **CI run for the last commit**  
      Link:

- [ ] **Merge / cherry-pick CI run**  
      Links:

## Type

🐛 Bug Fix

## Changes

`_build_ui_spend_logs_response` used `getattr(row, "session_id", None)` to collect session IDs, but `query_raw` returns plain dicts — `getattr` on a dict always returns `None`. So `session_total_count` was always 1 and the UI never grouped session rows.

Fixed to use `row.get("session_id")` for dict rows.