### PR TITLE
fix(ci): add prisma generate step to matrix CI workflow

### DIFF
--- a/.github/workflows/test-litellm-matrix.yml
+++ b/.github/workflows/test-litellm-matrix.yml
@@ -102,6 +102,10 @@ jobs:
         run: |
           cd enterprise && poetry run pip install -e . && cd ..
 
+      - name: Generate Prisma client
+        run: |
+          poetry run prisma generate --schema litellm/proxy/schema.prisma
+
       - name: Run tests - ${{ matrix.test-group.name }}
         run: |
           poetry run pytest ${{ matrix.test-group.path }} \


### PR DESCRIPTION
## Summary
- `tests/proxy_unit_tests/test_key_generate_prisma.py` imports `PrismaClient` at module level, which triggers a Prisma binary check at collection time
- The matrix CI workflow installs the `prisma` Python package (via `proxy-dev` extras) but never runs `prisma generate`
- This causes all tests in that file to ERROR with: `Unable to find Prisma binaries. Please run 'prisma generate' first.`
- Fix: add a `Generate Prisma client` step after dependency installation, using the existing schema at `litellm/proxy/schema.prisma`

## Test plan
- [ ] Verify `proxy-unit-a` CI job no longer errors on `test_key_generate_prisma.py` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)