### PR TITLE
fix(mcp): support refresh_token grant type in OAuth token endpoint

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -227,7 +227,7 @@ async def exchange_token_with_server(
                 status_code=400,
                 detail="refresh_token is required for grant_type=refresh_token",
             )
-        token_data = {
+        token_data: dict = {
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
             "client_id": resolved_client_id,
@@ -240,11 +240,9 @@ async def exchange_token_with_server(
             "grant_type": "authorization_code",
             "client_id": resolved_client_id,
             "redirect_uri": f"{proxy_base_url}/callback",
+            "client_secret": resolved_client_secret,
+            "code": code,
         }
-        if code:
-            token_data["code"] = code
-        if resolved_client_secret:
-            token_data["client_secret"] = resolved_client_secret
         if code_verifier:
             token_data["code_verifier"] = code_verifier
 

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -141,9 +141,7 @@ def _resolve_oauth2_server_for_root_endpoints(
     )
 
     registry = global_mcp_server_manager.get_filtered_registry(client_ip=client_ip)
-    oauth2_servers = [
-        s for s in registry.values() if s.auth_type == MCPAuth.oauth2
-    ]
+    oauth2_servers = [s for s in registry.values() if s.auth_type == MCPAuth.oauth2]
     if len(oauth2_servers) == 1:
         return oauth2_servers[0]
     return None
@@ -197,9 +195,7 @@ async def authorize_with_server(
     parsed_auth_url = urlparse(mcp_server.authorization_url)
     existing_params = dict(parse_qsl(parsed_auth_url.query))
     existing_params.update(params)
-    final_url = urlunparse(
-        parsed_auth_url._replace(query=urlencode(existing_params))
-    )
+    final_url = urlunparse(parsed_auth_url._replace(query=urlencode(existing_params)))
     return RedirectResponse(final_url)
 
 
@@ -212,26 +208,43 @@ async def exchange_token_with_server(
     client_id: str,
     client_secret: Optional[str],
     code_verifier: Optional[str],
+    refresh_token: Optional[str] = None,
 ):
-    if grant_type != "authorization_code":
+    if grant_type not in ("authorization_code", "refresh_token"):
         raise HTTPException(status_code=400, detail="Unsupported grant_type")
 
     if mcp_server.token_url is None:
         raise HTTPException(status_code=400, detail="MCP server token url is not set")
 
-    proxy_base_url = get_request_base_url(request)
-    token_data = {
-        "grant_type": "authorization_code",
-        "client_id": mcp_server.client_id if mcp_server.client_id else client_id,
-        "client_secret": mcp_server.client_secret
-        if mcp_server.client_secret
-        else client_secret,
-        "code": code,
-        "redirect_uri": f"{proxy_base_url}/callback",
-    }
+    resolved_client_id = mcp_server.client_id if mcp_server.client_id else client_id
+    resolved_client_secret = (
+        mcp_server.client_secret if mcp_server.client_secret else client_secret
+    )
 
-    if code_verifier:
-        token_data["code_verifier"] = code_verifier
+    if grant_type == "refresh_token":
+        if not refresh_token:
+            raise HTTPException(
+                status_code=400,
+                detail="refresh_token is required for grant_type=refresh_token",
+            )
+        token_data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": resolved_client_id,
+        }
+        if resolved_client_secret:
+            token_data["client_secret"] = resolved_client_secret
+    else:
+        proxy_base_url = get_request_base_url(request)
+        token_data = {
+            "grant_type": "authorization_code",
+            "client_id": resolved_client_id,
+            "client_secret": resolved_client_secret,
+            "code": code,
+            "redirect_uri": f"{proxy_base_url}/callback",
+        }
+        if code_verifier:
+            token_data["code_verifier"] = code_verifier
 
     async_client = get_async_httpx_client(llm_provider=httpxSpecialProvider.Oauth2Check)
     response = await async_client.post(
@@ -362,6 +375,7 @@ async def token_endpoint(
     client_id: str = Form(...),
     client_secret: Optional[str] = Form(None),
     code_verifier: str = Form(None),
+    refresh_token: Optional[str] = Form(None),
     mcp_server_name: Optional[str] = None,
 ):
     """
@@ -395,6 +409,7 @@ async def token_endpoint(
         client_id=client_id,
         client_secret=client_secret,
         code_verifier=code_verifier,
+        refresh_token=refresh_token,
     )
 
 
@@ -498,16 +513,18 @@ def _build_oauth_protected_resource_response(
             )
         ],
         "resource": resource_url,
-        "scopes_supported": mcp_server.scopes if mcp_server and mcp_server.scopes else [],
+        "scopes_supported": mcp_server.scopes
+        if mcp_server and mcp_server.scopes
+        else [],
     }
 
 
 # Standard MCP pattern: /.well-known/oauth-protected-resource/mcp/{server_name}
 # This is the pattern expected by standard MCP clients (mcp-inspector, VSCode Copilot)
-@router.get(f"/.well-known/oauth-protected-resource{'' if get_server_root_path() == '/' else get_server_root_path()}/mcp/{{mcp_server_name}}")
-async def oauth_protected_resource_mcp_standard(
-    request: Request, mcp_server_name: str
-):
+@router.get(
+    f"/.well-known/oauth-protected-resource{'' if get_server_root_path() == '/' else get_server_root_path()}/mcp/{{mcp_server_name}}"
+)
+async def oauth_protected_resource_mcp_standard(request: Request, mcp_server_name: str):
     """
     OAuth protected resource discovery endpoint using standard MCP URL pattern.
 
@@ -526,7 +543,9 @@ async def oauth_protected_resource_mcp_standard(
 
 # LiteLLM legacy pattern: /.well-known/oauth-protected-resource/{server_name}/mcp
 # Kept for backward compatibility with existing deployments
-@router.get(f"/.well-known/oauth-protected-resource{'' if get_server_root_path() == '/' else get_server_root_path()}/{{mcp_server_name}}/mcp")
+@router.get(
+    f"/.well-known/oauth-protected-resource{'' if get_server_root_path() == '/' else get_server_root_path()}/{{mcp_server_name}}/mcp"
+)
 @router.get("/.well-known/oauth-protected-resource")
 async def oauth_protected_resource_mcp(
     request: Request, mcp_server_name: Optional[str] = None
@@ -545,6 +564,7 @@ async def oauth_protected_resource_mcp(
         mcp_server_name=mcp_server_name,
         use_standard_pattern=False,
     )
+
 
 """
     https://datatracker.ietf.org/doc/html/rfc8414#section-3.1
@@ -605,17 +625,23 @@ def _build_oauth_authorization_server_response(
         "authorization_endpoint": authorization_endpoint,
         "token_endpoint": token_endpoint,
         "response_types_supported": ["code"],
-        "scopes_supported": mcp_server.scopes if mcp_server and mcp_server.scopes else [],
+        "scopes_supported": mcp_server.scopes
+        if mcp_server and mcp_server.scopes
+        else [],
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "code_challenge_methods_supported": ["S256"],
         "token_endpoint_auth_methods_supported": ["client_secret_post"],
         # Claude expects a registration endpoint, even if we just fake it
-        "registration_endpoint": f"{request_base_url}/{mcp_server_name}/register" if mcp_server_name else f"{request_base_url}/register",
+        "registration_endpoint": f"{request_base_url}/{mcp_server_name}/register"
+        if mcp_server_name
+        else f"{request_base_url}/register",
     }
 
 
 # Standard MCP pattern: /.well-known/oauth-authorization-server/mcp/{server_name}
-@router.get(f"/.well-known/oauth-authorization-server{'' if get_server_root_path() == '/' else get_server_root_path()}/mcp/{{mcp_server_name}}")
+@router.get(
+    f"/.well-known/oauth-authorization-server{'' if get_server_root_path() == '/' else get_server_root_path()}/mcp/{{mcp_server_name}}"
+)
 async def oauth_authorization_server_mcp_standard(
     request: Request, mcp_server_name: str
 ):
@@ -632,7 +658,9 @@ async def oauth_authorization_server_mcp_standard(
 
 
 # LiteLLM legacy pattern and root endpoint
-@router.get(f"/.well-known/oauth-authorization-server{'' if get_server_root_path() == '/' else get_server_root_path()}/{{mcp_server_name}}")
+@router.get(
+    f"/.well-known/oauth-authorization-server{'' if get_server_root_path() == '/' else get_server_root_path()}/{{mcp_server_name}}"
+)
 @router.get("/.well-known/oauth-authorization-server")
 async def oauth_authorization_server_mcp(
     request: Request, mcp_server_name: Optional[str] = None
@@ -656,9 +684,7 @@ async def openid_configuration(request: Request):
 
 # Additional legacy pattern support
 @router.get("/.well-known/oauth-authorization-server/{mcp_server_name}/mcp")
-async def oauth_authorization_server_legacy(
-    request: Request, mcp_server_name: str
-):
+async def oauth_authorization_server_legacy(request: Request, mcp_server_name: str):
     """
     OAuth authorization server discovery for legacy /{server_name}/mcp pattern.
     """
@@ -695,9 +721,7 @@ async def register_client(request: Request, mcp_server_name: Optional[str] = Non
                 client_name=data.get("client_name", ""),
                 grant_types=data.get("grant_types", []),
                 response_types=data.get("response_types", []),
-                token_endpoint_auth_method=data.get(
-                    "token_endpoint_auth_method", ""
-                ),
+                token_endpoint_auth_method=data.get("token_endpoint_auth_method", ""),
                 fallback_client_id=resolved.server_name or resolved.name,
             )
         return dummy_return

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -239,10 +239,12 @@ async def exchange_token_with_server(
         token_data = {
             "grant_type": "authorization_code",
             "client_id": resolved_client_id,
-            "client_secret": resolved_client_secret,
-            "code": code,
             "redirect_uri": f"{proxy_base_url}/callback",
         }
+        if code:
+            token_data["code"] = code
+        if resolved_client_secret:
+            token_data["client_secret"] = resolved_client_secret
         if code_verifier:
             token_data["code_verifier"] = code_verifier
 

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -382,10 +382,15 @@ async def token_endpoint(
     Accept the authorization code from client and exchange it for OAuth token.
     Supports PKCE flow by forwarding code_verifier to upstream provider.
 
+    For authorization_code:
     1. Call the token endpoint with PKCE parameters
     2. Store the user's token in the db - and generate a LiteLLM virtual key
     3. Return the token
     4. Return a virtual key in this response
+
+    For refresh_token:
+    1. Forward the refresh_token to the upstream OAuth provider
+    2. Return the refreshed token
     """
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
         global_mcp_server_manager,


### PR DESCRIPTION
## Relevant issues
### Summary
The MCP OAuth discovery metadata advertises `"grant_types_supported": ["authorization_code", "refresh_token"]`, but the token endpoint only accepts `authorization_code`. Any client (Claude Code/Codex, Cursor, etc.) that tries to refresh an expired OAuth token gets a `400 Bad Request` with `"Unsupported grant_type"`.
This PR adds the missing refresh_token grant type support to the token endpoint, forwarding refresh requests to the upstream OAuth provider.


### Problem
When using MCP servers with OAuth (e.g., Atlassian Rovo MCP via LiteLLM proxy), the initial authentication works fine. After the access token expires (~1 hour), the client sends a standard OAuth refresh request:
```
POST /{mcp_server_name}/token
Content-Type: application/x-www-form-urlencoded

grant_type=refresh_token&refresh_token=<value>&client_id=<value>
```

This fails because:
1. `exchange_token_with_server()` explicitly rejects anything other than authorization_code (line 216)
2. The `token_endpoint()` function has no `refresh_token` Form parameter, so the value is silently dropped by FastAPI
3. The discovery metadata at `/.well-known/oauth-authorization-server` claims refresh_token is supported (line 609)

### Testing
Added 4 tests to `tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py`:

1. `test_token_endpoint_refresh_token_grant `— verifies refresh request is forwarded upstream with correct fields
2. `test_token_endpoint_refresh_token_uses_server_client_id` — verifies server-configured client_id/client_secret take precedence
3. `test_token_endpoint_refresh_token_missing_value` — verifies 400 when refresh_token value is missing
4. `test_token_endpoint_unsupported_grant_type` — verifies unsupported grant types still return 400


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🆕 New Feature
🐛 Bug Fix

## Changes
File: `litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py`

- Added `refresh_token: Optional[str] = Form(None) to token_endpoint()` so FastAPI captures the form field
- Added `refresh_token: Optional[str] = None` parameter to `exchange_token_with_server()`
- Added `grant_type == "refresh_token"` branch that forwards `refresh_token`, `client_id`, and optionally `client_secret` to the upstream `token_url`
- Existing `authorization_code` flow is unchanged