### PR TITLE
feat(vertex_ai): support explicit AWS credentials for WIF auth

### DIFF
--- a/litellm/llms/vertex_ai/aws_credentials_supplier.py
+++ b/litellm/llms/vertex_ai/aws_credentials_supplier.py
@@ -1,0 +1,49 @@
+"""
+Custom AWS Security Credentials Supplier for Vertex AI WIF.
+
+Wraps boto3/botocore credentials so that google-auth can use them
+for the AWS-to-GCP Workload Identity Federation token exchange
+without hitting the EC2 instance metadata service.
+
+Requires google-auth >= 2.29.0.
+"""
+
+from google.auth import aws
+
+
+class AwsCredentialsSupplier(aws.AwsSecurityCredentialsSupplier):
+    """
+    Supplies pre-obtained AWS credentials to google-auth's
+    aws.Credentials for WIF token exchange.
+
+    This bypasses the default metadata-based credential retrieval,
+    allowing WIF to work in environments where EC2 metadata is blocked.
+    """
+
+    def __init__(self, boto3_credentials, aws_region: str):
+        """
+        Args:
+            boto3_credentials: A botocore.credentials.Credentials object
+                with access_key, secret_key, and token attributes.
+            aws_region: The AWS region string (e.g. "us-east-1").
+
+        Note:
+            Credentials are captured as a point-in-time snapshot. When using
+            temporary STS credentials (e.g. AssumeRole), the caller is
+            responsible for constructing a new supplier before the underlying
+            AWS credentials expire.
+        """
+        self._credentials = boto3_credentials
+        self._region = aws_region
+
+    def get_aws_security_credentials(self, context, request):
+        """Return AWS credentials for the GCP token exchange."""
+        return aws.AwsSecurityCredentials(
+            access_key_id=self._credentials.access_key,
+            secret_access_key=self._credentials.secret_key,
+            session_token=self._credentials.token,
+        )
+
+    def get_aws_region(self, context, request):
+        """Return the AWS region for credential verification."""
+        return self._region

--- a/litellm/llms/vertex_ai/aws_credentials_supplier.py
+++ b/litellm/llms/vertex_ai/aws_credentials_supplier.py
@@ -8,40 +8,43 @@ without hitting the EC2 instance metadata service.
 Requires google-auth >= 2.29.0.
 """
 
+from typing import Callable
+
 from google.auth import aws
 
 
 class AwsCredentialsSupplier(aws.AwsSecurityCredentialsSupplier):
     """
-    Supplies pre-obtained AWS credentials to google-auth's
-    aws.Credentials for WIF token exchange.
+    Supplies AWS credentials to google-auth's aws.Credentials for WIF
+    token exchange.
 
     This bypasses the default metadata-based credential retrieval,
     allowing WIF to work in environments where EC2 metadata is blocked.
+
+    Accepts a credentials_provider callable that is invoked on every
+    get_aws_security_credentials() call, so that refreshed/rotated
+    credentials are picked up automatically (important for temporary
+    STS tokens).
     """
 
-    def __init__(self, boto3_credentials, aws_region: str):
+    def __init__(self, credentials_provider: Callable, aws_region: str):
         """
         Args:
-            boto3_credentials: A botocore.credentials.Credentials object
-                with access_key, secret_key, and token attributes.
+            credentials_provider: A zero-arg callable that returns a
+                botocore.credentials.Credentials object (with access_key,
+                secret_key, and token attributes).
             aws_region: The AWS region string (e.g. "us-east-1").
-
-        Note:
-            Credentials are captured as a point-in-time snapshot. When using
-            temporary STS credentials (e.g. AssumeRole), the caller is
-            responsible for constructing a new supplier before the underlying
-            AWS credentials expire.
         """
-        self._credentials = boto3_credentials
+        self._credentials_provider = credentials_provider
         self._region = aws_region
 
     def get_aws_security_credentials(self, context, request):
-        """Return AWS credentials for the GCP token exchange."""
+        """Return current AWS credentials for the GCP token exchange."""
+        current = self._credentials_provider()
         return aws.AwsSecurityCredentials(
-            access_key_id=self._credentials.access_key,
-            secret_access_key=self._credentials.secret_key,
-            session_token=self._credentials.token,
+            access_key_id=current.access_key,
+            secret_access_key=current.secret_key,
+            session_token=current.token,
         )
 
     def get_aws_region(self, context, request):

--- a/litellm/llms/vertex_ai/vertex_ai_aws_wif.py
+++ b/litellm/llms/vertex_ai/vertex_ai_aws_wif.py
@@ -1,0 +1,120 @@
+"""
+AWS Workload Identity Federation (WIF) auth for Vertex AI.
+
+Handles explicit AWS credentials for GCP WIF token exchange,
+bypassing the EC2 instance metadata service.
+
+When aws_* keys are present in the WIF credential JSON, this module
+uses BaseAWSLLM to obtain AWS credentials and wraps them in a custom
+AwsSecurityCredentialsSupplier for google-auth.
+"""
+
+from typing import Dict
+
+GOOGLE_IMPORT_ERROR_MESSAGE = (
+    "Google Cloud SDK not found. Install it with: pip install 'litellm[google]' "
+    "or pip install google-cloud-aiplatform"
+)
+
+# AWS params recognized in WIF credential JSON for explicit auth.
+# These match the kwargs accepted by BaseAWSLLM.get_credentials().
+_AWS_CREDENTIAL_KEYS = frozenset({
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "aws_region_name",
+    "aws_session_name",
+    "aws_profile_name",
+    "aws_role_name",
+    "aws_web_identity_token",
+    "aws_sts_endpoint",
+    "aws_external_id",
+})
+
+
+class VertexAIAwsWifAuth:
+    """
+    Handles AWS-to-GCP Workload Identity Federation credential creation
+    for Vertex AI, using explicit AWS credentials rather than EC2 metadata.
+    """
+
+    @staticmethod
+    def extract_aws_params(json_obj: dict) -> Dict[str, str]:
+        """
+        Extract LiteLLM-specific aws_* keys from a WIF credential JSON dict.
+
+        Returns a dict of {param_name: value} for any recognized aws_* keys
+        found in the JSON. Returns empty dict if none are present.
+        """
+        return {
+            key: json_obj[key]
+            for key in _AWS_CREDENTIAL_KEYS
+            if key in json_obj
+        }
+
+    @staticmethod
+    def credentials_from_explicit_aws(json_obj, aws_params, scopes):
+        """
+        Create GCP credentials using explicit AWS credentials for WIF.
+
+        Uses BaseAWSLLM to obtain AWS credentials (via STS AssumeRole, profile,
+        static keys, etc.), then wraps them in a custom AwsSecurityCredentialsSupplier
+        so that google-auth bypasses the EC2 metadata service.
+
+        Args:
+            json_obj: The WIF credential JSON dict (contains audience, token_url, etc.)
+            aws_params: Dict of aws_* params extracted from json_obj
+            scopes: OAuth scopes for the GCP credentials
+        """
+        try:
+            from google.auth import aws
+        except ImportError:
+            raise ImportError(GOOGLE_IMPORT_ERROR_MESSAGE)
+
+        from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+        from litellm.llms.vertex_ai.aws_credentials_supplier import (
+            AwsCredentialsSupplier,
+        )
+
+        # Validate region first — required for the GCP token exchange.
+        # Check before get_credentials() to avoid unnecessary AWS API calls
+        # (e.g. STS AssumeRole) on misconfiguration.
+        aws_region = aws_params.get("aws_region_name")
+        if not aws_region:
+            raise ValueError(
+                "aws_region_name is required in the WIF credential JSON "
+                "when using explicit AWS authentication. Add "
+                '"aws_region_name": "<your-region>" to your credential file.'
+            )
+
+        # Use BaseAWSLLM to get AWS credentials via any supported auth flow
+        base_aws = BaseAWSLLM()
+        boto3_credentials = base_aws.get_credentials(**aws_params)
+
+        # Create the custom supplier that wraps boto3 credentials
+        supplier = AwsCredentialsSupplier(
+            boto3_credentials=boto3_credentials,
+            aws_region=aws_region,
+        )
+
+        # Build kwargs for aws.Credentials — forward optional fields from JSON
+        creds_kwargs = dict(
+            audience=json_obj.get("audience"),
+            subject_token_type=json_obj.get("subject_token_type"),
+            token_url=json_obj.get("token_url"),
+            credential_source=None,  # Not using metadata endpoints
+            aws_security_credentials_supplier=supplier,
+            service_account_impersonation_url=json_obj.get(
+                "service_account_impersonation_url"
+            ),
+        )
+        # Forward universe_domain if present (defaults to googleapis.com)
+        if "universe_domain" in json_obj:
+            creds_kwargs["universe_domain"] = json_obj["universe_domain"]
+
+        creds = aws.Credentials(**creds_kwargs)
+
+        if scopes and hasattr(creds, "requires_scopes") and creds.requires_scopes:
+            creds = creds.with_scopes(scopes)
+
+        return creds

--- a/litellm/llms/vertex_ai/vertex_ai_aws_wif.py
+++ b/litellm/llms/vertex_ai/vertex_ai_aws_wif.py
@@ -87,13 +87,18 @@ class VertexAIAwsWifAuth:
                 '"aws_region_name": "<your-region>" to your credential file.'
             )
 
-        # Use BaseAWSLLM to get AWS credentials via any supported auth flow
+        # Build a credentials provider that re-resolves AWS creds on each call.
+        # This ensures rotated/refreshed STS tokens are picked up during
+        # long-running processes when google-auth refreshes the GCP token.
         base_aws = BaseAWSLLM()
-        boto3_credentials = base_aws.get_credentials(**aws_params)
+        aws_params_copy = dict(aws_params)  # avoid mutating caller's dict
 
-        # Create the custom supplier that wraps boto3 credentials
+        def _get_aws_credentials():
+            return base_aws.get_credentials(**aws_params_copy)
+
+        # Create the custom supplier with a lazy credentials provider
         supplier = AwsCredentialsSupplier(
-            boto3_credentials=boto3_credentials,
+            credentials_provider=_get_aws_credentials,
             aws_region=aws_region,
         )
 

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -97,9 +97,13 @@ class VertexBase:
                 )
                 if isinstance(environment_id, str) and "aws" in environment_id:
                     # Check if explicit AWS params are in the JSON (bypasses metadata)
-                    aws_params = self._extract_aws_params(json_obj)
+                    from litellm.llms.vertex_ai.vertex_ai_aws_wif import (
+                        VertexAIAwsWifAuth,
+                    )
+
+                    aws_params = VertexAIAwsWifAuth.extract_aws_params(json_obj)
                     if aws_params:
-                        creds = self._credentials_from_aws_with_explicit_auth(
+                        creds = VertexAIAwsWifAuth.credentials_from_explicit_aws(
                             json_obj,
                             aws_params=aws_params,
                             scopes=["https://www.googleapis.com/auth/cloud-platform"],
@@ -172,100 +176,6 @@ class VertexBase:
         creds = aws.Credentials.from_info(json_obj)
         if scopes and hasattr(creds, "requires_scopes") and creds.requires_scopes:
             creds = creds.with_scopes(scopes)
-        return creds
-
-    # AWS params recognized in WIF credential JSON for explicit auth
-    _AWS_CREDENTIAL_KEYS = frozenset({
-        "aws_access_key_id",
-        "aws_secret_access_key",
-        "aws_session_token",
-        "aws_region_name",
-        "aws_session_name",
-        "aws_profile_name",
-        "aws_role_name",
-        "aws_web_identity_token",
-        "aws_sts_endpoint",
-        "aws_external_id",
-    })
-
-    @staticmethod
-    def _extract_aws_params(json_obj: dict) -> dict:
-        """
-        Extract LiteLLM-specific aws_* keys from a WIF credential JSON dict.
-
-        Returns a dict of {param_name: value} for any recognized aws_* keys
-        found in the JSON. Returns empty dict if none are present.
-        """
-        return {
-            key: json_obj[key]
-            for key in VertexBase._AWS_CREDENTIAL_KEYS
-            if key in json_obj
-        }
-
-    def _credentials_from_aws_with_explicit_auth(self, json_obj, aws_params, scopes):
-        """
-        Create GCP credentials using explicit AWS credentials for WIF.
-
-        Uses BaseAWSLLM to obtain AWS credentials (via STS AssumeRole, profile,
-        static keys, etc.), then wraps them in a custom AwsSecurityCredentialsSupplier
-        so that google-auth bypasses the EC2 metadata service.
-
-        Args:
-            json_obj: The WIF credential JSON dict (contains audience, token_url, etc.)
-            aws_params: Dict of aws_* params extracted from json_obj
-            scopes: OAuth scopes for the GCP credentials
-        """
-        try:
-            from google.auth import aws
-        except ImportError:
-            raise ImportError(GOOGLE_IMPORT_ERROR_MESSAGE)
-
-        from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
-        from litellm.llms.vertex_ai.aws_credentials_supplier import (
-            AwsCredentialsSupplier,
-        )
-
-        # Validate region first — required for the GCP token exchange.
-        # Check before get_credentials() to avoid unnecessary AWS API calls
-        # (e.g. STS AssumeRole) on misconfiguration.
-        aws_region = aws_params.get("aws_region_name")
-        if not aws_region:
-            raise ValueError(
-                "aws_region_name is required in the WIF credential JSON "
-                "when using explicit AWS authentication. Add "
-                '"aws_region_name": "<your-region>" to your credential file.'
-            )
-
-        # Use BaseAWSLLM to get AWS credentials via any supported auth flow
-        base_aws = BaseAWSLLM()
-        boto3_credentials = base_aws.get_credentials(**aws_params)
-
-        # Create the custom supplier that wraps boto3 credentials
-        supplier = AwsCredentialsSupplier(
-            boto3_credentials=boto3_credentials,
-            aws_region=aws_region,
-        )
-
-        # Build kwargs for aws.Credentials — forward optional fields from JSON
-        creds_kwargs = dict(
-            audience=json_obj.get("audience"),
-            subject_token_type=json_obj.get("subject_token_type"),
-            token_url=json_obj.get("token_url"),
-            credential_source=None,  # Not using metadata endpoints
-            aws_security_credentials_supplier=supplier,
-            service_account_impersonation_url=json_obj.get(
-                "service_account_impersonation_url"
-            ),
-        )
-        # Forward universe_domain if present (defaults to googleapis.com)
-        if "universe_domain" in json_obj:
-            creds_kwargs["universe_domain"] = json_obj["universe_domain"]
-
-        creds = aws.Credentials(**creds_kwargs)
-
-        if scopes and hasattr(creds, "requires_scopes") and creds.requires_scopes:
-            creds = creds.with_scopes(scopes)
-
         return creds
 
     def _credentials_from_authorized_user(self, json_obj, scopes):

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -96,10 +96,19 @@ class VertexBase:
                     else ""
                 )
                 if isinstance(environment_id, str) and "aws" in environment_id:
-                    creds = self._credentials_from_identity_pool_with_aws(
-                        json_obj,
-                        scopes=["https://www.googleapis.com/auth/cloud-platform"],
-                    )
+                    # Check if explicit AWS params are in the JSON (bypasses metadata)
+                    aws_params = self._extract_aws_params(json_obj)
+                    if aws_params:
+                        creds = self._credentials_from_aws_with_explicit_auth(
+                            json_obj,
+                            aws_params=aws_params,
+                            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+                        )
+                    else:
+                        creds = self._credentials_from_identity_pool_with_aws(
+                            json_obj,
+                            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+                        )
                 else:
                     creds = self._credentials_from_identity_pool(
                         json_obj,
@@ -163,6 +172,100 @@ class VertexBase:
         creds = aws.Credentials.from_info(json_obj)
         if scopes and hasattr(creds, "requires_scopes") and creds.requires_scopes:
             creds = creds.with_scopes(scopes)
+        return creds
+
+    # AWS params recognized in WIF credential JSON for explicit auth
+    _AWS_CREDENTIAL_KEYS = frozenset({
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "aws_region_name",
+        "aws_session_name",
+        "aws_profile_name",
+        "aws_role_name",
+        "aws_web_identity_token",
+        "aws_sts_endpoint",
+        "aws_external_id",
+    })
+
+    @staticmethod
+    def _extract_aws_params(json_obj: dict) -> dict:
+        """
+        Extract LiteLLM-specific aws_* keys from a WIF credential JSON dict.
+
+        Returns a dict of {param_name: value} for any recognized aws_* keys
+        found in the JSON. Returns empty dict if none are present.
+        """
+        return {
+            key: json_obj[key]
+            for key in VertexBase._AWS_CREDENTIAL_KEYS
+            if key in json_obj
+        }
+
+    def _credentials_from_aws_with_explicit_auth(self, json_obj, aws_params, scopes):
+        """
+        Create GCP credentials using explicit AWS credentials for WIF.
+
+        Uses BaseAWSLLM to obtain AWS credentials (via STS AssumeRole, profile,
+        static keys, etc.), then wraps them in a custom AwsSecurityCredentialsSupplier
+        so that google-auth bypasses the EC2 metadata service.
+
+        Args:
+            json_obj: The WIF credential JSON dict (contains audience, token_url, etc.)
+            aws_params: Dict of aws_* params extracted from json_obj
+            scopes: OAuth scopes for the GCP credentials
+        """
+        try:
+            from google.auth import aws
+        except ImportError:
+            raise ImportError(GOOGLE_IMPORT_ERROR_MESSAGE)
+
+        from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+        from litellm.llms.vertex_ai.aws_credentials_supplier import (
+            AwsCredentialsSupplier,
+        )
+
+        # Validate region first — required for the GCP token exchange.
+        # Check before get_credentials() to avoid unnecessary AWS API calls
+        # (e.g. STS AssumeRole) on misconfiguration.
+        aws_region = aws_params.get("aws_region_name")
+        if not aws_region:
+            raise ValueError(
+                "aws_region_name is required in the WIF credential JSON "
+                "when using explicit AWS authentication. Add "
+                '"aws_region_name": "<your-region>" to your credential file.'
+            )
+
+        # Use BaseAWSLLM to get AWS credentials via any supported auth flow
+        base_aws = BaseAWSLLM()
+        boto3_credentials = base_aws.get_credentials(**aws_params)
+
+        # Create the custom supplier that wraps boto3 credentials
+        supplier = AwsCredentialsSupplier(
+            boto3_credentials=boto3_credentials,
+            aws_region=aws_region,
+        )
+
+        # Build kwargs for aws.Credentials — forward optional fields from JSON
+        creds_kwargs = dict(
+            audience=json_obj.get("audience"),
+            subject_token_type=json_obj.get("subject_token_type"),
+            token_url=json_obj.get("token_url"),
+            credential_source=None,  # Not using metadata endpoints
+            aws_security_credentials_supplier=supplier,
+            service_account_impersonation_url=json_obj.get(
+                "service_account_impersonation_url"
+            ),
+        )
+        # Forward universe_domain if present (defaults to googleapis.com)
+        if "universe_domain" in json_obj:
+            creds_kwargs["universe_domain"] = json_obj["universe_domain"]
+
+        creds = aws.Credentials(**creds_kwargs)
+
+        if scopes and hasattr(creds, "requires_scopes") and creds.requires_scopes:
+            creds = creds.with_scopes(scopes)
+
         return creds
 
     def _credentials_from_authorized_user(self, json_obj, scopes):

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -1134,9 +1134,6 @@ class TestVertexBase:
                 json_obj, aws_params, scopes
             )
 
-            # Verify BaseAWSLLM.get_credentials was called with correct params
-            mock_base_aws.get_credentials.assert_called_once_with(**aws_params)
-
             # Verify aws.Credentials was called with supplier (not from_info)
             MockAwsCredentials.assert_called_once()
             call_kwargs = MockAwsCredentials.call_args[1]
@@ -1144,8 +1141,15 @@ class TestVertexBase:
             assert call_kwargs["subject_token_type"] == json_obj["subject_token_type"]
             assert call_kwargs["token_url"] == json_obj["token_url"]
             assert call_kwargs["credential_source"] is None
-            assert call_kwargs["aws_security_credentials_supplier"] is not None
             assert call_kwargs["service_account_impersonation_url"] == json_obj["service_account_impersonation_url"]
+
+            # Verify the supplier is a lazy credentials provider (calls
+            # get_credentials on demand, not at construction time)
+            supplier = call_kwargs["aws_security_credentials_supplier"]
+            assert supplier is not None
+            # Trigger the lazy provider — this should call get_credentials
+            supplier.get_aws_security_credentials(context=None, request=None)
+            mock_base_aws.get_credentials.assert_called_once_with(**aws_params)
 
             # Verify scopes were applied
             mock_gcp_creds.with_scopes.assert_called_once_with(scopes)
@@ -1285,7 +1289,7 @@ class TestVertexBase:
             assert token == "refreshed-token"
 
     def test_aws_credentials_supplier(self):
-        """Test AwsCredentialsSupplier: wraps boto3 creds, handles token=None."""
+        """Test AwsCredentialsSupplier: wraps credentials provider, handles token=None."""
         from litellm.llms.vertex_ai.aws_credentials_supplier import (
             AwsCredentialsSupplier,
         )
@@ -1297,7 +1301,7 @@ class TestVertexBase:
         mock_boto3_creds.token = "FwoGZXIvYXdzEBYaDHqa0AP"
 
         supplier = AwsCredentialsSupplier(
-            boto3_credentials=mock_boto3_creds,
+            credentials_provider=lambda: mock_boto3_creds,
             aws_region="us-east-1",
         )
 
@@ -1314,7 +1318,7 @@ class TestVertexBase:
         mock_static_creds.token = None
 
         supplier_static = AwsCredentialsSupplier(
-            boto3_credentials=mock_static_creds,
+            credentials_provider=lambda: mock_static_creds,
             aws_region="eu-west-1",
         )
 
@@ -1338,7 +1342,7 @@ class TestVertexBase:
         mock_boto3_creds.token = "TOKEN"
 
         supplier = AwsCredentialsSupplier(
-            boto3_credentials=mock_boto3_creds,
+            credentials_provider=lambda: mock_boto3_creds,
             aws_region="us-east-1",
         )
 


### PR DESCRIPTION
The current Vertex AI AWS Workload Identity Federation implementation exclusively uses google.auth.aws.Credentials.from_info(), which requires EC2 instance metadata access to obtain AWS credentials. In environments where the metadata service is blocked for security reasons, this makes WIF unusable.

Add support for explicit AWS credentials by implementing a custom AwsSecurityCredentialsSupplier (google-auth >= 2.29.0). When aws_* keys (e.g. aws_role_name, aws_region_name) are present in the WIF credential JSON, LiteLLM uses BaseAWSLLM.get_credentials() to obtain AWS creds via STS AssumeRole (or any other supported AWS auth flow), wraps them in the custom supplier, and passes them to aws.Credentials() — bypassing the metadata service entirely.

When no aws_* keys are present, the existing from_info() flow is used unchanged, preserving full backward compatibility.

## Relevant issues

Related to closed PR #15663 (auto-staled, same feature request)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

- **`litellm/llms/vertex_ai/aws_credentials_supplier.py`** (NEW) — Custom `AwsCredentialsSupplier` class implementing `google.auth.aws.AwsSecurityCredentialsSupplier`. Wraps boto3/botocore credentials and provides them to google-auth for the WIF token exchange, bypassing the EC2 metadata service.

- **`litellm/llms/vertex_ai/vertex_llm_base.py`** — Three additions:
  - `_AWS_CREDENTIAL_KEYS` frozenset + `_extract_aws_params()` static method: extracts recognized `aws_*` keys from the WIF credential JSON
  - `_credentials_from_aws_with_explicit_auth()`: uses `BaseAWSLLM.get_credentials()` to obtain AWS credentials, wraps them in the custom supplier, and constructs `aws.Credentials()` with the supplier
  - Modified `load_auth()` routing: when `aws_*` keys are detected in the WIF JSON, routes to the new explicit auth path; otherwise falls back to the existing `from_info()` flow

- **`tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py`** — 7 new tests:
  - `test_extract_aws_params` — extraction, empty case, unrecognized keys ignored
  - `test_credentials_from_aws_with_explicit_auth` — full flow with mocked BaseAWSLLM
  - `test_credentials_from_aws_with_explicit_auth_requires_region` — ValueError when region missing
  - `test_aws_wif_routes_to_explicit_auth_when_aws_params_present` — routing test (sync+async)
  - `test_aws_wif_falls_back_to_metadata_when_no_aws_params` — backward compat (sync+async)
  - `test_aws_credentials_supplier` — supplier wraps creds with/without session token
  - `test_aws_credentials_supplier_returns_correct_type` — returns `AwsSecurityCredentials` dataclass