### PR TITLE
fix(tests): use record.getMessage() instead of record.message for LogRecord

### DIFF
--- a/tests/test_litellm/test_cost_calculation_log_level.py
+++ b/tests/test_litellm/test_cost_calculation_log_level.py
@@ -67,7 +67,7 @@ def test_cost_calculation_uses_debug_level():
         # Find the cost calculation log records
         cost_calc_records = [
             record for record in handler.records
-            if "selected model name for cost calculation" in record.message
+            if "selected model name for cost calculation" in record.getMessage()
         ]
 
         # Verify that cost calculation logs are at DEBUG level
@@ -126,7 +126,7 @@ def test_batch_cost_calculation_uses_debug_level():
         # Find batch cost calculation log records
         batch_cost_records = [
             record for record in handler.records
-            if "Calculating batch cost per token" in record.message
+            if "Calculating batch cost per token" in record.getMessage()
         ]
 
         # Verify logs exist and are at DEBUG level


### PR DESCRIPTION
## Summary

- `LogRecord` objects don't have a `.message` attribute until after `Formatter.format()` is called on them
- The tests in `test_cost_calculation_log_level.py` were accessing `record.message` directly, causing `AttributeError: 'LogRecord' object has no attribute 'message'`
- Fix: use `record.getMessage()` which is the correct API to retrieve the formatted log message from a `LogRecord`

## Test plan

- [ ] `poetry run pytest tests/test_litellm/test_cost_calculation_log_level.py -v` — both tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)