### PR TITLE
fix(tests): add inference_geo to model prices JSON schema validator

### DIFF
--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -580,6 +580,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "annotation_cost_per_page": {"type": "number"},
                 "ocr_cost_per_page": {"type": "number"},
                 "code_interpreter_cost_per_session": {"type": "number"},
+                "inference_geo": {"type": "string"},
                 "litellm_provider": {"type": "string"},
                 "max_audio_length_hours": {"type": "number"},
                 "max_audio_per_prompt": {"type": "number"},


### PR DESCRIPTION
## Summary

- `model_prices_and_context_window_backup.json` includes `inference_geo` fields on geo-prefixed Anthropic models (e.g. `us/claude-sonnet-4-6`) used for cost calculation routing
- The JSON schema in `test_aaamodel_prices_and_context_window_json_is_valid` had `additionalProperties: false` but didn't list `inference_geo` as an allowed property
- This caused the test to fail with `ValidationError: Additional properties are not allowed ('inference_geo' was unexpected)`
- Fix: add `"inference_geo": {"type": "string"}` to the schema

## Test plan

- [ ] `poetry run pytest tests/test_litellm/test_utils.py::test_aaamodel_prices_and_context_window_json_is_valid -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)