### PR TITLE
fix(proxy): use prisma.Json for JSON fields in _rotate_master_key create_many()

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3096,8 +3096,8 @@ async def _rotate_master_key( # noqa: PLR0915
             )
             if new_model:
                 _dumped = new_model.model_dump(exclude_none=True)
-                _dumped["litellm_params"] = safe_dumps(_dumped["litellm_params"])
-                _dumped["model_info"] = safe_dumps(_dumped["model_info"])
+                _dumped["litellm_params"] = prisma.Json(_dumped["litellm_params"])  # type: ignore[attr-defined]
+                _dumped["model_info"] = prisma.Json(_dumped["model_info"])  # type: ignore[attr-defined]
                 new_models.append(_dumped)
         verbose_proxy_logger.debug("Resetting proxy model table")
         async with prisma_client.db.tx() as tx:


### PR DESCRIPTION
## Summary

- `_rotate_master_key` in `key_management_endpoints.py` was using `safe_dumps()` (returns `str`) for `litellm_params` and `model_info` before passing them to `create_many()`
- Prisma's `create_many()` requires JSON fields to be wrapped in `prisma.Json()`, not passed as raw JSON strings — passing strings causes Prisma validation errors
- The regression test `test_rotate_master_key_model_data_valid_for_prisma` already correctly asserted `isinstance(..., prisma.Json)`, exposing this mismatch
- Fix: replace `safe_dumps(...)` with `prisma.Json(...)` for both fields, consistent with the existing pattern in the same file (e.g. line 3134)

The `AttributeError: 'Json'` in the test was because `prisma.Json` requires `prisma generate` — now provided by CI (merged #21436).

## Test plan

- [ ] `test_rotate_master_key_model_data_valid_for_prisma` passes after running `prisma generate --schema litellm/proxy/schema.prisma`

🤖 Generated with [Claude Code](https://claude.com/claude-code)