### PR TITLE
fix(ci): force-reinstall enterprise package to override PyPI version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
           name: "Install local version of litellm-enterprise"
           command: |
             cd enterprise
-            python -m pip install -e .
+            python -m pip install --force-reinstall --no-deps -e .
             cd ..
   setup_litellm_test_deps:
     steps:

--- a/.github/workflows/test-litellm-matrix.yml
+++ b/.github/workflows/test-litellm-matrix.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Setup litellm-enterprise
         run: |
-          cd enterprise && poetry run pip install --force-reinstall -e . && cd ..
+          cd enterprise && poetry run pip install --force-reinstall --no-deps -e . && cd ..
 
       - name: Generate Prisma client
         run: |

--- a/.github/workflows/test-litellm-matrix.yml
+++ b/.github/workflows/test-litellm-matrix.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Setup litellm-enterprise
         run: |
-          cd enterprise && poetry run pip install -e . && cd ..
+          cd enterprise && poetry run pip install --force-reinstall -e . && cd ..
 
       - name: Generate Prisma client
         run: |

--- a/.github/workflows/test-litellm.yml
+++ b/.github/workflows/test-litellm.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Setup litellm-enterprise as local package
       run: |
         cd enterprise
-        poetry run pip install -e .
+        poetry run pip install --force-reinstall --no-deps -e .
         cd ..
     - name: Run tests
       run: |

--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Setup litellm-enterprise as local package
       run: |
         cd enterprise
-        python -m pip install -e .
+        python -m pip install --force-reinstall --no-deps -e .
         cd ..
 
     - name: Run MCP tests


### PR DESCRIPTION
## Summary

- Adds `--force-reinstall` to the `pip install -e enterprise/` step in the matrix CI workflow
- **Root cause**: `poetry install --extras "proxy ..."` installs `litellm-enterprise` from PyPI. When the local editable install step runs with the same version number, pip may skip reinstalling ("Requirement already satisfied"), leaving the PyPI build in place — which can lack methods added after the last PyPI release
- **Effect**: Enterprise tests fail with `AttributeError: '_PROXY_LiteLLMManagedFiles' object has no attribute '_get_batches_referencing_file'` (and similar) because the installed package is the old PyPI build
- **Fix**: `--force-reinstall` ensures the local source directory always overrides the PyPI-installed package

## Test plan
- [ ] Enterprise tests in `tests/test_litellm/enterprise/proxy/test_file_deletion_blocking.py` pass (all 13 tests)
- [ ] Enterprise tests in `tests/test_litellm/enterprise/proxy/test_managed_files_access_check.py` pass (all 4 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)