### PR TITLE
fix(tests): restore default_internal_user_params instead of delattr-ing it

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -642,12 +642,9 @@ async def test_new_user_default_teams_flow(mocker):
         assert response.key == "sk-test-token-123"
 
     finally:
-        # Restore original default params
-        if original_default_params is not None:
-            litellm.default_internal_user_params = original_default_params
-        else:
-            if hasattr(litellm, "default_internal_user_params"):
-                delattr(litellm, "default_internal_user_params")
+        # Restore original default params (always assign, never delattr — the attribute
+        # is defined in litellm/__init__.py and delattr-ing it breaks parallel tests)
+        litellm.default_internal_user_params = original_default_params
 
 
 def test_update_internal_new_user_params_proxy_admin_role():
@@ -694,12 +691,7 @@ def test_update_internal_new_user_params_proxy_admin_role():
         assert result["user_role"] == LitellmUserRoles.PROXY_ADMIN.value
 
     finally:
-        # Restore original default params
-        if original_default_params is not None:
-            litellm.default_internal_user_params = original_default_params
-        else:
-            if hasattr(litellm, "default_internal_user_params"):
-                delattr(litellm, "default_internal_user_params")
+        litellm.default_internal_user_params = original_default_params
 
 
 def test_update_internal_new_user_params_no_role_specified():
@@ -735,12 +727,7 @@ def test_update_internal_new_user_params_no_role_specified():
         assert result["user_email"] == "user@example.com"
 
     finally:
-        # Restore original default params
-        if original_default_params is not None:
-            litellm.default_internal_user_params = original_default_params
-        else:
-            if hasattr(litellm, "default_internal_user_params"):
-                delattr(litellm, "default_internal_user_params")
+        litellm.default_internal_user_params = original_default_params
 
 
 def test_update_internal_new_user_params_internal_user_role():
@@ -780,12 +767,7 @@ def test_update_internal_new_user_params_internal_user_role():
         assert result["user_role"] == LitellmUserRoles.INTERNAL_USER.value
 
     finally:
-        # Restore original default params
-        if original_default_params is not None:
-            litellm.default_internal_user_params = original_default_params
-        else:
-            if hasattr(litellm, "default_internal_user_params"):
-                delattr(litellm, "default_internal_user_params")
+        litellm.default_internal_user_params = original_default_params
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3682,12 +3682,9 @@ async def test_role_mappings_override_default_internal_user_params():
             # The models will be applied when new_user processes the request
 
     finally:
-        # Restore original default_internal_user_params
-        if original_default_params is not None:
-            litellm.default_internal_user_params = original_default_params
-        else:
-            if hasattr(litellm, "default_internal_user_params"):
-                delattr(litellm, "default_internal_user_params")
+        # Restore original default_internal_user_params (always assign, never delattr —
+        # the attribute is defined in litellm/__init__.py and delattr-ing it breaks parallel tests)
+        litellm.default_internal_user_params = original_default_params
 
 
 class TestSSOReadinessEndpoint:


### PR DESCRIPTION
## Summary

- Fixes `AttributeError: module 'litellm' has no attribute 'default_internal_user_params'` in `test_add_new_member_*` tests when run in parallel
- **Root cause**: 4 `finally` blocks in `test_internal_user_endpoints.py` and 1 in `test_ui_sso.py` used a flawed restore pattern that called `delattr(litellm, "default_internal_user_params")` when the original value was `None`
- Since the attribute is always defined in `litellm/__init__.py` as `Optional[Dict] = None`, saving it returns `None`, which triggers the `else` branch that permanently removes the attribute from the module
- **Effect**: Subsequent tests in the same pytest-xdist worker that access `litellm.default_internal_user_params` (e.g. `add_new_member` in `management_helpers/utils.py`) raise `AttributeError`
- **Fix**: Replace all 5 flawed `if/else delattr` blocks with a simple `litellm.default_internal_user_params = original_default_params` assignment

## Files changed
- `tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py` — 4 finally blocks fixed
- `tests/test_litellm/proxy/management_endpoints/test_ui_sso.py` — 1 finally block fixed

## Test plan
- [ ] `test_add_new_member_creates_new_budget_when_max_budget_provided` passes
- [ ] `test_add_new_member_uses_default_team_budget_id` passes
- [ ] `test_add_new_member_with_user_email` passes
- [ ] Modified tests in `test_internal_user_endpoints.py` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)