### PR TITLE
fix: guard against None metadata in prometheus metrics

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -22,6 +22,10 @@ from typing import (
 import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.core_helpers import (
+    get_litellm_metadata_from_kwargs,
+    get_metadata_variable_name_from_kwargs,
+)
 from litellm.proxy._types import (
     LiteLLM_DeletedVerificationToken,
     LiteLLM_TeamTable,
@@ -1960,7 +1964,7 @@ class PrometheusLogger(CustomLogger):
 
             api_base = standard_logging_payload["api_base"]
             _litellm_params = request_kwargs.get("litellm_params", {}) or {}
-            _metadata = _litellm_params.get("metadata", {})
+            _metadata = get_litellm_metadata_from_kwargs(request_kwargs)
             litellm_model_name = request_kwargs.get("model", None)
             llm_provider = _litellm_params.get("custom_llm_provider", None)
             _model_info = _metadata.get("model_info") or {}
@@ -2176,7 +2180,8 @@ class PrometheusLogger(CustomLogger):
             original_model_group,
             kwargs,
         )
-        _metadata = kwargs.get("metadata", {})
+        _metadata_key = get_metadata_variable_name_from_kwargs(kwargs)
+        _metadata = kwargs.get(_metadata_key) or {}
         standard_metadata: StandardLoggingMetadata = (
             StandardLoggingPayloadSetup.get_standard_logging_metadata(
                 metadata=_metadata
@@ -2221,7 +2226,8 @@ class PrometheusLogger(CustomLogger):
             kwargs,
         )
         _new_model = kwargs.get("model")
-        _metadata = kwargs.get("metadata", {})
+        _metadata_key = get_metadata_variable_name_from_kwargs(kwargs)
+        _metadata = kwargs.get(_metadata_key) or {}
         _tags = cast(List[str], kwargs.get("tags") or [])
         standard_metadata: StandardLoggingMetadata = (
             StandardLoggingPayloadSetup.get_standard_logging_metadata(

--- a/tests/test_litellm/integrations/test_prometheus_none_metadata.py
+++ b/tests/test_litellm/integrations/test_prometheus_none_metadata.py
@@ -1,0 +1,176 @@
+"""
+Unit tests for Prometheus handling of None metadata in litellm_params.
+
+When the Responses API sends streaming requests, litellm_params.metadata
+can be None, causing AttributeError: 'NoneType' object has no attribute 'get'
+in set_llm_deployment_success_metrics.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+import pytest
+from prometheus_client import REGISTRY
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.types.integrations.prometheus import UserAPIKeyLabelValues
+
+
+@pytest.fixture(scope="function")
+def prometheus_logger():
+    """Create a PrometheusLogger instance for testing."""
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        REGISTRY.unregister(collector)
+    return PrometheusLogger()
+
+
+class TestNoneMetadataHandling:
+    """
+    Test that Prometheus metrics don't crash when metadata is None.
+
+    This targets the bug where Responses API streaming sets
+    litellm_params["metadata"] = None, causing:
+        _metadata.get("model_info") -> AttributeError
+    """
+
+    def test_set_llm_deployment_success_metrics_with_none_metadata(
+        self, prometheus_logger
+    ):
+        """
+        set_llm_deployment_success_metrics should not raise when
+        litellm_params.metadata is None.
+        """
+        request_kwargs = {
+            "litellm_params": {
+                "metadata": None,  # Bug trigger
+                "custom_llm_provider": "openai",
+            },
+            "model": "gpt-4o",
+            "standard_logging_object": {
+                "api_base": "https://api.openai.com",
+                "hidden_params": {
+                    "additional_headers": None,
+                    "litellm_overhead_time_ms": None,
+                },
+                "metadata": {
+                    "user_api_key_hash": "test-key",
+                    "user_api_key_alias": None,
+                    "user_api_key_team_id": None,
+                    "user_api_key_team_alias": None,
+                },
+                "model": "gpt-4o",
+                "response_cost": 0.001,
+            },
+        }
+        enum_values = UserAPIKeyLabelValues(
+            end_user=None,
+            hashed_api_key="test-key",
+            api_key_alias=None,
+            team=None,
+            team_alias=None,
+            requested_model="gpt-4o",
+        )
+
+        # Should not raise AttributeError
+        prometheus_logger.set_llm_deployment_success_metrics(
+            request_kwargs=request_kwargs,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            enum_values=enum_values,
+            output_tokens=10.0,
+        )
+
+    def test_set_llm_deployment_success_metrics_with_missing_litellm_params(
+        self, prometheus_logger
+    ):
+        """
+        set_llm_deployment_success_metrics should not raise when
+        litellm_params is missing entirely.
+        """
+        request_kwargs = {
+            "model": "gpt-4o",
+            "standard_logging_object": {
+                "api_base": "https://api.openai.com",
+                "hidden_params": {
+                    "additional_headers": None,
+                    "litellm_overhead_time_ms": None,
+                },
+                "metadata": {
+                    "user_api_key_hash": "test-key",
+                    "user_api_key_alias": None,
+                    "user_api_key_team_id": None,
+                    "user_api_key_team_alias": None,
+                },
+                "model": "gpt-4o",
+                "response_cost": 0.001,
+            },
+        }
+        enum_values = UserAPIKeyLabelValues(
+            end_user=None,
+            hashed_api_key="test-key",
+            api_key_alias=None,
+            team=None,
+            team_alias=None,
+            requested_model="gpt-4o",
+        )
+
+        # Should not raise
+        prometheus_logger.set_llm_deployment_success_metrics(
+            request_kwargs=request_kwargs,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            enum_values=enum_values,
+            output_tokens=10.0,
+        )
+
+    def test_set_llm_deployment_success_metrics_with_litellm_metadata_key(
+        self, prometheus_logger
+    ):
+        """
+        set_llm_deployment_success_metrics should pick up litellm_metadata
+        when metadata is None, using get_litellm_metadata_from_kwargs.
+        """
+        request_kwargs = {
+            "litellm_params": {
+                "metadata": None,
+                "litellm_metadata": {"model_info": {"id": "test-model-id"}},
+                "custom_llm_provider": "openai",
+            },
+            "model": "gpt-4o",
+            "standard_logging_object": {
+                "api_base": "https://api.openai.com",
+                "hidden_params": {
+                    "additional_headers": None,
+                    "litellm_overhead_time_ms": None,
+                },
+                "metadata": {
+                    "user_api_key_hash": "test-key",
+                    "user_api_key_alias": None,
+                    "user_api_key_team_id": None,
+                    "user_api_key_team_alias": None,
+                },
+                "model": "gpt-4o",
+                "response_cost": 0.001,
+            },
+        }
+        enum_values = UserAPIKeyLabelValues(
+            end_user=None,
+            hashed_api_key="test-key",
+            api_key_alias=None,
+            team=None,
+            team_alias=None,
+            requested_model="gpt-4o",
+        )
+
+        # Should not raise, and should pick up litellm_metadata
+        prometheus_logger.set_llm_deployment_success_metrics(
+            request_kwargs=request_kwargs,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            enum_values=enum_values,
+            output_tokens=10.0,
+        )


### PR DESCRIPTION
## Relevant issues

Fixes prometheus `AttributeError: 'NoneType' object has no attribute 'get'` in `set_llm_deployment_success_metrics` when using Responses API streaming with prometheus callbacks.

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

When the Responses API handles streaming requests, `litellm_params["metadata"]` can be `None`. The pattern `.get("metadata", {})` returns `None` when the key exists with a `None` value (the default `{}` only kicks in when the key is missing). Then `.get("model_info")` on `None` throws `AttributeError`.

This happens on every streaming chunk, so the repeated exceptions in the logging thread cause CPU spikes.

Fix: use the existing `get_litellm_metadata_from_kwargs` and `get_metadata_variable_name_from_kwargs` helpers which handle None safely and also check both `metadata` and `litellm_metadata` keys.