### PR TITLE
fix(chatgpt): extract system/developer messages from input into instructions

### DIFF
--- a/docs/my-website/docs/providers/chatgpt.md
+++ b/docs/my-website/docs/providers/chatgpt.md
@@ -13,6 +13,7 @@ ChatGPT subscription access is native to the Responses API. Chat Completions req
 
 Notes:
 - The ChatGPT subscription backend rejects token limit fields (`max_tokens`, `max_output_tokens`, `max_completion_tokens`) and `metadata`. LiteLLM strips these fields for this provider.
+- When using `chatgpt/`, `system` and `developer` roles in `input` are not accepted. LiteLLM automatically extracts these messages and moves them to the `instructions` field, which serves the same function per the [OpenAI Responses API spec](https://platform.openai.com/docs/api-reference/responses/create) (*"A system (or developer) message inserted into the model's context"*).
 - `/v1/chat/completions` honors `stream`. When `stream` is false (default), LiteLLM aggregates the Responses stream into a single JSON response.
 
 ## Authentication

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -96,7 +96,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
                                 system_parts.append(block["text"])
                 else:
                     filtered.append(item)
-            if system_parts:
+            if system_parts or len(filtered) != len(raw_input):
                 request["input"] = filtered
 
         system_text = "\n\n".join(system_parts) if system_parts else None

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -73,13 +73,43 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             litellm_params,
             headers,
         )
+
+        # The ChatGPT backend rejects "system" and "developer" roles in input.
+        # Per OpenAI's spec, the `instructions` field serves the same purpose as
+        # a system/developer message ("A system (or developer) message inserted
+        # into the model's context"), so we extract them into `instructions`.
+        raw_input = request.get("input")
+        system_parts: list[str] = []
+        if isinstance(raw_input, list):
+            filtered: list[Any] = []
+            for item in raw_input:
+                if isinstance(item, dict) and item.get("role") in (
+                    "system",
+                    "developer",
+                ):
+                    content = item.get("content")
+                    if isinstance(content, str):
+                        system_parts.append(content)
+                    elif isinstance(content, list):
+                        for block in content:
+                            if isinstance(block, dict) and "text" in block:
+                                system_parts.append(block["text"])
+                else:
+                    filtered.append(item)
+            if system_parts:
+                request["input"] = filtered
+
+        system_text = "\n\n".join(system_parts) if system_parts else None
         base_instructions = get_chatgpt_default_instructions()
         existing_instructions = request.get("instructions")
         if existing_instructions:
-            if base_instructions not in existing_instructions:
-                request["instructions"] = (
-                    f"{base_instructions}\n\n{existing_instructions}"
-                )
+            parts = [base_instructions] if base_instructions not in existing_instructions else []
+            if system_text:
+                parts.append(system_text)
+            parts.append(existing_instructions)
+            request["instructions"] = "\n\n".join(parts) if parts else existing_instructions
+        elif system_text:
+            request["instructions"] = f"{base_instructions}\n\n{system_text}"
         else:
             request["instructions"] = base_instructions
         request["store"] = False


### PR DESCRIPTION
## Relevant issues

Fixes #21420

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

When using `chatgpt/`, the backend rejects `system` and `developer` roles in `input` with `"System messages are not allowed"`. Per the OpenAI Responses API spec, the `instructions` field serves the same purpose (*"A system (or developer) message inserted into the model's context"*), so we extract them automatically.

### Example

This request fails with `{"detail":"System messages are not allowed"}`:

```python
litellm.responses(
    model="chatgpt/gpt-5.2-codex",
    input=[
        {"role": "system", "content": "You are a helpful assistant"},
        {"role": "user", "content": "Hello"},
    ],
)
```

After this fix, LiteLLM transforms it into:

```python
# What actually gets sent to the ChatGPT backend:
{
    "model": "gpt-5.2-codex",
    "input": [
        {"role": "user", "content": "Hello"}
    ],
    "instructions": "<Codex default instructions>\n\nYou are a helpful assistant",
    ...
}
```

### Files changed

**`litellm/llms/chatgpt/responses/transformation.py`**
- In `transform_responses_api_request()`, extract messages with `role: "system"` or `"developer"` from `input` and merge their text into the `instructions` field
- Handles both string content and list-of-blocks content format

**`tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py`**
- 4 new tests: system extraction, developer extraction, merge with explicit instructions, no-op when no system messages

**`docs/my-website/docs/providers/chatgpt.md`**
- Added note documenting the limitation and automatic conversion