### PR TITLE
fix(bedrock): remove unconditional response_data.json write in stability image edit

### DIFF
--- a/litellm/llms/bedrock/image_edit/stability_transformation.py
+++ b/litellm/llms/bedrock/image_edit/stability_transformation.py
@@ -22,7 +22,6 @@ API Reference: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parame
 """
 
 import base64
-import json
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import httpx
@@ -285,8 +284,6 @@ class BedrockStabilityImageEditConfig(BaseImageEditConfig):
         """
         try:
             response_data = raw_response.json()
-            with open("response_data.json", "w") as f:
-                json.dump(response_data, f)
         except Exception as e:
             raise self.get_error_class(
                 error_message=f"Error parsing Bedrock Stability response: {e}",
@@ -396,4 +393,3 @@ class BedrockStabilityImageEditConfig(BaseImageEditConfig):
             headers["Content-Type"] = "application/json"
         
         return headers
-


### PR DESCRIPTION
## Summary
This PR removes an unconditional debug artifact in Bedrock Stability image-edit response handling that wrote raw provider responses to `response_data.json` on every request.

## Detailed Rationale
### What was wrong
In `BedrockStabilityImageEditConfig.transform_image_edit_response()` (`litellm/llms/bedrock/image_edit/stability_transformation.py`), the code executed:

- `response_data = raw_response.json()`
- `with open("response_data.json", "w") as f: json.dump(response_data, f)`

This happened unconditionally on every Bedrock Stability image-edit call.

### Why this is a bug
The file write had no functional role in response transformation and introduced production risk:

1. Sensitive data persistence
Raw response payloads include base64 image bytes and metadata (for example seeds). Persisting this to local disk can leak user-generated or sensitive content depending on deployment filesystem exposure and retention.

2. Runtime failures in read-only environments
In containers configured with read-only filesystems, `open(..., "w")` can throw `PermissionError`, failing otherwise valid image-edit requests.

3. Concurrency and data correctness hazards
All requests targeted a single fixed filename (`response_data.json`), so concurrent calls can overwrite each other and create nondeterministic artifacts.

4. Unnecessary I/O in a hot path
Every response incurred avoidable disk I/O, increasing latency and resource use without product value.

### Why this fix is correct
The PR removes only the debug write path and keeps all behavior needed for normal operation:

- `response_data` is still parsed from `raw_response.json()`.
- Existing error handling remains intact.
- Existing response mapping to `ImageResponse` remains unchanged.
- Cost/header logic remains unchanged.

This preserves endpoint behavior while removing side effects and reliability/security risk.

## Change Scope
- Removed unused `json` import.
- Removed unconditional file write of `response_data.json`.

## Backward Compatibility
No API contract changes. Response format, error semantics, and model cost header behavior are unchanged.

## Validation
- Confirmed diff is limited to the Bedrock Stability image-edit transformation file.
- Per request, no new tests were added in this PR.
