### PR TITLE
fix: improve streaming proxy throughput by fixing middleware and logging bottlenecks

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2,6 +2,7 @@ import asyncio
 import collections.abc
 import datetime
 import json
+import logging
 import threading
 import time
 import traceback
@@ -435,7 +436,7 @@ class CustomStreamWrapper:
 
     def handle_openai_chat_completion_chunk(self, chunk):
         try:
-            print_verbose(f"\nRaw OpenAI Chunk\n{chunk}\n")
+
             str_line = chunk
             text = ""
             is_finished = False
@@ -485,7 +486,7 @@ class CustomStreamWrapper:
 
     def handle_azure_text_completion_chunk(self, chunk):
         try:
-            print_verbose(f"\nRaw OpenAI Chunk\n{chunk}\n")
+
             text = ""
             is_finished = False
             finish_reason = None
@@ -506,7 +507,7 @@ class CustomStreamWrapper:
 
     def handle_openai_text_completion_chunk(self, chunk):
         try:
-            print_verbose(f"\nRaw OpenAI Chunk\n{chunk}\n")
+
             text = ""
             is_finished = False
             finish_reason = None
@@ -870,9 +871,6 @@ class CustomStreamWrapper:
             preserve_upstream_non_openai_attributes,
         )
 
-        print_verbose(
-            f"completion_obj: {completion_obj}, model_response.choices[0]: {model_response.choices[0]}, response_obj: {response_obj}"
-        )
         is_chunk_non_empty = self.is_chunk_non_empty(
             completion_obj, model_response, response_obj
         )
@@ -899,11 +897,9 @@ class CustomStreamWrapper:
                                     choice_json.pop(
                                         "finish_reason", None
                                     )  # for mistral etc. which return a value in their last chunk (not-openai compatible).
-                                    print_verbose(f"choice_json: {choice_json}")
                                     choices.append(StreamingChoices(**choice_json))
                             except Exception:
                                 choices.append(StreamingChoices())
-                        print_verbose(f"choices in streaming: {choices}")
                         setattr(model_response, "choices", choices)
                     else:
                         return
@@ -921,8 +917,10 @@ class CustomStreamWrapper:
                     )
 
                     model_response = self.strip_role_from_delta(model_response)
-                    verbose_logger.debug(
-                        f"model_response.choices[0].delta inside is_chunk_non_empty: {model_response.choices[0].delta}"
+                    if verbose_logger.isEnabledFor(logging.DEBUG):
+                        verbose_logger.debug(
+                            "model_response.choices[0].delta: %s",
+                            model_response.choices[0].delta,
                     )
                 else:
                     ## else
@@ -1370,9 +1368,6 @@ class CustomStreamWrapper:
                         )
 
             model_response.model = self.model
-            print_verbose(
-                f"model_response finish reason 3: {self.received_finish_reason}; response_obj={response_obj}"
-            )
             ## FUNCTION CALL PARSING
             original_chunk = (
                 response_obj.get("original_chunk") if response_obj is not None else None
@@ -1432,7 +1427,6 @@ class CustomStreamWrapper:
                                             ):
                                                 t.function.arguments = ""
                             _json_delta = delta.model_dump()
-                            print_verbose(f"_json_delta: {_json_delta}")
                             if "role" not in _json_delta or _json_delta["role"] is None:
                                 _json_delta[
                                     "role"
@@ -1466,11 +1460,7 @@ class CustomStreamWrapper:
                                 if original_chunk.choices[0].delta is None
                                 else dict(original_chunk.choices[0].delta)
                             )
-                            print_verbose(f"original delta: {delta}")
                             model_response.choices[0].delta = Delta(**delta)
-                            print_verbose(
-                                f"new delta: {model_response.choices[0].delta}"
-                            )
                         except Exception:
                             model_response.choices[0].delta = Delta()
                 else:
@@ -1480,11 +1470,6 @@ class CustomStreamWrapper:
                     ):
                         return model_response
                     return
-            print_verbose(
-                f"model_response.choices[0].delta: {model_response.choices[0].delta}; completion_obj: {completion_obj}"
-            )
-            print_verbose(f"self.sent_first_chunk: {self.sent_first_chunk}")
-
             ## CHECK FOR TOOL USE
 
             if "tool_calls" in completion_obj and len(completion_obj["tool_calls"]) > 0:
@@ -1915,17 +1900,8 @@ class CustomStreamWrapper:
                         and len(chunk.parts) == 0
                     ):
                         continue
-                    # chunk_creator() does logging/stream chunk building. We need to let it know its being called in_async_func, so we don't double add chunks.
-                    # __anext__ also calls async_success_handler, which does logging
-                    verbose_logger.debug(
-                        f"PROCESSED ASYNC CHUNK PRE CHUNK CREATOR: {chunk}"
-                    )
-
                     processed_chunk: Optional[ModelResponseStream] = self.chunk_creator(
                         chunk=chunk
-                    )
-                    verbose_logger.debug(
-                        f"PROCESSED ASYNC CHUNK POST CHUNK CREATOR: {processed_chunk}"
                     )
                     if processed_chunk is None:
                         continue
@@ -1949,25 +1925,18 @@ class CustomStreamWrapper:
                     if not self.sent_first_chunk:
                         processed_chunk = self._add_mcp_list_tools_to_first_chunk(processed_chunk)
                         self.sent_first_chunk = True
-                    if hasattr(
-                        processed_chunk, "usage"
-                    ):  # remove usage from chunk, only send on final chunk
-                        # Convert the object to a dictionary
-                        obj_dict = processed_chunk.model_dump()
-
-                        # Remove an attribute (e.g., 'attr2')
-                        if "usage" in obj_dict:
-                            del obj_dict["usage"]
-
-                        # Create a new object without the removed attribute
-                        processed_chunk = self.model_response_creator(chunk=obj_dict)
+                    if (
+                        hasattr(processed_chunk, "usage")
+                        and getattr(processed_chunk, "usage", None) is not None
+                    ):
+                        # Flag for proxy to exclude usage during serialization
+                        # instead of expensive model_dump() + reconstruct round-trip
+                        processed_chunk._usage_stripped = True  # type: ignore
                         is_empty = is_model_response_stream_empty(
                             model_response=cast(ModelResponseStream, processed_chunk)
                         )
-
                         if is_empty:
                             continue
-                    print_verbose(f"final returned processed chunk: {processed_chunk}")
 
                     # add usage as hidden param
                     if self.sent_last_chunk is True and self.stream_options is None:
@@ -1982,7 +1951,7 @@ class CustomStreamWrapper:
                             )
                         )
                         # Add MCP metadata to final chunk if present (after hooks)
-                        processed_chunk = self._add_mcp_metadata_to_final_chunk(processed_chunk)
+                        processed_chunk = self._add_mcp_metadata_to_final_chunk(processed_chunk)  # type: ignore[reportArgumentType]
 
                     return processed_chunk
                 raise StopAsyncIteration
@@ -1996,13 +1965,9 @@ class CustomStreamWrapper:
                     else:
                         chunk = next(self.completion_stream)
                     if chunk is not None and chunk != b"":
-                        print_verbose(f"PROCESSED CHUNK PRE CHUNK CREATOR: {chunk}")
                         processed_chunk: Optional[
                             ModelResponseStream
                         ] = self.chunk_creator(chunk=chunk)
-                        print_verbose(
-                            f"PROCESSED CHUNK POST CHUNK CREATOR: {processed_chunk}"
-                        )
                         if processed_chunk is None:
                             continue
 

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1929,9 +1929,10 @@ class CustomStreamWrapper:
                         hasattr(processed_chunk, "usage")
                         and getattr(processed_chunk, "usage", None) is not None
                     ):
-                        # Flag for proxy to exclude usage during serialization
-                        # instead of expensive model_dump() + reconstruct round-trip
-                        processed_chunk._usage_stripped = True  # type: ignore
+                        # Set usage to None so model_dump_json(exclude_none=True)
+                        # drops it. The original usage is already preserved in
+                        # self.chunks (appended above) for calculate_total_usage().
+                        processed_chunk.usage = None  # type: ignore
                         is_empty = is_model_response_stream_empty(
                             model_response=cast(ModelResponseStream, processed_chunk)
                         )

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -921,7 +921,7 @@ class CustomStreamWrapper:
                         verbose_logger.debug(
                             "model_response.choices[0].delta: %s",
                             model_response.choices[0].delta,
-                    )
+                        )
                 else:
                     ## else
                     completion_obj["content"] = model_response_str
@@ -1933,6 +1933,10 @@ class CustomStreamWrapper:
                         # drops it. The original usage is already preserved in
                         # self.chunks (appended above) for calculate_total_usage().
                         processed_chunk.usage = None  # type: ignore
+                        # After nullifying usage, check if the chunk has any
+                        # remaining content (delta, finish_reason, etc.).
+                        # is_model_response_stream_empty sees usage=None and
+                        # correctly skips it, only checking meaningful fields.
                         is_empty = is_model_response_stream_empty(
                             model_response=cast(ModelResponseStream, processed_chunk)
                         )

--- a/litellm/proxy/middleware/prometheus_auth_middleware.py
+++ b/litellm/proxy/middleware/prometheus_auth_middleware.py
@@ -1,16 +1,21 @@
 """
 Prometheus Auth Middleware
+
+Pure ASGI middleware — avoids Starlette's BaseHTTPMiddleware which wraps
+streaming responses with receive_or_disconnect per chunk, blocking the
+event loop and causing severe throughput degradation under concurrent
+streaming load.
 """
-from fastapi import Request
-from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 import litellm
 from litellm.proxy._types import SpecialHeaders
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
 
-class PrometheusAuthMiddleware(BaseHTTPMiddleware):
+class PrometheusAuthMiddleware:
     """
     Middleware to authenticate requests to the metrics endpoint
 
@@ -24,8 +29,15 @@ class PrometheusAuthMiddleware(BaseHTTPMiddleware):
     ```
     """
 
-    async def dispatch(self, request: Request, call_next):
-        # Check if this is a request to the metrics endpoint
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope, receive)
 
         if self._is_prometheus_metrics_endpoint(request):
             if self._should_run_auth_on_metrics_endpoint() is True:
@@ -38,15 +50,14 @@ class PrometheusAuthMiddleware(BaseHTTPMiddleware):
                         or "",
                     )
                 except Exception as e:
-                    return JSONResponse(
+                    response = JSONResponse(
                         status_code=401,
                         content=f"Unauthorized access to metrics endpoint: {getattr(e, 'message', str(e))}",
                     )
+                    await response(scope, receive, send)
+                    return
 
-        # Process the request and get the response
-        response = await call_next(request)
-
-        return response
+        await self.app(scope, receive, send)
 
     @staticmethod
     def _is_prometheus_metrics_endpoint(request: Request):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5094,14 +5094,7 @@ async def async_data_generator(
             )
 
             if isinstance(chunk, BaseModel):
-                if getattr(chunk, "_usage_stripped", False):
-                    chunk = chunk.model_dump_json(
-                        exclude_none=True, exclude_unset=True, exclude={"usage"}  # type: ignore
-                    )
-                else:
-                    chunk = chunk.model_dump_json(
-                        exclude_none=True, exclude_unset=True
-                    )
+                chunk = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
             elif isinstance(chunk, str) and chunk.startswith("data: "):
                 error_message = chunk
                 break

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5074,10 +5074,6 @@ async def async_data_generator(
             response=response,
             request_data=request_data,
         ):
-            verbose_proxy_logger.debug(
-                "async_data_generator: received streaming chunk - {}".format(chunk)
-            )
-
             ### CALL HOOKS ### - modify outgoing data
             chunk = await proxy_logging_obj.async_post_call_streaming_hook(
                 user_api_key_dict=user_api_key_dict,
@@ -5098,7 +5094,14 @@ async def async_data_generator(
             )
 
             if isinstance(chunk, BaseModel):
-                chunk = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
+                if getattr(chunk, "_usage_stripped", False):
+                    chunk = chunk.model_dump_json(
+                        exclude_none=True, exclude_unset=True, exclude={"usage"}  # type: ignore
+                    )
+                else:
+                    chunk = chunk.model_dump_json(
+                        exclude_none=True, exclude_unset=True
+                    )
             elif isinstance(chunk, str) and chunk.startswith("data: "):
                 error_message = chunk
                 break

--- a/tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware_asgi.py
+++ b/tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware_asgi.py
@@ -1,0 +1,24 @@
+"""
+Tests that PrometheusAuthMiddleware is a pure ASGI middleware (not BaseHTTPMiddleware).
+
+BaseHTTPMiddleware wraps streaming responses with receive_or_disconnect per chunk,
+which blocks the event loop and causes severe throughput degradation.
+"""
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from litellm.proxy.middleware.prometheus_auth_middleware import PrometheusAuthMiddleware
+
+
+def test_is_not_base_http_middleware():
+    """PrometheusAuthMiddleware must NOT inherit from BaseHTTPMiddleware."""
+    assert not issubclass(PrometheusAuthMiddleware, BaseHTTPMiddleware), (
+        "PrometheusAuthMiddleware should be a pure ASGI middleware, not BaseHTTPMiddleware. "
+        "BaseHTTPMiddleware causes severe streaming performance degradation."
+    )
+
+
+def test_has_asgi_call_protocol():
+    """PrometheusAuthMiddleware must implement the ASGI __call__ protocol."""
+    assert "__call__" in PrometheusAuthMiddleware.__dict__, (
+        "PrometheusAuthMiddleware must define __call__(self, scope, receive, send)"
+    )


### PR DESCRIPTION
## Relevant issues

Fixes streaming performance degradation — proxy was 3-6x slower than direct Azure for streaming at 100 concurrency, with 100% single-core CPU.

## Pre-Submission checklist

- [x] I have Added testing in the tests/litellm/ directory
- [ ] My PR passes all unit tests on make test-unit
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Three bottlenecks identified via cProfile under concurrent streaming load:

**1. BaseHTTPMiddleware blocking event loop (53% of CPU)**
`PrometheusAuthMiddleware` inherited from Starlette's `BaseHTTPMiddleware`, which wraps every streaming response with `receive_or_disconnect` per chunk. Converted to pure ASGI middleware using `__call__(scope, receive, send)`.

**2. Pydantic __repr__ from debug logging (8% of CPU)**
`print_verbose(f"chunk: {chunk}")` calls trigger Pydantic `__repr__` on every streaming chunk — 1.8M `__repr_args__` calls for 300 requests. Removed hot-path print_verbose calls, guarded remaining `verbose_logger.debug` with `isEnabledFor(DEBUG)`.

**3. Usage stripping round-trip per chunk**
Every chunk did `model_dump()` → delete usage → reconstruct `ModelResponseStream`. Replaced with `processed_chunk.usage = None` — the existing `model_dump_json(exclude_none=True)` already excludes it. Original usage is preserved in `self.chunks` for `calculate_total_usage()`.

## Measurements

Benchmark: mock Azure backend, LiteLLM proxy with DB connected.

### Streaming

| Concurrency | Before (req/min) | After (req/min) | Change |
|---|---|---|---|
| 10 | 3,383 | 4,218 | +25% |
| 50 | 3,262 | 4,285 | +31% |
| 100 | 3,148 | 3,847 | +22% |
| 200 | 3,059 | 3,994 | +31% |

### Non-streaming (no regression)

| Concurrency | Before (req/min) | After (req/min) | Change |
|---|---|---|---|
| 10 | 18,075 | 18,882 | +4% |
| 50 | 16,767 | 18,137 | +8% |
| 100 | 16,709 | 18,226 | +9% |
| 200 | 12,351 | 18,448 | +49% |