### PR TITLE
fix(types): add = None defaults to Optional[str] fields in managed table models

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3957,8 +3957,8 @@ class LiteLLM_ManagedFileTable(LiteLLMPydanticObjectBase):
     file_object: Optional[OpenAIFileObject] = None
     model_mappings: Dict[str, str]
     flat_model_file_ids: List[str]
-    created_by: Optional[str]
-    updated_by: Optional[str]
+    created_by: Optional[str] = None
+    updated_by: Optional[str] = None
     storage_backend: Optional[str] = None
     storage_url: Optional[str] = None
 
@@ -3976,8 +3976,8 @@ class LiteLLM_ManagedVectorStoreTable(LiteLLMPydanticObjectBase):
     resource_object: Optional[Any] = None  # VectorStoreCreateResponse
     model_mappings: Dict[str, str]
     flat_model_resource_ids: List[str]
-    created_by: Optional[str]
-    updated_by: Optional[str]
+    created_by: Optional[str] = None
+    updated_by: Optional[str] = None
     storage_backend: Optional[str] = None
     storage_url: Optional[str] = None
 


### PR DESCRIPTION
## Summary

- `LiteLLM_ManagedFileTable.created_by` and `updated_by` were declared as `Optional[str]` without a default value
- `LiteLLM_ManagedVectorStoreTable.created_by` and `updated_by` had the same issue
- In Pydantic v2, `Optional[str]` without a default is a **required** field — callers must explicitly pass `None`
- This caused `ValidationError` when constructing these models without providing `created_by`/`updated_by`
- Fixed by adding `= None` defaults to make the fields truly optional

## Root cause

Tests in `tests/test_litellm/enterprise/proxy/test_file_deletion_blocking.py` were failing with:
```
ValidationError: 2 validation errors for LiteLLM_ManagedFileTable
  created_by: Field required
  updated_by: Field required
```

The Pydantic v2 semantics require an explicit `= None` to make an `Optional[str]` field optional (not required).

## Test plan

- [ ] Run `poetry run pytest tests/test_litellm/enterprise/proxy/test_file_deletion_blocking.py -v`
- [ ] Verify no `ValidationError` for `created_by`/`updated_by` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)