### PR TITLE
fix: resolve credentials for UI-created models in batch file uploads

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6755,7 +6755,13 @@ class Router:
             credential_values = CredentialAccessor.get_credential_values(
                 deployment.litellm_params.litellm_credential_name
             )
+            if not credential_values:
+                verbose_router_logger.warning(
+                    f"Credential '{deployment.litellm_params.litellm_credential_name}' not found in credential_list"
+                )
             credentials.update(credential_values)
+            # Remove the credential name since we've resolved it
+            credentials.pop("litellm_credential_name", None)
 
         # Add custom_llm_provider
         if deployment.litellm_params.custom_llm_provider:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6750,6 +6750,13 @@ class Router:
             **deployment.litellm_params.model_dump(exclude_none=True)
         ).model_dump(exclude_none=True)
 
+        # Resolve litellm_credential_name to actual credentials
+        if deployment.litellm_params.litellm_credential_name is not None:
+            credential_values = CredentialAccessor.get_credential_values(
+                deployment.litellm_params.litellm_credential_name
+            )
+            credentials.update(credential_values)
+
         # Add custom_llm_provider
         if deployment.litellm_params.custom_llm_provider:
             credentials[


### PR DESCRIPTION

When models are created via UI with pre-existing credentials, they use litellm_credential_name to reference credentials stored separately.

The batch file upload endpoint uses get_deployment_credentials_with_provider() to retrieve model credentials, but this method was returning the credential reference name instead of resolving it to actual API keys and endpoints.

This fix adds credential resolution using CredentialAccessor.get_credential_values() to ensure UI-created models work the same as YAML-configured models for batch file uploads and other passthrough endpoints.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
