### PR TITLE
fix(ci): install enterprise package into main project venv, not enterprise's own venv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,7 @@ commands:
       - run:
           name: "Install local version of litellm-enterprise"
           command: |
-            cd enterprise
-            python -m pip install --force-reinstall --no-deps -e .
-            cd ..
+            pip install --force-reinstall --no-deps -e enterprise/
   setup_litellm_test_deps:
     steps:
       - checkout

--- a/.github/workflows/test-litellm-matrix.yml
+++ b/.github/workflows/test-litellm-matrix.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Setup litellm-enterprise
         run: |
-          cd enterprise && poetry run pip install --force-reinstall --no-deps -e . && cd ..
+          poetry run pip install --force-reinstall --no-deps -e enterprise/
 
       - name: Generate Prisma client
         run: |

--- a/.github/workflows/test-litellm.yml
+++ b/.github/workflows/test-litellm.yml
@@ -42,9 +42,7 @@ jobs:
         poetry run pip install "openapi-core"
     - name: Setup litellm-enterprise as local package
       run: |
-        cd enterprise
-        poetry run pip install --force-reinstall --no-deps -e .
-        cd ..
+        poetry run pip install --force-reinstall --no-deps -e enterprise/
     - name: Run tests
       run: |
         poetry run pytest tests/test_litellm --tb=short -vv --maxfail=10 -n 4 --durations=50

--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -40,9 +40,7 @@ jobs:
 
     - name: Setup litellm-enterprise as local package
       run: |
-        cd enterprise
-        python -m pip install --force-reinstall --no-deps -e .
-        cd ..
+        poetry run pip install --force-reinstall --no-deps -e enterprise/
 
     - name: Run MCP tests
       run: |


### PR DESCRIPTION
## Root Cause

`cd enterprise && poetry run pip install -e .` causes poetry to create a **separate virtualenv** in `enterprise/.venv` because `enterprise/` has its own `pyproject.toml`. However, tests run with the **main project's** `.venv/bin/python`. The enterprise package installed into `enterprise/.venv` is never visible to the test runner.

This is confirmed by the CI log:
```
Creating virtualenv litellm-enterprise in /home/runner/work/litellm/litellm/enterprise/.venv
...
Successfully installed litellm-enterprise-0.1.32
```
Then tests run as:
```
[gw1] linux -- Python 3.12.12 /home/runner/work/litellm/litellm/.venv/bin/python
AttributeError: '_PROXY_LiteLLMManagedFiles' object has no attribute '_check_file_deletion_allowed'
```

The test runner's `.venv` still has the old PyPI-published `litellm-enterprise` which lacks the new methods.

## Fix

Run `poetry run pip install -e enterprise/` **from the repo root** so poetry uses the main project's venv (`.venv`). Same fix applied to all 4 CI configs.

## Why `--force-reinstall` didn't help

PR #21481 added `--force-reinstall` but the install was still going to the wrong venv (`enterprise/.venv`), so it had no effect on what the tests actually saw.

## Test plan

- [ ] Verify enterprise tests pass in `test (other)` matrix job after this fix
- [ ] Specifically: `tests/test_litellm/enterprise/proxy/test_file_deletion_blocking.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)