### PR TITLE
[Bug] Allow internal_user_viewer to access RAG endpoints; restrict ingest to existing vector stores

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -307,6 +307,9 @@ class RouteChecks:
         ):
             return True
 
+        if route in LiteLLMRoutes.litellm_native_routes.value:
+            return True
+
         # fuzzy match routes like "/v1/threads/thread_49EIN5QF32s4mH20M7GFKdlZ"
         # Check for routes with placeholders or wildcard patterns
         for openai_route in LiteLLMRoutes.openai_routes.value:

--- a/tests/proxy_unit_tests/test_proxy_routes.py
+++ b/tests/proxy_unit_tests/test_proxy_routes.py
@@ -91,6 +91,11 @@ def test_routes_on_litellm_proxy():
         # Bedrock Pass Through Routes
         ("/bedrock/model/cohere.command-r-v1:0/converse", True),
         ("/vertex-ai/model/text-embedding-004/embeddings", True),
+        # LiteLLM native RAG routes
+        ("/rag/ingest", True),
+        ("/v1/rag/ingest", True),
+        ("/rag/query", True),
+        ("/v1/rag/query", True),
     ],
 )
 def test_is_llm_api_route(route: str, expected: bool):

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -181,6 +181,16 @@ def test_route_checks_is_llm_api_route():
     for route in mcp_routes:
         assert RouteChecks.is_llm_api_route(route=route), f"Route {route} should be identified as LLM API route"
 
+    # Test LiteLLM native RAG routes
+    rag_routes = [
+        "/rag/ingest",
+        "/v1/rag/ingest",
+        "/rag/query",
+        "/v1/rag/query",
+    ]
+    for route in rag_routes:
+        assert RouteChecks.is_llm_api_route(route=route), f"Route {route} should be identified as LLM API route"
+
     # Test routes with placeholders
     placeholder_routes = [
         "/v1/threads/thread_49EIN5QF32s4mH20M7GFKdlZ",

--- a/tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py
+++ b/tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py
@@ -1,0 +1,130 @@
+"""
+Tests for RAG proxy endpoints.
+
+Covers:
+- internal_user_viewer restriction: can only ingest to existing vector stores (must provide vector_store_id)
+"""
+
+import io
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(
+    0, os.path.abspath("../../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.proxy_server import app
+
+
+@pytest.fixture
+def client_internal_user_viewer():
+    """Test client with internal_user_viewer auth."""
+    mock_auth = UserAPIKeyAuth(
+        user_id="test_viewer_user",
+        user_role=LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value,
+    )
+    original_overrides = app.dependency_overrides.copy()
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_auth
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides = original_overrides
+
+
+@pytest.fixture
+def client_internal_user():
+    """Test client with internal_user auth (can create new vector stores)."""
+    mock_auth = UserAPIKeyAuth(
+        user_id="test_internal_user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    original_overrides = app.dependency_overrides.copy()
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_auth
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides = original_overrides
+
+
+def test_internal_user_viewer_rag_ingest_without_vector_store_id_rejected(
+    client_internal_user_viewer,
+):
+    """
+    internal_user_viewer cannot create new vector stores - must provide vector_store_id.
+    """
+    # Form upload without vector_store_id (would create new store)
+    response = client_internal_user_viewer.post(
+        "/v1/rag/ingest",
+        files={"file": ("sample.txt", io.BytesIO(b"test content"), "text/plain")},
+        data={
+            "request": '{"ingest_options":{"vector_store":{"custom_llm_provider":"openai"}}}'
+        },
+    )
+
+    assert response.status_code == 403
+    detail = response.json()
+    assert "detail" in detail
+    error_msg = (
+        detail["detail"]["error"]
+        if isinstance(detail["detail"], dict)
+        else str(detail["detail"])
+    )
+    assert "internal_user_viewer" in error_msg
+    assert "vector_store_id" in error_msg
+
+
+def test_internal_user_viewer_rag_ingest_with_vector_store_id_passes_check(
+    client_internal_user_viewer,
+):
+    """
+    internal_user_viewer with vector_store_id passes the role check.
+    (Actual ingest may fail due to missing API keys, but we get past 403.)
+    """
+    with patch(
+        "litellm.proxy.rag_endpoints.endpoints.litellm.aingest",
+        new_callable=AsyncMock,
+        return_value={"vector_store_id": "vs_existing", "file_id": "file_123"},
+    ):
+        response = client_internal_user_viewer.post(
+            "/v1/rag/ingest",
+            files={"file": ("sample.txt", io.BytesIO(b"test content"), "text/plain")},
+            data={
+                "request": '{"ingest_options":{"vector_store":{"custom_llm_provider":"openai","vector_store_id":"vs_699651f6b6688191b0a210c00a686d20"}}}'
+            },
+        )
+
+    # Should not be 403 (role check passed)
+    assert response.status_code != 403, (
+        f"internal_user_viewer with vector_store_id should pass role check. "
+        f"Response: {response.json()}"
+    )
+
+
+def test_internal_user_rag_ingest_without_vector_store_id_allowed(client_internal_user):
+    """
+    internal_user can create new vector stores (no vector_store_id required).
+    """
+    with patch(
+        "litellm.proxy.rag_endpoints.endpoints.litellm.aingest",
+        new_callable=AsyncMock,
+        return_value={"vector_store_id": "vs_new", "file_id": "file_123"},
+    ):
+        response = client_internal_user.post(
+            "/v1/rag/ingest",
+            files={"file": ("sample.txt", io.BytesIO(b"test content"), "text/plain")},
+            data={
+                "request": '{"ingest_options":{"vector_store":{"custom_llm_provider":"openai"}}}'
+            },
+        )
+
+    # Should not be 403
+    assert response.status_code != 403, (
+        f"internal_user should be allowed to create new vector stores. "
+        f"Response: {response.json()}"
+    )


### PR DESCRIPTION
## Relevant issues
internal_user_viewer JWT users could not call /rag/query or /rag/ingest, even though they can use /chat/completions. When access was fixed, viewers could create new vector stores, which should be limited to higher-privilege roles.
<!-- e.g. "Fixes #000" -->

RAG routes (/rag/ingest, /rag/query) were not included in is_llm_api_route(), so they were treated as non-LLM routes and blocked for internal_user_viewer. There was no rule preventing viewers from creating new vector stores via /rag/ingest.
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring
✅ Test

## Changes
Add litellm_native_routes to is_llm_api_route() so RAG routes are treated like other LLM API routes and internal_user_viewer can access them.
In the RAG ingest endpoint, require internal_user_viewer to provide vector_store_id in ingest_options.vector_store; reject requests that would create a new store with 403.
Add tests for RAG route recognition and for the ingest restriction.