### PR TITLE
fix: CI failures - missing env key doc + streaming test

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -494,6 +494,7 @@ router_settings:
 | DATABASE_USER | Username for database connection
 | DATABASE_USERNAME | Alias for database user
 | DATABRICKS_API_BASE | Base URL for Databricks API
+| DATABRICKS_API_KEY | API key (Personal Access Token) for Databricks API authentication
 | DATABRICKS_CLIENT_ID | Client ID for Databricks OAuth M2M authentication (Service Principal application ID)
 | DATABRICKS_CLIENT_SECRET | Client secret for Databricks OAuth M2M authentication
 | DATABRICKS_USER_AGENT | Custom user agent string for Databricks API requests. Used for partner telemetry attribution

--- a/tests/local_testing/test_streaming.py
+++ b/tests/local_testing/test_streaming.py
@@ -76,7 +76,7 @@ def validate_first_format(chunk):
     assert isinstance(chunk["created"], int), "'created' should be an integer."
     assert isinstance(chunk["model"], str), "'model' should be a string."
     assert isinstance(chunk["choices"], list), "'choices' should be a list."
-    assert not hasattr(chunk, "usage"), "Chunk cannot contain usage"
+    assert getattr(chunk, "usage", None) is None, "Chunk cannot contain usage"
 
     for choice in chunk["choices"]:
         assert isinstance(choice["index"], int), "'index' should be an integer."
@@ -108,7 +108,7 @@ def validate_second_format(chunk):
     assert isinstance(chunk["created"], int), "'created' should be an integer."
     assert isinstance(chunk["model"], str), "'model' should be a string."
     assert isinstance(chunk["choices"], list), "'choices' should be a list."
-    assert not hasattr(chunk, "usage"), "Chunk cannot contain usage"
+    assert getattr(chunk, "usage", None) is None, "Chunk cannot contain usage"
 
     for choice in chunk["choices"]:
         assert isinstance(choice["index"], int), "'index' should be an integer."
@@ -146,7 +146,7 @@ def validate_last_format(chunk):
     assert isinstance(chunk["created"], int), "'created' should be an integer."
     assert isinstance(chunk["model"], str), "'model' should be a string."
     assert isinstance(chunk["choices"], list), "'choices' should be a list."
-    assert not hasattr(chunk, "usage"), "Chunk cannot contain usage"
+    assert getattr(chunk, "usage", None) is None, "Chunk cannot contain usage"
 
     for choice in chunk["choices"]:
         assert isinstance(choice["index"], int), "'index' should be an integer."

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -233,15 +233,20 @@ class TestProxyInitializationHelpers:
 
         runner = CliRunner()
 
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
         with patch.dict(
             "sys.modules",
             {
-                "proxy_server": MagicMock(
-                    app=MagicMock(),
-                    ProxyConfig=MagicMock(),
-                    KeyManagementSettings=MagicMock(),
-                    save_worker_config=MagicMock(),
-                )
+                "proxy_server": mock_proxy_module,
+                # Prevent real import of proxy_server inside Click's
+                # isolation context (heavy side effects cause stream
+                # lifecycle issues with Click 8.2+)
+                "litellm.proxy.proxy_server": mock_proxy_module,
             },
         ), patch(
             "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"


### PR DESCRIPTION
## Changes

- Add `DATABRICKS_API_KEY` to env settings reference (fixes `test_env_keys.py`)
- Fix `assert not hasattr(chunk, "usage")` in streaming test helpers - `ModelResponseStream` is a Pydantic model so `usage` always exists. Changed to check value is `None`.
- Mock `litellm.proxy.proxy_server` in `test_skip_server_startup` to prevent real import inside Click's isolation context (causes stream lifecycle issues with Click 8.2+)

## Type

- [x] Bug fix