### PR TITLE
fix(pricing): add non-zero gpt-5.3-codex entries to model map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -17641,6 +17641,20 @@
         "max_tokens": 8191,
         "mode": "embedding"
     },
+    "chatgpt/gpt-5.3-codex": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
     "chatgpt/gpt-5.2-codex": {
         "litellm_provider": "chatgpt",
         "max_input_tokens": 128000,
@@ -20252,6 +20266,39 @@
         "supports_vision": true
     },
     "gpt-5.2-codex": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
+        "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "gpt-5.3-codex": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
         "input_cost_per_token": 1.75e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -17641,6 +17641,20 @@
         "max_tokens": 8191,
         "mode": "embedding"
     },
+    "chatgpt/gpt-5.3-codex": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
     "chatgpt/gpt-5.2-codex": {
         "litellm_provider": "chatgpt",
         "max_input_tokens": 128000,
@@ -20252,6 +20266,39 @@
         "supports_vision": true
     },
     "gpt-5.2-codex": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
+        "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "gpt-5.3-codex": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
         "input_cost_per_token": 1.75e-06,

--- a/tests/test_litellm/test_gpt_5_3_codex_config.py
+++ b/tests/test_litellm/test_gpt_5_3_codex_config.py
@@ -1,0 +1,57 @@
+"""
+Validate GPT-5.3 Codex model configuration entries.
+"""
+
+import json
+import os
+
+
+def _load_model_data() -> dict:
+    json_path = os.path.join(
+        os.path.dirname(__file__), "../../model_prices_and_context_window.json"
+    )
+    with open(json_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_chatgpt_gpt_5_3_codex_entry_exists():
+    model_data = _load_model_data()
+    assert "chatgpt/gpt-5.3-codex" in model_data
+
+    info = model_data["chatgpt/gpt-5.3-codex"]
+    assert info["litellm_provider"] == "chatgpt"
+    assert info["mode"] == "responses"
+    assert info["max_input_tokens"] == 128000
+    assert info["max_output_tokens"] == 128000
+    assert info["max_tokens"] == 128000
+
+
+def test_openai_gpt_5_3_codex_has_pricing():
+    model_data = _load_model_data()
+    assert "gpt-5.3-codex" in model_data
+
+    info = model_data["gpt-5.3-codex"]
+    assert info["litellm_provider"] == "openai"
+    assert info["mode"] == "responses"
+    assert info["input_cost_per_token"] == 1.75e-06
+    assert info["output_cost_per_token"] == 1.4e-05
+    assert info["cache_read_input_token_cost"] == 1.75e-07
+
+
+def test_openai_gpt_5_3_codex_pricing_matches_gpt_5_2_codex():
+    model_data = _load_model_data()
+
+    baseline = model_data["gpt-5.2-codex"]
+    target = model_data["gpt-5.3-codex"]
+
+    keys_to_match = [
+        "input_cost_per_token",
+        "input_cost_per_token_priority",
+        "output_cost_per_token",
+        "output_cost_per_token_priority",
+        "cache_read_input_token_cost",
+        "cache_read_input_token_cost_priority",
+    ]
+
+    for key in keys_to_match:
+        assert target[key] == baseline[key], f"Mismatch for {key}"


### PR DESCRIPTION
## Relevant issues

- Related: https://github.com/BerriAI/litellm/issues/21148
- Related: https://github.com/BerriAI/litellm/pull/20552

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

This fixes the `$0.00` pricing resolution path for `gpt-5.3-codex` by adding canonical non-zero entries in the model map.

- Added `chatgpt/gpt-5.3-codex` metadata entry (responses endpoint + capabilities)
- Added `gpt-5.3-codex` OpenAI-priced entry with:
  - `input_cost_per_token`: `1.75e-06`
  - `output_cost_per_token`: `1.4e-05`
  - `cache_read_input_token_cost`: `1.75e-07`
  - matching priority pricing fields and capabilities
- Synced `litellm/model_prices_and_context_window_backup.json` with root map
- Added regression tests in `tests/test_litellm/test_gpt_5_3_codex_config.py`

## Local validation

- `python3 ci_cd/check_files_match.py`
- `/Users/jack/tmp/litellm-work/.venv/bin/pytest tests/test_litellm/test_gpt_5_3_codex_config.py -q`
- `jq empty model_prices_and_context_window.json`
- `jq empty litellm/model_prices_and_context_window_backup.json`
