### PR TITLE
fix(mypy): resolve type errors from MCP user permissions commit

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/mcp_end_user_permission/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/mcp_end_user_permission/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, cast
 
 from litellm.types.guardrails import SupportedGuardrailIntegrations
 
@@ -14,7 +14,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
     # Default to always-on. Only disable if the user explicitly sets default_on: false.
     # We check the raw guardrail dict because LitellmParams normalizes None → False,
     # making it impossible to distinguish "not set" from "explicitly false" via litellm_params.
-    _raw_default_on = guardrail.get("litellm_params", {}).get("default_on")
+    _raw_default_on = cast(Dict[str, Any], guardrail).get("litellm_params", {}).get("default_on")
     _default_on = False if _raw_default_on is False else True
 
     _callback = MCPEndUserPermissionGuardrail(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1349,7 +1349,7 @@ class LiteLLMCompletionResponsesConfig:
                 result.append(tool)  # type: ignore
                 continue
             if tool.get("type") == "function":
-                fn = tool.get("function") or {}
+                fn: Dict[str, Any] = cast(Dict[str, Any], tool.get("function") or {})
                 parameters = dict(fn.get("parameters", {}) or {})
                 if not parameters or "type" not in parameters:
                     parameters["type"] = "object"


### PR DESCRIPTION
## Summary

- **Not related to any existing PR** — fixes MyPy errors introduced by commit `e00c181f0c` (Mcp user permissions, #21462) that surfaced in CI for other PRs.
- Fixes 5 MyPy errors across 2 files with minimal, targeted casts.

## Changes

### `litellm/proxy/guardrails/guardrail_hooks/mcp_end_user_permission/__init__.py`
Cast `guardrail` to `Dict[str, Any]` before calling `.get("litellm_params", {}).get("default_on")`.

**Root cause**: `Guardrail` is a TypedDict, and its `.get()` overloads use a `{}` default whose key type resolves to `Never`. When chained as `.get("litellm_params", {}).get("default_on")`, the `Dict[Never, Never]` type in the union causes MyPy to reject `"default_on"` as a valid key.

### `litellm/responses/litellm_completion_transformation/transformation.py`
Cast `fn` to `Dict[str, Any]` in `transform_chat_completion_tool_params_to_responses_api_tools`.

**Root cause**: `tool.get("function")` on `Union[ChatCompletionFunctionToolParam, OpenAIMcpServerTool]` returns `object` because `"function"` is not a declared key in `OpenAIMcpServerTool`. This makes all subsequent `fn.get(...)` calls fail with `"object" has no attribute 'get'`.

## Test plan

- [x] `poetry run python -m mypy litellm/responses/litellm_completion_transformation/transformation.py litellm/proxy/guardrails/guardrail_hooks/mcp_end_user_permission/__init__.py` — no errors
- [ ] Full CI lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)