### PR TITLE
fix(tests): update MCP tests broken by user permissions commit (#21462)

### DIFF
--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_jwt_mcp_enforcement.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_jwt_mcp_enforcement.py
@@ -184,6 +184,7 @@ async def test_e2e_jwt_team_mcp_permissions_enforced(monkeypatch):
     proxy_server_module.prisma_client = MagicMock()  # Mock prisma client
     proxy_server_module.user_api_key_cache = DualCache()
     proxy_server_module.proxy_logging_obj = MagicMock()
+    proxy_server_module.general_settings = {}
     monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", proxy_server_module)
 
     # Team "ABC" has MCP servers assigned via object_permission
@@ -389,6 +390,7 @@ async def test_e2e_jwt_team_mcp_key_intersection(monkeypatch):
     proxy_server_module.prisma_client = MagicMock()
     proxy_server_module.user_api_key_cache = DualCache()
     proxy_server_module.proxy_logging_obj = MagicMock()
+    proxy_server_module.general_settings = {}
     monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", proxy_server_module)
 
     # Team MCP servers

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -332,7 +332,7 @@ async def test_mcp_get_prompt_success():
         mock_manager.get_prompt_from_server = AsyncMock(return_value=prompt_result)
 
         result = await mcp_get_prompt(
-            name="hello",
+            name="server_a-hello",  # prefixed name since server prefixes are always added
             arguments={"foo": "bar"},
             user_api_key_auth=user_api_key_auth,
         )
@@ -1006,7 +1006,7 @@ async def test_oauth2_headers_passed_to_mcp_client():
 
 @pytest.mark.asyncio
 async def test_list_tools_single_server_unprefixed_names():
-    """When only one MCP server is allowed, list tools should return unprefixed names."""
+    """When only one MCP server is allowed, list tools should return prefixed names (server prefix is always added)."""
     try:
         from litellm.proxy._experimental.mcp_server.server import (
             _get_tools_from_mcp_servers,
@@ -1063,9 +1063,9 @@ async def test_list_tools_single_server_unprefixed_names():
             mcp_server_auth_headers=None,
         )
 
-    # Should be unprefixed since only one server is allowed
+    # Server prefix is always added regardless of number of allowed servers
     assert len(tools) == 1
-    assert tools[0].name == "toolA"
+    assert tools[0].name == "zapier-toolA"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Not related to PR #21439** — fixes 4 MCP test failures introduced by commit `e00c181f0c` (Mcp user permissions #21462).

The 3 spend failures in the same CI run (`test_spend_logs_payload_*`) are already covered by PR #21505.

## Root Causes & Fixes

### 1 & 2. `test_mcp_server.py` — Behavior change: server prefixes now always added

Commit `e00c181f0c` removed the conditional `add_prefix = not (len(allowed_mcp_servers) == 1)` and replaced it with `add_prefix=True` everywhere, so even single-server setups now prefix tool/prompt names.

- **`test_list_tools_single_server_unprefixed_names`**: Updated assertion from `"toolA"` → `"zapier-toolA"` and updated docstring to reflect the new always-prefix behavior.
- **`test_mcp_get_prompt_success`**: `mcp_get_prompt` now looks up the server by extracting its name from a prefixed prompt name (e.g. `"server_a-hello"` → `server_name="server_a"`). Passing unprefixed `"hello"` returned `server_name=""`, which matched no server → 403. Updated to pass `"server_a-hello"`.

### 3 & 4. `test_jwt_mcp_enforcement.py` — Missing `general_settings` in mock

Commit `e00c181f0c` replaced `from typing import List` with `from litellm.proxy.proxy_server import general_settings` in `MCPRequestHandler.get_allowed_mcp_servers()`. Both `test_e2e_jwt_team_mcp_permissions_enforced` and `test_e2e_jwt_team_mcp_key_intersection` mock `litellm.proxy.proxy_server` with a bare `types.ModuleType("proxy_server")` that lacked `general_settings`, causing `ImportError`. Added `proxy_server_module.general_settings = {}` to both mock setups.

## Test plan

- [x] All 4 failing tests now pass locally
- [x] `pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py::test_list_tools_single_server_unprefixed_names test_mcp_server.py::test_mcp_get_prompt_success` — 2 passed
- [x] `pytest test_jwt_mcp_enforcement.py::test_e2e_jwt_team_mcp_key_intersection test_jwt_mcp_enforcement.py::test_e2e_jwt_team_mcp_permissions_enforced` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)