### PR TITLE
[Feature] Allow team members to view entire team usage

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -237,6 +237,9 @@ class KeyManagementRoutes(str, enum.Enum):
     # list routes
     KEY_LIST = "/key/list"
 
+    # team usage routes
+    TEAM_DAILY_ACTIVITY = "/team/daily/activity"
+
 
 class LiteLLMRoutes(enum.Enum):
     openai_route_names = [
@@ -505,6 +508,7 @@ class LiteLLMRoutes(enum.Enum):
         KeyManagementRoutes.KEY_BLOCK.value,
         KeyManagementRoutes.KEY_UNBLOCK.value,
         KeyManagementRoutes.KEY_BULK_UPDATE.value,
+        KeyManagementRoutes.TEAM_DAILY_ACTIVITY.value,
     ]
 
     management_routes = [

--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -37,6 +37,25 @@ def _is_user_team_admin(
     return False
 
 
+def _team_member_has_permission(
+    user_api_key_dict: UserAPIKeyAuth,
+    team_obj: LiteLLM_TeamTable,
+    permission: str,
+) -> bool:
+    """Check if a non-admin team member has a specific permission on a team."""
+    if not team_obj.team_member_permissions:
+        return False
+    if permission not in team_obj.team_member_permissions:
+        return False
+    for member in team_obj.members_with_roles:
+        if (
+            member.user_id is not None
+            and member.user_id == user_api_key_dict.user_id
+        ):
+            return True
+    return False
+
+
 async def _user_has_admin_privileges(
     user_api_key_dict: UserAPIKeyAuth,
     prisma_client: Optional["PrismaClient"] = None,

--- a/ui/litellm-dashboard/src/components/team/member_permissions.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/member_permissions.test.tsx
@@ -97,6 +97,20 @@ describe("MemberPermissions", () => {
     }
   });
 
+  it("should render team daily activity permission with correct method and description", async () => {
+    vi.mocked(networking.getTeamPermissionsCall).mockResolvedValue({
+      all_available_permissions: ["/key/generate", "/team/daily/activity"],
+      team_member_permissions: [],
+    });
+
+    renderWithProviders(<MemberPermissions teamId="team-123" accessToken="token-123" canEditTeam={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("/team/daily/activity")).toBeInTheDocument();
+      expect(screen.getByText("Member can view all team usage data (not just their own)")).toBeInTheDocument();
+    });
+  });
+
   it("should not show save button when canEditTeam is false", async () => {
     vi.mocked(networking.getTeamPermissionsCall).mockResolvedValue({
       all_available_permissions: ["/key/generate", "/key/list"],

--- a/ui/litellm-dashboard/src/components/team/permission_definitions.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/permission_definitions.test.tsx
@@ -11,6 +11,10 @@ describe("permission_definitions", () => {
       expect(getMethodForEndpoint("/key/list")).toBe("GET");
     });
 
+    it("should return GET for activity endpoints", () => {
+      expect(getMethodForEndpoint("/team/daily/activity")).toBe("GET");
+    });
+
     it("should return POST for other endpoints", () => {
       expect(getMethodForEndpoint("/key/generate")).toBe("POST");
       expect(getMethodForEndpoint("/key/update")).toBe("POST");
@@ -48,12 +52,27 @@ describe("permission_definitions", () => {
       expect(result.description).toBe(PERMISSION_DESCRIPTIONS["/key/service-account/generate"]);
     });
 
+    it("should return correct info for team daily activity permission", () => {
+      const result = getPermissionInfo("/team/daily/activity");
+      expect(result.method).toBe("GET");
+      expect(result.endpoint).toBe("/team/daily/activity");
+      expect(result.description).toBe(PERMISSION_DESCRIPTIONS["/team/daily/activity"]);
+      expect(result.route).toBe("/team/daily/activity");
+    });
+
     it("should return fallback description for unknown permission", () => {
       const result = getPermissionInfo("/unknown/endpoint");
       expect(result.method).toBe("POST");
       expect(result.endpoint).toBe("/unknown/endpoint");
       expect(result.description).toBe("Access /unknown/endpoint");
       expect(result.route).toBe("/unknown/endpoint");
+    });
+  });
+
+  describe("PERMISSION_DESCRIPTIONS", () => {
+    it("should include team daily activity permission", () => {
+      expect(PERMISSION_DESCRIPTIONS["/team/daily/activity"]).toBeDefined();
+      expect(PERMISSION_DESCRIPTIONS["/team/daily/activity"]).toContain("team usage");
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/team/permission_definitions.tsx
+++ b/ui/litellm-dashboard/src/components/team/permission_definitions.tsx
@@ -20,13 +20,15 @@ export const PERMISSION_DESCRIPTIONS: Record<string, string> = {
   "/key/list": "Member can list virtual keys belonging to this team",
   "/key/block": "Member can block a virtual key belonging to this team",
   "/key/unblock": "Member can unblock a virtual key belonging to this team",
+  "/team/daily/activity":
+    "Member can view all team usage data (not just their own)",
 };
 
 /**
  * Determines the HTTP method for a given permission endpoint
  */
 export const getMethodForEndpoint = (endpoint: string): string => {
-  if (endpoint.includes("/info") || endpoint.includes("/list")) {
+  if (endpoint.includes("/info") || endpoint.includes("/list") || endpoint.includes("/activity")) {
     return "GET";
   }
   return "POST";


### PR DESCRIPTION
## Summary

### Problem
Currently only team admins can see the entire team's usage on the Usage page. Non-admin team members are restricted to seeing only their own API key usage data within the team.

### Fix
Adds a new configurable team member permission (`/team/daily/activity`) that team admins can enable to allow all team members to view the full team usage data. When granted, non-admin members see the same data as team admins in the Team Usage tab — no API key filtering is applied.

## Testing

- Added 2 backend unit tests (`test_get_team_daily_activity_member_with_permission_sees_all_spend`, `test_get_team_daily_activity_member_without_permission_filters_by_keys`)
- Added 3 frontend unit tests (permission description, method detection, component rendering)
- All existing `test_get_team_daily_activity` tests continue to pass
- `npm run build` passes
- Verified the new permission appears in the Member Permissions UI table

## Type

🆕 New Feature
✅ Test

## Screenshot
<img width="1162" height="219" alt="image" src="https://github.com/user-attachments/assets/dff883c4-cebc-41e9-ba12-84c423d95a9b" />

With Setting Turned On, user sees other team member's usage:
<img width="1275" height="784" alt="image" src="https://github.com/user-attachments/assets/b34b3b22-24fe-48d4-a1a5-4ad65894d5d5" />

