### PR TITLE
Fix: add stop param as supported for openai and azure

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -578,7 +578,6 @@ OPENAI_CHAT_COMPLETION_PARAMS = [
     "thinking",
     "web_search_options",
     "service_tier",
-    "store",
     "prompt_cache_key",
     "prompt_cache_retention",
     "safety_identifier",

--- a/litellm/llms/azure/chat/gpt_transformation.py
+++ b/litellm/llms/azure/chat/gpt_transformation.py
@@ -106,6 +106,7 @@ class AzureOpenAIConfig(BaseConfig):
             "audio",
             "web_search_options",
             "prompt_cache_key",
+            "store",
         ]
 
     def _is_response_format_supported_model(self, model: str) -> bool:
@@ -158,7 +159,6 @@ class AzureOpenAIConfig(BaseConfig):
         api_version: str = "",
     ) -> dict:
         supported_openai_params = self.get_supported_openai_params(model)
-
         api_version_times = api_version.split("-")
 
         if len(api_version_times) >= 3:
@@ -245,7 +245,6 @@ class AzureOpenAIConfig(BaseConfig):
                 optional_params["tools"].extend(value)
             elif param in supported_openai_params:
                 optional_params[param] = value
-
         return optional_params
 
     def transform_request(

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -162,6 +162,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             "service_tier",
             "safety_identifier",
             "prompt_cache_key",
+            "store",
         ]  # works across all models
 
         model_specific_params = []

--- a/tests/llm_translation/test_optional_params.py
+++ b/tests/llm_translation/test_optional_params.py
@@ -2045,3 +2045,42 @@ def test_store_in_openai_chat_completion_params():
     result = get_standard_openai_params({"store": True, "temperature": 0.7})
     assert "store" in result
     assert result["store"] is True
+
+
+def test_store_param_passed_through_openai_azure():
+    """
+    Test that the `store` parameter is correctly passed through to OpenAI
+    and Azure OpenAI providers when using get_optional_params().
+
+    This verifies the fix for the regression where `store` was being filtered
+    out by get_non_default_completion_params() due to architectural issues
+    in parameter processing pipeline.
+
+    Ref: https://github.com/BerriAI/litellm/issues/19700
+    """
+    # Test OpenAI provider
+    optional_params_openai = get_optional_params(
+        model="gpt-4o",
+        custom_llm_provider="openai",
+        store=True,
+    )
+    assert "store" in optional_params_openai
+    assert optional_params_openai["store"] is True
+
+    # Test Azure OpenAI provider
+    optional_params_azure = get_optional_params(
+        model="gpt-4.1-2025-04-14",
+        custom_llm_provider="azure",
+        store=True,
+    )
+    assert "store" in optional_params_azure
+    assert optional_params_azure["store"] is True
+
+    # Test with store=False
+    optional_params_false = get_optional_params(
+        model="gpt-4o",
+        custom_llm_provider="openai",
+        store=False,
+    )
+    assert "store" in optional_params_false
+    assert optional_params_false["store"] is False


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
config:
```
model_list:
  - model_name: gpt-4.1-2025-04-14
    litellm_params:
      model: azure/gpt-4.1-2025-04-14
      store: true
  - model_name: gpt-4o  
    litellm_params:  
      model: openai/gpt-4o  
      api_key: os.environ/OPENAI_API_KEY  
      store: true 

```
<img width="913" height="111" alt="image" src="https://github.com/user-attachments/assets/923f15da-3357-4ca3-889d-a4642306209a" />
