### PR TITLE
fix(bedrock): add Accept header for AgentCore MCP server requests

### DIFF
--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -114,6 +114,11 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         stream: Optional[bool] = None,
         fake_stream: Optional[bool] = None,
     ) -> Tuple[dict, Optional[bytes]]:
+        # Set Accept header required by MCP servers on AgentCore
+        # Per MCP spec (Streamable HTTP transport): client MUST include Accept header
+        # listing both application/json and text/event-stream as supported content types
+        headers["Accept"] = "application/json, text/event-stream"
+
         # Check if api_key (bearer token) is provided for Cognito authentication
         # Priority: api_key parameter first, then optional_params
         jwt_token = api_key or optional_params.get("api_key")

--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for Bedrock AgentCore transformation — Accept header fix.
+
+Verifies that AmazonAgentCoreConfig.sign_request() sets the
+Accept: application/json, text/event-stream header required by
+MCP servers on Bedrock AgentCore.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../../.."))
+
+from unittest.mock import MagicMock, patch
+
+import litellm
+from litellm.llms.bedrock.chat.agentcore.transformation import AmazonAgentCoreConfig
+
+
+class TestAgentCoreAcceptHeader:
+    """Tests for Accept header in AgentCore requests."""
+
+    @pytest.fixture
+    def config(self):
+        return AmazonAgentCoreConfig()
+
+    def test_sign_request_sets_accept_header_jwt_path(self, config):
+        """Test that sign_request sets Accept header when using JWT/Bearer auth."""
+        headers = {}
+        result_headers, body = config.sign_request(
+            headers=headers,
+            optional_params={},
+            request_data={"prompt": "test"},
+            api_base="https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/test/invocations",
+            api_key="test-jwt-token",
+        )
+        assert "Accept" in result_headers
+        assert result_headers["Accept"] == "application/json, text/event-stream"
+
+    def test_sign_request_sets_accept_header_sigv4_path(self, config):
+        """Test that sign_request sets Accept header when using SigV4 auth."""
+        headers = {}
+        # SigV4 path requires AWS credentials — mock _sign_request to avoid needing them
+        with patch.object(config, "_sign_request") as mock_sign:
+            mock_sign.return_value = ({"Authorization": "AWS4-HMAC-SHA256 ..."}, b'{"prompt":"test"}')
+            result_headers, body = config.sign_request(
+                headers=headers,
+                optional_params={},
+                request_data={"prompt": "test"},
+                api_base="https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/test/invocations",
+            )
+            # Verify _sign_request was called with Accept header already set
+            call_args = mock_sign.call_args
+            passed_headers = call_args.kwargs.get("headers") or call_args[1].get("headers", {})
+            assert "Accept" in passed_headers
+            assert passed_headers["Accept"] == "application/json, text/event-stream"
+
+    def test_accept_header_in_completion_request_jwt(self):
+        """
+        End-to-end test: verify Accept header appears in the final HTTP request
+        when using JWT auth through litellm.completion().
+        """
+        from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+        client = HTTPHandler()
+        with patch.object(client, "post", return_value=MagicMock()) as mock_post:
+            try:
+                litellm.completion(
+                    model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/test_runtime",
+                    messages=[{"role": "user", "content": "test"}],
+                    api_key="test-jwt-token",
+                    client=client,
+                )
+            except Exception:
+                pass
+
+            mock_post.assert_called_once()
+            headers = mock_post.call_args.kwargs["headers"]
+            assert "Accept" in headers
+            assert headers["Accept"] == "application/json, text/event-stream"


### PR DESCRIPTION
AgentCore MCP server endpoints require the Accept header to contain both application/json and text/event-stream per the MCP specification (Streamable HTTP transport). Without this header, requests are rejected with a 406 Not Acceptable error (JSON-RPC code -32011).

Sets the Accept header at the top of sign_request() so both JWT/Bearer and SigV4 authentication paths include it.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🐛 Bug Fix

## Changes

- **`litellm/llms/bedrock/chat/agentcore/transformation.py`**: Added `headers["Accept"] = "application/json, text/event-stream"` at the top of `sign_request()`, before the JWT/SigV4 authentication branch. This ensures the header is present for all AgentCore requests regardless of auth method.
- **`tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py`**: Added 3 unit tests:
  - `test_sign_request_sets_accept_header_jwt_path` — verifies Accept header on JWT/Bearer auth path
  - `test_sign_request_sets_accept_header_sigv4_path` — verifies Accept header is passed to SigV4 signing
  - `test_accept_header_in_completion_request_jwt` — end-to-end test via `litellm.completion()` confirming the header reaches the HTTP request