### PR TITLE
fix: aws key rotation edge case

### DIFF
--- a/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
+++ b/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
@@ -43,7 +43,10 @@ class TestKeyManagementEventHooksIndependentOperations:
         mock_data.send_invite_email = True
 
         mock_response = MagicMock()
-        mock_response.model_dump.return_value = {"key": "sk-test", "token": "test-token"}
+        mock_response.model_dump.return_value = {
+            "key": "sk-test",
+            "token": "test-token",
+        }
         mock_response.model_dump_json.return_value = '{"key": "sk-test"}'
         mock_response.token_id = "token-123"
         mock_response.key = "sk-test-key"
@@ -104,7 +107,10 @@ class TestKeyManagementEventHooksIndependentOperations:
         mock_data.send_invite_email = True
 
         mock_response = MagicMock()
-        mock_response.model_dump.return_value = {"key": "sk-test", "token": "test-token"}
+        mock_response.model_dump.return_value = {
+            "key": "sk-test",
+            "token": "test-token",
+        }
         mock_response.model_dump_json.return_value = '{"key": "sk-test"}'
         mock_response.token_id = "token-123"
         mock_response.key = "sk-test-key"
@@ -147,49 +153,55 @@ class TestRotateVirtualKeyInSecretManager:
     @pytest.mark.asyncio
     async def test_rotate_virtual_key_with_team_id(self):
         """Test that team_id is passed to async_rotate_secret."""
-        from litellm.types.secret_managers.main import KeyManagementSystem, KeyManagementSettings
+        from litellm.types.secret_managers.main import (
+            KeyManagementSystem,
+            KeyManagementSettings,
+        )
         from litellm.secret_managers.base_secret_manager import BaseSecretManager
         import litellm
-        
+
         # Setup - Create a mock that inherits from BaseSecretManager
         mock_secret_manager = MagicMock(spec=BaseSecretManager)
-        mock_secret_manager.async_rotate_secret = AsyncMock(return_value={"status": "success"})
-        
+        mock_secret_manager.async_rotate_secret = AsyncMock(
+            return_value={"status": "success"}
+        )
+
         litellm.secret_manager_client = mock_secret_manager
         litellm._key_management_system = KeyManagementSystem.HASHICORP_VAULT
         litellm._key_management_settings = KeyManagementSettings(
             store_virtual_keys=True,
             prefix_for_stored_virtual_keys="litellm/",
         )
-        
+
         current_secret_name = "virtual-key-old"
         new_secret_name = "virtual-key-new"
         new_secret_value = "sk-new-key-value"
         team_id = "team-123"
-        
+
         # Mock _get_secret_manager_optional_params to return team settings
         team_settings = {
             "namespace": "team-namespace",
             "mount": "kv-team",
             "path_prefix": "teams/custom",
         }
-        
+
         # Patch isinstance in the key_management_event_hooks module to return True for BaseSecretManager check
         import builtins
+
         original_isinstance = builtins.isinstance
-        
+
         def mock_isinstance(obj, cls):
             if cls == BaseSecretManager and obj == mock_secret_manager:
                 return True
             return original_isinstance(obj, cls)
-        
+
         with patch.object(
             KeyManagementEventHooks,
             "_get_secret_manager_optional_params",
             return_value=team_settings,
         ) as mock_get_params, patch(
             "litellm.proxy.hooks.key_management_event_hooks.isinstance",
-            side_effect=mock_isinstance
+            side_effect=mock_isinstance,
         ):
             await KeyManagementEventHooks._rotate_virtual_key_in_secret_manager(
                 current_secret_name=current_secret_name,
@@ -197,14 +209,14 @@ class TestRotateVirtualKeyInSecretManager:
                 new_secret_value=new_secret_value,
                 team_id=team_id,
             )
-            
+
             # Verify _get_secret_manager_optional_params was called with team_id
             mock_get_params.assert_called_once_with(team_id)
-            
+
             # Verify async_rotate_secret was called with correct parameters
             mock_secret_manager.async_rotate_secret.assert_called_once()
             call_kwargs = mock_secret_manager.async_rotate_secret.call_args[1]
-            
+
             # Verify secret names have prefix
             assert call_kwargs["current_secret_name"] == "litellm/virtual-key-old"
             assert call_kwargs["new_secret_name"] == "litellm/virtual-key-new"
@@ -214,34 +226,40 @@ class TestRotateVirtualKeyInSecretManager:
     @pytest.mark.asyncio
     async def test_rotate_virtual_key_without_team_id(self):
         """Test that None team_id is handled correctly."""
-        from litellm.types.secret_managers.main import KeyManagementSystem, KeyManagementSettings
+        from litellm.types.secret_managers.main import (
+            KeyManagementSystem,
+            KeyManagementSettings,
+        )
         from litellm.secret_managers.base_secret_manager import BaseSecretManager
         import litellm
-        
+
         # Setup - Create a mock that inherits from BaseSecretManager
         mock_secret_manager = MagicMock(spec=BaseSecretManager)
-        mock_secret_manager.async_rotate_secret = AsyncMock(return_value={"status": "success"})
-        
+        mock_secret_manager.async_rotate_secret = AsyncMock(
+            return_value={"status": "success"}
+        )
+
         litellm.secret_manager_client = mock_secret_manager
         litellm._key_management_system = KeyManagementSystem.HASHICORP_VAULT
         litellm._key_management_settings = KeyManagementSettings(
             store_virtual_keys=True,
             prefix_for_stored_virtual_keys="litellm/",
         )
-        
+
         current_secret_name = "virtual-key-old"
         new_secret_name = "virtual-key-new"
         new_secret_value = "sk-new-key-value"
-        
+
         # Patch isinstance in the key_management_event_hooks module to return True for BaseSecretManager check
         import builtins
+
         original_isinstance = builtins.isinstance
-        
+
         def mock_isinstance(obj, cls):
             if cls == BaseSecretManager and obj == mock_secret_manager:
                 return True
             return original_isinstance(obj, cls)
-        
+
         # Mock _get_secret_manager_optional_params to return None (no team settings)
         with patch.object(
             KeyManagementEventHooks,
@@ -249,7 +267,7 @@ class TestRotateVirtualKeyInSecretManager:
             return_value=None,
         ) as mock_get_params, patch(
             "litellm.proxy.hooks.key_management_event_hooks.isinstance",
-            side_effect=mock_isinstance
+            side_effect=mock_isinstance,
         ):
             await KeyManagementEventHooks._rotate_virtual_key_in_secret_manager(
                 current_secret_name=current_secret_name,
@@ -257,10 +275,10 @@ class TestRotateVirtualKeyInSecretManager:
                 new_secret_value=new_secret_value,
                 team_id=None,
             )
-            
+
             # Verify _get_secret_manager_optional_params was called with None
             mock_get_params.assert_called_once_with(None)
-            
+
             # Verify async_rotate_secret was called with None optional_params
             mock_secret_manager.async_rotate_secret.assert_called_once()
             call_kwargs = mock_secret_manager.async_rotate_secret.call_args[1]
@@ -269,51 +287,58 @@ class TestRotateVirtualKeyInSecretManager:
     @pytest.mark.asyncio
     async def test_rotate_virtual_key_in_key_rotated_hook(self):
         """Test that async_key_rotated_hook passes team_id to _rotate_virtual_key_in_secret_manager."""
-        from litellm.proxy._types import LiteLLM_VerificationToken, GenerateKeyResponse, RegenerateKeyRequest
-        from litellm.types.secret_managers.main import KeyManagementSystem, KeyManagementSettings
+        from litellm.proxy._types import (
+            LiteLLM_VerificationToken,
+            GenerateKeyResponse,
+            RegenerateKeyRequest,
+        )
+        from litellm.types.secret_managers.main import (
+            KeyManagementSystem,
+            KeyManagementSettings,
+        )
         import litellm
-        
+
         # Setup
         mock_secret_manager = MagicMock()
-        mock_secret_manager.async_rotate_secret = AsyncMock(return_value={"status": "success"})
-        
+        mock_secret_manager.async_rotate_secret = AsyncMock(
+            return_value={"status": "success"}
+        )
+
         litellm.secret_manager_client = mock_secret_manager
         litellm._key_management_system = KeyManagementSystem.HASHICORP_VAULT
         litellm._key_management_settings = KeyManagementSettings(
             store_virtual_keys=True,
             prefix_for_stored_virtual_keys="litellm/",
         )
-        
+
         # Create mock existing key row with team_id
         existing_key_row = LiteLLM_VerificationToken(
             token="sk-old-key",
             key_alias="test-key-alias",
             team_id="team-456",
         )
-        
+
         # Create mock response
         response = GenerateKeyResponse(
             token_id="token-new-123",
             key="sk-new-key",
             key_alias="test-key-alias-new",
         )
-        
+
         # Create mock request
         data = RegenerateKeyRequest(
             key="sk-old-key",
             key_alias="test-key-alias-new",
         )
-        
+
         mock_user_api_key_dict = MagicMock()
-        
+
         # Mock _rotate_virtual_key_in_secret_manager to track calls
         with patch.object(
             KeyManagementEventHooks,
             "_rotate_virtual_key_in_secret_manager",
             new_callable=AsyncMock,
-        ) as mock_rotate, patch(
-            "litellm.store_audit_logs", False
-        ), patch.object(
+        ) as mock_rotate, patch("litellm.store_audit_logs", False), patch.object(
             KeyManagementEventHooks,
             "_send_key_rotated_email",
             new_callable=AsyncMock,
@@ -324,11 +349,11 @@ class TestRotateVirtualKeyInSecretManager:
                 response=response,
                 user_api_key_dict=mock_user_api_key_dict,
             )
-            
+
             # Verify _rotate_virtual_key_in_secret_manager was called
             mock_rotate.assert_called_once()
             call_kwargs = mock_rotate.call_args[1]
-            
+
             # Verify team_id was passed
             assert call_kwargs["team_id"] == "team-456"
             assert call_kwargs["current_secret_name"] == "test-key-alias"
@@ -336,29 +361,93 @@ class TestRotateVirtualKeyInSecretManager:
             assert call_kwargs["new_secret_value"] == "sk-new-key"
 
     @pytest.mark.asyncio
+    async def test_rotated_hook_uses_initial_secret_name_when_alias_invalid(self):
+        """When key_alias is '-' or empty, hook uses initial_secret_name so we update in place (no orphan secrets)."""
+        from litellm.proxy._types import (
+            LiteLLM_VerificationToken,
+            GenerateKeyResponse,
+            RegenerateKeyRequest,
+        )
+        from litellm.types.secret_managers.main import (
+            KeyManagementSystem,
+            KeyManagementSettings,
+        )
+        import litellm
+
+        mock_secret_manager = MagicMock()
+        mock_secret_manager.async_rotate_secret = AsyncMock(
+            return_value={"status": "success"}
+        )
+
+        litellm.secret_manager_client = mock_secret_manager
+        litellm._key_management_system = KeyManagementSystem.HASHICORP_VAULT
+        litellm._key_management_settings = KeyManagementSettings(
+            store_virtual_keys=True,
+            prefix_for_stored_virtual_keys="litellm/",
+        )
+
+        existing_key_row = LiteLLM_VerificationToken(
+            token="sk-old-key",
+            key_alias="-",
+            team_id=None,
+        )
+        response = GenerateKeyResponse(
+            token_id="token-new-123",
+            key="sk-new-key",
+            key_alias="-",
+        )
+        data = RegenerateKeyRequest(key="sk-old-key", key_alias="-")
+        mock_user_api_key_dict = MagicMock()
+
+        with patch.object(
+            KeyManagementEventHooks,
+            "_rotate_virtual_key_in_secret_manager",
+            new_callable=AsyncMock,
+        ) as mock_rotate, patch("litellm.store_audit_logs", False), patch.object(
+            KeyManagementEventHooks,
+            "_send_key_rotated_email",
+            new_callable=AsyncMock,
+        ):
+            await KeyManagementEventHooks.async_key_rotated_hook(
+                data=data,
+                existing_key_row=existing_key_row,
+                response=response,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+            mock_rotate.assert_called_once()
+            call_kwargs = mock_rotate.call_args[1]
+            # Same name → in-place update, no new secret
+            assert call_kwargs["current_secret_name"] == "-"
+            assert call_kwargs["new_secret_name"] == "-"
+
+    @pytest.mark.asyncio
     async def test_rotate_virtual_key_when_store_virtual_keys_disabled(self):
         """Test that rotation is skipped when store_virtual_keys is False."""
-        from litellm.types.secret_managers.main import KeyManagementSystem, KeyManagementSettings
+        from litellm.types.secret_managers.main import (
+            KeyManagementSystem,
+            KeyManagementSettings,
+        )
         import litellm
-        
+
         # Setup
         mock_secret_manager = MagicMock()
         mock_secret_manager.async_rotate_secret = AsyncMock()
-        
+
         litellm.secret_manager_client = mock_secret_manager
         litellm._key_management_system = KeyManagementSystem.HASHICORP_VAULT
         litellm._key_management_settings = KeyManagementSettings(
             store_virtual_keys=False,  # Disabled
             prefix_for_stored_virtual_keys="litellm/",
         )
-        
+
         await KeyManagementEventHooks._rotate_virtual_key_in_secret_manager(
             current_secret_name="old-key",
             new_secret_name="new-key",
             new_secret_value="sk-new-value",
             team_id="team-123",
         )
-        
+
         # Verify async_rotate_secret was NOT called
         mock_secret_manager.async_rotate_secret.assert_not_called()
 
@@ -367,17 +456,17 @@ class TestRotateVirtualKeyInSecretManager:
         """Test that rotation is skipped when secret_manager_client is None."""
         from litellm.types.secret_managers.main import KeyManagementSettings
         import litellm
-        
+
         # Setup
         litellm.secret_manager_client = None
         litellm._key_management_settings = KeyManagementSettings(
             store_virtual_keys=True,
             prefix_for_stored_virtual_keys="litellm/",
         )
-        
+
         mock_secret_manager = MagicMock()
         mock_secret_manager.async_rotate_secret = AsyncMock()
-        
+
         # Should not raise an error, just skip
         await KeyManagementEventHooks._rotate_virtual_key_in_secret_manager(
             current_secret_name="old-key",
@@ -385,6 +474,6 @@ class TestRotateVirtualKeyInSecretManager:
             new_secret_value="sk-new-value",
             team_id="team-123",
         )
-        
+
         # Verify async_rotate_secret was NOT called
         mock_secret_manager.async_rotate_secret.assert_not_called()


### PR DESCRIPTION

<img width="1846" height="600" alt="image" src="https://github.com/user-attachments/assets/f123cfdd-7471-4694-9491-6176fc7989c1" />

## Problem
When `key_alias` was invalid (e.g., `"-"`, empty string, or whitespace-only), the auto-rotation process generated a fallback secret name in the format:
`virtual-key-{token_id}`

Because `token_id` changes on each rotation, a new secret name was produced every time. This caused:
* **AWS Secret Sprawl:** A new secret created in AWS Secrets Manager on every rotation.
* **Orphaned Secrets:** Multiple unused secrets left behind in the cloud provider.
* **Sync Issues:** Secret naming became unstable, breaking downstream dependencies.

## ✅ Fix

### 1. Validation Enforcement
Added strict validation for `key_alias` during `generate` and `update` operations.
* **Rejected Values:** `""`, `"-"`, or whitespace-only strings.
* **Error Handling:** Returns a `400 ProxyException` with a clear message to prevent invalid aliases from being persisted.

### 2. Rotation Hook Safeguard
Updated the `key-rotated` hook logic to protect existing records:
* If the resolved alias is invalid during rotation, the system now **reuses the existing secret name** (`initial_secret_name`).
* The secret is updated **in-place** instead of creating a new one.
* Ensures stability across rotations even if the initial configuration was misconfigured.

---

## 🧪 Tests Added
- [x] **Unit tests** for the alias validation helper logic.
- [x] **Integration tests** verifying `_enforce_unique_key_alias` rejects invalid aliases.
- [x] **Regression tests** confirming the rotation hook falls back to `initial_secret_name` when the alias is invalid.

## 🛠️ Impact
- **Service:** Secret Management / Rotation Engine
- **Infrastructure:** AWS Secrets Manager
- **Risk Level:** Low (Fixes resource duplication)