### PR TITLE
fix(types): fix mypy errors in pass-through endpoint query param types

### DIFF
--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Mapping, Optional, Union
 from urllib.parse import parse_qs
 
 import httpx
@@ -10,7 +10,7 @@ class BasePassthroughUtils:
     @staticmethod
     def get_merged_query_parameters(
         existing_url: httpx.URL,
-        request_query_params: Dict[str, Union[str, list]],
+        request_query_params: Mapping[str, Union[str, list]],
         default_query_params: Optional[Dict[str, Union[str, list]]] = None
     ) -> Dict[str, Union[str, List[str]]]:
         # Get the existing query params from the target URL

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1221,7 +1221,7 @@ def create_pass_through_route(
                 forward_headers=cast(Optional[bool], param_forward_headers),
                 merge_query_params=cast(Optional[bool], param_merge_query_params),
                 query_params=final_query_params,
-                default_query_params=param_default_query_params,
+                default_query_params=cast(Optional[dict], param_default_query_params),
                 stream=is_streaming_request or stream,
                 custom_body=final_custom_body,
                 cost_per_request=cast(Optional[float], param_cost_per_request),


### PR DESCRIPTION
## Root cause

Not related to any specific PR — two mypy errors in `pass_through_endpoints.py` caused by type mismatches:

### Error 1 — `pass_through_endpoints.py:667`
```
Argument "request_query_params" to "get_merged_query_parameters" has incompatible type
"dict[str, str]"; expected "dict[str, str | list[Any]]"
```
`dict(request.query_params)` produces `dict[str, str]`. The parameter was typed as `Dict[str, Union[str, list]]`, but `dict` is **invariant** in its value type, so `dict[str, str]` does not satisfy `dict[str, str | list]`.

**Fix:** Changed the parameter type in `BasePassthroughUtils.get_merged_query_parameters` from `Dict` → `Mapping`, which is **covariant** in the value type (as suggested by the mypy note).

### Error 2 — `pass_through_endpoints.py:1224`
```
Argument "default_query_params" has incompatible type "str | dict[Any, Any] | bool | float | None";
expected "dict[Any, Any] | None"
```
`param_default_query_params` is extracted via `.get()` from an untyped `dict`, so mypy infers the union of all possible value types. `pass_through_request` expects `Optional[dict]`.

**Fix:** Added `cast(Optional[dict], ...)`, consistent with how the other params extracted from the same dict are already handled (`cast(Optional[bool], param_forward_headers)`, `cast(Optional[float], param_cost_per_request)`, etc.).

## Changes
- `litellm/passthrough/utils.py` — `Dict` → `Mapping` for `request_query_params` parameter (+ import `Mapping`)
- `litellm/proxy/pass_through_endpoints/pass_through_endpoints.py` — add `cast(Optional[dict], ...)` at line 1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)