### PR TITLE
fix: handle deprovisioning operations without path field

### DIFF
--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -1128,6 +1128,12 @@ def _apply_patch_ops(
         value = op.value
         op_type = op.op
 
+        # Handle SCIM operations without path where value contains the fields
+        if not path and isinstance(value, dict):
+            if "active" in value:
+                _handle_active_update(op_type, value["active"], metadata)
+            continue
+
         if path == "displayname":
             _handle_displayname_update(op_type, value, update_data)
         elif path == "externalid":

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_patch_user.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_patch_user.py
@@ -143,3 +143,71 @@ async def test_patch_user_manages_group_memberships():
     assert "new-team" in call_args[1]["data"]["teams"]
     assert result == mock_scim_user
 
+
+@pytest.mark.asyncio
+async def test_patch_user_deprovision_without_path():
+    """
+    Test SCIM deprovisioning when operation has no path field.
+    Some SCIM providers send: {"op": "replace", "value": {"active": false}}
+    """
+    mock_user = LiteLLM_UserTable(
+        user_id="user-3",
+        user_email="test@example.com",
+        user_alias="Test User",
+        teams=[],
+        metadata={"scim_active": True, "scim_metadata": {"givenName": "Test", "familyName": "User"}},
+    )
+
+    updated_user = LiteLLM_UserTable(
+        user_id="user-3",
+        user_email="test@example.com",
+        user_alias="Test User",
+        teams=[],
+        metadata={"scim_active": False, "scim_metadata": {"givenName": "Test", "familyName": "User"}},
+    )
+
+    async def mock_update(*, where, data):
+        return updated_user
+
+    mock_client = MagicMock()
+    mock_db = MagicMock()
+    mock_client.db = mock_db
+    mock_db.litellm_usertable.find_unique = AsyncMock(return_value=mock_user)
+    mock_db.litellm_usertable.update = AsyncMock(side_effect=mock_update)
+
+    mock_scim_user = SCIMUser(
+        schemas=["urn:ietf:params:scim:schemas:core:2.0:User"],
+        id="user-3",
+        userName="user-3",
+        displayName="Test User",
+        name=SCIMUserName(familyName="User", givenName="Test"),
+        emails=[SCIMUserEmail(value="test@example.com")],
+        active=False,
+    )
+
+    # SCIM operation without path field
+    patch_ops = SCIMPatchOp(
+        Operations=[
+            SCIMPatchOperation(op="replace", value={"active": False}),
+        ]
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_client), \
+         patch("litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
+               AsyncMock(return_value=mock_scim_user)):
+        result = await patch_user(user_id="user-3", patch_ops=patch_ops)
+
+    # Verify metadata was updated correctly
+    call_args = mock_db.litellm_usertable.update.call_args
+    metadata = call_args[1]["data"]["metadata"]
+    
+    # Parse JSON string back to dict if needed
+    if isinstance(metadata, str):
+        import json
+        metadata = json.loads(metadata)
+    
+    assert metadata["scim_active"] is False
+    assert "" not in metadata  # Ensure no empty string key
+    assert result.active is False
+
+


### PR DESCRIPTION
When SCIM providers send deprovisioning requests without a path field (e.g., {"op": "replace", "value": {"active": false}}), the code was storing the value under an empty string key in metadata.

```
Post-provisioning:
{
  "scim_active": true,
  "scim_metadata": {
    "givenName": "First",
    "familyName": "Last"
  }
}

Post-deprovisioning
{
  "": {
    "active": false
  },
  "scim_metadata": {
    "givenName": "First",
    "familyName": "Last"
  }
}
```

This fix:
- Detects operations with no path where value is a dict
- Extracts and handles known fields like 'active' correctly
- Sets metadata["scim_active"] = false instead of metadata[""] = {"active": false}

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- sets metadata["scim_active"] = false instead of metadata[""] = {"active": false}