### PR TITLE
Add OpenAPI-to-MCP support via API and UI

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -71,7 +71,9 @@ try:
     from mcp.shared.tool_name_validation import (
         validate_tool_name,  # pyright: ignore[reportAssignmentType]
     )
-    from mcp.shared.tool_name_validation import SEP_986_URL
+    from mcp.shared.tool_name_validation import (
+        SEP_986_URL,
+    )
 except ImportError:
     from pydantic import BaseModel
 
@@ -608,6 +610,7 @@ class MCPServerManager:
             alias=getattr(mcp_server, "alias", None),
             server_name=getattr(mcp_server, "server_name", None),
             url=mcp_server.url,
+            spec_path=getattr(mcp_server, "spec_path", None),
             transport=cast(MCPTransportType, mcp_server.transport),
             auth_type=auth_type,
             authentication_token=auth_value,

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1077,6 +1077,7 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
     auth_type: Optional[MCPAuthType] = None
     credentials: Optional[MCPCredentials] = None
     url: Optional[str] = None
+    spec_path: Optional[str] = None
     mcp_info: Optional[MCPInfo] = None
     mcp_access_groups: List[str] = Field(default_factory=list)
     allowed_tools: Optional[List[str]] = None
@@ -1103,8 +1104,8 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
                 if not values.get("args"):
                     raise ValueError("args is required for stdio transport")
             elif transport in [MCPTransport.http, MCPTransport.sse]:
-                if not values.get("url"):
-                    raise ValueError("url is required for HTTP/SSE transport")
+                if not values.get("url") and not values.get("spec_path"):
+                    raise ValueError("url or spec_path is required for HTTP/SSE transport")
         return values
 
     @model_validator(mode="before")
@@ -1139,6 +1140,7 @@ class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
     auth_type: Optional[MCPAuthType] = None
     credentials: Optional[MCPCredentials] = None
     url: Optional[str] = None
+    spec_path: Optional[str] = None
     mcp_info: Optional[MCPInfo] = None
     mcp_access_groups: List[str] = Field(default_factory=list)
     allowed_tools: Optional[List[str]] = None
@@ -1165,8 +1167,8 @@ class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
                 if not values.get("args"):
                     raise ValueError("args is required for stdio transport")
             elif transport in [MCPTransport.http, MCPTransport.sse]:
-                if not values.get("url"):
-                    raise ValueError("url is required for HTTP/SSE transport")
+                if not values.get("url") and not values.get("spec_path"):
+                    raise ValueError("url or spec_path is required for HTTP/SSE transport")
         return values
 
 
@@ -1178,6 +1180,7 @@ class LiteLLM_MCPServerTable(LiteLLMPydanticObjectBase):
     alias: Optional[str] = None
     description: Optional[str] = None
     url: Optional[str] = None
+    spec_path: Optional[str] = None
     transport: MCPTransportType
     auth_type: Optional[MCPAuthType] = None
     credentials: Optional[MCPCredentials] = None

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -273,6 +273,7 @@ model LiteLLM_MCPServerTable {
   alias        String?
   description  String?
   url          String?
+  spec_path    String?
   transport    String         @default("sse")
   auth_type    String?        
   credentials  Json?          @default("{}")

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -3,7 +3,7 @@ import { Modal, Tooltip, Form, Select, Input } from "antd";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button, TextInput } from "@tremor/react";
 import { createMCPServer } from "../networking";
-import { AUTH_TYPE, DiscoverableMCPServer, OAUTH_FLOW, MCPServer, MCPServerCostInfo } from "./types";
+import { AUTH_TYPE, DiscoverableMCPServer, OAUTH_FLOW, MCPServer, MCPServerCostInfo, TRANSPORT } from "./types";
 import OAuthFormFields from "./OAuthFormFields";
 import MCPServerCostConfig from "./mcp_server_cost_config";
 import MCPConnectionStatus from "./mcp_connection_status";
@@ -316,6 +316,11 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         }
       }
 
+      // Map "openapi" transport to "http" for the backend
+      if (restValues.transport === TRANSPORT.OPENAPI) {
+        restValues.transport = "http";
+      }
+
       // Prepare the payload with cost configuration and allowed tools
       const payload: Record<string, any> = {
         ...restValues,
@@ -377,9 +382,11 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     setTransportType(value);
     // Clear fields that are not relevant for the selected transport
     if (value === "stdio") {
-      form.setFieldsValue({ url: undefined, auth_type: undefined, credentials: undefined });
+      form.setFieldsValue({ url: undefined, spec_path: undefined, auth_type: undefined, credentials: undefined });
+    } else if (value === TRANSPORT.OPENAPI) {
+      form.setFieldsValue({ url: undefined, command: undefined, args: undefined, env: undefined });
     } else {
-      form.setFieldsValue({ command: undefined, args: undefined, env: undefined });
+      form.setFieldsValue({ spec_path: undefined, command: undefined, args: undefined, env: undefined });
     }
   };
 
@@ -555,15 +562,17 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                 <Select.Option value="http">Streamable HTTP (Recommended)</Select.Option>
                 <Select.Option value="sse">Server-Sent Events (SSE)</Select.Option>
                 <Select.Option value="stdio">Standard Input/Output (stdio)</Select.Option>
+                <Select.Option value={TRANSPORT.OPENAPI}>OpenAPI Spec</Select.Option>
               </Select>
             </Form.Item>
 
             {/* URL field - only show for HTTP and SSE */}
-            {transportType !== "stdio" && (
+            {(transportType === "http" || transportType === "sse") && (
               <Form.Item
                 label={<span className="text-sm font-medium text-gray-700">MCP Server URL</span>}
                 name="url"
                 rules={[
+                  { required: true, message: "Please enter a server URL" },
                   { validator: (_, value) => validateMCPServerUrl(value) },
                 ]}
               >
@@ -574,28 +583,29 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
               </Form.Item>
             )}
 
-            {/* OpenAPI Spec URL - only show for HTTP and SSE */}
-            {transportType !== "stdio" && (
+            {/* OpenAPI Spec URL - only show for OpenAPI transport */}
+            {transportType === TRANSPORT.OPENAPI && (
               <Form.Item
                 label={
                   <span className="text-sm font-medium text-gray-700 flex items-center">
-                    OpenAPI Spec URL (optional)
-                    <Tooltip title="Provide an OpenAPI spec URL to automatically generate MCP tools from the API endpoints. When set, tools are generated from the spec instead of connecting to an MCP server.">
+                    OpenAPI Spec URL
+                    <Tooltip title="URL to an OpenAPI specification (JSON or YAML). MCP tools will be automatically generated from the API endpoints defined in the spec.">
                       <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
                     </Tooltip>
                   </span>
                 }
                 name="spec_path"
+                rules={[{ required: true, message: "Please enter an OpenAPI spec URL" }]}
               >
                 <Input
-                  placeholder="https://api.example.com/openapi.json"
+                  placeholder="https://petstore3.swagger.io/api/v3/openapi.json"
                   className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                 />
               </Form.Item>
             )}
 
-            {/* Authentication - only show for HTTP and SSE */}
-            {transportType !== "stdio" && (
+            {/* Authentication - show for HTTP, SSE, and OpenAPI */}
+            {transportType !== "stdio" && transportType !== "" && (
               <Form.Item
                 label={<span className="text-sm font-medium text-gray-700">Authentication</span>}
                 name="auth_type"
@@ -611,7 +621,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
               </Form.Item>
             )}
 
-            {transportType !== "stdio" && shouldShowAuthValueField && (
+            {transportType !== "stdio" && transportType !== "" && shouldShowAuthValueField && (
               <Form.Item
                 label={
                   <span className="text-sm font-medium text-gray-700 flex items-center">
@@ -632,7 +642,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
               </Form.Item>
             )}
 
-            {transportType !== "stdio" && isOAuthAuthType && (
+            {transportType !== "stdio" && transportType !== "" && isOAuthAuthType && (
               <OAuthFormFields
                 isM2M={isM2MFlow}
                 initialFlowType={OAUTH_FLOW.INTERACTIVE}

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -564,12 +564,31 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                 label={<span className="text-sm font-medium text-gray-700">MCP Server URL</span>}
                 name="url"
                 rules={[
-                  { required: true, message: "Please enter a server URL" },
                   { validator: (_, value) => validateMCPServerUrl(value) },
                 ]}
               >
                 <Input
                   placeholder="https://your-mcp-server.com"
+                  className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                />
+              </Form.Item>
+            )}
+
+            {/* OpenAPI Spec URL - only show for HTTP and SSE */}
+            {transportType !== "stdio" && (
+              <Form.Item
+                label={
+                  <span className="text-sm font-medium text-gray-700 flex items-center">
+                    OpenAPI Spec URL (optional)
+                    <Tooltip title="Provide an OpenAPI spec URL to automatically generate MCP tools from the API endpoints. When set, tools are generated from the spec instead of connecting to an MCP server.">
+                      <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+                    </Tooltip>
+                  </span>
+                }
+                name="spec_path"
+              >
+                <Input
+                  placeholder="https://api.example.com/openapi.json"
                   className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                 />
               </Form.Item>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_connection_status.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_connection_status.tsx
@@ -25,7 +25,7 @@ const MCPConnectionStatus: React.FC<MCPConnectionStatusProps> = ({ accessToken, 
   }, [tools, onToolsLoaded]);
 
   // Don't show anything if required fields aren't filled
-  if (!canFetchTools && !formValues.url) {
+  if (!canFetchTools && !formValues.url && !formValues.spec_path) {
     return null;
   }
 
@@ -37,7 +37,7 @@ const MCPConnectionStatus: React.FC<MCPConnectionStatusProps> = ({ accessToken, 
           <Title>Connection Status</Title>
         </div>
 
-        {!canFetchTools && formValues.url && (
+        {!canFetchTools && (formValues.url || formValues.spec_path) && (
           <div className="text-center py-6 text-gray-400 border rounded-lg border-dashed">
             <ToolOutlined className="text-2xl mb-2" />
             <Text>Complete required fields to test connection</Text>
@@ -60,7 +60,7 @@ const MCPConnectionStatus: React.FC<MCPConnectionStatusProps> = ({ accessToken, 
                         : "Ready to test connection"}
                 </Text>
                 <br />
-                <Text className="text-gray-500 text-sm">Server: {formValues.url}</Text>
+                <Text className="text-gray-500 text-sm">Server: {formValues.url || formValues.spec_path}</Text>
               </div>
 
               {isLoadingTools && (

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Form, Select, Button as AntdButton, Tooltip, Input } from "antd";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button, TabGroup, TabList, Tab, TabPanels, TabPanel } from "@tremor/react";
-import { AUTH_TYPE, OAUTH_FLOW, MCPServer, MCPServerCostInfo } from "./types";
+import { AUTH_TYPE, OAUTH_FLOW, MCPServer, MCPServerCostInfo, TRANSPORT } from "./types";
 import { updateMCPServer, testMCPToolsListRequest } from "../networking";
 import MCPServerCostConfig from "./mcp_server_cost_config";
 import MCPPermissionManagement from "./MCPPermissionManagement";
@@ -42,6 +42,8 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   const authType = Form.useWatch("auth_type", form) as string | undefined;
   const transportType = Form.useWatch("transport", form) as string | undefined;
   const isStdioTransport = transportType === "stdio";
+  const isOpenAPITransport = transportType === TRANSPORT.OPENAPI;
+  const isMCPTransport = !isStdioTransport && !isOpenAPITransport;
   const shouldShowAuthValueField = authType ? AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(authType) : false;
   const isOAuthAuthType = authType === AUTH_TYPE.OAUTH2;
   const oauthFlowTypeValue = Form.useWatch("oauth_flow_type", form) as string | undefined;
@@ -142,13 +144,22 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   }, [mcpServer.env]);
 
 
+  // If server has spec_path and no url, show it as "openapi" transport in the UI
+  const effectiveTransport = React.useMemo(() => {
+    if (mcpServer.spec_path && !mcpServer.url && mcpServer.transport !== "stdio") {
+      return TRANSPORT.OPENAPI;
+    }
+    return mcpServer.transport;
+  }, [mcpServer]);
+
   const initialValues = React.useMemo(
     () => ({
       ...mcpServer,
+      transport: effectiveTransport,
       static_headers: initialStaticHeaders,
       oauth_flow_type: mcpServer.token_url ? OAUTH_FLOW.M2M : OAUTH_FLOW.INTERACTIVE,
     }),
-    [mcpServer, initialStaticHeaders, initialEnvJson],
+    [mcpServer, effectiveTransport, initialStaticHeaders, initialEnvJson],
   );
 
   // Initialize cost config from existing server data
@@ -231,8 +242,8 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   const fetchTools = async () => {
     if (!accessToken) return;
 
-    // HTTP/SSE requires a URL; stdio does not.
-    if (mcpServer.transport !== "stdio" && !mcpServer.url) return;
+    // HTTP/SSE requires a URL (unless spec_path is set); stdio does not.
+    if (mcpServer.transport !== "stdio" && !mcpServer.url && !mcpServer.spec_path) return;
 
     const isM2M = mcpServer.auth_type === AUTH_TYPE.OAUTH2 && !!mcpServer.token_url;
     if (mcpServer.auth_type === AUTH_TYPE.OAUTH2 && !isM2M && !oauthAccessToken) {
@@ -311,14 +322,24 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     if (value === "stdio") {
       form.setFieldsValue({
         url: undefined,
+        spec_path: undefined,
         auth_type: undefined,
         credentials: undefined,
         authorization_url: undefined,
         token_url: undefined,
         registration_url: undefined,
       });
+    } else if (value === TRANSPORT.OPENAPI) {
+      form.setFieldsValue({
+        url: undefined,
+        command: undefined,
+        args: undefined,
+        env_json: undefined,
+        stdio_config: undefined,
+      });
     } else {
       form.setFieldsValue({
+        spec_path: undefined,
         command: undefined,
         args: undefined,
         env_json: undefined,
@@ -457,6 +478,11 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         }
       }
 
+      // Map "openapi" transport to "http" for the backend
+      if (restValues.transport === TRANSPORT.OPENAPI) {
+        restValues.transport = "http";
+      }
+
       // Prepare the payload with cost configuration and permission fields
       const mcpInfoServerName =
         restValues.server_name ||
@@ -543,14 +569,15 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
             </Form.Item>
             <Form.Item label="Transport Type" name="transport" rules={[{ required: true }]}>
               <Select onChange={handleTransportChange}>
-                <Select.Option value="sse">Server-Sent Events (SSE)</Select.Option>
                 <Select.Option value="http">Streamable HTTP (Recommended)</Select.Option>
+                <Select.Option value="sse">Server-Sent Events (SSE)</Select.Option>
                 <Select.Option value="stdio">Standard Input/Output (stdio)</Select.Option>
+                <Select.Option value={TRANSPORT.OPENAPI}>OpenAPI Spec</Select.Option>
               </Select>
             </Form.Item>
 
-            {/* URL/Auth fields are only applicable for HTTP/SSE */}
-            {!isStdioTransport && (
+            {/* URL field - only for HTTP/SSE */}
+            {isMCPTransport && (
               <Form.Item
                 label="MCP Server URL"
                 name="url"
@@ -566,25 +593,28 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
               </Form.Item>
             )}
 
-            {!isStdioTransport && (
+            {/* OpenAPI Spec URL - only for OpenAPI transport */}
+            {isOpenAPITransport && (
               <Form.Item
                 label={
                   <span className="text-sm font-medium text-gray-700 flex items-center">
-                    OpenAPI Spec URL (optional)
-                    <Tooltip title="Provide an OpenAPI spec URL to automatically generate MCP tools from the API endpoints. When set, tools are generated from the spec instead of connecting to an MCP server.">
+                    OpenAPI Spec URL
+                    <Tooltip title="URL to an OpenAPI specification (JSON or YAML). MCP tools will be automatically generated from the API endpoints defined in the spec.">
                       <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
                     </Tooltip>
                   </span>
                 }
                 name="spec_path"
+                rules={[{ required: true, message: "Please enter an OpenAPI spec URL" }]}
               >
                 <Input
-                  placeholder="https://api.example.com/openapi.json"
+                  placeholder="https://petstore3.swagger.io/api/v3/openapi.json"
                   className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                 />
               </Form.Item>
             )}
 
+            {/* Authentication - for HTTP, SSE, and OpenAPI */}
             {!isStdioTransport && (
               <Form.Item label="Authentication" name="auth_type" rules={[{ required: true }]}>
                 <Select>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -567,6 +567,25 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
             )}
 
             {!isStdioTransport && (
+              <Form.Item
+                label={
+                  <span className="text-sm font-medium text-gray-700 flex items-center">
+                    OpenAPI Spec URL (optional)
+                    <Tooltip title="Provide an OpenAPI spec URL to automatically generate MCP tools from the API endpoints. When set, tools are generated from the spec instead of connecting to an MCP server.">
+                      <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+                    </Tooltip>
+                  </span>
+                }
+                name="spec_path"
+              >
+                <Input
+                  placeholder="https://api.example.com/openapi.json"
+                  className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                />
+              </Form.Item>
+            )}
+
+            {!isStdioTransport && (
               <Form.Item label="Authentication" name="auth_type" rules={[{ required: true }]}>
                 <Select>
                   <Select.Option value="none">None</Select.Option>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_tool_configuration.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_tool_configuration.tsx
@@ -71,7 +71,7 @@ const MCPToolConfiguration: React.FC<MCPToolConfigurationProps> = ({
   };
 
   // Don't show anything if required fields aren't filled
-  if (!canFetchTools && !formValues.url) {
+  if (!canFetchTools && !formValues.url && !formValues.spec_path) {
     return null;
   }
 
@@ -130,7 +130,7 @@ const MCPToolConfiguration: React.FC<MCPToolConfigurationProps> = ({
         )}
 
         {/* Incomplete form state */}
-        {!canFetchTools && formValues.url && (
+        {!canFetchTools && (formValues.url || formValues.spec_path) && (
           <div className="text-center py-6 text-gray-400 border rounded-lg border-dashed">
             <ToolOutlined className="text-2xl mb-2" />
             <Text>Complete required fields to configure tools</Text>

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -143,6 +143,7 @@ export interface MCPServer {
    * For `stdio`, the backend can return null/undefined.
    */
   url?: string | null;
+  spec_path?: string | null;
   transport?: string | null;
   auth_type?: string | null;
   authorization_url?: string | null;

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -22,6 +22,7 @@ export const TRANSPORT = {
   SSE: "sse",
   HTTP: "http",
   STDIO: "stdio",
+  OPENAPI: "openapi",
 };
 
 export const handleTransport = (transport?: string | null): string => {


### PR DESCRIPTION
## feat: add spec_path (OpenAPI-to-MCP) support to API and UI

<img width="529" height="668" alt="Screenshot 2026-02-19 at 12 21 54 PM" src="https://github.com/user-attachments/assets/fc59b778-340b-42eb-a742-98c250e51eb3" />


Enables creating MCP servers with `spec_path` via API and UI, not just config.yaml.

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🆕 New Feature

## Changes

The OpenAPI-to-MCP converter (`spec_path`) previously only worked via config.yaml. This adds support for setting it through the API and UI.

**Backend:**
- `schema.prisma`: add `spec_path String?` column to `LiteLLM_MCPServerTable`
- `_types.py`: add `spec_path` to `NewMCPServerRequest`, `UpdateMCPServerRequest`, and `LiteLLM_MCPServerTable`. Validators now accept `spec_path` as alternative to `url` for HTTP/SSE transport.
- `mcp_server_manager.py`: wire `spec_path` through `build_mcp_server_from_table()` so DB records populate the MCPServer object

**UI:**
- Add `spec_path` to TypeScript `MCPServer` interface
- Add "OpenAPI Spec URL" input field to both create and edit forms

Example API call:
```bash
curl -X POST http://localhost:4000/v1/mcp/server \
  -H "Authorization: Bearer sk-..." \
  -d '{"transport": "http", "spec_path": "https://api.example.com/openapi.json"}'
```