### PR TITLE
fix(openai): correct supported_openai_params for GPT-5 model family

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -69,13 +69,19 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             base_gpt_series_params.remove("tool_choice")
 
         non_supported_params = [
-            "logprobs",
-            "top_p",
             "presence_penalty",
             "frequency_penalty",
-            "top_logprobs",
             "stop",
+            "logit_bias",
+            "modalities",
+            "prediction",
+            "audio",
+            "web_search_options",
         ]
+
+        # gpt-5.1/5.2 support logprobs, top_p, top_logprobs when reasoning_effort="none"
+        if not self.is_model_gpt_5_1_model(model):
+            non_supported_params.extend(["logprobs", "top_p", "top_logprobs"])
 
         return [
             param

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -473,3 +473,39 @@ def test_gpt5_1_top_p_passthrough(config: OpenAIConfig):
         drop_params=False,
     )
     assert params["top_p"] == 0.9
+
+
+def test_gpt5_1_logprobs_rejected_with_reasoning_effort(config: OpenAIConfig):
+    """logprobs/top_p/top_logprobs are rejected when reasoning_effort != 'none'."""
+    for effort in ["low", "medium", "high"]:
+        with pytest.raises(litellm.utils.UnsupportedParamsError):
+            config.map_openai_params(
+                non_default_params={"logprobs": True, "reasoning_effort": effort},
+                optional_params={},
+                model="gpt-5.1",
+                drop_params=False,
+            )
+
+
+def test_gpt5_1_top_p_rejected_with_reasoning_effort(config: OpenAIConfig):
+    """top_p is rejected when reasoning_effort != 'none'."""
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"top_p": 0.9, "reasoning_effort": "high"},
+            optional_params={},
+            model="gpt-5.1",
+            drop_params=False,
+        )
+
+
+def test_gpt5_1_logprobs_dropped_with_reasoning_effort(config: OpenAIConfig):
+    """logprobs/top_p are dropped when reasoning_effort != 'none' and drop_params=True."""
+    params = config.map_openai_params(
+        non_default_params={"logprobs": True, "top_p": 0.9, "reasoning_effort": "high"},
+        optional_params={},
+        model="gpt-5.1",
+        drop_params=True,
+    )
+    assert "logprobs" not in params
+    assert "top_p" not in params
+    assert params["reasoning_effort"] == "high"


### PR DESCRIPTION
## Relevant issues

Related to #21572

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Audited `supported_openai_params` for GPT-5 models against the actual OpenAI API. Found 5 params incorrectly listed as supported (OpenAI rejects them) and 3 params incorrectly removed for gpt-5.1/5.2.

### Removed from supported (all GPT-5 reasoning models)

Validated via direct API calls — OpenAI returns 400 for all of these:

- `logit_bias` — "Unsupported parameter: not supported with this model"
- `modalities` — "Unknown parameter"
- `prediction` — "Unsupported parameter: not supported with this model"
- `audio` — "Unknown parameter"
- `web_search_options` — "Unknown parameter" (only for gpt-5-search-api, handled in #21574)

### Added for gpt-5.1/gpt-5.2

These params work when `reasoning_effort="none"` (the default for 5.1/5.2):

- `logprobs`
- `top_p`
- `top_logprobs`

Previously these were unconditionally removed for all GPT-5 models.

### Tests added (5)

- `test_gpt5_rejects_params_unsupported_by_openai` — 5 rejected params across all GPT-5 variants
- `test_gpt5_1_supports_logprobs_top_p` — gpt-5.1/5.2 list logprobs/top_p/top_logprobs
- `test_gpt5_base_does_not_support_logprobs_top_p` — gpt-5/mini/codex do NOT list them
- `test_gpt5_1_logprobs_passthrough` — logprobs passes through map_openai_params
- `test_gpt5_1_top_p_passthrough` — top_p passes through map_openai_params