### PR TITLE
fix(azure_ai): resolve api_base from env var in Document Intelligence OCR

### DIFF
--- a/litellm/llms/azure_ai/ocr/document_intelligence/transformation.py
+++ b/litellm/llms/azure_ai/ocr/document_intelligence/transformation.py
@@ -122,6 +122,9 @@ class AzureDocumentIntelligenceOCRConfig(BaseOCRConfig):
         Returns: Complete URL for Azure DI analyze endpoint
         """
         if api_base is None:
+            api_base = get_secret_str("AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT")
+
+        if api_base is None:
             raise ValueError(
                 "Missing Azure Document Intelligence Endpoint - Set AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT environment variable or pass api_base parameter"
             )


### PR DESCRIPTION
## Relevant issues

Fixes #21034

## Pre-Submission checklist

- [ ] I have Added testing in the `tests/litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`litellm.ocr()` with Azure Document Intelligence fails when `api_base` is set via env var (`AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT`) instead of passed directly.

`get_complete_url()` now resolves the env var as a fallback, matching the pattern already used in `validate_environment()`.