### PR TITLE
fix(models): function calling for PublicAI Apertus models

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25907,8 +25907,8 @@
         "mode": "chat",
         "output_cost_per_token": 0.0,
         "source": "https://platform.publicai.co/docs",
-        "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_function_calling": false,
+        "supports_tool_choice": false
     },
     "publicai/swiss-ai/apertus-70b-instruct": {
         "input_cost_per_token": 0.0,
@@ -25919,8 +25919,8 @@
         "mode": "chat",
         "output_cost_per_token": 0.0,
         "source": "https://platform.publicai.co/docs",
-        "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_function_calling": false,
+        "supports_tool_choice": false
     },
     "publicai/aisingapore/Gemma-SEA-LION-v4-27B-IT": {
         "input_cost_per_token": 0.0,


### PR DESCRIPTION
## Relevant issues

Fixes #21124

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

> **Note:** This is a JSON-only data fix (no code logic changes), so no new tests are required.

## Type

🐛 Bug Fix

## Changes

The PublicAI Apertus models (8B and 70B) incorrectly report `supports_function_calling: true` and `supports_tool_choice: true`, but they do not support standard OpenAI-style tool calling.

Per [Swiss AI's docs](https://huggingface.co/swiss-ai/Apertus-8B-Instruct-2509/discussions/18), tool use integration into inference engines is still in development — the models have been trained on initial tool calling data but only work with custom chat templates, not the standard `tools`/`tool_choice` parameters.

This PR sets both flags to `false` in `model_prices_and_context_window.json`. The existing `JSONProviderConfig.get_supported_openai_params()` in `dynamic_config.py` already filters out tool-related params when `supports_function_calling` is `false`, so no code changes are needed.