### PR TITLE
fix(vertex_ai): pass through native Gemini imageConfig params for image generation

### DIFF
--- a/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
@@ -43,13 +43,20 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
     
     def get_supported_openai_params(
         self, model: str
-    ) -> List[OpenAIImageGenerationOptionalParams]:
+    ) -> list:
         """
         Gemini image generation supported parameters
+
+        Includes native Gemini imageConfig params (aspectRatio, imageSize)
+        in both camelCase and snake_case variants.
         """
         return [
             "n",
             "size",
+            "aspectRatio",
+            "aspect_ratio",
+            "imageSize",
+            "image_size",
         ]
     
     def map_openai_params(
@@ -71,6 +78,10 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
                     elif k == "size":
                         # Map OpenAI size format to Gemini aspectRatio
                         mapped_params["aspectRatio"] = self._map_size_to_aspect_ratio(v)
+                    elif k in ("aspectRatio", "aspect_ratio"):
+                        mapped_params["aspectRatio"] = v
+                    elif k in ("imageSize", "image_size"):
+                        mapped_params["imageSize"] = v
                     else:
                         mapped_params[k] = v
         

--- a/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
@@ -65,6 +65,42 @@ class TestVertexAIGeminiImageGenerationConfig:
         assert self.config._map_size_to_aspect_ratio("896x1280") == "3:4"
         assert self.config._map_size_to_aspect_ratio("unknown") == "1:1"  # default
 
+    def test_get_supported_openai_params_includes_native_gemini_params(self):
+        """Test that native Gemini imageConfig params are supported"""
+        supported = self.config.get_supported_openai_params("gemini-3-pro-image-preview")
+        assert "aspectRatio" in supported
+        assert "aspect_ratio" in supported
+        assert "imageSize" in supported
+        assert "image_size" in supported
+
+    def test_map_openai_params_aspect_ratio_camel_case(self):
+        """Test mapping native aspectRatio parameter"""
+        result = self.config.map_openai_params(
+            {"aspectRatio": "9:16"}, {}, "gemini-3-pro-image-preview", False
+        )
+        assert result["aspectRatio"] == "9:16"
+
+    def test_map_openai_params_aspect_ratio_snake_case(self):
+        """Test mapping native aspect_ratio parameter"""
+        result = self.config.map_openai_params(
+            {"aspect_ratio": "16:9"}, {}, "gemini-3-pro-image-preview", False
+        )
+        assert result["aspectRatio"] == "16:9"
+
+    def test_map_openai_params_image_size_camel_case(self):
+        """Test mapping native imageSize parameter"""
+        result = self.config.map_openai_params(
+            {"imageSize": "4K"}, {}, "gemini-3-pro-image-preview", False
+        )
+        assert result["imageSize"] == "4K"
+
+    def test_map_openai_params_image_size_snake_case(self):
+        """Test mapping native image_size parameter"""
+        result = self.config.map_openai_params(
+            {"image_size": "2K"}, {}, "gemini-3-pro-image-preview", False
+        )
+        assert result["imageSize"] == "2K"
+
     def test_transform_image_generation_request_basic(self):
         """Test basic request transformation"""
         request = self.config.transform_image_generation_request(


### PR DESCRIPTION
## Relevant issues

Fixes #21070

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`aspectRatio` and `imageSize` parameters were dropped when calling Vertex AI Gemini image generation models (`gemini-3-pro-image-preview`, `gemini-2.5-flash-image`).

**Fix:**
- Added `aspectRatio`, `aspect_ratio`, `imageSize`, `image_size` to `get_supported_openai_params()` so they pass validation
- Added explicit mapping in `map_openai_params()` to normalize snake_case variants to camelCase
- 5 new unit tests covering both camelCase and snake_case variants

**Example*
```python
response = litellm.image_generation(
    model="vertex_ai/gemini-3-pro-image-preview",
    prompt="A landscape photo of mountains",
    aspectRatio="9:16",
    imageSize="4K",
)
```

After this fix, both params are correctly forwarded to the Gemini API