### PR TITLE
fix(moonshot): preserve image_url blocks in multimodal messages

### DIFF
--- a/docs/my-website/docs/providers/moonshot.md
+++ b/docs/my-website/docs/providers/moonshot.md
@@ -219,6 +219,37 @@ curl http://localhost:4000/v1/chat/completions \
 
 For more detailed information on using the LiteLLM Proxy, see the [LiteLLM Proxy documentation](../providers/litellm_proxy).
 
+## Image / Vision Support
+
+Moonshot vision models (`kimi-k2.5`, `kimi-latest`, `moonshot-v1-*-vision-preview`, etc.) accept the standard OpenAI content array with `image_url` blocks.
+
+LiteLLM automatically detects when your messages contain images and preserves the content array so the image payload reaches the Moonshot API. For text-only requests the content is flattened to a plain string, as required by Moonshot text models.
+
+```python showLineNumbers title="Moonshot Vision Example"
+import os
+import litellm
+
+os.environ["MOONSHOT_API_KEY"] = ""
+
+response = litellm.completion(
+    model="moonshot/kimi-k2.5",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this image?"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.png"},
+                },
+            ],
+        }
+    ],
+)
+
+print(response.choices[0].message.content)
+```
+
 ## Moonshot AI Limitations & LiteLLM Handling
 
 LiteLLM automatically handles the following [Moonshot AI limitations](https://platform.moonshot.ai/docs/guide/migrating-from-openai-to-kimi#about-api-compatibility) to provide seamless OpenAI compatibility:


### PR DESCRIPTION
## Relevant issues

Fixes #20862

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix
📖 Documentation

## Changes

Moonshot's `_transform_messages` unconditionally flattened content arrays to plain strings via `handle_messages_with_content_list_to_str_conversion()`, dropping all non-text content blocks (`image_url`, `input_audio`, `video_url`, `file`, etc.). Multimodal models like `kimi-k2.5` accept the standard OpenAI content array format.

**Fix:** Before flattening, check if any message contains a non-text content part (`type != "text"`). If so, skip flattening and preserve the content array. If all parts are text-only, flatten as before (required by Moonshot text models). This covers the full OpenAI content spec, not just images.

### Example request

```python
import litellm

response = litellm.completion(
    model="moonshot/kimi-k2.5",
    messages=[
        {
            "role": "user",
            "content": [
                {"type": "text", "text": "What is in this image?"},
                {
                    "type": "image_url",
                    "image_url": {"url": "https://example.com/image.png"},
                },
            ],
        }
    ],
)
```

**Before fix:** the content array was flattened to the string `"What is in this image?"` — the `image_url` block was dropped.

**After fix:** the content array is preserved as-is, and the multimodal payload reaches the Moonshot API.

### Files changed

- **`litellm/llms/moonshot/chat/transformation.py`** — Skip flattening when any content part has `type != "text"`
- **`tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py`** — 3 new tests: image_url preserved, input_audio preserved, text-only flattened
- **`docs/my-website/docs/providers/moonshot.md`** — Add "Image / Vision Support" section with usage example