### PR TITLE
fix(gemini): preserve $ref in JSON Schema for Gemini 2.0+

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3865,18 +3865,6 @@ def get_optional_params(  # noqa: PLR0915
 ):
     passed_params = locals().copy()
     special_params = passed_params.pop("kwargs")
-    non_default_params = pre_process_non_default_params(
-        passed_params=passed_params,
-        special_params=special_params,
-        custom_llm_provider=custom_llm_provider,
-        additional_drop_params=additional_drop_params,
-        model=model,
-    )
-    optional_params = pre_process_optional_params(
-        passed_params=passed_params,
-        non_default_params=non_default_params,
-        custom_llm_provider=custom_llm_provider,
-    )
     provider_config: Optional[BaseConfig] = None
     if custom_llm_provider is not None and custom_llm_provider in [
         provider.value for provider in LlmProviders
@@ -3884,6 +3872,19 @@ def get_optional_params(  # noqa: PLR0915
         provider_config = ProviderConfigManager.get_provider_chat_config(
             model=model, provider=LlmProviders(custom_llm_provider)
         )
+    non_default_params = pre_process_non_default_params(
+        passed_params=passed_params,
+        special_params=special_params,
+        custom_llm_provider=custom_llm_provider,
+        additional_drop_params=additional_drop_params,
+        model=model,
+        provider_config=provider_config,
+    )
+    optional_params = pre_process_optional_params(
+        passed_params=passed_params,
+        non_default_params=non_default_params,
+        custom_llm_provider=custom_llm_provider,
+    )
 
     def _check_valid_arg(supported_params: List[str]):
         """


### PR DESCRIPTION
## Relevant issues

Fixes #21014

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🐛 Bug Fix

## Changes

Gemini 2.0+ with `responseJsonSchema` natively supports standard JSON Schema including `$ref`, `$defs`, and `anyOf` — no transformations needed.

When using `response_format` with nested Pydantic models on Gemini, litellm triggered "exceeds maximum allowed nesting depth" errors because:

1. OpenAI's `to_strict_json_schema()` was inlining all `$ref` references, inflating a ~1.5KB schema to ~5.5KB with much deeper nesting
2. `_build_json_schema()` applied additional unnecessary transformations

**Changes:**
- Override `get_json_schema_from_pydantic_object` in `VertexGeminiConfig` to use Pydantic's `model_json_schema()` (preserves `$ref`) instead of OpenAI's `to_strict_json_schema()` (inlines everything)
- Simplify `_build_json_schema()` to pass schemas through unchanged for Gemini 2.0+
- Move `provider_config` resolution earlier in `get_optional_params()` so the override is used during schema conversion

Gemini 1.5 models still work — they use a separate code path (`_build_vertex_schema()` via `responseSchema`).