### PR TITLE
fix(lint): remove redundant router import in policy_endpoints __init__

### DIFF
--- a/litellm/proxy/management_endpoints/policy_endpoints/__init__.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints/__init__.py
@@ -8,6 +8,3 @@ are imported directly into this namespace.
 """
 
 from litellm.proxy.management_endpoints.policy_endpoints.endpoints import *  # noqa: F401, F403
-from litellm.proxy.management_endpoints.policy_endpoints.endpoints import (
-    router,
-)


### PR DESCRIPTION
## Root cause

Not related to PR #21600 (docs only). Pre-existing ruff F401 on `main`:

```
proxy/management_endpoints/policy_endpoints/__init__.py:12:5: F401
`litellm.proxy.management_endpoints.policy_endpoints.endpoints.router` imported but unused
```

The file does `from .endpoints import *` (line 10) which already re-exports `router` into the package namespace. The explicit `from .endpoints import (router,)` on lines 11–13 is therefore redundant and triggers the lint error.

## Fix

Remove the 3-line explicit import block. The `*` import continues to satisfy `proxy_server.py:394`:
```python
from litellm.proxy.management_endpoints.policy_endpoints import router as policy_router
```

## Changes
- `litellm/proxy/management_endpoints/policy_endpoints/__init__.py` — 3 lines removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)