### PR TITLE
fix(ci): fix YAML syntax error in regenerate-poetry-lock workflow

### DIFF
--- a/.github/workflows/regenerate-poetry-lock.yml
+++ b/.github/workflows/regenerate-poetry-lock.yml
@@ -54,20 +54,23 @@ jobs:
           git add poetry.lock
           git commit -m "chore: regenerate poetry.lock to match pyproject.toml"
           git push -f origin "$BRANCH"
+
+          # Write body to a temp file to avoid heredoc/quoting issues in YAML
+          cat > /tmp/pr-body.md << 'BODY'
+          Automated regeneration of `poetry.lock` after `pyproject.toml` was updated on `main`.
+
+          Fixes the recurring CI failure:
+          ```
+          pyproject.toml changed significantly since poetry.lock was last generated.
+          Run `poetry lock` to fix the lock file.
+          ```
+
+          Regenerated with `poetry lock --no-update` (existing package versions are preserved; only the lock file metadata is updated to match the new constraints).
+          BODY
+
           gh pr create \
             --title "chore: regenerate poetry.lock to match pyproject.toml" \
-            --body "$(cat <<'EOF'
-Automated regeneration of \`poetry.lock\` after \`pyproject.toml\` was updated on \`main\`.
-
-Fixes the recurring CI failure:
-\`\`\`
-pyproject.toml changed significantly since poetry.lock was last generated.
-Run \`poetry lock\` to fix the lock file.
-\`\`\`
-
-Regenerated with \`poetry lock --no-update\` (existing package versions are preserved; only the lock file metadata is updated to match the new constraints).
-EOF
-)" \
+            --body-file /tmp/pr-body.md \
             --head "$BRANCH" \
             --base main
         env:


### PR DESCRIPTION
## Problem

The workflow merged in #21610 has a YAML syntax error on line 60 that prevents it from running at all:

```
Invalid workflow file: .github/workflows/regenerate-poetry-lock.yml#L60
You have an error in your yaml syntax on line 60
```

**Root cause:** a heredoc (`<<'EOF'`) inside `$()` inside a double-quoted string inside a YAML multiline `run:` block confuses the YAML parser — the unindented heredoc body on line 60 is interpreted as a YAML key.

## Fix

Write the PR body to `/tmp/pr-body.md` using a standalone heredoc, then pass it via `gh pr create --body-file`. No logic changes, just the quoting approach.

## Validation

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/regenerate-poetry-lock.yml')); print('OK')"
# → YAML OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)