### PR TITLE
fix(ci): remove --no-update flag removed in Poetry 2.x

### DIFF
--- a/.github/workflows/regenerate-poetry-lock.yml
+++ b/.github/workflows/regenerate-poetry-lock.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Regenerate poetry.lock
         # --no-update: re-solve only what pyproject.toml requires without
         # upgrading packages that are already in the lock file.
-        run: poetry lock --no-update
+        run: poetry lock
 
       - name: Check whether poetry.lock actually changed
         id: diff
@@ -64,7 +64,7 @@ jobs:
           Run `poetry lock` to fix the lock file.
           ```
 
-          Regenerated with `poetry lock --no-update` (existing package versions are preserved; only the lock file metadata is updated to match the new constraints).
+          Regenerated with `poetry lock` (existing package versions are preserved; only the lock file metadata is updated to match the new constraints).
           BODY
 
           gh pr create \


### PR DESCRIPTION
## Problem

The workflow fails with:
```
The option "--no-update" does not exist
```

`--no-update` was a Poetry 1.x flag that was removed in Poetry 2.x.

## Fix

Replace `poetry lock --no-update` with plain `poetry lock`. In Poetry 2.x this is already the correct behaviour — it only re-solves what the changed `pyproject.toml` constraints require, without upgrading already-locked packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)