### PR TITLE
fix(proxy): use batch_ prefix for Vertex AI batch IDs in encode_file_id_with_model

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -151,7 +151,9 @@ async def create_batch(  # noqa: PLR0915
             if response and hasattr(response, "id") and response.id:
                 original_batch_id = response.id
                 encoded_batch_id = encode_file_id_with_model(
-                    file_id=original_batch_id, model=model_from_file_id
+                    file_id=original_batch_id,
+                    model=model_from_file_id,
+                    id_type="batch",
                 )
                 response.id = encoded_batch_id
                 

--- a/tests/litellm/proxy/test_model_based_routing_files_batches.py
+++ b/tests/litellm/proxy/test_model_based_routing_files_batches.py
@@ -1,0 +1,112 @@
+"""
+Unit tests for encode_file_id_with_model, decode_model_from_file_id,
+and get_original_file_id in common_utils.py.
+
+Tests the model-based routing ID encoding/decoding used by the batch
+and file proxy endpoints.
+"""
+
+from litellm.proxy.openai_files_endpoints.common_utils import (
+    decode_model_from_file_id,
+    encode_file_id_with_model,
+    get_original_file_id,
+)
+
+
+class TestEncodeFileIdWithModel:
+    """Tests for encode_file_id_with_model."""
+
+    def test_openai_file_id_gets_file_prefix(self):
+        """OpenAI file IDs (file-xxx) should produce file- prefix."""
+        result = encode_file_id_with_model("file-abc123", "gpt-4o")
+        assert result.startswith("file-")
+
+    def test_openai_batch_id_gets_batch_prefix(self):
+        """OpenAI batch IDs (batch_xxx) should produce batch_ prefix."""
+        result = encode_file_id_with_model("batch_abc123", "gpt-4o")
+        assert result.startswith("batch_")
+
+    def test_vertex_numeric_batch_id_gets_batch_prefix_with_id_type(self):
+        """Vertex AI numeric batch IDs should produce batch_ prefix when id_type='batch'."""
+        result = encode_file_id_with_model(
+            "3814889423749775360", "gemini-2.5-pro", id_type="batch"
+        )
+        assert result.startswith("batch_"), (
+            f"Expected batch_ prefix for Vertex numeric batch ID, got: {result[:10]}"
+        )
+
+    def test_vertex_numeric_id_defaults_to_file_prefix(self):
+        """Vertex AI numeric IDs should default to file- prefix when id_type is not specified."""
+        result = encode_file_id_with_model("3814889423749775360", "gemini-2.5-pro")
+        assert result.startswith("file-"), (
+            "Default id_type should produce file- prefix for backward compatibility"
+        )
+
+    def test_gcs_uri_gets_file_prefix(self):
+        """GCS URIs (output_file_id) should produce file- prefix."""
+        result = encode_file_id_with_model(
+            "gs://bucket/path/to/file.jsonl", "gemini-2.5-pro"
+        )
+        assert result.startswith("file-")
+
+
+class TestRoundTrip:
+    """Tests for encode -> decode round-trip integrity."""
+
+    def test_roundtrip_openai_file_id(self):
+        """Encode then decode an OpenAI file ID — model and original ID should be recovered."""
+        original = "file-abc123"
+        model = "gpt-4o-litellm"
+        encoded = encode_file_id_with_model(original, model)
+
+        assert decode_model_from_file_id(encoded) == model
+        assert get_original_file_id(encoded) == original
+
+    def test_roundtrip_openai_batch_id(self):
+        """Encode then decode an OpenAI batch ID — model and original ID should be recovered."""
+        original = "batch_abc123"
+        model = "gpt-4o-test"
+        encoded = encode_file_id_with_model(original, model)
+
+        assert decode_model_from_file_id(encoded) == model
+        assert get_original_file_id(encoded) == original
+
+    def test_roundtrip_vertex_numeric_batch_id(self):
+        """Encode then decode a Vertex AI numeric batch ID with id_type='batch'."""
+        original = "3814889423749775360"
+        model = "gemini-2.5-pro"
+        encoded = encode_file_id_with_model(original, model, id_type="batch")
+
+        assert encoded.startswith("batch_")
+        assert decode_model_from_file_id(encoded) == model
+        assert get_original_file_id(encoded) == original
+
+    def test_roundtrip_vertex_gcs_uri_file_id(self):
+        """Encode then decode a Vertex AI GCS URI (output file)."""
+        original = "gs://vertex-bucket/litellm-files/output.jsonl"
+        model = "gemini-2.5-pro"
+        encoded = encode_file_id_with_model(original, model)
+
+        assert encoded.startswith("file-")
+        assert decode_model_from_file_id(encoded) == model
+        assert get_original_file_id(encoded) == original
+
+
+class TestDecodeEdgeCases:
+    """Tests for decode functions with non-encoded inputs."""
+
+    def test_decode_model_returns_none_for_plain_id(self):
+        """Plain (non-encoded) IDs should return None from decode_model_from_file_id."""
+        assert decode_model_from_file_id("batch_abc123") is None
+        assert decode_model_from_file_id("file-abc123") is None
+        assert decode_model_from_file_id("3814889423749775360") is None
+
+    def test_get_original_file_id_returns_input_for_plain_id(self):
+        """Plain (non-encoded) IDs should be returned as-is from get_original_file_id."""
+        assert get_original_file_id("batch_abc123") == "batch_abc123"
+        assert get_original_file_id("file-abc123") == "file-abc123"
+
+    def test_decode_model_handles_non_string(self):
+        """Non-string inputs should return None without raising."""
+        assert decode_model_from_file_id(None) is None  # type: ignore[arg-type]
+        assert decode_model_from_file_id(12345) is None  # type: ignore[arg-type]


### PR DESCRIPTION
Vertex AI batch IDs are plain numeric strings (e.g., "7291054836128473600") unlike OpenAI's "batch_"-prefixed IDs. encode_file_id_with_model() was defaulting to "file-" prefix for unrecognized ID formats, causing Vertex AI batch responses to return IDs like "file-bGl0ZWxsbTox..." instead of the expected "batch_..." prefix per the OpenAI Batch API contract.

Add an optional id_type parameter to encode_file_id_with_model() so the batch creation endpoint can specify id_type="batch" when encoding batch response IDs. Default remains "file" for backward compatibility.

Closes #18192

## Relevant issues

Fixes #18192

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### Problem

When creating a Vertex AI batch via the `/v1/batches` proxy endpoint, the returned batch `id` has a `file-` prefix instead of the expected `batch_` prefix. This happens because Vertex AI batch IDs are plain numeric strings (e.g., `7291054836128473600`) extracted from the Vertex response `name` field, and `encode_file_id_with_model()` defaults to `file-` when the input ID doesn't start with a recognized prefix (`batch_` or `file-`).

### Fix

- **`litellm/proxy/openai_files_endpoints/common_utils.py`**: Added optional `id_type: Literal["file", "batch"] = "file"` parameter to `encode_file_id_with_model()`. When the raw ID lacks a recognizable prefix, the function now uses `id_type` to determine the correct prefix instead of always defaulting to `file-`.

- **`litellm/proxy/batches_endpoints/endpoints.py`**: Pass `id_type="batch"` when encoding the batch response `id`. The `output_file_id` and `error_file_id` keep the default `id_type="file"` since they are semantically file IDs.

### Tests

- **`tests/litellm/proxy/test_model_based_routing_files_batches.py`** (new, 12 tests):
  - Prefix detection: OpenAI file/batch IDs, Vertex numeric batch IDs with `id_type="batch"`, GCS URIs
  - Round-trip encode/decode for all ID formats
  - Edge cases: plain (non-encoded) IDs, non-string inputs