### PR TITLE
fix(ci): drop PAT_TOKEN_2 approval, use github.token for auto-merge

### DIFF
--- a/.github/workflows/regenerate-poetry-lock.yml
+++ b/.github/workflows/regenerate-poetry-lock.yml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   contents: write       # needed to push the auto/regenerate-poetry-lock-* branch
-  pull-requests: write  # needed to open and approve the PR
+  pull-requests: write  # needed to open the PR and enable auto-merge
 
 jobs:
   regenerate-lock:
@@ -72,12 +72,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Approve and enable auto-merge
+      - name: Enable auto-merge
         if: steps.diff.outputs.changed == 'true'
         run: |
-          # Approve with PAT_TOKEN_2 (a different identity from the creator,
-          # since GitHub does not allow a token to approve its own PR).
-          gh pr review "${{ steps.open-pr.outputs.pr_url }}" --approve
-          gh pr merge  "${{ steps.open-pr.outputs.pr_url }}" --auto --squash
+          gh pr merge "${{ steps.open-pr.outputs.pr_url }}" --auto --squash
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN_2 }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

```
failed to create review: GraphQL: Resource not accessible by personal access token (addPullRequestReview)
```

`PAT_TOKEN_2` does not have the scope required to approve PRs. `github.token` cannot approve its own PR either (GitHub blocks self-approval by design).

## Fix

Drop the approval step entirely. Keep only `gh pr merge --auto --squash` with `github.token` — the PR will merge automatically once required CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)