### PR TITLE
fix(anthropic): empty system messages in translate_system_message

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1048,7 +1048,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         anthropic_system_message_list: List[AnthropicSystemMessageContent] = []
         for idx, message in enumerate(messages):
             if message["role"] == "system":
-                valid_content: bool = False
+                system_prompt_indices.append(idx)
                 system_message_block = ChatCompletionSystemMessage(**message)
                 if isinstance(system_message_block["content"], str):
                     # Skip empty text blocks - Anthropic API raises errors for empty text
@@ -1068,7 +1068,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     anthropic_system_message_list.append(
                         anthropic_system_message_content
                     )
-                    valid_content = True
                 elif isinstance(message["content"], list):
                     for _content in message["content"]:
                         # Skip empty text blocks - Anthropic API raises errors for empty text
@@ -1092,10 +1091,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         anthropic_system_message_list.append(
                             anthropic_system_message_content
                         )
-                    valid_content = True
 
-                if valid_content:
-                    system_prompt_indices.append(idx)
         if len(system_prompt_indices) > 0:
             for idx in reversed(system_prompt_indices):
                 messages.pop(idx)

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1739,6 +1739,8 @@ def test_translate_system_message_skips_empty_string_content():
 
     # Empty system message should produce no anthropic content blocks
     assert len(result) == 0
+    # System message must be removed from messages so it doesn't reach anthropic_messages_pt
+    assert all(m["role"] != "system" for m in messages)
 
 
 def test_translate_system_message_skips_empty_list_content():


### PR DESCRIPTION
## Relevant issues

Fixes #21622

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Empty system messages (`{"role": "system", "content": ""}`) were not being removed from the `messages` list in `translate_system_message`. The empty content was correctly skipped for the Anthropic `system` parameter, but the `continue` statement also skipped tracking the index for removal. The leftover system message then reached `anthropic_messages_pt`, which doesn't handle the `"system"` role, causing a `BadRequestError`.

```python
import litellm

litellm.completion(
    model="anthropic/claude-haiku-4-5-20251001",
    messages=[
        {"role": "system", "content": ""},
        {"role": "user", "content": "Hello"},
    ],
)
```

Updated test to verify empty system messages are removed when sending to Anthropic API.