### PR TITLE
fix: handle explicit None model_info in LowestLatencyLoggingHandler

### DIFF
--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -52,7 +52,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                     "model_group", None
                 )
 
-                id = kwargs["litellm_params"].get("model_info", {}).get("id", None)
+                id = (kwargs["litellm_params"].get("model_info") or {}).get("id", None)
                 if model_group is None or id is None:
                     return
                 elif isinstance(id, int):
@@ -204,7 +204,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                         "model_group", None
                     )
 
-                    id = kwargs["litellm_params"].get("model_info", {}).get("id", None)
+                    id = (kwargs["litellm_params"].get("model_info") or {}).get("id", None)
                     if model_group is None or id is None:
                         return
                     elif isinstance(id, int):
@@ -273,7 +273,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                     "model_group", None
                 )
 
-                id = kwargs["litellm_params"].get("model_info", {}).get("id", None)
+                id = (kwargs["litellm_params"].get("model_info") or {}).get("id", None)
                 if model_group is None or id is None:
                     return
                 elif isinstance(id, int):


### PR DESCRIPTION
## Summary

- **Fixes `AttributeError: 'NoneType' object has no attribute 'get'`** in `LowestLatencyLoggingHandler` (`litellm/router_strategy/lowest_latency.py`) on lines 55, 207, and 276
- Uses the `(x or {})` pattern already established in `router.py` (lines 5298, 5419, 5521) to safely handle `model_info` being explicitly `None`

## Steps to Reproduce

**1. Configure the proxy with the `lowest-latency` routing strategy:**

```yaml
router_settings:
  routing_strategy: "latency-based-routing"
```

**2. Define an Anthropic model group with a Vertex AI fallback:**

```yaml
model_list:
  - model_name: claude-sonnet
    litellm_params:
      model: anthropic/claude-sonnet-4-20250514
      api_key: sk-ant-...
  - model_name: claude-sonnet-vertex
    litellm_params:
      model: vertex_ai/claude-sonnet-4@20250514
      vertex_project: my-project
      vertex_location: us-east5

  fallbacks:
    - claude-sonnet: ["claude-sonnet-vertex"]
```

**3. Send a request that causes the primary Anthropic model to fail** (e.g., the Anthropic API key has hit its usage limit):

```
POST /v1/messages
{
  "model": "claude-sonnet",
  "messages": [{"role": "user", "content": "Hello"}]
}
```

Anthropic returns:
```json
{"type": "error", "error": {"type": "invalid_request_error", "message": "You have reached your specified API usage limits."}}
```

**4. The router falls back to the Vertex AI deployment, which succeeds.**

**5. Bug is triggered:** The `log_success_event` callback in `LowestLatencyLoggingHandler` fires for the successful Vertex AI response, but `litellm_params["model_info"]` is explicitly `None` (set in `get_litellm_params.py:112`), causing:

```
AttributeError: 'NoneType' object has no attribute 'get'
  File "litellm/router_strategy/lowest_latency.py", line 55, in log_success_event
    id = kwargs["litellm_params"].get("model_info", {}).get("id", None)
```

## Root Cause

When `model_info` is not provided to a request, `get_litellm_params()` in `litellm/litellm_core_utils/get_litellm_params.py:112` stores it as an **explicit `None`** value — the key exists, but its value is `None`.

The pattern `.get("model_info", {})` only uses the default `{}` when the key is **missing**. When the key is present with a `None` value, it returns `None`, and then `None.get("id")` raises `AttributeError`.

## Impact

The error is caught by the existing `try/except` so it's non-fatal, but **latency tracking silently fails** for these requests. Over time, this degrades the quality of lowest-latency routing decisions since the strategy loses visibility into successful fallback response times.

## Fix

Changed 3 lines from:
```python
id = kwargs["litellm_params"].get("model_info", {}).get("id", None)
```
to:
```python
id = (kwargs["litellm_params"].get("model_info") or {}).get("id", None)
```

This matches the safe pattern already used in `router.py` (lines 5298, 5419, 5521).

## Test plan

- [x] Verified the fix handles `model_info=None` without raising `AttributeError`
- [x] Verified existing behavior is preserved when `model_info` is a valid dict
- [x] Verified existing behavior is preserved when `model_info` key is missing
