### PR TITLE
fix: guard against str response from Azure before calling model_dump()

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -343,6 +343,11 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 headers, response = self.make_sync_azure_openai_chat_completion_request(
                     azure_client=azure_client, data=data, timeout=timeout
                 )
+                if isinstance(response, str):
+                    raise AzureOpenAIError(
+                        status_code=500,
+                        message=f"Unexpected string response from Azure: {response[:500]}",
+                    )
                 stringified_response = response.model_dump()
                 ## LOGGING
                 logging_obj.post_call(
@@ -432,6 +437,11 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             )
             logging_obj.model_call_details["response_headers"] = headers
 
+            if isinstance(response, str):
+                raise AzureOpenAIError(
+                    status_code=500,
+                    message=f"Unexpected string response from Azure: {response[:500]}",
+                )
             stringified_response = response.model_dump()
             logging_obj.post_call(
                 input=data["messages"],
@@ -690,7 +700,11 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     status_code=raw_response.status_code or 500,
                     message=f"Failed to parse raw Azure embedding response: {str(json_error)}"
                 ) from json_error
-            
+            if isinstance(response, str):
+                raise AzureOpenAIError(
+                    status_code=raw_response.status_code or 500,
+                    message=f"Unexpected string response from Azure: {response[:500]}",
+                )
             stringified_response = response.model_dump()
 
             ## LOGGING
@@ -792,6 +806,11 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             raw_response = azure_client.embeddings.with_raw_response.create(**data, timeout=timeout)  # type: ignore
             headers = dict(raw_response.headers)
             response = raw_response.parse()
+            if isinstance(response, str):
+                raise AzureOpenAIError(
+                    status_code=raw_response.status_code or 500,
+                    message=f"Unexpected string response from Azure: {response[:500]}",
+                )
             ## LOGGING
             logging_obj.post_call(
                 input=input,


### PR DESCRIPTION
## Summary

- **Fixes `AttributeError: 'str' object has no attribute 'model_dump'`** in `AzureChatCompletion` (`litellm/llms/azure/azure.py`)
- Adds `isinstance(response, str)` type guards before all 4 `response.model_dump()` call sites in the Azure chat completion and embedding paths

## Steps to Reproduce

**1. Configure the proxy with an Azure OpenAI deployment:**

```yaml
model_list:
  - model_name: gpt-4
    litellm_params:
      model: azure/gpt-4
      api_key: os.environ/AZURE_API_KEY
      api_base: https://my-deployment.openai.azure.com/
      api_version: "2024-06-01"
```

**2. Trigger a condition where Azure returns a non-JSON response.** This can happen when:
- Azure returns an HTML error page (e.g., proxy/gateway error)
- Azure returns a `text/plain` content type instead of `application/json`
- A network intermediary (load balancer, WAF) intercepts the request and returns a non-JSON response

**3. Send a chat completion request:**

```
POST /chat/completions
{
  "model": "gpt-4",
  "messages": [{"role": "user", "content": "Hello"}]
}
```

**4. Bug is triggered:** The OpenAI SDK's `raw_response.parse()` returns the raw response text as a plain `str` (instead of a `ChatCompletion` Pydantic model) when the response content type is not JSON. Then `response.model_dump()` fails:

```
AttributeError: 'str' object has no attribute 'model_dump'
  File "litellm/llms/azure/azure.py", line 429, in acompletion
    stringified_response = response.model_dump()
```

## Production Log Evidence

Observed in production on Feb 9, 2026 (2 occurrences at the same timestamp, likely a retry):

```
Traceback (most recent call last):
  File "litellm/llms/azure/azure.py", line 429, in acompletion
    stringified_response = response.model_dump()
                           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'model_dump'
```

Which gets caught and re-raised as:

```
Traceback (most recent call last):
  File "litellm/llms/azure/azure.py", line 475, in acompletion
    raise AzureOpenAIError(status_code=500, message=message, body=body)
litellm.llms.azure.common_utils.AzureOpenAIError: 'str' object has no attribute 'model_dump'
```

The original `AttributeError` masks the real problem (a non-JSON Azure response), making it difficult to debug.

## Root Cause

The OpenAI SDK's `APIResponse._parse()` method has a fallback path ([source](https://github.com/openai/openai-python/blob/main/src/openai/_response.py)):

```python
# If the API responds with content that isn't JSON then we just return
# the (decoded) text without performing any parsing so that you can still
# handle the response however you need to.
return response.text  # returns a str
```

This means `raw_response.parse()` can return a `str` when Azure returns a non-JSON content type. LiteLLM then calls `response.model_dump()` on this `str`, which raises `AttributeError`.

## Fix

Added `isinstance(response, str)` guards before all 4 `response.model_dump()` call sites:

```python
if isinstance(response, str):
    raise AzureOpenAIError(
        status_code=500,
        message=f"Unexpected string response from Azure: {response[:500]}",
    )
stringified_response = response.model_dump()
```

**Affected locations (4):**
- Line 346: sync `completion()` — chat completions
- Line 435: async `acompletion()` — chat completions (the one observed in production)
- Line 694: async `aembedding()` — embeddings
- Line 803: sync `embedding()` — embeddings

This converts the opaque `AttributeError` into a clear `AzureOpenAIError` that includes the first 500 characters of the unexpected response body, making it much easier to diagnose what Azure actually returned.

## Test plan

- [x] Existing Azure exception mapping tests pass
- [x] Existing Azure chat transformation tests pass (26 tests)
- [x] Verified fix raises `AzureOpenAIError` with descriptive message when `response` is a `str`
- [x] Verified normal behavior is preserved when `response` is a valid Pydantic model
