### PR TITLE
[Fix] /get_image Ignores UI_LOGO_PATH When cached_logo.jpg Exists

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10694,12 +10694,16 @@ async def get_image():
     cache_dir = assets_dir if os.access(assets_dir, os.W_OK) else current_dir
     cache_path = os.path.join(cache_dir, "cached_logo.jpg")
 
-    # [OPTIMIZATION] Check if the cached image exists first
-    if os.path.exists(cache_path):
-        return FileResponse(cache_path, media_type="image/jpeg")
-
     logo_path = os.getenv("UI_LOGO_PATH", default_logo)
     verbose_proxy_logger.debug("Reading logo from path: %s", logo_path)
+
+    # If UI_LOGO_PATH points to a local file, serve it directly (skip cache)
+    if logo_path != default_logo and not logo_path.startswith(("http://", "https://")):
+        return FileResponse(logo_path, media_type="image/jpeg")
+
+    # [OPTIMIZATION] For HTTP URLs and default logo, check if the cached image exists
+    if os.path.exists(cache_path):
+        return FileResponse(cache_path, media_type="image/jpeg")
 
     # Check if the logo path is an HTTP/HTTPS URL
     if logo_path.startswith(("http://", "https://")):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10699,7 +10699,9 @@ async def get_image():
 
     # If UI_LOGO_PATH points to a local file, serve it directly (skip cache)
     if logo_path != default_logo and not logo_path.startswith(("http://", "https://")):
-        return FileResponse(logo_path, media_type="image/jpeg")
+        if os.path.exists(logo_path):
+            return FileResponse(logo_path, media_type="image/jpeg")
+        # Fall through to cache or default if custom path doesn't exist
 
     # [OPTIMIZATION] For HTTP URLs and default logo, check if the cached image exists
     if os.path.exists(cache_path):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10701,7 +10701,11 @@ async def get_image():
     if logo_path != default_logo and not logo_path.startswith(("http://", "https://")):
         if os.path.exists(logo_path):
             return FileResponse(logo_path, media_type="image/jpeg")
-        # Fall through to cache or default if custom path doesn't exist
+        # Custom path doesn't exist — fall back to default
+        verbose_proxy_logger.warning(
+            f"UI_LOGO_PATH '{logo_path}' does not exist, falling back to default logo"
+        )
+        logo_path = default_logo
 
     # [OPTIMIZATION] For HTTP URLs and default logo, check if the cached image exists
     if os.path.exists(cache_path):


### PR DESCRIPTION
## Relevant issues

Custom `UI_LOGO_PATH` environment variable is ignored when a `cached_logo.jpg` file already exists in the base Docker image.

## Summary

### Failure Path (Before Fix)

The `/get_image` endpoint checked for `cached_logo.jpg` **before** reading the `UI_LOGO_PATH` environment variable. Since the base Docker image ships with a pre-baked `cached_logo.jpg` (the default logo), the cache was always returned — the custom logo was never served regardless of `UI_LOGO_PATH`.

### Fix

Read `UI_LOGO_PATH` before the cache check. When it points to a local file, serve it directly and bypass the cache. The cache optimization is preserved for HTTP URLs and the default logo where downloading/caching is actually beneficial.

## Testing

- Added `test_get_image_custom_local_logo_bypasses_cache` — verifies a custom local `UI_LOGO_PATH` is served directly, not the stale cache
- Added `test_get_image_default_logo_still_uses_cache` — verifies the cache optimization still works for the default logo
- All existing `get_image` tests continue to pass

Tested locally by building docker file and setting a custom image

## Type

🐛 Bug Fix
✅ Test