### PR TITLE
fix(policy): use litellm.acompletion directly in AiPolicySuggester

### DIFF
--- a/litellm/proxy/management_endpoints/policy_endpoints/ai_policy_suggester.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints/ai_policy_suggester.py
@@ -6,6 +6,7 @@ based on user-provided attack examples and descriptions.
 import json
 from typing import List, Optional
 
+import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import DEFAULT_COMPETITOR_DISCOVERY_MODEL
 
@@ -56,17 +57,12 @@ class AiPolicySuggester:
         description: str,
         model: Optional[str] = None,
     ) -> dict:
-        from litellm.proxy.proxy_server import llm_router
-
-        if llm_router is None:
-            raise ValueError("LLM router not initialized")
-
         system_prompt = self._build_system_prompt(templates)
         user_prompt = self._build_user_prompt(attack_examples, description)
         model = model or DEFAULT_COMPETITOR_DISCOVERY_MODEL
 
         try:
-            response = await llm_router.acompletion(
+            response = await litellm.acompletion(
                 model=model,
                 messages=[
                     {"role": "system", "content": system_prompt},


### PR DESCRIPTION
## Problem

Not related to PR #21634.

All 4 async tests in `test_ai_policy_suggester.py` fail with:
```
ValueError: LLM router not initialized
```

`suggest()` was importing and calling `llm_router.acompletion()` from the proxy server, which is `None` unless a full proxy router is configured — it's never set in unit tests.

## Root cause

```python
# before
from litellm.proxy.proxy_server import llm_router
if llm_router is None:
    raise ValueError("LLM router not initialized")
response = await llm_router.acompletion(...)
```

`AiPolicySuggester` is a self-contained feature that calls an LLM directly. It has no need for proxy routing. The tests already correctly mock `litellm.acompletion`.

## Fix

```python
# after
import litellm
response = await litellm.acompletion(...)
```

Remove the `llm_router` dependency entirely.

## Tests

```
10 passed in 0.40s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)