### PR TITLE
fix(lint): remove unused imports in semantic_guard and policy_endpoints

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/semantic_guard/semantic_guard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/semantic_guard/semantic_guard.py
@@ -26,7 +26,6 @@ except ImportError:
 
 if TYPE_CHECKING:
     from semantic_router.routers import SemanticRouter
-    from semantic_router.schema import RouteChoice
 
     from litellm.caching import DualCache
     from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth

--- a/litellm/proxy/management_endpoints/policy_endpoints/__init__.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints/__init__.py
@@ -8,6 +8,3 @@ are imported directly into this namespace.
 """
 
 from litellm.proxy.management_endpoints.policy_endpoints.endpoints import *  # noqa: F401, F403
-from litellm.proxy.management_endpoints.policy_endpoints.endpoints import (
-    router,
-)


### PR DESCRIPTION
## Summary

- Remove unused `RouteChoice` import from `semantic_guard.py` TYPE_CHECKING block — it is only referenced in a docstring, never used as a type annotation
- Remove redundant explicit `router` import from `policy_endpoints/__init__.py` — already re-exported by the `import *` on the preceding line

## Root cause

Two Ruff `F401` (unused import) errors were caught by CI linting. Neither file is part of PR #21638; these are pre-existing issues fixed here in a scoped PR.

## Test plan

- [x] `ruff check` passes on both changed files — no F401 errors
- [x] No logic changes; purely removing dead import statements