### PR TITLE
feat(bedrock): support optional regional STS endpoint in role assumption

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -735,6 +735,7 @@ class BaseAWSLLM:
         region: str,
         web_identity_token_file: str,
         aws_external_id: Optional[str] = None,
+        aws_sts_endpoint: Optional[str] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> dict:
         """Handle cross-account role assumption for IRSA."""
@@ -746,11 +747,13 @@ class BaseAWSLLM:
         with open(web_identity_token_file, "r") as f:
             web_identity_token = f.read().strip()
 
+        irsa_sts_kwargs: dict = {"region_name": region, "verify": self._get_ssl_verify(ssl_verify)}
+        if aws_sts_endpoint is not None:
+            irsa_sts_kwargs["endpoint_url"] = aws_sts_endpoint
+
         # Create an STS client without credentials
         with tracer.trace("boto3.client(sts) for manual IRSA"):
-            sts_client = boto3.client(
-                "sts", region_name=region, verify=self._get_ssl_verify(ssl_verify)
-            )
+            sts_client = boto3.client("sts", **irsa_sts_kwargs)
 
         # Manually assume the IRSA role with the session name
         verbose_logger.debug(
@@ -769,11 +772,10 @@ class BaseAWSLLM:
         with tracer.trace("boto3.client(sts) with manual IRSA credentials"):
             sts_client_with_creds = boto3.client(
                 "sts",
-                region_name=region,
                 aws_access_key_id=irsa_creds["AccessKeyId"],
                 aws_secret_access_key=irsa_creds["SecretAccessKey"],
                 aws_session_token=irsa_creds["SessionToken"],
-                verify=self._get_ssl_verify(ssl_verify),
+                **irsa_sts_kwargs,
             )
 
         # Get current caller identity for debugging
@@ -806,16 +808,19 @@ class BaseAWSLLM:
         aws_session_name: str,
         region: str,
         aws_external_id: Optional[str] = None,
+        aws_sts_endpoint: Optional[str] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> dict:
         """Handle same-account role assumption for IRSA."""
         import boto3
 
+        irsa_sts_kwargs: dict = {"region_name": region, "verify": self._get_ssl_verify(ssl_verify)}
+        if aws_sts_endpoint is not None:
+            irsa_sts_kwargs["endpoint_url"] = aws_sts_endpoint
+
         verbose_logger.debug("Same account role assumption, using automatic IRSA")
         with tracer.trace("boto3.client(sts) with automatic IRSA"):
-            sts_client = boto3.client(
-                "sts", region_name=region, verify=self._get_ssl_verify(ssl_verify)
-            )
+            sts_client = boto3.client("sts", **irsa_sts_kwargs)
 
         # Get current caller identity for debugging
         try:
@@ -884,6 +889,8 @@ class BaseAWSLLM:
         web_identity_token_file = os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE")
         irsa_role_arn = os.getenv("AWS_ROLE_ARN")
 
+        region = aws_region_name or os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+
         # If we have IRSA environment variables and no explicit credentials,
         # we need to use the web identity token flow
         if (
@@ -899,12 +906,8 @@ class BaseAWSLLM:
             )
 
             try:
-                # Get region from environment
-                region = (
-                    os.getenv("AWS_REGION")
-                    or os.getenv("AWS_DEFAULT_REGION")
-                    or "us-east-1"
-                )
+                # Use passed-in region when set, else env, else default (align with AssumeRole path)
+                region = region or "us-east-1"
 
                 # Check if we need to do cross-account role assumption
                 if aws_role_name != irsa_role_arn:
@@ -915,6 +918,7 @@ class BaseAWSLLM:
                         region,
                         web_identity_token_file,
                         aws_external_id,
+                        aws_sts_endpoint=aws_sts_endpoint,
                         ssl_verify=ssl_verify,
                     )
                 else:
@@ -923,6 +927,7 @@ class BaseAWSLLM:
                         aws_session_name,
                         region,
                         aws_external_id,
+                        aws_sts_endpoint=aws_sts_endpoint,
                         ssl_verify=ssl_verify,
                     )
 
@@ -945,8 +950,8 @@ class BaseAWSLLM:
         # In EKS/IRSA environments, use ambient credentials (no explicit keys needed)
         # This allows the web identity token to work automatically
         sts_client_kwargs: dict = {"verify": self._get_ssl_verify(ssl_verify)}
-        if aws_region_name is not None:
-            sts_client_kwargs["region_name"] = aws_region_name
+        if region is not None:
+            sts_client_kwargs["region_name"] = region
         if aws_sts_endpoint is not None:
             sts_client_kwargs["endpoint_url"] = aws_sts_endpoint
         if aws_access_key_id is None and aws_secret_access_key is None:

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -942,22 +942,20 @@ class BaseAWSLLM:
 
         # In EKS/IRSA environments, use ambient credentials (no explicit keys needed)
         # This allows the web identity token to work automatically
+        sts_client_kwargs: dict = {"verify": self._get_ssl_verify(ssl_verify)}
+        if aws_region_name is not None:
+            sts_client_kwargs["region_name"] = aws_region_name
         if aws_access_key_id is None and aws_secret_access_key is None:
             with tracer.trace("boto3.client(sts)"):
-                sts_client = boto3.client(
-                    "sts",
-                    region_name=aws_region_name,
-                    verify=self._get_ssl_verify(ssl_verify)
-                )
+                sts_client = boto3.client("sts", **sts_client_kwargs)
         else:
             with tracer.trace("boto3.client(sts)"):
                 sts_client = boto3.client(
                     "sts",
-                    region_name=aws_region_name,
                     aws_access_key_id=aws_access_key_id,
                     aws_secret_access_key=aws_secret_access_key,
                     aws_session_token=aws_session_token,
-                    verify=self._get_ssl_verify(ssl_verify),
+                    **sts_client_kwargs,
                 )
 
         assume_role_params = {

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -234,6 +234,7 @@ class BaseAWSLLM:
                     aws_session_token=aws_session_token,
                     aws_role_name=aws_role_name,
                     aws_session_name=aws_session_name,
+                    aws_region_name=aws_region_name,
                     aws_external_id=aws_external_id,
                     ssl_verify=ssl_verify,
                 )
@@ -867,6 +868,7 @@ class BaseAWSLLM:
         aws_session_token: Optional[str],
         aws_role_name: str,
         aws_session_name: str,
+        aws_region_name: Optional[str] = None,
         aws_external_id: Optional[str] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> Tuple[Credentials, Optional[int]]:
@@ -943,12 +945,15 @@ class BaseAWSLLM:
         if aws_access_key_id is None and aws_secret_access_key is None:
             with tracer.trace("boto3.client(sts)"):
                 sts_client = boto3.client(
-                    "sts", verify=self._get_ssl_verify(ssl_verify)
+                    "sts",
+                    region_name=aws_region_name,
+                    verify=self._get_ssl_verify(ssl_verify)
                 )
         else:
             with tracer.trace("boto3.client(sts)"):
                 sts_client = boto3.client(
                     "sts",
+                    region_name=aws_region_name,
                     aws_access_key_id=aws_access_key_id,
                     aws_secret_access_key=aws_secret_access_key,
                     aws_session_token=aws_session_token,

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -235,6 +235,7 @@ class BaseAWSLLM:
                     aws_role_name=aws_role_name,
                     aws_session_name=aws_session_name,
                     aws_region_name=aws_region_name,
+                    aws_sts_endpoint=aws_sts_endpoint,
                     aws_external_id=aws_external_id,
                     ssl_verify=ssl_verify,
                 )
@@ -869,6 +870,7 @@ class BaseAWSLLM:
         aws_role_name: str,
         aws_session_name: str,
         aws_region_name: Optional[str] = None,
+        aws_sts_endpoint: Optional[str] = None,
         aws_external_id: Optional[str] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> Tuple[Credentials, Optional[int]]:
@@ -945,6 +947,8 @@ class BaseAWSLLM:
         sts_client_kwargs: dict = {"verify": self._get_ssl_verify(ssl_verify)}
         if aws_region_name is not None:
             sts_client_kwargs["region_name"] = aws_region_name
+        if aws_sts_endpoint is not None:
+            sts_client_kwargs["endpoint_url"] = aws_sts_endpoint
         if aws_access_key_id is None and aws_secret_access_key is None:
             with tracer.trace("boto3.client(sts)"):
                 sts_client = boto3.client("sts", **sts_client_kwargs)

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -548,9 +548,6 @@ def test_eks_irsa_ambient_credentials_used():
     """
     base_aws_llm = BaseAWSLLM()
     
-    # Mock the boto3 STS client
-    mock_sts_client = MagicMock()
-    
     # Mock the STS response with proper expiration handling
     mock_expiry = MagicMock()
     mock_expiry.tzinfo = timezone.utc
@@ -568,6 +565,9 @@ def test_eks_irsa_ambient_credentials_used():
             "Expiration": mock_expiry,
         }
     }
+    
+    # Case 1: only aws_role_name and aws_session_name (no aws_region_name)
+    mock_sts_client = MagicMock()
     mock_sts_client.assume_role.return_value = mock_sts_response
     
     with patch("boto3.client", return_value=mock_sts_client) as mock_boto3_client:
@@ -588,13 +588,31 @@ def test_eks_irsa_ambient_credentials_used():
         # Should call assume_role
         mock_sts_client.assume_role.assert_called_once_with(
             RoleArn="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole",
-            RoleSessionName="test-session"
+            RoleSessionName="test-session",
         )
         
         # Verify credentials are returned correctly
         assert credentials.access_key == "assumed-access-key"
-        assert credentials.secret_key == "assumed-secret-key"
-        assert credentials.token == "assumed-session-token"
+        assert ttl is not None
+
+    # Case 2: aws_role_name, aws_session_name, and aws_region_name (regional STS)
+    mock_sts_client2 = MagicMock()
+    mock_sts_client2.assume_role.return_value = mock_sts_response
+    with patch("boto3.client", return_value=mock_sts_client2) as mock_boto3_client:
+        credentials, ttl = base_aws_llm._auth_with_aws_role(
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            aws_role_name="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole",
+            aws_session_name="test-session",
+            aws_region_name="us-east-1",
+        )
+        mock_boto3_client.assert_called_once_with("sts", region_name="us-east-1", verify=True)
+        mock_sts_client2.assume_role.assert_called_once_with(
+            RoleArn="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole",
+            RoleSessionName="test-session",
+        )
+        assert credentials.access_key == "assumed-access-key"
         assert ttl is not None
 
 

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -555,9 +555,15 @@ def test_different_roles_without_session_names_should_not_share_cache():
 )
 def test_eks_irsa_ambient_credentials_used(role_kwargs, expected_client_kwargs):
     """
-    When only aws_role_name and aws_session_name are passed (no explicit creds),
-    boto3.client("sts", **expected) is called with no credential kwargs.
+    Test that in EKS/IRSA environments, ambient credentials are used when no explicit keys provided.
+    This allows web identity tokens to work automatically.
     """
+    # Isolate from ambient AWS_REGION/AWS_DEFAULT_REGION so no_region_or_endpoint is deterministic
+    env_without_aws_region = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("AWS_REGION", "AWS_DEFAULT_REGION")
+    }
     base_aws_llm = BaseAWSLLM()
     mock_expiry = MagicMock()
     mock_expiry.tzinfo = timezone.utc
@@ -575,22 +581,25 @@ def test_eks_irsa_ambient_credentials_used(role_kwargs, expected_client_kwargs):
     mock_sts_client = MagicMock()
     mock_sts_client.assume_role.return_value = mock_sts_response
 
-    with patch("boto3.client", return_value=mock_sts_client) as mock_boto3_client:
-        credentials, ttl = base_aws_llm._auth_with_aws_role(
-            aws_access_key_id=None,
-            aws_secret_access_key=None,
-            aws_session_token=None,
-            aws_role_name="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole",
-            aws_session_name="test-session",
-            **role_kwargs,
-        )
-        mock_boto3_client.assert_called_once_with("sts", **expected_client_kwargs)
-        mock_sts_client.assume_role.assert_called_once_with(
-            RoleArn="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole",
-            RoleSessionName="test-session",
-        )
-        assert credentials.access_key == "assumed-access-key"
-        assert ttl is not None
+    with patch.dict(os.environ, env_without_aws_region, clear=True):
+        with patch("boto3.client", return_value=mock_sts_client) as mock_boto3_client:
+            credentials, ttl = base_aws_llm._auth_with_aws_role(
+                aws_access_key_id=None,
+                aws_secret_access_key=None,
+                aws_session_token=None,
+                aws_role_name="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole",
+                aws_session_name="test-session",
+                **role_kwargs,
+            )
+            mock_boto3_client.assert_called_once_with(
+                "sts", **expected_client_kwargs
+            )
+            mock_sts_client.assume_role.assert_called_once_with(
+                RoleArn="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole",
+                RoleSessionName="test-session",
+            )
+            assert credentials.access_key == "assumed-access-key"
+            assert ttl is not None
 
 
 @pytest.mark.parametrize(
@@ -632,9 +641,13 @@ def test_explicit_credentials_used_when_provided(role_kwargs, expected_client_kw
     """
     Test that explicit credentials are used when provided (non-EKS/IRSA scenario).
     """
+    # Isolate from ambient AWS_REGION/AWS_DEFAULT_REGION so no_region_or_endpoint is deterministic
+    env_without_aws_region = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("AWS_REGION", "AWS_DEFAULT_REGION")
+    }
     base_aws_llm = BaseAWSLLM()
-        
-    # Mock the STS response with proper expiration handling
     mock_expiry = MagicMock()
     mock_expiry.tzinfo = timezone.utc
     # Create a timedelta object that returns 3600 when total_seconds() is called
@@ -652,24 +665,27 @@ def test_explicit_credentials_used_when_provided(role_kwargs, expected_client_kw
     mock_sts_client = MagicMock()
     mock_sts_client.assume_role.return_value = mock_sts_response
 
-    with patch("boto3.client", return_value=mock_sts_client) as mock_boto3_client:
-        credentials, ttl = base_aws_llm._auth_with_aws_role(
-            aws_access_key_id="explicit-access-key",
-            aws_secret_access_key="explicit-secret-key",
-            aws_session_token="assumed-session-token",
-            aws_role_name="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole",
-            aws_session_name="test-session",
-            **role_kwargs
-        )
-        mock_boto3_client.assert_called_once_with("sts", **expected_client_kwargs)
-        mock_sts_client.assume_role.assert_called_once_with(
-            RoleArn="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole",
-            RoleSessionName="test-session"
-        )
-        assert credentials.access_key == "assumed-access-key"
-        assert credentials.secret_key == "assumed-secret-key"
-        assert credentials.token == "assumed-session-token"
-        assert ttl is not None
+    with patch.dict(os.environ, env_without_aws_region, clear=True):
+        with patch("boto3.client", return_value=mock_sts_client) as mock_boto3_client:
+            credentials, ttl = base_aws_llm._auth_with_aws_role(
+                aws_access_key_id="explicit-access-key",
+                aws_secret_access_key="explicit-secret-key",
+                aws_session_token="assumed-session-token",
+                aws_role_name="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole",
+                aws_session_name="test-session",
+                **role_kwargs,
+            )
+            mock_boto3_client.assert_called_once_with(
+                "sts", **expected_client_kwargs
+            )
+            mock_sts_client.assume_role.assert_called_once_with(
+                RoleArn="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole",
+                RoleSessionName="test-session",
+            )
+            assert credentials.access_key == "assumed-access-key"
+            assert credentials.secret_key == "assumed-secret-key"
+            assert credentials.token == "assumed-session-token"
+            assert ttl is not None
 
 
 def test_partial_credentials_still_use_ambient():


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

Add optional **regional STS** and **custom STS endpoint** support for AWS role assumption.

- `aws_region_name` — When set, the STS client is created with that region (e.g. `us-east-1`). When not set, `region_name` is not passed to `boto3.client("sts", ...)` and behavior is unchanged. Combined with environment variable `AWS_STS_REGIONAL_ENDPOINTS=regional`, this field would direct assume role requests to the regional STS endpoint. 
- `aws_sts_endpoint` — When set, the STS client uses the specified URL (e.g. `https://sts.us-east-1.amazonaws.com`), so callers can force a regional or global STS endpoint without relying on `AWS_STS_REGIONAL_ENDPOINTS`. When not set, no `endpoint_url` is passed.

### What changed
- `_auth_with_aws_role` in [litellm/llms/bedrock/base_aws_llm.py](https://github.com/BerriAI/litellm/blob/v1.81.13/litellm/llms/bedrock/base_aws_llm.py) - New optional parameters: `aws_region_name: Optional[str] = None` and `aws_sts_endpoint: Optional[str] = None`. Region is resolved once as `region = aws_region_name or os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")` and used for both the IRSA and AssumeRole path. STS client is built from a kwargs dict: `verify` is always set; `region_name` and `endpoint_url` are added only when the corresponding parameter is not `None`, so existing call sites stay unchanged.
- IRSA handlers — `_handle_irsa_cross_account` and `_handle_irsa_same_account` now accept `aws_sts_endpoint: Optional[str] = None` and use it when creating STS clients (both the no-creds and with-creds clients in cross-account, and the single client in same-account). Callers in IRSA environments can use regional or custom STS endpoints for assume-role.
- Tests
    - `test_eks_irsa_ambient_credentials_used` is now parametrized with three cases: (1) no region or endpoint, (2) `aws_region_name="us-east-1"`, (3) `aws_sts_endpoint="https://sts.eu-west-1.amazonaws.com"`. Each case asserts `boto3.client("sts", **expected_kwargs)` is called with no credential `kwargs` (ambient path).
    - `test_explicit_credentials_used_when_provided` is parametrized the same way for explicit credentials: (1) no extra, (2) `aws_region_name="us-east-1"`, (3) `aws_sts_endpoint="https://sts.eu-west-1.amazonaws.com".`

### Why
- Regional STS — Some environments require or prefer a regional STS endpoint (e.g. `sts.us-east-1.amazonaws.com`) instead of the global one for assume-role. Passing `aws_region_name` grants users the flexibility to target that endpoint.
- Explicit STS endpoint — When `AWS_STS_REGIONAL_ENDPOINTS` is not set, the SDK may still use the global STS endpoint. Passing `aws_sts_endpoint` forces the client to use that URL from code. In the reverse case, this also allows users to target the global endpoint for certain models when `AWS_STS_REGIONAL_ENDPOINTS` is set, allowing more flexibility.