### PR TITLE
fix(tests): set premium_user=True in JWT tests that call user_api_key_auth

### DIFF
--- a/tests/proxy_unit_tests/test_jwt.py
+++ b/tests/proxy_unit_tests/test_jwt.py
@@ -418,6 +418,7 @@ async def test_team_token_output(prisma_client, audience, monkeypatch):
 
     ## 1. INITIAL TEAM CALL - should fail
     # use generated key to auth in
+    setattr(litellm.proxy.proxy_server, "premium_user", True)
     setattr(
         litellm.proxy.proxy_server,
         "general_settings",
@@ -840,6 +841,7 @@ async def test_allowed_routes_admin(
 
         ## 1. INITIAL TEAM CALL - should fail
         # use generated key to auth in
+        setattr(litellm.proxy.proxy_server, "premium_user", True)
         setattr(
             litellm.proxy.proxy_server,
             "general_settings",
@@ -1014,6 +1016,7 @@ async def test_allow_access_by_email(
 
     ## 1. INITIAL TEAM CALL - should fail
     # use generated key to auth in
+    setattr(litellm.proxy.proxy_server, "premium_user", True)
     setattr(
         litellm.proxy.proxy_server,
         "general_settings",
@@ -1175,6 +1178,7 @@ async def test_end_user_jwt_auth(monkeypatch):
         ),
     )
     
+    setattr(litellm.proxy.proxy_server, "premium_user", True)
     setattr(
         litellm.proxy.proxy_server,
         "general_settings",


### PR DESCRIPTION
## Summary

Four JWT tests in `tests/proxy_unit_tests/test_jwt.py` were failing with:

```
ValueError: JWT Auth is an enterprise only feature. You must be a LiteLLM Enterprise user...
```

Because `user_api_key_auth` gates `enable_jwt_auth` behind the enterprise license check:

```python
if general_settings.get("enable_jwt_auth", False) is True:
    if premium_user is not True:
        raise ValueError("JWT Auth is an enterprise only feature. ...")
```

The tests set `enable_jwt_auth: True` but did not set `premium_user = True`, causing them to hit the gate instead of testing JWT logic.

## Fix

Add `setattr(litellm.proxy.proxy_server, "premium_user", True)` immediately before the `general_settings` setattr in each failing test — the same pattern used by PR #21285.

**Affected tests:**
- `test_team_token_output`
- `test_allowed_routes_admin`
- `test_allow_access_by_email`
- `test_end_user_jwt_auth`

## Relation to PR #21634

These failures are **not related to PR #21634** (which only touches `litellm/llms/azure/azure.py`). The same test failures are present on `main` independently.

## Test plan

- [x] `test_allow_access_by_email[ishaan@berri.ai-True]` passes locally after fix
- [x] `test_end_user_jwt_auth` passes locally after fix
- [x] `test_team_token_output` and `test_allowed_routes_admin` require a live DB (CI) — the enterprise gate was the first failure; fixing it unblocks the JWT logic tests