### PR TITLE
fix(model-pricing): add missing fireworks_ai model pricing for glm-4p7, minimax-m2p1, kimi-k2p5

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12621,6 +12621,21 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
+    "fireworks_ai/accounts/fireworks/models/glm-4p7": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 202800,
+        "max_output_tokens": 202800,
+        "max_tokens": 202800,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-06,
+        "source": "https://fireworks.ai/models/fireworks/glm-4p7",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "fireworks_ai/accounts/fireworks/models/gpt-oss-120b": {
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "fireworks_ai",
@@ -12805,6 +12820,20 @@
         "supports_response_schema": true,
         "supports_tool_choice": false
     },
+    "fireworks_ai/accounts/fireworks/models/minimax-m2p1": {
+        "cache_read_input_token_cost": 3e-08,
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 204800,
+        "max_tokens": 204800,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://fireworks.ai/models/fireworks/minimax-m2p1",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "fireworks_ai/accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
         "input_cost_per_token": 1.2e-06,
         "litellm_provider": "fireworks_ai",
@@ -12856,6 +12885,49 @@
         "supports_function_calling": false,
         "supports_response_schema": true,
         "supports_tool_choice": false
+    },
+    "fireworks_ai/glm-4p7": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 202800,
+        "max_output_tokens": 202800,
+        "max_tokens": 202800,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-06,
+        "source": "https://fireworks.ai/models/fireworks/glm-4p7",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "fireworks_ai/kimi-k2p5": {
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://fireworks.ai/pricing",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "fireworks_ai/minimax-m2p1": {
+        "cache_read_input_token_cost": 3e-08,
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 204800,
+        "max_tokens": 204800,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://fireworks.ai/models/fireworks/minimax-m2p1",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "fireworks_ai/nomic-ai/nomic-embed-text-v1": {
         "input_cost_per_token": 8e-09,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12705,6 +12705,7 @@
         "supports_web_search": true
     },
     "fireworks_ai/accounts/fireworks/models/kimi-k2p5": {
+        "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12621,6 +12621,21 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
+    "fireworks_ai/accounts/fireworks/models/glm-4p7": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 202800,
+        "max_output_tokens": 202800,
+        "max_tokens": 202800,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-06,
+        "source": "https://fireworks.ai/models/fireworks/glm-4p7",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "fireworks_ai/accounts/fireworks/models/gpt-oss-120b": {
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "fireworks_ai",
@@ -12805,6 +12820,20 @@
         "supports_response_schema": true,
         "supports_tool_choice": false
     },
+    "fireworks_ai/accounts/fireworks/models/minimax-m2p1": {
+        "cache_read_input_token_cost": 3e-08,
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 204800,
+        "max_tokens": 204800,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://fireworks.ai/models/fireworks/minimax-m2p1",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "fireworks_ai/accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
         "input_cost_per_token": 1.2e-06,
         "litellm_provider": "fireworks_ai",
@@ -12856,6 +12885,49 @@
         "supports_function_calling": false,
         "supports_response_schema": true,
         "supports_tool_choice": false
+    },
+    "fireworks_ai/glm-4p7": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 202800,
+        "max_output_tokens": 202800,
+        "max_tokens": 202800,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-06,
+        "source": "https://fireworks.ai/models/fireworks/glm-4p7",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "fireworks_ai/kimi-k2p5": {
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://fireworks.ai/pricing",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "fireworks_ai/minimax-m2p1": {
+        "cache_read_input_token_cost": 3e-08,
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 204800,
+        "max_tokens": 204800,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://fireworks.ai/models/fireworks/minimax-m2p1",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "fireworks_ai/nomic-ai/nomic-embed-text-v1": {
         "input_cost_per_token": 8e-09,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12705,6 +12705,7 @@
         "supports_web_search": true
     },
     "fireworks_ai/accounts/fireworks/models/kimi-k2p5": {
+        "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -2657,6 +2657,59 @@ def test_model_info_for_openrouter_kimi_k2_5():
     print("openrouter kimi-k2.5 model info", model_info)
 
 
+def test_model_info_for_fireworks_short_form_models():
+    """
+    Test that fireworks_ai short-form model entries (fireworks_ai/<model>)
+    are correctly configured in model_prices_and_context_window.json.
+
+    These entries enable cost attribution for models called via short-form
+    names (e.g., fireworks_ai/glm-4p7 instead of
+    fireworks_ai/accounts/fireworks/models/glm-4p7).
+    """
+    import json
+    from pathlib import Path
+
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(json_path) as f:
+        model_cost = json.load(f)
+
+    # glm-4p7: short-form and long-form
+    for key in [
+        "fireworks_ai/glm-4p7",
+        "fireworks_ai/accounts/fireworks/models/glm-4p7",
+    ]:
+        info = model_cost.get(key)
+        assert info is not None, f"{key} not found in model_prices_and_context_window.json"
+        assert info["litellm_provider"] == "fireworks_ai"
+        assert info["mode"] == "chat"
+        assert info["input_cost_per_token"] == 6e-07
+        assert info["output_cost_per_token"] == 2.2e-06
+        assert info["max_input_tokens"] == 202800
+        assert info["supports_reasoning"] is True
+
+    # minimax-m2p1: short-form and long-form
+    for key in [
+        "fireworks_ai/minimax-m2p1",
+        "fireworks_ai/accounts/fireworks/models/minimax-m2p1",
+    ]:
+        info = model_cost.get(key)
+        assert info is not None, f"{key} not found in model_prices_and_context_window.json"
+        assert info["litellm_provider"] == "fireworks_ai"
+        assert info["mode"] == "chat"
+        assert info["input_cost_per_token"] == 3e-07
+        assert info["output_cost_per_token"] == 1.2e-06
+        assert info["max_input_tokens"] == 204800
+
+    # kimi-k2p5: short-form only (long-form already existed)
+    info = model_cost.get("fireworks_ai/kimi-k2p5")
+    assert info is not None, "fireworks_ai/kimi-k2p5 not found in model_prices_and_context_window.json"
+    assert info["litellm_provider"] == "fireworks_ai"
+    assert info["mode"] == "chat"
+    assert info["input_cost_per_token"] == 6e-07
+    assert info["output_cost_per_token"] == 3e-06
+    assert info["max_input_tokens"] == 262144
+
+
 class TestGetValidModelsWithCLI:
     """Test get_valid_models function as used in CLI token usage"""
 


### PR DESCRIPTION
Fireworks AI models called via short-form (fireworks_ai/<model>) were reporting $0.00 cost because the pricing JSON lacked short-form entries. The lookup fell through to the fireworks-ai-default bucket which has zero cost.

Added 5 new entries to model_prices_and_context_window.json:
- fireworks_ai/accounts/fireworks/models/glm-4p7 (new long-form)
- fireworks_ai/accounts/fireworks/models/minimax-m2p1 (new long-form)
- fireworks_ai/glm-4p7 (new short-form)
- fireworks_ai/minimax-m2p1 (new short-form)
- fireworks_ai/kimi-k2p5 (new short-form; long-form already existed)

Pricing sourced from fireworks.ai model pages and pricing page.

## Relevant issues

Relates to closed PR #21591 (same changes, self-closed by maintainer)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🆕 New Feature

## Changes

Added pricing entries to `model_prices_and_context_window.json` for 3 Fireworks AI models that were missing cost attribution:

| Model | Issue | Fix |
|---|---|---|
| `fireworks_ai/glm-4p7` | No entry at all — cost reported as $0.00 | Added long-form + short-form entries ($0.60/1M input, $2.20/1M output) |
| `fireworks_ai/minimax-m2p1` | No entry at all — cost reported as $0.00 | Added long-form + short-form entries ($0.30/1M input, $1.20/1M output) |
| `fireworks_ai/kimi-k2p5` | Long-form existed but short-form missing — cost reported as $0.00 via short-form | Added short-form entry ($0.60/1M input, $3.00/1M output) |

**Root cause**: The pricing lookup for `fireworks_ai/<model>` never tries the long-form path `fireworks_ai/accounts/fireworks/models/<model>`. When no short-form entry exists, the lookup falls through to the `fireworks-ai-default` bucket which has `$0.00` cost.

**What's NOT changed** (already works without changes):
- `bedrock/converse/moonshotai.kimi-k2.5` — resolved by `strip_bedrock_routing_prefix`
- `openai/gpt-5-search-api` / `openai/gpt-5-search-api-2025-10-14` — resolved by prefix-strip fallback

Pricing sourced from fireworks.ai model pages and cross-verified against PR #21591.

**Test added**: `test_model_info_for_fireworks_short_form_models` in `tests/test_litellm/test_utils.py` — validates all new entries exist with correct pricing, provider, and context window values.