### PR TITLE
fix(tests): pass host to RedisCache in test_team_update_redis

### DIFF
--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -962,7 +962,7 @@ async def test_team_update_redis():
         litellm.proxy.proxy_server, "proxy_logging_obj"
     )
 
-    redis_cache = RedisCache()
+    redis_cache = RedisCache(host="localhost")
 
     with patch.object(
         redis_cache,


### PR DESCRIPTION
## Summary

- `test_team_update_redis` was failing with `ValueError: Either 'host' or 'url' must be specified for redis.` because `RedisCache()` is called with no arguments
- The fix passes `host="localhost"` so the `RedisCache` object can be constructed; the actual Redis connection failure is caught silently by the constructor
- Unlike `test_get_team_redis` (which uses `client_no_auth` → `fake_env_vars` that sets `REDIS_HOST=localhost`), `test_team_update_redis` has no fixture that sets `REDIS_HOST`, causing the construction to fail

The `async_set_cache` method is patched with `AsyncMock()` so no real Redis connection is needed.

## Test plan

- [x] `test_team_update_redis` passes locally after fix
- [x] `test_get_team_redis` still passes (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)