### PR TITLE
perf: reduce import litellm time

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -33,7 +33,6 @@ from typing import (
     overload,
     Type,
 )
-from litellm.types.integrations.datadog import DatadogInitParams
 from litellm._logging import (
     set_verbose,
     _turn_on_debug,
@@ -318,9 +317,8 @@ guardrail_name_config_map: Dict[str, GuardrailItem] = {}
 include_cost_in_streaming_usage: bool = False
 reasoning_auto_summary: bool = False
 ### PROMPTS ####
-from litellm.types.prompts.init_prompts import PromptSpec
-
-prompt_name_config_map: Dict[str, PromptSpec] = {}
+# PromptSpec is lazy-loaded via __getattr__
+prompt_name_config_map: Dict[str, "PromptSpec"] = {}
 
 ##################
 ### PREVIEW FEATURES ###
@@ -485,9 +483,51 @@ _key_management_system: Optional["KeyManagementSystem"] = None
 #### PII MASKING ####
 output_parse_pii: bool = False
 #############################################
-from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
+from litellm.litellm_core_utils.get_model_cost_map import (
+    GetModelCostMap,
+    _cost_map_source_info,
+    _expand_model_aliases,
+    get_model_cost_map,
+)
 
-model_cost = get_model_cost_map(url=model_cost_map_url)
+# Load local backup instantly (no network I/O) then fetch remote in background
+model_cost = _expand_model_aliases(GetModelCostMap.load_local_model_cost_map())
+if os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", "").lower() != "true":
+    import threading
+
+    _cost_map_source_info.url = model_cost_map_url
+
+    def _fetch_remote_model_cost_map():
+        try:
+            remote = GetModelCostMap.fetch_remote_model_cost_map(model_cost_map_url)
+            if GetModelCostMap.validate_model_cost_map(
+                fetched_map=remote,
+                backup_model_count=len(model_cost),
+            ):
+                merged = {**globals()["model_cost"], **remote}
+                globals()["model_cost"] = _expand_model_aliases(merged)
+                _cost_map_source_info.source = "remote"
+                _cost_map_source_info.fallback_reason = None
+                try:
+                    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+                    _invalidate_model_cost_lowercase_map()
+                except Exception as e:
+                    verbose_logger.debug("failed to invalidate model cost cache: %s", e)
+            else:
+                _cost_map_source_info.source = "local"
+                _cost_map_source_info.fallback_reason = (
+                    "Remote data failed integrity validation"
+                )
+        except Exception as e:
+            _cost_map_source_info.source = "local"
+            _cost_map_source_info.fallback_reason = f"Background fetch failed: {str(e)}"
+            verbose_logger.debug("background model cost fetch failed: %s", e)
+
+    threading.Thread(target=_fetch_remote_model_cost_map, daemon=True).start()
+else:
+    _cost_map_source_info.source = "local"
+    _cost_map_source_info.is_env_forced = True
 cost_discount_config: Dict[str, float] = (
     {}
 )  # Provider-specific cost discounts {"vertex_ai": 0.05} = 5% discount
@@ -1176,31 +1216,12 @@ from .utils import client
 # Note: Most other utils imports are lazy-loaded via __getattr__ to avoid loading utils.py
 # (which imports tiktoken) at import time
 
-from .llms.custom_llm import CustomLLM
-from .llms.anthropic.common_utils import AnthropicModelInfo
-from .llms.ai21.chat.transformation import AI21ChatConfig, AI21ChatConfig as AI21Config
-from .llms.deprecated_providers.palm import (
-    PalmConfig,
-)  # here to prevent breaking changes
-from .llms.deprecated_providers.aleph_alpha import AlephAlphaConfig
-from .llms.gemini.common_utils import GeminiModelInfo
-
-
-from .llms.vertex_ai.vertex_embeddings.transformation import (
-    VertexAITextEmbeddingConfig,
-)
-
-vertexAITextEmbeddingConfig = VertexAITextEmbeddingConfig()
-
-
-from .llms.bedrock.embed.amazon_titan_v2_transformation import (
-    AmazonTitanV2Config,
-)
-from .llms.topaz.common_utils import TopazModelInfo
-
 # OpenAIOSeriesConfig is lazy loaded - openaiOSeriesConfig will be created on first access
 # OpenAIGPTConfig, OpenAIGPT5Config, etc. are lazy loaded - instances will be created on first access
-from .llms.xai.common_utils import XAIModelInfo
+# The following are lazy-loaded via __getattr__:
+#   CustomLLM, AnthropicModelInfo, AI21ChatConfig, AI21Config, PalmConfig,
+#   AlephAlphaConfig, GeminiModelInfo, VertexAITextEmbeddingConfig,
+#   vertexAITextEmbeddingConfig, AmazonTitanV2Config, TopazModelInfo, XAIModelInfo
 
 # PublicAI now uses JSON-based configuration (see litellm/llms/openai_like/providers.json)
 # All remaining configs are now lazy loaded - see _lazy_imports_registry.py
@@ -1273,9 +1294,8 @@ from .exceptions import (
     LITELLM_EXCEPTION_TYPES,
     MockException,
 )
-from .budget_manager import BudgetManager
-from .proxy.proxy_cli import run_server
-from .router import Router
+
+# BudgetManager, run_server, Router are lazy-loaded via __getattr__
 from .assistants.main import *
 from .batches.main import *
 from .images.main import *
@@ -1287,19 +1307,7 @@ from .responses.main import *
 
 # Interactions API is available as litellm.interactions module
 # Usage: litellm.interactions.create(), litellm.interactions.get(), etc.
-from . import interactions
-from .interactions.agents.main import (
-    acreate as acreate_agent,
-    create as create_agent,
-    alist as alist_agents,
-    list as list_agents,
-    aget as aget_agent,
-    get as get_agent,
-    adelete as adelete_agent,
-    delete as delete_agent,
-    alist_versions as alist_agent_versions,
-    list_versions as list_agent_versions,
-)
+# interactions module and agent functions are lazy-loaded via __getattr__
 from .skills.main import (
     create_skill,
     acreate_skill,
@@ -2012,8 +2020,44 @@ if TYPE_CHECKING:
     # Custom logger class (lazy-loaded)
     from litellm.integrations.custom_logger import CustomLogger
 
-    # Datadog LLM observability params (lazy-loaded)
+    # Datadog params (lazy-loaded)
+    from litellm.types.integrations.datadog import DatadogInitParams
     from litellm.types.integrations.datadog_llm_obs import DatadogLLMObsInitParams
+
+    # Lazy-loaded model info / config classes (deferred from top-level imports)
+    from litellm.budget_manager import BudgetManager
+    from litellm.llms.ai21.chat.transformation import AI21ChatConfig
+    from litellm.llms.ai21.chat.transformation import AI21ChatConfig as AI21Config
+    from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+    from litellm.llms.bedrock.embed.amazon_titan_v2_transformation import (
+        AmazonTitanV2Config,
+    )
+    from litellm.llms.custom_llm import CustomLLM
+    from litellm.llms.deprecated_providers.aleph_alpha import AlephAlphaConfig
+    from litellm.llms.deprecated_providers.palm import PalmConfig
+    from litellm.llms.gemini.common_utils import GeminiModelInfo
+    from litellm.llms.topaz.common_utils import TopazModelInfo
+    from litellm.llms.vertex_ai.vertex_embeddings.transformation import (
+        VertexAITextEmbeddingConfig,
+    )
+    from litellm.llms.xai.common_utils import XAIModelInfo
+    from litellm.proxy.proxy_cli import run_server
+    from litellm.router import Router
+    from litellm.types.prompts.init_prompts import PromptSpec
+
+    # Agent functions (lazy-loaded from interactions.agents.main)
+    from litellm.interactions.agents.main import acreate as acreate_agent
+    from litellm.interactions.agents.main import adelete as adelete_agent
+    from litellm.interactions.agents.main import aget as aget_agent
+    from litellm.interactions.agents.main import alist as alist_agents
+    from litellm.interactions.agents.main import alist_versions as alist_agent_versions
+    from litellm.interactions.agents.main import create as create_agent
+    from litellm.interactions.agents.main import delete as delete_agent
+    from litellm.interactions.agents.main import get as get_agent
+    from litellm.interactions.agents.main import list as list_agents
+    from litellm.interactions.agents.main import list_versions as list_agent_versions
+
+    vertexAITextEmbeddingConfig: VertexAITextEmbeddingConfig
 
     # Logging callback manager class and instance (lazy-loaded)
     from litellm.litellm_core_utils.logging_callback_manager import (
@@ -2032,6 +2076,49 @@ if TYPE_CHECKING:
 
 # Track if async client cleanup has been registered (for lazy loading)
 _async_client_cleanup_registered = False
+
+# Lazy-loaded model info / config classes (deferred from top-level imports)
+_lazy_class_imports = {
+    "CustomLLM": ("litellm.llms.custom_llm", "CustomLLM"),
+    "AnthropicModelInfo": (
+        "litellm.llms.anthropic.common_utils",
+        "AnthropicModelInfo",
+    ),
+    "AI21ChatConfig": ("litellm.llms.ai21.chat.transformation", "AI21ChatConfig"),
+    "AI21Config": ("litellm.llms.ai21.chat.transformation", "AI21ChatConfig"),
+    "PalmConfig": ("litellm.llms.deprecated_providers.palm", "PalmConfig"),
+    "AlephAlphaConfig": (
+        "litellm.llms.deprecated_providers.aleph_alpha",
+        "AlephAlphaConfig",
+    ),
+    "GeminiModelInfo": ("litellm.llms.gemini.common_utils", "GeminiModelInfo"),
+    "VertexAITextEmbeddingConfig": (
+        "litellm.llms.vertex_ai.vertex_embeddings.transformation",
+        "VertexAITextEmbeddingConfig",
+    ),
+    "AmazonTitanV2Config": (
+        "litellm.llms.bedrock.embed.amazon_titan_v2_transformation",
+        "AmazonTitanV2Config",
+    ),
+    "TopazModelInfo": ("litellm.llms.topaz.common_utils", "TopazModelInfo"),
+    "XAIModelInfo": ("litellm.llms.xai.common_utils", "XAIModelInfo"),
+    "DatadogInitParams": ("litellm.types.integrations.datadog", "DatadogInitParams"),
+    "PromptSpec": ("litellm.types.prompts.init_prompts", "PromptSpec"),
+    "BudgetManager": ("litellm.budget_manager", "BudgetManager"),
+    "Router": ("litellm.router", "Router"),
+    "run_server": ("litellm.proxy.proxy_cli", "run_server"),
+    # Agent functions (lazy-loaded from interactions.agents.main)
+    "acreate_agent": ("litellm.interactions.agents.main", "acreate"),
+    "create_agent": ("litellm.interactions.agents.main", "create"),
+    "alist_agents": ("litellm.interactions.agents.main", "alist"),
+    "list_agents": ("litellm.interactions.agents.main", "list"),
+    "aget_agent": ("litellm.interactions.agents.main", "aget"),
+    "get_agent": ("litellm.interactions.agents.main", "get"),
+    "adelete_agent": ("litellm.interactions.agents.main", "adelete"),
+    "delete_agent": ("litellm.interactions.agents.main", "delete"),
+    "alist_agent_versions": ("litellm.interactions.agents.main", "alist_versions"),
+    "list_agent_versions": ("litellm.interactions.agents.main", "list_versions"),
+}
 
 # Eager loading for backwards compatibility with VCR and other HTTP recording tools
 # When LITELLM_DISABLE_LAZY_LOADING is set, lazy-loaded attributes are loaded at import time
@@ -2055,6 +2142,38 @@ def __getattr__(name: str) -> Any:
 
         register_async_client_cleanup()
         _async_client_cleanup_registered = True
+
+    # Lazy load interactions module
+    if name == "interactions":
+        import importlib
+
+        _interactions = importlib.import_module(".interactions", __name__)
+        globals()["interactions"] = _interactions
+        return _interactions
+
+    # Lazy load router submodule
+    if name == "router":
+        import importlib
+
+        _router = importlib.import_module(".router", __name__)
+        globals()["router"] = _router
+        return _router
+
+    if name in _lazy_class_imports:
+        mod_path, attr = _lazy_class_imports[name]
+        import importlib
+
+        mod = importlib.import_module(mod_path)
+        val = getattr(mod, attr)
+        globals()[name] = val
+        return val
+
+    # Lazy-loaded config instance
+    if name == "vertexAITextEmbeddingConfig":
+        cls = __getattr__("VertexAITextEmbeddingConfig")
+        instance = cls()
+        globals()["vertexAITextEmbeddingConfig"] = instance
+        return instance
 
     # Use cached registry from _lazy_imports instead of importing tuples every time
     from ._lazy_imports import _get_lazy_import_registry

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -361,9 +361,8 @@ guardrail_name_config_map: Dict[str, GuardrailItem] = {}
 include_cost_in_streaming_usage: bool = False
 reasoning_auto_summary: bool = False
 ### PROMPTS ####
-from litellm.types.prompts.init_prompts import PromptSpec
-
-prompt_name_config_map: Dict[str, PromptSpec] = {}
+# PromptSpec is lazy-loaded via __getattr__
+prompt_name_config_map: Dict[str, "PromptSpec"] = {}  # mutable-ok: registry populated as prompts are registered
 
 ##################
 ### PREVIEW FEATURES ###
@@ -525,9 +524,44 @@ _key_management_system: Optional["KeyManagementSystem"] = None
 #### PII MASKING ####
 output_parse_pii: bool = False
 #############################################
-from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
+from litellm.litellm_core_utils.get_model_cost_map import (
+    GetModelCostMap,
+    _finalize_model_cost_map,  # pyright: ignore[reportPrivateUsage]  # litellm-internal cost-map finalizer
+    get_model_cost_map,
+)
 
-model_cost = get_model_cost_map(url=model_cost_map_url)
+if os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", "").lower() == "true":
+    model_cost = get_model_cost_map(url=model_cost_map_url)
+else:
+    # Populate model_cost from the bundled backup instantly so import never blocks
+    # on network I/O, then refresh from the remote map in a background thread.
+    model_cost = _finalize_model_cost_map(GetModelCostMap.load_local_model_cost_map())
+
+    def _fetch_remote_model_cost_map() -> None:
+        try:
+            # Fetch first: this network call gives `import litellm` on the main
+            # thread time to finish importing litellm.utils below, so importing
+            # utils here never races the main thread's own `from .utils import ...`.
+            new_model_cost: Final = get_model_cost_map(url=model_cost_map_url)
+            from litellm.utils import (
+                _invalidate_model_cost_lowercase_map,  # pyright: ignore[reportPrivateUsage]  # litellm-internal cache invalidation
+                _runtime_registered_model_cost,  # pyright: ignore[reportPrivateUsage]  # litellm-internal runtime pricing store
+            )
+
+            # Overlay runtime register_model pricing onto the fresh catalog so the
+            # refresh only updates prices rather than discarding operator overrides,
+            # which cost tracking would otherwise read as zero. Built locally and
+            # published with a single atomic rebind so concurrent readers (including
+            # a re-import) never observe a dict mutating mid-iteration. tuple() takes
+            # a snapshot so a concurrent register_model cannot resize mid-iteration.
+            for key, overrides in tuple(_runtime_registered_model_cost.items()):
+                new_model_cost[key] = {**new_model_cost.get(key, {}), **overrides}  # mutable-ok: plain model_cost entry
+            globals()["model_cost"] = new_model_cost
+            _invalidate_model_cost_lowercase_map()
+        except Exception as e:
+            verbose_logger.debug("background model cost fetch failed: %s", e)
+
+    threading.Thread(target=_fetch_remote_model_cost_map, daemon=True).start()
 cost_discount_config: Dict[str, float] = {}  # Provider-specific cost discounts {"vertex_ai": 0.05} = 5% discount
 cost_margin_config: Dict[
     str, Union[float, Dict[str, float]]
@@ -1257,31 +1291,12 @@ from .utils import client
 # Note: Most other utils imports are lazy-loaded via __getattr__ to avoid loading utils.py
 # (which imports tiktoken) at import time
 
-from .llms.custom_llm import CustomLLM
-from .llms.anthropic.common_utils import AnthropicModelInfo
-from .llms.ai21.chat.transformation import AI21ChatConfig, AI21ChatConfig as AI21Config
-from .llms.deprecated_providers.palm import (
-    PalmConfig,
-)  # here to prevent breaking changes
-from .llms.deprecated_providers.aleph_alpha import AlephAlphaConfig
-from .llms.gemini.common_utils import GeminiModelInfo
-
-
-from .llms.vertex_ai.vertex_embeddings.transformation import (
-    VertexAITextEmbeddingConfig,
-)
-
-vertexAITextEmbeddingConfig = VertexAITextEmbeddingConfig()
-
-
-from .llms.bedrock.embed.amazon_titan_v2_transformation import (
-    AmazonTitanV2Config,
-)
-from .llms.topaz.common_utils import TopazModelInfo
-
 # OpenAIOSeriesConfig is lazy loaded - openaiOSeriesConfig will be created on first access
 # OpenAIGPTConfig, OpenAIGPT5Config, etc. are lazy loaded - instances will be created on first access
-from .llms.xai.common_utils import XAIModelInfo
+# The following are lazy-loaded via __getattr__:
+#   CustomLLM, AnthropicModelInfo, AI21ChatConfig, AI21Config, PalmConfig,
+#   AlephAlphaConfig, GeminiModelInfo, VertexAITextEmbeddingConfig,
+#   vertexAITextEmbeddingConfig, AmazonTitanV2Config, TopazModelInfo, XAIModelInfo
 
 # PublicAI now uses JSON-based configuration (see litellm/llms/openai_like/providers.json)
 # All remaining configs are now lazy loaded - see _lazy_imports_registry.py
@@ -1356,9 +1371,8 @@ from .exceptions import (
     LITELLM_EXCEPTION_TYPES,
     MockException,
 )
-from .budget_manager import BudgetManager
-from .proxy.proxy_cli import run_server
-from .router import Router
+
+# BudgetManager, run_server, Router are lazy-loaded via __getattr__
 from .assistants.main import *
 from .batches.main import *
 from .images.main import *
@@ -1370,19 +1384,7 @@ from .responses.main import *
 
 # Interactions API is available as litellm.interactions module
 # Usage: litellm.interactions.create(), litellm.interactions.get(), etc.
-from . import interactions
-from .interactions.agents.main import (
-    acreate as acreate_agent,
-    create as create_agent,
-    alist as alist_agents,
-    list as list_agents,
-    aget as aget_agent,
-    get as get_agent,
-    adelete as adelete_agent,
-    delete as delete_agent,
-    alist_versions as alist_agent_versions,
-    list_versions as list_agent_versions,
-)
+# interactions module and agent functions are lazy-loaded via __getattr__
 from .skills.main import (
     create_skill,
     acreate_skill,
@@ -2116,8 +2118,44 @@ if TYPE_CHECKING:
     # Custom logger class (lazy-loaded)
     from litellm.integrations.custom_logger import CustomLogger
 
-    # Datadog LLM observability params (lazy-loaded)
+    # Datadog params (lazy-loaded)
+    from litellm.types.integrations.datadog import DatadogInitParams
     from litellm.types.integrations.datadog_llm_obs import DatadogLLMObsInitParams
+
+    # Lazy-loaded model info / config classes (deferred from top-level imports)
+    from litellm.budget_manager import BudgetManager
+    from litellm.llms.ai21.chat.transformation import AI21ChatConfig
+    from litellm.llms.ai21.chat.transformation import AI21ChatConfig as AI21Config
+    from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+    from litellm.llms.bedrock.embed.amazon_titan_v2_transformation import (
+        AmazonTitanV2Config,
+    )
+    from litellm.llms.custom_llm import CustomLLM
+    from litellm.llms.deprecated_providers.aleph_alpha import AlephAlphaConfig
+    from litellm.llms.deprecated_providers.palm import PalmConfig
+    from litellm.llms.gemini.common_utils import GeminiModelInfo
+    from litellm.llms.topaz.common_utils import TopazModelInfo
+    from litellm.llms.vertex_ai.vertex_embeddings.transformation import (
+        VertexAITextEmbeddingConfig,
+    )
+    from litellm.llms.xai.common_utils import XAIModelInfo
+    from litellm.proxy.proxy_cli import run_server
+    from litellm.router import Router
+    from litellm.types.prompts.init_prompts import PromptSpec
+
+    # Agent functions (lazy-loaded from interactions.agents.main)
+    from litellm.interactions.agents.main import acreate as acreate_agent
+    from litellm.interactions.agents.main import adelete as adelete_agent
+    from litellm.interactions.agents.main import aget as aget_agent
+    from litellm.interactions.agents.main import alist as alist_agents
+    from litellm.interactions.agents.main import alist_versions as alist_agent_versions
+    from litellm.interactions.agents.main import create as create_agent
+    from litellm.interactions.agents.main import delete as delete_agent
+    from litellm.interactions.agents.main import get as get_agent
+    from litellm.interactions.agents.main import list as list_agents
+    from litellm.interactions.agents.main import list_versions as list_agent_versions
+
+    vertexAITextEmbeddingConfig: VertexAITextEmbeddingConfig
 
     # Logging callback manager class and instance (lazy-loaded)
     from litellm.litellm_core_utils.logging_callback_manager import (
@@ -2136,6 +2174,49 @@ if TYPE_CHECKING:
 
 # Track if async client cleanup has been registered (for lazy loading)
 _async_client_cleanup_registered = False
+
+# Lazy-loaded model info / config classes (deferred from top-level imports)
+_lazy_class_imports = {  # mutable-ok: static lazy-import lookup table, never mutated after definition
+    "CustomLLM": ("litellm.llms.custom_llm", "CustomLLM"),
+    "AnthropicModelInfo": (
+        "litellm.llms.anthropic.common_utils",
+        "AnthropicModelInfo",
+    ),
+    "AI21ChatConfig": ("litellm.llms.ai21.chat.transformation", "AI21ChatConfig"),
+    "AI21Config": ("litellm.llms.ai21.chat.transformation", "AI21ChatConfig"),
+    "PalmConfig": ("litellm.llms.deprecated_providers.palm", "PalmConfig"),
+    "AlephAlphaConfig": (
+        "litellm.llms.deprecated_providers.aleph_alpha",
+        "AlephAlphaConfig",
+    ),
+    "GeminiModelInfo": ("litellm.llms.gemini.common_utils", "GeminiModelInfo"),
+    "VertexAITextEmbeddingConfig": (
+        "litellm.llms.vertex_ai.vertex_embeddings.transformation",
+        "VertexAITextEmbeddingConfig",
+    ),
+    "AmazonTitanV2Config": (
+        "litellm.llms.bedrock.embed.amazon_titan_v2_transformation",
+        "AmazonTitanV2Config",
+    ),
+    "TopazModelInfo": ("litellm.llms.topaz.common_utils", "TopazModelInfo"),
+    "XAIModelInfo": ("litellm.llms.xai.common_utils", "XAIModelInfo"),
+    "DatadogInitParams": ("litellm.types.integrations.datadog", "DatadogInitParams"),
+    "PromptSpec": ("litellm.types.prompts.init_prompts", "PromptSpec"),
+    "BudgetManager": ("litellm.budget_manager", "BudgetManager"),
+    "Router": ("litellm.router", "Router"),
+    "run_server": ("litellm.proxy.proxy_cli", "run_server"),
+    # Agent functions (lazy-loaded from interactions.agents.main)
+    "acreate_agent": ("litellm.interactions.agents.main", "acreate"),
+    "create_agent": ("litellm.interactions.agents.main", "create"),
+    "alist_agents": ("litellm.interactions.agents.main", "alist"),
+    "list_agents": ("litellm.interactions.agents.main", "list"),
+    "aget_agent": ("litellm.interactions.agents.main", "aget"),
+    "get_agent": ("litellm.interactions.agents.main", "get"),
+    "adelete_agent": ("litellm.interactions.agents.main", "adelete"),
+    "delete_agent": ("litellm.interactions.agents.main", "delete"),
+    "alist_agent_versions": ("litellm.interactions.agents.main", "alist_versions"),
+    "list_agent_versions": ("litellm.interactions.agents.main", "list_versions"),
+}
 
 # Eager loading for backwards compatibility with VCR and other HTTP recording tools
 # When LITELLM_DISABLE_LAZY_LOADING is set, lazy-loaded attributes are loaded at import time
@@ -2159,6 +2240,38 @@ def __getattr__(name: str) -> Any:
 
         register_async_client_cleanup()
         _async_client_cleanup_registered = True
+
+    # Lazy load interactions module
+    if name == "interactions":
+        import importlib
+
+        _interactions: Final = importlib.import_module(".interactions", __name__)
+        globals()["interactions"] = _interactions
+        return _interactions
+
+    # Lazy load router submodule
+    if name == "router":
+        import importlib
+
+        _router: Final = importlib.import_module(".router", __name__)
+        globals()["router"] = _router
+        return _router
+
+    if name in _lazy_class_imports:
+        mod_path, attr = _lazy_class_imports[name]
+        import importlib
+
+        mod: Final = importlib.import_module(mod_path)
+        val: Final = getattr(mod, attr)
+        globals()[name] = val
+        return val
+
+    # Lazy-loaded config instance
+    if name == "vertexAITextEmbeddingConfig":
+        cls: Final = __getattr__("VertexAITextEmbeddingConfig")
+        instance: Final = cls()
+        globals()["vertexAITextEmbeddingConfig"] = instance
+        return instance
 
     # Use cached registry from _lazy_imports instead of importing tuples every time
     from ._lazy_imports import _get_lazy_import_registry

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -33,11 +33,6 @@ from litellm.types.utils import (
     StandardLoggingGuardrailInformation,
 )
 
-try:
-    from fastapi.exceptions import HTTPException
-except ImportError:
-    HTTPException = None  # type: ignore
-
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 dc = DualCache()
@@ -751,9 +746,9 @@ class CustomGuardrail(CustomLogger):
         if isinstance(e, (GuardrailRaisedException, BlockedPiiEntityError)):
             return True
         if (
-            HTTPException is not None
-            and isinstance(e, HTTPException)
-            and e.status_code == 400
+            type(e).__name__ == "HTTPException"
+            and type(e).__module__.startswith(("fastapi", "starlette"))
+            and getattr(e, "status_code", None) == 400
         ):
             return True
         return False

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -31,11 +31,6 @@ from litellm.types.utils import (
     StandardLoggingGuardrailInformation,
 )
 
-try:
-    from fastapi.exceptions import HTTPException
-except ImportError:
-    HTTPException = None
-
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 dc: Final = DualCache()
@@ -1097,11 +1092,14 @@ class CustomGuardrail(CustomLogger):
             ),
         ):
             return True
-        if (
-            HTTPException is not None
-            and isinstance(e, HTTPException)
-            and e.status_code in _GUARDRAIL_BLOCK_STATUS_CODES
-        ):
+        # Imported lazily so `import litellm` never pulls in FastAPI. isinstance,
+        # not a name/module check, so subclasses defined by guardrail providers
+        # (e.g. NomaBlockedMessage) are still recognised as deliberate blocks.
+        try:
+            from fastapi.exceptions import HTTPException
+        except ImportError:
+            return False
+        if isinstance(e, HTTPException) and getattr(e, "status_code", None) in _GUARDRAIL_BLOCK_STATUS_CODES:
             return True
         return False
 

--- a/litellm/integrations/gcs_bucket/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket.py
@@ -14,7 +14,6 @@ from litellm.integrations.gcs_bucket.gcs_bucket_base import GCSBucketBase
 from litellm.litellm_core_utils.cloud_storage_security import (
     sanitize_cloud_object_component,
 )
-from litellm.proxy._types import CommonProxyErrors
 from litellm.types.integrations.base_health_check import IntegrationHealthCheckStatus
 from litellm.types.integrations.gcs_bucket import *
 from litellm.types.utils import StandardLoggingPayload
@@ -28,6 +27,7 @@ else:
 class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
     def __init__(self, bucket_name: Optional[str] = None) -> None:
         from litellm.proxy.proxy_server import premium_user
+        from litellm.proxy._types import CommonProxyErrors
 
         super().__init__(bucket_name=bucket_name)
 
@@ -61,6 +61,7 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
     #### ASYNC ####
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         from litellm.proxy.proxy_server import premium_user
+        from litellm.proxy._types import CommonProxyErrors
 
         if premium_user is not True:
             raise ValueError(

--- a/litellm/integrations/gcs_bucket/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket.py
@@ -14,7 +14,6 @@ from litellm.integrations.gcs_bucket.gcs_bucket_base import GCSBucketBase
 from litellm.litellm_core_utils.cloud_storage_security import (
     sanitize_cloud_object_component,
 )
-from litellm.proxy._types import CommonProxyErrors
 from litellm.types.integrations.base_health_check import IntegrationHealthCheckStatus
 from litellm.types.integrations.gcs_bucket import *
 from litellm.types.utils import StandardLoggingPayload
@@ -27,6 +26,7 @@ else:
 
 class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
     def __init__(self, bucket_name: str | None = None) -> None:
+        from litellm.proxy._types import CommonProxyErrors
         from litellm.proxy.proxy_server import premium_user
 
         super().__init__(bucket_name=bucket_name)
@@ -53,6 +53,7 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
 
     #### ASYNC ####
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        from litellm.proxy._types import CommonProxyErrors
         from litellm.proxy.proxy_server import premium_user
 
         if premium_user is not True:

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 from urllib.parse import urlparse
 
 import litellm
@@ -6,7 +6,10 @@ from litellm.constants import REPLICATE_MODEL_NAME_WITH_ID_LENGTH
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.secret_managers.main import get_secret, get_secret_str
 
-from ..types.router import LiteLLM_Params
+if TYPE_CHECKING:
+    from ..types.router import LiteLLM_Params
+else:
+    LiteLLM_Params = Any
 
 
 def _endpoint_matches_api_base(endpoint: str, api_base: str) -> bool:

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -1,4 +1,4 @@
-from typing import Final, cast
+from typing import TYPE_CHECKING, Final, TypeAlias, cast
 from urllib.parse import urlparse
 
 import litellm
@@ -9,7 +9,11 @@ from litellm.litellm_core_utils.fallback_generalizations import (
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.secret_managers.main import get_secret, get_secret_str
 
-from ..types.router import GenericLiteLLMParams, LiteLLM_Params
+if TYPE_CHECKING:
+    from ..types.router import GenericLiteLLMParams, LiteLLM_Params
+else:
+    GenericLiteLLMParams: TypeAlias = object
+    LiteLLM_Params: TypeAlias = object
 
 
 def _endpoint_matches_api_base(endpoint: str, api_base: str) -> bool:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -140,7 +140,6 @@ from ..integrations.datadog.datadog_metrics import DatadogMetricsLogger
 from ..integrations.dotprompt import DotpromptManager
 from ..integrations.dynamodb import DyanmoDBLogger
 from ..integrations.galileo import GalileoObserve
-from ..integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
 from ..integrations.gcs_pubsub.pub_sub import GcsPubSubLogger
 from ..integrations.greenscale import GreenscaleLogger
 from ..integrations.helicone import HeliconeLogger
@@ -3828,6 +3827,8 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
             _in_memory_loggers.append(_azure_sentinel_logger)
             return _azure_sentinel_logger  # type: ignore
         elif logging_integration == "gcs_bucket":
+            from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
+
             for callback in _in_memory_loggers:
                 if isinstance(callback, GCSBucketLogger):
                     return callback  # type: ignore
@@ -4453,6 +4454,8 @@ def get_custom_logger_compatible_class(  # noqa: PLR0915
                 if isinstance(callback, AzureSentinelLogger):
                     return callback
         elif logging_integration == "gcs_bucket":
+            from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
+
             for callback in _in_memory_loggers:
                 if isinstance(callback, GCSBucketLogger):
                     return callback

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -149,7 +149,6 @@ from ..integrations.datadog.datadog_metrics import DatadogMetricsLogger
 from ..integrations.dotprompt import DotpromptManager
 from ..integrations.dynamodb import DyanmoDBLogger
 from ..integrations.galileo import GalileoObserve
-from ..integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
 from ..integrations.gcs_pubsub.pub_sub import GcsPubSubLogger
 from ..integrations.greenscale import GreenscaleLogger
 from ..integrations.helicone import HeliconeLogger
@@ -3986,6 +3985,8 @@ def _init_custom_logger_compatible_class(
             _in_memory_loggers.append(_azure_sentinel_logger)
             return _azure_sentinel_logger
         elif logging_integration == "gcs_bucket":
+            from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
+
             for callback in _in_memory_loggers:
                 if isinstance(callback, GCSBucketLogger):
                     return callback
@@ -4612,6 +4613,8 @@ def get_custom_logger_compatible_class(
                 if isinstance(callback, AzureSentinelLogger):
                     return callback
         elif logging_integration == "gcs_bucket":
+            from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
+
             for callback in _in_memory_loggers:
                 if isinstance(callback, GCSBucketLogger):
                     return callback

--- a/litellm/llms/base_llm/anthropic_messages/transformation.py
+++ b/litellm/llms/base_llm/anthropic_messages/transformation.py
@@ -6,14 +6,15 @@ import httpx
 from litellm.types.llms.anthropic_messages.anthropic_response import (
     AnthropicMessagesResponse,
 )
-from litellm.types.router import GenericLiteLLMParams
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
     from litellm.llms.base_llm.chat.transformation import BaseLLMException
+    from litellm.types.router import GenericLiteLLMParams
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
+    GenericLiteLLMParams = Any
     LiteLLMLoggingObj = Any
 
 

--- a/litellm/llms/base_llm/anthropic_messages/transformation.py
+++ b/litellm/llms/base_llm/anthropic_messages/transformation.py
@@ -1,20 +1,21 @@
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import httpx
 
 from litellm.types.llms.anthropic_messages.anthropic_response import (
     AnthropicMessagesResponse,
 )
-from litellm.types.router import GenericLiteLLMParams
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
     from litellm.llms.base_llm.chat.transformation import BaseLLMException
+    from litellm.types.router import GenericLiteLLMParams
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
+    GenericLiteLLMParams: TypeAlias = Any
     LiteLLMLoggingObj = Any
 
 

--- a/litellm/llms/base_llm/containers/transformation.py
+++ b/litellm/llms/base_llm/containers/transformation.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from litellm.types.containers.main import ContainerCreateOptionalRequestParams
-from litellm.types.router import GenericLiteLLMParams
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
@@ -21,6 +20,7 @@ if TYPE_CHECKING:
     from litellm.types.containers.main import (
         DeleteContainerResult as _DeleteContainerResult,
     )
+    from litellm.types.router import GenericLiteLLMParams
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
 
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     ContainerListResponse = _ContainerListResponse
     ContainerFileListResponse = _ContainerFileListResponse
 else:
+    GenericLiteLLMParams = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
     ContainerObject = Any

--- a/litellm/llms/base_llm/containers/transformation.py
+++ b/litellm/llms/base_llm/containers/transformation.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import types
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, TypeAlias
 
 import httpx
 
 from litellm.types.containers.main import ContainerCreateOptionalRequestParams
-from litellm.types.router import GenericLiteLLMParams
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
@@ -21,6 +20,7 @@ if TYPE_CHECKING:
     from litellm.types.containers.main import (
         DeleteContainerResult as _DeleteContainerResult,
     )
+    from litellm.types.router import GenericLiteLLMParams
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
 
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     ContainerListResponse = _ContainerListResponse
     ContainerFileListResponse = _ContainerFileListResponse
 else:
+    GenericLiteLLMParams: TypeAlias = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
     ContainerObject = Any

--- a/litellm/llms/base_llm/evals/transformation.py
+++ b/litellm/llms/base_llm/evals/transformation.py
@@ -23,14 +23,15 @@ from litellm.types.llms.openai_evals import (
     RunDeleteResponse,
     UpdateEvalRequest,
 )
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
+    GenericLiteLLMParams = Any
     LiteLLMLoggingObj = Any
 
 

--- a/litellm/llms/base_llm/evals/transformation.py
+++ b/litellm/llms/base_llm/evals/transformation.py
@@ -3,7 +3,7 @@ Base configuration class for Evals API
 """
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import httpx
 
@@ -23,14 +23,15 @@ from litellm.types.llms.openai_evals import (
     RunDeleteResponse,
     UpdateEvalRequest,
 )
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
+    GenericLiteLLMParams: TypeAlias = Any
     LiteLLMLoggingObj = Any
 
 

--- a/litellm/llms/base_llm/files/transformation.py
+++ b/litellm/llms/base_llm/files/transformation.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 import httpx
 from openai.types.file_deleted import FileDeleted
 
-from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.files import TwoStepFileUploadConfig
 from litellm.types.llms.openai import (
     AllMessageValues,
@@ -20,6 +19,7 @@ from ..chat.transformation import BaseConfig
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.proxy._types import UserAPIKeyAuth
     from litellm.router import Router as _Router
     from litellm.types.llms.openai import HttpxBinaryResponseContent
 
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     Router = _Router
 else:
     LiteLLMLoggingObj = Any
+    UserAPIKeyAuth = Any
     Span = Any
     Router = Any
 

--- a/litellm/llms/base_llm/files/transformation.py
+++ b/litellm/llms/base_llm/files/transformation.py
@@ -1,11 +1,10 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, TypeAlias, Union
 
 import httpx
 from openai.types.file_deleted import FileDeleted
 
-from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.files import TwoStepFileUploadConfig
 from litellm.types.llms.openai import (
     AllMessageValues,
@@ -21,6 +20,7 @@ from ..chat.transformation import BaseConfig
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.proxy._types import UserAPIKeyAuth
     from litellm.router import Router as _Router
     from litellm.types.llms.openai import HttpxBinaryResponseContent
 
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     Router = _Router
 else:
     LiteLLMLoggingObj = Any
+    UserAPIKeyAuth: TypeAlias = Any
     Span = Any
     Router = Any
 

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -12,14 +12,14 @@ if TYPE_CHECKING:
         GenerateContentResponse,
         ToolConfigDict,
     )
+    from litellm.types.router import GenericLiteLLMParams
 else:
     GenerateContentConfigDict = Any
     GenerateContentContentListUnionDict = Any
     GenerateContentResponse = Any
+    GenericLiteLLMParams = Any
     LiteLLMLoggingObj = Any
     ToolConfigDict = Any
-
-from litellm.types.router import GenericLiteLLMParams
 
 
 class BaseGoogleGenAIGenerateContentConfig(ABC):

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -1,6 +1,6 @@
 import types
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import httpx
 
@@ -12,14 +12,14 @@ if TYPE_CHECKING:
         GenerateContentResponse,
         ToolConfigDict,
     )
+    from litellm.types.router import GenericLiteLLMParams
 else:
     GenerateContentConfigDict = Any
     GenerateContentContentListUnionDict = Any
     GenerateContentResponse = Any
+    GenericLiteLLMParams: TypeAlias = Any
     LiteLLMLoggingObj = Any
     ToolConfigDict = Any
-
-from litellm.types.router import GenericLiteLLMParams
 
 
 class BaseGoogleGenAIGenerateContentConfig(ABC):

--- a/litellm/llms/base_llm/image_edit/transformation.py
+++ b/litellm/llms/base_llm/image_edit/transformation.py
@@ -7,11 +7,11 @@ from httpx._types import RequestFiles
 
 from litellm.types.images.main import ImageEditOptionalRequestParams
 from litellm.types.responses.main import *
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import FileTypes
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
     from litellm.utils import ImageResponse as _ImageResponse
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     BaseLLMException = _BaseLLMException
     ImageResponse = _ImageResponse
 else:
+    GenericLiteLLMParams = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
     ImageResponse = Any

--- a/litellm/llms/base_llm/image_edit/transformation.py
+++ b/litellm/llms/base_llm/image_edit/transformation.py
@@ -1,17 +1,17 @@
 import types
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import httpx
 from httpx._types import RequestFiles
 
 from litellm.types.images.main import ImageEditOptionalRequestParams
 from litellm.types.responses.main import *
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import FileTypes
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
     from litellm.utils import ImageResponse as _ImageResponse
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     BaseLLMException = _BaseLLMException
     ImageResponse = _ImageResponse
 else:
+    GenericLiteLLMParams: TypeAlias = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
     ImageResponse = Any

--- a/litellm/llms/base_llm/interactions/transformation.py
+++ b/litellm/llms/base_llm/interactions/transformation.py
@@ -23,17 +23,18 @@ from litellm.types.interactions import (
     InteractionsAPIResponse,
     InteractionsAPIStreamingResponse,
 )
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
     BaseLLMException = _BaseLLMException
 else:
+    GenericLiteLLMParams = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
 

--- a/litellm/llms/base_llm/interactions/transformation.py
+++ b/litellm/llms/base_llm/interactions/transformation.py
@@ -11,7 +11,7 @@ Per OpenAPI spec (https://ai.google.dev/static/api/interactions.openapi.json):
 
 import types
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import httpx
 
@@ -23,17 +23,18 @@ from litellm.types.interactions import (
     InteractionsAPIResponse,
     InteractionsAPIStreamingResponse,
 )
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
     BaseLLMException = _BaseLLMException
 else:
+    GenericLiteLLMParams: TypeAlias = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
 

--- a/litellm/llms/base_llm/responses/transformation.py
+++ b/litellm/llms/base_llm/responses/transformation.py
@@ -11,17 +11,18 @@ from litellm.types.llms.openai import (
     ResponsesAPIStreamingResponse,
 )
 from litellm.types.responses.main import *
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
     BaseLLMException = _BaseLLMException
 else:
+    GenericLiteLLMParams = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
 

--- a/litellm/llms/base_llm/responses/transformation.py
+++ b/litellm/llms/base_llm/responses/transformation.py
@@ -1,6 +1,6 @@
 import types
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Final, cast
+from typing import TYPE_CHECKING, Any, Final, TypeAlias, cast
 
 import httpx
 
@@ -11,17 +11,18 @@ from litellm.types.llms.openai import (
     ResponsesAPIStreamingResponse,
 )
 from litellm.types.responses.main import *
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
     BaseLLMException = _BaseLLMException
 else:
+    GenericLiteLLMParams: TypeAlias = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
 

--- a/litellm/llms/base_llm/skills/transformation.py
+++ b/litellm/llms/base_llm/skills/transformation.py
@@ -15,14 +15,15 @@ from litellm.types.llms.anthropic_skills import (
     ListSkillsResponse,
     Skill,
 )
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
+    GenericLiteLLMParams = Any
     LiteLLMLoggingObj = Any
 
 

--- a/litellm/llms/base_llm/skills/transformation.py
+++ b/litellm/llms/base_llm/skills/transformation.py
@@ -3,7 +3,7 @@ Base configuration class for Skills API
 """
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import httpx
 
@@ -15,14 +15,15 @@ from litellm.types.llms.anthropic_skills import (
     ListSkillsResponse,
     Skill,
 )
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
+    GenericLiteLLMParams: TypeAlias = Any
     LiteLLMLoggingObj = Any
 
 

--- a/litellm/llms/base_llm/vector_store/transformation.py
+++ b/litellm/llms/base_llm/vector_store/transformation.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import httpx
 
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.vector_stores import (
     VECTOR_STORE_OPENAI_PARAMS,
     BaseVectorStoreAuthCredentials,
@@ -16,12 +15,14 @@ from litellm.types.vector_stores import (
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
     BaseLLMException = _BaseLLMException
 else:
+    GenericLiteLLMParams = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
 

--- a/litellm/llms/base_llm/vector_store/transformation.py
+++ b/litellm/llms/base_llm/vector_store/transformation.py
@@ -1,10 +1,9 @@
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn, TypeAlias
 
 import httpx
 
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.vector_stores import (
     VECTOR_STORE_OPENAI_PARAMS,
     BaseVectorStoreAuthCredentials,
@@ -17,12 +16,14 @@ from litellm.types.vector_stores import (
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
     BaseLLMException = _BaseLLMException
 else:
+    GenericLiteLLMParams: TypeAlias = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
 

--- a/litellm/llms/base_llm/vector_store_files/transformation.py
+++ b/litellm/llms/base_llm/vector_store_files/transformation.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import httpx
 
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.vector_store_files import (
     VectorStoreFileAuthCredentials,
     VectorStoreFileChunkingStrategy,
@@ -18,12 +17,14 @@ from litellm.types.vector_store_files import (
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
     BaseLLMException = _BaseLLMException
 else:
+    GenericLiteLLMParams = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
 

--- a/litellm/llms/base_llm/vector_store_files/transformation.py
+++ b/litellm/llms/base_llm/vector_store_files/transformation.py
@@ -1,9 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import httpx
 
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.vector_store_files import (
     VectorStoreFileAuthCredentials,
     VectorStoreFileChunkingStrategy,
@@ -18,12 +17,14 @@ from litellm.types.vector_store_files import (
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
     BaseLLMException = _BaseLLMException
 else:
+    GenericLiteLLMParams: TypeAlias = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
 

--- a/litellm/llms/base_llm/videos/transformation.py
+++ b/litellm/llms/base_llm/videos/transformation.py
@@ -6,11 +6,11 @@ import httpx
 from httpx._types import RequestFiles
 
 from litellm.types.responses.main import *
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.videos.main import VideoCreateOptionalRequestParams
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
     from litellm.types.videos.main import CharacterObject as _CharacterObject
     from litellm.types.videos.main import VideoObject as _VideoObject
 
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     VideoObject = _VideoObject
     CharacterObject = _CharacterObject
 else:
+    GenericLiteLLMParams = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
     VideoObject = Any

--- a/litellm/llms/base_llm/videos/transformation.py
+++ b/litellm/llms/base_llm/videos/transformation.py
@@ -1,16 +1,16 @@
 import types
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import httpx
 from httpx._types import RequestFiles
 
 from litellm.types.responses.main import *
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.videos.main import VideoCreateOptionalRequestParams
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.router import GenericLiteLLMParams
     from litellm.types.videos.main import CharacterObject as _CharacterObject
     from litellm.types.videos.main import VideoObject as _VideoObject
 
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     VideoObject = _VideoObject
     CharacterObject = _CharacterObject
 else:
+    GenericLiteLLMParams: TypeAlias = Any
     LiteLLMLoggingObj = Any
     BaseLLMException = Any
     VideoObject = Any

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.proxy._types import SpendLogsPayload
 from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
 from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import (
@@ -15,10 +14,12 @@ from litellm.types.llms.openai import (
 from litellm.types.utils import ChatCompletionMessageToolCall, Message, ModelResponse
 
 if TYPE_CHECKING:
+    from litellm.proxy._types import SpendLogsPayload
     from litellm.responses.litellm_completion_transformation.transformation import (
         ChatCompletionSession,
     )
 else:
+    SpendLogsPayload = Any
     ChatCompletionSession = Any
 
 ########################################################

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -1,9 +1,8 @@
 import json
-from typing import TYPE_CHECKING, Any, Final, cast
+from typing import TYPE_CHECKING, Any, Final, TypeAlias, cast
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.proxy._types import SpendLogsPayload
 from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
 from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import (
@@ -15,10 +14,12 @@ from litellm.types.llms.openai import (
 from litellm.types.utils import ChatCompletionMessageToolCall, Message, ModelResponse
 
 if TYPE_CHECKING:
+    from litellm.proxy._types import SpendLogsPayload
     from litellm.responses.litellm_completion_transformation.transformation import (
         ChatCompletionSession,
     )
 else:
+    SpendLogsPayload: TypeAlias = Any
     ChatCompletionSession = Any
 
 ########################################################

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1682,6 +1682,28 @@ class TestGuardrailInterventionClassification:
         exc = HTTPException(status_code=status_code, detail="guardrail api error")
         assert CustomGuardrail._is_guardrail_intervention(exc) is False
 
+    def test_http_exception_subclass_is_intervention(self):
+        """Guardrail providers raise HTTPException subclasses (e.g. Noma's
+        NomaBlockedMessage) from their own module to signal a block. Detection
+        must use isinstance so a subclass is not misread as a technical error."""
+        from fastapi.exceptions import HTTPException
+
+        class NomaBlockedMessage(HTTPException):
+            pass
+
+        assert (
+            CustomGuardrail._is_guardrail_intervention(
+                NomaBlockedMessage(status_code=400, detail="blocked content")
+            )
+            is True
+        )
+        assert (
+            CustomGuardrail._is_guardrail_intervention(
+                NomaBlockedMessage(status_code=429, detail="rate limited")
+            )
+            is False
+        )
+
     @pytest.mark.asyncio
     async def test_non_400_4xx_logged_as_intervened_not_failed(self):
         from fastapi.exceptions import HTTPException

--- a/tests/test_litellm/test_import_time.py
+++ b/tests/test_litellm/test_import_time.py
@@ -1,0 +1,74 @@
+"""Test that litellm import time doesn't regress.
+
+Ref https://github.com/BerriAI/litellm/issues/7605
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def test_proxy_types_not_imported_eagerly():
+    """Ensure proxy._types is not loaded during import litellm.
+
+    Note: litellm_enterprise (if installed) may pull in proxy._types
+    through its own imports. We skip in that case since the enterprise
+    package is not part of the core import chain.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import litellm; import sys; "
+                "enterprise = 'litellm_enterprise' in sys.modules; "
+                "loaded = 'litellm.proxy._types' in sys.modules; "
+                "print(f'{loaded},{enterprise}')"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "LITELLM_LOCAL_MODEL_COST_MAP": "true"},
+    )
+    assert result.returncode == 0
+    loaded, enterprise = result.stdout.strip().split(",")
+    if enterprise == "True":
+        pytest.skip("litellm_enterprise installed. Pulls in proxy._types independently")
+    assert (
+        loaded == "False"
+    ), "litellm.proxy._types should not be loaded during import litellm"
+
+
+def test_import_safety():
+    """Ensure `from litellm import *` still works after import changes."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from litellm import *; print('OK')",
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "LITELLM_LOCAL_MODEL_COST_MAP": "true"},
+    )
+    assert result.returncode == 0, f"from litellm import * failed: {result.stderr}"
+    assert "OK" in result.stdout
+
+
+def test_model_cost_loaded():
+    """Ensure model_cost dict is populated from local backup at import time."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import litellm; print(len(litellm.model_cost))",
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "LITELLM_LOCAL_MODEL_COST_MAP": "true"},
+    )
+    assert result.returncode == 0
+    count = int(result.stdout.strip())
+    assert count > 100, f"model_cost should have >100 models, got {count}"


### PR DESCRIPTION
## Relevant issues

Ref #7605

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] Greptile confidence score: **5/5**

## Type

🧹 Refactoring
🚄 Infrastructure
✅ Test

## Changes

**Before:** `import litellm` takes ~0.85s
**After:** `import litellm` takes ~0.53s (~38% faster)

### What changed
- **Background model cost map fetch:** load local JSON backup instantly, fetch remote in daemon thread with `_cost_map_source_info` tracking and `_expand_model_aliases` on both paths
- **Defer heavy imports via `__getattr__`:** DatadogInitParams, AnthropicModelInfo, AI21ChatConfig, PalmConfig, AlephAlphaConfig, GeminiModelInfo, VertexAITextEmbeddingConfig, AmazonTitanV2Config, TopazModelInfo, XAIModelInfo, CustomLLM, PromptSpec, Router, BudgetManager, run_server
- **Defer `proxy._types` and `GenericLiteLLMParams`:** moved behind `TYPE_CHECKING` guards in base_llm transformation files
- **Remove fastapi from `custom_guardrail.py`:** duck-type check on HTTPException instead of `isinstance`
- **Lazy-load `litellm.interactions`:** `__getattr__` based loading on first access
- **Invalidate model cost cache** after background update completes

Based on @krrishdholakia's suggestions in [#7605](https://github.com/BerriAI/litellm/issues/7605#issuecomment-2925363941)