### PR TITLE
fix(cost-calc): use per-image pricing for Bedrock multimodal embeddings

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -602,7 +602,7 @@ def generic_cost_per_token(  # noqa: PLR0915
     total_details = text_tokens + cache_hit + audio_tokens + cache_creation + image_tokens
     has_double_counting = cache_hit > 0 and total_details > usage.prompt_tokens
 
-    if text_tokens == 0 or has_double_counting:
+    if (text_tokens == 0 and prompt_tokens_details["image_count"] == 0) or has_double_counting:
         text_tokens = (
             usage.prompt_tokens
             - cache_hit

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -158,6 +158,7 @@ class BedrockEmbedding(BaseAWSLLM):
         model: str,
         provider: BEDROCK_EMBEDDING_PROVIDERS_LITERAL,
         is_async_invoke: Optional[bool] = False,
+        batch_data: Optional[List[dict]] = None,
     ) -> Optional[EmbeddingResponse]:
         """
         Transforms the response from the Bedrock embedding provider to the OpenAI format.
@@ -212,7 +213,7 @@ class BedrockEmbedding(BaseAWSLLM):
             if model == "amazon.titan-embed-image-v1":
                 returned_response = (
                     AmazonTitanMultimodalEmbeddingG1Config()._transform_response(
-                        response_list=response_list, model=model
+                        response_list=response_list, model=model, batch_data=batch_data
                     )
                 )
             elif model == "amazon.titan-embed-text-v1":
@@ -231,7 +232,7 @@ class BedrockEmbedding(BaseAWSLLM):
                 )
             elif provider == "nova":
                 returned_response = AmazonNovaEmbeddingConfig()._transform_response(
-                    response_list=response_list, model=model
+                    response_list=response_list, model=model, batch_data=batch_data
                 )
 
         ##########################################################
@@ -310,6 +311,7 @@ class BedrockEmbedding(BaseAWSLLM):
             model=model,
             provider=provider,
             is_async_invoke=is_async_invoke,
+            batch_data=batch_data,
         )
 
     async def _async_single_func_embeddings(
@@ -379,6 +381,7 @@ class BedrockEmbedding(BaseAWSLLM):
             model=model,
             provider=provider,
             is_async_invoke=is_async_invoke,
+            batch_data=batch_data,
         )
 
     def embeddings(  # noqa: PLR0915


### PR DESCRIPTION
Bedrock multimodal embedding models (Titan and Nova) were being costed using the per-token text rate instead of the correct flat per-image rate ($0.00006/image). The pricing data was correct but never applied because image_count was never populated in prompt_tokens_details.

Pass batch_data to Titan/Nova response transformers so they can count image inputs and set PromptTokensDetailsWrapper(image_count=N) on Usage, mirroring the existing Vertex AI pattern from PR #9623. Also fix the text_tokens fallback in generic_cost_per_token to not override text_tokens=0 when image_count > 0 (image-only requests).

## Relevant issues

None found — no existing GitHub issue for Bedrock image embedding cost tracking.

## Pre-Submission checklist

- [x] I have Added testing — 8 new tests across existing test files for Bedrock embeddings and cost calculation
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Source changes (4 files)

1. **`litellm/llms/bedrock/embed/amazon_titan_multimodal_transformation.py`** — Add `batch_data` param to `_transform_response()`, count `inputImage` keys in requests, populate `PromptTokensDetailsWrapper(image_count=N)` in `Usage`

2. **`litellm/llms/bedrock/embed/amazon_nova_transformation.py`** — Same pattern for Nova: add `batch_data` param, count `image` keys in `singleEmbeddingParams`/`segmentedEmbeddingParams`, populate `prompt_tokens_details`

3. **`litellm/llms/bedrock/embed/embedding.py`** — Add `batch_data` param to handler's `_transform_response()`, thread it through to Titan and Nova model-specific transformers from both `_single_func_embeddings` and `_async_single_func_embeddings`

4. **`litellm/litellm_core_utils/llm_cost_calc/utils.py`** — One-line fix (line 605): add `and prompt_tokens_details["image_count"] == 0` to the `text_tokens` fallback condition so image-only requests aren't double-charged

### Tests added (8 new tests across 3 files)

- `tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py`: 4 tests — Titan image cost tracking, text-only no image_count, backward compat without batch_data, e2e via litellm.embedding()
- `tests/llm_translation/test_bedrock_nova_embedding.py`: 3 tests — Nova image cost tracking, text-only no image_count, backward compat without batch_data
- `tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py`: 1 test — regression test that image_count > 0 prevents text_tokens fallback double-charging