### PR TITLE
fix: forward retry-after header from upstream providers to clients

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/get_headers.py
+++ b/litellm/litellm_core_utils/llm_response_utils/get_headers.py
@@ -35,6 +35,8 @@ def get_response_headers(_response_headers: Optional[dict] = None) -> dict:
         openai_headers["x-ratelimit-remaining-tokens"] = _response_headers[
             "x-ratelimit-remaining-tokens"
         ]
+    if "retry-after" in _response_headers:
+        openai_headers["retry-after"] = _response_headers["retry-after"]
     llm_provider_headers = _get_llm_provider_headers(_response_headers)
     return {**llm_provider_headers, **openai_headers}
 


### PR DESCRIPTION
## Summary

- Forward the upstream provider's `retry-after` header as a bare `retry-after` on the proxy's error response, in addition to the existing `llm_provider-retry-after` prefix
- Follows the same pattern already used for `x-ratelimit-*` headers in `get_response_headers()`
- Clients using the OpenAI Python SDK pointed at a LiteLLM proxy will now correctly respect the provider's retry-after timing on 429 responses

## Fix Details

When an upstream provider (e.g., AzureOpenAI) returns a `429 Too Many Requests` with a `retry-after` header, `get_response_headers()` previously only emitted `llm_provider-retry-after`. The bare `retry-after` header was absent, so the OpenAI SDK's built-in retry logic never saw it.

The fix adds `retry-after` to the set of headers preserved as-is (alongside the `x-ratelimit-*` family), so the proxy's 429 response now includes both:
- `retry-after: <value>` (for SDK compatibility)
- `llm_provider-retry-after: <value>` (existing behavior, preserved for backward compat)

## Test plan

- [x] Unit test `test_get_response_headers_with_retry_after` verifies the header is preserved
- [x] Unit test `test_get_response_headers_without_retry_after` verifies no header leak when absent
- [x] Integration-style test `test_proxy_forwards_retry_after_from_upstream_429` simulates the full proxy error path

Fixes #21553

🤖 Generated with [Claude Code](https://claude.com/claude-code)