### PR TITLE
feat(semantic-cache): support configurable vector dimensions

### DIFF
--- a/docs/my-website/docs/caching/all_caches.md
+++ b/docs/my-website/docs/caching/all_caches.md
@@ -297,6 +297,7 @@ litellm.cache = Cache(
     similarity_threshold=0.7, # similarity threshold for cache hits, 0 == no similarity, 1 = exact matches, 0.5 == 50% similarity
     qdrant_quantization_config ="binary", # can be one of 'binary', 'product' or 'scalar' quantizations that is supported by qdrant
     qdrant_semantic_cache_embedding_model="text-embedding-ada-002", # this model is passed to litellm.embedding(), any litellm.embedding() model is supported here
+    qdrant_semantic_cache_vector_size=1536, # vector size for the embedding model, must match the dimensionality of the embedding model used
 )
 
 response1 = completion(
@@ -635,6 +636,7 @@ def __init__(
     qdrant_quantization_config: Optional[str] = None,
     qdrant_semantic_cache_embedding_model="text-embedding-ada-002",
 
+    qdrant_semantic_cache_vector_size: Optional[int] = None,
     **kwargs
 ):
 ```

--- a/docs/my-website/docs/proxy/caching.md
+++ b/docs/my-website/docs/proxy/caching.md
@@ -340,6 +340,7 @@ litellm_settings:
     qdrant_semantic_cache_embedding_model: openai-embedding # the model should be defined on the model_list
     qdrant_collection_name: test_collection
     qdrant_quantization_config: binary
+    qdrant_semantic_cache_vector_size: 1536 # vector size must match embedding model dimensionality
     similarity_threshold: 0.8 # similarity threshold for semantic cache
 ```
 

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -73,6 +73,7 @@ litellm_settings:
     qdrant_semantic_cache_embedding_model: openai-embedding # the model should be defined on the model_list
     qdrant_collection_name: test_collection
     qdrant_quantization_config: binary
+    qdrant_semantic_cache_vector_size: 1536 # vector size must match embedding model dimensionality
     similarity_threshold: 0.8 # similarity threshold for semantic cache
 
     # Optional - S3 Cache Settings

--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -108,6 +108,7 @@ class Cache:
         qdrant_collection_name: Optional[str] = None,
         qdrant_quantization_config: Optional[str] = None,
         qdrant_semantic_cache_embedding_model: str = "text-embedding-ada-002",
+        qdrant_semantic_cache_vector_size: Optional[int] = None,
         # GCP IAM authentication parameters
         gcp_service_account: Optional[str] = None,
         gcp_ssl_ca_certs: Optional[str] = None,
@@ -207,6 +208,7 @@ class Cache:
                 similarity_threshold=similarity_threshold,
                 quantization_config=qdrant_quantization_config,
                 embedding_model=qdrant_semantic_cache_embedding_model,
+                vector_size=qdrant_semantic_cache_vector_size,
             )
         elif type == LiteLLMCacheType.LOCAL:
             self.cache = InMemoryCache()

--- a/litellm/caching/qdrant_semantic_cache.py
+++ b/litellm/caching/qdrant_semantic_cache.py
@@ -31,6 +31,7 @@ class QdrantSemanticCache(BaseCache):
         quantization_config=None,
         embedding_model="text-embedding-ada-002",
         host_type=None,
+        vector_size=None,
     ):
         import os
 
@@ -53,6 +54,7 @@ class QdrantSemanticCache(BaseCache):
             raise Exception("similarity_threshold must be provided, passed None")
         self.similarity_threshold = similarity_threshold
         self.embedding_model = embedding_model
+        self.vector_size = vector_size if vector_size is not None else QDRANT_VECTOR_SIZE
         headers = {}
 
         # check if defined as os.environ/ variable
@@ -138,7 +140,7 @@ class QdrantSemanticCache(BaseCache):
             new_collection_status = self.sync_client.put(
                 url=f"{self.qdrant_api_base}/collections/{self.collection_name}",
                 json={
-                    "vectors": {"size": QDRANT_VECTOR_SIZE, "distance": "Cosine"},
+                    "vectors": {"size": self.vector_size, "distance": "Cosine"},
                     "quantization_config": quantization_params,
                 },
                 headers=self.headers,


### PR DESCRIPTION
## Summary
- Add `vector_size` parameter to `QdrantSemanticCache` to support flexible embedding dimensionality instead of hardcoded 1536
- Expose the parameter through the `Cache` facade as `qdrant_semantic_cache_vector_size` for use in both SDK and proxy YAML config
- Defaults to `QDRANT_VECTOR_SIZE` env var (1536) for backward compatibility

This enables users to use embedding models with dimensions other than OpenAI's default 1536, such as:
- Stella (1024d) - better quality than text-embedding-3-large, 2x cheaper
- bge-en-icl (4096d) - outperforms text-embedding-3-large
- Smaller models (384d, 768d) for cost savings

Closes #9377

## Changes
- `litellm/caching/qdrant_semantic_cache.py`: Add `vector_size` parameter, store as instance attribute, use when creating Qdrant collections
- `litellm/caching/caching.py`: Add `qdrant_semantic_cache_vector_size` parameter to `Cache.__init__`, pass through to `QdrantSemanticCache`
- `tests/test_litellm/caching/test_qdrant_semantic_cache.py`: Add 3 tests for custom, default, and large vector sizes
- `docs/`: Update SDK usage examples, proxy YAML config examples, and config settings docs

## Usage

### SDK
```python
litellm.cache = Cache(
    type="qdrant-semantic",
    qdrant_semantic_cache_embedding_model="stella-en-1.5B-v5",
    qdrant_semantic_cache_vector_size=1024,
    # ... other params
)
```

### Proxy config
```yaml
litellm_settings:
  cache: True
  cache_params:
    type: qdrant-semantic
    qdrant_semantic_cache_embedding_model: my-embedding-model
    qdrant_semantic_cache_vector_size: 1024
    similarity_threshold: 0.8
```

## Test plan
- [x] `test_qdrant_semantic_cache_custom_vector_size` - verifies custom vector size (768) is used in collection creation payload
- [x] `test_qdrant_semantic_cache_default_vector_size` - verifies default falls back to `QDRANT_VECTOR_SIZE` constant
- [x] `test_qdrant_semantic_cache_large_vector_size` - verifies large dimensions (4096) work correctly
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)