### PR TITLE
fix(bedrock): prevent double UUID in create_file S3 key

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -3014,8 +3014,11 @@ class BaseLLMHTTPHandler:
             raise ValueError(f"Unsupported transformed_request type: {type(transformed_request)}")
 
         # Store the upload URL in litellm_params for the transformation method
+        # Honour the URL already set by transform_create_file_request (e.g. Bedrock pre-signed S3 uploads),
+        # fall back to api_base for providers that do not set it.
         litellm_params_with_url = dict(litellm_params)
-        litellm_params_with_url["upload_url"] = api_base
+        if "upload_url" not in litellm_params:
+            litellm_params_with_url["upload_url"] = api_base
 
         return provider_config.transform_create_file_response(
             model=None,


### PR DESCRIPTION
## Summary
- **Bug**: `litellm.create_file` for Bedrock returned a `file_id` with a different UUID than the one used for the actual S3 upload, causing `create_batch` to fail with "No jsonl files found"
- **Root cause**: In `llm_http_handler.py`, the sync `create_file` path unconditionally overwrites `litellm_params["upload_url"]` with `api_base` (UUID-1), discarding the correct URL (UUID-2) that Bedrock's `transform_create_file_request` had already set
- **Fix**: Only set `upload_url` to `api_base` when `transform_create_file_request` has not already set it, preserving the Bedrock provider's value

Closes #21546

## Test plan
- Verified that the conditional fallback preserves the URL set by Bedrock's `transform_create_file_request` (UUID-2) while remaining backward-compatible for providers that do not set `upload_url` (e.g. Vertex AI)
- The async path (`async_create_file`) was already correct and is unaffected by this change