### PR TITLE
fix(ui): prevent infinite fetch loop in audit logs page

### DIFF
--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -8213,6 +8213,9 @@ export const uiAuditLogsCall = async (
   end_date?: string,
   page?: number,
   page_size?: number,
+  action?: string,
+  table_name?: string,
+  object_id?: string,
 ) => {
   try {
     // Construct base URL
@@ -8224,6 +8227,9 @@ export const uiAuditLogsCall = async (
     // if (end_date) queryParams.append('end_date', end_date);
     if (page) queryParams.append("page", page.toString());
     if (page_size) queryParams.append("page_size", page_size.toString());
+    if (action) queryParams.append("action", action);
+    if (table_name) queryParams.append("table_name", table_name);
+    if (object_id) queryParams.append("object_id", object_id);
 
     // Append query parameters to URL if any exist
     const queryString = queryParams.toString();


### PR DESCRIPTION
## Summary
- **Removed the do-while loop** that fetched ALL audit log pages into a single in-memory array on each query. Now fetches only the current page using server-side pagination.
- **Removed `refetchInterval: 5000` and `refetchIntervalInBackground: true`** which caused the full fetch-all-pages cycle to repeat every 5 seconds, even in background tabs. Users can use the existing Refresh button for manual updates.
- **Pagination now uses server-side page tracking** — `currentPage` is part of the React Query key, so page navigation triggers a single-page fetch automatically.

Closes #21513

## Test plan
- [ ] Open the Audit Logs page and verify it loads only one page of results (check Network tab — should see a single `/audit?page=1&page_size=50` request)
- [ ] Click Next/Previous buttons and verify each page change triggers exactly one API call for that page
- [ ] Confirm no repeated polling requests in the Network tab (no 5-second intervals)
- [ ] Switch to a different browser tab and back — verify no background fetches occurred
- [ ] Click the Refresh button and verify it triggers a single re-fetch of the current page
- [ ] Test client-side filters (Action, Table, Object ID search) still work correctly on the current page's data