### PR TITLE
fix(proxy): use completion_model as fallback instead of override

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -597,10 +597,10 @@ class ProxyBaseLLMRequestProcessing:
             ] = queue_time_seconds
 
         self.data["model"] = (
-            general_settings.get("completion_model", None)  # server default
+            self.data.get("model", None)  # model passed in http request
             or user_model  # model name passed via cli args
             or model  # for azure deployments
-            or self.data.get("model", None)  # default passed in http request
+            or general_settings.get("completion_model", None)  # server default (fallback)
         )
 
         # override with user settings, these are params passed via cli

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -168,9 +168,9 @@ async def chat_completion_pass_through_endpoint(  # noqa: PLR0915
             "Request received by LiteLLM:\n{}".format(json.dumps(data, indent=4)),
         )
         data["model"] = (
-            general_settings.get("completion_model", None)  # server default
+            data.get("model", None)  # model passed in http request
             or user_model  # model name passed via cli args
-            or data.get("model", None)  # default passed in http request
+            or general_settings.get("completion_model", None)  # server default (fallback)
         )
         if user_model:
             data["model"] = user_model


### PR DESCRIPTION
## Summary
- `completion_model` in `general_settings` always overrode the client-specified model instead of acting as a fallback
- Changed logic to only use `completion_model` when the client doesn't specify a model, matching the documented behavior

The bug was in the model resolution `or` chain in both `common_request_processing.py` and `pass_through_endpoints.py`. Because `completion_model` was evaluated **first**, it always took priority over the client-specified model whenever it was set. The fix reorders the chain so the client request model is checked first, and `completion_model` is used as the last fallback.

Closes #21554

## Test plan
- Verified client-specified model takes precedence over `completion_model`
- Verified `completion_model` is used as fallback when no model is specified in the request
- Verified `user_model` (CLI args) still takes precedence when client omits model