### PR TITLE
Fix: api_base is required. Unable to determine the correct api_base for the request

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -31,10 +31,11 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
 
         Validate the environment for the request
         """
+        vertex_ai_project = VertexBase.safe_get_vertex_ai_project(litellm_params)
+        vertex_ai_location = VertexBase.safe_get_vertex_ai_location(litellm_params)
+        
         if "Authorization" not in headers:
-            vertex_ai_project = VertexBase.get_vertex_ai_project(litellm_params)
-            vertex_credentials = VertexBase.get_vertex_ai_credentials(litellm_params)
-            vertex_ai_location = VertexBase.get_vertex_ai_location(litellm_params)
+            vertex_credentials = VertexBase.safe_get_vertex_ai_credentials(litellm_params)
 
             access_token, project_id = self._ensure_access_token(
                 credentials=vertex_credentials,
@@ -43,7 +44,12 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
             )
 
             headers["Authorization"] = f"Bearer {access_token}"
+        else:
+            # Authorization already in headers, but we still need project_id
+            project_id = vertex_ai_project
 
+        # Always calculate api_base if not provided, regardless of Authorization header
+        if api_base is None:
             api_base = self.get_complete_vertex_url(
                 custom_api_base=api_base,
                 vertex_location=vertex_ai_location,


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix


## Changes
My Fix Addresses TWO Issues:
1. Dictionary Mutation (using safe methods)
Changed from .pop() to .get() so that vertex_project, vertex_location, and vertex_credentials are never removed from litellm_params.
2. Authorization Check Logic (always calculate api_base)
Even if Authorization is already in headers (from cached/mutated extra_headers), we now always calculate api_base when it's None. This was the bug causing your "api_base is required" error.