### PR TITLE
feat(openrouter): add openrouter/minimax/minimax-m2.5 pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25951,10 +25951,13 @@
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
+        "source": "https://openrouter.ai/minimax/minimax-m2.5",
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_reasoning": true,
-        "supports_prompt_caching": true
+        "supports_vision": false,
+        "supports_prompt_caching": true,
+        "supports_computer_use": false
     },
     "ovhcloud/DeepSeek-R1-Distill-Llama-70B": {
         "input_cost_per_token": 6.7e-07,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25942,6 +25942,20 @@
         "supports_prompt_caching": false,
         "supports_computer_use": false
     },
+    "openrouter/minimax/minimax-m2.5": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.1e-06,
+        "cache_read_input_token_cost": 1.5e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 196608,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true
+    },
     "ovhcloud/DeepSeek-R1-Distill-Llama-70B": {
         "input_cost_per_token": 6.7e-07,
         "litellm_provider": "ovhcloud",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25951,10 +25951,13 @@
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
+        "source": "https://openrouter.ai/minimax/minimax-m2.5",
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_reasoning": true,
-        "supports_prompt_caching": true
+        "supports_vision": false,
+        "supports_prompt_caching": true,
+        "supports_computer_use": false
     },
     "ovhcloud/DeepSeek-R1-Distill-Llama-70B": {
         "input_cost_per_token": 6.7e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25942,6 +25942,20 @@
         "supports_prompt_caching": false,
         "supports_computer_use": false
     },
+    "openrouter/minimax/minimax-m2.5": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.1e-06,
+        "cache_read_input_token_cost": 1.5e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 196608,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true
+    },
     "ovhcloud/DeepSeek-R1-Distill-Llama-70B": {
         "input_cost_per_token": 6.7e-07,
         "litellm_provider": "ovhcloud",


### PR DESCRIPTION
## Relevant issues

Closes #21054 follow-up — adds the OpenRouter-specific entry for MiniMax M2.5 which was missing.

## What this PR does

Adds `openrouter/minimax/minimax-m2.5` to the model pricing configuration.

`minimax/MiniMax-M2.5` (direct provider) was added in #21054, but the OpenRouter routing entry `openrouter/minimax/minimax-m2.5` was not included, making the model invisible in LiteLLM UI when browsing OpenRouter models.

MiniMax M2.5 was added to OpenRouter on **2026-02-12** (`created: 1770908502`).

### Pricing (from OpenRouter API)

| | Cost |
|---|---|
| Input | $0.30 / M tokens |
| Output | $1.10 / M tokens |
| Cache read | $0.15 / M tokens |
| Context | 196,608 tokens |
| Max output | 65,536 tokens |

## Pre-Submission checklist

- [x] I have signed the CLA
- [x] My change is isolated in scope (one model addition)