### PR TITLE
fix(tests): update test_max_effort_rejected_for_opus_45 regex to match current error message

### DIFF
--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1662,7 +1662,7 @@ def test_max_effort_rejected_for_opus_45():
 
     messages = [{"role": "user", "content": "Test"}]
 
-    with pytest.raises(ValueError, match="effort='max' is only supported by Claude Opus 4.6"):
+    with pytest.raises(ValueError, match="effort='max' is only supported by Claude 4.6 models"):
         optional_params = {"output_config": {"effort": "max"}}
         config.transform_request(
             model="claude-opus-4-5-20251101",


### PR DESCRIPTION
## Summary

- `test_max_effort_rejected_for_opus_45` was failing because the production error message was expanded when Sonnet 4.6 was added as a supported model for `effort='max'`
- Old message: `"effort='max' is only supported by Claude Opus 4.6"`
- New message: `"effort='max' is only supported by Claude 4.6 models (Opus 4.6, Sonnet 4.6). Got model: ..."`
- Updated the test's `match=` regex to `"effort='max' is only supported by Claude 4.6 models"` which matches the current message

Not related to PR #21664 (which only touches pricing JSON files).

## Test plan

- [x] `test_max_effort_rejected_for_opus_45` passes locally after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)