### PR TITLE
fix(policy_endpoints): re-export private helper functions from package __init__.py

### DIFF
--- a/litellm/proxy/management_endpoints/policy_endpoints/__init__.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints/__init__.py
@@ -8,3 +8,13 @@ are imported directly into this namespace.
 """
 
 from litellm.proxy.management_endpoints.policy_endpoints.endpoints import *  # noqa: F401, F403
+from litellm.proxy.management_endpoints.policy_endpoints.endpoints import (  # noqa: F401
+    _build_all_names_per_competitor,
+    _build_comparison_blocked_words,
+    _build_competitor_guardrail_definitions,
+    _build_name_blocked_words,
+    _build_recommendation_blocked_words,
+    _build_refinement_prompt,
+    _clean_competitor_line,
+    _parse_variations_response,
+)


### PR DESCRIPTION
## Summary

- `test_policy_endpoints.py` was failing at collection with:
  ```
  ImportError: cannot import name '_build_all_names_per_competitor' from 'litellm.proxy.management_endpoints.policy_endpoints'
  ```
- **Root cause:** Python's `import *` does not re-export names beginning with `_`. The `__init__.py` only used `from .endpoints import *`, so the 8 private competitor-enrichment helper functions were invisible at the package level.
- **Fix:** Added an explicit import block for all 8 private helpers so they are accessible from the package namespace.

Not related to PR #21664 (pricing JSON changes).

## Test plan

- [x] `pytest tests/test_litellm/proxy/management_endpoints/test_policy_endpoints.py --collect-only` now collects 43 tests (previously import error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)