### PR TITLE
fix(tests): set premium_user=True in test_aasync_call_with_key_over_model_budget

### DIFF
--- a/tests/proxy_unit_tests/test_key_generate_prisma.py
+++ b/tests/proxy_unit_tests/test_key_generate_prisma.py
@@ -1779,6 +1779,7 @@ async def test_aasync_call_with_key_over_model_budget(
     # 12. Make a call with a key over budget, expect to fail
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
     setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+    setattr(litellm.proxy.proxy_server, "premium_user", True)
     await litellm.proxy.proxy_server.prisma_client.connect()
     verbose_proxy_logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
## Summary

- `test_aasync_call_with_key_over_model_budget` (all 3 parametrized variants) was failing because `generate_key_fn` calls `validate_model_max_budget`, which raises `"You must have an enterprise license to set model_max_budget"` when `premium_user` is not `True`
- The enterprise gate fires **before** the test can exercise the actual per-model budget logic, so:
  - `[gpt-4o-mini-False]` / `[openai/gpt-4o-mini-False]`: got an enterprise error instead of `"exceeded budget for model=..."`
  - `[gpt-4o-True]`: caught the enterprise exception in the `except` block, triggering `assert (should_pass is False)` which failed because `should_pass=True`
- Fix: add `setattr(litellm.proxy.proxy_server, "premium_user", True)` alongside the other proxy-server setatrs at the top of the test, matching the pattern used in JWT tests (PR #21641)

Not related to PR #21107 (bedrock) or PR #21664 (pricing JSON).

## Test plan

- [x] One-line fix, same pattern as merged PR #21285 / #21641

🤖 Generated with [Claude Code](https://claude.com/claude-code)