### PR TITLE
fix(tests): correct medium reasoning_effort assertion for gemini-3-pro-preview

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -1972,7 +1972,7 @@ def test_reasoning_effort_maps_to_thinking_level_gemini_3():
         model=model,
         drop_params=False,
     )
-    assert result["thinkingConfig"]["thinkingLevel"] == "medium"
+    assert result["thinkingConfig"]["thinkingLevel"] == "high"
     assert result["thinkingConfig"]["includeThoughts"] is True
 
     # Test high -> high + includeThoughts=True
@@ -2061,7 +2061,7 @@ def test_reasoning_effort_dict_format_gemini_3():
         model=model,
         drop_params=False,
     )
-    assert result["thinkingConfig"]["thinkingLevel"] == "medium"
+    assert result["thinkingConfig"]["thinkingLevel"] == "high"
     assert result["thinkingConfig"]["includeThoughts"] is True
 
     # Test dict format without effort key - should fall back to Gemini 3 default (low)


### PR DESCRIPTION
## Summary

- Fixes 2 failing tests in `test_vertex_and_google_ai_studio_gemini.py`
- For `gemini-3-pro-preview`, `reasoning_effort="medium"` maps to `thinkingLevel="high"` because the `"medium"` thinking level is only available on `gemini-3-flash` and `gemini-3.1-pro-preview` variants
- Both tests had the **correct comment** (`# Test medium -> high`) but the **wrong assertion** (`== "medium"` instead of `== "high"`)
- Production code in `_map_reasoning_effort_to_thinking_level` is correct — test assertions were wrong

## Test plan

- [x] `test_reasoning_effort_maps_to_thinking_level_gemini_3` passes
- [x] `test_reasoning_effort_dict_format_gemini_3` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)