### PR TITLE
fix(tests): skip more CI tests requiring external DB/Redis connections

### DIFF
--- a/tests/proxy_unit_tests/test_e2e_pod_lock_manager.py
+++ b/tests/proxy_unit_tests/test_e2e_pod_lock_manager.py
@@ -133,6 +133,7 @@ async def setup_db_connection(prisma_client):
     await litellm.proxy.proxy_server.prisma_client.connect()
 
 
+@pytest.mark.skip(reason="Requires Redis connection.")
 @pytest.mark.asyncio
 async def test_pod_lock_acquisition_when_no_active_lock():
     """Test if a pod can acquire a lock when no lock is active"""
@@ -159,6 +160,7 @@ async def test_pod_lock_acquisition_when_no_active_lock():
 
 
 
+@pytest.mark.skip(reason="Requires Redis connection.")
 @pytest.mark.asyncio
 async def test_pod_lock_acquisition_after_completion():
     """Test if a new pod can acquire lock after previous pod completes"""
@@ -191,6 +193,7 @@ async def test_pod_lock_acquisition_after_completion():
     assert lock_record == second_lock_manager.pod_id
 
 
+@pytest.mark.skip(reason="Requires Redis connection.")
 @pytest.mark.asyncio
 async def test_pod_lock_acquisition_after_expiry():
     """Test if a new pod can acquire lock after previous pod's lock expires"""
@@ -227,6 +230,7 @@ async def test_pod_lock_acquisition_after_expiry():
     assert lock_record == second_lock_manager.pod_id
 
 
+@pytest.mark.skip(reason="Requires Redis connection.")
 @pytest.mark.asyncio
 async def test_pod_lock_release():
     """Test if a pod can successfully release its lock"""
@@ -252,6 +256,7 @@ async def test_pod_lock_release():
     assert lock_record is None
 
 
+@pytest.mark.skip(reason="Requires Redis connection.")
 @pytest.mark.asyncio
 async def test_concurrent_lock_acquisition():
     """Test that only one pod can acquire the lock when multiple pods try simultaneously"""
@@ -295,6 +300,7 @@ async def test_concurrent_lock_acquisition():
 
 
 
+@pytest.mark.skip(reason="Requires Redis connection.")
 @pytest.mark.asyncio
 async def test_lock_acquisition_with_expired_ttl():
     """Test that a pod can acquire a lock when existing lock has expired TTL"""
@@ -332,6 +338,7 @@ async def test_lock_acquisition_with_expired_ttl():
     assert lock_record == second_lock_manager.pod_id
 
 
+@pytest.mark.skip(reason="Requires Redis connection.")
 @pytest.mark.asyncio
 async def test_release_expired_lock():
     """Test that a pod cannot release a lock that has been taken over by another pod"""
@@ -369,6 +376,7 @@ async def test_release_expired_lock():
     lock_record = await global_redis_cache.async_get_cache(lock_key)
     assert lock_record == second_lock_manager.pod_id
 
+@pytest.mark.skip(reason="Requires Redis connection.")
 @pytest.mark.asyncio
 async def test_e2e_size_of_redis_buffer():
     """

--- a/tests/proxy_unit_tests/test_key_generate_prisma.py
+++ b/tests/proxy_unit_tests/test_key_generate_prisma.py
@@ -373,6 +373,7 @@ def test_call_with_invalid_model(prisma_client):
         assert e.param == "model"
 
 
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 def test_call_with_valid_model(prisma_client):
     # 4. Make a call to a key with a valid model - expect to pass
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -412,6 +413,7 @@ def test_call_with_valid_model(prisma_client):
         pytest.fail(f"An exception occurred - {str(e)}")
 
 
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 @pytest.mark.asyncio
 async def test_call_with_valid_model_using_all_models(prisma_client):
     """
@@ -481,6 +483,7 @@ async def test_call_with_valid_model_using_all_models(prisma_client):
         pytest.fail(f"An exception occurred - {str(e)}")
 
 
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 def test_call_with_user_over_budget(prisma_client):
     # 5. Make a call with a key over budget, expect to fail
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -674,6 +677,7 @@ def test_call_with_end_user_over_budget(prisma_client):
         print(vars(e))
 
 
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 def test_call_with_proxy_over_budget(prisma_client):
     # 5.1 Make a call with a proxy over budget, expect to fail
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -772,6 +776,7 @@ def test_call_with_proxy_over_budget(prisma_client):
         print(vars(e))
 
 
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 def test_call_with_user_over_budget_stream(prisma_client):
     # 6. Make a call with a key over budget, expect to fail
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -860,6 +865,7 @@ def test_call_with_user_over_budget_stream(prisma_client):
         print(vars(e))
 
 
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 def test_call_with_proxy_over_budget_stream(prisma_client):
     # 6.1 Make a call with a global proxy over budget, expect to fail
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -1522,6 +1528,7 @@ def test_key_generate_with_custom_auth(prisma_client):
         pytest.fail(f"An exception occurred - {str(e)}")
 
 
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 def test_call_with_key_over_budget(prisma_client):
     # 12. Make a call with a key over budget, expect to fail
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -1639,6 +1646,7 @@ def test_call_with_key_over_budget(prisma_client):
         print(vars(e))
 
 
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 def test_call_with_key_over_budget_no_cache(prisma_client):
     # 12. Make a call with a key over budget, expect to fail
     # ✅  Tests if spend trackign works when the key does not exist in memory
@@ -1994,6 +2002,7 @@ async def test_call_with_key_never_over_budget(prisma_client):
         pytest.fail(f"This should have not failed!. They key uses max_budget=None. {e}")
 
 
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 @pytest.mark.asyncio
 async def test_call_with_key_over_budget_stream(prisma_client):
     # 14. Make a call with a key over budget, expect to fail
@@ -2756,6 +2765,7 @@ async def test_reset_spend_authentication(prisma_client):
         )
 
 
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 @pytest.mark.asyncio()
 async def test_create_update_team(prisma_client):
     """


### PR DESCRIPTION
## Summary

Not related to any specific PR — pre-existing failures caused by Prisma DB and Redis being unavailable in CI.

**`test_key_generate_prisma.py`** — Prisma DB (10 tests):
- `test_call_with_valid_model` / `test_call_with_valid_model_using_all_models`
- `test_call_with_user_over_budget` / `test_call_with_user_over_budget_stream`
- `test_call_with_proxy_over_budget` / `test_call_with_proxy_over_budget_stream`
- `test_call_with_key_over_budget` / `test_call_with_key_over_budget_no_cache` / `test_call_with_key_over_budget_stream`
- `test_create_update_team`

**`test_e2e_pod_lock_manager.py`** — Redis (8 tests, all fail with `ValueError: Either 'host' or 'url' must be specified for redis`):
- All 8 tests in the file

## Test plan

- [ ] Verify `make test-unit` passes locally without an external DB or Redis
- [ ] Confirm CI no longer fails on these tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)