### PR TITLE
fix(tests): add spec_path=None to MCP server mocks to fix Pydantic validation

### DIFF
--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -1430,6 +1430,7 @@ async def test_add_update_server_with_alias():
     mock_mcp_server.command = None
     mock_mcp_server.args = []
     mock_mcp_server.env = None
+    mock_mcp_server.spec_path = None
     # OAuth fields - set explicitly to None to avoid MagicMock objects
     mock_mcp_server.client_id = None
     mock_mcp_server.client_secret = None
@@ -1470,6 +1471,7 @@ async def test_add_update_server_without_alias():
     mock_mcp_server.command = None
     mock_mcp_server.args = []
     mock_mcp_server.env = None
+    mock_mcp_server.spec_path = None
     # OAuth fields - set explicitly to None to avoid MagicMock objects
     mock_mcp_server.client_id = None
     mock_mcp_server.client_secret = None
@@ -1510,6 +1512,7 @@ async def test_add_update_server_fallback_to_server_id():
     mock_mcp_server.command = None
     mock_mcp_server.args = []
     mock_mcp_server.env = None
+    mock_mcp_server.spec_path = None
     # OAuth fields - set explicitly to None to avoid MagicMock objects
     mock_mcp_server.client_id = None
     mock_mcp_server.client_secret = None


### PR DESCRIPTION
## Summary

`spec_path` was added to `LiteLLM_MCPServerTable` (PR #21575) but three `MagicMock`-based test setups in `test_mcp_server.py` weren't updated. `MagicMock` auto-creates a `MagicMock` object for any unset attribute, which fails Pydantic's `Optional[str]` validation for `MCPServer.spec_path`.

Added `mock_mcp_server.spec_path = None` to all three affected tests, following the existing pattern used for OAuth fields.

**Tests fixed:**
- `test_add_update_server_with_alias`
- `test_add_update_server_without_alias`
- `test_add_update_server_fallback_to_server_id`

## Test plan
- [x] All three `test_add_update_server_*` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)