### PR TITLE
fix(tests): skip remaining real prisma DB tests in CI and related test suites

### DIFF
--- a/tests/local_testing/test_add_update_models.py
+++ b/tests/local_testing/test_add_update_models.py
@@ -219,6 +219,7 @@ async def _create_new_team(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_add_team_model_to_db(prisma_client):
     """
     Test adding a team model and verifying the team_public_model_name is stored correctly

--- a/tests/local_testing/test_blocked_user_list.py
+++ b/tests/local_testing/test_blocked_user_list.py
@@ -95,6 +95,7 @@ def prisma_client():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_block_user_check(prisma_client):
     """
     - Set a blocked user as a litellm module value
@@ -140,6 +141,7 @@ async def test_block_user_check(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_block_user_db_check(prisma_client):
     """
     - Block end user via "/user/block"

--- a/tests/local_testing/test_update_spend.py
+++ b/tests/local_testing/test_update_spend.py
@@ -94,6 +94,7 @@ def prisma_client():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_batch_update_spend(prisma_client):
     await proxy_logging_obj.db_spend_update_writer.spend_update_queue.add_update(
         SpendUpdateQueueItem(

--- a/tests/proxy_admin_ui_tests/test_key_management.py
+++ b/tests/proxy_admin_ui_tests/test_key_management.py
@@ -122,6 +122,7 @@ def prisma_client():
 
 ################ Unit Tests for testing regeneration of keys ###########
 @pytest.mark.asyncio()
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_regenerate_api_key(prisma_client):
     litellm.set_verbose = True
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -223,6 +224,7 @@ async def test_regenerate_api_key(prisma_client):
 
 
 @pytest.mark.asyncio()
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_regenerate_api_key_with_new_alias_and_expiration(prisma_client):
     litellm.set_verbose = True
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -274,6 +276,7 @@ async def test_regenerate_api_key_with_new_alias_and_expiration(prisma_client):
 
 
 @pytest.mark.asyncio()
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_regenerate_key_ui(prisma_client):
     litellm.set_verbose = True
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -327,6 +330,7 @@ async def test_regenerate_key_ui(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_get_users(prisma_client):
     """
     Tests /users/list endpoint
@@ -378,6 +382,7 @@ async def test_get_users(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_get_users_filters_dashboard_keys(prisma_client):
     """
     Tests that /users/list endpoint doesn't return keys with team_id='litellm-dashboard'
@@ -464,6 +469,7 @@ async def test_get_users_filters_dashboard_keys(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_get_users_key_count(prisma_client):
     """
     Test that verifies the key_count in get_users increases when a new key is created for a user
@@ -547,6 +553,7 @@ async def cleanup_existing_teams(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_list_teams(prisma_client):
     """
     Tests /team/list endpoint to verify it returns both keys and members_with_roles
@@ -866,6 +873,7 @@ def test_prepare_metadata_fields(
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_key_update_with_model_specific_params(prisma_client):
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
     setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
@@ -939,6 +947,7 @@ async def test_key_update_with_model_specific_params(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_list_key_helper(prisma_client):
     """
     Test _list_key_helper function with various scenarios:
@@ -1096,6 +1105,7 @@ async def test_list_key_helper(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_list_key_helper_team_filtering(prisma_client):
     """
     Test _list_key_helper function's team filtering behavior:
@@ -1251,6 +1261,7 @@ async def test_key_generate_always_db_team(mock_get_team_object):
         ("o-3", False),  # Should fail - not in aliases
     ],
 )
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_team_model_alias(prisma_client, requested_model, should_pass):
     """
     Test team model alias functionality:

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -132,6 +132,7 @@ RBAC Tests
         LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
     ],
 )
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_create_new_user_in_organization(prisma_client, user_role):
     """
 
@@ -193,6 +194,7 @@ async def test_create_new_user_in_organization(prisma_client, user_role):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_org_admin_create_team_permissions(prisma_client):
     """
     Create a new org admin
@@ -264,6 +266,7 @@ async def test_org_admin_create_team_permissions(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_org_admin_create_user_permissions(prisma_client):
     """
     1. Create a new org admin
@@ -337,6 +340,7 @@ async def test_org_admin_create_user_permissions(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_org_admin_create_user_team_wrong_org_permissions(prisma_client):
     """
     Create a new org admin
@@ -486,6 +490,7 @@ async def test_org_admin_create_user_team_wrong_org_permissions(prisma_client):
         ("/organization/member_add", LitellmUserRoles.INTERNAL_USER, False),
     ],
 )
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_user_role_permissions(prisma_client, route, user_role, expected_result):
     """Test user role based permissions for different routes"""
     try:

--- a/tests/proxy_admin_ui_tests/test_usage_endpoints.py
+++ b/tests/proxy_admin_ui_tests/test_usage_endpoints.py
@@ -132,6 +132,7 @@ def prisma_client():
 
 
 @pytest.mark.asyncio()
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_view_daily_spend_ui(prisma_client):
     print("prisma client=", prisma_client)
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -176,6 +177,7 @@ async def test_view_daily_spend_ui(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_global_spend_models(prisma_client):
     print("prisma client=", prisma_client)
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -268,6 +270,7 @@ async def test_global_spend_models(prisma_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_global_spend_keys(prisma_client):
     print("prisma client=", prisma_client)
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -1035,6 +1035,7 @@ from test_key_generate_prisma import prisma_client
     [LitellmUserRoles.INTERNAL_USER.value, LitellmUserRoles.PROXY_ADMIN.value],
 )
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_create_user_default_budget(prisma_client, user_role):
 
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
@@ -1075,6 +1076,7 @@ async def test_create_user_default_budget(prisma_client, user_role):
 
 @pytest.mark.parametrize("new_member_method", ["user_id", "user_email"])
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_create_team_member_add(prisma_client, new_member_method):
     import time
 
@@ -1363,6 +1365,7 @@ async def test_create_team_member_add_team_admin(
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_user_info_team_list(prisma_client):
     """Assert user_info for admin calls team_list function"""
     from litellm.proxy._types import LiteLLM_UserTable
@@ -1966,6 +1969,7 @@ async def test_gemini_pass_through_endpoint():
 
 @pytest.mark.parametrize("hidden", [True, False])
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_proxy_model_group_alias_checks(prisma_client, hidden):
     """
     Check if model group alias is returned on
@@ -2046,6 +2050,7 @@ async def test_proxy_model_group_alias_checks(prisma_client, hidden):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
 async def test_proxy_model_group_info_rerank(prisma_client):
     """
     Check if rerank model is returned on the following endpoints


### PR DESCRIPTION
## Summary

- Adds `@pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")` to all test functions that use the real `prisma_client` fixture (requiring an external PostgreSQL connection)
- 28 skip markers added across 7 test files
- Tests using `mock_prisma_client` (properly mocked) are **unaffected**

### Files updated

| File | Tests skipped |
|------|--------------|
| `tests/proxy_unit_tests/test_proxy_server.py` | 5 |
| `tests/proxy_admin_ui_tests/test_key_management.py` | 11 |
| `tests/proxy_admin_ui_tests/test_role_based_access.py` | 5 |
| `tests/proxy_admin_ui_tests/test_usage_endpoints.py` | 3 |
| `tests/local_testing/test_blocked_user_list.py` | 2 |
| `tests/local_testing/test_add_update_models.py` | 1 |
| `tests/local_testing/test_update_spend.py` | 1 |

## Test plan

- [x] Verify `make test-unit` passes (skipped tests no longer attempt live DB connections)
- [x] Verify mock-based tests are unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)