### PR TITLE
fix(types): resolve MyPy assignment type errors in logging_utils and vertex transformation

### DIFF
--- a/litellm/litellm_core_utils/logging_utils.py
+++ b/litellm/litellm_core_utils/logging_utils.py
@@ -101,7 +101,7 @@ def _truncate_base64_in_value(value: Any) -> Any:
                 if isinstance(v, str):
                     container[k] = _truncate_base64_in_string(v)
                 elif isinstance(v, dict):
-                    copy = {ck: cv for ck, cv in v.items()}
+                    copy: Union[dict, list] = {ck: cv for ck, cv in v.items()}
                     container[k] = copy
                     stack.append((copy, depth + 1))
                 elif isinstance(v, list):

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -34,6 +34,7 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
         vertex_ai_project = VertexBase.safe_get_vertex_ai_project(litellm_params)
         vertex_ai_location = VertexBase.safe_get_vertex_ai_location(litellm_params)
         
+        project_id: Optional[str] = None
         if "Authorization" not in headers:
             vertex_credentials = VertexBase.safe_get_vertex_ai_credentials(litellm_params)
 
@@ -54,7 +55,7 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
                 custom_api_base=api_base,
                 vertex_location=vertex_ai_location,
                 vertex_project=vertex_ai_project,
-                project_id=project_id,
+                project_id=project_id or "",
                 partner=VertexPartnerProvider.claude,
                 stream=optional_params.get("stream", False),
                 model=model,


### PR DESCRIPTION
## Summary

Fixes 3 MyPy `[assignment]` errors unrelated to PR #21674.

### `litellm/litellm_core_utils/logging_utils.py` (lines 108, 120)

`copy` was first assigned as `dict` then reassigned as `list` in the same scope. MyPy inferred `copy: dict[Any, Any]` from the first assignment and rejected the `list` reassignment.

**Fix:** annotate `copy: Union[dict, list]` on the first assignment so both branches are compatible.

### `litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py` (line 51)

`project_id` was inferred as `str` (from `_ensure_access_token` return `Tuple[str, str]`) then reassigned as `str | None` (`vertex_ai_project`) in the `else` branch.

**Fix:** pre-declare `project_id: Optional[str] = None` before the if/else block; use `project_id or ""` when passing to `get_complete_vertex_url` which requires `str`.

## Test plan

- [x] `mypy litellm/litellm_core_utils/logging_utils.py litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py` → `Success: no issues found in 2 source files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)