### PR TITLE
DRAFT: Add pre-flight message validation for tool call sequences

### DIFF
--- a/litellm/litellm_core_utils/message_validation.py
+++ b/litellm/litellm_core_utils/message_validation.py
@@ -1,0 +1,271 @@
+"""
+Pre-flight validation for LLM message sequences.
+
+Validates message sequences before sending to LLM providers to catch common
+issues that would cause API errors. This saves API costs and provides clearer
+error messages than provider-side validation.
+
+Validates:
+- Tool call / tool response pairing (no orphans, no duplicates)
+- Message role sequencing rules
+- Provider-specific constraints
+
+Example usage:
+    from litellm.litellm_core_utils.message_validation import validate_messages
+
+    messages = [
+        {"role": "user", "content": "Run ls"},
+        {"role": "assistant", "tool_calls": [{"id": "tc1", ...}]},
+        {"role": "tool", "tool_call_id": "tc1", "content": "file.txt"},
+    ]
+
+    errors = validate_messages(messages, provider="openai")
+    if errors:
+        raise ValueError(f"Invalid messages: {errors}")
+"""
+
+from typing import Any, Literal
+
+# Provider types supported by validation
+ProviderType = Literal["openai", "anthropic", "auto"]
+
+
+def validate_messages(
+    messages: list[dict[str, Any]],
+    provider: ProviderType = "auto",
+    tools_defined: bool = False,
+) -> list[str]:
+    """Validate a message sequence for LLM API compatibility.
+
+    Checks for common issues that cause API errors:
+    - Tool calls without matching tool responses
+    - Duplicate tool responses for the same tool_call_id
+    - Invalid message ordering
+
+    Args:
+        messages: List of message dictionaries in OpenAI or Anthropic format
+        provider: Target provider ("openai", "anthropic", or "auto" to detect)
+        tools_defined: Whether tools are defined in the request
+
+    Returns:
+        List of validation error messages (empty if valid)
+    """
+    if not messages:
+        return []
+
+    # Auto-detect provider from message format
+    if provider == "auto":
+        provider = _detect_provider(messages)
+
+    if provider == "anthropic":
+        return _validate_anthropic_messages(messages, tools_defined)
+    else:
+        return _validate_openai_messages(messages, tools_defined)
+
+
+def _detect_provider(messages: list[dict[str, Any]]) -> Literal["openai", "anthropic"]:
+    """Detect provider from message format."""
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    block_type = block.get("type", "")
+                    if block_type in ("tool_use", "tool_result"):
+                        return "anthropic"
+    return "openai"
+
+
+def _validate_openai_messages(
+    messages: list[dict[str, Any]],
+    tools_defined: bool,
+) -> list[str]:
+    """Validate OpenAI Chat Completions message format.
+
+    OpenAI rules:
+    - Each tool_call in an assistant message must have exactly one
+      corresponding tool message with matching tool_call_id
+    - Tool messages must follow the assistant message containing the tool_call
+    - No duplicate tool_call_ids in tool responses
+    """
+    errors: list[str] = []
+
+    # Track tool_call_ids and their responses
+    pending_tool_calls: dict[str, int] = {}  # tool_call_id -> message index
+    seen_tool_responses: set[str] = set()
+
+    for i, msg in enumerate(messages):
+        role = msg.get("role")
+
+        if role == "assistant":
+            tool_calls = msg.get("tool_calls") or []
+            for tc in tool_calls:
+                tc_id = tc.get("id")
+                if tc_id:
+                    if tc_id in pending_tool_calls:
+                        errors.append(
+                            f"Duplicate tool_call id '{tc_id}' in assistant messages"
+                        )
+                    pending_tool_calls[tc_id] = i
+
+        elif role == "tool":
+            tc_id = msg.get("tool_call_id")
+            if tc_id:
+                if tc_id in seen_tool_responses:
+                    errors.append(
+                        f"Duplicate tool response for tool_call_id '{tc_id}'"
+                    )
+                seen_tool_responses.add(tc_id)
+
+                if tc_id in pending_tool_calls:
+                    del pending_tool_calls[tc_id]
+                else:
+                    errors.append(
+                        f"Tool response for unknown tool_call_id '{tc_id}' "
+                        f"(no matching tool_call found)"
+                    )
+
+        elif role in ("user", "system", "developer"):
+            # User/system messages after tool_calls but before tool responses
+            # indicate missing tool responses
+            if pending_tool_calls and tools_defined:
+                unresolved = list(pending_tool_calls.keys())
+                errors.append(
+                    f"Unresolved tool_calls before {role} message: {unresolved}. "
+                    f"Each tool_call must have a matching tool response."
+                )
+
+    # Check for any remaining unresolved tool calls at end of messages
+    if pending_tool_calls and tools_defined:
+        unresolved = list(pending_tool_calls.keys())
+        errors.append(
+            f"Unresolved tool_calls at end of messages: {unresolved}. "
+            f"Each tool_call must have a matching tool response."
+        )
+
+    return errors
+
+
+def _validate_anthropic_messages(
+    messages: list[dict[str, Any]],
+    tools_defined: bool,
+) -> list[str]:
+    """Validate Anthropic Messages API format.
+
+    Anthropic rules:
+    - Each tool_use block must have exactly one tool_result block
+      with matching id in a subsequent user message
+    - tool_result must come in the user message immediately following
+      the assistant message with tool_use
+    - No duplicate tool_use_ids in tool_result blocks
+    """
+    errors: list[str] = []
+
+    # Track tool_use ids and their results
+    pending_tool_uses: dict[str, int] = {}  # tool_use_id -> message index
+    seen_tool_results: set[str] = set()
+
+    for i, msg in enumerate(messages):
+        role = msg.get("role")
+        content = msg.get("content")
+
+        if role == "assistant" and isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    tu_id = block.get("id")
+                    if tu_id:
+                        if tu_id in pending_tool_uses:
+                            errors.append(
+                                f"Duplicate tool_use id '{tu_id}' in assistant messages"
+                            )
+                        pending_tool_uses[tu_id] = i
+
+        elif role == "user" and isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    tu_id = block.get("tool_use_id")
+                    if tu_id:
+                        if tu_id in seen_tool_results:
+                            errors.append(
+                                f"Duplicate tool_result for tool_use_id '{tu_id}'"
+                            )
+                        seen_tool_results.add(tu_id)
+
+                        if tu_id in pending_tool_uses:
+                            del pending_tool_uses[tu_id]
+                        else:
+                            errors.append(
+                                f"tool_result for unknown tool_use_id '{tu_id}' "
+                                f"(no matching tool_use found)"
+                            )
+
+        elif role == "user" and not isinstance(content, list):
+            # Plain user message after tool_use but before tool_result
+            if pending_tool_uses and tools_defined:
+                unresolved = list(pending_tool_uses.keys())
+                errors.append(
+                    f"Unresolved tool_use blocks before user message: {unresolved}. "
+                    f"Each tool_use must have a matching tool_result."
+                )
+
+    # Check for any remaining unresolved tool uses at end of messages
+    if pending_tool_uses and tools_defined:
+        unresolved = list(pending_tool_uses.keys())
+        errors.append(
+            f"Unresolved tool_use blocks at end of messages: {unresolved}. "
+            f"Each tool_use must have a matching tool_result."
+        )
+
+    return errors
+
+
+def validate_responses_input(
+    input_items: list[dict[str, Any]],
+    tools_defined: bool = False,
+) -> list[str]:
+    """Validate OpenAI Responses API input format.
+
+    Responses API rules:
+    - Each function_call must have exactly one function_call_output
+      with matching call_id
+    - No duplicate call_ids in function_call_output items
+    """
+    errors: list[str] = []
+
+    pending_calls: dict[str, int] = {}  # call_id -> item index
+    seen_outputs: set[str] = set()
+
+    for i, item in enumerate(input_items):
+        item_type = item.get("type")
+
+        if item_type == "function_call":
+            call_id = item.get("call_id")
+            if call_id:
+                if call_id in pending_calls:
+                    errors.append(f"Duplicate function_call id '{call_id}'")
+                pending_calls[call_id] = i
+
+        elif item_type == "function_call_output":
+            call_id = item.get("call_id")
+            if call_id:
+                if call_id in seen_outputs:
+                    errors.append(
+                        f"Duplicate function_call_output for call_id '{call_id}'"
+                    )
+                seen_outputs.add(call_id)
+
+                if call_id in pending_calls:
+                    del pending_calls[call_id]
+                else:
+                    errors.append(
+                        f"function_call_output for unknown call_id '{call_id}'"
+                    )
+
+    if pending_calls and tools_defined:
+        unresolved = list(pending_calls.keys())
+        errors.append(
+            f"Unresolved function_calls: {unresolved}. "
+            f"Each function_call must have a matching function_call_output."
+        )
+
+    return errors

--- a/litellm/litellm_core_utils/message_validation.py
+++ b/litellm/litellm_core_utils/message_validation.py
@@ -22,19 +22,23 @@ Example usage:
     errors = validate_messages(messages, provider="openai")
     if errors:
         raise ValueError(f"Invalid messages: {errors}")
+
+TODO: Integration - This module is not yet integrated into the main completion flow.
+Planned integration point: litellm/main.py near validate_and_fix_openai_messages() call.
+Can be used as an opt-in utility via direct import until integrated.
 """
 
-from typing import Any, Literal
+from typing import Any, Dict, List, Literal, Set
 
 # Provider types supported by validation
 ProviderType = Literal["openai", "anthropic", "auto"]
 
 
 def validate_messages(
-    messages: list[dict[str, Any]],
+    messages: List[Dict[str, Any]],
     provider: ProviderType = "auto",
     tools_defined: bool = False,
-) -> list[str]:
+) -> List[str]:
     """Validate a message sequence for LLM API compatibility.
 
     Checks for common issues that cause API errors:
@@ -63,7 +67,7 @@ def validate_messages(
         return _validate_openai_messages(messages, tools_defined)
 
 
-def _detect_provider(messages: list[dict[str, Any]]) -> Literal["openai", "anthropic"]:
+def _detect_provider(messages: List[Dict[str, Any]]) -> Literal["openai", "anthropic"]:
     """Detect provider from message format."""
     for msg in messages:
         content = msg.get("content")
@@ -77,9 +81,9 @@ def _detect_provider(messages: list[dict[str, Any]]) -> Literal["openai", "anthr
 
 
 def _validate_openai_messages(
-    messages: list[dict[str, Any]],
+    messages: List[Dict[str, Any]],
     tools_defined: bool,
-) -> list[str]:
+) -> List[str]:
     """Validate OpenAI Chat Completions message format.
 
     OpenAI rules:
@@ -88,11 +92,11 @@ def _validate_openai_messages(
     - Tool messages must follow the assistant message containing the tool_call
     - No duplicate tool_call_ids in tool responses
     """
-    errors: list[str] = []
+    errors: List[str] = []
 
     # Track tool_call_ids and their responses
-    pending_tool_calls: dict[str, int] = {}  # tool_call_id -> message index
-    seen_tool_responses: set[str] = set()
+    pending_tool_calls: Dict[str, int] = {}  # tool_call_id -> message index
+    seen_tool_responses: Set[str] = set()
 
     for i, msg in enumerate(messages):
         role = msg.get("role")
@@ -134,6 +138,7 @@ def _validate_openai_messages(
                     f"Unresolved tool_calls before {role} message: {unresolved}. "
                     f"Each tool_call must have a matching tool response."
                 )
+                pending_tool_calls.clear()
 
     # Check for any remaining unresolved tool calls at end of messages
     if pending_tool_calls and tools_defined:
@@ -147,9 +152,9 @@ def _validate_openai_messages(
 
 
 def _validate_anthropic_messages(
-    messages: list[dict[str, Any]],
+    messages: List[Dict[str, Any]],
     tools_defined: bool,
-) -> list[str]:
+) -> List[str]:
     """Validate Anthropic Messages API format.
 
     Anthropic rules:
@@ -159,11 +164,11 @@ def _validate_anthropic_messages(
       the assistant message with tool_use
     - No duplicate tool_use_ids in tool_result blocks
     """
-    errors: list[str] = []
+    errors: List[str] = []
 
     # Track tool_use ids and their results
-    pending_tool_uses: dict[str, int] = {}  # tool_use_id -> message index
-    seen_tool_results: set[str] = set()
+    pending_tool_uses: Dict[str, int] = {}  # tool_use_id -> message index
+    seen_tool_results: Set[str] = set()
 
     for i, msg in enumerate(messages):
         role = msg.get("role")
@@ -207,6 +212,7 @@ def _validate_anthropic_messages(
                     f"Unresolved tool_use blocks before user message: {unresolved}. "
                     f"Each tool_use must have a matching tool_result."
                 )
+                pending_tool_uses.clear()
 
     # Check for any remaining unresolved tool uses at end of messages
     if pending_tool_uses and tools_defined:
@@ -220,9 +226,9 @@ def _validate_anthropic_messages(
 
 
 def validate_responses_input(
-    input_items: list[dict[str, Any]],
+    input_items: List[Dict[str, Any]],
     tools_defined: bool = False,
-) -> list[str]:
+) -> List[str]:
     """Validate OpenAI Responses API input format.
 
     Responses API rules:
@@ -230,10 +236,10 @@ def validate_responses_input(
       with matching call_id
     - No duplicate call_ids in function_call_output items
     """
-    errors: list[str] = []
+    errors: List[str] = []
 
-    pending_calls: dict[str, int] = {}  # call_id -> item index
-    seen_outputs: set[str] = set()
+    pending_calls: Dict[str, int] = {}  # call_id -> item index
+    seen_outputs: Set[str] = set()
 
     for i, item in enumerate(input_items):
         item_type = item.get("type")

--- a/tests/litellm_core_utils/test_message_validation.py
+++ b/tests/litellm_core_utils/test_message_validation.py
@@ -1,0 +1,233 @@
+"""Tests for pre-flight message validation.
+
+Tests validate detection of common issues that cause LLM API errors:
+- Orphan tool calls (tool_call without response)
+- Duplicate tool responses
+- Invalid message sequencing
+"""
+
+import pytest
+
+from litellm.litellm_core_utils.message_validation import (
+    validate_messages,
+    validate_responses_input,
+)
+
+
+class TestOpenAIValidation:
+    """Test OpenAI Chat Completions message validation."""
+
+    def test_valid_tool_call_sequence(self):
+        """Valid: tool_call followed by matching tool response."""
+        messages = [
+            {"role": "user", "content": "Run ls"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"cmd":"ls"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_123", "content": "file.txt"},
+        ]
+        errors = validate_messages(messages, provider="openai", tools_defined=True)
+        assert errors == []
+
+    def test_orphan_tool_call(self):
+        """Invalid: tool_call without matching tool response."""
+        messages = [
+            {"role": "user", "content": "Run ls"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_orphan",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "What happened?"},
+        ]
+        errors = validate_messages(messages, provider="openai", tools_defined=True)
+        assert len(errors) >= 1
+        assert any("unresolved" in e.lower() for e in errors)
+
+    def test_duplicate_tool_response(self):
+        """Invalid: multiple tool responses for same tool_call_id."""
+        messages = [
+            {"role": "user", "content": "Run ls"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_dup", "type": "function", "function": {"name": "x", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_dup", "content": "first"},
+            {"role": "tool", "tool_call_id": "call_dup", "content": "duplicate"},
+        ]
+        errors = validate_messages(messages, provider="openai", tools_defined=True)
+        assert len(errors) >= 1
+        assert any("duplicate" in e.lower() for e in errors)
+
+    def test_orphan_tool_response(self):
+        """Invalid: tool response without matching tool_call."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "tool", "tool_call_id": "unknown_id", "content": "result"},
+        ]
+        errors = validate_messages(messages, provider="openai", tools_defined=True)
+        assert len(errors) >= 1
+        assert any("unknown" in e.lower() for e in errors)
+
+    def test_multiple_parallel_tool_calls(self):
+        """Valid: multiple tool_calls in one message, all resolved."""
+        messages = [
+            {"role": "user", "content": "Run commands"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "c1", "type": "function", "function": {"name": "a", "arguments": "{}"}},
+                    {"id": "c2", "type": "function", "function": {"name": "b", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "result1"},
+            {"role": "tool", "tool_call_id": "c2", "content": "result2"},
+        ]
+        errors = validate_messages(messages, provider="openai", tools_defined=True)
+        assert errors == []
+
+
+class TestAnthropicValidation:
+    """Test Anthropic Messages API validation."""
+
+    def test_valid_tool_use_sequence(self):
+        """Valid: tool_use followed by tool_result in next user message."""
+        messages = [
+            {"role": "user", "content": "Run ls"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Running command"},
+                    {"type": "tool_use", "id": "tu_123", "name": "terminal", "input": {}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu_123", "content": "file.txt"},
+                ],
+            },
+        ]
+        errors = validate_messages(messages, provider="anthropic", tools_defined=True)
+        assert errors == []
+
+    def test_orphan_tool_use(self):
+        """Invalid: tool_use without matching tool_result."""
+        messages = [
+            {"role": "user", "content": "Run ls"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "tu_orphan", "name": "terminal", "input": {}},
+                ],
+            },
+            {"role": "user", "content": "What happened?"},
+        ]
+        errors = validate_messages(messages, provider="anthropic", tools_defined=True)
+        assert len(errors) >= 1
+        assert any("unresolved" in e.lower() for e in errors)
+
+    def test_duplicate_tool_result(self):
+        """Invalid: multiple tool_results for same tool_use_id."""
+        messages = [
+            {"role": "user", "content": "Run ls"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "tu_dup", "name": "x", "input": {}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu_dup", "content": "first"},
+                    {"type": "tool_result", "tool_use_id": "tu_dup", "content": "dup"},
+                ],
+            },
+        ]
+        errors = validate_messages(messages, provider="anthropic", tools_defined=True)
+        assert len(errors) >= 1
+        assert any("duplicate" in e.lower() for e in errors)
+
+
+class TestResponsesAPIValidation:
+    """Test OpenAI Responses API input validation."""
+
+    def test_valid_function_call_sequence(self):
+        """Valid: function_call followed by function_call_output."""
+        input_items = [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Run ls"}],
+            },
+            {"type": "function_call", "call_id": "fc_123", "name": "terminal", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "fc_123", "output": "file.txt"},
+        ]
+        errors = validate_responses_input(input_items, tools_defined=True)
+        assert errors == []
+
+    def test_orphan_function_call(self):
+        """Invalid: function_call without function_call_output."""
+        input_items = [
+            {"type": "function_call", "call_id": "fc_orphan", "name": "x", "arguments": "{}"},
+        ]
+        errors = validate_responses_input(input_items, tools_defined=True)
+        assert len(errors) >= 1
+        assert any("unresolved" in e.lower() for e in errors)
+
+    def test_duplicate_function_output(self):
+        """Invalid: multiple outputs for same call_id."""
+        input_items = [
+            {"type": "function_call", "call_id": "fc_dup", "name": "x", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "fc_dup", "output": "first"},
+            {"type": "function_call_output", "call_id": "fc_dup", "output": "dup"},
+        ]
+        errors = validate_responses_input(input_items, tools_defined=True)
+        assert len(errors) >= 1
+        assert any("duplicate" in e.lower() for e in errors)
+
+
+class TestAutoDetection:
+    """Test automatic provider detection."""
+
+    def test_detects_openai_format(self):
+        """Detects OpenAI format from tool_calls structure."""
+        messages = [
+            {"role": "assistant", "tool_calls": [{"id": "c1"}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "x"},
+        ]
+        errors = validate_messages(messages, provider="auto", tools_defined=True)
+        # Should not error - valid OpenAI format
+        assert errors == []
+
+    def test_detects_anthropic_format(self):
+        """Detects Anthropic format from tool_use/tool_result blocks."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "tu1", "name": "x", "input": {}}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "tu1", "content": "x"}],
+            },
+        ]
+        errors = validate_messages(messages, provider="auto", tools_defined=True)
+        # Should not error - valid Anthropic format
+        assert errors == []

--- a/tests/litellm_core_utils/test_message_validation.py
+++ b/tests/litellm_core_utils/test_message_validation.py
@@ -54,11 +54,16 @@ class TestOpenAIValidation:
             {"role": "user", "content": "What happened?"},
         ]
         errors = validate_messages(messages, provider="openai", tools_defined=True)
-        assert len(errors) >= 1
-        assert any("unresolved" in e.lower() for e in errors)
+        assert len(errors) == 1
+        assert "unresolved" in errors[0].lower()
 
     def test_duplicate_tool_response(self):
-        """Invalid: multiple tool responses for same tool_call_id."""
+        """Invalid: multiple tool responses for same tool_call_id.
+        
+        After first response resolves the call, second response triggers:
+        1. Duplicate error (same ID seen before)
+        2. Unknown ID error (call was already resolved)
+        """
         messages = [
             {"role": "user", "content": "Run ls"},
             {
@@ -71,7 +76,7 @@ class TestOpenAIValidation:
             {"role": "tool", "tool_call_id": "call_dup", "content": "duplicate"},
         ]
         errors = validate_messages(messages, provider="openai", tools_defined=True)
-        assert len(errors) >= 1
+        assert len(errors) == 2
         assert any("duplicate" in e.lower() for e in errors)
 
     def test_orphan_tool_response(self):
@@ -81,8 +86,8 @@ class TestOpenAIValidation:
             {"role": "tool", "tool_call_id": "unknown_id", "content": "result"},
         ]
         errors = validate_messages(messages, provider="openai", tools_defined=True)
-        assert len(errors) >= 1
-        assert any("unknown" in e.lower() for e in errors)
+        assert len(errors) == 1
+        assert "unknown" in errors[0].lower()
 
     def test_multiple_parallel_tool_calls(self):
         """Valid: multiple tool_calls in one message, all resolved."""
@@ -139,11 +144,16 @@ class TestAnthropicValidation:
             {"role": "user", "content": "What happened?"},
         ]
         errors = validate_messages(messages, provider="anthropic", tools_defined=True)
-        assert len(errors) >= 1
-        assert any("unresolved" in e.lower() for e in errors)
+        assert len(errors) == 1
+        assert "unresolved" in errors[0].lower()
 
     def test_duplicate_tool_result(self):
-        """Invalid: multiple tool_results for same tool_use_id."""
+        """Invalid: multiple tool_results for same tool_use_id.
+        
+        After first result resolves the tool_use, second result triggers:
+        1. Duplicate error (same ID seen before)
+        2. Unknown ID error (tool_use was already resolved)
+        """
         messages = [
             {"role": "user", "content": "Run ls"},
             {
@@ -161,7 +171,7 @@ class TestAnthropicValidation:
             },
         ]
         errors = validate_messages(messages, provider="anthropic", tools_defined=True)
-        assert len(errors) >= 1
+        assert len(errors) == 2
         assert any("duplicate" in e.lower() for e in errors)
 
 
@@ -188,18 +198,23 @@ class TestResponsesAPIValidation:
             {"type": "function_call", "call_id": "fc_orphan", "name": "x", "arguments": "{}"},
         ]
         errors = validate_responses_input(input_items, tools_defined=True)
-        assert len(errors) >= 1
-        assert any("unresolved" in e.lower() for e in errors)
+        assert len(errors) == 1
+        assert "unresolved" in errors[0].lower()
 
     def test_duplicate_function_output(self):
-        """Invalid: multiple outputs for same call_id."""
+        """Invalid: multiple outputs for same call_id.
+        
+        After first output resolves the call, second output triggers:
+        1. Duplicate error (same ID seen before)
+        2. Unknown ID error (call was already resolved)
+        """
         input_items = [
             {"type": "function_call", "call_id": "fc_dup", "name": "x", "arguments": "{}"},
             {"type": "function_call_output", "call_id": "fc_dup", "output": "first"},
             {"type": "function_call_output", "call_id": "fc_dup", "output": "dup"},
         ]
         errors = validate_responses_input(input_items, tools_defined=True)
-        assert len(errors) >= 1
+        assert len(errors) == 2
         assert any("duplicate" in e.lower() for e in errors)
 
 


### PR DESCRIPTION
## Summary

Adds pre-flight validation for LLM message sequences to catch common issues before API calls. This saves API costs and provides clearer error messages than provider-side validation.

## New Module

`litellm/litellm_core_utils/message_validation.py` with:

- `validate_messages()`: Validates OpenAI Chat and Anthropic message formats
- `validate_responses_input()`: Validates OpenAI Responses API input
- Auto-detection of provider from message format

## Issues Detected

| Issue | Description |
|-------|-------------|
| Orphan tool calls | `tool_call` without matching `tool` response |
| Duplicate tool responses | Multiple responses for same `tool_call_id` |
| Invalid ordering | User/system message before tool response |

## Example Usage

```python
from litellm.litellm_core_utils.message_validation import validate_messages

messages = [
    {"role": "user", "content": "Run ls"},
    {"role": "assistant", "tool_calls": [{"id": "tc1", ...}]},
    {"role": "tool", "tool_call_id": "tc1", "content": "file.txt"},
]

errors = validate_messages(messages, provider="auto", tools_defined=True)
if errors:
    raise ValueError(f"Invalid messages: {errors}")
```

## Provider Support

- **OpenAI Chat Completions**: `tool_calls` / `tool` messages
- **Anthropic Messages**: `tool_use` / `tool_result` blocks
- **OpenAI Responses API**: `function_call` / `function_call_output` items
- **Auto-detection**: Detects provider from message format

## Tests

Added `tests/litellm_core_utils/test_message_validation.py` with comprehensive tests for all validation scenarios.

---

## Evidence

### Test Results

All 13 tests pass:

```
tests/litellm_core_utils/test_message_validation.py::TestOpenAIValidation::test_valid_tool_call_sequence PASSED
tests/litellm_core_utils/test_message_validation.py::TestOpenAIValidation::test_orphan_tool_call PASSED
tests/litellm_core_utils/test_message_validation.py::TestOpenAIValidation::test_duplicate_tool_response PASSED
tests/litellm_core_utils/test_message_validation.py::TestOpenAIValidation::test_orphan_tool_response PASSED
tests/litellm_core_utils/test_message_validation.py::TestOpenAIValidation::test_multiple_parallel_tool_calls PASSED
tests/litellm_core_utils/test_message_validation.py::TestAnthropicValidation::test_valid_tool_use_sequence PASSED
tests/litellm_core_utils/test_message_validation.py::TestAnthropicValidation::test_orphan_tool_use PASSED
tests/litellm_core_utils/test_message_validation.py::TestAnthropicValidation::test_duplicate_tool_result PASSED
tests/litellm_core_utils/test_message_validation.py::TestResponsesAPIValidation::test_valid_function_call_sequence PASSED
tests/litellm_core_utils/test_message_validation.py::TestResponsesAPIValidation::test_orphan_function_call PASSED
tests/litellm_core_utils/test_message_validation.py::TestResponsesAPIValidation::test_duplicate_function_output PASSED
tests/litellm_core_utils/test_message_validation.py::TestAutoDetection::test_detects_openai_format PASSED
tests/litellm_core_utils/test_message_validation.py::TestAutoDetection::test_detects_anthropic_format PASSED

============ 13 passed in 3.54s ============
```

### Validation Demo

**1. Valid OpenAI tool call sequence:**
```python
messages = [
    {'role': 'user', 'content': 'Run ls'},
    {'role': 'assistant', 'content': None, 'tool_calls': [{'id': 'call_123', ...}]},
    {'role': 'tool', 'tool_call_id': 'call_123', 'content': 'file.txt'},
]
errors = validate_messages(messages, provider='openai', tools_defined=True)
# Result: [] (no errors) ✓
```

**2. Invalid - Orphan tool call (no response):**
```python
messages = [
    {'role': 'user', 'content': 'Run ls'},
    {'role': 'assistant', 'tool_calls': [{'id': 'call_orphan', ...}]},
    {'role': 'user', 'content': 'What happened?'},  # Missing tool response!
]
errors = validate_messages(messages, provider='openai', tools_defined=True)
# Result: ["Unresolved tool_calls before user message: ['call_orphan']. Each tool_call must have a matching tool response."]
```

**3. Invalid - Duplicate tool response:**
```python
messages = [
    {'role': 'user', 'content': 'Run ls'},
    {'role': 'assistant', 'tool_calls': [{'id': 'call_dup', ...}]},
    {'role': 'tool', 'tool_call_id': 'call_dup', 'content': 'first'},
    {'role': 'tool', 'tool_call_id': 'call_dup', 'content': 'duplicate!'},
]
errors = validate_messages(messages, provider='openai', tools_defined=True)
# Result: ["Duplicate tool response for tool_call_id 'call_dup'"]
```

**4. Auto-detection works for both OpenAI and Anthropic formats:**
- OpenAI format (tool_calls/tool) detected and validated ✓
- Anthropic format (tool_use/tool_result) detected and validated ✓

---

*This is a draft PR for discussion. Looking for feedback on the API design and whether this would be useful to integrate into litellm's completion flow.*
