### PR TITLE
fix(bedrock): encode model arns for OpenAI compatible bedrock imported models

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_openai_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_openai_transformation.py
@@ -14,6 +14,7 @@ import httpx
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+from litellm.passthrough.utils import CommonUtils
 from litellm.types.llms.openai import AllMessageValues
 
 if TYPE_CHECKING:
@@ -94,6 +95,9 @@ class AmazonBedrockOpenAIConfig(OpenAIGPTConfig, BaseAWSLLM):
             aws_bedrock_runtime_endpoint=aws_bedrock_runtime_endpoint,
             aws_region_name=aws_region_name,
         )
+
+        # Encode model ID for ARNs (e.g., :imported-model/ -> :imported-model%2F)
+        model_id = CommonUtils.encode_bedrock_runtime_modelid_arn(model_id)
         
         # Build the invoke URL
         if stream:

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -3517,7 +3517,7 @@ def test_bedrock_openai_imported_model():
         print(f"URL: {url}")
         assert "bedrock-runtime.us-east-1.amazonaws.com" in url
         assert (
-            "arn:aws:bedrock:us-east-1:117159858402:imported-model/m4gc1mrfuddy" in url
+            "arn:aws:bedrock:us-east-1:117159858402:imported-model%2Fm4gc1mrfuddy" in url
         )
         assert "/invoke" in url
 


### PR DESCRIPTION
## Relevant issues

Fixes error in https://github.com/BerriAI/litellm/pull/17097 when OpenAI compatible Bedrock imported models were introduced. 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

This PR fixes a bug in how Bedrock model ARNs are sent when using the `bedrock/openai/` provider route. Model IDs that are ARNs (e.g. arn:aws:bedrock:...:imported-model/xyz123xyz123) must be URL-encoded when used in the request path; otherwise the AWS API misparses the path and returns an `UnknownOperationException ` error.

```
# AWS Accepts
POST /bedrock/model/arn:aws:bedrock:us-west-2:123456789000:imported-model%2Fxyz123xyz123/invoke
# AWS return com.amazon.coral.service#UnknownOperationException 
POST /bedrock/model/arn:aws:bedrock:us-west-2:123456789000:imported-model/xyz123xyz123/invoke
```

This only affects Bedrock models that use the OpenAI-compatible Runtime API (e.g. imported Qwen2.5, Qwen2-VL, Qwen2.5-VL, and GPT-OSS). For models that are invoked through the Converse API, the model arns are automatically encoded in [converse_handler.py](https://github.com/BerriAI/litellm/blob/main/litellm/llms/bedrock/chat/converse_handler.py#L269-L273); and  the Runtime invoke path did not, so ARNs containing / (e.g. :imported-model/...) were sent unencoded and triggered the error.