### PR TITLE
Virtual-Keys-Team

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -3343,8 +3343,49 @@ async def list_team_v2(
     # Calculate total pages
     total_pages = -(-total_count // page_size)  # Ceiling division
 
-    # Convert Prisma models to Pydantic models, preserving deleted fields when applicable
-    team_list = _convert_teams_to_response(teams, use_deleted_table)
+    # Build team list with keys and team_memberships for active teams
+    if use_deleted_table:
+        team_list = _convert_teams_to_response(teams, use_deleted_table)
+    else:
+        _team_ids = [team.team_id for team in teams]
+        returned_tm = await get_all_team_memberships(
+            prisma_client, _team_ids, user_id=user_id
+        )
+
+        team_list: List[Union[TeamListResponseObject, LiteLLM_TeamTable]] = []
+        for team in teams:
+            _team_memberships: List[LiteLLM_TeamMembership] = []
+            for tm in returned_tm:
+                if tm.team_id == team.team_id:
+                    _team_memberships.append(tm)
+
+            # Fetch keys for this team 
+            keys = await prisma_client.db.litellm_verificationtoken.find_many(
+                where={"team_id": team.team_id}
+            )
+
+            # Sanitize keys
+            sanitized_keys = []
+            for key in keys:
+                try:
+                    key_dict = key.model_dump()
+                except Exception:
+                    key_dict = key.dict()
+                key_dict.pop("token", None)
+                sanitized_keys.append(key_dict)
+
+            try:
+                team_dict = team.model_dump()
+            except Exception:
+                team_dict = team.dict()
+
+            team_list.append(
+                TeamListResponseObject(
+                    **team_dict,
+                    team_memberships=_team_memberships,
+                    keys=sanitized_keys,
+                )
+            )
 
     return {
         "teams": team_list,

--- a/litellm/types/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/types/proxy/management_endpoints/team_endpoints.py
@@ -8,6 +8,7 @@ from litellm.proxy._types import (
     LiteLLM_TeamTable,
     LiteLLM_UserTable,
     Member,
+    TeamListResponseObject,
 )
 
 
@@ -45,8 +46,9 @@ class UpdateTeamMemberPermissionsRequest(BaseModel):
 
 class TeamListResponse(BaseModel):
     """Response to get the list of teams"""
-
-    teams: List[Union[LiteLLM_TeamTable, LiteLLM_DeletedTeamTable]]
+    ## /v2/team/list can return active teams with keys (TeamListResponseObject) or deleted-team records
+    # include all variants here so response_model doesn't strip keys or reject results.
+    teams: List[Union[TeamListResponseObject, LiteLLM_TeamTable, LiteLLM_DeletedTeamTable]]
     total: int
     page: int
     page_size: int


### PR DESCRIPTION
Updated /v2/team/list to return team objects that include keys and team_memberships for active teams, matching /team/list behavior.


https://github.com/user-attachments/assets/8818cd31-5216-4d6d-a7be-05b702079ca2


## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring
✅ Test

## Changes
