### PR TITLE
[Feature] UI - Logs: Show retry count for requests

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3044,6 +3044,8 @@ class SpendLogsMetadata(TypedDict):
         str
     ]  # S3/GCS object key for cold storage retrieval
     litellm_overhead_time_ms: Optional[float]  # LiteLLM overhead time in milliseconds
+    attempted_retries: Optional[int]  # Number of retries attempted (0 = first attempt succeeded)
+    max_retries: Optional[int]  # Max retries configured for this request
     cost_breakdown: Optional[
         CostBreakdown
     ]  # Detailed cost breakdown (input_cost, output_cost, margin, discount, etc.)

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -86,6 +86,8 @@ def _get_spend_logs_metadata(
             guardrail_information=None,
             cold_storage_object_key=cold_storage_object_key,
             litellm_overhead_time_ms=None,
+            attempted_retries=None,
+            max_retries=None,
             cost_breakdown=None,
         )
     verbose_proxy_logger.debug(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5130,7 +5130,7 @@ class Router:
         )
         ## ADD RETRY TRACKING TO METADATA - used for spend logs retry tracking
         _metadata["attempted_retries"] = 0
-        _metadata["max_retries"] = num_retries
+        _metadata["max_retries"] = num_retries  # Updated after overrides in exception handler
         try:
             self._handle_mock_testing_rate_limit_error(
                 model_group=model_group, kwargs=kwargs
@@ -5196,6 +5196,9 @@ class Router:
                     regular_fallbacks=fallbacks,
                     content_policy_fallbacks=content_policy_fallbacks,
                 )
+            # Update max_retries after overrides (deployment_num_retries / retry_policy)
+            _metadata["max_retries"] = num_retries
+
             ## LOGGING
             if num_retries > 0:
                 kwargs = self.log_retry(kwargs=kwargs, e=original_exception)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5128,6 +5128,9 @@ class Router:
         verbose_router_logger.debug(
             f"async function w/ retries: original_function - {original_function}, num_retries - {num_retries}"
         )
+        ## ADD RETRY TRACKING TO METADATA - used for spend logs retry tracking
+        _metadata["attempted_retries"] = 0
+        _metadata["max_retries"] = num_retries
         try:
             self._handle_mock_testing_rate_limit_error(
                 model_group=model_group, kwargs=kwargs
@@ -5215,6 +5218,9 @@ class Router:
 
             for current_attempt in range(num_retries):
                 try:
+                    # Update retry tracking metadata before each retry attempt
+                    _metadata["attempted_retries"] = current_attempt + 1
+                    _metadata["max_retries"] = num_retries
                     # if the function call is successful, no exception will be raised and we'll break out of the loop
                     response = await self.make_call(original_function, *args, **kwargs)
                     if coroutine_checker.is_async_callable(

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -296,6 +296,14 @@ function MetricsSection({ logEntry, metadata }: { logEntry: LogEntry; metadata: 
             </Descriptions.Item>
           )}
 
+          {metadata?.attempted_retries !== undefined && metadata?.attempted_retries !== null && (
+            <Descriptions.Item label="Retries">
+              {metadata.attempted_retries > 0
+                ? <>{metadata.attempted_retries}{metadata.max_retries !== undefined && metadata.max_retries !== null ? ` / ${metadata.max_retries}` : ''}</>
+                : "Not Retried"}
+            </Descriptions.Item>
+          )}
+
           <Descriptions.Item label="Start Time">
             {moment(logEntry.startTime).format("YYYY-MM-DDTHH:mm:ss.SSS[Z]")}
           </Descriptions.Item>

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -296,13 +296,13 @@ function MetricsSection({ logEntry, metadata }: { logEntry: LogEntry; metadata: 
             </Descriptions.Item>
           )}
 
-          {metadata?.attempted_retries !== undefined && metadata?.attempted_retries !== null && (
-            <Descriptions.Item label="Retries">
-              {metadata.attempted_retries > 0
+          <Descriptions.Item label="Retries">
+            {metadata?.attempted_retries !== undefined && metadata?.attempted_retries !== null
+              ? metadata.attempted_retries > 0
                 ? <>{metadata.attempted_retries}{metadata.max_retries !== undefined && metadata.max_retries !== null ? ` / ${metadata.max_retries}` : ''}</>
-                : "Not Retried"}
-            </Descriptions.Item>
-          )}
+                : <Tag color="green">None</Tag>
+              : "-"}
+          </Descriptions.Item>
 
           <Descriptions.Item label="Start Time">
             {moment(logEntry.startTime).format("YYYY-MM-DDTHH:mm:ss.SSS[Z]")}

--- a/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
@@ -123,6 +123,54 @@ describe("Request Viewer", () => {
 
     expect(screen.queryByText("LiteLLM Overhead:")).not.toBeInTheDocument();
   });
+
+  it("should display retry count when attempted_retries > 0 in metadata", () => {
+    render(
+      <RequestViewer
+        row={createRow({
+          metadata: {
+            status: "success",
+            attempted_retries: 2,
+            max_retries: 3,
+            additional_usage_values: {
+              cache_read_input_tokens: 0,
+              cache_creation_input_tokens: 0,
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Retries:")).toBeInTheDocument();
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+  });
+
+  it("should display 'Not Retried' when attempted_retries is 0", () => {
+    render(
+      <RequestViewer
+        row={createRow({
+          metadata: {
+            status: "success",
+            attempted_retries: 0,
+            max_retries: 3,
+            additional_usage_values: {
+              cache_read_input_tokens: 0,
+              cache_creation_input_tokens: 0,
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Retries:")).toBeInTheDocument();
+    expect(screen.getByText("Not Retried")).toBeInTheDocument();
+  });
+
+  it("should not display Retries when attempted_retries is not present in metadata", () => {
+    render(<RequestViewer row={createRow()} />);
+
+    expect(screen.queryByText("Retries:")).not.toBeInTheDocument();
+  });
 });
 
 describe("SpendLogsTable", () => {

--- a/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
@@ -145,7 +145,7 @@ describe("Request Viewer", () => {
     expect(screen.getByText("2 / 3")).toBeInTheDocument();
   });
 
-  it("should display 'Not Retried' when attempted_retries is 0", () => {
+  it("should display green 'None' tag when attempted_retries is 0", () => {
     render(
       <RequestViewer
         row={createRow({
@@ -163,13 +163,14 @@ describe("Request Viewer", () => {
     );
 
     expect(screen.getByText("Retries:")).toBeInTheDocument();
-    expect(screen.getByText("Not Retried")).toBeInTheDocument();
+    expect(screen.getByText("None")).toBeInTheDocument();
   });
 
-  it("should not display Retries when attempted_retries is not present in metadata", () => {
+  it("should display '-' for Retries when attempted_retries is not present in metadata", () => {
     render(<RequestViewer row={createRow()} />);
 
-    expect(screen.queryByText("Retries:")).not.toBeInTheDocument();
+    expect(screen.getByText("Retries:")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
   });
 });
 

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -7,7 +7,7 @@ import { truncateString } from "@/utils/textUtils";
 import { SettingOutlined, SyncOutlined } from "@ant-design/icons";
 import { Row } from "@tanstack/react-table";
 import { Switch, Tab, TabGroup, TabList, TabPanel, TabPanels } from "@tremor/react";
-import { Button, Tooltip } from "antd";
+import { Button, Tag, Tooltip } from "antd";
 import { internalUserRoles } from "../../utils/roles";
 import DeletedKeysPage from "../DeletedKeysPage/DeletedKeysPage";
 import DeletedTeamsPage from "../DeletedTeamsPage/DeletedTeamsPage";
@@ -960,16 +960,16 @@ export function RequestViewer({ row, onOpenSettings }: { row: Row<LogEntry>; onO
                 <span>{row.original.metadata.litellm_overhead_time_ms} ms</span>
               </div>
             )}
-            {row.original.metadata?.attempted_retries !== undefined && row.original.metadata?.attempted_retries !== null && (
-              <div className="flex">
-                <span className="font-medium w-1/3">Retries:</span>
-                <span>
-                  {row.original.metadata.attempted_retries > 0
+            <div className="flex">
+              <span className="font-medium w-1/3">Retries:</span>
+              <span>
+                {row.original.metadata?.attempted_retries !== undefined && row.original.metadata?.attempted_retries !== null
+                  ? row.original.metadata.attempted_retries > 0
                     ? `${row.original.metadata.attempted_retries}${row.original.metadata.max_retries !== undefined && row.original.metadata.max_retries !== null ? ` / ${row.original.metadata.max_retries}` : ''}`
-                    : 'Not Retried'}
-                </span>
-              </div>
-            )}
+                    : <Tag color="green">None</Tag>
+                  : '-'}
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -960,6 +960,16 @@ export function RequestViewer({ row, onOpenSettings }: { row: Row<LogEntry>; onO
                 <span>{row.original.metadata.litellm_overhead_time_ms} ms</span>
               </div>
             )}
+            {row.original.metadata?.attempted_retries !== undefined && row.original.metadata?.attempted_retries !== null && (
+              <div className="flex">
+                <span className="font-medium w-1/3">Retries:</span>
+                <span>
+                  {row.original.metadata.attempted_retries > 0
+                    ? `${row.original.metadata.attempted_retries}${row.original.metadata.max_retries !== undefined && row.original.metadata.max_retries !== null ? ` / ${row.original.metadata.max_retries}` : ''}`
+                    : 'Not Retried'}
+                </span>
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Summary

### Problem
The Logs page does not show how many retries were attempted for each request. The router tracks retry attempts via response headers (`x-litellm-attempted-retries`, `x-litellm-max-retries`), but this information is never persisted to spend logs because the headers are added *after* the spend log is written inside `make_call`.

### Fix
Inject `attempted_retries` and `max_retries` into the request metadata *before* `make_call` in the router's retry loop. This metadata flows through the logging pipeline into `SpendLogsMetadata` and is stored in the spend logs JSON. The UI then reads these fields and displays retry status in both the detail drawer and the legacy expanded row view.

- When `attempted_retries > 0`: shows "2 / 3" format (attempted / max)
- When `attempted_retries == 0`: shows "Not Retried"
- When field is absent (older logs): row is hidden

## Testing

- Backend: 2 new tests in `test_spend_tracking_utils.py` — verifies retry info appears in spend logs metadata and handles missing retry info gracefully
- Frontend: 3 new tests in `index.test.tsx` — verifies retry display for retried, not-retried, and absent cases
- All existing tests pass with no regressions

## Type

🆕 New Feature
✅ Test

## Screenshot
<img width="912" height="241" alt="image" src="https://github.com/user-attachments/assets/de26a235-488e-483c-9026-5ae7020cd444" />

<img width="903" height="616" alt="image" src="https://github.com/user-attachments/assets/4aaa08c3-e8b9-40c3-b33d-dcb29854771f" />
