### PR TITLE
fix(proxy): self-heal Prisma connection for auth and runtime

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2003,8 +2003,14 @@ async def _fetch_key_object_from_db_with_reconnect(
         if PrismaDBExceptionHandler.is_database_connection_error(e):
             did_reconnect = False
             if hasattr(prisma_client, "attempt_db_reconnect"):
+                auth_reconnect_timeout = getattr(
+                    prisma_client, "_db_auth_reconnect_timeout_seconds", 2.0
+                )
+                if not isinstance(auth_reconnect_timeout, (int, float)):
+                    auth_reconnect_timeout = 2.0
                 did_reconnect = await prisma_client.attempt_db_reconnect(
-                    reason="auth_get_key_object_lookup_failure"
+                    reason="auth_get_key_object_lookup_failure",
+                    timeout_seconds=auth_reconnect_timeout,
                 )
             if did_reconnect:
                 return await prisma_client.get_data(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2008,9 +2008,15 @@ async def _fetch_key_object_from_db_with_reconnect(
                 )
                 if not isinstance(auth_reconnect_timeout, (int, float)):
                     auth_reconnect_timeout = 2.0
+                auth_reconnect_lock_timeout = getattr(
+                    prisma_client, "_db_auth_reconnect_lock_timeout_seconds", 0.1
+                )
+                if not isinstance(auth_reconnect_lock_timeout, (int, float)):
+                    auth_reconnect_lock_timeout = 0.1
                 did_reconnect = await prisma_client.attempt_db_reconnect(
                     reason="auth_get_key_object_lookup_failure",
                     timeout_seconds=auth_reconnect_timeout,
+                    lock_timeout_seconds=auth_reconnect_lock_timeout,
                 )
             if did_reconnect:
                 return await prisma_client.get_data(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -388,10 +388,10 @@ from litellm.proxy.management_endpoints.model_management_endpoints import (
 from litellm.proxy.management_endpoints.organization_endpoints import (
     router as organization_router,
 )
+from litellm.proxy.management_endpoints.policy_endpoints import router as policy_router
 from litellm.proxy.management_endpoints.project_endpoints import (
     router as project_router,
 )
-from litellm.proxy.management_endpoints.policy_endpoints import router as policy_router
 from litellm.proxy.management_endpoints.router_settings_endpoints import (
     router as router_settings_router,
 )
@@ -901,6 +901,15 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
             await prisma_client.db.stop_token_refresh_task()
         except Exception as e:
             verbose_proxy_logger.error(f"Error stopping token refresh task: {e}")
+
+    # Shutdown event - stop Prisma DB health watchdog task
+    if prisma_client is not None and hasattr(
+        prisma_client, "stop_db_health_watchdog_task"
+    ):
+        try:
+            await prisma_client.stop_db_health_watchdog_task()
+        except Exception as e:
+            verbose_proxy_logger.error(f"Error stopping DB health watchdog task: {e}")
 
     await proxy_shutdown_event()  # type: ignore[reportGeneralTypeIssues]
 
@@ -5829,6 +5838,9 @@ class ProxyStartupEvent:
                     is not True
                 ):
                     await prisma_client.health_check()
+
+                if hasattr(prisma_client, "start_db_health_watchdog_task"):
+                    await prisma_client.start_db_health_watchdog_task()
             return prisma_client
         except Exception as e:
             PrismaDBExceptionHandler.handle_db_exception(e)

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -10,6 +10,7 @@ sys.path.insert(
 
 from datetime import datetime, timedelta
 
+import httpx
 import pytest
 
 import litellm
@@ -33,6 +34,7 @@ from litellm.proxy.auth.auth_checks import (
     _log_budget_lookup_failure,
     _virtual_key_max_budget_alert_check,
     _virtual_key_soft_budget_check,
+    get_key_object,
     get_user_object,
     vector_store_access_check,
 )
@@ -50,9 +52,10 @@ def set_salt_key(monkeypatch):
 def reset_constants_module():
     """Reset constants module to ensure clean state before each test"""
     import importlib
+
     from litellm import constants
     from litellm.proxy.auth import auth_checks
-    
+
     # Reload modules before test
     importlib.reload(constants)
     importlib.reload(auth_checks)
@@ -151,6 +154,55 @@ def test_get_key_object_from_ui_hash_key_invalid():
     assert key_object is None
 
 
+@pytest.mark.asyncio
+async def test_get_key_object_should_reconnect_once_on_db_connection_error():
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.get_data = AsyncMock(
+        side_effect=[
+            httpx.ConnectError("db connection reset"),
+            UserAPIKeyAuth(token="hashed-token-1"),
+        ]
+    )
+    mock_prisma_client.attempt_db_reconnect = AsyncMock(return_value=True)
+
+    mock_cache = MagicMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+    mock_cache.async_set_cache = AsyncMock()
+
+    key_obj = await get_key_object(
+        hashed_token="hashed-token-1",
+        prisma_client=mock_prisma_client,
+        user_api_key_cache=mock_cache,
+    )
+
+    assert key_obj.token == "hashed-token-1"
+    assert mock_prisma_client.get_data.await_count == 2
+    mock_prisma_client.attempt_db_reconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_key_object_should_raise_if_reconnect_fails_on_db_connection_error():
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.get_data = AsyncMock(
+        side_effect=httpx.ConnectError("db not reachable after outage")
+    )
+    mock_prisma_client.attempt_db_reconnect = AsyncMock(return_value=False)
+
+    mock_cache = MagicMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+    mock_cache.async_set_cache = AsyncMock()
+
+    with pytest.raises(Exception, match="db not reachable after outage"):
+        await get_key_object(
+            hashed_token="hashed-token-2",
+            prisma_client=mock_prisma_client,
+            user_api_key_cache=mock_cache,
+        )
+
+    mock_prisma_client.attempt_db_reconnect.assert_awaited_once()
+    assert mock_prisma_client.get_data.await_count == 1
+
+
 def test_get_cli_jwt_auth_token_default_expiration(valid_sso_user_defined_values):
     """Test generating CLI JWT token with default 24-hour expiration"""
     token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(valid_sso_user_defined_values)
@@ -180,9 +232,10 @@ def test_get_cli_jwt_auth_token_custom_expiration(
 ):
     """Test generating CLI JWT token with custom expiration via environment variable"""
     import importlib
+
     from litellm import constants
     from litellm.proxy.auth import auth_checks
-    
+
     # Set custom expiration to 48 hours
     monkeypatch.setenv("LITELLM_CLI_JWT_EXPIRATION_HOURS", "48")
     

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -177,7 +177,10 @@ async def test_get_key_object_should_reconnect_once_on_db_connection_error():
 
     assert key_obj.token == "hashed-token-1"
     assert mock_prisma_client.get_data.await_count == 2
-    mock_prisma_client.attempt_db_reconnect.assert_awaited_once()
+    mock_prisma_client.attempt_db_reconnect.assert_awaited_once_with(
+        reason="auth_get_key_object_lookup_failure",
+        timeout_seconds=2.0,
+    )
 
 
 @pytest.mark.asyncio
@@ -199,7 +202,10 @@ async def test_get_key_object_should_raise_if_reconnect_fails_on_db_connection_e
             user_api_key_cache=mock_cache,
         )
 
-    mock_prisma_client.attempt_db_reconnect.assert_awaited_once()
+    mock_prisma_client.attempt_db_reconnect.assert_awaited_once_with(
+        reason="auth_get_key_object_lookup_failure",
+        timeout_seconds=2.0,
+    )
     assert mock_prisma_client.get_data.await_count == 1
 
 

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -180,6 +180,7 @@ async def test_get_key_object_should_reconnect_once_on_db_connection_error():
     mock_prisma_client.attempt_db_reconnect.assert_awaited_once_with(
         reason="auth_get_key_object_lookup_failure",
         timeout_seconds=2.0,
+        lock_timeout_seconds=0.1,
     )
 
 
@@ -205,6 +206,7 @@ async def test_get_key_object_should_raise_if_reconnect_fails_on_db_connection_e
     mock_prisma_client.attempt_db_reconnect.assert_awaited_once_with(
         reason="auth_get_key_object_lookup_failure",
         timeout_seconds=2.0,
+        lock_timeout_seconds=0.1,
     )
     assert mock_prisma_client.get_data.await_count == 1
 

--- a/tests/test_litellm/proxy/db/test_exception_handler.py
+++ b/tests/test_litellm/proxy/db/test_exception_handler.py
@@ -34,7 +34,25 @@ from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 @pytest.mark.parametrize(
     "prisma_error",
     [
+        HTTPClientClosedError(),
+        ClientNotConnectedError(),
+        PrismaError("can't reach database server"),
+        PrismaError("connection refused"),
+        PrismaError("timed out while connecting"),
+    ],
+)
+def test_is_database_connection_error_prisma_connection_errors(prisma_error):
+    """
+    Test that only Prisma connection-related errors are considered DB connection errors.
+    """
+    assert PrismaDBExceptionHandler.is_database_connection_error(prisma_error) == True
+
+
+@pytest.mark.parametrize(
+    "prisma_error",
+    [
         PrismaError(),
+        PrismaError("validation failed on query"),
         DataError(data={"user_facing_error": {"meta": {"table": "test_table"}}}),
         UniqueViolationError(
             data={"user_facing_error": {"meta": {"table": "test_table"}}}
@@ -52,15 +70,10 @@ from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
         RecordNotFoundError(
             data={"user_facing_error": {"meta": {"table": "test_table"}}}
         ),
-        HTTPClientClosedError(),
-        ClientNotConnectedError(),
     ],
 )
-def test_is_database_connection_error_prisma_errors(prisma_error):
-    """
-    Test that all Prisma errors are considered database connection errors
-    """
-    assert PrismaDBExceptionHandler.is_database_connection_error(prisma_error) == True
+def test_is_database_connection_error_non_connection_prisma_errors(prisma_error):
+    assert PrismaDBExceptionHandler.is_database_connection_error(prisma_error) == False
 
 
 def test_is_database_connection_generic_errors():

--- a/tests/test_litellm/proxy/db/test_prisma_self_heal.py
+++ b/tests/test_litellm/proxy/db/test_prisma_self_heal.py
@@ -1,0 +1,111 @@
+import asyncio
+import os
+import sys
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.proxy.utils import PrismaClient, ProxyLogging
+
+
+@pytest.fixture(autouse=True)
+def mock_prisma_binary():
+    """Mock prisma.Prisma to avoid requiring generated Prisma binaries for unit tests."""
+    mock_module = MagicMock()
+    with patch.dict(sys.modules, {"prisma": mock_module}):
+        yield
+
+
+@pytest.fixture
+def mock_proxy_logging():
+    proxy_logging = AsyncMock(spec=ProxyLogging)
+    proxy_logging.failure_handler = AsyncMock()
+    return proxy_logging
+
+
+@pytest.mark.asyncio
+async def test_attempt_db_reconnect_should_succeed(mock_proxy_logging):
+    client = PrismaClient(database_url="mock://test", proxy_logging_obj=mock_proxy_logging)
+    client.disconnect = AsyncMock(return_value=None)
+    client.connect = AsyncMock(return_value=None)
+    client.health_check = AsyncMock(return_value=[{"result": 1}])
+
+    result = await client.attempt_db_reconnect(
+        reason="unit_test_reconnect_success",
+        force=True,
+    )
+
+    assert result is True
+    client.disconnect.assert_awaited_once()
+    client.connect.assert_awaited_once()
+    client.health_check.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_attempt_db_reconnect_should_skip_when_in_cooldown(mock_proxy_logging):
+    client = PrismaClient(database_url="mock://test", proxy_logging_obj=mock_proxy_logging)
+    client.disconnect = AsyncMock(return_value=None)
+    client.connect = AsyncMock(return_value=None)
+    client.health_check = AsyncMock(return_value=[{"result": 1}])
+    client._db_reconnect_cooldown_seconds = 120
+    client._db_last_reconnect_attempt_ts = time.time()
+
+    result = await client.attempt_db_reconnect(
+        reason="unit_test_reconnect_cooldown",
+        force=False,
+    )
+
+    assert result is False
+    client.disconnect.assert_not_called()
+    client.connect.assert_not_called()
+    client.health_check.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_db_health_watchdog_should_trigger_reconnect_on_db_error(mock_proxy_logging):
+    client = PrismaClient(database_url="mock://test", proxy_logging_obj=mock_proxy_logging)
+    client.health_check = AsyncMock(side_effect=Exception("db connection dropped"))
+    client.attempt_db_reconnect = AsyncMock(return_value=True)
+    client._db_health_watchdog_interval_seconds = 1
+
+    with patch(
+        "litellm.proxy.utils.asyncio.sleep",
+        AsyncMock(side_effect=[None, asyncio.CancelledError()]),
+    ), patch(
+        "litellm.proxy.db.exception_handler.PrismaDBExceptionHandler.is_database_connection_error",
+        return_value=True,
+    ):
+        await client._db_health_watchdog_loop()
+
+    client.attempt_db_reconnect.assert_awaited_once_with(
+        reason="db_health_watchdog_connection_error"
+    )
+
+
+@pytest.mark.asyncio
+async def test_db_health_watchdog_start_stop_lifecycle(mock_proxy_logging):
+    client = PrismaClient(database_url="mock://test", proxy_logging_obj=mock_proxy_logging)
+    client._db_health_watchdog_enabled = True
+    client._db_health_watchdog_interval_seconds = 3600
+
+    loop = asyncio.get_running_loop()
+    dummy_task = loop.create_task(asyncio.sleep(3600))
+
+    def _fake_create_task(coro):
+        # create_task is patched in this test, so explicitly close the incoming coroutine
+        # to avoid "coroutine was never awaited" warnings.
+        coro.close()
+        return dummy_task
+
+    with patch("litellm.proxy.utils.asyncio.create_task", side_effect=_fake_create_task):
+        await client.start_db_health_watchdog_task()
+        assert client._db_health_watchdog_task is dummy_task
+
+        await client.stop_db_health_watchdog_task()
+        assert client._db_health_watchdog_task is None
+        assert dummy_task.cancelled() is True


### PR DESCRIPTION
## Summary
This PR adds Prisma self-healing for the outage pattern where DB connectivity drops, network recovers, but LiteLLM continues failing auth lookups until process restart.

### Changes
- Add Prisma reconnect primitive with cooldown + singleflight lock in `PrismaClient`
- Add background DB health watcher task (start on startup, stop on shutdown). If it looses connection, it will self heal / reconnect 
- Add auth / critical path reconnect-once behavior in `get_key_object` for DB-connection-class errors

## Why
During transient network failures, Prisma can remain in a degraded connection state. Before this, there was no proactive runtime reconnect loop, and auth DB lookups could continue failing after network recovery.


### E2E: Live Proxy + Postgres

| Scenario | Endpoint | Observed Status | Notes |
|---|---|---:|---|
| DB up | `GET /key/info` | `200` | Healthy baseline |
| DB down | `GET /key/info` | `500` | DB unavailable |
| Recovered | `GET /key/info` | `200` | Recovered in ~`14s` |
| DB up (virtual key auth) | `GET /v1/models` | `200` | Healthy baseline |
| DB down (virtual key auth) | `GET /v1/models` | `401` | Auth lookup fails while DB down |
| Recovered (virtual key auth) | `GET /v1/models` | `200` | Recovered in ~`15s` |
| Readiness while DB up/down/recovered | `GET /health/readiness` | `200` | Reported `db=connected` in all sampled states |

### Live log proof captured on this branch
Source: `.context/e2e_compare/after_pr_proof_lines.txt`

```text
386: ... "GET /key/info?..." 500 Internal Server Error
387: ... Attempting Prisma DB reconnect. reason=auth_get_key_object_lookup_failure
459: ... "GET /v1/models HTTP/1.1" 401 Unauthorized
765: ... Attempting Prisma DB reconnect. reason=db_health_watchdog_connection_error
767: ... Prisma DB reconnect succeeded. reason=db_health_watchdog_connection_error
769: ... "GET /key/info?..." 200 OK
770: ... "GET /v1/models HTTP/1.1" 200 OK
```

