### PR TITLE
[Fix] UI - Logs: Fix table not updating and pagination issues

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -259,7 +259,7 @@ export default function SpendLogsTable({
       if (!accessToken) return;
 
       try {
-        const response = await keyListCall(accessToken, null, null, keyAlias, null, null, currentPage, pageSize);
+        const response = await keyListCall(accessToken, null, null, keyAlias, null, null, 1, pageSize);
 
         const selectedKey = response.keys.find((key: any) => key.key_alias === keyAlias);
 
@@ -270,7 +270,7 @@ export default function SpendLogsTable({
         console.error("Error fetching key hash for alias:", error);
       }
     },
-    [accessToken, currentPage, pageSize],
+    [accessToken, pageSize],
   );
 
   const handleFilterReset = useCallback(() => {

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
@@ -570,6 +570,63 @@ describe("useLogFilterLogic", () => {
     );
   });
 
+  it("should refetch when startTime changes and backend filters are active", async () => {
+    vi.mocked(uiSpendLogsCall).mockResolvedValue(
+      createPaginatedResponse([createLogEntry()]),
+    );
+    const logs = createPaginatedResponse([createLogEntry()]);
+    const { result, rerender } = renderHook(
+      (props: { startTime?: string }) =>
+        useLogFilterLogic({ ...defaultProps, logs, ...props }),
+      { wrapper, initialProps: { startTime: "2025-01-01T00:00:00Z" } },
+    );
+
+    act(() => {
+      result.current.handleFilterChange({ "Key Alias": "alias-1" });
+    });
+
+    await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalledTimes(1), {
+      timeout: 500,
+    });
+
+    rerender({ startTime: "2025-01-02T00:00:00Z" });
+
+    await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalledTimes(2), {
+      timeout: 500,
+    });
+    expect(uiSpendLogsCall).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        start_date: "2025-01-02 00:00:00",
+      }),
+    );
+  });
+
+  it("should refetch when isCustomDate changes and backend filters are active", async () => {
+    vi.mocked(uiSpendLogsCall).mockResolvedValue(
+      createPaginatedResponse([createLogEntry()]),
+    );
+    const logs = createPaginatedResponse([createLogEntry()]);
+    const { result, rerender } = renderHook(
+      (props: { isCustomDate?: boolean }) =>
+        useLogFilterLogic({ ...defaultProps, logs, ...props }),
+      { wrapper, initialProps: { isCustomDate: false } },
+    );
+
+    act(() => {
+      result.current.handleFilterChange({ "Key Alias": "alias-1" });
+    });
+
+    await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalledTimes(1), {
+      timeout: 500,
+    });
+
+    rerender({ isCustomDate: true });
+
+    await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalledTimes(2), {
+      timeout: 500,
+    });
+  });
+
   it("should not call setCurrentPage when handleFilterChange receives identical filters", async () => {
     const setCurrentPage = vi.fn();
     const logs = createPaginatedResponse([createLogEntry()]);

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -165,7 +165,12 @@ export function useLogFilterLogic({
       debouncedSearch.cancel();
       performSearch(filters, currentPage);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Intentionally omitted from deps:
+    // - `filters` / `debouncedSearch` / `performSearch`: filter changes are handled by
+    //   handleFilterChange → debouncedSearch; adding them here would double-fetch on filter apply.
+    // - `hasBackendFilters` / `accessToken`: stable across sort/page/time changes; including them
+    //   would cause spurious re-runs when the filter state first becomes active.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortBy, sortOrder, currentPage, startTime, endTime, isCustomDate]);
 
   // Compute client-side filtered logs directly from incoming logs and filters

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -309,6 +309,7 @@ export function useLogFilterLogic({
   return {
     filters,
     filteredLogs,
+    hasBackendFilters,
     allKeyAliases,
     allTeams,
     handleFilterChange,

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -158,12 +158,15 @@ export function useLogFilterLogic({
     [filters],
   );
 
-  // Refetch when sort or page changes (backend filters use their own fetch, not the main query)
+  // Refetch when sort, page, or time range changes (backend filters use their own fetch, not the main query)
   useEffect(() => {
     if (hasBackendFilters && accessToken) {
+      // Cancel any pending debounced search to prevent it from overwriting this page's results
+      debouncedSearch.cancel();
       performSearch(filters, currentPage);
     }
-  }, [sortBy, sortOrder, currentPage]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sortBy, sortOrder, currentPage, startTime, endTime, isCustomDate]);
 
   // Compute client-side filtered logs directly from incoming logs and filters
   const clientDerivedFilteredLogs: PaginatedResponse = useMemo(() => {


### PR DESCRIPTION
## Summary

Fixed bugs in the logs table when using backend filters (Key Alias, Key Hash, Model, etc.) with the custom time range picker.

**Bug 1 - Table doesn't update with custom time range**: When a backend filter was active and the user selected a custom time range, `performSearch` received the new times but the table showed stale results. Root cause: the effect calling `performSearch` only watched `[sortBy, sortOrder, currentPage]`, so `startTime`/`endTime`/`isCustomDate` changes were invisible to it.

**Bug 2 - Duplicate redundant requests**: After fixing Bug 1, two requests were observed — one with `api_key=<hash>` and one with `key_alias=<alias>` — because `fetchKeyHashForAlias` was translating the alias to a hash and setting `selectedKeyHash`, which triggered the main query in addition to `performSearch`.

**Bug 3 - Automatic unfiltered request after user-triggered filter request**: With a backend filter active, changing the custom date fired a second request without the filter ~3 seconds later. Root cause: the main `logs` query has `startTime`/`endTime` in its `queryKey`, so React Query auto-refetched it on any date change even though its result is unused when `hasBackendFilters=true`.

## Changes

- Added `startTime`, `endTime`, `isCustomDate` to the `performSearch` effect's dependency array so backend filters re-fetch when time range changes
- Removed `fetchKeyHashForAlias` and the alias→hash translation to prevent duplicate requests
- Added `setCurrentPage(1)` to the quick-select time range handler so page resets on time range switch
- Added `debouncedSearch.cancel()` to prevent debounced searches from overwriting paginated results
- Exposed `hasBackendFilters` from `useLogFilterLogic` and used it to disable the main query when backend filters are active, preventing wasteful unfiltered requests
- Added tests verifying time range changes trigger refetch when backend filters are active

## Type

🐛 Bug Fix
✅ Test