### PR TITLE
fix(responses): eliminate per-chunk thread spawning in async streaming path

### DIFF
--- a/tests/llm_responses_api_testing/test_anthropic_responses_api.py
+++ b/tests/llm_responses_api_testing/test_anthropic_responses_api.py
@@ -30,7 +30,7 @@ class TestAnthropicResponsesAPITest(BaseResponsesAPITest):
     def get_base_completion_call_args(self):
         #litellm._turn_on_debug()
         return {
-            "model": "anthropic/claude-sonnet-4-5-20250929",
+            "model": "anthropic/claude-sonnet-4-5",
         }
     
     async def test_basic_openai_responses_delete_endpoint(self, sync_mode=False):

--- a/tests/llm_responses_api_testing/test_anthropic_responses_api.py
+++ b/tests/llm_responses_api_testing/test_anthropic_responses_api.py
@@ -79,7 +79,7 @@ def test_multiturn_tool_calls():
             ], 
             'type': 'message'
         }],
-        model='anthropic/claude-3-7-sonnet-latest',
+        model='anthropic/claude-sonnet-4-5',
         instructions='You are a helpful coding assistant.',
         tools=[shell_tool]
     )
@@ -105,7 +105,7 @@ def test_multiturn_tool_calls():
 
     # Use await with asyncio.run for the async function
     follow_up_response = litellm.responses(
-        model='anthropic/claude-3-7-sonnet-latest',
+        model='anthropic/claude-sonnet-4-5',
         previous_response_id=response_id,
         input=[{
             'type': 'function_call_output',

--- a/tests/llm_responses_api_testing/test_anthropic_tool_result_empty_call_id.py
+++ b/tests/llm_responses_api_testing/test_anthropic_tool_result_empty_call_id.py
@@ -242,7 +242,7 @@ def test_anthropic_transformation_with_fixed_messages():
     optional_params = {"tools": [shell_tool]}
     
     anthropic_data = anthropic_config.transform_request(
-        model="claude-3-7-sonnet-latest",
+        model="claude-sonnet-4-5",
         messages=fixed_messages,
         optional_params=optional_params,
         litellm_params={},

--- a/tests/llm_responses_api_testing/test_anthropic_tool_result_fix.py
+++ b/tests/llm_responses_api_testing/test_anthropic_tool_result_fix.py
@@ -114,7 +114,7 @@ def test_fix_ensures_tool_calls_for_tool_results():
     optional_params = {"tools": [shell_tool]}
     
     anthropic_data = anthropic_config.transform_request(
-        model="claude-3-7-sonnet-latest",
+        model="claude-sonnet-4-5",
         messages=fixed_messages,
         optional_params=optional_params,
         litellm_params={},


### PR DESCRIPTION
## Summary

- **Root cause**: `BaseResponsesAPIStreamingIterator._process_chunk()` called `run_async_function()` on every SSE chunk. When called from an async context (`ResponsesAPIStreamingIterator.__anext__`), this creates a `ThreadPoolExecutor` + spawns a new OS thread + creates a new `asyncio` event loop **per chunk**, then blocks waiting for the result.
- **Impact**: For a user sending 30 sequential streaming requests (~450 SSE events each), this causes **13,500 thread spawn/teardown cycles**, resulting in ~60s of CPU throttled time on K8s pods.
- **Fix**: Move the hook call out of `_process_chunk` into the callers: async `__anext__` directly `await`s it, sync `__next__` uses `run_async_function`.

## E2E Profiling Data

Full pipeline benchmark (SSE parsing → JSON decode → OpenAI transform → hook → Pydantic serialization → SSE framing):

| | Before | After |
|---|---|---|
| **30 requests total** | **2.413s** | **0.357s** |
| Per-request (450 chunks) | 80.4ms | 11.9ms |
| Per-chunk | 0.179ms | 0.026ms |
| **Speedup** | | **6.8x** |
| **CPU saved** | | **85%** |

> Measured on M-series Mac. On CPU-limited K8s pods, thread creation overhead scales worse due to kernel scheduling pressure under cgroup limits, so real-world improvement is likely larger.

### Thread spawning overhead (isolated)

| Method | Total Time | Per-Chunk |
|--------|-----------|-----------|
| `run_async_function` (before) | **1,493ms** | 0.111ms |
| Direct `await` (after) | **1.6ms** | 0.000ms |
| **Overhead ratio** | **956x** | |

cProfile confirms 64% of CPU time spent in `_thread.lock.acquire`:
```
ncalls  tottime  filename:lineno(function)
  4950    0.042  {method 'acquire' of '_thread.lock' objects}
   450    0.004  {built-in method _thread.start_new_thread}
  1350    0.002  threading.py:295(wait)
   450    0.001  asyncify.py:72(run_async_function)
```

## Test plan

- [x] Existing unit tests pass: `test_base_responses_api_streaming_iterator.py` (8 passed)
- [x] Existing hook tests pass: `test_responses_hooks.py` (3 passed)
- [ ] Verify streaming works end-to-end with OpenAI Responses API
- [ ] Verify sync streaming path still works (unchanged, uses `_process_chunk`)

