### PR TITLE
[Fix] Suppress warning for litellm-dashboard team in agent permission handler

### DIFF
--- a/litellm/proxy/agent_endpoints/auth/agent_permission_handler.py
+++ b/litellm/proxy/agent_endpoints/auth/agent_permission_handler.py
@@ -266,7 +266,7 @@ class AgentRequestHandler:
         except Exception as e:
             # litellm-dashboard is the default UI team and will never have agents;
             # skip noisy warnings for it.
-            if user_api_key_auth.team_id != "litellm-dashboard":
+            if user_api_key_auth.team_id != UI_SESSION_TOKEN_TEAM_ID:
                 verbose_logger.warning(
                     f"Failed to get allowed agents for team: {str(e)}"
                 )

--- a/litellm/proxy/agent_endpoints/auth/agent_permission_handler.py
+++ b/litellm/proxy/agent_endpoints/auth/agent_permission_handler.py
@@ -11,6 +11,7 @@ from litellm._logging import verbose_logger
 from litellm.proxy._types import (
     LiteLLM_ObjectPermissionTable,
     LiteLLM_TeamTable,
+    UI_TEAM_ID,
     UserAPIKeyAuth,
 )
 
@@ -266,7 +267,7 @@ class AgentRequestHandler:
         except Exception as e:
             # litellm-dashboard is the default UI team and will never have agents;
             # skip noisy warnings for it.
-            if user_api_key_auth.team_id != UI_SESSION_TOKEN_TEAM_ID:
+            if user_api_key_auth.team_id != UI_TEAM_ID:
                 verbose_logger.warning(
                     f"Failed to get allowed agents for team: {str(e)}"
                 )

--- a/litellm/proxy/agent_endpoints/auth/agent_permission_handler.py
+++ b/litellm/proxy/agent_endpoints/auth/agent_permission_handler.py
@@ -264,7 +264,12 @@ class AgentRequestHandler:
 
             return list(set(all_agents))
         except Exception as e:
-            verbose_logger.warning(f"Failed to get allowed agents for team: {str(e)}")
+            # litellm-dashboard is the default UI team and will never have agents;
+            # skip noisy warnings for it.
+            if user_api_key_auth.team_id != "litellm-dashboard":
+                verbose_logger.warning(
+                    f"Failed to get allowed agents for team: {str(e)}"
+                )
             return []
 
     @staticmethod


### PR DESCRIPTION
## Summary

### Problem

The `litellm-dashboard` team is the default UI team and will never have agents attached to it. Every time the agent permission handler tries to look it up, `get_team_object` raises a 404, triggering a noisy warning in logs:

```
Failed to get allowed agents for team: 404: {'error': "Team doesn't exist in db. Team=litellm-dashboard. Create team via `/team/new` call."}
```

### Fix

Added a guard in `AgentRequestHandler._get_allowed_agents_for_team` to skip the warning log when the failing team is `litellm-dashboard`. The method still returns `[]` as before; only the log line is suppressed.

## Testing

Existing tests cover the agent permission handler. No new test needed since this is a log suppression guard with no behavioral change.

## Type

🐛 Bug Fix