### PR TITLE
UI: Redesign guardrail creation form with vertical stepper

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/categories/denied_financial_advice.yaml
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/categories/denied_financial_advice.yaml
@@ -1,5 +1,6 @@
 # Financial advice and investment guidance detection
 category_name: "denied_financial_advice"
+display_name: "Denied Financial / Investment Advice"
 description: "Detects requests for personalized financial advice, investment recommendations, or financial planning that should be provided by licensed financial advisors"
 default_action: "BLOCK"
 

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/patterns.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/patterns.py
@@ -162,8 +162,8 @@ def get_available_content_categories() -> List[Dict[str, str]]:
                     category_data = yaml.safe_load(f)
 
                 if category_data and "category_name" in category_data:
-                    # Create display name from category name (convert harmful_self_harm -> Harmful Self Harm)
-                    display_name = (
+                    # Use explicit display_name if provided, otherwise auto-generate from category_name
+                    display_name = category_data.get("display_name") or (
                         category_data["category_name"].replace("_", " ").title()
                     )
 

--- a/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentCategoryConfiguration.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentCategoryConfiguration.tsx
@@ -241,12 +241,12 @@ const ContentCategoryConfiguration: React.FC<ContentCategoryConfigurationProps> 
   return (
     <Card
       title={
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 8 }}>
           <Title level={5} style={{ margin: 0 }}>
-            Content Categories
+            Blocked topics
           </Title>
-          <Text type="secondary" style={{ fontSize: 14, fontWeight: 400 }}>
-            Detect harmful content, bias, and inappropriate advice using semantic analysis
+          <Text type="secondary" style={{ fontSize: 12, fontWeight: 400 }}>
+            Select topics to block using keyword and semantic analysis
           </Text>
         </div>
       }
@@ -316,10 +316,13 @@ const ContentCategoryConfiguration: React.FC<ContentCategoryConfigurationProps> 
                 borderRadius: "4px",
                 overflow: "auto",
                 maxHeight: "300px",
+                maxWidth: "100%",
                 fontSize: "12px",
                 lineHeight: "1.5",
                 margin: 0,
                 border: "1px solid #e0e0e0",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
               }}
             >
               <code>{previewYaml}</code>
@@ -410,7 +413,7 @@ const ContentCategoryConfiguration: React.FC<ContentCategoryConfigurationProps> 
             borderRadius: "4px",
           }}
         >
-          No content categories selected. Add categories to detect harmful content, bias, or inappropriate advice.
+          No blocked topics selected. Add topics to detect and block harmful content.
         </div>
       )}
     </Card>


### PR DESCRIPTION
## Relevant issues

N/A - UX improvement

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring

## Changes

Reworked the "Add Guardrail" modal to use an inline vertical stepper instead of the old horizontal Ant Design Steps. Completed steps collapse to a single line with an "Edit" link, and the active step expands to show its form. Wider modal (1000px), Tremor buttons to match MCP modal styling.

Also renamed some steps for clarity ("Content categories" -> "Denied topics", etc.) and updated the denied_financial_advice category to show "Denied Financial / Investment Advice" as its display name. Added support for an explicit `display_name` field in category YAML files so names don't have to be auto-generated from the category_name slug.

**Files changed:**
- `ui/.../guardrails/add_guardrail_form.tsx` - new vertical stepper layout, Tremor buttons, step renaming
- `ui/.../content_filter/ContentCategoryConfiguration.tsx` - renamed "Content Categories" to "Blocked topics", fixed YAML preview overflow
- `litellm/.../litellm_content_filter/patterns.py` - support explicit `display_name` in category YAML
- `litellm/.../categories/denied_financial_advice.yaml` - added display_name field