### PR TITLE
fix: iterate all deployment indices instead of only checking first

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6517,15 +6517,18 @@ class Router:
         # O(1) lookup in model_name index
         if model_group_name in self.model_name_to_deployment_indices:
             indices = self.model_name_to_deployment_indices[model_group_name]
-            if indices:
-                # Return first deployment for this model_name
-                model = self.model_list[indices[0]]
+            for idx in indices:
+                if idx >= len(self.model_list):
+                    continue
+                model = self.model_list[idx]
                 if isinstance(model, dict):
                     return Deployment(**model)
                 elif isinstance(model, Deployment):
                     return model
                 else:
-                    raise Exception("Model Name invalid - {}".format(type(model)))
+                    raise Exception(
+                        "Model Name invalid - {}".format(type(model))
+                    )
         return None
 
     def get_deployment_credentials_with_provider(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6483,6 +6483,8 @@ class Router:
         # Use O(1) lookup via model_id_to_deployment_index_map only
         if model_id in self.model_id_to_deployment_index_map:
             idx = self.model_id_to_deployment_index_map[model_id]
+            if idx >= len(self.model_list):
+                return None
             model = self.model_list[idx]
             if isinstance(model, dict):
                 return Deployment(**model)
@@ -6692,6 +6694,8 @@ class Router:
         # O(1) lookup via model_id_to_deployment_index_map
         if id in self.model_id_to_deployment_index_map:
             idx = self.model_id_to_deployment_index_map[id]
+            if idx >= len(self.model_list):
+                return None
             return self.model_list[idx]
         return None
 
@@ -7237,6 +7241,8 @@ class Router:
             if model_name in self.model_name_to_deployment_indices:
                 indices = self.model_name_to_deployment_indices[model_name]
                 for idx in indices:
+                    if idx >= len(self.model_list):
+                        continue
                     model = self.model_list[idx]
                     if "model_info" in model and "id" in model["model_info"]:
                         if exclude_team_models and model["model_info"].get("team_id"):
@@ -7247,6 +7253,8 @@ class Router:
             # Use the index map keys for O(n) where n = total deployments
             for model_id in self.model_id_to_deployment_index_map.keys():
                 idx = self.model_id_to_deployment_index_map[model_id]
+                if idx >= len(self.model_list):
+                    continue
                 model = self.model_list[idx]
                 if "model_info" in model and "id" in model["model_info"]:
                     if exclude_team_models and model["model_info"].get("team_id"):
@@ -7379,6 +7387,8 @@ class Router:
 
             # O(k) where k = deployments for this model_name (typically 1-10)
             for idx in indices:
+                if idx >= len(self.model_list):
+                    continue
                 model = self.model_list[idx]
                 if self.should_include_deployment(
                     model_name=model_name, model=model, team_id=team_id


### PR DESCRIPTION
Fixes the case where stale indices after concurrent deployment removal cause the function to return None instead of trying remaining indices.

**Changes:**
- `litellm/router.py`: iterate all indices in `get_deployment_by_model_group_name` with bounds check, matching `_get_all_deployments` pattern