### PR TITLE
fix: SpendUpdateQueue aggregation mutating original dicts in place

### DIFF
--- a/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
@@ -112,7 +112,7 @@ class SpendUpdateQueue(BaseUpdateQueue):
         for update in updates:
             _key = f"{update.get('entity_type')}:{update.get('entity_id')}"
             if _key not in _in_memory_map:
-                _in_memory_map[_key] = update
+                _in_memory_map[_key] = update.copy()
             else:
                 current_cost = _in_memory_map[_key].get("response_cost", 0) or 0
                 update_cost = update.get("response_cost", 0) or 0


### PR DESCRIPTION
Fixes a bug where aggregation in SpendUpdateQueue mutates the original dicts passed to it, causing incorrect spend tracking when the same dict is referenced elsewhere.

Uses .copy() before aggregation to preserve original data.