### PR TITLE
fix: router retry loop using stale exception for Retry-After backoff

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5035,7 +5035,7 @@ class Router:
                     else:
                         _healthy_deployments = []
                     _timeout = self._time_to_sleep_before_retry(
-                        e=original_exception,
+                        e=e,
                         remaining_retries=remaining_retries,
                         num_retries=num_retries,
                         healthy_deployments=_healthy_deployments,


### PR DESCRIPTION
The retry loop used the original exception for Retry-After header extraction instead of the current exception, causing incorrect backoff timing after rate limits.

Changes `e=original_exception` to `e=e` in the retry loop.