### PR TITLE
fix: add missing async call types (acreate_file, acreate_thread, etc.) to _is_async_request

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2075,6 +2075,10 @@ def _is_async_request(
         or kwargs.get("_arealtime", False) is True
         or kwargs.get("acreate_batch", False) is True
         or kwargs.get("acreate_fine_tuning_job", False) is True
+        or kwargs.get("acreate_file", False) is True
+        or kwargs.get("acreate_thread", False) is True
+        or kwargs.get("acreate_skill", False) is True
+        or kwargs.get("acreate_interaction", False) is True
         or is_pass_through is True
     ):
         return True

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3305,3 +3305,51 @@ class TestIsStreamingRequest:
 
     def test_stream_true_overrides_non_streaming_call_type(self):
         assert _is_streaming_request(kwargs={"stream": True}, call_type=CallTypes.acompletion) is True
+
+
+def test_is_async_request_includes_acreate_file():
+    """
+    Verify that _is_async_request recognizes acreate_file as an async call.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/20798.
+    Missing acreate_file caused RuntimeWarning: coroutine was never awaited.
+    """
+    from litellm.utils import _is_async_request
+
+    # All async file/thread/skill/interaction operations should be recognized
+    assert _is_async_request({"acreate_file": True}) is True
+    assert _is_async_request({"acreate_thread": True}) is True
+    assert _is_async_request({"acreate_skill": True}) is True
+    assert _is_async_request({"acreate_interaction": True}) is True
+
+    # Pre-existing ones should still work
+    assert _is_async_request({"acompletion": True}) is True
+    assert _is_async_request({"acreate_batch": True}) is True
+
+    # Non-async should return False
+    assert _is_async_request({"some_other_key": True}) is False
+    assert _is_async_request(None) is False
+
+
+def test_is_async_request_includes_acreate_file():
+    """
+    Verify that _is_async_request recognizes acreate_file as an async call.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/20798.
+    Missing acreate_file caused RuntimeWarning: coroutine was never awaited.
+    """
+    from litellm.utils import _is_async_request
+
+    # All async file/thread/skill/interaction operations should be recognized
+    assert _is_async_request({"acreate_file": True}) is True
+    assert _is_async_request({"acreate_thread": True}) is True
+    assert _is_async_request({"acreate_skill": True}) is True
+    assert _is_async_request({"acreate_interaction": True}) is True
+
+    # Pre-existing ones should still work
+    assert _is_async_request({"acompletion": True}) is True
+    assert _is_async_request({"acreate_batch": True}) is True
+
+    # Non-async should return False
+    assert _is_async_request({"some_other_key": True}) is False
+    assert _is_async_request(None) is False


### PR DESCRIPTION
Missing async call types (acreate_file, acreate_thread, acreate_skill, acreate_interaction) in _is_async_request caused coroutine-never-awaited warnings.