### PR TITLE
fix: add missing async call types (acreate_file, acreate_thread, etc.) to _is_async_request

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2075,6 +2075,10 @@ def _is_async_request(
         or kwargs.get("_arealtime", False) is True
         or kwargs.get("acreate_batch", False) is True
         or kwargs.get("acreate_fine_tuning_job", False) is True
+        or kwargs.get("acreate_file", False) is True
+        or kwargs.get("acreate_thread", False) is True
+        or kwargs.get("acreate_skill", False) is True
+        or kwargs.get("acreate_interaction", False) is True
         or is_pass_through is True
     ):
         return True


### PR DESCRIPTION
Missing async call types (acreate_file, acreate_thread, acreate_skill, acreate_interaction) in _is_async_request caused coroutine-never-awaited warnings.