### PR TITLE
fix: avoid mutating caller-owned dicts in SpendUpdateQueue aggregation

### DIFF
--- a/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
@@ -112,7 +112,8 @@ class SpendUpdateQueue(BaseUpdateQueue):
         for update in updates:
             _key = f"{update.get('entity_type')}:{update.get('entity_id')}"
             if _key not in _in_memory_map:
-                _in_memory_map[_key] = update
+                # avoid mutating caller-owned dicts while aggregating queue entries
+                _in_memory_map[_key] = update.copy()
             else:
                 current_cost = _in_memory_map[_key].get("response_cost", 0) or 0
                 update_cost = update.get("response_cost", 0) or 0


### PR DESCRIPTION
Uses .copy() when storing new entries in the aggregation map to avoid mutating caller-owned dicts.