### PR TITLE
fix(budget): fix timezone config lookup and replace hardcoded timezone map with ZoneInfo

### DIFF
--- a/docs/my-website/docs/proxy/budget_reset_and_tz.md
+++ b/docs/my-website/docs/proxy/budget_reset_and_tz.md
@@ -22,6 +22,8 @@ litellm_settings:
 This ensures that all budget resets happen at midnight in your specified timezone rather than in UTC.
 If no timezone is specified, UTC will be used by default.
 
+Any valid [IANA timezone string](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) is supported (powered by Python's `zoneinfo` module). DST transitions are handled automatically.
+
 Common timezone values:
 
 - `UTC` - Coordinated Universal Time

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -417,6 +417,7 @@ const sidebars = {
             "proxy/dynamic_rate_limit",
             "proxy/rate_limit_tiers",
             "proxy/temporary_budget_increase",
+            "proxy/budget_reset_and_tz",
           ],
         },
         "proxy/caching",

--- a/litellm/proxy/common_utils/timezone_utils.py
+++ b/litellm/proxy/common_utils/timezone_utils.py
@@ -17,7 +17,7 @@ def get_budget_reset_timezone():
 
 def get_budget_reset_time(budget_duration: str):
     """
-    Get the budget reset time from general_settings.
+    Get the budget reset time based on the configured timezone.
     Falls back to UTC if not specified.
     """
 

--- a/litellm/proxy/common_utils/timezone_utils.py
+++ b/litellm/proxy/common_utils/timezone_utils.py
@@ -1,22 +1,18 @@
 from datetime import datetime, timezone
 
+import litellm
 from litellm.litellm_core_utils.duration_parser import get_next_standardized_reset_time
 
 
 def get_budget_reset_timezone():
     """
-    Get the budget reset timezone from general_settings.
+    Get the budget reset timezone from litellm_settings.
     Falls back to UTC if not specified.
+
+    litellm_settings values are set as attributes on the litellm module
+    by proxy_server.py at startup (via setattr(litellm, key, value)).
     """
-    # Import at function level to avoid circular imports
-    from litellm.proxy.proxy_server import general_settings
-
-    if general_settings:
-        litellm_settings = general_settings.get("litellm_settings", {})
-        if litellm_settings and "timezone" in litellm_settings:
-            return litellm_settings["timezone"]
-
-    return "UTC"
+    return getattr(litellm, "timezone", None) or "UTC"
 
 
 def get_budget_reset_time(budget_duration: str):

--- a/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
@@ -1,18 +1,17 @@
-import asyncio
-import json
 import os
 import sys
-import time
-from datetime import datetime, timedelta, timezone
-
-import pytest
-from fastapi.testclient import TestClient
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+import litellm
+from litellm.proxy.common_utils.timezone_utils import (
+    get_budget_reset_time,
+    get_budget_reset_timezone,
+)
 
 
 def test_get_budget_reset_time():
@@ -33,3 +32,71 @@ def test_get_budget_reset_time():
 
     # Verify budget_reset_at is set to first of next month
     assert get_budget_reset_time(budget_duration="1mo") == expected_reset_at
+
+
+def test_get_budget_reset_timezone_reads_litellm_attr():
+    """
+    Test that get_budget_reset_timezone reads from litellm.timezone attribute.
+    """
+    original = getattr(litellm, "timezone", None)
+    try:
+        litellm.timezone = "Asia/Tokyo"
+        assert get_budget_reset_timezone() == "Asia/Tokyo"
+    finally:
+        if original is None:
+            if hasattr(litellm, "timezone"):
+                delattr(litellm, "timezone")
+        else:
+            litellm.timezone = original
+
+
+def test_get_budget_reset_timezone_fallback_utc():
+    """
+    Test that get_budget_reset_timezone falls back to UTC when litellm.timezone is not set.
+    """
+    original = getattr(litellm, "timezone", None)
+    try:
+        if hasattr(litellm, "timezone"):
+            delattr(litellm, "timezone")
+        assert get_budget_reset_timezone() == "UTC"
+    finally:
+        if original is not None:
+            litellm.timezone = original
+
+
+def test_get_budget_reset_timezone_fallback_on_none():
+    """
+    Test that get_budget_reset_timezone falls back to UTC when litellm.timezone is None.
+    """
+    original = getattr(litellm, "timezone", None)
+    try:
+        litellm.timezone = None
+        assert get_budget_reset_timezone() == "UTC"
+    finally:
+        if original is None:
+            if hasattr(litellm, "timezone"):
+                delattr(litellm, "timezone")
+        else:
+            litellm.timezone = original
+
+
+def test_get_budget_reset_time_respects_timezone():
+    """
+    Test that get_budget_reset_time uses the configured timezone for reset calculation.
+    A daily reset should align to midnight in the configured timezone.
+    """
+    original = getattr(litellm, "timezone", None)
+    try:
+        litellm.timezone = "Asia/Tokyo"
+        reset_at = get_budget_reset_time(budget_duration="1d")
+        # The reset time should be midnight in Asia/Tokyo
+        tokyo_reset = reset_at.astimezone(ZoneInfo("Asia/Tokyo"))
+        assert tokyo_reset.hour == 0
+        assert tokyo_reset.minute == 0
+        assert tokyo_reset.second == 0
+    finally:
+        if original is None:
+            if hasattr(litellm, "timezone"):
+                delattr(litellm, "timezone")
+        else:
+            litellm.timezone = original


### PR DESCRIPTION
## Relevant issues

Fixes budget reset always using UTC regardless of `litellm_settings.timezone` configuration.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Bug 1: `timezone_utils.py` — wrong config lookup path
- `general_settings.get("litellm_settings", {}).get("timezone", "UTC")` always fell back to UTC because `litellm_settings` is not nested inside `general_settings`
- Fixed to `getattr(litellm, "timezone", None) or "UTC"`, matching the `setattr(litellm, key, value)` pattern used in `proxy_server.py`

### Bug 2: `duration_parser.py` — hardcoded timezone map
- Only 6 timezones were supported (US/Eastern, US/Pacific, Asia/Kolkata, Asia/Bangkok, Europe/London, UTC), no DST handling
- Replaced with `ZoneInfo(timezone_str)` for full IANA timezone support with automatic DST handling
- Broadened exception catch to `except Exception` for safe UTC fallback on any invalid timezone input

### Tests
- Added tests for previously unsupported IANA timezones (Asia/Tokyo, Australia/Sydney, America/Chicago)
- Added DST transition tests (fall-back and spring-forward)
- Added tests for `get_budget_reset_timezone()` config reading

### Docs (optional)
- Added IANA timezone support note to `budget_reset_and_tz.md`
- Registered the existing orphan doc page in `sidebars.js`
- **If doc changes are not desired, I'm happy to remove them and keep this PR as a pure bug fix.**
