### PR TITLE
feat(vault): add separate namespace support for vault login and secrets

### DIFF
--- a/docs/my-website/docs/secret_managers/hashicorp_vault.md
+++ b/docs/my-website/docs/secret_managers/hashicorp_vault.md
@@ -49,6 +49,8 @@ HCP_VAULT_TOKEN="hvs.CAESIG52gL6ljBSdmq*****"
 HCP_VAULT_REFRESH_INTERVAL="86400" # defaults to 86400, frequency of cache refresh for Hashicorp Vault
 HCP_VAULT_MOUNT_NAME="secret" # OPTIONAL. defaults to "secret", set this if your KV engine is mounted elsewhere
 HCP_VAULT_PATH_PREFIX="litellm" # OPTIONAL. defaults to None, set this if your secrets live under a custom prefix like secret/data/litellm/OPENAI_API_KEY
+HCP_VAULT_LOGIN_NAMESPACE="admin" # OPTIONAL. defaults to HCP_VAULT_NAMESPACE, namespace used for AppRole/TLS authentication
+HCP_VAULT_SECRET_NAMESPACE="teams" # OPTIONAL. defaults to HCP_VAULT_NAMESPACE, namespace used for reading/writing secrets
 ```
 
 **Step 2.** Add to proxy config.yaml


### PR DESCRIPTION
## Relevant issues

Fixes #LIT-1983

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm_utils_tests/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test
📖 Documentation

## Changes

<img width="948" height="589" alt="image" src="https://github.com/user-attachments/assets/63c90e77-ee26-4408-9c9a-4fa683ce816e" />


This PR introduces the ability to configure separate HashiCorp Vault namespaces for authentication and secret retrieval, accommodating Enterprise Vault setups where AppRoles reside in a different namespace (e.g., `admin`) than the secrets they access (e.g., `teams/myteam`).

1. Added `HCP_VAULT_LOGIN_NAMESPACE` for AppRole/TLS authentication routing.
2. Added `HCP_VAULT_SECRET_NAMESPACE` for secret URL construction and API headers.
3. Included `X-Vault-Namespace` header in API requests for secret operations.
4. Maintained backward compatibility by falling back to `HCP_VAULT_NAMESPACE` if specific namespaces are unset.
5. Added 4 new tests specifically validating the isolated namespace header logic and backward compatibility.
6. Fixed failing test cases due to missing base credentials in the test setup via `monkeypatch`.
7. Updated documentation in `docs/my-website/docs/secret_managers/hashicorp_vault.md`.
