### PR TITLE
feat: add session_id to have better routing

### DIFF
--- a/docs/my-website/docs/response_api.md
+++ b/docs/my-website/docs/response_api.md
@@ -887,7 +887,8 @@ router = litellm.Router(
     # `responses_api_deployment_check` ensures Requests with `previous_response_id`
     # are routed to the same deployment. `deployment_affinity` adds sticky sessions
     # for requests without `previous_response_id` (useful for implicit caching).
-    optional_pre_call_checks=["responses_api_deployment_check", "deployment_affinity"],
+    # `session_affinity` adds sticky sessions based on `session_id` metadata.
+    optional_pre_call_checks=["responses_api_deployment_check", "deployment_affinity", "session_affinity"],
     # Optional (default is 3600 seconds / 1 hour)
     deployment_affinity_ttl_seconds=3600,
 )
@@ -919,10 +920,12 @@ follow_up = await router.aresponses(
 To enable session continuity for Responses API in your LiteLLM proxy, set `optional_pre_call_checks` in your proxy config.yaml.
 
 - `responses_api_deployment_check`: high priority routing when `previous_response_id` is provided
+- `session_affinity`: sticky sessions based on session id (takes priority over `deployment_affinity`)
 - `deployment_affinity`: sticky sessions based on user key (applies even without `previous_response_id`)
 
 Notes:
 - User-key affinity is keyed on `metadata.user_api_key_hash` (the API key hash). The OpenAI `user` request parameter is an end-user identifier and is intentionally not used for deployment affinity.
+- Session-ID affinity is keyed on `metadata.session_id`. For proxy requests, this can be passed via the `x-litellm-session-id` HTTP header. For Python SDK requests, you can pass it via `litellm_metadata={"session_id": "value"}` in request args.
 - `user_api_key_hash` is already SHA-256, and is used as-is (no double hashing).
 - Affinity is scoped by a stable model identifier (the model-map key, e.g. `model_map_information.model_map_key`) so model aliases map to the same stickiness bucket.
 - The mapping TTL is controlled by `deployment_affinity_ttl_seconds` (configured on Router init / proxy startup).
@@ -945,6 +948,7 @@ model_list:
 router_settings:
   optional_pre_call_checks:
     - responses_api_deployment_check
+    - session_affinity
     - deployment_affinity
   # Optional (default is 3600 seconds / 1 hour)
   deployment_affinity_ttl_seconds: 3600

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -569,13 +569,25 @@ class LiteLLMProxyRequestSetup:
         #########################################################################################
         agent_id_from_header = headers.get("x-litellm-agent-id")
         trace_id_from_header = headers.get("x-litellm-trace-id")
+        session_id_from_header = headers.get("x-litellm-session-id")
+
         if agent_id_from_header:
             metadata_from_headers["agent_id"] = agent_id_from_header
-            verbose_proxy_logger.debug(f"Extracted agent_id from header: {agent_id_from_header}")
-        
+            verbose_proxy_logger.debug(
+                f"Extracted agent_id from header: {agent_id_from_header}"
+            )
+
         if trace_id_from_header:
             metadata_from_headers["trace_id"] = trace_id_from_header
-            verbose_proxy_logger.debug(f"Extracted trace_id from header: {trace_id_from_header}")
+            verbose_proxy_logger.debug(
+                f"Extracted trace_id from header: {trace_id_from_header}"
+            )
+
+        if session_id_from_header:
+            metadata_from_headers["session_id"] = session_id_from_header
+            verbose_proxy_logger.debug(
+                f"Extracted session_id from header: {session_id_from_header}"
+            )
 
         if isinstance(data[_metadata_variable_name], dict):
             data[_metadata_variable_name].update(metadata_from_headers)
@@ -1589,9 +1601,7 @@ def _match_and_track_policies(
         for name in applied_policy_names
         if name in policy_reasons
     }
-    add_policy_sources_to_metadata(
-        request_data=data, policy_sources=applied_reasons
-    )
+    add_policy_sources_to_metadata(request_data=data, policy_sources=applied_reasons)
 
     return applied_policy_names, policy_reasons
 
@@ -1626,9 +1636,9 @@ def _apply_resolved_guardrails_to_metadata(
             pipelines
         )
         data[metadata_variable_name]["_guardrail_pipelines"] = pipelines
-        data[metadata_variable_name]["_pipeline_managed_guardrails"] = (
-            pipeline_managed_guardrails
-        )
+        data[metadata_variable_name][
+            "_pipeline_managed_guardrails"
+        ] = pipeline_managed_guardrails
         verbose_proxy_logger.debug(
             f"Policy engine: resolved {len(pipelines)} pipeline(s), "
             f"managed guardrails: {pipeline_managed_guardrails}"

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -803,6 +803,7 @@ OptionalPreCallChecks = List[
         "router_budget_limiting",
         "responses_api_deployment_check",
         "deployment_affinity",
+        "session_affinity",
         "forward_client_headers_by_model_group",
         "enforce_model_rate_limits",
     ]

--- a/tests/test_litellm/router_utils/pre_call_checks/test_session_id_affinity.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_session_id_affinity.py
@@ -1,0 +1,179 @@
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import json
+
+import litellm
+from litellm.caching.dual_cache import DualCache
+from litellm.router_utils.pre_call_checks.deployment_affinity_check import (
+    DeploymentAffinityCheck,
+)
+
+
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self._json_data = json_data
+        self.status_code = status_code
+        self.text = json.dumps(json_data)
+        self.headers = {}
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.mark.asyncio
+async def test_async_session_id_affinity_routes_to_same_deployment():
+    """
+    When session_affinity is enabled, subsequent requests from the same session id
+    should route to the same deployment.
+    """
+    mock_response_data = {
+        "id": "resp_mock-resp-123",
+        "object": "response",
+        "created_at": 1741476542,
+        "status": "completed",
+        "model": "azure/computer-use-preview",
+        "output": [
+            {
+                "type": "message",
+                "id": "msg_123",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": "Hello there!", "annotations": []}
+                ],
+            }
+        ],
+        "parallel_tool_calls": True,
+        "usage": {
+            "input_tokens": 5,
+            "output_tokens": 10,
+            "total_tokens": 15,
+            "output_tokens_details": {"reasoning_tokens": 0},
+        },
+        "text": {"format": {"type": "text"}},
+        "error": None,
+        "previous_response_id": None,
+    }
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "azure-computer-use-preview",
+                "litellm_params": {
+                    "model": "azure/computer-use-preview-1",
+                    "api_key": "mock-api-key-1",
+                    "api_version": "mock-api-version",
+                    "api_base": "https://mock-endpoint-1.openai.azure.com",
+                },
+                "model_info": {"base_model": "computer-use-preview"},
+            },
+            {
+                "model_name": "azure-computer-use-preview",
+                "litellm_params": {
+                    "model": "azure/computer-use-preview-2",
+                    "api_key": "mock-api-key-2",
+                    "api_version": "mock-api-version-2",
+                    "api_base": "https://mock-endpoint-2.openai.azure.com",
+                },
+                "model_info": {"base_model": "computer-use-preview"},
+            },
+        ],
+        optional_pre_call_checks=["session_affinity"],
+    )
+
+    model_group = "azure-computer-use-preview"
+    session_id = "test-session-id-1"
+
+    choice_calls = {"count": 0}
+
+    def deterministic_choice(seq):
+        choice_calls["count"] += 1
+        if choice_calls["count"] == 1:
+            return seq[0]
+        return seq[1] if len(seq) > 1 else seq[0]
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post, patch(
+        "litellm.router_strategy.simple_shuffle.random.choice",
+        side_effect=deterministic_choice,
+    ):
+        mock_post.return_value = MockResponse(mock_response_data, 200)
+
+        first_response = await router.aresponses(
+            model=model_group,
+            input="Hello, how are you?",
+            truncation="auto",
+            litellm_metadata={"session_id": session_id},
+        )
+        first_model_id = first_response._hidden_params["model_id"]
+
+        second_response = await router.aresponses(
+            model=model_group,
+            input="Follow-up question",
+            truncation="auto",
+            litellm_metadata={"session_id": session_id},
+        )
+        assert second_response._hidden_params["model_id"] == first_model_id
+
+
+@pytest.mark.asyncio
+async def test_async_session_id_affinity_priority_over_user_key():
+    """
+    If both session_affinity and deployment_affinity are enabled,
+    session_affinity should have priority. We test this by sending different
+    session ids for the same user.
+    """
+    cache = DualCache()
+    callback = DeploymentAffinityCheck(
+        cache=cache,
+        ttl_seconds=123,
+        enable_user_key_affinity=True,
+        enable_responses_api_affinity=False,
+        enable_session_id_affinity=True,
+    )
+
+    healthy_deployments = [
+        {
+            "model_name": "model_group",
+            "litellm_params": {"model": "model_1"},
+            "model_info": {"id": "deployment-1"},
+        },
+        {
+            "model_name": "model_group",
+            "litellm_params": {"model": "model_2"},
+            "model_info": {"id": "deployment-2"},
+        },
+    ]
+
+    await callback.cache.async_set_cache(
+        DeploymentAffinityCheck.get_affinity_cache_key("model_group", "user1"),
+        {"model_id": "deployment-1"},
+    )
+
+    await callback.cache.async_set_cache(
+        DeploymentAffinityCheck.get_session_affinity_cache_key(
+            "model_group", "session1"
+        ),
+        {"model_id": "deployment-2"},
+    )
+
+    # Should use session mapping
+    filtered = await callback.async_filter_deployments(
+        model="model_group",
+        healthy_deployments=healthy_deployments,
+        messages=[],
+        request_kwargs={
+            "metadata": {"user_api_key_hash": "user1", "session_id": "session1"}
+        },
+    )
+
+    assert len(filtered) == 1
+    assert filtered[0]["model_info"]["id"] == "deployment-2"


### PR DESCRIPTION
## Relevant issues

Allow sticky sessions with weighted routing

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
📖 Documentation
✅ Test

## Changes

**Sticky Sessions using Session IDs (Session Affinity)**

This PR introduces the ability to route subsequent requests from the same session to the exact same deployment that handled the initial request, bypassing regular load-balancing. This is particularly useful for maximizing prompt caching efficiency and preserving context continuity.

<img width="1175" height="1476" alt="image" src="https://github.com/user-attachments/assets/d0835864-53a2-4e06-b5c2-09ce10e18039" />

### e2e verification
<img width="887" height="601" alt="image" src="https://github.com/user-attachments/assets/58db3afe-5d0b-4cb4-9f9e-56be6d6e54dd" />
