### PR TITLE
fix: resolve flaky test failures in health, spend logs, and CLI tests

### DIFF
--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -299,6 +299,8 @@ ignored_keys = [
     "metadata.status",
     "metadata.proxy_server_request",
     "metadata.error_information",
+    "metadata.attempted_retries",
+    "metadata.max_retries",
 ]
 
 MODEL_LIST = [
@@ -1196,6 +1198,18 @@ async def test_ui_view_spend_logs_with_key_hash(client, monkeypatch):
     assert data["data"][0]["api_key"] == "sk-test-key-1"
 
 
+async def _wait_for_mock_call(mock, timeout=10, interval=0.1):
+    """Poll until mock has been called at least once, or timeout."""
+    import time
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if mock.call_count > 0:
+            return
+        await asyncio.sleep(interval)
+    mock.assert_called_once()  # will raise with a clear message
+
+
 class TestSpendLogsPayload:
     @pytest.mark.asyncio
     async def test_spend_logs_payload_e2e(self):
@@ -1215,9 +1229,7 @@ class TestSpendLogsPayload:
 
             assert response.choices[0].message.content == "Hello, world!"
 
-            await asyncio.sleep(1)
-
-            mock_client.assert_called_once()
+            await _wait_for_mock_call(mock_client)
 
             kwargs = mock_client.call_args.kwargs
             payload: SpendLogsPayload = kwargs["payload"]
@@ -1310,9 +1322,7 @@ class TestSpendLogsPayload:
 
             assert response.choices[0].message.content == "Hi! My name is Claude."
 
-            await asyncio.sleep(1)
-
-            mock_client.assert_called_once()
+            await _wait_for_mock_call(mock_client)
 
             kwargs = mock_client.call_args.kwargs
             payload: SpendLogsPayload = kwargs["payload"]
@@ -1402,9 +1412,7 @@ class TestSpendLogsPayload:
 
             assert response.choices[0].message.content == "Hi! My name is Claude."
 
-            await asyncio.sleep(1)
-
-            mock_client.assert_called_once()
+            await _wait_for_mock_call(mock_client)
 
             kwargs = mock_client.call_args.kwargs
             payload: SpendLogsPayload = kwargs["payload"]

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -233,7 +233,7 @@ class TestProxyInitializationHelpers:
 
         from litellm.proxy.proxy_cli import run_server
 
-        runner = CliRunner(mix_stderr=False)
+        runner = CliRunner()
 
         mock_proxy_module = MagicMock(
             app=MagicMock(),
@@ -241,7 +241,12 @@ class TestProxyInitializationHelpers:
             KeyManagementSettings=MagicMock(),
             save_worker_config=MagicMock(),
         )
+        # Remove DATABASE_URL/DIRECT_URL so the CLI doesn't attempt
+        # real prisma operations when these are set in CI.
+        clean_env = {k: v for k, v in os.environ.items() if k not in ("DATABASE_URL", "DIRECT_URL")}
         with patch.dict(
+            os.environ, clean_env, clear=True,
+        ), patch.dict(
             "sys.modules",
             {
                 "proxy_server": mock_proxy_module,
@@ -262,7 +267,7 @@ class TestProxyInitializationHelpers:
             # --- skip startup ---
             result = runner.invoke(run_server, ["--local", "--skip_server_startup"])
 
-            assert result.exit_code == 0
+            assert result.exit_code == 0, f"exit_code={result.exit_code}, output={result.output}"
             assert "Skipping server startup" in result.output
             mock_uvicorn_run.assert_not_called()
 
@@ -271,7 +276,7 @@ class TestProxyInitializationHelpers:
 
             result = runner.invoke(run_server, ["--local"])
 
-            assert result.exit_code == 0
+            assert result.exit_code == 0, f"exit_code={result.exit_code}, output={result.output}"
             mock_uvicorn_run.assert_called_once()
 
     @patch("uvicorn.run")


### PR DESCRIPTION
## Relevant issues

Fixes flaky CI tests.

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Fixes 5 flaky/failing tests (test-only changes, no production code modified):

- `test_db_health_readiness_check_with_prisma_error` — reset `db_health_cache` on the source module instead of the test module; use `PrismaError("Can't reach database server")` so the exception handler recognizes it as a connection error
- `test_spend_logs_payload_e2e`, `test_spend_logs_payload_success_log_with_api_base`, `test_spend_logs_payload_success_log_with_router` — replace `asyncio.sleep(1)` with a polling loop (10s timeout) since `GLOBAL_LOGGING_WORKER` processes callbacks asynchronously via a queue
- `test_skip_server_startup` — strip `DATABASE_URL`/`DIRECT_URL` from env during test to prevent real prisma operations in CI; remove `mix_stderr=False` (unsupported in some Click versions)