### PR TITLE
fix(test): update claude model name in test_get_valid_models_from_dynamic_api_key

### DIFF
--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -2348,7 +2348,7 @@ def test_get_valid_models_from_dynamic_api_key():
         check_provider_endpoint=True,
     )
     assert len(valid_models) > 0
-    assert "anthropic/claude-3-7-sonnet-20250219" in valid_models
+    assert "anthropic/claude-sonnet-4-6" in valid_models
 
 
 def test_get_whitelisted_models():


### PR DESCRIPTION
## Relevant issues

N/A

## Pre-Submission checklist

- [x] I have added at least 1 test (this IS the test fix)
- [x] `make test-unit` passes

## Changes

`anthropic/claude-3-7-sonnet-20250219` was renamed to `anthropic/claude-sonnet-4-6` in Anthropic's model list, causing `test_get_valid_models_from_dynamic_api_key` to fail. Updated the assertion to use the current model name.