### PR TITLE
fix(test): skip 'projects' field in team update test assertion

### DIFF
--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -533,6 +533,7 @@ async def test_team_update_sc_2():
                 or k == "litellm_model_table"
                 or k == "policies"
                 or k == "allow_team_guardrail_config"
+                or k == "projects"
             ):
                 pass
             else:


### PR DESCRIPTION
## Relevant issues

Fixes CI `KeyError: 'projects'` in `test_team_update_sc_2` at `tests/test_team.py:539`

## Pre-Submission checklist

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Added `projects` to the skip list in the team update test assertion loop. The `/team/update` response now includes a `projects` relation field from the Prisma model, which wasn't in the skip list, causing `KeyError` when comparing against the original team data.