### PR TITLE
fix(proxy): add is_database_transport_error for reconnect; restore broad is_database_connection_error

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2000,7 +2000,7 @@ async def _fetch_key_object_from_db_with_reconnect(
             proxy_logging_obj=proxy_logging_obj,
         )
     except Exception as e:
-        if PrismaDBExceptionHandler.is_database_connection_error(e):
+        if PrismaDBExceptionHandler.is_database_transport_error(e):
             did_reconnect = False
             if hasattr(prisma_client, "attempt_db_reconnect"):
                 auth_reconnect_timeout = getattr(

--- a/litellm/proxy/db/exception_handler.py
+++ b/litellm/proxy/db/exception_handler.py
@@ -32,7 +32,28 @@ class PrismaDBExceptionHandler:
     @staticmethod
     def is_database_connection_error(e: Exception) -> bool:
         """
-        Returns True if the exception is from a database outage / connection error
+        Returns True if the exception is from a database outage / connection error.
+        Any PrismaError qualifies — the DB failed to serve the request.
+        Used by allow_requests_on_db_unavailable logic.
+        """
+        import prisma
+
+        if isinstance(e, DB_CONNECTION_ERROR_TYPES):
+            return True
+        if isinstance(e, prisma.errors.PrismaError):
+            return True
+        if isinstance(e, ProxyException) and e.type == ProxyErrorTypes.no_db_connection:
+            return True
+        return False
+
+    @staticmethod
+    def is_database_transport_error(e: Exception) -> bool:
+        """
+        Returns True only for transport/connectivity failures where a reconnect
+        attempt makes sense (e.g. DB is unreachable, connection dropped).
+
+        Use this for reconnect logic — data-layer errors like UniqueViolationError
+        mean the DB IS reachable, so reconnecting would be pointless.
         """
         import prisma
 
@@ -44,8 +65,6 @@ class PrismaDBExceptionHandler:
             return True
         if isinstance(e, prisma.errors.PrismaError):
             error_message = str(e).lower()
-            # Treat generic PrismaError as connection error only when its text
-            # clearly indicates transport/connectivity failure.
             connection_keywords = (
                 "can't reach database server",
                 "cannot reach database server",

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3578,8 +3578,8 @@ class PrismaClient:
         """
         try:
             engine = self.db._original_prisma._engine  # type: ignore[attr-defined]
-            if engine is not None and engine.process is not None:
-                return engine.process.pid
+            if engine is not None and engine.process is not None:  # type: ignore[union-attr]
+                return engine.process.pid  # type: ignore[union-attr]
         except (AttributeError, TypeError):
             pass
 
@@ -4125,7 +4125,7 @@ class PrismaClient:
             except Exception as e:
                 if isinstance(
                     e, asyncio.TimeoutError
-                ) or PrismaDBExceptionHandler.is_database_connection_error(e):
+                ) or PrismaDBExceptionHandler.is_database_transport_error(e):
                     await self.attempt_db_reconnect(
                         reason="db_health_watchdog_connection_error",
                         timeout_seconds=self._db_watchdog_reconnect_timeout_seconds,

--- a/tests/test_litellm/proxy/db/test_exception_handler.py
+++ b/tests/test_litellm/proxy/db/test_exception_handler.py
@@ -72,8 +72,9 @@ def test_is_database_connection_error_prisma_connection_errors(prisma_error):
         ),
     ],
 )
-def test_is_database_connection_error_non_connection_prisma_errors(prisma_error):
-    assert PrismaDBExceptionHandler.is_database_connection_error(prisma_error) == False
+def test_is_database_transport_error_non_connection_prisma_errors(prisma_error):
+    """Data-layer errors should not trigger reconnect — DB is reachable when these occur."""
+    assert PrismaDBExceptionHandler.is_database_transport_error(prisma_error) == False
 
 
 def test_is_database_connection_generic_errors():

--- a/tests/test_litellm/proxy/db/test_prisma_self_heal.py
+++ b/tests/test_litellm/proxy/db/test_prisma_self_heal.py
@@ -215,7 +215,7 @@ async def test_db_health_watchdog_should_trigger_reconnect_on_db_error(mock_prox
         "litellm.proxy.utils.asyncio.sleep",
         AsyncMock(side_effect=[None, asyncio.CancelledError()]),
     ), patch(
-        "litellm.proxy.db.exception_handler.PrismaDBExceptionHandler.is_database_connection_error",
+        "litellm.proxy.db.exception_handler.PrismaDBExceptionHandler.is_database_transport_error",
         return_value=True,
     ):
         await client._db_health_watchdog_loop()


### PR DESCRIPTION
## Relevant issues

Fixes regression from #21706.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`#21706` narrowed `is_database_connection_error` so only `PrismaError`s with specific connectivity keywords count as connection errors. That was the right intent for the reconnect logic, but it also silently changed the `allow_requests_on_db_unavailable` behavior as a side effect — requests now only get let through on real transport errors, not on any prisma error.

The root cause: one method was serving two purposes with different semantics.

**Fix:**
- Add `is_database_transport_error` — narrow, keyword-gated check for cases where a reconnect actually makes sense (DB is unreachable, connection dropped). Data-layer errors like `UniqueViolationError` mean the DB IS up, so reconnecting is pointless.
- Restore `is_database_connection_error` to its original broad behavior (any `PrismaError` subclass) for the `allow_requests_on_db_unavailable` path.
- Update the two reconnect call sites from #21706 (`auth_checks.py` key lookup retry, `utils.py` watchdog) to use `is_database_transport_error`.
- Update the tests from #21706 that asserted the narrow behavior onto `is_database_connection_error` — move those assertions to `is_database_transport_error` where they belong.

**Files changed:**
- `litellm/proxy/db/exception_handler.py` — add `is_database_transport_error`, restore `is_database_connection_error`
- `litellm/proxy/auth/auth_checks.py` — reconnect retry uses `is_database_transport_error`
- `litellm/proxy/utils.py` — watchdog uses `is_database_transport_error`
- `tests/test_litellm/proxy/db/test_exception_handler.py` — assert narrow behavior on `is_database_transport_error`
- `tests/test_litellm/proxy/db/test_prisma_self_heal.py` — patch `is_database_transport_error` in watchdog test