### PR TITLE
fix(tests): read CI_CD_DEFAULT_ANTHROPIC_MODEL env var instead of hardcoding model

### DIFF
--- a/tests/local_testing/test_router.py
+++ b/tests/local_testing/test_router.py
@@ -105,7 +105,7 @@ async def test_router_provider_wildcard_routing():
     print("router model list = ", router.get_model_list())
 
     response1 = await router.acompletion(
-        model="anthropic/claude-sonnet-4-5-20250929",
+        model=f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
         messages=[{"role": "user", "content": "hello"}],
     )
 
@@ -126,7 +126,7 @@ async def test_router_provider_wildcard_routing():
     print("response 3 = ", response3)
 
     response4 = await router.acompletion(
-        model="claude-sonnet-4-5-20250929",
+        model=os.environ.get("CI_CD_DEFAULT_ANTHROPIC_MODEL", "claude-haiku-4-5-20251001"),
         messages=[{"role": "user", "content": "hello"}],
     )
 
@@ -1650,7 +1650,7 @@ def test_router_anthropic_key_dynamic():
         {
             "model_name": "anthropic-claude",
             "litellm_params": {
-                "model": "claude-3-5-haiku-20241022",
+                "model": os.environ.get("CI_CD_DEFAULT_ANTHROPIC_MODEL", "claude-haiku-4-5-20251001"),
                 "api_key": anthropic_api_key,
             },
         }

--- a/tests/local_testing/test_router_retries.py
+++ b/tests/local_testing/test_router_retries.py
@@ -859,7 +859,7 @@ async def test_router_timeout_model_specific_and_global():
             {
                 "model_name": "anthropic-claude",
                 "litellm_params": {
-                    "model": "anthropic/claude-sonnet-4-5-20250929",
+                    "model": f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
                     "timeout": 1,
                 },
             }

--- a/tests/local_testing/test_router_timeout.py
+++ b/tests/local_testing/test_router_timeout.py
@@ -160,7 +160,7 @@ def test_router_timeout_with_retries_anthropic_model(num_retries, expected_call_
             {
                 "model_name": "claude-3-haiku",
                 "litellm_params": {
-                    "model": "anthropic/claude-3-haiku-20240307",
+                    "model": f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
                 },
             }
         ],

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -181,7 +181,7 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call_streaming(s
     # litellm._turn_on_debug()
     async_client = AsyncHTTPHandler()
     response = await litellm.acompletion(
-        model="anthropic/claude-3-5-haiku-latest",
+        model=f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
         messages=[{"role": "user", "content": "what is litellm?"}],
         vector_store_ids = [
             "T37J8R4WTM"
@@ -232,7 +232,7 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call_with_tools(
     # Init client
     litellm._turn_on_debug()
     response = await litellm.acompletion(
-        model="anthropic/claude-3-5-haiku-latest",
+        model=f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
         messages=[{"role": "user", "content": "what is litellm?"}],
         max_tokens=10,
         tools=[
@@ -255,7 +255,7 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call_with_tools_
     litellm._turn_on_debug()
     
     response = await litellm.acompletion(
-        model="anthropic/claude-3-5-haiku-latest",
+        model=f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
         messages=[{"role": "user", "content": "what is litellm?"}],
         max_tokens=10,
         tools=[
@@ -350,7 +350,7 @@ async def test_bedrock_kb_request_body_has_transformed_filters(setup_vector_stor
         new=AsyncMock(side_effect=fake_async_vector_store_search_handler),
     ):
         response = await litellm.acompletion(
-            model="anthropic/claude-3-5-haiku-latest",
+            model=f"anthropic/{os.environ.get('CI_CD_DEFAULT_ANTHROPIC_MODEL', 'claude-haiku-4-5-20251001')}",
             messages=[{"role": "user", "content": "what is litellm?"}],
             max_tokens=10,
             tools=[


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

✅ Test

## Changes

Several tests had hardcoded Anthropic model names that were going stale. They now read `CI_CD_DEFAULT_ANTHROPIC_MODEL` from the environment at runtime, falling back to `claude-haiku-4-5-20251001`.

Files changed:
- `tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py`
- `tests/local_testing/test_router.py`
- `tests/local_testing/test_router_retries.py`
- `tests/local_testing/test_router_timeout.py`

Set `CI_CD_DEFAULT_ANTHROPIC_MODEL=claude-haiku-4-5-20251001` in CI to use the latest Haiku 4.5 model.