### PR TITLE
fix(ui): fix 6 failing ui_unit_tests

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
@@ -645,7 +645,6 @@ describe("UsagePage", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Organization usage is a new feature.")).toBeInTheDocument();
       const entityUsageElements = screen.getAllByText("Entity Usage");
       expect(entityUsageElements.length).toBeGreaterThan(0);
     });
@@ -1073,17 +1072,8 @@ describe("UsagePage", () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText("Customer usage is a new feature.")).toBeInTheDocument();
-      });
-
-      // Click the close button
-      const closeButton = screen.getByLabelText("Close");
-      act(() => {
-        fireEvent.click(closeButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.queryByText("Customer usage is a new feature.")).not.toBeInTheDocument();
+        const entityUsageElements = screen.getAllByText("Entity Usage");
+        expect(entityUsageElements.length).toBeGreaterThan(0);
       });
     });
   });
@@ -1108,7 +1098,8 @@ describe("UsagePage", () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText("Agent usage (A2A) is a new feature.")).toBeInTheDocument();
+        const entityUsageElements = screen.getAllByText("Entity Usage");
+        expect(entityUsageElements.length).toBeGreaterThan(0);
       });
     });
   });

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
@@ -168,7 +168,7 @@ describe("TeamMembersComponent", () => {
     renderWithProviders(
       <TeamMembersComponent
         teamData={createMockTeamData()}
-        canEditTeam={false}
+        canEditTeam={true}
         handleMemberDelete={mockHandleMemberDelete}
         setSelectedEditMember={mockSetSelectedEditMember}
         setIsEditMemberModalVisible={mockSetIsEditMemberModalVisible}

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { LogDetailContent } from "./LogDetailContent";
@@ -341,6 +341,6 @@ describe("LogDetailContent", () => {
 
     const descriptions = screen.getByText("Provider").closest(".ant-descriptions-item");
     expect(descriptions).toBeInTheDocument();
-    expect(screen.getByText("-")).toBeInTheDocument();
+    expect(within(descriptions as HTMLElement).getByText("-")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Relevant issues

Fixes 6 failing tests in the \`ui_unit_tests\` CI job (build 1261078).

## Changes

Three test files had stale assertions after source changes:

**\`TeamMemberTab.test.tsx\`** — "should render Add Member button" passed \`canEditTeam={false}\`, but \`MemberTable\` only renders the button when \`canEdit\` is true. Changed to \`canEditTeam={true}\`.

**\`UsagePageView.test.tsx\`** — Three tests asserted banner text ("Organization usage is a new feature.", "Customer usage is a new feature.", "Agent usage (A2A) is a new feature.") that was removed from the source. Removed stale banner assertions; kept the EntityUsage render checks.

**\`LogDetailContent.test.tsx\`** — \`getByText("-")\` failed because the component now renders multiple "-" values. Scoped the lookup to the Provider description item using \`within()\`.

## Pre-Submission Checklist

- [ ] Test-only fixes

## Type

- Bug fix (test alignment with current source)