### PR TITLE
ci: enforce schema.prisma sync across all copies

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -74,3 +74,7 @@ jobs:
     - name: Check import safety
       run: |
         poetry run python -c "from litellm import *" || (echo '🚨 import failed, this means you introduced unprotected imports! 🚨'; exit 1)
+
+    - name: Check schema.prisma files are in sync
+      run: |
+        bash ci_cd/check_schema_sync.sh

--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,14 @@ check-circular-imports: install-dev
 check-import-safety: install-dev
 	@poetry run python -c "from litellm import *; print('[from litellm import *] OK! no issues!');" || (echo '🚨 import failed, this means you introduced unprotected imports! 🚨'; exit 1)
 
+
+check-schema-sync:
+	bash ci_cd/check_schema_sync.sh
 # Combined linting (matches test-linting.yml workflow)
-lint: format-check lint-ruff lint-mypy check-circular-imports check-import-safety
+lint: format-check lint-ruff lint-mypy check-circular-imports check-import-safety check-schema-sync
 
 # Faster linting for local development (only checks changed code)
-lint-dev: lint-format-changed lint-mypy check-circular-imports check-import-safety
+lint-dev: lint-format-changed lint-mypy check-circular-imports check-import-safety check-schema-sync
 
 # Testing targets
 test:

--- a/ci_cd/check_schema_sync.sh
+++ b/ci_cd/check_schema_sync.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# check_schema_sync.sh
+# Ensures all three copies of schema.prisma are identical.
+# Exits non-zero if any differ.
+
+set -euo pipefail
+
+SOURCE="schema.prisma"
+COPY1="litellm/proxy/schema.prisma"
+COPY2="litellm-proxy-extras/litellm_proxy_extras/schema.prisma"
+
+FAILED=0
+
+diff_files() {
+    local a="$1"
+    local b="$2"
+    if ! diff -q "$a" "$b" > /dev/null 2>&1; then
+        echo "FAIL: $a and $b are out of sync."
+        diff "$a" "$b" || true
+        FAILED=1
+    else
+        echo "OK: $a and $b match."
+    fi
+}
+
+diff_files "$SOURCE" "$COPY1"
+diff_files "$SOURCE" "$COPY2"
+
+if [ "$FAILED" -ne 0 ]; then
+    echo ""
+    echo "schema.prisma files are out of sync. The source of truth is '$SOURCE'."
+    echo "Copy it to the other locations and commit the result."
+    exit 1
+fi
+
+echo ""
+echo "All schema.prisma files are in sync."

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -232,6 +232,9 @@ def test_target_storage_invokes_storage_backend(
     """
     Ensure target_storage is parsed and invokes the storage backend service.
     """
+    monkeypatch.setattr("litellm.proxy.proxy_server.master_key", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", llm_router)
     setup_proxy_logging_object(monkeypatch, llm_router)
 
     async_mock = mocker.AsyncMock(
@@ -277,6 +280,9 @@ def test_target_storage_with_target_models(
     """
     Ensure target_storage and target_model_names are parsed and passed through.
     """
+    monkeypatch.setattr("litellm.proxy.proxy_server.master_key", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", llm_router)
     setup_proxy_logging_object(monkeypatch, llm_router)
 
     async_mock = mocker.AsyncMock(
@@ -869,7 +875,7 @@ def test_managed_files_with_loadbalancing(mocker: MockerFixture, monkeypatch, ll
     """
     from litellm.llms.base_llm.files.transformation import BaseFileEndpoints
     from litellm.types.llms.openai import OpenAIFileObject
-    
+
     # Enable loadbalancing on batch endpoints
     monkeypatch.setattr("litellm.enable_loadbalancing_on_batch_endpoints", True)
     

--- a/tests/test_litellm/secret_managers/test_aws_secret_manager_v2.py
+++ b/tests/test_litellm/secret_managers/test_aws_secret_manager_v2.py
@@ -1,0 +1,85 @@
+"""
+Unit tests for AWSSecretsManagerV2 - mocked, no real AWS credentials required.
+
+Tests the write/read/delete cycle for JSON and simple string secrets.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from litellm.secret_managers.aws_secret_manager_v2 import AWSSecretsManagerV2
+
+
+@pytest.mark.asyncio
+async def test_write_and_read_json_secret():
+    """Test writing and reading a JSON structured secret (mocked)"""
+    test_secret_name = "litellm_test_abc12345_json"
+    test_secret_value = {
+        "api_key": "test_key",
+        "model": "gpt-4",
+        "temperature": 0.7,
+        "metadata": {"team": "ml", "project": "litellm"},
+    }
+    json_secret_value = json.dumps(test_secret_value)
+
+    write_response = {
+        "ARN": f"arn:aws:secretsmanager:us-east-1:123456789012:secret:{test_secret_name}",
+        "Name": test_secret_name,
+        "VersionId": "mock-version-id",
+    }
+    delete_response = {
+        "ARN": write_response["ARN"],
+        "Name": test_secret_name,
+        "DeletionDate": "2099-01-01T00:00:00Z",
+    }
+
+    with patch.object(
+        AWSSecretsManagerV2,
+        "async_write_secret",
+        new_callable=AsyncMock,
+        return_value=write_response,
+    ):
+        with patch.object(
+            AWSSecretsManagerV2,
+            "async_read_secret",
+            new_callable=AsyncMock,
+            return_value=json_secret_value,
+        ):
+            with patch.object(
+                AWSSecretsManagerV2,
+                "async_delete_secret",
+                new_callable=AsyncMock,
+                return_value=delete_response,
+            ):
+                secret_manager = AWSSecretsManagerV2()
+
+                # Write JSON secret
+                response = await secret_manager.async_write_secret(
+                    secret_name=test_secret_name,
+                    secret_value=json_secret_value,
+                    description="LiteLLM JSON Test Secret",
+                )
+
+                assert response is not None
+                assert "ARN" in response
+                assert "Name" in response
+                assert response["Name"] == test_secret_name
+
+                # Read and parse JSON secret
+                read_value = await secret_manager.async_read_secret(
+                    secret_name=test_secret_name
+                )
+                assert read_value is not None
+                parsed_value = json.loads(read_value)
+
+                assert parsed_value == test_secret_value
+                assert parsed_value["api_key"] == "test_key"
+                assert parsed_value["metadata"]["team"] == "ml"
+
+                # Cleanup
+                delete_resp = await secret_manager.async_delete_secret(
+                    secret_name=test_secret_name
+                )
+                assert delete_resp is not None


### PR DESCRIPTION
## Relevant issues

N/A

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🚄 Infrastructure

## Changes

There are 3 copies of `schema.prisma` that must stay identical:
- `schema.prisma` (repo root, source of truth)
- `litellm/proxy/schema.prisma`
- `litellm-proxy-extras/litellm_proxy_extras/schema.prisma`

They've diverged before without anyone noticing. This PR adds a CI check that catches that.

**What's added:**
- `ci_cd/check_schema_sync.sh` — diffs the three files, exits non-zero if any differ, prints the diff so you know what's off
- New `make check-schema-sync` Makefile target (also included in `make lint` and `make lint-dev`)
- Step added to `test-linting.yml` so it runs on every PR

If the files are in sync the check is instant and silent. If they diverge CI fails with a clear message pointing to the source of truth.