### PR TITLE
fix(tests): add flaky retries to flaky CI tests

### DIFF
--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -489,6 +489,7 @@ def test_gemini_finish_reason():
     assert response.choices[0].finish_reason == "length"
 
 
+@pytest.mark.flaky(retries=3, delay=2)
 def test_gemini_url_context():
     from litellm import completion
 


### PR DESCRIPTION
## Relevant issues

Fixes flaky CI tests: `test_create_eval`, `test_cohere_v2_conversation_history`, `test_gemini_url_context`

## Pre-Submission checklist

- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

✅ Test

## Changes

- `test_create_eval`: added `@pytest.mark.flaky(retries=3, delay=2)` and try/except for transient API errors (Timeout, ServiceUnavailableError)
- `test_cohere_v2_conversation_history`: added `@pytest.mark.flaky(retries=3, delay=1)`, replaced bare `except Exception` with specific exception handling so retries actually work
- `test_gemini_url_context`: added `@pytest.mark.flaky(retries=3, delay=2)`