### PR TITLE
fix(proxy): restore broad is_database_connection_error; add is_database_transport_error for reconnect

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2000,7 +2000,7 @@ async def _fetch_key_object_from_db_with_reconnect(
             proxy_logging_obj=proxy_logging_obj,
         )
     except Exception as e:
-        if PrismaDBExceptionHandler.is_database_connection_error(e):
+        if PrismaDBExceptionHandler.is_database_transport_error(e):
             did_reconnect = False
             if hasattr(prisma_client, "attempt_db_reconnect"):
                 auth_reconnect_timeout = getattr(

--- a/tests/test_litellm/proxy/db/test_exception_handler.py
+++ b/tests/test_litellm/proxy/db/test_exception_handler.py
@@ -72,8 +72,9 @@ def test_is_database_connection_error_prisma_connection_errors(prisma_error):
         ),
     ],
 )
-def test_is_database_connection_error_non_connection_prisma_errors(prisma_error):
-    assert PrismaDBExceptionHandler.is_database_connection_error(prisma_error) == False
+def test_is_database_transport_error_non_connection_prisma_errors(prisma_error):
+    """Data-layer errors should not trigger reconnect — DB is reachable when these occur."""
+    assert PrismaDBExceptionHandler.is_database_transport_error(prisma_error) == False
 
 
 def test_is_database_connection_generic_errors():


### PR DESCRIPTION
## Relevant issues

Fixes regression from #21706 which narrowed `is_database_connection_error` to only match `PrismaError` with specific connection keywords. This broke:
- `test_delete_access_group_503_on_db_connection_error` (assert 500 == 503)
- `test_handle_authentication_error_db_unavailable[prisma_error*]` (10 parametrized tests)

## Changes

**`litellm/proxy/db/exception_handler.py`**
- Restored `is_database_connection_error` to treat any `PrismaError` as a DB connection error — this is what drives 503 responses and `allow_requests_on_db_unavailable`
- Added `is_database_transport_error` with the narrow keyword-based check — only for reconnect logic where we need to distinguish "DB unreachable" from "DB returned a data error like UniqueViolationError"

**`litellm/proxy/auth/auth_checks.py`**
- Changed reconnect call site to use `is_database_transport_error` instead of `is_database_connection_error`

**`tests/test_litellm/proxy/db/test_exception_handler.py`**
- Renamed `test_is_database_connection_error_non_connection_prisma_errors` → `test_is_database_transport_error_non_connection_prisma_errors`
- Updated assertion to use `is_database_transport_error` (data-layer errors should not trigger reconnect, but they should still trigger 503)

## Pre-Submission checklist

- [x] Added tests — existing tests updated to cover `is_database_transport_error`
- [x] `make test-unit` passes locally

## Type

- [x] Bug fix

## Changes