### PR TITLE
fix(tests): add missing start_db_health_watchdog_task mock

### DIFF
--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -2205,6 +2205,7 @@ async def test_proxy_server_prisma_setup():
         mock_client._set_spend_logs_row_count_in_proxy_state = (
             AsyncMock()
         )  # Mock the _set_spend_logs_row_count_in_proxy_state method
+        mock_client.start_db_health_watchdog_task = AsyncMock()
         # Mock the db attribute with start_token_refresh_task for RDS IAM token refresh
         mock_db = MagicMock()
         mock_db.start_token_refresh_task = AsyncMock()

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -1623,6 +1623,7 @@ async def test_health_check_not_called_when_disabled(monkeypatch):
     mock_prisma.health_check = AsyncMock()
     mock_prisma.check_view_exists = AsyncMock()
     mock_prisma._set_spend_logs_row_count_in_proxy_state = AsyncMock()
+    mock_prisma.start_db_health_watchdog_task = AsyncMock()
     # Mock the db attribute with start_token_refresh_task for RDS IAM token refresh
     mock_db = MagicMock()
     mock_db.start_token_refresh_task = AsyncMock()


### PR DESCRIPTION
## Relevant issues

Fixes flaky test failures for `test_proxy_server_prisma_setup` and `test_health_check_not_called_when_disabled`.

## Pre-Submission checklist

- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`_setup_prisma_client` now calls `await prisma_client.start_db_health_watchdog_task()` but both tests were missing the `AsyncMock` for it, causing `TypeError: object MagicMock can't be used in 'await' expression`.