### PR TITLE
fix(tests): replace asyncio.sleep(1) with event-based wait to fix flaky metadata callback tests

### DIFF
--- a/tests/test_litellm/responses/test_metadata_codex_callback.py
+++ b/tests/test_litellm/responses/test_metadata_codex_callback.py
@@ -44,11 +44,13 @@ class MetadataCaptureCallback(CustomLogger):
 
     def __init__(self):
         self.captured_kwargs: Optional[dict] = None
+        self.event = asyncio.Event()
 
     async def async_log_success_event(
         self, kwargs, response_obj, start_time, end_time
     ):
         self.captured_kwargs = kwargs
+        self.event.set()
 
 
 @pytest.mark.asyncio
@@ -104,7 +106,7 @@ async def test_metadata_passed_to_custom_callback_codex_models():
             metadata=test_metadata,
         )
 
-    await asyncio.sleep(1)
+    await asyncio.wait_for(callback.event.wait(), timeout=5.0)
 
     assert callback.captured_kwargs is not None, "Callback should have been invoked"
 
@@ -165,7 +167,7 @@ async def test_metadata_passed_via_litellm_metadata_responses_api():
             litellm_metadata=test_metadata,
         )
 
-    await asyncio.sleep(1)
+    await asyncio.wait_for(callback.event.wait(), timeout=5.0)
 
     assert callback.captured_kwargs is not None
 


### PR DESCRIPTION
## Relevant issues

Fixes flaky test `test_metadata_passed_via_litellm_metadata_responses_api` (CI test ID: litellm_mapped_tests_core/1262471).

## What changed

The two tests in `test_metadata_codex_callback.py` used `await asyncio.sleep(1)` to wait for the custom callback to fire. The callback is dispatched via `asyncio.create_task()` in `utils.py`, so the fixed 1-second sleep races against the event loop scheduler — causing intermittent failures.

Fix: add an `asyncio.Event` to `MetadataCaptureCallback` that gets `.set()` inside `async_log_success_event`. Tests now do `asyncio.wait_for(callback.event.wait(), timeout=5.0)` — deterministic, no timing dependency.

## Pre-Submission checklist

- [x] Added at least 1 test (fixing existing tests to be reliable)
- [x] `make test-unit` passes locally

## Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Other

## Changes

- `tests/test_litellm/responses/test_metadata_codex_callback.py`: replace `asyncio.sleep(1)` with `asyncio.Event`-based wait in both test functions