### PR TITLE
docs: mark v1.81.12 as stable

### DIFF
--- a/docs/my-website/release_notes/v1.81.12.md
+++ b/docs/my-website/release_notes/v1.81.12.md
@@ -1,5 +1,5 @@
 ---
-title: "[Preview] v1.81.12 - Guardrail Policy Templates & Action Builder"
+title: "v1.81.12-stable - Guardrail Policy Templates & Action Builder"
 slug: "v1-81-12"
 date: 2026-02-14T00:00:00
 authors:
@@ -27,14 +27,14 @@ import Image from '@theme/IdealImage';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-ghcr.io/berriai/litellm:main-v1.81.12.rc.1
+docker.litellm.ai/berriai/litellm:v1.81.12-stable
 ```
 
 </TabItem>
 <TabItem value="pip" label="Pip">
 
 ``` showLineNumbers title="pip install litellm"
-pip install litellm==1.81.12.rc1
+pip install litellm==1.81.12
 ```
 
 </TabItem>

--- a/docs/my-website/release_notes/v1.81.12.md
+++ b/docs/my-website/release_notes/v1.81.12.md
@@ -27,7 +27,7 @@ import Image from '@theme/IdealImage';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-docker.litellm.ai/berriai/litellm:v1.81.12-stable
+ghcr.io/berriai/litellm:main-v1.81.12-stable
 ```
 
 </TabItem>


### PR DESCRIPTION
## Relevant issues

None

## Pre-Submission checklist

- [x] Read contributing.md
- [x] Added docs

## Type

- [x] Documentation

## Changes

Updates `v1.81.12.md` release notes from preview to stable:

- Title: `[Preview] v1.81.12` → `v1.81.12-stable`
- Docker: `ghcr.io/berriai/litellm:main-v1.81.12.rc.1` → `docker.litellm.ai/berriai/litellm:v1.81.12-stable`
- Pip: `litellm==1.81.12.rc1` → `litellm==1.81.12`