### PR TITLE
fix(test): prevent hang in test_async_no_duplicate_spend_logs

### DIFF
--- a/tests/test_litellm/responses/test_no_duplicate_spend_logs.py
+++ b/tests/test_litellm/responses/test_no_duplicate_spend_logs.py
@@ -96,6 +96,12 @@ async def test_async_no_duplicate_spend_logs():
             litellm_call_id=test_request_id,
         )
 
+        # Yield to the event loop so the _client_async_logging_helper task
+        # (scheduled via asyncio.create_task in the @client decorator) runs first
+        # and initializes GLOBAL_LOGGING_WORKER on the current event loop.
+        # Without this, flush() may block on a stale queue from a previous test's loop.
+        await asyncio.sleep(0)
+
         # Wait for async logging to complete
         from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
         await GLOBAL_LOGGING_WORKER.flush()


### PR DESCRIPTION
## Relevant issues

Fixes flaky CI failure in `litellm_mapped_tests_core` — `test_async_no_duplicate_spend_logs` was timing out after 300s.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

✅ Test

## Changes

The `@client` decorator on `aresponses` fires off logging via `asyncio.create_task(_client_async_logging_helper(...))` — this schedules the task but doesn't run it immediately.

The test was calling `await GLOBAL_LOGGING_WORKER.flush()` right after `aresponses()` returned, before the scheduled task had a chance to run. So `flush()` was operating on the stale `_queue` from a previous test's event loop (which had `_unfinished_tasks > 0` but a dead worker). `queue.join()` then blocked forever.

Fix: add `await asyncio.sleep(0)` before `flush()`. This yields to the event loop, lets `_client_async_logging_helper` run, which calls `ensure_initialized_and_enqueue()` → `_ensure_queue()` detects the loop change and creates a fresh queue. Then `flush()` operates on the correct queue and completes normally.