### PR TITLE
fix(logging): cost should be 0 for cached responses

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1394,6 +1394,12 @@ class Logging(LiteLLMLoggingBaseClass):
         used for consistent cost calculation across response headers + logging integrations.
         """
 
+        if cache_hit is None:
+            cache_hit = self.model_call_details.get("cache_hit", False)
+
+        if cache_hit is True:
+            return 0.0
+
         if isinstance(result, BaseModel) and hasattr(result, "_hidden_params"):
             hidden_params = getattr(result, "_hidden_params", {})
             if (


### PR DESCRIPTION
## Relevant issues

Fixes `test_cost_tracking_with_caching` - cached responses were reporting non-zero cost.

## Root cause

Regression from bdf01fa283. That commit added a `_hidden_params["response_cost"]` short-circuit in `_response_cost_calculator` to avoid recomputing cost. But cached responses carry the original call's cost in their `_hidden_params`, so the short-circuit returned the real cost instead of `0.0` — the `cache_hit` check was never reached.

## Fix

Resolve `cache_hit` and return `0.0` at the top of `_response_cost_calculator`, before the `_hidden_params` block.

## Pre-Submission checklist

- [x] Added test coverage (existing `test_cost_tracking_with_caching` covers this)
- [x] `make test-unit` passes

## Type

Bug fix

## Changes

- `litellm/litellm_core_utils/litellm_logging.py`: move `cache_hit` resolution before `_hidden_params` short-circuit in `_response_cost_calculator`