### PR TITLE
fix(tests): replace fake France Azure endpoint in test_router_azure_acompletion

### DIFF
--- a/tests/local_testing/test_router.py
+++ b/tests/local_testing/test_router.py
@@ -622,10 +622,10 @@ def test_router_azure_acompletion():
             {
                 "model_name": "gpt-3.5-turbo",  # openai model name
                 "litellm_params": {  # params for litellm completion/embedding call
-                    "model": "azure/gpt-turbo",
-                    "api_key": os.getenv("AZURE_FRANCE_API_KEY"),
+                    "model": "azure/gpt-4.1-mini",
+                    "api_key": old_api_key,
                     "api_version": os.getenv("AZURE_API_VERSION"),
-                    "api_base": "https://openai-france-1234.openai.azure.com",
+                    "api_base": os.getenv("AZURE_API_BASE"),
                 },
                 "rpm": 1800,
             },


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

✅ Test

## Changes

`test_router_azure_acompletion` was flaky because the second model in the pool used a hardcoded fake URL (`https://openai-france-1234.openai.azure.com`) with `AZURE_FRANCE_API_KEY`. With `simple-shuffle` routing, the router would sometimes pick this model first and exhaust all retries hitting the unreachable URL before ever trying the real endpoint.

Fix: replace the fake France model with the same real Azure credentials (`AZURE_API_KEY` + `AZURE_API_BASE` + `azure/gpt-4.1-mini`) that the first model uses. This is consistent with every other Azure test in the file.