### PR TITLE
fix(tests): clear ANTHROPIC_BASE_URL env var in spend log api_base tests

### DIFF
--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1324,6 +1324,10 @@ class TestSpendLogsPayload:
     async def test_spend_logs_payload_success_log_with_api_base(self, monkeypatch):
         from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
+        # Clear any env overrides that would change the recorded api_base
+        monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_BASE", raising=False)
+
         litellm.callbacks = [_ProxyDBLogger(message_logging=False)]
         # litellm._turn_on_debug()
 
@@ -1397,8 +1401,12 @@ class TestSpendLogsPayload:
                 assert False, f"Dictionary mismatch: {differences}"
 
     @pytest.mark.asyncio
-    async def test_spend_logs_payload_success_log_with_router(self):
+    async def test_spend_logs_payload_success_log_with_router(self, monkeypatch):
         from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+        # Clear any env overrides that would change the recorded api_base
+        monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_BASE", raising=False)
 
         litellm.callbacks = [_ProxyDBLogger(message_logging=False)]
         # litellm._turn_on_debug()


### PR DESCRIPTION
## Relevant issues

Fixes flaky `test_spend_logs_payload_success_log_with_api_base` and `test_spend_logs_payload_success_log_with_router`.

## Root cause

Both tests hardcode `api_base: "https://api.anthropic.com/v1/messages"` in the expected spend log payload. If `ANTHROPIC_BASE_URL` is set in the environment (e.g. pointing to a LiteLLM proxy), the recorded `api_base` changes, causing a mismatch assertion failure.

## Fix

Clear `ANTHROPIC_BASE_URL` and `ANTHROPIC_API_BASE` via `monkeypatch.delenv` at the start of each test so the expected URL is always the real Anthropic endpoint regardless of local env setup.

## Pre-Submission checklist

- [x] Passes locally with `ANTHROPIC_BASE_URL` set
- [x] `make test-unit` passes

## Type

Bug fix

## Changes

- `tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py`: add `monkeypatch.delenv` for `ANTHROPIC_BASE_URL` and `ANTHROPIC_API_BASE` in both affected tests