### PR TITLE
fix(tests): isolate litellm.cache and CLI env in flaky tests

### DIFF
--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1231,9 +1231,12 @@ async def _wait_for_mock_call(mock, timeout=10, interval=0.1):
 class TestSpendLogsPayload:
     def setup_method(self):
         self._original_callbacks = litellm.callbacks[:]
+        self._original_cache = litellm.cache
+        litellm.cache = None
 
     def teardown_method(self):
         litellm.callbacks = self._original_callbacks
+        litellm.cache = self._original_cache
 
     @pytest.mark.asyncio
     async def test_spend_logs_payload_e2e(self):


### PR DESCRIPTION
## Relevant issues

Fixes flaky/failing tests: `test_spend_logs_payload_e2e`, `test_spend_logs_payload_success_log_with_api_base`, `test_spend_logs_payload_success_log_with_router`, `test_use_prisma_db_push_flag_behavior`

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

✅ Test

## Changes

Two test isolation fixes:

**`TestSpendLogsPayload` (spend log tests)**: Added `litellm.cache` save/restore in `setup_method`/`teardown_method`. When a prior test sets `litellm.cache`, the spend log tests were getting a hash value instead of `"Cache OFF"` in the `cache_key` field, failing the assertion. The existing `setup_method` only reset `litellm.callbacks`, not `litellm.cache`.

**`test_use_prisma_db_push_flag_behavior` (CLI test)**: Switched from a `@patch.dict(os.environ, ...)` decorator (which adds `DATABASE_URL` but leaves `DIRECT_URL` set) to a `clean_env` dict built inside the test that strips both `DATABASE_URL` and `DIRECT_URL`, then sets `DATABASE_URL` to the test value. This matches the pattern used in `test_skip_server_startup` and avoids Click 8.3.x `StreamMixer` stream lifecycle issues when real DB env vars are present in CI.