### PR TITLE
fix(ui): preserve logging_settings in key metadata on update

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -203,7 +203,7 @@ export default function KeyInfoView({
             ...parsedMetadata,
             ...(Array.isArray(formValues.tags) && formValues.tags.length > 0 ? { tags: formValues.tags } : {}),
             ...(formValues.guardrails?.length > 0 ? { guardrails: formValues.guardrails } : {}),
-            ...(formValues.logging_settings ? { logging: formValues.logging_settings } : {}),
+            ...(Array.isArray(formValues.logging_settings) && formValues.logging_settings.length > 0 ? { logging: formValues.logging_settings } : {}),
             ...(formValues.disabled_callbacks?.length > 0
               ? {
                 litellm_disabled_callbacks: mapDisplayToInternalNames(formValues.disabled_callbacks),
@@ -222,7 +222,7 @@ export default function KeyInfoView({
           ...rest,
           ...(Array.isArray(formValues.tags) && formValues.tags.length > 0 ? { tags: formValues.tags } : {}),
           ...(formValues.guardrails?.length > 0 ? { guardrails: formValues.guardrails } : {}),
-          ...(formValues.logging_settings ? { logging: formValues.logging_settings } : {}),
+          ...(Array.isArray(formValues.logging_settings) && formValues.logging_settings.length > 0 ? { logging: formValues.logging_settings } : {}),
           ...(formValues.disabled_callbacks?.length > 0
             ? {
               litellm_disabled_callbacks: mapDisplayToInternalNames(formValues.disabled_callbacks),


### PR DESCRIPTION
## Summary

Fixes a bug where the Admin UI drops the `logging` array content from key metadata when updating a key, preventing per-key logging configuration (e.g., `turn_off_message_logging`) from being saved.

## Steps to Reproduce

**1. Create a key with per-key logging settings via the API:**

```bash
curl -X POST 'http://localhost:4000/key/update' \
  -H 'Authorization: Bearer sk-master-key' \
  -H 'Content-Type: application/json' \
  -d '{
    "key": "sk-your-key",
    "metadata": {
      "logging": [{
        "callback_name": "spend_logs",
        "callback_type": "success_and_failure",
        "callback_vars": {
          "turn_off_message_logging": "true"
        }
      }]
    }
  }'
```

This works correctly — the metadata is saved with the full `logging` array.

**2. Now edit the same key in the Admin UI** (e.g., change any field and save).

**3. Check the database:**

```sql
SELECT metadata FROM "LiteLLM_VerificationToken" WHERE key_alias = 'your-key';
```

**Result:** The `logging` array is now `[]` — the content was stripped.

## Root Cause

In `ui/litellm-dashboard/src/components/templates/key_info_view.tsx`, the `handleKeyUpdate()` function reconstructs metadata from separate form fields on lines 206 and 225:

```javascript
// Before (buggy):
...(formValues.logging_settings ? { logging: formValues.logging_settings } : {}),
```

The bare truthiness check on `formValues.logging_settings` fails when the form field is `undefined` or not properly synced from the `EditLoggingSettings` component. When the condition is falsy, the spread produces `{}` and the `logging` field is omitted from the metadata.

This is inconsistent with how `tags` is handled on the same line (204/223), which correctly uses `Array.isArray()`:
```javascript
...(Array.isArray(formValues.tags) && formValues.tags.length > 0 ? { tags: formValues.tags } : {}),
```

## Fix

Changed both occurrences (lines 206 and 225) to use the same `Array.isArray()` pattern:

```javascript
// After (fixed):
...(Array.isArray(formValues.logging_settings) && formValues.logging_settings.length > 0
    ? { logging: formValues.logging_settings }
    : {}),
```

## Impact

Without this fix, any Admin UI edit to a key silently destroys per-key logging configuration, including:
- `turn_off_message_logging` (per-key message redaction)
- Per-key callback routing (e.g., separate Langfuse projects per key)
- Any other `callback_vars` settings

The workaround is to use the `/key/update` API directly instead of the Admin UI.

## Test plan

- [x] Verified the API endpoint `/key/update` correctly saves and preserves logging metadata
- [x] Verified the fix uses the same Array.isArray() pattern as the tags field
- [x] Verified both code paths (string metadata and object metadata) are fixed
