### PR TITLE
fix(tests): isolate auth in vertex passthrough and spend logs date range tests

### DIFF
--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -446,12 +446,16 @@ class TestVertexAIPassThroughHandler:
             "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
         ) as mock_create_route, mock.patch(
             "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.get_vertex_pass_through_handler"
-        ) as mock_get_handler:
+        ) as mock_get_handler, mock.patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.user_api_key_auth",
+            new_callable=AsyncMock,
+        ) as mock_auth:
             # Mock credentials object with necessary attributes
             mock_credentials = Mock()
             mock_credentials.token = default_credentials
 
             mock_load_auth.return_value = (mock_credentials, default_project)
+            mock_auth.return_value = MagicMock()
 
             # Mock the vertex handler
             mock_handler = Mock()


### PR DESCRIPTION
## Relevant issues

Follows up on #21810 which fixed auth isolation for several tests but missed these two.

## Changes

Two tests fail intermittently in `litellm_mapped_tests_proxy_part2` when a prior xdist worker sets `master_key` — the test requests then hit auth failures before the code under test is reached.

**`test_vertex_passthrough_with_default_credentials[v1/projects/bad-project/...]`**
- `vertex_proxy_route` calls `user_api_key_auth` internally; when `master_key` is set, the unauthenticated mock request is rejected and `create_pass_through_route` is never called (→ "Called 0 times")
- Fix: add `user_api_key_auth` AsyncMock in the `with mock.patch()` block, same pattern as `test_vertex_passthrough_with_no_default_credentials` in #21810

**`test_view_spend_logs_with_date_range_summarized`**
- Uses `"Bearer sk-test"` with no auth override; when `master_key` is set → 401
- Fix: wrap request in `app.dependency_overrides[ps.user_api_key_auth]` with try/finally cleanup, same pattern as the other spend log tests fixed in #21810

## Pre-Submission checklist

- [ ] Added tests (both are test-only changes)
- [x] `make test-unit` passes

## Type

- [x] Bug fix