### PR TITLE
fix(tests): clear _async_success_callback in vertex fine-tune mocked tests

### DIFF
--- a/tests/batches_tests/test_fine_tuning_api.py
+++ b/tests/batches_tests/test_fine_tuning_api.py
@@ -210,9 +210,13 @@ async def test_create_vertex_fine_tune_jobs_mocked():
 
     # Save original callbacks to restore later
     original_callbacks = litellm.callbacks
-    # Disable callbacks to avoid Datadog logging interfering with the mock
+    original_success_callback = litellm.success_callback
+    original_async_success_callback = litellm._async_success_callback
+    # Disable all callbacks to avoid Datadog/other loggers interfering with the mock
     litellm.callbacks = []
-    
+    litellm.success_callback = []
+    litellm._async_success_callback = []
+
     try:
         with patch(
             "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
@@ -259,6 +263,8 @@ async def test_create_vertex_fine_tune_jobs_mocked():
     finally:
         # Restore original callbacks
         litellm.callbacks = original_callbacks
+        litellm.success_callback = original_success_callback
+        litellm._async_success_callback = original_async_success_callback
 
 
 @pytest.mark.asyncio()
@@ -291,9 +297,13 @@ async def test_create_vertex_fine_tune_jobs_mocked_with_hyperparameters():
 
     # Save original callbacks to restore later
     original_callbacks = litellm.callbacks
-    # Disable callbacks to avoid Datadog logging interfering with the mock
+    original_success_callback = litellm.success_callback
+    original_async_success_callback = litellm._async_success_callback
+    # Disable all callbacks to avoid Datadog/other loggers interfering with the mock
     litellm.callbacks = []
-    
+    litellm.success_callback = []
+    litellm._async_success_callback = []
+
     try:
         with patch(
             "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
@@ -352,6 +362,8 @@ async def test_create_vertex_fine_tune_jobs_mocked_with_hyperparameters():
     finally:
         # Restore original callbacks
         litellm.callbacks = original_callbacks
+        litellm.success_callback = original_success_callback
+        litellm._async_success_callback = original_async_success_callback
 
 
 # Testing OpenAI -> Vertex AI param mapping


### PR DESCRIPTION
## Relevant issues

Fixes failing CI test: \`test_create_vertex_fine_tune_jobs_mocked\` - \"Expected 'post' to have been called once. Called 2 times.\"

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

✅ Test

## Changes

The two mocked Vertex fine-tune tests were clearing `litellm.callbacks = []` to stop Datadog from interfering with the `AsyncHTTPHandler.post` mock, but that only clears the `callbacks` list. In CI, `DD_API_KEY` is set which registers Datadog directly into `litellm._async_success_callback`. When the fine-tune job completes, the success handler fires the Datadog batch logger, which also calls `AsyncHTTPHandler.post` — making `mock_post.assert_called_once()` fail with "Called 2 times."

Fix: also save/clear/restore `litellm.success_callback` and `litellm._async_success_callback` around the patch context in both affected tests.