### PR TITLE
fix(tests): add atexit.register mock to fix flaky test_use_prisma_db_push_flag_behavior

### DIFF
--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -583,6 +583,7 @@ class TestHealthAppFactory:
         assert isinstance(health_app_2, fastapi.FastAPI)
 
     @patch("subprocess.run")
+    @patch("atexit.register")  # critical: prevents atexit handlers from closing Click's isolation streams
     @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
     @patch("litellm.proxy.db.check_migration.check_prisma_schema_diff")
     @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema")
@@ -591,6 +592,7 @@ class TestHealthAppFactory:
         mock_should_update_schema,
         mock_check_schema_diff,
         mock_setup_database,
+        mock_atexit_register,
         mock_subprocess_run,
     ):
         """Test that use_prisma_db_push flag correctly controls PrismaManager.setup_database use_migrate parameter"""


### PR DESCRIPTION
## Relevant issues

Fixes flaky CI failure in `litellm_mapped_tests_proxy_part2`:
```
FAILED tests/test_litellm/proxy/test_proxy_cli.py::TestHealthAppFactory::test_use_prisma_db_push_flag_behavior - ValueError: I/O operation on closed file.
```

## What's happening

When Click's `CliRunner` runs a CLI command and that command exits (via `sys.exit(0)`), Python runs any registered `atexit` handlers. Some of those handlers interact with file streams. In Click 8.2+, this closes the `BytesIO` backing the isolation context, so when Click tries to call `outstreams[0].getvalue()` in its `finally` block, it gets `ValueError: I/O operation on closed file`.

The passing `test_skip_server_startup` already has `@patch("atexit.register")  # critical` for exactly this reason. `test_use_prisma_db_push_flag_behavior` was missing it.

## Fix

Add `@patch("atexit.register")` to the failing test, matching the pattern in `test_skip_server_startup`.

## Pre-Submission checklist

- [x] Test added in `tests/test_litellm/`
- [x] `make test-unit` passes locally

## Type

- [ ] New Feature
- [x] Bug fix
- [ ] Refactoring

## Changes

- `tests/test_litellm/proxy/test_proxy_cli.py`: add `@patch("atexit.register")` and `mock_atexit_register` parameter to `test_use_prisma_db_push_flag_behavior`