### PR TITLE
[Fix] remove prompt from getting logged with during file prompt caching

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -726,10 +726,12 @@ def _count_content_list(
                 if thinking_text:
                     num_tokens += count_function(thinking_text)
             else:
+                content_type = (
+                    c.get("type", type(c).__name__) if isinstance(c, dict) else type(c).__name__
+                )
                 raise ValueError(
-                    f"Invalid content item type: {type(c).__name__}. "
-                    f"Expected str or dict with 'type' field. "
-                    f"Value: {c!r}"
+                    f"Invalid content item type: {content_type}. "
+                    f"Expected str or dict with 'type' field (text, image_url, tool_use, tool_result, thinking)."
                 )
         return num_tokens
     except Exception as e:


### PR DESCRIPTION
## Relevant issues
When using prompt caching with file content (e.g. PDFs via file_data), the token counter could raise a ValueError for unsupported content types (such as input_file) and include the full content in the error message via {c!r}. That caused sensitive data (including base64 payloads) to be logged at ERROR level by callers like is_prompt_caching_valid_prompt and the token-trimming exception handler. 
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix


## Changes
The fix removes the content from the error message and only logs the content type and the expected types, so prompts and file data are no longer exposed in logs.