### PR TITLE
fix(tests): use monkeypatch for Redis pool max_connections tests

### DIFF
--- a/tests/test_litellm/caching/test_redis_connection_pool.py
+++ b/tests/test_litellm/caching/test_redis_connection_pool.py
@@ -39,29 +39,25 @@ def test_url_config_falls_back_to_from_url_without_pool():
     assert client.connection_pool is not None
 
 
-def test_max_connections_url_config():
+def test_max_connections_url_config(monkeypatch):
     """max_connections should be respected when using URL-based config."""
-    with patch("litellm._redis._get_redis_client_logic") as mock_logic:
-        mock_logic.return_value = {
-            "url": "redis://localhost:6379/0",
-            "max_connections": 10,
-        }
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.setenv("REDIS_MAX_CONNECTIONS", "10")
 
-        pool = get_redis_connection_pool()
+    pool = get_redis_connection_pool()
 
     assert pool.max_connections == 10
 
 
-def test_max_connections_url_config_string_value():
+def test_max_connections_url_config_string_value(monkeypatch):
     """max_connections provided as a string (from env var) should be
     cast to int."""
-    with patch("litellm._redis._get_redis_client_logic") as mock_logic:
-        mock_logic.return_value = {
-            "url": "redis://localhost:6379/0",
-            "max_connections": "25",
-        }
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.setenv("REDIS_MAX_CONNECTIONS", "25")
 
-        pool = get_redis_connection_pool()
+    pool = get_redis_connection_pool()
 
     assert pool.max_connections == 25
 


### PR DESCRIPTION
## Relevant issues

Fixes CI failures in `test_redis_connection_pool.py::test_max_connections_url_config` and `test_max_connections_url_config_string_value`.

## What changed

The two failing tests were mocking `litellm._redis._get_redis_client_logic` to control the Redis config. In CI, `REDIS_URL` is set to the real Redis Cloud server, and for some reason the mock wasn't intercepting the call — the real function ran, returned the cloud URL with no `max_connections`, so the pool defaulted to `max_connections=50` instead of 10/25.

Replaced the mock approach with `monkeypatch.setenv("REDIS_URL", ...)` + `monkeypatch.setenv("REDIS_MAX_CONNECTIONS", ...)`. This is actually a better test because it exercises the full env-var-reading path (which is the actual production code path for this config), and `monkeypatch` guarantees cleanup after each test regardless of CI environment.

## Pre-Submission checklist

- [x] Tests added (the tests themselves are the fix)
- [x] `make test-unit` passes locally

## Type

- [ ] Bug fix
- [x] Tests