### PR TITLE
Allow duplicate guardrail names for load balancing

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260221230500_allow_duplicate_guardrail_names/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260221230500_allow_duplicate_guardrail_names/migration.sql
@@ -1,0 +1,5 @@
+-- Drop unique constraint on guardrail_name and add non-unique index for lookup
+DROP INDEX IF EXISTS "LiteLLM_GuardrailsTable_guardrail_name_key";
+
+CREATE INDEX IF NOT EXISTS "LiteLLM_GuardrailsTable_guardrail_name_idx"
+ON "LiteLLM_GuardrailsTable"("guardrail_name");

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -904,12 +904,14 @@ model LiteLLM_ManagedVectorStoresTable {
 // Guardrails table for storing guardrail configurations
 model LiteLLM_GuardrailsTable {
   guardrail_id String @id @default(uuid())
-  guardrail_name String @unique
+  guardrail_name String
   litellm_params Json
   guardrail_info Json?
   team_id String?
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
+
+  @@index([guardrail_name])
 }
 
 // Prompt table for storing prompt configurations

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -366,10 +366,12 @@ class GuardrailRegistry:
         self, guardrail_name: str, prisma_client: PrismaClient
     ) -> Optional[Guardrail]:
         """
-        Get a guardrail by its name from the database
+        Get a guardrail by its name from the database.
+
+        Note: guardrail_name is not unique; this returns the first match.
         """
         try:
-            guardrail = await prisma_client.db.litellm_guardrailstable.find_unique(
+            guardrail = await prisma_client.db.litellm_guardrailstable.find_first(
                 where={"guardrail_name": guardrail_name}
             )
 

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -368,11 +368,12 @@ class GuardrailRegistry:
         """
         Get a guardrail by its name from the database.
 
-        Note: guardrail_name is not unique; this returns the first match.
+        Note: guardrail_name is not unique; this returns the oldest match.
         """
         try:
             guardrail = await prisma_client.db.litellm_guardrailstable.find_first(
-                where={"guardrail_name": guardrail_name}
+                where={"guardrail_name": guardrail_name},
+                order_by={"created_at": "asc"},
             )
 
             if not guardrail:

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -858,12 +858,14 @@ model LiteLLM_ManagedVectorStoresTable {
 // Guardrails table for storing guardrail configurations
 model LiteLLM_GuardrailsTable {
   guardrail_id String @id @default(uuid())
-  guardrail_name String @unique
+  guardrail_name String
   litellm_params Json
   guardrail_info Json?
   team_id String?
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
+
+  @@index([guardrail_name])
 }
 
 // Prompt table for storing prompt configurations

--- a/schema.prisma
+++ b/schema.prisma
@@ -858,12 +858,14 @@ model LiteLLM_ManagedVectorStoresTable {
 // Guardrails table for storing guardrail configurations
 model LiteLLM_GuardrailsTable {
   guardrail_id String @id @default(uuid())
-  guardrail_name String @unique
+  guardrail_name String
   litellm_params Json
   guardrail_info Json?
   team_id String?
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
+
+  @@index([guardrail_name])
 }
 
 // Prompt table for storing prompt configurations

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
@@ -75,6 +75,9 @@ async def test_get_guardrail_by_name_allows_duplicates():
         "duplicate-name", prisma_client
     )
 
-    table.find_first.assert_awaited_once_with(where={"guardrail_name": "duplicate-name"})
+    table.find_first.assert_awaited_once_with(
+        where={"guardrail_name": "duplicate-name"},
+        order_by={"created_at": "asc"},
+    )
     assert guardrail["guardrail_id"] == "id-1"
     assert guardrail["guardrail_name"] == "duplicate-name"


### PR DESCRIPTION
Relevant issue: Fixes #21673

Pre-submission checklist
Added testing in tests/litellm (added 1 test): yes
Unit tests make test-unit: no (known failures listed below, same on origin/main baseline)
Scope isolated to single problem: yes
Greptile review requested: yes

Type: Bug Fix

Changes
Allow duplicate guardrail_name entries by removing unique constraints in all schema.prisma copies
Use deterministic lookup by ordering find_first on created_at ascending
Add migration to drop the unique index and add a non-unique index on guardrail_name
Add unit test to verify lookup uses deterministic ordering

Tests run
DYLD_LIBRARY_PATH=/opt/homebrew/opt/libpq/lib /Users/aissam/workspace/litellm-1/.venv/bin/python -m pytest tests/test_litellm -x -vv -n 4 --import-mode=importlib
DYLD_LIBRARY_PATH=/opt/homebrew/opt/libpq/lib /Users/aissam/workspace/litellm-1/.venv/bin/python -m pytest tests/test_litellm/proxy/guardrails/test_guardrail_registry.py -q

Known test failures (also failing on origin/main baseline)
Tests/test_litellm/enterprise/enterprise_callbacks/test_callback_controls.py::TestEnterpriseCallbackControls::test_callback_disabled_langfuse_customlogger
Tests/test_litellm/enterprise/proxy/test_file_deletion_blocking.py::test_database_limit_respected
Tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py::TestVertexGemmaCompletion::test_acompletion_basic_request
Tests/test_litellm/proxy/db/test_prisma_self_heal.py::test_attempt_db_reconnect_should_set_cooldown_after_attempt
