### PR TITLE
fix(tests): fix flaky test_create_vertex_fine_tune_jobs_mocked

### DIFF
--- a/tests/batches_tests/test_fine_tuning_api.py
+++ b/tests/batches_tests/test_fine_tuning_api.py
@@ -230,11 +230,17 @@ async def test_create_vertex_fine_tune_jobs_mocked():
                 vertex_location=location,
             )
 
-            # Verify the request
-            mock_post.assert_called_once()
+            # Verify the request - filter to only Vertex AI calls (Datadog batch logger
+            # may flush in the background and make additional POST calls)
+            vertex_calls = [
+                c
+                for c in mock_post.call_args_list
+                if "aiplatform.googleapis.com" in str(c.kwargs.get("url", ""))
+            ]
+            assert len(vertex_calls) == 1
 
             # Validate the request
-            assert mock_post.call_args.kwargs["json"] == {
+            assert vertex_calls[0].kwargs["json"] == {
                 "baseModel": base_model,
                 "supervisedTuningSpec": {"training_dataset_uri": training_file},
                 "tunedModelDisplayName": None,
@@ -322,11 +328,17 @@ async def test_create_vertex_fine_tune_jobs_mocked_with_hyperparameters():
                 },
             )
 
-            # Verify the request
-            mock_post.assert_called_once()
+            # Verify the request - filter to only Vertex AI calls (Datadog batch logger
+            # may flush in the background and make additional POST calls)
+            vertex_calls = [
+                c
+                for c in mock_post.call_args_list
+                if "aiplatform.googleapis.com" in str(c.kwargs.get("url", ""))
+            ]
+            assert len(vertex_calls) == 1
 
             # Validate the request
-            assert mock_post.call_args.kwargs["json"] == {
+            assert vertex_calls[0].kwargs["json"] == {
                 "baseModel": base_model,
                 "supervisedTuningSpec": {
                     "training_dataset_uri": training_file,


### PR DESCRIPTION
## Relevant issues

Fixes flaky `test_create_vertex_fine_tune_jobs_mocked` (and `_with_hyperparameters` variant) in `tests/batches_tests/test_fine_tuning_api.py`.

## What's happening

The test patches `AsyncHTTPHandler.post` and asserts `called_once()`. But Datadog's `CustomBatchLogger` runs a background flush worker — when a previous test triggers Datadog logging, the worker flushes *during* this test and makes its own `POST` to `https://http-intake.logs.datadoghq.com` through the same mock. This causes the `assert_called_once()` to fail with "Called 2 times."

The test already tries to clear `litellm.callbacks` etc., but that only prevents new Datadog registrations — it can't stop an already-queued background flush.

## Fix

Replace `mock_post.assert_called_once()` with a targeted check: filter `call_args_list` to only calls whose `url` contains `aiplatform.googleapis.com`, then assert exactly 1 such call and verify its payload. Background Datadog (or any other logger) calls are ignored.

## Pre-Submission checklist

- [x] Test added in `tests/` (`test_create_vertex_fine_tune_jobs_mocked` and `_with_hyperparameters`)
- [ ] `make test-unit` passes

## Type

- [x] Bug fix (flaky test)

## Changes

- `tests/batches_tests/test_fine_tuning_api.py`: replace `assert_called_once()` with URL-filtered assertion in both mocked Vertex fine-tuning tests