### PR TITLE
fix(logging): zero out response_cost for cache hits in _process_hidden_params_and_response_cost

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1632,7 +1632,9 @@ class Logging(LiteLLMLoggingBaseClass):
                     self.model_call_details["litellm_params"]["metadata"] = {}
                 self.model_call_details["litellm_params"]["metadata"]["hidden_params"] = getattr(logging_result, "_hidden_params", {})  # type: ignore
 
-        if "response_cost" in hidden_params:
+        if self.model_call_details.get("cache_hit") is True:
+            self.model_call_details["response_cost"] = 0.0
+        elif "response_cost" in hidden_params:
             self.model_call_details["response_cost"] = hidden_params["response_cost"]
         else:
             self.model_call_details["response_cost"] = self._response_cost_calculator(


### PR DESCRIPTION
## Relevant issues

Fixes `test_cost_tracking_with_caching` - cached responses were reporting non-zero cost.

## Changes

In `_process_hidden_params_and_response_cost`, when a cached response object has a pre-calculated `response_cost` in its `_hidden_params` (from the original non-cached response), the method was using it directly without checking `cache_hit`. This bypassed the cache_hit → 0.0 logic in `_response_cost_calculator`.

The fix: check `model_call_details["cache_hit"]` first. If True, set `response_cost = 0.0` unconditionally.

Root cause: the cached response's `_hidden_params["response_cost"]` = 3.5e-05 was short-circuiting to be used directly via the `elif "response_cost" in hidden_params` branch, never reaching `_response_cost_calculator` where the `cache_hit` check lives.

## Pre-Submission checklist

- [x] Added at least 1 test (existing `test_cost_tracking_with_caching`)
- [x] `make test-unit` passes

## Type

- Bug fix