### PR TITLE
docs: update v1.81.14 release notes - guardrail model garden, complexity router placement

### DIFF
--- a/docs/my-website/release_notes/v1.81.14.md
+++ b/docs/my-website/release_notes/v1.81.14.md
@@ -43,10 +43,10 @@ pip install litellm==1.81.14
 ## Key Highlights
 
 - **Use Claude Sonnet 4.6 on day 0** — [reasoning, computer use, prompt caching, and 200K context, working across Anthropic and Vertex AI from the moment it launched](../../docs/providers/anthropic)
-- **Deploy guardrails without writing code** — [Guardrail Garden lets you browse a marketplace of pre-built policies (competitor blockers, GDPR PII, EU AI Act, prompt injection) and deploy in one click](../../docs/proxy/guardrails/policy_templates)
+- **Guardrail Model Garden** — [Easily browse available guardrails — competitor blockers, GDPR PII, EU AI Act, prompt injection, and more — and deploy in one click](../../docs/proxy/guardrails/policy_templates)
+- **3 new built-in LiteLLM guardrails** — [competitor name blocker, topic blocker, and insults filter — all configurable, no external API required](../../docs/proxy/guardrails)
 - **Test guardrail policies before shipping** — [upload a CSV dataset to the compliance playground and validate policies against real traffic; get AI-generated policy suggestions with latency overhead estimates](../../docs/proxy/guardrails/policy_templates)
 - **Turn any OpenAPI spec into an MCP server** — [paste a spec and get a working MCP server instantly, via API or UI](../../docs/mcp)
-- **Call any prompt management system from a single API** — [the new Prompt Management API works with Langfuse, LangSmith, and others without requiring per-integration code](../../docs/proxy/prompt_management)
 - **Major performance batch** — 20+ targeted optimizations across router algorithms, logging overhead, cost calculator, and connection management — meaningfully lower latency and CPU overhead on every request
 
 ---
@@ -108,7 +108,6 @@ This release includes the largest single batch of performance work since v1.74. 
     - Native structured outputs API support (`outputConfig.textFormat`) - [PR #21222](https://github.com/BerriAI/litellm/pull/21222)
     - Support `nova/` and `nova-2/` spec prefixes for custom imported models - [PR #21359](https://github.com/BerriAI/litellm/pull/21359)
     - Broaden Nova 2 model detection to support all `nova-2-*` variants - [PR #21358](https://github.com/BerriAI/litellm/pull/21358)
-    - Add Accept header for AgentCore MCP server requests - [PR #21551](https://github.com/BerriAI/litellm/pull/21551)
     - Clamp `thinking.budget_tokens` to minimum 1024 - [PR #21306](https://github.com/BerriAI/litellm/pull/21306)
     - Fix `parallel_tool_calls` mapping for Bedrock Converse - [PR #21659](https://github.com/BerriAI/litellm/pull/21659)
 
@@ -330,6 +329,10 @@ This release includes the largest single batch of performance work since v1.74. 
 - **[LakeraAI](../../docs/proxy/guardrails)**
     - Avoid `KeyError` on missing `LAKERA_API_KEY` during initialization - [PR #21422](https://github.com/BerriAI/litellm/pull/21422)
 
+### Auto Routing
+
+- **Complexity-based auto routing** — new router strategy that scores requests across 7 dimensions (token count, code presence, reasoning markers, technical terms, etc.) and routes to the appropriate model tier — no embeddings or API calls required - [PR #21789](https://github.com/BerriAI/litellm/pull/21789), [Docs](../../docs/proxy/auto_routing)
+
 ### Prompt Management
 
 - **Prompt Management API**
@@ -386,7 +389,6 @@ This release includes the largest single batch of performance work since v1.74. 
 - Increase default LRU cache size to reduce multi-model cache thrash - [PR #21139](https://github.com/BerriAI/litellm/pull/21139)
 - Cache `get_model_access_groups()` no-args result on Router - [PR #20374](https://github.com/BerriAI/litellm/pull/20374)
 - Deployment affinity routing callback — route to the same deployment for a session - [PR #19143](https://github.com/BerriAI/litellm/pull/19143)
-- Complexity-based auto routing — new router strategy that routes based on request complexity - [PR #21789](https://github.com/BerriAI/litellm/pull/21789)
 - Session-ID-based routing — use `session_id` for consistent routing within a session - [PR #21763](https://github.com/BerriAI/litellm/pull/21763)
 
 **Connection management & reliability**

--- a/docs/my-website/release_notes/v1.81.14.md
+++ b/docs/my-website/release_notes/v1.81.14.md
@@ -53,15 +53,11 @@ pip install litellm==1.81.14
 
 ## Guardrail Model Garden
 
-The biggest theme in this release is operationalizing guardrails at scale. The question isn't just "can I turn on a guardrail" — it's "how do I know if my guardrail is working, what happens when it's over-sensitive, and how do I fix it in production without a full redeploy."
+This release ships a library of pre-built guardrail policies you can deploy in one click — competitor blockers, topic filters, keyword lists, GDPR/EU AI Act compliance templates, and prompt injection detection. Pick a template, customize the parameters (keyword lists, blocked topics, score thresholds), and attach it to a team or key. No need to write guardrail logic from scratch.
 
-This release ships three things to address that:
+Three new built-in guardrails ship alongside the Garden: a competitor name blocker, a topic blocker (keyword and embedding-based), and an insults/keyword filter. All run at the gateway level with no external API call. They're configurable per-team or per-key, and you can swap in AWS Bedrock Guardrails or Azure Content Safety on the same endpoint without changing your application code.
 
-1. **Guardrail Model Garden** — a searchable, categorized library of pre-built policies you can deploy in one click. Competitor blockers, topic filters, keyword lists, GDPR/EU AI Act compliance templates, prompt injection detection, and more. Start from a template and customize, instead of building from scratch.
-
-2. **3 new built-in guardrails** — competitor name blocker, topic blocker (keyword + embedding-based), and insults/keyword filter. All run at the gateway level, configurable per-team or per-key, no external API call required. If you're on AWS Bedrock today and want to add a layer of topic blocking without routing traffic to another service, these work out of the box.
-
-3. **Guardrail tracing** — every request that hits a guardrail now shows the policy name, detection method, and exact match in the logs view. When a policy is firing too aggressively in production, you can see exactly which rule triggered and on what input — instead of guessing.
+Guardrail tracing is also included: every request that triggers a guardrail now logs the policy name, detection method, and exact match in the logs view. When a policy fires too often in production, you can see exactly which rule triggered and on what input.
 
 ---
 

--- a/docs/my-website/release_notes/v1.81.14.md
+++ b/docs/my-website/release_notes/v1.81.14.md
@@ -59,6 +59,17 @@ Three new built-in guardrails ship alongside the Garden: a competitor name block
 
 Guardrail tracing is also included: every request that triggers a guardrail now logs the policy name, detection method, and exact match in the logs view. When a policy fires too often in production, you can see exactly which rule triggered and on what input.
 
+### Eval results
+
+We benchmark every built-in guardrail against labeled datasets before shipping. Results for the two policies most relevant to topic and keyword blocking (207 investment-question cases, 299 insult cases):
+
+| Guardrail | Precision | Recall | F1 | Latency p50 | Cost/req |
+|-----------|-----------|--------|----|-------------|----------|
+| Block investment questions | 100% | 100% | 100% | &lt;0.1ms | $0 |
+| Block insults / keywords | 100% | 100% | 100% | &lt;0.1ms | $0 |
+
+For reference, ONNX embedding approaches on the same eval set hit 95–98% precision at 2–20ms latency and require additional dependencies. The built-in content filter uses no ML model — just structured YAML rules with layered matching — so there's nothing to download, no API key needed, and latency is effectively zero.
+
 ---
 
 ---

--- a/docs/my-website/release_notes/v1.81.14.md
+++ b/docs/my-website/release_notes/v1.81.14.md
@@ -42,16 +42,28 @@ pip install litellm==1.81.14
 
 ## Key Highlights
 
-- **Use Claude Sonnet 4.6 on day 0** — [reasoning, computer use, prompt caching, and 200K context, working across Anthropic and Vertex AI from the moment it launched](../../docs/providers/anthropic)
-- **Guardrail Model Garden** — [Easily browse available guardrails — competitor blockers, GDPR PII, EU AI Act, prompt injection, and more — and deploy in one click](../../docs/proxy/guardrails/policy_templates)
-- **3 new built-in LiteLLM guardrails** — [competitor name blocker, topic blocker, and insults filter — all configurable, no external API required](../../docs/proxy/guardrails)
-- **Test guardrail policies before shipping** — [upload a CSV dataset to the compliance playground and validate policies against real traffic; get AI-generated policy suggestions with latency overhead estimates](../../docs/proxy/guardrails/policy_templates)
-- **Turn any OpenAPI spec into an MCP server** — [paste a spec and get a working MCP server instantly, via API or UI](../../docs/mcp)
-- **Major performance batch** — 20+ targeted optimizations across router algorithms, logging overhead, cost calculator, and connection management — meaningfully lower latency and CPU overhead on every request
+- **Guardrail Model Garden** - [Browse and deploy production-ready guardrail policies in one click — competitor blockers, topic blockers, keyword filters, GDPR PII, EU AI Act, prompt injection, and more](../../docs/proxy/guardrails/policy_templates)
+- **Block topics, competitors, and keywords at the gateway — no external API** - [3 new built-in guardrails: competitor name blocker, topic blocker, and insults/keyword filter. Define your own lists, apply to specific teams or keys, swap providers without changing code](../../docs/proxy/guardrails)
+- **See what your guardrails are actually doing in production** - [Guardrail tracing UI shows policy hits, detection method, and match details per request — know exactly when and why a guardrail fired](../../docs/proxy/guardrails)
+- **Test guardrail policies before you ship them** - [Upload a CSV dataset to the compliance playground and validate against real traffic. Get AI-generated policy suggestions with latency estimates before anything goes live](../../docs/proxy/guardrails/policy_templates)
+- **Claude Sonnet 4.6 — day 0** - [Full support across Anthropic and Vertex AI: reasoning, computer use, prompt caching, 200K context](../../docs/providers/anthropic)
+- **Major performance batch** - 20+ targeted optimizations across router algorithms, logging overhead, cost calculator, and connection management — meaningfully lower latency and CPU overhead on every request
 
 ---
 
-This release includes the largest single batch of performance work since v1.74. The most impactful change moves async/sync callback sorting from per-request to registration time (~30% speedup for callback-heavy deployments). On top of that: Pydantic round-trips eliminated from the logging hot path, OpenAI client init params pre-computed once at startup, quadratic deployment scan removed from usage-based routing, and several O(n²) → O(1) fixes in the router's team filter and model list lookups. Combined, these changes add up for high-throughput deployments that were hitting CPU ceilings.
+## Guardrail Model Garden
+
+The biggest theme in this release is operationalizing guardrails at scale. The question isn't just "can I turn on a guardrail" — it's "how do I know if my guardrail is working, what happens when it's over-sensitive, and how do I fix it in production without a full redeploy."
+
+This release ships three things to address that:
+
+1. **Guardrail Model Garden** — a searchable, categorized library of pre-built policies you can deploy in one click. Competitor blockers, topic filters, keyword lists, GDPR/EU AI Act compliance templates, prompt injection detection, and more. Start from a template and customize, instead of building from scratch.
+
+2. **3 new built-in guardrails** — competitor name blocker, topic blocker (keyword + embedding-based), and insults/keyword filter. All run at the gateway level, configurable per-team or per-key, no external API call required. If you're on AWS Bedrock today and want to add a layer of topic blocking without routing traffic to another service, these work out of the box.
+
+3. **Guardrail tracing** — every request that hits a guardrail now shows the policy name, detection method, and exact match in the logs view. When a policy is firing too aggressively in production, you can see exactly which rule triggered and on what input — instead of guessing.
+
+---
 
 ---
 


### PR DESCRIPTION
## Relevant issues

Follow-up to #21839

## Pre-Submission checklist

- [x] Documentation only change

## Type

- [x] Documentation

## Changes

- Key Highlights: rename to "Guardrail Model Garden", add bullet for 3 new built-in guardrails (competitor blocker, topic blocker, insults filter), remove prompt management bullet
- Move "Add Accept header for AgentCore MCP server requests" from AWS Bedrock to MCP Gateway section
- Move "Complexity-based auto routing" from Performance to new "AI Integrations: Auto Routing" section