### PR TITLE
fix(tests): fix flaky test_use_prisma_db_push_flag_behavior

### DIFF
--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -583,7 +583,7 @@ class TestHealthAppFactory:
         assert isinstance(health_app_2, fastapi.FastAPI)
 
     @patch("subprocess.run")
-    @patch("atexit.register")  # critical: prevents atexit handlers from closing Click's isolation streams
+    @patch("atexit.register")
     @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
     @patch("litellm.proxy.db.check_migration.check_prisma_schema_diff")
     @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema")
@@ -596,11 +596,7 @@ class TestHealthAppFactory:
         mock_subprocess_run,
     ):
         """Test that use_prisma_db_push flag correctly controls PrismaManager.setup_database use_migrate parameter"""
-        from click.testing import CliRunner
-
         from litellm.proxy.proxy_cli import run_server
-
-        runner = CliRunner()
 
         # Mock subprocess.run to simulate prisma being available
         mock_subprocess_run.return_value = MagicMock(returncode=0)
@@ -615,9 +611,6 @@ class TestHealthAppFactory:
             save_worker_config=MagicMock(),
         )
 
-        # Strip DIRECT_URL and set DATABASE_URL to a test value so Click's
-        # CliRunner doesn't encounter real DB env vars (causes stream lifecycle
-        # issues with Click 8.3.x in CI environments).
         clean_env = {
             k: v
             for k, v in os.environ.items()
@@ -642,11 +635,15 @@ class TestHealthAppFactory:
                 "port": 8000,
             }
 
+            # Use standalone_mode=False to bypass Click's CliRunner stream
+            # isolation which causes flaky "I/O operation on closed file"
+            # errors in CI environments (Click 8.3.x stream lifecycle issue).
+
             # Test 1: Without --use_prisma_db_push flag (default behavior)
             # use_prisma_db_push should be False (default), so use_migrate should be True
-            result = runner.invoke(run_server, ["--local", "--skip_server_startup"])
-
-            assert result.exit_code == 0
+            run_server.main(
+                ["--local", "--skip_server_startup"], standalone_mode=False
+            )
             mock_setup_database.assert_called_with(use_migrate=True)
 
             # Reset mocks
@@ -656,9 +653,8 @@ class TestHealthAppFactory:
 
             # Test 2: With --use_prisma_db_push flag set
             # use_prisma_db_push should be True, so use_migrate should be False
-            result = runner.invoke(
-                run_server, ["--local", "--skip_server_startup", "--use_prisma_db_push"]
+            run_server.main(
+                ["--local", "--skip_server_startup", "--use_prisma_db_push"],
+                standalone_mode=False,
             )
-
-            assert result.exit_code == 0
             mock_setup_database.assert_called_with(use_migrate=False)


### PR DESCRIPTION
## Relevant issues

Fixes flaky `test_use_prisma_db_push_flag_behavior` test that fails intermittently in CI with `ValueError: I/O operation on closed file`.

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

✅ Test

## Changes

Replaced Click's `CliRunner.invoke()` with `run_server.main(standalone_mode=False)` in the test. Click's CliRunner creates isolated BytesIO streams for stdout/stderr capture, and something in the CLI execution path closes those streams before CliRunner can read them back - causing `ValueError: I/O operation on closed file`. Since the test only checks mock assertions (not CLI output), `standalone_mode=False` gives us Click's argument parsing without the fragile stream isolation.