### PR TITLE
fix: enable context-1m-2025-08-07 beta header for vertex_ai provider

### DIFF
--- a/litellm/anthropic_beta_headers_config.json
+++ b/litellm/anthropic_beta_headers_config.json
@@ -127,7 +127,7 @@
     "compact-2026-01-12": null,
     "computer-use-2025-01-24": "computer-use-2025-01-24",
     "computer-use-2025-11-24": "computer-use-2025-11-24",
-    "context-1m-2025-08-07": null,
+    "context-1m-2025-08-07": "context-1m-2025-08-07",
     "context-management-2025-06-27": "context-management-2025-06-27",
     "effort-2025-11-24": null,
     "fast-mode-2026-02-01": null,


### PR DESCRIPTION
## Description

Fixes #21861

### Root Cause

In `litellm/anthropic_beta_headers_config.json`, the `context-1m-2025-08-07` beta header was set to `null` for the `vertex_ai` provider:

```json
"vertex_ai": {
  "context-1m-2025-08-07": null,  // ← bug: should be "context-1m-2025-08-07"
  ...
}
```

This caused `filter_and_transform_beta_headers` to filter out the header when users set `extra_headers: {anthropic-beta: context-1m-2025-08-07}` in their Vertex AI config, resulting in a `BadRequestError` (prompt too long) instead of enabling 1M context.

### Fix

Set `context-1m-2025-08-07` to `"context-1m-2025-08-07"` for `vertex_ai`, consistent with:
- `bedrock_converse`: already `"context-1m-2025-08-07"`
- `azure_ai`: already `"context-1m-2025-08-07"`
- Anthropic's documentation: Vertex AI supports the same options as the Messages API

### Testing

The existing test suite in `tests/test_litellm/test_anthropic_beta_headers_filtering.py` is data-driven and reads directly from the config file, so it will automatically validate this fix.