### PR TITLE
fix(vertex_ai): add 'audio' to supported OpenAI params for TTS

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -269,6 +269,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             "logprobs",
             "top_logprobs",
             "modalities",
+            "audio",
             "parallel_tool_calls",
             "web_search_options",
         ]

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -269,7 +269,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             "logprobs",
             "top_logprobs",
             "modalities",
-            "audio",
             "parallel_tool_calls",
             "web_search_options",
         ]
@@ -281,6 +280,11 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         if supports_reasoning(model):
             supported_params.append("reasoning_effort")
             supported_params.append("thinking")
+
+        # Add audio param for TTS models (consistent with GoogleAIStudioGeminiConfig)
+        if "tts" in model:
+            supported_params.append("audio")
+
         return supported_params
 
     def map_tool_choice_values(

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -423,6 +423,11 @@ def test_all_model_configs():
         drop_params=False,
     ) == {"max_output_tokens": 10}
 
+    # Test that audio param is supported for TTS (fixes #21702)
+    assert "audio" in VertexGeminiConfig().get_supported_openai_params(
+        model="gemini-2.5-flash-preview-tts"
+    )
+
 
 def test_anthropic_web_search_in_model_info():
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"


### PR DESCRIPTION
## Problem

`/v1/audio/speech` fails with `400 INVALID_ARGUMENT` when using `vertex_ai/` Gemini TTS models.

## Root Cause

`VertexGeminiConfig.get_supported_openai_params()` does not include `"audio"` in its return list. The `audio` parameter is silently filtered out before reaching `map_openai_params()`, which already has the correct `audio` → `speechConfig` mapping.

## Fix

Add `"audio"` to the list of supported OpenAI params in `VertexGeminiConfig.get_supported_openai_params()`.

## Changes

- `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`: Added `"audio"` to supported params list
- `tests/test_litellm/test_utils.py`: Added test case to verify audio param is supported

## Testing

The mapping logic already exists and works — this fix just ensures the param reaches it.

Fixes #21702