### PR TITLE
fix(proxy): don't replace response model with alias

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -281,8 +281,11 @@ def _override_openai_response_model(
     else:
         try:
             setattr(response_obj, "model", stripped)
-        except Exception:
-            pass
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                "%s: failed to strip provider prefix on response.model, error=%s",
+                log_context, str(e),
+            )
 
 
 def _get_cost_breakdown_from_logging_obj(

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -280,7 +280,7 @@ def _override_openai_response_model(
         response_obj["model"] = stripped
     else:
         try:
-            response_obj.model = stripped
+            setattr(response_obj, "model", stripped)
         except Exception:
             pass
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5264,7 +5264,7 @@ def _restamp_streaming_chunk_model(
         chunk["model"] = stripped
     else:
         try:
-            chunk.model = stripped
+            setattr(chunk, "model", stripped)
         except Exception:
             pass
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -98,6 +98,7 @@ from litellm.types.utils import (
     ModelResponseStream,
     TextCompletionResponse,
     TokenCountResponse,
+    LlmProvidersSet,
 )
 from litellm.utils import (
     _invalidate_model_cost_lowercase_map,
@@ -5229,64 +5230,43 @@ async def async_assistants_data_generator(
         yield f"data: {error_returned}\n\n"
 
 
-def _get_client_requested_model_for_streaming(request_data: dict) -> str:
-    """
-    Prefer the original client-requested model (pre-alias mapping) when available.
-
-    Pre-call processing can rewrite `request_data["model"]` for aliasing/routing purposes.
-    The OpenAI-compatible public `model` field should reflect what the client sent.
-    """
-    requested_model = request_data.get("_litellm_client_requested_model")
-    if isinstance(requested_model, str):
-        return requested_model
-
-    requested_model = request_data.get("model")
-    return requested_model if isinstance(requested_model, str) else ""
-
-
 def _restamp_streaming_chunk_model(
     *,
     chunk: Any,
-    requested_model_from_client: str,
     request_data: dict,
     model_mismatch_logged: bool,
 ) -> Tuple[Any, bool]:
-    # Always return the client-requested model name (not provider-prefixed internal identifiers)
-    # on streaming chunks.
-    #
-    # Note: This warning is intentionally verbose. A mismatch is a useful signal that an
-    # internal provider/deployment identifier is leaking into the public API, and helps
-    # maintainers/operators catch regressions while preserving OpenAI-compatible output.
-    if not requested_model_from_client or not isinstance(chunk, (BaseModel, dict)):
+    """Strip known provider prefixes from streaming chunk model field."""
+    if not isinstance(chunk, (BaseModel, dict)):
         return chunk, model_mismatch_logged
 
     downstream_model = (
         chunk.get("model") if isinstance(chunk, dict) else getattr(chunk, "model", None)
     )
-    if not model_mismatch_logged and downstream_model != requested_model_from_client:
+
+    if not downstream_model or not isinstance(downstream_model, str) or "/" not in downstream_model:
+        return chunk, model_mismatch_logged
+
+    prefix = downstream_model.split("/", 1)[0]
+    if prefix not in LlmProvidersSet:
+        return chunk, model_mismatch_logged
+
+    stripped = downstream_model.split("/", 1)[1]
+
+    if not model_mismatch_logged:
         verbose_proxy_logger.debug(
-            "litellm_call_id=%s: streaming chunk model mismatch - requested=%r downstream=%r. Overriding model to requested.",
-            request_data.get("litellm_call_id"),
-            requested_model_from_client,
-            downstream_model,
+            "litellm_call_id=%s: stripping provider prefix %r from chunk model %r",
+            request_data.get("litellm_call_id"), prefix, downstream_model,
         )
         model_mismatch_logged = True
 
     if isinstance(chunk, dict):
-        chunk["model"] = requested_model_from_client
-        return chunk, model_mismatch_logged
-
-    try:
-        setattr(chunk, "model", requested_model_from_client)
-    except Exception as e:
-        verbose_proxy_logger.error(
-            "litellm_call_id=%s: failed to override chunk.model=%r on chunk_type=%s. error=%s",
-            request_data.get("litellm_call_id"),
-            requested_model_from_client,
-            type(chunk),
-            str(e),
-            exc_info=True,
-        )
+        chunk["model"] = stripped
+    else:
+        try:
+            chunk.model = stripped
+        except Exception:
+            pass
 
     return chunk, model_mismatch_logged
 
@@ -5299,9 +5279,6 @@ async def async_data_generator(
         # Use a list to accumulate response segments to avoid O(n^2) string concatenation
         str_so_far_parts: list[str] = []
         error_message: Optional[str] = None
-        requested_model_from_client = _get_client_requested_model_for_streaming(
-            request_data=request_data
-        )
         model_mismatch_logged = False
         async for chunk in proxy_logging_obj.async_post_call_streaming_iterator_hook(
             user_api_key_dict=user_api_key_dict,
@@ -5322,7 +5299,6 @@ async def async_data_generator(
 
             chunk, model_mismatch_logged = _restamp_streaming_chunk_model(
                 chunk=chunk,
-                requested_model_from_client=requested_model_from_client,
                 request_data=request_data,
                 model_mismatch_logged=model_mismatch_logged,
             )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5265,8 +5265,11 @@ def _restamp_streaming_chunk_model(
     else:
         try:
             setattr(chunk, "model", stripped)
-        except Exception:
-            pass
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                "litellm_call_id=%s: failed to strip provider prefix on chunk.model, error=%s",
+                request_data.get("litellm_call_id"), str(e),
+            )
 
     return chunk, model_mismatch_logged
 

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1131,225 +1131,29 @@ class TestExtractErrorFromSSEChunk:
 
 
 class TestOverrideOpenAIResponseModel:
-    """Tests for _override_openai_response_model function"""
+    """Tests for _override_openai_response_model provider prefix stripping."""
 
-    def test_override_model_preserves_fallback_model_when_fallback_occurred_object(
-        self,
-    ):
-        """
-        Test that when a fallback occurred (x-litellm-attempted-fallbacks > 0),
-        the actual model used (fallback model) is preserved instead of being
-        overridden with the requested model.
-
-        This is the regression test to ensure the model being called is properly
-        displayed when a fallback happens.
-        """
-        requested_model = "gpt-4"
-        fallback_model = "gpt-3.5-turbo"
-
-        # Create a mock object response with fallback model
-        # _hidden_params is an attribute (not a dict key) accessed via getattr
+    def test_strips_known_provider_prefix_from_object(self):
         response_obj = MagicMock()
-        response_obj.model = fallback_model
-        response_obj._hidden_params = {
-            "additional_headers": {"x-litellm-attempted-fallbacks": 1}
-        }
+        response_obj.model = "hosted_vllm/my-model"
+        _override_openai_response_model(response_obj=response_obj, log_context="test")
+        assert response_obj.model == "my-model"
 
-        # Call the function - should preserve fallback model
-        _override_openai_response_model(
-            response_obj=response_obj,
-            requested_model=requested_model,
-            log_context="test_context",
-        )
+    def test_strips_known_provider_prefix_from_dict(self):
+        response_obj = {"model": "bedrock/anthropic.claude-v2"}
+        _override_openai_response_model(response_obj=response_obj, log_context="test")
+        assert response_obj["model"] == "anthropic.claude-v2"
 
-        # Verify the model was NOT overridden - should still be the fallback model
-        assert response_obj.model == fallback_model
-        assert response_obj.model != requested_model
-
-    def test_override_model_preserves_fallback_model_multiple_fallbacks(self):
-        """
-        Test that when multiple fallbacks occurred, the actual model used
-        (fallback model) is preserved.
-        """
-        requested_model = "gpt-4"
-        fallback_model = "claude-haiku-4-5-20251001"
-
-        # Create a mock object response with fallback model
+    def test_leaves_model_without_prefix_alone(self):
         response_obj = MagicMock()
-        response_obj.model = fallback_model
-        response_obj._hidden_params = {
-            "additional_headers": {
-                "x-litellm-attempted-fallbacks": 2  # Multiple fallbacks
-            }
-        }
+        response_obj.model = "gpt-4"
+        _override_openai_response_model(response_obj=response_obj, log_context="test")
+        assert response_obj.model == "gpt-4"
 
-        # Call the function - should preserve fallback model
-        _override_openai_response_model(
-            response_obj=response_obj,
-            requested_model=requested_model,
-            log_context="test_context",
-        )
-
-        # Verify the model was NOT overridden - should still be the fallback model
-        assert response_obj.model == fallback_model
-        assert response_obj.model != requested_model
-
-    def test_override_model_overrides_when_no_fallback_dict(self):
-        """
-        Test that when no fallback occurred, the model is overridden
-        to match the requested model (dict response).
-        """
-        requested_model = "gpt-4"
-        downstream_model = "gpt-3.5-turbo"
-
-        # Create a dict response without fallback
-        # For dict responses, _hidden_params won't be found via getattr,
-        # so the fallback check won't trigger and model will be overridden
-        response_obj = {"model": downstream_model}
-
-        # Call the function - should override to requested model
-        _override_openai_response_model(
-            response_obj=response_obj,
-            requested_model=requested_model,
-            log_context="test_context",
-        )
-
-        # Verify the model WAS overridden to requested model
-        assert response_obj["model"] == requested_model
-
-    def test_override_model_overrides_when_no_fallback_object(self):
-        """
-        Test that when no fallback occurred (object response), the model is overridden
-        to match the requested model.
-        """
-        requested_model = "gpt-4"
-        downstream_model = "gpt-3.5-turbo"
-
-        # Create a mock object response without fallback
-        response_obj = MagicMock()
-        response_obj.model = downstream_model
-        response_obj._hidden_params = {
-            "additional_headers": {}  # No attempted_fallbacks header
-        }
-
-        # Call the function - should override to requested model
-        _override_openai_response_model(
-            response_obj=response_obj,
-            requested_model=requested_model,
-            log_context="test_context",
-        )
-
-        # Verify the model WAS overridden to requested model
-        assert response_obj.model == requested_model
-
-    def test_override_model_overrides_when_attempted_fallbacks_is_zero(self):
-        """
-        Test that when attempted_fallbacks is 0 (no fallback occurred),
-        the model is overridden to match the requested model.
-        """
-        requested_model = "gpt-4"
-        downstream_model = "gpt-3.5-turbo"
-
-        # Create a mock object response
-        response_obj = MagicMock()
-        response_obj.model = downstream_model
-        response_obj._hidden_params = {
-            "additional_headers": {
-                "x-litellm-attempted-fallbacks": 0  # Zero means no fallback occurred
-            }
-        }
-
-        # Call the function - should override to requested model
-        _override_openai_response_model(
-            response_obj=response_obj,
-            requested_model=requested_model,
-            log_context="test_context",
-        )
-
-        # Verify the model WAS overridden to requested model
-        assert response_obj.model == requested_model
-
-    def test_override_model_overrides_when_attempted_fallbacks_is_none(self):
-        """
-        Test that when attempted_fallbacks is None (not set),
-        the model is overridden to match the requested model.
-        """
-        requested_model = "gpt-4"
-        downstream_model = "gpt-3.5-turbo"
-
-        # Create a mock object response
-        response_obj = MagicMock()
-        response_obj.model = downstream_model
-        response_obj._hidden_params = {
-            "additional_headers": {"x-litellm-attempted-fallbacks": None}
-        }
-
-        # Call the function - should override to requested model
-        _override_openai_response_model(
-            response_obj=response_obj,
-            requested_model=requested_model,
-            log_context="test_context",
-        )
-
-        # Verify the model WAS overridden to requested model
-        assert response_obj.model == requested_model
-
-    def test_override_model_no_hidden_params(self):
-        """
-        Test that when _hidden_params is not present, the model is overridden
-        to match the requested model.
-        """
-        requested_model = "gpt-4"
-        downstream_model = "gpt-3.5-turbo"
-
-        # Create a mock object response without _hidden_params
-        response_obj = MagicMock()
-        response_obj.model = downstream_model
-        # Don't set _hidden_params - getattr will return {}
-
-        # Call the function - should override to requested model
-        _override_openai_response_model(
-            response_obj=response_obj,
-            requested_model=requested_model,
-            log_context="test_context",
-        )
-
-        # Verify the model WAS overridden to requested model
-        assert response_obj.model == requested_model
-
-    def test_override_model_no_requested_model(self):
-        """
-        Test that when requested_model is None or empty, the function returns early
-        without modifying the response.
-        """
-        fallback_model = "gpt-3.5-turbo"
-
-        # Create a mock object response
-        response_obj = MagicMock()
-        response_obj.model = fallback_model
-        response_obj._hidden_params = {
-            "additional_headers": {"x-litellm-attempted-fallbacks": 1}
-        }
-
-        # Call the function with None requested_model
-        _override_openai_response_model(
-            response_obj=response_obj,
-            requested_model=None,
-            log_context="test_context",
-        )
-
-        # Verify the model was not changed
-        assert response_obj.model == fallback_model
-
-        # Call with empty string
-        _override_openai_response_model(
-            response_obj=response_obj,
-            requested_model="",
-            log_context="test_context",
-        )
-
-        # Verify the model was not changed
-        assert response_obj.model == fallback_model
+    def test_leaves_unknown_prefix_alone(self):
+        response_obj = {"model": "my-company/custom-model"}
+        _override_openai_response_model(response_obj=response_obj, log_context="test")
+        assert response_obj["model"] == "my-company/custom-model"
 
 
 class TestStreamingOverheadHeader:

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1155,6 +1155,10 @@ class TestOverrideOpenAIResponseModel:
         _override_openai_response_model(response_obj=response_obj, log_context="test")
         assert response_obj["model"] == "my-company/custom-model"
 
+    def test_strips_prefix_preserving_nested_slashes(self):
+        response_obj = {"model": "groq/meta-llama/llama-4-maverick-17b-128e-instruct"}
+        _override_openai_response_model(response_obj=response_obj, log_context="test")
+        assert response_obj["model"] == "meta-llama/llama-4-maverick-17b-128e-instruct"
 
 class TestStreamingOverheadHeader:
     """

--- a/tests/test_litellm/proxy/test_response_model_sanitization.py
+++ b/tests/test_litellm/proxy/test_response_model_sanitization.py
@@ -166,11 +166,7 @@ async def test_proxy_streaming_chunks_do_not_return_provider_prefixed_model(monk
 @pytest.mark.asyncio
 async def test_proxy_streaming_chunks_use_client_requested_model_before_alias_mapping(monkeypatch):
     """
-    Regression test for alias mapping on streaming:
-
-    - `common_processing_pre_call_logic` can rewrite `request_data["model"]` via model_alias_map / key-specific aliases.
-    - Non-streaming responses are restamped using the original client-requested model (captured before the rewrite).
-    - Streaming chunks must do the same to avoid mismatched `model` values between streaming and non-streaming.
+    Streaming chunks should have provider prefixes stripped even when alias mapping is in play.
     """
     client_model_alias = "alias-model"
     canonical_model = "vllm-model"
@@ -200,7 +196,6 @@ async def test_proxy_streaming_chunks_use_client_requested_model_before_alias_ma
         user_api_key_dict=user_api_key_dict,
         request_data={
             "model": canonical_model,
-            "_litellm_client_requested_model": client_model_alias,
         },
     )
 


### PR DESCRIPTION
## Relevant issues

Fixes #21665

@cyberjunk you were right, it was from #19943 (ba17f518). That PR meant to strip internal provider prefixes like `hosted_vllm/` from responses but also started replacing `response.model` with whatever the client sent (the alias) in all cases.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Instead of replacing `response.model` with the client alias, now we just strip known provider prefixes (using `LlmProvidersSet`). Same fix in both non-streaming and streaming paths. Also cleaned up `_get_client_requested_model_for_streaming()` and `_litellm_client_requested_model` since they're dead code now.