### PR TITLE
docs(ui): add pre-PR checklist to UI contributing guide

### DIFF
--- a/docs/my-website/docs/contributing.md
+++ b/docs/my-website/docs/contributing.md
@@ -79,7 +79,27 @@ cp -r out/* ../../litellm/proxy/_experimental/out/
 
 Then restart the proxy and access the UI at `http://localhost:4000/ui`
 
-## 4. Submitting a PR
+## 4. Pre-PR Checklist
+
+Before submitting your pull request, make sure the following pass locally from `ui/litellm-dashboard/`:
+
+**Run tests related to your changes:**
+
+```bash
+npx vitest run src/components/path/to/YourComponent.test.tsx
+```
+
+Tests are co-located with components (e.g., `TeamInfo.tsx` → `TeamInfo.test.tsx`). If you add a new component, add a corresponding `.test.tsx` file next to it.
+
+**Run the build:**
+
+```bash
+npm run build
+```
+
+These map to the `ui_tests` and `ui_build` CI checks.
+
+## 5. Submitting a PR
 
 1. Create a new branch for your changes:
 ```bash


### PR DESCRIPTION
## Relevant issues

N/A

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

Adds a **Pre-PR Checklist** section (Section 4) to the UI contributing guide (`docs/my-website/docs/contributing.md`) per feedback from @yjiang-litellm:

- **Run related tests per-file**: `npx vitest run src/components/path/to/YourComponent.test.tsx`
- **Run the build**: `npm run build`
- Notes that these map to the `ui_tests` and `ui_build` CI checks