### PR TITLE
fix(google_genai): add type:object for anyOf parametersJsonSchema in tools transformation

### DIFF
--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -339,7 +339,12 @@ class GoogleGenAIAdapter:
                     if "description" in func_decl:
                         function_chunk["description"] = func_decl["description"]
                     if "parametersJsonSchema" in func_decl:
-                        function_chunk["parameters"] = func_decl["parametersJsonSchema"]
+                    params = func_decl["parametersJsonSchema"]
+                    # Anthropic requires 'type': 'object' for input_schema
+                    # Especially if 'anyOf' is present but 'type' is missing at top level
+                    if isinstance(params, dict) and "type" not in params:
+                        params["type"] = "object"
+                    function_chunk["parameters"] = params
 
                     openai_tool = {"type": "function", "function": function_chunk}
                     openai_tools.append(openai_tool)

--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -339,12 +339,12 @@ class GoogleGenAIAdapter:
                     if "description" in func_decl:
                         function_chunk["description"] = func_decl["description"]
                     if "parametersJsonSchema" in func_decl:
-                    params = func_decl["parametersJsonSchema"]
-                    # Anthropic requires 'type': 'object' for input_schema
-                    # Especially if 'anyOf' is present but 'type' is missing at top level
-                    if isinstance(params, dict) and "type" not in params:
-                        params["type"] = "object"
-                    function_chunk["parameters"] = params
+                        params = func_decl["parametersJsonSchema"]
+                        # Anthropic requires 'type': 'object' for input_schema
+                        # Especially if 'anyOf' is present but 'type' is missing at top level
+                                if isinstance(params, dict) and "type" not in params:
+                            params["type"] = "object"
+                        function_chunk["parameters"] = params
 
                     openai_tool = {"type": "function", "function": function_chunk}
                     openai_tools.append(openai_tool)

--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -342,7 +342,7 @@ class GoogleGenAIAdapter:
                         params = func_decl["parametersJsonSchema"]
                         # Anthropic requires 'type': 'object' for input_schema
                         # Especially if 'anyOf' is present but 'type' is missing at top level
-                                if isinstance(params, dict) and "type" not in params:
+                    if isinstance(params, dict) and "type" not in params:
                             params["type"] = "object"
                         function_chunk["parameters"] = params
 

--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -342,7 +342,7 @@ class GoogleGenAIAdapter:
                         params = func_decl["parametersJsonSchema"]
                         # Anthropic requires 'type': 'object' for input_schema
                         # Especially if 'anyOf' is present but 'type' is missing at top level
-                    if isinstance(params, dict) and "type" not in params:
+                        if isinstance(params, dict) and "type" not in params:
                             params["type"] = "object"
                         function_chunk["parameters"] = params
 

--- a/tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py
+++ b/tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py
@@ -354,3 +354,74 @@ def test_extra_headers_not_present():
     # Verify metadata is still forwarded
     assert "metadata" in completion_kwargs
     assert completion_kwargs["metadata"]["user_id"] == "test-user"
+
+def test_parameters_json_schema_anyof_adds_type_object():
+    """Test that parametersJsonSchema with anyOf at top level gets type:object added (fixes #21584).
+    
+    When Gemini CLI sends tools with parametersJsonSchema using anyOf at the top level
+    (without a 'type' field), the schema should have 'type': 'object' added so that
+    downstream providers like Anthropic don't reject it.
+    """
+    adapter = GoogleGenAIAdapter()
+
+    # Case 1: anyOf at top level without 'type' - should get type:object added
+    tools_anyof = [
+        {
+            "functionDeclarations": [
+                {
+                    "name": "get_data",
+                    "description": "Get some data",
+                    "parametersJsonSchema": {
+                        "anyOf": [
+                            {"type": "object", "properties": {"key": {"type": "string"}}},
+                            {"type": "null"}
+                        ]
+                    }
+                }
+            ]
+        }
+    ]
+    openai_tools = adapter._transform_google_genai_tools_to_openai(tools_anyof)
+    assert len(openai_tools) == 1
+    params = openai_tools[0]["function"]["parameters"]
+    assert "type" in params, "type should be added when anyOf is present at top level"
+    assert params["type"] == "object", "type should default to 'object'"
+    assert "anyOf" in params, "anyOf should be preserved"
+
+    # Case 2: schema already has 'type' - should NOT be overwritten
+    tools_with_type = [
+        {
+            "functionDeclarations": [
+                {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parametersJsonSchema": {
+                        "type": "object",
+                        "properties": {
+                            "location": {"type": "string"}
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+    openai_tools2 = adapter._transform_google_genai_tools_to_openai(tools_with_type)
+    assert len(openai_tools2) == 1
+    params2 = openai_tools2[0]["function"]["parameters"]
+    assert params2["type"] == "object", "existing type should be preserved"
+
+    # Case 3: function declaration WITHOUT parametersJsonSchema - should not crash
+    tools_no_schema = [
+        {
+            "functionDeclarations": [
+                {
+                    "name": "no_params_func",
+                    "description": "A function with no parameters"
+                }
+            ]
+        }
+    ]
+    openai_tools3 = adapter._transform_google_genai_tools_to_openai(tools_no_schema)
+    assert len(openai_tools3) == 1
+    assert openai_tools3[0]["function"]["name"] == "no_params_func"
+    assert "parameters" not in openai_tools3[0]["function"] or openai_tools3[0]["function"].get("parameters") is None


### PR DESCRIPTION
…tools transformation

Fixes #21584

When Gemini CLI sends tools with parametersJsonSchema using anyOf at the top level (without a 'type' field), the schema was passed as-is to the OpenAI tools format. This caused downstream providers like Anthropic to return an error: tools.1.custom.input_schema.type: Field required

The fix adds a check: if the parametersJsonSchema is a dict and does not have a top-level 'type' key, we default it to 'object', satisfying Anthropic's API requirement.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
