### PR TITLE
fix(google_genai): add type:object for anyOf parametersJsonSchema in tools transformation

### DIFF
--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -339,7 +339,12 @@ class GoogleGenAIAdapter:
                     if "description" in func_decl:
                         function_chunk["description"] = func_decl["description"]
                     if "parametersJsonSchema" in func_decl:
-                        function_chunk["parameters"] = func_decl["parametersJsonSchema"]
+                    params = func_decl["parametersJsonSchema"]
+                                        # Anthropic requires 'type': 'object' for input_schema
+                                        # Especially if 'anyOf' is present but 'type' is missing at top level
+                                        if isinstance(params, dict) and "type" not in params:
+                                                                    params["type"] = "object"
+                                                                function_chunk["parameters"] = params
 
                     openai_tool = {"type": "function", "function": function_chunk}
                     openai_tools.append(openai_tool)


### PR DESCRIPTION
## Summary

Fixes #21584

When Gemini CLI sends tools with `parametersJsonSchema` using `anyOf` at the top level (without a `type` field), the schema was passed as-is to the OpenAI tools format. This caused downstream providers like Anthropic to return an error:

```
tools.1.custom.input_schema.type: Field required
```

The fix adds a check: if `parametersJsonSchema` is a dict and does not have a top-level `type` key, default it to `'object'`, satisfying Anthropic's API requirement.

## Changes

- `litellm/google_genai/adapters/transformation.py`: Added `type: object` fallback in `_transform_google_genai_tools_to_openai` when `parametersJsonSchema` lacks a top-level `type` field
- `tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py`: Added `test_parameters_json_schema_anyof_adds_type_object` covering:
  - anyOf at top level without `type` → gets `type: object` added
  - Schema already has `type` → unchanged
  - Function without `parametersJsonSchema` → no crash

## Type

🐛 Bug Fix