### PR TITLE
fix(openai_like/utils): normalize extra_body=None to {} to prevent TypeError

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -1196,7 +1196,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 model_response._hidden_params["model"] = litellm_params.get("base_model", None)
 
             # Azure image generation API doesn't support extra_body parameter
-            extra_body = optional_params.pop("extra_body", {})
+            extra_body = optional_params.pop("extra_body", {}) or {}
             flattened_params = {**optional_params, **extra_body}
             
             base_model = litellm_params.get("base_model", None) if litellm_params else None

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -221,7 +221,7 @@ class AzureAIStudioConfig(OpenAIConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        extra_body = optional_params.pop("extra_body", {})
+        extra_body = optional_params.pop("extra_body", {}) or {}
         if extra_body and isinstance(extra_body, dict):
             optional_params.update(extra_body)
         optional_params.pop("max_retries", None)

--- a/litellm/llms/cometapi/chat/transformation.py
+++ b/litellm/llms/cometapi/chat/transformation.py
@@ -81,7 +81,7 @@ class CometAPIConfig(OpenAIGPTConfig):
         Returns:
             dict: The transformed request. Sent as the body of the API call.
         """
-        extra_body = optional_params.pop("extra_body", {})
+        extra_body = optional_params.pop("extra_body", {}) or {}
         response = super().transform_request(
             model, messages, optional_params, litellm_params, headers
         )

--- a/litellm/llms/openai_like/chat/handler.py
+++ b/litellm/llms/openai_like/chat/handler.py
@@ -254,7 +254,7 @@ class OpenAILikeChatHandler(OpenAILikeBase):
         )
 
         stream: bool = optional_params.pop("stream", None) or False
-        extra_body = optional_params.pop("extra_body", {})
+        extra_body = optional_params.pop("extra_body", {}) or {}
         json_mode = optional_params.pop("json_mode", None)
         optional_params.pop("max_retries", None)
         if not fake_stream:

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -161,7 +161,7 @@ class OpenrouterConfig(OpenAIGPTConfig):
         if self._supports_cache_control_in_content(model):
             messages = self._move_cache_control_to_content(messages)
         
-        extra_body = optional_params.pop("extra_body", {})
+        extra_body = optional_params.pop("extra_body", {}) or {}
         response = super().transform_request(
             model, messages, optional_params, litellm_params, headers
         )

--- a/litellm/llms/ovhcloud/chat/transformation.py
+++ b/litellm/llms/ovhcloud/chat/transformation.py
@@ -91,7 +91,7 @@ class OVHCloudChatConfig(OpenAIGPTConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        extra_body = optional_params.pop("extra_body", {})
+        extra_body = optional_params.pop("extra_body", {}) or {}
         response = super().transform_request(
             model, messages, optional_params, litellm_params, headers
         )

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -250,7 +250,7 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         headers: dict,
     ) -> dict:
         stream: bool = optional_params.pop("stream", None) or False
-        extra_body = optional_params.pop("extra_body", {})
+        extra_body = optional_params.pop("extra_body", {}) or {}
 
         ## TOOL CALLING
         # Transform tools from OpenAI format to Snowflake's tool_spec format

--- a/litellm/llms/watsonx/completion/transformation.py
+++ b/litellm/llms/watsonx/completion/transformation.py
@@ -232,7 +232,7 @@ class IBMWatsonXAIConfig(IBMWatsonXMixin, BaseConfig):
         self, model: str, prompt: str, optional_params: Dict
     ) -> Dict:
         """Shared logic to build request payload"""
-        extra_body_params = optional_params.pop("extra_body", {})
+        extra_body_params = optional_params.pop("extra_body", {}) or {}
         optional_params.update(extra_body_params)
         watsonx_api_params = _get_api_params(params=optional_params, model=model)
         watsonx_auth_payload = self._prepare_payload(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4644,13 +4644,13 @@ def add_provider_specific_params_to_optional_params(
             )
             is False
         ):
-            extra_body = passed_params.pop("extra_body", {})
+            extra_body = passed_params.pop("extra_body", {}) or {}
             for k in passed_params.keys():
                 if k not in openai_params and passed_params[k] is not None:
                     extra_body[k] = passed_params[k]
             optional_params.setdefault("extra_body", {})
             initial_extra_body = {
-                **optional_params["extra_body"],
+                **(optional_params.get("extra_body") or {}),
                 **extra_body,
             }
 

--- a/tests/litellm/llms/openai_like/test_extra_body_none_fix.py
+++ b/tests/litellm/llms/openai_like/test_extra_body_none_fix.py
@@ -1,0 +1,137 @@
+"""
+Unit tests for fix: normalize extra_body=None to {} to prevent TypeError
+Fixes: https://github.com/BerriAI/litellm/issues/21891
+
+When extra_body is explicitly passed as None (e.g. via litellm.responses(..., extra_body=None)),
+two code paths would crash with TypeError: 'NoneType' object is not a mapping
+when trying to unpack **extra_body or **optional_params["extra_body"].
+"""
+
+import sys
+import os
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+)
+
+import pytest
+
+
+class TestOpenAILikeChatHandlerExtraBodyNone:
+    """
+    Tests for fix in litellm/llms/openai_like/chat/handler.py:
+    extra_body = optional_params.pop("extra_body", {}) or {}
+    """
+
+    def test_transform_request_extra_body_none_does_not_raise(self):
+        """extra_body=None must not raise TypeError when building request dict."""
+        from litellm.llms.openai_like.chat.transformation import OpenAIGPTConfig
+
+        config = OpenAIGPTConfig()
+        optional_params = {
+            "stream": False,
+            "extra_body": None,  # explicitly None
+        }
+        # Should not raise TypeError: 'NoneType' object is not a mapping
+        result = config.transform_request(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+        assert isinstance(result, dict)
+        # extra_body=None should be treated as {} - no extra keys added
+        assert "extra_body" not in result
+
+    def test_transform_request_extra_body_empty_dict_works(self):
+        """extra_body={} (normal case) must continue to work."""
+        from litellm.llms.openai_like.chat.transformation import OpenAIGPTConfig
+
+        config = OpenAIGPTConfig()
+        optional_params = {
+            "stream": False,
+            "extra_body": {},
+        }
+        result = config.transform_request(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+        assert isinstance(result, dict)
+
+    def test_transform_request_extra_body_with_dict_merges(self):
+        """extra_body with real keys should still be merged into request."""
+        from litellm.llms.openai_like.chat.transformation import OpenAIGPTConfig
+
+        config = OpenAIGPTConfig()
+        optional_params = {
+            "stream": False,
+            "extra_body": {"custom_param": "custom_value"},
+        }
+        result = config.transform_request(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+        assert isinstance(result, dict)
+        assert result.get("custom_param") == "custom_value"
+
+
+class TestAddProviderSpecificParamsExtraBodyNone:
+    """
+    Tests for fix in litellm/utils.py: add_provider_specific_params_to_optional_params()
+    """
+
+    def test_get_optional_params_extra_body_none_does_not_raise(self):
+        """get_optional_params with extra_body=None must not raise TypeError."""
+        import litellm
+
+        # Should not raise TypeError: 'NoneType' object is not a mapping
+        result = litellm.utils.get_optional_params(
+            model="gpt-4o",
+            custom_llm_provider="openai",
+            extra_body=None,  # explicitly None
+        )
+        assert isinstance(result, dict)
+        # extra_body=None should produce empty extra_body or no extra_body key
+        extra_body = result.get("extra_body", {})
+        assert extra_body == {} or extra_body is None
+
+    def test_get_optional_params_extra_body_empty_dict_works(self):
+        """get_optional_params with extra_body={} must continue to work."""
+        import litellm
+
+        result = litellm.utils.get_optional_params(
+            model="gpt-4o",
+            custom_llm_provider="openai",
+            extra_body={},
+        )
+        assert isinstance(result, dict)
+
+    def test_get_optional_params_extra_body_none_for_hosted_vllm(self):
+        """get_optional_params with extra_body=None for hosted_vllm (openai_compatible_providers) must not raise."""
+        import litellm
+
+        # Should not raise TypeError
+        result = litellm.utils.get_optional_params(
+            model="gpt-4o",
+            custom_llm_provider="hosted_vllm",
+            extra_body=None,
+        )
+        assert isinstance(result, dict)
+
+    def test_get_optional_params_extra_body_none_for_openrouter(self):
+        """get_optional_params with extra_body=None for openrouter must not raise."""
+        import litellm
+
+        result = litellm.utils.get_optional_params(
+            model="gpt-4o",
+            custom_llm_provider="openrouter",
+            extra_body=None,
+        )
+        assert isinstance(result, dict)


### PR DESCRIPTION
## Relevant issues

Fixes #21891

## What changed

When `extra_body` is explicitly passed as `None` (e.g. via `litellm.responses(..., extra_body=None)`), two code paths would crash with `TypeError: 'NoneType' object is not a mapping` when trying to unpack `**extra_body` or `**optional_params["extra_body"]`.

### Fix 1 — `litellm/llms/openai_like/chat/handler.py`

Normalize `extra_body` after popping from `optional_params`:
```python
# Before
extra_body = optional_params.pop("extra_body", {})
# After
extra_body = optional_params.pop("extra_body", {}) or {}
```

### Fix 2 — `litellm/utils.py` (`add_provider_specific_params_to_optional_params`)

1. Normalize `extra_body` from `passed_params`:
```python
# Before
extra_body = passed_params.pop("extra_body", {})
# After
extra_body = passed_params.pop("extra_body", {}) or {}
```

2. Guard against `optional_params["extra_body"]` being `None` when merging:
```python
# Before
initial_extra_body = {**optional_params["extra_body"], **extra_body,}
# After
initial_extra_body = {**(optional_params.get("extra_body") or {}), **extra_body,}
```

## Testing

- All existing tests pass
- Fixes `TypeError: 'NoneType' object is not a mapping` when `extra_body=None` is passed to OpenAI-compatible providers (including `hosted_vllm`) via Router or `/responses` endpoint

## Additional fixes (greptile-bot recommendations)

Applied the same `or {}` normalization to all other providers with the identical vulnerable pattern:

- `litellm/llms/snowflake/chat/transformation.py`
- `litellm/llms/ovhcloud/chat/transformation.py`
- `litellm/llms/cometapi/chat/transformation.py`
- `litellm/llms/openrouter/chat/transformation.py`
- `litellm/llms/azure/azure.py` (image generation)
- `litellm/llms/azure_ai/chat/transformation.py`
- `litellm/llms/watsonx/completion/transformation.py`

Added unit tests in `tests/litellm/llms/openai_like/test_extra_body_none_fix.py` covering:
- `extra_body=None` does not raise TypeError (OpenAI-like handler)
- `extra_body={}` (empty dict) continues to work
- `extra_body={...}` with real keys is correctly merged
- `get_optional_params` with `extra_body=None` for openai, hosted_vllm, openrouter providers