### PR TITLE
fix: Add PROXY_ADMIN role to system user for key rotation

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2410,6 +2410,7 @@ class UserAPIKeyAuth(
             key_alias=LITELLM_INTERNAL_JOBS_SERVICE_ACCOUNT_NAME,
             team_alias="system",
             user_id="system",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
         )
 
 

--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -45,3 +45,27 @@ def test_audit_log_masking():
     json_before_value = json.loads(audit_log.before_value)
     assert json_before_value["token"] == "1q2132r222"
     assert json_before_value["key"] == "sk-1*****7890"
+
+
+def test_internal_jobs_user_has_proxy_admin_role():
+    """
+    Test that the internal jobs system user has PROXY_ADMIN role.
+    
+    This is critical for key rotation to work properly. The system user needs
+    PROXY_ADMIN role to bypass team permission checks in
+    TeamMemberPermissionChecks.can_team_member_execute_key_management_endpoint()
+    
+    Regression test for: https://github.com/BerriAI/litellm/pull/21896
+    """
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+
+    # Get the system user used for internal jobs like key rotation
+    system_user = UserAPIKeyAuth.get_litellm_internal_jobs_user_api_key_auth()
+
+    # Verify the system user has PROXY_ADMIN role
+    assert system_user.user_role == LitellmUserRoles.PROXY_ADMIN
+    
+    # Verify other expected properties
+    assert system_user.user_id == "system"
+    assert system_user.team_id == "system"
+    assert system_user.team_alias == "system"


### PR DESCRIPTION
Fixes key rotation authorization issue for team keys

## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] Fix has been verified with test script confirming system user has PROXY_ADMIN role
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)
> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  Link:
- [ ] **CI run for the last commit**  Link:
- [ ] **Merge / cherry-pick CI run**  Links:

## Type
🐛 Bug Fix

## Changes

### Problem
The key rotation worker fails with authorization error when attempting to rotate team keys:
```
You are not authorized to regenerate this key
```

### Root Cause
The system user created by `UserAPIKeyAuth.get_litellm_internal_jobs_user_api_key_auth()` was missing the `user_role` field. Without `user_role=PROXY_ADMIN`, the system user couldn't bypass team permission checks in `can_team_member_execute_key_management_endpoint()`, causing authorization failures.

### Solution
Added `user_role=LitellmUserRoles.PROXY_ADMIN` to the system user in `litellm/proxy/_types.py`. This allows the internal key rotation worker to bypass team permission checks and successfully rotate keys for all teams.

### Reproduction Steps
1. Enable key rotation:
   ```bash
   export LITELLM_KEY_ROTATION_ENABLED=true
   export LITELLM_KEY_ROTATION_CHECK_INTERVAL_SECONDS=60
   ```

2. Create a team key with auto-rotation:
   ```bash
   curl -X POST http://localhost:4000/key/generate \
     -H "Authorization: Bearer sk-1234" \
     -H "Content-Type: application/json" \
     -d '{
       "team_id": "team-123",
       "auto_rotate": true,
       "rotation_interval": "30d"
     }'
   ```

3. Wait for rotation worker to run → observe authorization error

### Files Modified
- `litellm/proxy/_types.py`: Added `user_role=LitellmUserRoles.PROXY_ADMIN` to system user (1 line change)

### Impact
- Fixes automated key rotation for team keys
- Minimal change with no side effects (system user only used by key rotation worker)