### PR TITLE
Fix timezone_utils: avoid circular import in get_budget_reset_timezone

### DIFF
--- a/litellm/proxy/common_utils/timezone_utils.py
+++ b/litellm/proxy/common_utils/timezone_utils.py
@@ -5,18 +5,12 @@ from litellm.litellm_core_utils.duration_parser import get_next_standardized_res
 
 def get_budget_reset_timezone():
     """
-    Get the budget reset timezone from general_settings.
+    Get the budget reset timezone from litellm module attributes.
     Falls back to UTC if not specified.
     """
-    # Import at function level to avoid circular imports
-    from litellm.proxy.proxy_server import general_settings
+    import litellm
 
-    if general_settings:
-        litellm_settings = general_settings.get("litellm_settings", {})
-        if litellm_settings and "timezone" in litellm_settings:
-            return litellm_settings["timezone"]
-
-    return "UTC"
+    return getattr(litellm, "timezone", None) or "UTC"
 
 
 def get_budget_reset_time(budget_duration: str):

--- a/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
@@ -41,7 +41,7 @@ def test_get_budget_reset_time():
 
 class TestGetBudgetResetTimezone:
     """
-    Tests for get_budget_reset_time()
+    Tests for get_budget_reset_timezone()
     """
 
     def test_returns_utc_when_timezone_not_set(self):
@@ -72,7 +72,7 @@ class TestGetBudgetResetTimezone:
         has_attr = hasattr(litellm, "timezone")
 
         try:
-            litellm.timezone = original
+            litellm.timezone = None
             assert get_budget_reset_timezone() == "UTC"
         finally:
             if has_attr:
@@ -116,4 +116,3 @@ class TestGetBudgetResetTimezone:
                 litellm.timezone = original
             elif hasattr(litellm, "timezone"):
                 delattr(litellm, "timezone")
-        

--- a/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -12,7 +13,10 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+from litellm.proxy.common_utils.timezone_utils import (
+    get_budget_reset_time,
+    get_budget_reset_timezone,
+)
 
 
 def test_get_budget_reset_time():
@@ -33,3 +37,83 @@ def test_get_budget_reset_time():
 
     # Verify budget_reset_at is set to first of next month
     assert get_budget_reset_time(budget_duration="1mo") == expected_reset_at
+
+
+class TestGetBudgetResetTimezone:
+    """
+    Tests for get_budget_reset_time()
+    """
+
+    def test_returns_utc_when_timezone_not_set(self):
+        """
+        When litellm.timezone is not set, the function returns UTC. 
+        """
+
+        import litellm
+
+        if hasattr(litellm, "timezone"):
+            original = litellm.timezone
+            delattr(litellm, "timezone")
+            try:
+                assert get_budget_reset_timezone() == "UTC"
+            finally:
+                litellm.timezone = original
+        else:
+            assert get_budget_reset_timezone() == "UTC"
+
+    def test_returns_utc_when_timezone_is_none(self):
+        """
+        When litellm.timezone is None, the function returns UTC. 
+        """
+
+        import litellm
+
+        original = getattr(litellm, "timezone", None)
+        has_attr = hasattr(litellm, "timezone")
+
+        try:
+            litellm.timezone = original
+            assert get_budget_reset_timezone() == "UTC"
+        finally:
+            if has_attr:
+                litellm.timezone = original
+            elif hasattr(litellm, "timezone"):
+                delattr(litellm, "timezone")
+    
+    def test_returns_cofigured_timezone(self):
+        """
+        When litellm.timezone is any timezone ( Asia/Tokyo etc. ), the function returns connfigured value. 
+        """
+
+        import litellm
+
+        original = getattr(litellm, "timezone", None)
+        has_attr = hasattr(litellm, "timezone")
+
+        try:
+            litellm.timezone = "Asia/Tokyo"
+            assert get_budget_reset_timezone() == "Asia/Tokyo"
+        finally:
+            if has_attr:
+                litellm.timezone = original
+            elif hasattr(litellm, "timezone"):
+                delattr(litellm, "timezone")
+
+    def test_returns_empty_string_fails_back_to_utc(self):
+        """
+        When litellm.timezone is empty, the function returns UTC. 
+        """
+        import litellm
+
+        original = getattr(litellm, "timezone", None)
+        has_attr = hasattr(litellm, "timezone")
+
+        try:
+            litellm.timezone = ""
+            assert get_budget_reset_timezone() == "UTC"
+        finally:
+            if has_attr:
+                litellm.timezone = original
+            elif hasattr(litellm, "timezone"):
+                delattr(litellm, "timezone")
+        

--- a/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
@@ -4,7 +4,6 @@ import os
 import sys
 import time
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -80,7 +79,7 @@ class TestGetBudgetResetTimezone:
             elif hasattr(litellm, "timezone"):
                 delattr(litellm, "timezone")
     
-    def test_returns_cofigured_timezone(self):
+    def test_returns_configured_timezone(self):
         """
         When litellm.timezone is any timezone ( Asia/Tokyo etc. ), the function returns connfigured value. 
         """


### PR DESCRIPTION
## Relevant issues

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [✓ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [✓ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ✓] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ✓] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
`get_budget_reset_timezone()`  imported `general_settings` from `proxy_server`, which cloud case circular imports

### Fix
- Read `litellm.timezone` module attribute directory via `getattr` instead of importing `general_settings`
- Fall back to `"UTC"` when the attribute is unset, `None`, or empty string 


### Tests
- Added 4 test cases in `TestGetBudgetResetTimezone`:
   - timezone not set -> returns UTC
   - timezone is `None` -> returns UTC
   - timezone is configured -> returns that value
   - timezone is empty string -> returns UTC 