### PR TITLE
feat(bedrock): add context_management support for Anthropic models

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -874,7 +874,7 @@ class AmazonConverseConfig(BaseConfig):
         ):
             optional_params["fake_stream"] = True
 
-    def map_openai_params(
+    def map_openai_params(  # noqa: PLR0915
         self,
         non_default_params: dict,
         optional_params: dict,

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -947,9 +947,15 @@ class AmazonConverseConfig(BaseConfig):
                     optional_params = self._add_tools_to_optional_params(
                         optional_params=optional_params, tools=[grounding_tool]
                     )
-            if param == "context_management" and isinstance(value, dict):
-                # Pass through Anthropic-specific context_management parameter
-                optional_params["context_management"] = value
+            if param == "context_management" and isinstance(value, (list, dict)):
+                # Supports both OpenAI list format and Anthropic dict format
+                anthropic_context_management = (
+                    AnthropicConfig.map_openai_context_management_to_anthropic(value)
+                )
+                if anthropic_context_management is not None:
+                    optional_params["context_management"] = (
+                        anthropic_context_management
+                    )
 
         # Only update thinking tokens for non-GPT-OSS models and non-Nova-Lite-2 models
         # Nova 2 handles token budgeting differently through reasoningConfig

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -577,6 +577,11 @@ class AmazonConverseConfig(BaseConfig):
         ):
             supported_params.append("thinking")
             supported_params.append("reasoning_effort")
+
+        # Anthropic models on Bedrock support context_management
+        if base_model.startswith("anthropic"):
+            supported_params.append("context_management")
+
         return supported_params
 
     def map_tool_choice_values(
@@ -942,6 +947,9 @@ class AmazonConverseConfig(BaseConfig):
                     optional_params = self._add_tools_to_optional_params(
                         optional_params=optional_params, tools=[grounding_tool]
                     )
+            if param == "context_management" and isinstance(value, dict):
+                # Pass through Anthropic-specific context_management parameter
+                optional_params["context_management"] = value
 
         # Only update thinking tokens for non-GPT-OSS models and non-Nova-Lite-2 models
         # Nova 2 handles token budgeting differently through reasoningConfig


### PR DESCRIPTION
## Summary

Fixes #21912

- Add `context_management` to `AmazonConverseConfig.get_supported_openai_params()` for Anthropic models on Bedrock
- Add pass-through handling in `map_openai_params()` so the parameter flows into `additionalModelRequestFields`

The beta header (`context-management-2025-06-27`) is already marked as supported for `bedrock_converse` in `anthropic_beta_headers_config.json`, so no changes needed there.

## Context

After upgrading from v1.80.5 to v1.81.x, `context_management` started being rejected for Bedrock Anthropic models with `UnsupportedParamsError`. In v1.80.5 the param was silently dropped because it wasn't in `DEFAULT_CHAT_COMPLETION_PARAM_VALUES`. In v1.81.x it was added there and to the Anthropic provider — but not to the Bedrock Converse config.

## Test plan

- [ ] Verify `context_management` param is accepted for Bedrock Anthropic models (e.g. `bedrock/eu.anthropic.claude-sonnet-4-6`)
- [ ] Verify `context_management` flows into `additionalModelRequestFields` in the Bedrock Converse request
- [ ] Verify non-Anthropic Bedrock models are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)