### PR TITLE
feat(router): add force_non_streaming per-deployment config

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1802,6 +1802,17 @@ class Router:
             }
             input_kwargs.pop("silent_model", None)
 
+            # If the deployment config specifies force_non_streaming=True,
+            # override the client's stream parameter. This is needed when
+            # the backend doesn't support streaming properly (e.g., vLLM
+            # streaming doesn't emit tool_use events for Anthropic format).
+            # See: https://github.com/BerriAI/litellm/issues/5416
+            if litellm_params.get("force_non_streaming") is True:
+                input_kwargs["stream"] = False
+                input_kwargs.pop("force_non_streaming", None)
+            else:
+                input_kwargs.pop("force_non_streaming", None)
+
             _response = litellm.acompletion(**input_kwargs)
 
             logging_obj: Optional[LiteLLMLogging] = kwargs.get(
@@ -3516,13 +3527,22 @@ class Router:
                 kwargs=kwargs, model=model, model_name=model_name
             )
             ### get custom
-            response = original_generic_function(
-                **{
-                    **data,
-                    "caching": self.cache_responses,
-                    **kwargs,
-                }
-            )
+            _merged_kwargs = {
+                **data,
+                "caching": self.cache_responses,
+                **kwargs,
+            }
+
+            # If the deployment config specifies force_non_streaming=True,
+            # override the client's stream parameter. This is needed when
+            # the backend doesn't support streaming properly (e.g., vLLM
+            # streaming doesn't emit tool_use events for Anthropic format).
+            # See: https://github.com/BerriAI/litellm/issues/5416
+            if data.get("force_non_streaming") is True:
+                _merged_kwargs["stream"] = False
+            _merged_kwargs.pop("force_non_streaming", None)
+
+            response = original_generic_function(**_merged_kwargs)
 
             rpm_semaphore = self._get_client(
                 deployment=deployment,
@@ -3607,14 +3627,23 @@ class Router:
             except Exception:
                 custom_llm_provider = None
 
-            response = original_function(
-                **{
-                    **data,
-                    "custom_llm_provider": custom_llm_provider,
-                    "caching": self.cache_responses,
-                    **kwargs,
-                }
-            )
+            _merged_kwargs = {
+                **data,
+                "custom_llm_provider": custom_llm_provider,
+                "caching": self.cache_responses,
+                **kwargs,
+            }
+
+            # If the deployment config specifies force_non_streaming=True,
+            # override the client's stream parameter. This is needed when
+            # the backend doesn't support streaming properly (e.g., vLLM
+            # streaming doesn't emit tool_use events for Anthropic format).
+            # See: https://github.com/BerriAI/litellm/issues/5416
+            if data.get("force_non_streaming") is True:
+                _merged_kwargs["stream"] = False
+            _merged_kwargs.pop("force_non_streaming", None)
+
+            response = original_function(**_merged_kwargs)
 
             self.success_calls[model_name] += 1
             verbose_router_logger.info(

--- a/tests/test_litellm/test_router_force_non_streaming.py
+++ b/tests/test_litellm/test_router_force_non_streaming.py
@@ -1,0 +1,161 @@
+"""
+Test force_non_streaming litellm_params option.
+
+When a deployment specifies `force_non_streaming: True` in its litellm_params,
+the router should override `stream=True` from the client request to `stream=False`
+before calling the LLM API. This is needed when backends don't support streaming
+properly (e.g., vLLM streaming doesn't emit tool_use events for Anthropic format).
+
+See: https://github.com/BerriAI/litellm/issues/5416
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm
+
+
+@pytest.fixture
+def router_with_force_non_streaming():
+    """Create a router with one deployment that has force_non_streaming=True."""
+    return litellm.Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "openai/test-model",
+                    "api_key": "fake-key",
+                    "api_base": "http://localhost:8000",
+                    "force_non_streaming": True,
+                },
+            }
+        ],
+    )
+
+
+@pytest.fixture
+def router_without_force_non_streaming():
+    """Create a router with a normal deployment (no force_non_streaming)."""
+    return litellm.Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "openai/test-model",
+                    "api_key": "fake-key",
+                    "api_base": "http://localhost:8000",
+                },
+            }
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_non_streaming_overrides_stream_true(
+    router_with_force_non_streaming,
+):
+    """
+    When force_non_streaming=True in litellm_params and client sends stream=True,
+    the actual call to litellm.acompletion should have stream=False.
+    """
+    captured_kwargs = {}
+
+    async def mock_acompletion(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        # Return a minimal mock response
+        return litellm.ModelResponse(
+            id="test",
+            choices=[
+                {
+                    "message": {"role": "assistant", "content": "test"},
+                    "index": 0,
+                    "finish_reason": "stop",
+                }
+            ],
+            model="test-model",
+        )
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        await router_with_force_non_streaming.acompletion(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=True,  # Client wants streaming
+        )
+
+    # The router should have overridden stream to False
+    assert captured_kwargs.get("stream") is False
+    # force_non_streaming should NOT be passed through to the LLM call
+    assert "force_non_streaming" not in captured_kwargs
+
+
+@pytest.mark.asyncio
+async def test_normal_streaming_preserved_without_force(
+    router_without_force_non_streaming,
+):
+    """
+    When force_non_streaming is NOT set, stream=True should be preserved.
+    """
+    captured_kwargs = {}
+
+    async def mock_acompletion(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return litellm.ModelResponse(
+            id="test",
+            choices=[
+                {
+                    "message": {"role": "assistant", "content": "test"},
+                    "index": 0,
+                    "finish_reason": "stop",
+                }
+            ],
+            model="test-model",
+        )
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        await router_without_force_non_streaming.acompletion(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=True,
+        )
+
+    # stream=True should be preserved
+    assert captured_kwargs.get("stream") is True
+
+
+@pytest.mark.asyncio
+async def test_force_non_streaming_not_passed_to_llm(
+    router_with_force_non_streaming,
+):
+    """
+    force_non_streaming should be consumed by the router and NOT passed
+    through to the underlying litellm.acompletion call.
+    """
+    captured_kwargs = {}
+
+    async def mock_acompletion(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return litellm.ModelResponse(
+            id="test",
+            choices=[
+                {
+                    "message": {"role": "assistant", "content": "test"},
+                    "index": 0,
+                    "finish_reason": "stop",
+                }
+            ],
+            model="test-model",
+        )
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        await router_with_force_non_streaming.acompletion(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=False,  # Even without stream=True, force_non_streaming should not leak
+        )
+
+    assert "force_non_streaming" not in captured_kwargs


### PR DESCRIPTION
## Summary

When a backend doesn't support streaming properly (e.g., vLLM's Anthropic-compatible `/v1/messages` endpoint doesn't emit proper `tool_use` SSE events during streaming, falling back to XML `<tool_call>` text deltas), there's currently no way to force non-streaming at the deployment level.

Setting `stream: false` in `litellm_params` doesn't work because the router merges kwargs with `{**litellm_params, ..., **kwargs}`, so the client's `stream=True` always overwrites the deployment config.

This PR adds a `force_non_streaming: True` option in `litellm_params` that the router explicitly checks *after* the kwargs merge to override `stream` back to `False`. The parameter is consumed by the router and never leaked to the downstream LLM call.

### Usage

```yaml
model_list:
  - model_name: my-vllm-model
    litellm_params:
      model: openai/my-model
      api_base: http://vllm:8000
      force_non_streaming: true  # Forces stream=false regardless of client request
```

### Changes

- **`litellm/router.py`**: Check `force_non_streaming` after kwargs merge in `_acompletion`, `_ageneric_api_call_with_fallbacks_helper`, and `_generic_api_call_with_fallbacks`
- **`tests/test_litellm/test_router_force_non_streaming.py`**: 3 test cases covering override behavior, normal streaming preservation, and parameter non-leakage

### Test plan

- [ ] `force_non_streaming=True` with `stream=True` → actual call gets `stream=False`
- [x] Without `force_non_streaming`, `stream=True` preserved normally
- [x] `force_non_streaming` never passed through to underlying LLM call
- [x] All existing router tests unaffected

Fixes #5416