### PR TITLE
fix: drop_params not dropping temperature for gpt-5.2-chat models

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -36,15 +36,15 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
     
     @classmethod
     def is_model_gpt_5_1_model(cls, model: str) -> bool:
-        """Check if the model is a gpt-5.1 or gpt-5.2 chat variant.
-        
+        """Check if the model is a gpt-5.1 or gpt-5.2 reasoning variant.
+
         gpt-5.1/5.2 support temperature when reasoning_effort="none",
         unlike base gpt-5 which only supports temperature=1. Excludes
-        pro variants which keep stricter knobs.
+        pro and chat variants which don't support flexible temperature.
         """
-        model_name = model.split("/")[-1]
-        is_gpt_5_1 = model_name.startswith("gpt-5.1")
-        is_gpt_5_2 = model_name.startswith("gpt-5.2") and "pro" not in model_name
+        model_name = model.split("/")[-1]  # handle provider prefixes
+        is_gpt_5_1 = model_name.startswith("gpt-5.1") and "-chat" not in model_name
+        is_gpt_5_2 = model_name.startswith("gpt-5.2") and "pro" not in model_name and "-chat" not in model_name
         return is_gpt_5_1 or is_gpt_5_2
 
     @classmethod


### PR DESCRIPTION
## Summary

Fixes #21911

`drop_params: true` was not dropping `temperature` for `gpt-5.2-chat` / `gpt-5.2-chat-latest` models. The root cause was that `is_model_gpt_5_1_model()` incorrectly classified `-chat` variants (e.g. `gpt-5.2-chat-latest`) as reasoning models, which allowed any temperature value through when `reasoning_effort` was `None`.

## Changes

- **`litellm/llms/openai/chat/gpt_5_transformation.py`**: Added `-chat` exclusion to both `is_gpt_5_1` and `is_gpt_5_2` checks in `is_model_gpt_5_1_model()`, so chat variants are no longer treated as reasoning models with flexible temperature support.
- **`tests/test_litellm/llms/openai/test_gpt5_transformation.py`**: Updated model detection test and added 5 new tests covering `gpt-5.2-chat` temperature handling (drop, error, temperature=1 allowed, base model unaffected).

## Root Cause

`is_model_gpt_5_1_model()` checked `model_name.startswith("gpt-5.2") and "pro" not in model_name` - this matched `gpt-5.2-chat-latest` because it starts with `gpt-5.2` and doesn't contain `pro`. The method is used in `map_openai_params()` to allow any temperature when `reasoning_effort` is `None`, so `gpt-5.2-chat` was getting the reasoning model's temperature bypass instead of being treated as a regular chat model.

## Test Plan

- [x] `test_gpt5_2_chat_temperature_drop` - temperature dropped with `drop_params=True`
- [x] `test_gpt5_2_chat_latest_temperature_drop` - same for `-latest` variant
- [x] `test_gpt5_2_chat_temperature_error` - raises `UnsupportedParamsError` with `drop_params=False`
- [x] `test_gpt5_2_chat_temperature_one_allowed` - `temperature=1` still works
- [x] `test_gpt5_2_base_still_allows_temperature` - `gpt-5.2` reasoning model unaffected
- [x] All 36 existing tests pass
