### PR TITLE
perf(spendlogs): optimize old spendlog deletion cron job

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -500,6 +500,7 @@ model LiteLLM_SpendLogs {
   agent_id            String?
   proxy_server_request Json?     @default("{}")
   @@index([startTime])
+  @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
 }

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -499,6 +499,7 @@ model LiteLLM_SpendLogs {
   agent_id            String?
   proxy_server_request Json?     @default("{}")
   @@index([startTime])
+  @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
 }


### PR DESCRIPTION
## Relevant issues

Fixes an issue where the background cron job responsible for cleaning up old `spendlogs` would consistently trigger database timeouts and High Memory usage alerts in production. 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:
- [ ] **CI run for the last commit**  
       Link:
- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

1. **Database Infrastructure:** Added a composite index `@@index([startTime, request_id])` to the `LiteLLM_SpendLogs` model in [schema.prisma](cci:7://file:///d:/OSS/litellm/schema.prisma:0:0-0:0) and `litellm_proxy_extras`. This enables Postgres to perform an Index-Only Scan when looking up request IDs by time, completely eliminating massive heap-reads of JSON payload columns.
2. **Code Implementation:** Rewrote the cron job deletion logic in [spend_log_cleanup.py](cci:7://file:///d:/OSS/litellm/tests/test_litellm/proxy/test_spend_log_cleanup.py:0:0-0:0). Replaced the fetching of 10,000 full rows to application memory (`find_many()`) followed by a separate deletion (`delete_many()`), with a single, highly-optimized raw SQL `DELETE` correlated subquery (`execute_raw`).
3. **Tests:** Updated existing mocks in `test_spend_log_cleanup.py` to assert the correct execution signatures for `execute_raw`.
