### PR TITLE
fix(test): correct file path for model_prices_and_context_window.json in test

### DIFF
--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -577,6 +577,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
 
     If this test fails after you update the json, you need to update the schema or correct the change you made.
     """
+    from pathlib import Path
 
     INTENDED_SCHEMA = {
         "type": "object",

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -808,8 +808,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
         },
     }
 
-    prod_json = "litellm/model_prices_and_context_window.json"
-    # prod_json = "../../model_prices_and_context_window.json"
+    prod_json = "./model_prices_and_context_window.json"
     with open(prod_json, "r") as model_prices_file:
         actual_json = json.load(model_prices_file)
     assert isinstance(actual_json, dict)

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -808,7 +808,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
         },
     }
 
-    prod_json = "./model_prices_and_context_window.json"
+    prod_json = str(Path(__file__).parent.parent.parent / "model_prices_and_context_window.json")
     with open(prod_json, "r") as model_prices_file:
         actual_json = json.load(model_prices_file)
     assert isinstance(actual_json, dict)


### PR DESCRIPTION
## Summary

- **Fix `test_aaamodel_prices_and_context_window_json_is_valid` failure** caused by an incorrect file path introduced in commit 2f8d36be1b.
- The model_prices_and_context_window.json file was moved to the repository root (in commit c5151aa), but the test path was incorrectly changed to litellm/model_prices_and_context_window.json which does not exist. This fix uses Path(__file__)-based resolution to correctly locate the file, consistent with other tests in the same file.

## Changes

`tests/test_litellm/test_utils.py`:
```diff
+    from pathlib import Path
+    ...
-    prod_json = "litellm/model_prices_and_context_window.json"
-    # prod_json = "../../model_prices_and_context_window.json"
+    prod_json = str(Path(__file__).parent.parent.parent / "model_prices_and_context_window.json")
```

## Test plan

- [x] The `test (root)` CI job should now pass (this test was failing with `FileNotFoundError`)
- [x] No other files are affected — this is a 1-line path fix