### PR TITLE
fix(tests): use absolute path for model_prices JSON validation test

### DIFF
--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -808,7 +808,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
         },
     }
 
-    prod_json = os.path.join(os.path.dirname(__file__), "..", "..", "model_prices_and_context_window.json")
+    prod_json = Path(__file__).parent.parent.parent / "model_prices_and_context_window.json"
     with open(prod_json, "r") as model_prices_file:
         actual_json = json.load(model_prices_file)
     assert isinstance(actual_json, dict)

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -808,7 +808,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
         },
     }
 
-    prod_json = Path(__file__).parent.parent.parent / "model_prices_and_context_window.json"
+    prod_json = os.path.join(os.path.dirname(__file__), "..", "..", "model_prices_and_context_window.json")
     with open(prod_json, "r") as model_prices_file:
         actual_json = json.load(model_prices_file)
     assert isinstance(actual_json, dict)

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -808,8 +808,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
         },
     }
 
-    prod_json = "litellm/model_prices_and_context_window.json"
-    # prod_json = "../../model_prices_and_context_window.json"
+    prod_json = os.path.join(os.path.dirname(__file__), "..", "..", "model_prices_and_context_window.json")
     with open(prod_json, "r") as model_prices_file:
         actual_json = json.load(model_prices_file)
     assert isinstance(actual_json, dict)


### PR DESCRIPTION
## Summary
- Fixed `test_aaamodel_prices_and_context_window_json_is_valid` failing with `FileNotFoundError` when pytest working directory differs from repo root
- The test used a hardcoded relative path `'litellm/model_prices_and_context_window.json'` — replaced with `os.path.join(os.path.dirname(__file__), ...)` to resolve reliably regardless of CWD

## Test plan
- [x] Test passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)