### PR TITLE
fix(tests): add INCOMPLETE to interactions status enum expected values

### DIFF
--- a/litellm/types/interactions/generated.py
+++ b/litellm/types/interactions/generated.py
@@ -392,6 +392,7 @@ class Status3(Enum):
     COMPLETED = 'COMPLETED'
     FAILED = 'FAILED'
     CANCELLED = 'CANCELLED'
+    INCOMPLETE = 'INCOMPLETE'
 
 
 class ModelOption(RootModel[str]):

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -148,7 +148,7 @@ class TestResponseCompliance:
         schema = spec_dict["components"]["schemas"]["CreateModelInteractionParams"]
         status_prop = schema["properties"]["status"]
         
-        expected_statuses = ["UNSPECIFIED", "IN_PROGRESS", "REQUIRES_ACTION", "COMPLETED", "FAILED", "CANCELLED"]
+        expected_statuses = ["UNSPECIFIED", "IN_PROGRESS", "REQUIRES_ACTION", "COMPLETED", "FAILED", "CANCELLED", "INCOMPLETE"]
         assert status_prop["enum"] == expected_statuses
         print(f"✓ Status enum values: {expected_statuses}")
 


### PR DESCRIPTION
## Summary
- Google added `INCOMPLETE` to the Interactions API OpenAPI spec status enum
- Updated the hardcoded expected values in `test_status_enum_values` to match the live spec

## Test plan
- [x] Verified against live spec at https://ai.google.dev/static/api/interactions.openapi.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)