### PR TITLE
feat: add groq/openai/gpt-oss-safeguard-20b model pricing

### DIFF
--- a/docs/my-website/docs/providers/groq.md
+++ b/docs/my-website/docs/providers/groq.md
@@ -159,6 +159,7 @@ We support ALL Groq models, just set `groq/` as a prefix when sending completion
 | moonshotai/kimi-k2-instruct-0905 | `completion(model="groq/moonshotai/kimi-k2-instruct-0905", messages)` |
 | openai/gpt-oss-120b | `completion(model="groq/openai/gpt-oss-120b", messages)` |
 | openai/gpt-oss-20b | `completion(model="groq/openai/gpt-oss-20b", messages)` |
+| openai/gpt-oss-safeguard-20b | `completion(model="groq/openai/gpt-oss-safeguard-20b", messages)` |
 
 ## Groq - Tool / Function Calling Example
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -21238,6 +21238,21 @@
         "supports_tool_choice": true,
         "supports_web_search": true
     },
+    "groq/openai/gpt-oss-safeguard-20b": {
+        "cache_read_input_token_cost": 3.7e-08,
+        "input_cost_per_token": 7.5e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 3e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_web_search": true
+    },
     "groq/playai-tts": {
         "input_cost_per_character": 5e-05,
         "litellm_provider": "groq",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21238,6 +21238,21 @@
         "supports_tool_choice": true,
         "supports_web_search": true
     },
+    "groq/openai/gpt-oss-safeguard-20b": {
+        "cache_read_input_token_cost": 3.7e-08,
+        "input_cost_per_token": 7.5e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 3e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_web_search": true
+    },
     "groq/playai-tts": {
         "input_cost_per_character": 5e-05,
         "litellm_provider": "groq",


### PR DESCRIPTION
## Pre-Submission checklist

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory — N/A, this is a data-only change
- [X] My PR passes all unit tests on [`make test-unit`](https://github.com/BerriAI/litellm/blob/main/Makefile#L5)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Adds pricing and context window data for `groq/openai/gpt-oss-safeguard-20b` — OpenAI's first open-weight reasoning model trained for safety classification tasks, now available on Groq.

| Field | Value |
|---|---|
| Input cost | $0.075 / 1M tokens |
| Cached input cost | $0.0375 / 1M tokens |
| Output cost | $0.30 / 1M tokens |
| Context window | 131,072 tokens |
| Max output tokens | 65,536 tokens |

Updated both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`.

Reference: https://console.groq.com/docs/model/openai/gpt-oss-safeguard-20b