### PR TITLE
fix: populate hidden_params in metadata for streaming requestt

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1666,33 +1666,54 @@ class Logging(LiteLLMLoggingBaseClass):
         logging_result,
         start_time,
         end_time,
+        should_emit: bool = True,
     ):
-        hidden_params = getattr(logging_result, "_hidden_params", {})
-        if hidden_params:
-            if self.model_call_details.get("litellm_params") is not None:
-                self.model_call_details["litellm_params"].setdefault("metadata", {})
-                if self.model_call_details["litellm_params"]["metadata"] is None:
-                    self.model_call_details["litellm_params"]["metadata"] = {}
-                self.model_call_details["litellm_params"]["metadata"]["hidden_params"] = getattr(logging_result, "_hidden_params", {})  # type: ignore
+        """
+        Populate litellm_params.metadata.hidden_params, compute/attach response_cost,
+        build the standard logging payload, and (optionally) emit it.
 
-        if self.model_call_details.get("cache_hit") is True:
-            self.model_call_details["response_cost"] = 0.0
-        elif "response_cost" in hidden_params:
-            self.model_call_details["response_cost"] = hidden_params["response_cost"]
-        elif self.model_call_details.get("response_cost") is not None:
-            # Preserve response_cost if already calculated (e.g., by pass-through
-            # handlers like Gemini/Vertex which call completion_cost directly)
-            pass
-        else:
-            self.model_call_details["response_cost"] = self._response_cost_calculator(
-                result=logging_result
+        This is used by both streaming and non-streaming paths to ensure consistent
+        behavior.
+        """
+        hidden_params = getattr(logging_result, "_hidden_params", {}) or {}
+
+        # 1) Persist hidden_params to litellm_params.metadata for OTEL / callbacks
+        if hidden_params and self.model_call_details.get("litellm_params") is not None:
+            self.model_call_details["litellm_params"].setdefault("metadata", {})
+            if self.model_call_details["litellm_params"]["metadata"] is None:
+                self.model_call_details["litellm_params"]["metadata"] = {}
+            self.model_call_details["litellm_params"]["metadata"]["hidden_params"] = hidden_params  # type: ignore
+
+        # 2) Compute response_cost while being resilient to NotFoundError
+        try:
+            if self.model_call_details.get("cache_hit") is True:
+                # Cached responses should never be charged again
+                self.model_call_details["response_cost"] = 0.0
+            elif "response_cost" in hidden_params:
+                # Prefer explicit response_cost from provider / upstream handler
+                self.model_call_details["response_cost"] = hidden_params["response_cost"]
+            elif self.model_call_details.get("response_cost") is not None:
+                # Preserve response_cost if already calculated (e.g., by pass-through
+                # handlers like Gemini/Vertex which call completion_cost directly)
+                pass
+            else:
+                # Fallback: calculate from usage and pricing tables
+                self.model_call_details["response_cost"] = self._response_cost_calculator(
+                    result=logging_result
+                )
+        except litellm.NotFoundError:
+            # Unknown model in pricing map; keep the span but drop cost
+            verbose_logger.warning(
+                f"Model={self.model} not found in completion cost map. Setting 'response_cost' to None"
             )
+            self.model_call_details["response_cost"] = None
 
+        # 3) Build & optionally emit the standard logging payload
         self.model_call_details["standard_logging_object"] = (
             self._build_standard_logging_payload(logging_result, start_time, end_time)
         )
 
-        if (
+        if should_emit and (
             standard_logging_payload := self.model_call_details.get(
                 "standard_logging_object"
             )
@@ -1982,23 +2003,13 @@ class Logging(LiteLLMLoggingBaseClass):
                 self.model_call_details["complete_streaming_response"] = (
                     complete_streaming_response
                 )
-                self.model_call_details["response_cost"] = (
-                    self._response_cost_calculator(result=complete_streaming_response)
+                # Use shared helper so streaming follows same code path as non-streaming
+                self._process_hidden_params_and_response_cost(
+                    logging_result=complete_streaming_response,
+                    start_time=start_time,
+                    end_time=end_time,
+                    should_emit=is_sync_request,
                 )
-                ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details["standard_logging_object"] = (
-                    self._build_standard_logging_payload(
-                        complete_streaming_response, start_time, end_time
-                    )
-                )
-                if (
-                    standard_logging_payload := self.model_call_details.get(
-                        "standard_logging_object"
-                    )
-                ) is not None:
-                    # Only emit for sync requests (async_success_handler handles async)
-                    if is_sync_request:
-                        emit_standard_logging_payload(standard_logging_payload)
             callbacks = self.get_combined_callback_list(
                 dynamic_success_callbacks=self.dynamic_success_callbacks,
                 global_callbacks=litellm.success_callback,
@@ -2496,44 +2507,13 @@ class Logging(LiteLLMLoggingBaseClass):
                 complete_streaming_response
             )
 
-            try:
-                if self.model_call_details.get("cache_hit", False) is True:
-                    self.model_call_details["response_cost"] = 0.0
-                else:
-                    # check if base_model set on azure
-                    _get_base_model_from_metadata(
-                        model_call_details=self.model_call_details
-                    )
-                    # base_model defaults to None if not set on model_info
-                    self.model_call_details["response_cost"] = (
-                        self._response_cost_calculator(
-                            result=complete_streaming_response
-                        )
-                    )
-
-                verbose_logger.debug(
-                    f"Model={self.model}; cost={self.model_call_details['response_cost']}"
-                )
-            except litellm.NotFoundError:
-                verbose_logger.warning(
-                    f"Model={self.model} not found in completion cost map. Setting 'response_cost' to None"
-                )
-                self.model_call_details["response_cost"] = None
-
-            ## STANDARDIZED LOGGING PAYLOAD
-            self.model_call_details["standard_logging_object"] = (
-                self._build_standard_logging_payload(
-                    complete_streaming_response, start_time, end_time
-                )
+            # Use shared helper so async streaming follows same code path as non-streaming.
+            # NotFoundError during cost calc is handled inside; span is still emitted.
+            self._process_hidden_params_and_response_cost(
+                logging_result=complete_streaming_response,
+                start_time=start_time,
+                end_time=end_time,
             )
-
-            # print standard logging payload
-            if (
-                standard_logging_payload := self.model_call_details.get(
-                    "standard_logging_object"
-                )
-            ) is not None:
-                emit_standard_logging_payload(standard_logging_payload)
         elif self.call_type == "pass_through_endpoint":
             print_verbose(
                 "Async success callbacks: Got a pass-through endpoint response"

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1702,11 +1702,16 @@ class Logging(LiteLLMLoggingBaseClass):
                     result=logging_result
                 )
         except litellm.NotFoundError:
-            # Unknown model in pricing map; keep the span but drop cost
+            # Defensive: _response_cost_calculator catches Exception internally and returns None,
+            # but guard here in case that changes in the future.
             verbose_logger.warning(
                 f"Model={self.model} not found in completion cost map. Setting 'response_cost' to None"
             )
             self.model_call_details["response_cost"] = None
+
+        verbose_logger.debug(
+            f"Model={self.model}; cost={self.model_call_details.get('response_cost')}"
+        )
 
         # 3) Build & optionally emit the standard logging payload
         self.model_call_details["standard_logging_object"] = (

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1713,6 +1713,8 @@ class Logging(LiteLLMLoggingBaseClass):
             self._build_standard_logging_payload(logging_result, start_time, end_time)
         )
 
+        # Only emit for sync requests to avoid double emission
+        # (async_success_handler will emit for async requests)
         if should_emit and (
             standard_logging_payload := self.model_call_details.get(
                 "standard_logging_object"
@@ -2003,7 +2005,7 @@ class Logging(LiteLLMLoggingBaseClass):
                 self.model_call_details["complete_streaming_response"] = (
                     complete_streaming_response
                 )
-                # Use shared helper so streaming follows same code path as non-streaming
+                # Use shared helper; only emit for sync (async_success_handler handles async)
                 self._process_hidden_params_and_response_cost(
                     logging_result=complete_streaming_response,
                     start_time=start_time,

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1975,21 +1975,21 @@ def test_streaming_populates_hidden_params_in_metadata():
     """
     Regression test for LIT-1274: Streaming requests should populate hidden_params
     in litellm_params.metadata for OTEL/callback integrations.
-    
+
     This test verifies that when streaming completes, the success_handler calls
     _process_hidden_params_and_response_cost() which writes hidden_params to metadata.
     """
     import datetime
     from unittest.mock import patch
-    
+
     # Create logging object with stream=True
     logging_obj = _make_logging_obj(stream=True)
-    
+
     # Set up litellm_params with metadata
     logging_obj.model_call_details["litellm_params"] = {
         "metadata": {}
     }
-    
+
     # Create a complete streaming response with hidden_params
     complete_response = ModelResponse(
         id="resp-1",
@@ -2003,23 +2003,23 @@ def test_streaming_populates_hidden_params_in_metadata():
         "response_cost": 0.00015,
         "litellm_call_id": "test-123"
     }
-    
-    # Mock the streaming chunks
-    logging_obj.sync_streaming_chunks = [complete_response]
-    
+
     start_time = datetime.datetime.now()
     end_time = datetime.datetime.now()
-    
-    # Mock get_combined_callback_list to avoid callback execution
-    with patch.object(logging_obj, "get_combined_callback_list", return_value=[]):
-        # Call success_handler which should populate metadata
+
+    with patch.object(
+        logging_obj,
+        "_process_hidden_params_and_response_cost",
+        wraps=logging_obj._process_hidden_params_and_response_cost,
+    ) as spy, patch.object(logging_obj, "get_combined_callback_list", return_value=[]):
         logging_obj.success_handler(
             result=complete_response,
             start_time=start_time,
             end_time=end_time,
             cache_hit=False
         )
-    
+        spy.assert_called_once()
+
     # Assert that hidden_params was written to metadata
     assert "litellm_params" in logging_obj.model_call_details
     assert "metadata" in logging_obj.model_call_details["litellm_params"]
@@ -2038,22 +2038,22 @@ async def test_async_streaming_populates_hidden_params_in_metadata():
     """
     Regression test for LIT-1274: Async streaming requests should populate hidden_params
     in litellm_params.metadata for OTEL/callback integrations.
-    
+
     This test verifies that when async streaming completes, the async_success_handler calls
     _process_hidden_params_and_response_cost() which writes hidden_params to metadata.
     """
     import datetime
     from unittest.mock import patch
-    
+
     # Create logging object with stream=True
     logging_obj = _make_logging_obj(stream=True)
-    
+
     # Set up litellm_params with metadata
     logging_obj.model_call_details["litellm_params"] = {
         "metadata": {},
         "acompletion": True  # Mark as async
     }
-    
+
     # Create a complete streaming response with hidden_params
     complete_response = ModelResponse(
         id="resp-1",
@@ -2067,23 +2067,23 @@ async def test_async_streaming_populates_hidden_params_in_metadata():
         "response_cost": 0.00015,
         "litellm_call_id": "test-456"
     }
-    
-    # Mock the streaming chunks
-    logging_obj.streaming_chunks = [complete_response]
-    
+
     start_time = datetime.datetime.now()
     end_time = datetime.datetime.now()
-    
-    # Mock get_combined_callback_list to avoid callback execution
-    with patch.object(logging_obj, "get_combined_callback_list", return_value=[]):
-        # Call async_success_handler which should populate metadata
+
+    with patch.object(
+        logging_obj,
+        "_process_hidden_params_and_response_cost",
+        wraps=logging_obj._process_hidden_params_and_response_cost,
+    ) as spy, patch.object(logging_obj, "get_combined_callback_list", return_value=[]):
         await logging_obj.async_success_handler(
             result=complete_response,
             start_time=start_time,
             end_time=end_time,
             cache_hit=False
         )
-    
+        spy.assert_called_once()
+
     # Assert that hidden_params was written to metadata
     assert "litellm_params" in logging_obj.model_call_details
     assert "metadata" in logging_obj.model_call_details["litellm_params"]

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2118,6 +2118,7 @@ async def test_async_streaming_notfounderror_still_emits_span(monkeypatch):
         call_type="completion",
         start_time=time.time(),
         litellm_call_id="notfound-async-stream",
+        function_id="test-fn-id",
     )
 
     complete_streaming_response = ModelResponse(
@@ -2139,7 +2140,9 @@ async def test_async_streaming_notfounderror_still_emits_span(monkeypatch):
     )
 
     def _raise_not_found(*_, **__):
-        raise litellm.NotFoundError("missing pricing for model")
+        raise litellm.NotFoundError(
+            "missing pricing for model", model="unknown/model", llm_provider="custom"
+        )
 
     monkeypatch.setattr(logging_obj, "_response_cost_calculator", _raise_not_found)
 

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1969,3 +1969,196 @@ def test_function_setup_empty_metadata_falls_back_to_litellm_metadata():
     assert metadata is not None
     assert metadata.get("user_api_key_hash") == "sk-hashed-empty-test"
     assert metadata.get("user_api_key_team_id") == "team-empty-test"
+
+
+def test_streaming_populates_hidden_params_in_metadata():
+    """
+    Regression test for LIT-1274: Streaming requests should populate hidden_params
+    in litellm_params.metadata for OTEL/callback integrations.
+    
+    This test verifies that when streaming completes, the success_handler calls
+    _process_hidden_params_and_response_cost() which writes hidden_params to metadata.
+    """
+    import datetime
+    from unittest.mock import patch
+    
+    # Create logging object with stream=True
+    logging_obj = _make_logging_obj(stream=True)
+    
+    # Set up litellm_params with metadata
+    logging_obj.model_call_details["litellm_params"] = {
+        "metadata": {}
+    }
+    
+    # Create a complete streaming response with hidden_params
+    complete_response = ModelResponse(
+        id="resp-1",
+        choices=[],
+        model="gpt-3.5-turbo",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    )
+    complete_response._hidden_params = {
+        "custom_llm_provider": "openai",
+        "api_base": "https://api.openai.com",
+        "response_cost": 0.00015,
+        "litellm_call_id": "test-123"
+    }
+    
+    # Mock the streaming chunks
+    logging_obj.sync_streaming_chunks = [complete_response]
+    
+    start_time = datetime.datetime.now()
+    end_time = datetime.datetime.now()
+    
+    # Mock get_combined_callback_list to avoid callback execution
+    with patch.object(logging_obj, "get_combined_callback_list", return_value=[]):
+        # Call success_handler which should populate metadata
+        logging_obj.success_handler(
+            result=complete_response,
+            start_time=start_time,
+            end_time=end_time,
+            cache_hit=False
+        )
+    
+    # Assert that hidden_params was written to metadata
+    assert "litellm_params" in logging_obj.model_call_details
+    assert "metadata" in logging_obj.model_call_details["litellm_params"]
+    assert "hidden_params" in logging_obj.model_call_details["litellm_params"]["metadata"]
+    
+    # Verify the content of hidden_params
+    hidden_params = logging_obj.model_call_details["litellm_params"]["metadata"]["hidden_params"]
+    assert hidden_params["custom_llm_provider"] == "openai"
+    assert hidden_params["api_base"] == "https://api.openai.com"
+    assert "response_cost" in hidden_params
+    assert hidden_params["litellm_call_id"] == "test-123"
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_populates_hidden_params_in_metadata():
+    """
+    Regression test for LIT-1274: Async streaming requests should populate hidden_params
+    in litellm_params.metadata for OTEL/callback integrations.
+    
+    This test verifies that when async streaming completes, the async_success_handler calls
+    _process_hidden_params_and_response_cost() which writes hidden_params to metadata.
+    """
+    import datetime
+    from unittest.mock import patch
+    
+    # Create logging object with stream=True
+    logging_obj = _make_logging_obj(stream=True)
+    
+    # Set up litellm_params with metadata
+    logging_obj.model_call_details["litellm_params"] = {
+        "metadata": {},
+        "acompletion": True  # Mark as async
+    }
+    
+    # Create a complete streaming response with hidden_params
+    complete_response = ModelResponse(
+        id="resp-1",
+        choices=[],
+        model="gpt-3.5-turbo",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    )
+    complete_response._hidden_params = {
+        "custom_llm_provider": "openai",
+        "api_base": "https://api.openai.com",
+        "response_cost": 0.00015,
+        "litellm_call_id": "test-456"
+    }
+    
+    # Mock the streaming chunks
+    logging_obj.streaming_chunks = [complete_response]
+    
+    start_time = datetime.datetime.now()
+    end_time = datetime.datetime.now()
+    
+    # Mock get_combined_callback_list to avoid callback execution
+    with patch.object(logging_obj, "get_combined_callback_list", return_value=[]):
+        # Call async_success_handler which should populate metadata
+        await logging_obj.async_success_handler(
+            result=complete_response,
+            start_time=start_time,
+            end_time=end_time,
+            cache_hit=False
+        )
+    
+    # Assert that hidden_params was written to metadata
+    assert "litellm_params" in logging_obj.model_call_details
+    assert "metadata" in logging_obj.model_call_details["litellm_params"]
+    assert "hidden_params" in logging_obj.model_call_details["litellm_params"]["metadata"]
+    
+    # Verify the content of hidden_params
+    hidden_params = logging_obj.model_call_details["litellm_params"]["metadata"]["hidden_params"]
+    assert hidden_params["custom_llm_provider"] == "openai"
+    assert hidden_params["api_base"] == "https://api.openai.com"
+    assert "response_cost" in hidden_params
+    assert hidden_params["litellm_call_id"] == "test-456"
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_notfounderror_still_emits_span(monkeypatch):
+    """
+    If cost calculation raises NotFoundError for async streaming, we should still
+    build and emit the standard logging payload (span present, cost optional).
+    Addresses Harshit's review: OTEL/callbacks must not lose the span for unknown models.
+    """
+    from datetime import datetime
+    from unittest.mock import patch
+
+    import litellm
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+    from litellm.types.utils import ModelResponse
+
+    logging_obj = LiteLLMLoggingObj(
+        model="unknown/model",
+        messages=[{"role": "user", "content": "Hey"}],
+        stream=True,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="notfound-async-stream",
+    )
+
+    complete_streaming_response = ModelResponse(
+        id="cmpl-1",
+        model="unknown/model",
+        choices=[],
+        usage=None,
+    )
+    setattr(
+        complete_streaming_response,
+        "_hidden_params",
+        {"api_base": "https://api.example.com", "custom_llm_provider": "custom"},
+    )
+
+    monkeypatch.setattr(
+        logging_obj,
+        "_get_assembled_streaming_response",
+        lambda **_: complete_streaming_response,
+    )
+
+    def _raise_not_found(*_, **__):
+        raise litellm.NotFoundError("missing pricing for model")
+
+    monkeypatch.setattr(logging_obj, "_response_cost_calculator", _raise_not_found)
+
+    with patch(
+        "litellm.litellm_core_utils.litellm_logging.emit_standard_logging_payload"
+    ) as mock_emit, patch.object(
+        logging_obj, "get_combined_callback_list", return_value=[]
+    ):
+        start_time = datetime.now()
+        end_time = datetime.now()
+
+        await logging_obj.async_success_handler(
+            result=complete_streaming_response,
+            start_time=start_time,
+            end_time=end_time,
+            cache_hit=False,
+        )
+
+        mock_emit.assert_called_once()
+        payload = mock_emit.call_args[0][0]
+        assert payload is not None
+        assert logging_obj.model_call_details.get("response_cost") is None


### PR DESCRIPTION
## Problem

When using `stream=True`, the `hidden_params` attribute is missing from `litellm_params.metadata`, causing OTEL spans to be missing cost data in OpenSearch.

### Root Cause

The streaming handlers (`success_handler` anåd `async_success_handler`) were not populating `litellm_params.metadata["hidden_params"]` like the non-streaming path does. They had duplicated code that calculated `response_cost` but never wrote `hidden_params` back to metadata.

## Solution

Refactored both streaming handlers to call the existing `_process_hidden_params_and_response_cost()` function, which:
1. Extracts `_hidden_params` from the response
2. Writes to `litellm_params.metadata["hidden_params"]` (THE FIX)
3. Calculates `response_cost` with proper cache_hit handling
4. Builds standard logging payload
5. Emits the payload

This ensures streaming follows the same code path as non-streaming.

## Changes

### Files Modified

1. **`litellm/litellm_core_utils/litellm_logging.py`**
   - Sync streaming handler: Replaced 18 lines of duplicated logic with 7 lines calling `_process_hidden_params_and_response_cost()`
   - Async streaming handler: Replaced 30 lines of duplicated logic with 11 lines calling `_process_hidden_params_and_response_cost()`
   - Net reduction: 29 lines of code

2. **`tests/test_litellm/litellm_core_utils/test_litellm_logging.py`**
   - Added `test_streaming_populates_hidden_params_in_metadata()` - sync version
   - Added `test_async_streaming_populates_hidden_params_in_metadata()` - async version

## Testing

### Unit Tests
```bash
poetry run pytest tests/test_litellm/litellm_core_utils/test_litellm_logging.py::test_streaming_populates_hidden_params_in_metadata tests/test_litellm/litellm_core_utils/test_litellm_logging.py::test_async_streaming_populates_hidden_params_in_metadata -v -p no:postgresql
```

Result: 2 passed, 1 warning in 0.19s

### Manual Verification

Reproduction script confirmed the fix:
- **Before**: Streaming had empty `hidden_params: {}`
- **After**: Streaming has populated `hidden_params: {'response_cost': ..., 'api_base': ..., 'custom_llm_provider': ..., ...}`

## Impact

- OTEL `@log_db_metrics` decorator now receives cost data for streaming requests
- Eliminates 29 lines of duplicated code
- Ensures consistency between streaming and non-streaming code paths
- Makes future maintenance easier (one place to update)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
> 
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  Link:
- [ ] **CI run for the last commit**  Link:
- [ ] **Merge / cherry-pick CI run**  Links:

## Type

Bug Fix
Refactoring

## Changes

- Refactored sync and async streaming handlers to call existing `_process_hidden_params_and_response_cost()`
- This ensures `hidden_params` is written to `litellm_params.metadata` for OTEL/callback integrations
- Eliminates 29 lines of duplicated code
- Added regression tests for both sync and async streaming