### PR TITLE
[Fix] Spend Update Queue Aggregation Never Triggers with Default Presets

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -242,9 +242,13 @@ REDIS_DAILY_END_USER_SPEND_UPDATE_BUFFER_KEY = (
 REDIS_DAILY_AGENT_SPEND_UPDATE_BUFFER_KEY = "litellm_daily_agent_spend_update_buffer"
 REDIS_DAILY_TAG_SPEND_UPDATE_BUFFER_KEY = "litellm_daily_tag_spend_update_buffer"
 MAX_REDIS_BUFFER_DEQUEUE_COUNT = int(os.getenv("MAX_REDIS_BUFFER_DEQUEUE_COUNT", 100))
-MAX_SIZE_IN_MEMORY_QUEUE = int(os.getenv("MAX_SIZE_IN_MEMORY_QUEUE", 2000))
 # Bounds asyncio.Queue() instances (log queues, spend update queues, etc.) to prevent unbounded memory growth
 LITELLM_ASYNCIO_QUEUE_MAXSIZE = int(os.getenv("LITELLM_ASYNCIO_QUEUE_MAXSIZE", 1000))
+# Aggregation threshold: default to 80% of the asyncio queue maxsize so the check can always trigger.
+# Must be < LITELLM_ASYNCIO_QUEUE_MAXSIZE; if set higher the aggregation logic will never fire.
+MAX_SIZE_IN_MEMORY_QUEUE = int(
+    os.getenv("MAX_SIZE_IN_MEMORY_QUEUE", int(LITELLM_ASYNCIO_QUEUE_MAXSIZE * 0.8))
+)
 MAX_IN_MEMORY_QUEUE_FLUSH_COUNT = int(
     os.getenv("MAX_IN_MEMORY_QUEUE_FLUSH_COUNT", 1000)
 )

--- a/litellm/proxy/db/db_transaction_queue/base_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/base_update_queue.py
@@ -23,6 +23,15 @@ class BaseUpdateQueue:
     def __init__(self):
         self.update_queue = asyncio.Queue(maxsize=LITELLM_ASYNCIO_QUEUE_MAXSIZE)
         self.MAX_SIZE_IN_MEMORY_QUEUE = MAX_SIZE_IN_MEMORY_QUEUE
+        if MAX_SIZE_IN_MEMORY_QUEUE >= LITELLM_ASYNCIO_QUEUE_MAXSIZE:
+            verbose_proxy_logger.warning(
+                "Misconfigured queue thresholds: MAX_SIZE_IN_MEMORY_QUEUE (%d) >= LITELLM_ASYNCIO_QUEUE_MAXSIZE (%d). "
+                "The spend aggregation check will never trigger because the asyncio.Queue blocks at %d items. "
+                "Set MAX_SIZE_IN_MEMORY_QUEUE to a value less than LITELLM_ASYNCIO_QUEUE_MAXSIZE (recommended: 80%% of it).",
+                MAX_SIZE_IN_MEMORY_QUEUE,
+                LITELLM_ASYNCIO_QUEUE_MAXSIZE,
+                LITELLM_ASYNCIO_QUEUE_MAXSIZE,
+            )
 
     async def add_update(self, update):
         """Enqueue an update."""


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Summary

`MAX_SIZE_IN_MEMORY_QUEUE` defaulted to `2000` while `LITELLM_ASYNCIO_QUEUE_MAXSIZE` (the hard cap on the underlying `asyncio.Queue`) defaulted to `1000`. Because `asyncio.Queue` blocks on `.put()` once it reaches its `maxsize`, `qsize()` can never reach `2000`, so the aggregation branch in `SpendUpdateQueue.add_update()` was dead code.

### Fix

- Moved `LITELLM_ASYNCIO_QUEUE_MAXSIZE` before `MAX_SIZE_IN_MEMORY_QUEUE` in `constants.py` so the former can be referenced in the latter's default.
- `MAX_SIZE_IN_MEMORY_QUEUE` now defaults to `int(LITELLM_ASYNCIO_QUEUE_MAXSIZE * 0.8)` (800), ensuring the aggregation threshold is always reachable.
- Added a startup warning in `BaseUpdateQueue.__init__` that fires whenever `MAX_SIZE_IN_MEMORY_QUEUE >= LITELLM_ASYNCIO_QUEUE_MAXSIZE`, catching any misconfiguration set via environment variables.

## Testing

Added `test_misconfigured_queue_thresholds_warns` in `tests/test_litellm/proxy/db/db_transaction_queue/test_base_update_queue.py` — patches both constants to simulate the broken configuration and asserts the warning is emitted.

## Type

🐛 Bug Fix
✅ Test