### PR TITLE
fix claude ttl

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4131,6 +4131,7 @@ class BedrockConverseMessagesProcessor:
                                         OpenAIMessageContentListBlock, element
                                     ),
                                     block_type="content_block",
+                                    model=model,
                                 )
                             )
                             if _cache_point_block is not None:
@@ -4142,7 +4143,7 @@ class BedrockConverseMessagesProcessor:
                     _part = BedrockContentBlock(text=messages[msg_i]["content"])
                     _cache_point_block = (
                         litellm.AmazonConverseConfig()._get_cache_point_block(
-                            message_block, block_type="content_block"
+                            message_block, block_type="content_block", model=model
                         )
                     )
                     user_content.append(_part)
@@ -4294,6 +4295,7 @@ class BedrockConverseMessagesProcessor:
                                     OpenAIMessageContentListBlock, element
                                 ),
                                 block_type="content_block",
+                                model=model,
                             )
                         )
                         if _cache_point_block is not None:
@@ -4311,7 +4313,7 @@ class BedrockConverseMessagesProcessor:
                     # Add cache point block for assistant string content
                     _cache_point_block = (
                         litellm.AmazonConverseConfig()._get_cache_point_block(
-                            assistant_message_block, block_type="content_block"
+                            assistant_message_block, block_type="content_block", model=model
                         )
                     )
                     if _cache_point_block is not None:
@@ -4505,6 +4507,7 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
                                     OpenAIMessageContentListBlock, element
                                 ),
                                 block_type="content_block",
+                                model=model,
                             )
                         )
                         if _cache_point_block is not None:
@@ -4514,7 +4517,7 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
                 _part = BedrockContentBlock(text=messages[msg_i]["content"])
                 _cache_point_block = (
                     litellm.AmazonConverseConfig()._get_cache_point_block(
-                        message_block, block_type="content_block"
+                        message_block, block_type="content_block", model=model
                     )
                 )
                 user_content.append(_part)
@@ -4659,6 +4662,7 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
                                     OpenAIMessageContentListBlock, element
                                 ),
                                 block_type="content_block",
+                                model=model,
                             )
                         )
                         if _cache_point_block is not None:
@@ -4671,7 +4675,7 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
                 # Add cache point block for assistant string content
                 _cache_point_block = (
                     litellm.AmazonConverseConfig()._get_cache_point_block(
-                        assistant_message_block, block_type="content_block"
+                        assistant_message_block, block_type="content_block", model=model
                     )
                 )
                 if _cache_point_block is not None:


### PR DESCRIPTION
## Relevant issues

Fixes follow-up issue for #20338 - Model parameter not passed to `_get_cache_point_block` method

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### Summary
Fixed TTL parameter not being effective for Claude 4.5 models in Bedrock Converse API by ensuring the `model` parameter is properly passed to `_get_cache_point_block()` method.

### Problem
PR #20338 added support for TTL (Time-To-Live) field in prompt caching for Claude 4.5 models. However, the `_get_cache_point_block()` method in `converse_transformation.py` checks if the current model is a Claude 4 series model using `_is_claude_4_5_on_bedrock(model)`. When this method is called from `factory.py` (or other locations), the `model` parameter was not passed, resulting in `model=None` and the TTL parameter not taking effect.

### Solution
- Updated the call site(s) in `factory.py` to pass the `model` parameter when calling `_get_cache_point_block()`
- Ensured the model information flows correctly through the call chain to enable proper Claude 4.5 model detection
- This allows TTL values ("5m" and "1h") to be correctly preserved for Claude 4.5 models while being removed for other models

### Files Modified
- `litellm/llms/bedrock/chat/factory.py` (or the relevant file where `_get_cache_point_block` is called without model parameter)
- Updated method call to include `model` parameter from the available context

### Testing
- [ ] Added test case verifying TTL is preserved for Claude 4.5 models when using Converse API
- [ ] Verified existing tests still pass with the change
- [ ] Tested with actual Claude 4.5 model calls to confirm TTL parameter works correctly