### PR TITLE
Handle stream-required fallback

### DIFF
--- a/litellm/litellm_core_utils/error_utils.py
+++ b/litellm/litellm_core_utils/error_utils.py
@@ -1,0 +1,47 @@
+"""Shared error-detection helpers."""
+
+import json
+from typing import Any
+
+_STREAM_REQUIRED_TEXT = "stream must be set to true"
+
+
+def _contains_stream_required_text(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            value = value.decode("utf-8", errors="ignore")
+        except Exception:
+            value = str(value)
+    if isinstance(value, str):
+        lowered = value.lower()
+        if _STREAM_REQUIRED_TEXT in lowered:
+            return True
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return False
+        return _contains_stream_required_text(parsed)
+    if isinstance(value, dict):
+        for key in ("detail", "message", "error"):
+            if key in value and _contains_stream_required_text(value[key]):
+                return True
+        return any(_contains_stream_required_text(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_contains_stream_required_text(v) for v in value)
+    return False
+
+
+def is_stream_required_error(err: Exception) -> bool:
+    for attr in ("body", "message", "text"):
+        if _contains_stream_required_text(getattr(err, attr, None)):
+            return True
+    response = getattr(err, "response", None)
+    if response is not None:
+        try:
+            if _contains_stream_required_text(getattr(response, "text", None)):
+                return True
+        except Exception:
+            return False
+    return _contains_stream_required_text(str(err))

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -34,6 +34,7 @@ import litellm
 from litellm import LlmProviders
 from litellm._logging import verbose_logger
 from litellm.constants import DEFAULT_MAX_RETRIES
+from litellm.litellm_core_utils.error_utils import is_stream_required_error
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.logging_utils import track_llm_api_timing
 from litellm.llms.base_llm.base_model_iterator import BaseModelResponseIterator
@@ -340,13 +341,6 @@ class OpenAIChatCompletionResponseIterator(BaseModelResponseIterator):
 class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
     def __init__(self) -> None:
         super().__init__()
-
-    @staticmethod
-    def _is_stream_required_error(e: Exception) -> bool:
-        message = getattr(e, "message", None) or getattr(e, "text", None) or str(e)
-        if isinstance(message, dict):
-            message = json.dumps(message)
-        return "stream must be set to true" in str(message).lower()
 
     @staticmethod
     def _merge_stream_hidden_params(
@@ -935,7 +929,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     elif (
                         stream is False
                         and return_complete_response is False
-                        and self._is_stream_required_error(e)
+                        and is_stream_required_error(e)
                     ):
                         stream = True
                         return_complete_response = True


### PR DESCRIPTION
## Changes

- When upstream returns “Stream must be set to true” for non‑stream requests, LiteLLM now retries with `stream=true` upstream and locally aggregates the streaming chunks back into a non‑stream response.
- Applied to:
  - Responses API bridge path (`/v1/chat/completions` → responses handler)
  - OpenAI chat path
  - OpenAI‑compatible custom HTTP handler
  
before:
<img width="982" height="739" alt="image" src="https://github.com/user-attachments/assets/32f3a82d-0cd2-4a95-a2c9-dfac625a396a" />
after:
<img width="1024" height="820" alt="image" src="https://github.com/user-attachments/assets/d97b3ae0-8df5-47bf-b168-16a8e2e61086" />
