### PR TITLE
fix(assemblyai): fix binary upload crash in pass-through route

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1282,9 +1282,11 @@ async def assemblyai_proxy_route(
     is_streaming_request = False
     # assemblyai is streaming when 'stream' = True is in the body
     if request.method == "POST":
-        _request_body = await request.json()
-        if _request_body.get("stream"):
-            is_streaming_request = True
+        content_type = request.headers.get("content-type", "")
+        if "application/json" in content_type:
+            _request_body = await request.json()
+            if _request_body.get("stream"):
+                is_streaming_request = True
 
     ## CREATE PASS-THROUGH
     endpoint_func = create_pass_through_route(

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -437,7 +437,7 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
             )
         else:
             content_type = request.headers.get("content-type", "")
-            if _parsed_body is None and "application/json" not in content_type:
+            if "application/json" not in content_type:
                 # Non-JSON request (e.g. binary upload) — forward raw bytes
                 response = await async_client.request(
                     method=request.method,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -437,7 +437,7 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
             )
         else:
             content_type = request.headers.get("content-type", "")
-            if "application/json" not in content_type:
+            if content_type and "application/json" not in content_type:
                 # Non-JSON request (e.g. binary upload) — forward raw bytes
                 response = await async_client.request(
                     method=request.method,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -436,14 +436,25 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
                 requested_query_params=requested_query_params,
             )
         else:
-            # Generic httpx method
-            response = await async_client.request(
-                method=request.method,
-                url=url,
-                headers=headers,
-                params=requested_query_params,
-                json=_parsed_body,
-            )
+            content_type = request.headers.get("content-type", "")
+            if _parsed_body is None and "application/json" not in content_type:
+                # Non-JSON request (e.g. binary upload) — forward raw bytes
+                response = await async_client.request(
+                    method=request.method,
+                    url=url,
+                    headers=headers,
+                    params=requested_query_params,
+                    content=await request.body(),
+                )
+            else:
+                # JSON request — forward parsed body
+                response = await async_client.request(
+                    method=request.method,
+                    url=url,
+                    headers=headers,
+                    params=requested_query_params,
+                    json=_parsed_body,
+                )
         return response
 
     @staticmethod

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -1093,9 +1093,9 @@ class TestVertexAIPassThroughHandler:
 
         assert result is not None
         assert result["result"] is not None
-        assert result["kwargs"].get("custom_llm_provider") == "gemini", (
-            "Google AI Studio embedContent URLs must set custom_llm_provider=gemini, not vertex_ai"
-        )
+        assert (
+            result["kwargs"].get("custom_llm_provider") == "gemini"
+        ), "Google AI Studio embedContent URLs must set custom_llm_provider=gemini, not vertex_ai"
         assert result["kwargs"].get("model") == "gemini-embedding-2-preview"
         mock_completion_cost.assert_called_once()
 
@@ -2903,17 +2903,22 @@ async def test_assemblyai_proxy_route_binary_upload_no_json_parse():
     mock_request.method = "POST"
     mock_request.headers = {"content-type": "application/octet-stream"}
     mock_request.url = "https://api.assemblyai.com/v2/upload"
-    mock_request.json = AsyncMock(side_effect=UnicodeDecodeError("utf-8", b"", 0, 1, ""))
+    mock_request.json = AsyncMock(
+        side_effect=UnicodeDecodeError("utf-8", b"", 0, 1, "")
+    )
 
     mock_response = MagicMock()
     mock_user_api_key_dict = MagicMock()
 
-    with patch(
-        "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
-        return_value="test-api-key",
-    ), patch(
-        "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
-    ) as mock_create_route:
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+            return_value="test-api-key",
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+        ) as mock_create_route,
+    ):
         mock_endpoint_func = AsyncMock(return_value="ok")
         mock_create_route.return_value = mock_endpoint_func
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -2899,11 +2899,6 @@ async def test_assemblyai_proxy_route_binary_upload_no_json_parse():
     Regression test: POST with application/octet-stream should NOT call request.json().
     Before fix, this raised UnicodeDecodeError crashing the request.
     """
-    from unittest.mock import AsyncMock, MagicMock, patch
-    from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-        assemblyai_proxy_route,
-    )
-
     mock_request = AsyncMock()
     mock_request.method = "POST"
     mock_request.headers = {"content-type": "application/octet-stream"}

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -18,6 +18,7 @@ import litellm
 from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     BaseOpenAIPassThroughHandler,
     RouteChecks,
+    assemblyai_proxy_route,
     bedrock_llm_proxy_route,
     create_pass_through_route,
     cursor_proxy_route,
@@ -2890,3 +2891,45 @@ class TestCursorProxyRoute:
             assert call_args["target"] == "https://api.cursor.com/v0/agents"
             assert result["id"] == "bc_abc123"
             assert result["status"] == "CREATING"
+
+
+@pytest.mark.asyncio
+async def test_assemblyai_proxy_route_binary_upload_no_json_parse():
+    """
+    Regression test: POST with application/octet-stream should NOT call request.json().
+    Before fix, this raised UnicodeDecodeError crashing the request.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+        assemblyai_proxy_route,
+    )
+
+    mock_request = AsyncMock()
+    mock_request.method = "POST"
+    mock_request.headers = {"content-type": "application/octet-stream"}
+    mock_request.url = "https://api.assemblyai.com/v2/upload"
+    mock_request.json = AsyncMock(side_effect=UnicodeDecodeError("utf-8", b"", 0, 1, ""))
+
+    mock_response = MagicMock()
+    mock_user_api_key_dict = MagicMock()
+
+    with patch(
+        "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+        return_value="test-api-key",
+    ), patch(
+        "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+    ) as mock_create_route:
+        mock_endpoint_func = AsyncMock(return_value="ok")
+        mock_create_route.return_value = mock_endpoint_func
+
+        result = await assemblyai_proxy_route(
+            endpoint="v2/upload",
+            request=mock_request,
+            fastapi_response=mock_response,
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+        # request.json() should NOT have been called for octet-stream
+        mock_request.json.assert_not_called()
+        # create_pass_through_route should still be called (non-streaming)
+        mock_create_route.assert_called_once()

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -2618,3 +2618,36 @@ def test_get_response_headers_strips_server_and_date():
     assert lowered["content-type"] == "application/json"
     assert lowered["x-request-id"] == "req_abc"
     assert lowered["anthropic-ratelimit-requests-remaining"] == "100"
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_handler_forwards_raw_body_for_binary():
+    """
+    Regression test: When _parsed_body is None and content-type is not JSON,
+    the handler should forward raw bytes instead of json=None.
+    """
+    mock_request = MagicMock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.headers = Headers({"content-type": "application/octet-stream"})
+    raw_bytes = b"\x00\x01\x02audio-data"
+    mock_request.body = AsyncMock(return_value=raw_bytes)
+
+    mock_client = AsyncMock()
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_client.request.return_value = mock_response
+
+    url = httpx.URL("https://api.assemblyai.com/v2/upload")
+
+    result = await HttpPassThroughEndpointHelpers.non_streaming_http_request_handler(
+        request=mock_request,
+        async_client=mock_client,
+        url=url,
+        headers={"Authorization": "test-key", "content-type": "application/octet-stream"},
+        _parsed_body=None,
+    )
+
+    # Should send raw bytes via content=, NOT json=None
+    mock_client.request.assert_called_once()
+    call_kwargs = mock_client.request.call_args
+    assert "content" in call_kwargs.kwargs
+    assert call_kwargs.kwargs["content"] == raw_bytes

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -2623,8 +2623,9 @@ def test_get_response_headers_strips_server_and_date():
 @pytest.mark.asyncio
 async def test_non_streaming_handler_forwards_raw_body_for_binary():
     """
-    Regression test: When _parsed_body is None and content-type is not JSON,
-    the handler should forward raw bytes instead of json=None.
+    Regression test: When content-type is not JSON, the handler should forward
+    raw bytes instead of json=_parsed_body — even when _parsed_body is non-None
+    (caller always injects litellm_logging_obj).
     """
     mock_request = MagicMock(spec=Request)
     mock_request.method = "POST"
@@ -2638,12 +2639,15 @@ async def test_non_streaming_handler_forwards_raw_body_for_binary():
 
     url = httpx.URL("https://api.assemblyai.com/v2/upload")
 
+    # Use a realistic _parsed_body (caller always injects litellm_logging_obj)
+    parsed_body = {"litellm_logging_obj": MagicMock()}
+
     result = await HttpPassThroughEndpointHelpers.non_streaming_http_request_handler(
         request=mock_request,
         async_client=mock_client,
         url=url,
         headers={"Authorization": "test-key", "content-type": "application/octet-stream"},
-        _parsed_body=None,
+        _parsed_body=parsed_body,
     )
 
     # Should send raw bytes via content=, NOT json=None

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -2646,7 +2646,10 @@ async def test_non_streaming_handler_forwards_raw_body_for_binary():
         request=mock_request,
         async_client=mock_client,
         url=url,
-        headers={"Authorization": "test-key", "content-type": "application/octet-stream"},
+        headers={
+            "Authorization": "test-key",
+            "content-type": "application/octet-stream",
+        },
         _parsed_body=parsed_body,
     )
 


### PR DESCRIPTION
## Summary

Two bugs prevent binary audio uploads through the AssemblyAI pass-through route:

1. **`assemblyai_proxy_route()` crashes on binary POST**: Calls `await request.json()` on every POST, including binary audio uploads (`Content-Type: application/octet-stream`). This causes `UnicodeDecodeError` → HTTP 500.

2. **`non_streaming_http_request_handler()` drops binary body**: Always sends `json=_parsed_body` to the upstream API. For binary uploads the parsed body is not the raw audio — an incorrect payload is forwarded instead of the original bytes.

### Changes

1. **Content-type guard** (`llm_passthrough_endpoints.py`): Only call `request.json()` when `Content-Type` contains `application/json`
2. **Raw body fallback** (`pass_through_endpoints.py`): When content-type is not `application/json`, send `content=await request.body()` (raw bytes) instead of `json=_parsed_body`

## Test plan

- [x] Unit test: binary POST to assemblyai route does not call `request.json()`
- [x] Unit test: non-JSON body is forwarded as raw bytes (with realistic non-None `_parsed_body`)
- [x] Existing pass-through tests pass (no regression)
- [x] Tested against AssemblyAI `/v2/upload` endpoint with `.wav` audio file — returns `upload_url` successfully