### PR TITLE
fix(assemblyai): fix auth header and refactor handler to async

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import time
 import urllib.parse
 from datetime import datetime
 from typing import Literal, Optional
@@ -15,7 +14,6 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.litellm_core_utils.litellm_logging import (
     get_standard_logging_object_payload,
 )
-from litellm.litellm_core_utils.thread_pool_executor import executor
 from litellm.types.passthrough_endpoints.assembly_ai import (
     ASSEMBLY_AI_MAX_POLLING_ATTEMPTS,
     ASSEMBLY_AI_POLLING_INTERVAL,
@@ -53,7 +51,7 @@ class AssemblyAIPassthroughLoggingHandler:
         The maximum number of polling attempts for the AssemblyAI API.
         """
 
-    def assemblyai_passthrough_logging_handler(
+    async def assemblyai_passthrough_logging_handler(
         self,
         httpx_response: httpx.Response,
         response_body: dict,
@@ -66,10 +64,11 @@ class AssemblyAIPassthroughLoggingHandler:
         **kwargs,
     ):
         """
-        Since cost tracking requires polling the AssemblyAI API, we need to handle this in a separate thread. Hence the executor.submit.
+        Handles logging for AssemblyAI passthrough requests.
+        Polls for transcript completion and calculates dynamic cost.
+        Runs in the caller's async context for proper DB access.
         """
-        executor.submit(
-            self._handle_assemblyai_passthrough_logging,
+        await self._handle_assemblyai_passthrough_logging(
             httpx_response,
             response_body,
             logging_obj,
@@ -81,7 +80,7 @@ class AssemblyAIPassthroughLoggingHandler:
             **kwargs,
         )
 
-    def _handle_assemblyai_passthrough_logging(
+    async def _handle_assemblyai_passthrough_logging(
         self,
         httpx_response: httpx.Response,
         response_body: dict,
@@ -111,7 +110,7 @@ class AssemblyAIPassthroughLoggingHandler:
             raise ValueError(
                 "Transcript ID is required to log the cost of the transcription"
             )
-        transcript_response = self._poll_assembly_for_transcript_response(
+        transcript_response = await self._poll_assembly_for_transcript_response(
             transcript_id=transcript_id, url_route=url_route
         )
         verbose_proxy_logger.debug(
@@ -152,21 +151,17 @@ class AssemblyAIPassthroughLoggingHandler:
         logging_obj.model_call_details["custom_llm_provider"] = "assemblyai"
         logging_obj.model_call_details["response_cost"] = response_cost
 
-        asyncio.run(
-            pass_through_endpoint_logging._handle_logging(
-                logging_obj=logging_obj,
-                standard_logging_response_object=self._get_response_to_log(
-                    transcript_response
-                ),
-                result=result,
-                start_time=start_time,
-                end_time=end_time,
-                cache_hit=cache_hit,
-                **kwargs,
-            )
+        await pass_through_endpoint_logging._handle_logging(
+            logging_obj=logging_obj,
+            standard_logging_response_object=self._get_response_to_log(
+                transcript_response
+            ),
+            result=result,
+            start_time=start_time,
+            end_time=end_time,
+            cache_hit=cache_hit,
+            **kwargs,
         )
-
-        pass
 
     def _get_response_to_log(
         self, transcript_response: Optional[AssemblyAITranscriptResponse]
@@ -175,7 +170,7 @@ class AssemblyAIPassthroughLoggingHandler:
             return {}
         return dict(transcript_response)
 
-    def _get_assembly_transcript(
+    async def _get_assembly_transcript(
         self,
         transcript_id: str,
         request_region: Optional[Literal["eu"]] = None,
@@ -215,12 +210,13 @@ class AssemblyAIPassthroughLoggingHandler:
         try:
             url = f"{_base_url}/v2/transcript/{safe_transcript_id}"
             headers = {
-                "Authorization": f"Bearer {_api_key}",
+                "Authorization": f"{_api_key}",
                 "Content-Type": "application/json",
             }
 
-            response = httpx.get(url, headers=headers)
-            response.raise_for_status()
+            async with httpx.AsyncClient() as client:
+                response = await client.get(url, headers=headers)
+                response.raise_for_status()
 
             return response.json()
         except Exception as e:
@@ -229,7 +225,7 @@ class AssemblyAIPassthroughLoggingHandler:
             )
             return None
 
-    def _poll_assembly_for_transcript_response(
+    async def _poll_assembly_for_transcript_response(
         self,
         transcript_id: str,
         url_route: Optional[str] = None,
@@ -240,7 +236,7 @@ class AssemblyAIPassthroughLoggingHandler:
         for _ in range(
             self.max_polling_attempts
         ):  # 180 attempts * 10s = 30 minutes max
-            transcript = self._get_assembly_transcript(
+            transcript = await self._get_assembly_transcript(
                 request_region=AssemblyAIPassthroughLoggingHandler._get_assembly_region_from_url(
                     url=url_route
                 ),
@@ -253,7 +249,7 @@ class AssemblyAIPassthroughLoggingHandler:
                 or transcript.get("status") == "error"
             ):
                 return AssemblyAITranscriptResponse(**transcript)
-            time.sleep(self.polling_interval)
+            await asyncio.sleep(self.polling_interval)
         return None
 
     @staticmethod

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
@@ -14,6 +14,8 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.litellm_core_utils.litellm_logging import (
     get_standard_logging_object_payload,
 )
+from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+from litellm.types.llms.custom_http import httpxSpecialProvider
 from litellm.types.passthrough_endpoints.assembly_ai import (
     ASSEMBLY_AI_MAX_POLLING_ATTEMPTS,
     ASSEMBLY_AI_POLLING_INTERVAL,
@@ -173,13 +175,15 @@ class AssemblyAIPassthroughLoggingHandler:
     async def _get_assembly_transcript(
         self,
         transcript_id: str,
+        client: httpx.AsyncClient,
         request_region: Optional[Literal["eu"]] = None,
     ) -> Optional[dict]:
         """
         Get the transcript details from AssemblyAI API
 
         Args:
-            response_body (dict): Response containing the transcript ID
+            transcript_id (str): The transcript ID to poll
+            client (httpx.AsyncClient): Reusable HTTP client for polling
 
         Returns:
             Optional[dict]: Transcript details if successful, None otherwise
@@ -210,13 +214,12 @@ class AssemblyAIPassthroughLoggingHandler:
         try:
             url = f"{_base_url}/v2/transcript/{safe_transcript_id}"
             headers = {
-                "Authorization": f"{_api_key}",
+                "Authorization": _api_key,
                 "Content-Type": "application/json",
             }
 
-            async with httpx.AsyncClient() as client:
-                response = await client.get(url, headers=headers)
-                response.raise_for_status()
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
 
             return response.json()
         except Exception as e:
@@ -233,6 +236,10 @@ class AssemblyAIPassthroughLoggingHandler:
         """
         Poll the status of the transcript until it is completed or timeout (30 minutes)
         """
+        async_client_obj = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.PassThroughEndpoint,
+        )
+        client = async_client_obj.client
         for _ in range(
             self.max_polling_attempts
         ):  # 180 attempts * 10s = 30 minutes max
@@ -241,6 +248,7 @@ class AssemblyAIPassthroughLoggingHandler:
                     url=url_route
                 ),
                 transcript_id=transcript_id,
+                client=client,
             )
             if transcript is None:
                 return None

--- a/litellm/proxy/pass_through_endpoints/success_handler.py
+++ b/litellm/proxy/pass_through_endpoints/success_handler.py
@@ -321,7 +321,7 @@ class PassThroughEndpointLogging:
                 is not True
             ):
                 return
-            self.assemblyai_passthrough_logging_handler.assemblyai_passthrough_logging_handler(
+            await self.assemblyai_passthrough_logging_handler.assemblyai_passthrough_logging_handler(
                 httpx_response=httpx_response,
                 response_body=response_body or {},
                 logging_obj=logging_obj,

--- a/tests/pass_through_unit_tests/test_assemblyai_unit_tests_passthrough.py
+++ b/tests/pass_through_unit_tests/test_assemblyai_unit_tests_passthrough.py
@@ -60,23 +60,21 @@ async def test_get_assembly_transcript(assembly_handler, mock_transcript_respons
         mock_response.json.return_value = mock_transcript_response
         mock_response.raise_for_status.return_value = None
 
-        with patch("httpx.AsyncClient") as MockClient:
-            mock_client_instance = AsyncMock()
-            mock_client_instance.get.return_value = mock_response
-            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
-            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
-            MockClient.return_value = mock_client_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
 
-            transcript = await assembly_handler._get_assembly_transcript("test-transcript-id")
-            assert transcript == mock_transcript_response
+        transcript = await assembly_handler._get_assembly_transcript(
+            "test-transcript-id", client=mock_client
+        )
+        assert transcript == mock_transcript_response
 
-            mock_client_instance.get.assert_called_once_with(
-                "https://api.assemblyai.com/v2/transcript/test-transcript-id",
-                headers={
-                    "Authorization": "test-key",
-                    "Content-Type": "application/json",
-                },
-            )
+        mock_client.get.assert_called_once_with(
+            "https://api.assemblyai.com/v2/transcript/test-transcript-id",
+            headers={
+                "Authorization": "test-key",
+                "Content-Type": "application/json",
+            },
+        )
 
 
 @pytest.mark.asyncio
@@ -87,7 +85,8 @@ async def test_poll_assembly_for_transcript_response(
     Test that the _poll_assembly_for_transcript_response method returns the correct transcript response
     """
     with patch.object(
-        assembly_handler, "_get_assembly_transcript",
+        assembly_handler,
+        "_get_assembly_transcript",
         new_callable=AsyncMock,
         return_value=mock_transcript_response,
     ):
@@ -97,9 +96,7 @@ async def test_poll_assembly_for_transcript_response(
         transcript = await assembly_handler._poll_assembly_for_transcript_response(
             "test-transcript-id",
         )
-        assert transcript == AssemblyAITranscriptResponse(
-            **mock_transcript_response
-        )
+        assert transcript == AssemblyAITranscriptResponse(**mock_transcript_response)
 
 
 def test_is_assemblyai_route():
@@ -134,7 +131,9 @@ async def test_get_assembly_transcript_rejects_slash_in_id(assembly_handler):
         return_value="test-key",
     ):
         with pytest.raises(ValueError, match="disallowed characters"):
-            await assembly_handler._get_assembly_transcript("../../admin/credentials")
+            await assembly_handler._get_assembly_transcript(
+                "../../admin/credentials", client=AsyncMock()
+            )
 
 
 @pytest.mark.asyncio
@@ -144,7 +143,9 @@ async def test_get_assembly_transcript_rejects_dotdot_in_id(assembly_handler):
         return_value="test-key",
     ):
         with pytest.raises(ValueError, match="disallowed characters"):
-            await assembly_handler._get_assembly_transcript("..evil")
+            await assembly_handler._get_assembly_transcript(
+                "..evil", client=AsyncMock()
+            )
 
 
 @pytest.mark.asyncio
@@ -154,7 +155,9 @@ async def test_get_assembly_transcript_rejects_fragment_in_id(assembly_handler):
         return_value="test-key",
     ):
         with pytest.raises(ValueError, match="disallowed characters"):
-            await assembly_handler._get_assembly_transcript("abc#suffix")
+            await assembly_handler._get_assembly_transcript(
+                "abc#suffix", client=AsyncMock()
+            )
 
 
 @pytest.mark.asyncio
@@ -164,7 +167,9 @@ async def test_get_assembly_transcript_rejects_query_in_id(assembly_handler):
         return_value="test-key",
     ):
         with pytest.raises(ValueError, match="disallowed characters"):
-            await assembly_handler._get_assembly_transcript("abc?x=1")
+            await assembly_handler._get_assembly_transcript(
+                "abc?x=1", client=AsyncMock()
+            )
 
 
 @pytest.mark.asyncio
@@ -179,22 +184,16 @@ async def test_get_assembly_transcript_allows_valid_id(
         mock_response.json.return_value = mock_transcript_response
         mock_response.raise_for_status.return_value = None
 
-        with patch("httpx.AsyncClient") as MockClient:
-            mock_client_instance = AsyncMock()
-            mock_client_instance.get.return_value = mock_response
-            mock_client_instance.__aenter__ = AsyncMock(
-                return_value=mock_client_instance
-            )
-            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
-            MockClient.return_value = mock_client_instance
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
 
-            transcript = await assembly_handler._get_assembly_transcript(
-                "abc123-valid-id_xyz"
-            )
-            assert transcript == mock_transcript_response
-            called_url = mock_client_instance.get.call_args[0][0]
-            assert "abc123-valid-id_xyz" in called_url
-            assert ".." not in called_url
+        transcript = await assembly_handler._get_assembly_transcript(
+            "abc123-valid-id_xyz", client=mock_client
+        )
+        assert transcript == mock_transcript_response
+        called_url = mock_client.get.call_args[0][0]
+        assert "abc123-valid-id_xyz" in called_url
+        assert ".." not in called_url
 
 
 @pytest.mark.asyncio
@@ -216,17 +215,22 @@ async def test_assemblyai_handler_runs_in_async_context():
     response_body = {"id": "test-id", "status": "queued", "speech_model": "nano"}
     mock_transcript = {"id": "test-id", "status": "completed", "audio_duration": 60.0}
 
-    with patch.object(
-        handler, "_poll_assembly_for_transcript_response",
-        new_callable=AsyncMock,
-        return_value=AssemblyAITranscriptResponse(**mock_transcript),
-    ), patch(
-        "litellm.proxy.pass_through_endpoints.llm_provider_handlers.assembly_passthrough_logging_handler.get_standard_logging_object_payload",
-        return_value={},
-    ), patch(
-        "litellm.proxy.pass_through_endpoints.success_handler.PassThroughEndpointLogging._handle_logging",
-        new_callable=AsyncMock,
-    ) as mock_handle_logging:
+    with (
+        patch.object(
+            handler,
+            "_poll_assembly_for_transcript_response",
+            new_callable=AsyncMock,
+            return_value=AssemblyAITranscriptResponse(**mock_transcript),
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.assembly_passthrough_logging_handler.get_standard_logging_object_payload",
+            return_value={},
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.success_handler.PassThroughEndpointLogging._handle_logging",
+            new_callable=AsyncMock,
+        ) as mock_handle_logging,
+    ):
         # This must be awaitable (async), not fire-and-forget (thread pool)
         await handler.assemblyai_passthrough_logging_handler(
             httpx_response=mock_httpx_response,

--- a/tests/pass_through_unit_tests/test_assemblyai_unit_tests_passthrough.py
+++ b/tests/pass_through_unit_tests/test_assemblyai_unit_tests_passthrough.py
@@ -13,22 +13,6 @@ import httpx
 import pytest
 import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-
-
-import json
-import os
-import sys
-from datetime import datetime
-from unittest.mock import AsyncMock, Mock, patch
-
-sys.path.insert(
-    0, os.path.abspath("../..")
-)  # Adds the parent directory to the system-path
-
-import httpx
-import pytest
-import litellm
-from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.assembly_passthrough_logging_handler import (
     AssemblyAIPassthroughLoggingHandler,
     AssemblyAITranscriptResponse,
@@ -62,56 +46,60 @@ def test_should_log_request():
     assert handler._should_log_request("GET") == False
 
 
-def test_get_assembly_transcript(assembly_handler, mock_transcript_response):
+@pytest.mark.asyncio
+async def test_get_assembly_transcript(assembly_handler, mock_transcript_response):
     """
     Test that the _get_assembly_transcript method calls GET /v2/transcript/{transcript_id}
     and uses the test key returned by the mocked get_credentials.
     """
-    # Patch get_credentials to return "test-key"
     with patch(
         "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
         return_value="test-key",
     ):
-        with patch("httpx.get") as mock_get:
-            mock_get.return_value.json.return_value = mock_transcript_response
-            mock_get.return_value.raise_for_status.return_value = None
+        mock_response = Mock()
+        mock_response.json.return_value = mock_transcript_response
+        mock_response.raise_for_status.return_value = None
 
-            transcript = assembly_handler._get_assembly_transcript("test-transcript-id")
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            transcript = await assembly_handler._get_assembly_transcript("test-transcript-id")
             assert transcript == mock_transcript_response
 
-            mock_get.assert_called_once_with(
+            mock_client_instance.get.assert_called_once_with(
                 "https://api.assemblyai.com/v2/transcript/test-transcript-id",
                 headers={
-                    "Authorization": "Bearer test-key",
+                    "Authorization": "test-key",
                     "Content-Type": "application/json",
                 },
             )
 
 
-def test_poll_assembly_for_transcript_response(
+@pytest.mark.asyncio
+async def test_poll_assembly_for_transcript_response(
     assembly_handler, mock_transcript_response
 ):
     """
     Test that the _poll_assembly_for_transcript_response method returns the correct transcript response
     """
-    with patch(
-        "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
-        return_value="test-key",
+    with patch.object(
+        assembly_handler, "_get_assembly_transcript",
+        new_callable=AsyncMock,
+        return_value=mock_transcript_response,
     ):
-        with patch("httpx.get") as mock_get:
-            mock_get.return_value.json.return_value = mock_transcript_response
-            mock_get.return_value.raise_for_status.return_value = None
+        assembly_handler.polling_interval = 0.01
+        assembly_handler.max_polling_attempts = 2
 
-            # Override polling settings for faster test
-            assembly_handler.polling_interval = 0.01
-            assembly_handler.max_polling_attempts = 2
-
-            transcript = assembly_handler._poll_assembly_for_transcript_response(
-                "test-transcript-id",
-            )
-            assert transcript == AssemblyAITranscriptResponse(
-                **mock_transcript_response
-            )
+        transcript = await assembly_handler._poll_assembly_for_transcript_response(
+            "test-transcript-id",
+        )
+        assert transcript == AssemblyAITranscriptResponse(
+            **mock_transcript_response
+        )
 
 
 def test_is_assemblyai_route():
@@ -139,57 +127,117 @@ def test_is_assemblyai_route():
 # --- Security: SSRF via transcript_id path traversal ---
 
 
-def test_get_assembly_transcript_rejects_slash_in_id(assembly_handler):
+@pytest.mark.asyncio
+async def test_get_assembly_transcript_rejects_slash_in_id(assembly_handler):
     with patch(
         "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
         return_value="test-key",
     ):
         with pytest.raises(ValueError, match="disallowed characters"):
-            assembly_handler._get_assembly_transcript("../../admin/credentials")
+            await assembly_handler._get_assembly_transcript("../../admin/credentials")
 
 
-def test_get_assembly_transcript_rejects_dotdot_in_id(assembly_handler):
+@pytest.mark.asyncio
+async def test_get_assembly_transcript_rejects_dotdot_in_id(assembly_handler):
     with patch(
         "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
         return_value="test-key",
     ):
         with pytest.raises(ValueError, match="disallowed characters"):
-            assembly_handler._get_assembly_transcript("..evil")
+            await assembly_handler._get_assembly_transcript("..evil")
 
 
-def test_get_assembly_transcript_rejects_fragment_in_id(assembly_handler):
+@pytest.mark.asyncio
+async def test_get_assembly_transcript_rejects_fragment_in_id(assembly_handler):
     with patch(
         "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
         return_value="test-key",
     ):
         with pytest.raises(ValueError, match="disallowed characters"):
-            assembly_handler._get_assembly_transcript("abc#suffix")
+            await assembly_handler._get_assembly_transcript("abc#suffix")
 
 
-def test_get_assembly_transcript_rejects_query_in_id(assembly_handler):
+@pytest.mark.asyncio
+async def test_get_assembly_transcript_rejects_query_in_id(assembly_handler):
     with patch(
         "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
         return_value="test-key",
     ):
         with pytest.raises(ValueError, match="disallowed characters"):
-            assembly_handler._get_assembly_transcript("abc?x=1")
+            await assembly_handler._get_assembly_transcript("abc?x=1")
 
 
-def test_get_assembly_transcript_allows_valid_id(
+@pytest.mark.asyncio
+async def test_get_assembly_transcript_allows_valid_id(
     assembly_handler, mock_transcript_response
 ):
     with patch(
         "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
         return_value="test-key",
     ):
-        with patch("httpx.get") as mock_get:
-            mock_get.return_value.json.return_value = mock_transcript_response
-            mock_get.return_value.raise_for_status.return_value = None
+        mock_response = Mock()
+        mock_response.json.return_value = mock_transcript_response
+        mock_response.raise_for_status.return_value = None
 
-            transcript = assembly_handler._get_assembly_transcript(
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get.return_value = mock_response
+            mock_client_instance.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client_instance
+
+            transcript = await assembly_handler._get_assembly_transcript(
                 "abc123-valid-id_xyz"
             )
             assert transcript == mock_transcript_response
-            called_url = mock_get.call_args[0][0]
+            called_url = mock_client_instance.get.call_args[0][0]
             assert "abc123-valid-id_xyz" in called_url
             assert ".." not in called_url
+
+
+@pytest.mark.asyncio
+async def test_assemblyai_handler_runs_in_async_context():
+    """
+    The handler must be awaitable and run in the caller's async context
+    (not a thread pool) so _handle_logging() can access the database.
+    """
+    handler = AssemblyAIPassthroughLoggingHandler()
+
+    mock_httpx_response = Mock(spec=httpx.Response)
+    mock_httpx_response.request = Mock()
+    mock_httpx_response.request.method = "POST"
+    mock_httpx_response.text = '{"id": "test-id", "status": "queued"}'
+
+    mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+    mock_logging_obj.model_call_details = {}
+
+    response_body = {"id": "test-id", "status": "queued", "speech_model": "nano"}
+    mock_transcript = {"id": "test-id", "status": "completed", "audio_duration": 60.0}
+
+    with patch.object(
+        handler, "_poll_assembly_for_transcript_response",
+        new_callable=AsyncMock,
+        return_value=AssemblyAITranscriptResponse(**mock_transcript),
+    ), patch(
+        "litellm.proxy.pass_through_endpoints.llm_provider_handlers.assembly_passthrough_logging_handler.get_standard_logging_object_payload",
+        return_value={},
+    ), patch(
+        "litellm.proxy.pass_through_endpoints.success_handler.PassThroughEndpointLogging._handle_logging",
+        new_callable=AsyncMock,
+    ) as mock_handle_logging:
+        # This must be awaitable (async), not fire-and-forget (thread pool)
+        await handler.assemblyai_passthrough_logging_handler(
+            httpx_response=mock_httpx_response,
+            response_body=response_body,
+            logging_obj=mock_logging_obj,
+            url_route="https://api.assemblyai.com/v2/transcript",
+            result="{}",
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            cache_hit=False,
+        )
+
+        # response_cost should be set from dynamic calculation
+        assert mock_logging_obj.model_call_details.get("response_cost") is not None


### PR DESCRIPTION
## Summary

Fixes the AssemblyAI pass-through handler so that dynamic cost tracking works correctly:

- **Fix auth header in polling requests**: Removed erroneous `Bearer` prefix from the `Authorization` header when polling `GET /v2/transcript/{id}`. AssemblyAI expects `Authorization: <api_key>`, not `Authorization: Bearer <api_key>`. This caused silent 401 failures during transcript polling, preventing cost calculation.
- **Refactor handler from sync-in-thread to native async**: The handler previously ran synchronously inside `executor.submit()` with `asyncio.run()`, which created a separate event loop unable to access the FastAPI app's DB connection pool. Converted all handler methods to `async` using `httpx.AsyncClient` and `asyncio.sleep`, and updated `success_handler.py` to `await` the handler call.
- **Updated unit tests**: Converted existing tests to async and added a new test verifying the handler runs in the caller's async context.

## Test plan

- [x] Existing unit tests pass (`pytest tests/pass_through_unit_tests/test_assemblyai_unit_tests_passthrough.py`)
- [x] New `test_assemblyai_handler_runs_in_async_context` test passes
- [x] Integration tested with Docker: submitted transcription via `/assemblyai/v2/transcript`, polling completed successfully, dynamic cost `$0.0290` recorded on key (not hardcoded `$0.50`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)