### PR TITLE
fix(bedrock): pass anthropic_beta through for ARN-based inference profiles

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -350,7 +350,9 @@ class AmazonConverseConfig(BaseConfig):
 
         # Check if the model is a Nova 2 model (matches nova-2-lite, nova-2-pro, etc.)
         # Also check for nova-2/ spec prefix for imported models
-        return model_without_region.startswith("amazon.nova-2-") or model_without_region.startswith("nova-2/")
+        return model_without_region.startswith(
+            "amazon.nova-2-"
+        ) or model_without_region.startswith("nova-2/")
 
     def _map_web_search_options(
         self, web_search_options: dict, model: str
@@ -764,8 +766,7 @@ class AmazonConverseConfig(BaseConfig):
     def _supports_native_structured_outputs(model: str) -> bool:
         """Check if the Bedrock model supports native structured outputs (outputConfig.textFormat)."""
         return any(
-            substring in model
-            for substring in BEDROCK_NATIVE_STRUCTURED_OUTPUT_MODELS
+            substring in model for substring in BEDROCK_NATIVE_STRUCTURED_OUTPUT_MODELS
         )
 
     @staticmethod
@@ -919,9 +920,7 @@ class AmazonConverseConfig(BaseConfig):
             if param == "parallel_tool_calls":
                 disable_parallel = not value
                 optional_params["_parallel_tool_use_config"] = {
-                    "tool_choice": {
-                        "disable_parallel_tool_use": disable_parallel
-                    }
+                    "tool_choice": {"disable_parallel_tool_use": disable_parallel}
                 }
             if param == "thinking":
                 optional_params["thinking"] = value
@@ -1219,10 +1218,17 @@ class AmazonConverseConfig(BaseConfig):
         }
 
         # Handle parallel_tool_calls configuration
-        parallel_tool_use_config = additional_request_params.pop("_parallel_tool_use_config", None)
+        parallel_tool_use_config = additional_request_params.pop(
+            "_parallel_tool_use_config", None
+        )
         if parallel_tool_use_config is not None and is_claude_4_5_on_bedrock(model):
+            # Merge the tool_choice config from parallel_tool_calls into additional_request_params
             for key, value in parallel_tool_use_config.items():
-                if key in additional_request_params and isinstance(additional_request_params[key], dict) and isinstance(value, dict):
+                if (
+                    key in additional_request_params
+                    and isinstance(additional_request_params[key], dict)
+                    and isinstance(value, dict)
+                ):
                     additional_request_params[key].update(value)
                 else:
                     additional_request_params[key] = value
@@ -1304,7 +1310,16 @@ class AmazonConverseConfig(BaseConfig):
                 # "computer-use-2025-01-24" for Claude Sonnet 4.5, Haiku 4.5, Opus 4.1, Sonnet 4, Opus 4, and Sonnet 3.7
                 # "computer-use-2024-10-22" for older models
                 model_lower = model.lower()
-                if "opus-4.6" in model_lower or "opus_4.6" in model_lower or "opus-4-6" in model_lower or "opus_4_6" in model_lower or "sonnet-4.6" in model_lower or "sonnet_4.6" in model_lower or "sonnet-4-6" in model_lower or "sonnet_4_6" in model_lower:
+                if (
+                    "opus-4.6" in model_lower
+                    or "opus_4.6" in model_lower
+                    or "opus-4-6" in model_lower
+                    or "opus_4_6" in model_lower
+                    or "sonnet-4.6" in model_lower
+                    or "sonnet_4.6" in model_lower
+                    or "sonnet-4-6" in model_lower
+                    or "sonnet_4_6" in model_lower
+                ):
                     computer_use_header = "computer-use-2025-11-24"
                 elif (
                     "opus-4.5" in model_lower
@@ -1355,10 +1370,16 @@ class AmazonConverseConfig(BaseConfig):
         # Append pre-formatted tools (systemTool etc.) after transformation
         bedrock_tools.extend(pre_formatted_tools)
 
-        # Set anthropic_beta in additional_request_params if we have any beta features
-        # ONLY apply to Anthropic/Claude models - other models (e.g., Qwen, Llama) don't support this field
+        # Set anthropic_beta in additional_request_params if we have any beta features.
+        # ONLY apply to Anthropic/Claude models - other models (e.g., Qwen, Llama) don't support this field.
+        # For inference profile ARNs, get_base_model() returns the opaque profile ID — the model family
+        # cannot be determined from the ARN alone. We trust the caller's explicit anthropic-beta header:
+        # if they set it, they know what model is behind their profile. This is consistent with how
+        # get_supported_openai_params() handles ARN models (adds all params without model-family checks).
         base_model = BedrockModelInfo.get_base_model(model)
-        if anthropic_beta_list and base_model.startswith("anthropic"):
+        if anthropic_beta_list and (
+            base_model.startswith("anthropic") or "arn" in model.lower()
+        ):
             additional_request_params["anthropic_beta"] = anthropic_beta_list
 
         return bedrock_tools, anthropic_beta_list

--- a/tests/test_litellm/llms/bedrock/test_anthropic_beta_support.py
+++ b/tests/test_litellm/llms/bedrock/test_anthropic_beta_support.py
@@ -43,7 +43,9 @@ class TestAnthropicBetaHeaderSupport:
 
     def test_get_anthropic_beta_from_headers_whitespace(self):
         """Test header extraction handles whitespace correctly."""
-        headers = {"anthropic-beta": " context-1m-2025-08-07 , computer-use-2024-10-22 "}
+        headers = {
+            "anthropic-beta": " context-1m-2025-08-07 , computer-use-2024-10-22 "
+        }
         result = get_anthropic_beta_from_headers(headers)
         assert result == ["context-1m-2025-08-07", "computer-use-2024-10-22"]
 
@@ -51,51 +53,58 @@ class TestAnthropicBetaHeaderSupport:
         """Test that Invoke API transformation includes anthropic_beta in request."""
         config = AmazonAnthropicClaudeConfig()
         headers = {"anthropic-beta": "context-1m-2025-08-07,computer-use-2024-10-22"}
-        
+
         result = config.transform_request(
             model="anthropic.claude-3-5-sonnet-20241022-v2:0",
             messages=[{"role": "user", "content": "Test"}],
             optional_params={},
             litellm_params={},
-            headers=headers
+            headers=headers,
         )
-        
+
         assert "anthropic_beta" in result
         # Beta flags are stored as sets, so order may vary
-        assert set(result["anthropic_beta"]) == {"context-1m-2025-08-07", "computer-use-2024-10-22"}
+        assert set(result["anthropic_beta"]) == {
+            "context-1m-2025-08-07",
+            "computer-use-2024-10-22",
+        }
 
     def test_converse_transformation_anthropic_beta(self):
         """Test that Converse API transformation includes anthropic_beta in additionalModelRequestFields."""
         config = AmazonConverseConfig()
-        headers = {"anthropic-beta": "context-1m-2025-08-07,interleaved-thinking-2025-05-14"}
-        
+        headers = {
+            "anthropic-beta": "context-1m-2025-08-07,interleaved-thinking-2025-05-14"
+        }
+
         result = config._transform_request_helper(
             model="anthropic.claude-3-5-sonnet-20241022-v2:0",
             system_content_blocks=[],
             optional_params={},
             messages=[{"role": "user", "content": "Test"}],
-            headers=headers
+            headers=headers,
         )
-        
+
         assert "additionalModelRequestFields" in result
         additional_fields = result["additionalModelRequestFields"]
         assert "anthropic_beta" in additional_fields
         # Sort both arrays before comparing to avoid flakiness from ordering differences
-        assert sorted(additional_fields["anthropic_beta"]) == sorted(["context-1m-2025-08-07", "interleaved-thinking-2025-05-14"])
+        assert sorted(additional_fields["anthropic_beta"]) == sorted(
+            ["context-1m-2025-08-07", "interleaved-thinking-2025-05-14"]
+        )
 
     def test_messages_transformation_anthropic_beta(self):
         """Test that Messages API transformation includes anthropic_beta in request."""
         config = AmazonAnthropicClaudeMessagesConfig()
         headers = {"anthropic-beta": "output-128k-2025-02-19"}
-        
+
         result = config.transform_anthropic_messages_request(
             model="anthropic.claude-3-5-sonnet-20241022-v2:0",
             messages=[{"role": "user", "content": "Test"}],
             anthropic_messages_optional_request_params={"max_tokens": 100},
             litellm_params={},
-            headers=headers
+            headers=headers,
         )
-        
+
         assert "anthropic_beta" in result
         # Sort both arrays before comparing to avoid flakiness from ordering differences
         assert sorted(result["anthropic_beta"]) == sorted(["output-128k-2025-02-19"])
@@ -104,28 +113,28 @@ class TestAnthropicBetaHeaderSupport:
         """Test that user anthropic_beta headers work with computer use tools."""
         config = AmazonConverseConfig()
         headers = {"anthropic-beta": "context-1m-2025-08-07"}
-        
+
         # Computer use tools should automatically add computer-use-2024-10-22
         tools = [
             {
                 "type": "computer_20241022",
                 "name": "computer",
                 "display_width_px": 1024,
-                "display_height_px": 768
+                "display_height_px": 768,
             }
         ]
-        
+
         result = config._transform_request_helper(
             model="anthropic.claude-3-5-sonnet-20241022-v2:0",
             system_content_blocks=[],
             optional_params={"tools": tools},
             messages=[{"role": "user", "content": "Test"}],
-            headers=headers
+            headers=headers,
         )
-        
+
         additional_fields = result["additionalModelRequestFields"]
         betas = additional_fields["anthropic_beta"]
-        
+
         # Should contain both user-provided and auto-added beta headers
         assert "context-1m-2025-08-07" in betas
         assert "computer-use-2024-10-22" in betas
@@ -135,15 +144,15 @@ class TestAnthropicBetaHeaderSupport:
         """Test that transformations work correctly when no anthropic_beta headers are provided."""
         config = AmazonConverseConfig()
         headers = {}
-        
+
         result = config._transform_request_helper(
             model="anthropic.claude-3-5-sonnet-20241022-v2:0",
             system_content_blocks=[],
             optional_params={},
             messages=[{"role": "user", "content": "Test"}],
-            headers=headers
+            headers=headers,
         )
-        
+
         additional_fields = result.get("additionalModelRequestFields", {})
         assert "anthropic_beta" not in additional_fields
 
@@ -156,33 +165,33 @@ class TestAnthropicBetaHeaderSupport:
             "token-efficient-tools-2025-02-19",
             "interleaved-thinking-2025-05-14",
             "output-128k-2025-02-19",
-            "dev-full-thinking-2025-05-14"
+            "dev-full-thinking-2025-05-14",
         ]
-        
+
         config = AmazonAnthropicClaudeConfig()
         headers = {"anthropic-beta": ",".join(supported_features)}
-        
+
         result = config.transform_request(
             model="anthropic.claude-3-5-sonnet-20241022-v2:0",
             messages=[{"role": "user", "content": "Test"}],
             optional_params={},
             litellm_params={},
-            headers=headers
+            headers=headers,
         )
-        
+
         assert "anthropic_beta" in result
         # Beta flags are stored as sets, so order may vary
         assert set(result["anthropic_beta"]) == set(supported_features)
 
     def test_prompt_caching_no_beta_header_messages_api(self):
         """Test that prompt caching (cache_control) does NOT add prompt-caching-2024-07-31 beta header for Bedrock.
-        
+
         Bedrock recognizes prompt caching via the request body (cache_control field),
         not through beta headers. This test verifies the fix.
         """
         config = AmazonAnthropicClaudeMessagesConfig()
         headers = {}
-        
+
         # Messages with cache_control set (prompt caching enabled)
         messages = [
             {
@@ -191,20 +200,20 @@ class TestAnthropicBetaHeaderSupport:
                     {
                         "type": "text",
                         "text": "Hello",
-                        "cache_control": {"type": "ephemeral"}
+                        "cache_control": {"type": "ephemeral"},
                     }
-                ]
+                ],
             }
         ]
-        
+
         result = config.transform_anthropic_messages_request(
             model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
             messages=messages,
             anthropic_messages_optional_request_params={"max_tokens": 100},
             litellm_params={},
-            headers=headers
+            headers=headers,
         )
-        
+
         # Verify prompt-caching-2024-07-31 is NOT in anthropic_beta
         if "anthropic_beta" in result:
             assert "prompt-caching-2024-07-31" not in result["anthropic_beta"], (
@@ -217,13 +226,13 @@ class TestAnthropicBetaHeaderSupport:
 
     def test_prompt_caching_no_beta_header_chat_api(self):
         """Test that prompt caching (cache_control) does NOT add prompt-caching-2024-07-31 beta header for Bedrock Chat API.
-        
+
         Bedrock recognizes prompt caching via the request body (cache_control field),
         not through beta headers. This test verifies the fix.
         """
         config = AmazonAnthropicClaudeConfig()
         headers = {}
-        
+
         # Messages with cache_control set (prompt caching enabled)
         messages = [
             {
@@ -232,20 +241,20 @@ class TestAnthropicBetaHeaderSupport:
                     {
                         "type": "text",
                         "text": "Hello",
-                        "cache_control": {"type": "ephemeral"}
+                        "cache_control": {"type": "ephemeral"},
                     }
-                ]
+                ],
             }
         ]
-        
+
         result = config.transform_request(
             model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
             messages=messages,
             optional_params={},
             litellm_params={},
-            headers=headers
+            headers=headers,
         )
-        
+
         # Verify prompt-caching-2024-07-31 is NOT in anthropic_beta
         if "anthropic_beta" in result:
             assert "prompt-caching-2024-07-31" not in result["anthropic_beta"], (
@@ -260,7 +269,7 @@ class TestAnthropicBetaHeaderSupport:
         """Test that prompt caching doesn't interfere with other valid beta headers."""
         config = AmazonAnthropicClaudeMessagesConfig()
         headers = {"anthropic-beta": "context-1m-2025-08-07"}
-        
+
         # Messages with cache_control set
         messages = [
             {
@@ -269,20 +278,20 @@ class TestAnthropicBetaHeaderSupport:
                     {
                         "type": "text",
                         "text": "Hello",
-                        "cache_control": {"type": "ephemeral"}
+                        "cache_control": {"type": "ephemeral"},
                     }
-                ]
+                ],
             }
         ]
-        
+
         result = config.transform_anthropic_messages_request(
             model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
             messages=messages,
             anthropic_messages_optional_request_params={"max_tokens": 100},
             litellm_params={},
-            headers=headers
+            headers=headers,
         )
-        
+
         # Should have the user-provided beta header but NOT prompt-caching
         if "anthropic_beta" in result:
             assert "context-1m-2025-08-07" in result["anthropic_beta"]
@@ -293,23 +302,25 @@ class TestAnthropicBetaHeaderSupport:
 
     def test_converse_non_anthropic_model_no_anthropic_beta(self):
         """Test that non-Anthropic models (e.g., Qwen) do NOT get anthropic_beta in additionalModelRequestFields.
-        
+
         This is critical because non-Anthropic models on Bedrock will error with
         "unknown variant anthropic_beta" if this field is included.
         """
         config = AmazonConverseConfig()
         # Even if headers contain anthropic-beta, non-Anthropic models should NOT get it
-        headers = {"anthropic-beta": "context-1m-2025-08-07,interleaved-thinking-2025-05-14"}
-        
+        headers = {
+            "anthropic-beta": "context-1m-2025-08-07,interleaved-thinking-2025-05-14"
+        }
+
         # Test with Qwen model (using ARN format like the user's config)
         result = config._transform_request_helper(
             model="qwen.qwen3-coder-480b-a35b-v1:0",
             system_content_blocks=[],
             optional_params={},
             messages=[{"role": "user", "content": "Test"}],
-            headers=headers
+            headers=headers,
         )
-        
+
         additional_fields = result.get("additionalModelRequestFields", {})
         assert "anthropic_beta" not in additional_fields, (
             "anthropic_beta should NOT be added for non-Anthropic models like Qwen. "
@@ -320,73 +331,138 @@ class TestAnthropicBetaHeaderSupport:
         """Test that Llama models do NOT get anthropic_beta in additionalModelRequestFields."""
         config = AmazonConverseConfig()
         headers = {"anthropic-beta": "context-1m-2025-08-07"}
-        
+
         result = config._transform_request_helper(
             model="meta.llama3-2-11b-instruct-v1:0",
             system_content_blocks=[],
             optional_params={},
             messages=[{"role": "user", "content": "Test"}],
-            headers=headers
+            headers=headers,
         )
-        
+
         additional_fields = result.get("additionalModelRequestFields", {})
-        assert "anthropic_beta" not in additional_fields, (
-            "anthropic_beta should NOT be added for Llama models."
-        )
+        assert (
+            "anthropic_beta" not in additional_fields
+        ), "anthropic_beta should NOT be added for Llama models."
 
     def test_converse_nova_model_no_anthropic_beta(self):
         """Test that Amazon Nova models do NOT get anthropic_beta in additionalModelRequestFields."""
         config = AmazonConverseConfig()
         headers = {"anthropic-beta": "computer-use-2024-10-22"}
-        
+
         result = config._transform_request_helper(
             model="amazon.nova-pro-v1:0",
             system_content_blocks=[],
             optional_params={},
             messages=[{"role": "user", "content": "Test"}],
-            headers=headers
+            headers=headers,
         )
-        
+
         additional_fields = result.get("additionalModelRequestFields", {})
-        assert "anthropic_beta" not in additional_fields, (
-            "anthropic_beta should NOT be added for Amazon Nova models."
-        )
+        assert (
+            "anthropic_beta" not in additional_fields
+        ), "anthropic_beta should NOT be added for Amazon Nova models."
 
     def test_converse_anthropic_model_gets_anthropic_beta(self):
         """Test that Anthropic models DO get anthropic_beta in additionalModelRequestFields."""
         config = AmazonConverseConfig()
         headers = {"anthropic-beta": "context-1m-2025-08-07"}
-        
+
         result = config._transform_request_helper(
             model="anthropic.claude-3-5-sonnet-20241022-v2:0",
             system_content_blocks=[],
             optional_params={},
             messages=[{"role": "user", "content": "Test"}],
-            headers=headers
+            headers=headers,
         )
-        
+
         additional_fields = result.get("additionalModelRequestFields", {})
-        assert "anthropic_beta" in additional_fields, (
-            "anthropic_beta SHOULD be added for Anthropic models."
-        )
+        assert (
+            "anthropic_beta" in additional_fields
+        ), "anthropic_beta SHOULD be added for Anthropic models."
         assert "context-1m-2025-08-07" in additional_fields["anthropic_beta"]
 
     def test_converse_anthropic_model_with_cross_region_prefix(self):
         """Test that Anthropic models with cross-region prefix still get anthropic_beta."""
         config = AmazonConverseConfig()
         headers = {"anthropic-beta": "context-1m-2025-08-07"}
-        
+
         # Model with 'us.' cross-region prefix
         result = config._transform_request_helper(
             model="us.anthropic.claude-3-5-sonnet-20241022-v2:0",
             system_content_blocks=[],
             optional_params={},
             messages=[{"role": "user", "content": "Test"}],
-            headers=headers
+            headers=headers,
         )
-        
+
+        additional_fields = result.get("additionalModelRequestFields", {})
+        assert (
+            "anthropic_beta" in additional_fields
+        ), "anthropic_beta SHOULD be added for Anthropic models with cross-region prefix."
+        assert "context-1m-2025-08-07" in additional_fields["anthropic_beta"]
+
+    def test_converse_arn_inference_profile_gets_anthropic_beta(self):
+        """Regression test: ARN-based inference profiles should get anthropic_beta.
+
+        Bug: _process_tools_and_beta() calls BedrockModelInfo.get_base_model(model)
+        which, for an ARN like
+        arn:aws:bedrock:us-east-1:123456789012:inference-profile/ow66n5rz5qt0,
+        returns the opaque profile ID ('ow66n5rz5qt0') rather than 'anthropic.claude-*'.
+        The guard `base_model.startswith("anthropic")` then silently drops the flag.
+        """
+        config = AmazonConverseConfig()
+        headers = {"anthropic-beta": "context-1m-2025-08-07"}
+
+        arn_model = (
+            "arn:aws:bedrock:us-east-1:123456789012:inference-profile/ow66n5rz5qt0"
+        )
+
+        result = config._transform_request_helper(
+            model=arn_model,
+            system_content_blocks=[],
+            optional_params={},
+            messages=[{"role": "user", "content": "Test"}],
+            headers=headers,
+        )
+
         additional_fields = result.get("additionalModelRequestFields", {})
         assert "anthropic_beta" in additional_fields, (
-            "anthropic_beta SHOULD be added for Anthropic models with cross-region prefix."
+            "anthropic_beta SHOULD be added for ARN-based inference profiles. "
+            "get_base_model() returns the profile ID for ARN models, so the "
+            "startswith('anthropic') guard incorrectly drops the flag."
         )
         assert "context-1m-2025-08-07" in additional_fields["anthropic_beta"]
+
+    def test_converse_inference_profile_arn_respects_explicit_anthropic_beta(self):
+        """Inference profile ARNs must pass through explicitly-set anthropic-beta headers.
+
+        For inference profile ARNs, LiteLLM cannot determine the underlying model family
+        from the ARN alone — the profile ID is opaque (e.g. 'ow66n5rz5qt0'). If the user
+        has explicitly sent an anthropic-beta header, they know what model is behind their
+        profile and we must respect that. Dropping it silently breaks features like 1M
+        context for users who route via inference profiles for cost-tracking/tagging.
+        """
+        config = AmazonConverseConfig()
+        headers = {"anthropic-beta": "context-1m-2025-08-07"}
+
+        # Application inference profile — opaque ID, model family unknown to LiteLLM
+        for arn_model in [
+            "arn:aws:bedrock:us-east-1:123456789012:inference-profile/ow66n5rz5qt0",
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/ab12cd34",
+        ]:
+            result = config._transform_request_helper(
+                model=arn_model,
+                system_content_blocks=[],
+                optional_params={},
+                messages=[{"role": "user", "content": "Test"}],
+                headers=headers,
+            )
+
+            additional_fields = result.get("additionalModelRequestFields", {})
+            assert "anthropic_beta" in additional_fields, (
+                f"anthropic_beta SHOULD be passed through for inference profile ARN {arn_model}. "
+                "The model family cannot be determined from the ARN — the user's explicit header "
+                "must be respected."
+            )
+            assert "context-1m-2025-08-07" in additional_fields["anthropic_beta"]


### PR DESCRIPTION
## Relevant issues

Fixes #22016

## Pre-Submission checklist

- [x] I have added testing in `tests/test_litellm/llms/bedrock/test_anthropic_beta_support.py`
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

When a Bedrock model is specified as an ARN-based inference profile (e.g.
`arn:aws:bedrock:us-east-1:123456789012:inference-profile/ow66n5rz5qt0`),
`anthropic-beta` headers such as `context-1m-2025-08-07` are silently dropped
and never reach `additionalModelRequestFields`.

`_process_tools_and_beta()` in `converse_transformation.py` guards:

```python
if anthropic_beta_list and base_model.startswith("anthropic"):
```

For ARN models, `BedrockModelInfo.get_base_model()` calls
`extract_model_name_from_bedrock_arn()` which returns the opaque profile ID
after the last `/` (e.g. `ow66n5rz5qt0`) — not `anthropic.claude-*`. The guard
always fails, silently dropping the flag.

### History

This is a regression from PR #20935 (`litellm_anthropic_filter_bedrock_headers`), which added the `base_model.startswith("anthropic")` guard to prevent non-Anthropic models (e.g. Qwen, Llama) from receiving `anthropic_beta`. The original fix in PR #13590 set `anthropic_beta` unconditionally. The guard is correct for named models but breaks ARN-based inference profiles where the underlying model family cannot be inferred from the identifier.

### Background
AWS Bedrock application inference profiles allow tagging, which enables
per-team or per-project cost allocation. Without inference profiles, all
usage of a base model in an account lands in one cost bucket. This makes
ARN-based inference profiles a common production pattern for anyone doing
cost tracking — making this bug a practical blocker for `anthropic-beta`
features (e.g. 1M context) in those environments.

### Fix
One condition added to the guard — also allow through when `"arn"` is present
in the model string, consistent with the same pattern already used in
`get_supported_openai_params()`.

### Backwards compatibility
Named models (`anthropic.claude-*`, `us.anthropic.claude-*`) are unaffected —
the existing `startswith("anthropic")` path is unchanged.

### Tests added
`test_converse_arn_inference_profile_gets_anthropic_beta` in
`tests/test_litellm/llms/bedrock/test_anthropic_beta_support.py` — asserts
`anthropic_beta` reaches `additionalModelRequestFields` when an ARN model is used.