### PR TITLE
fix(bedrock): pass timeout param to bedrock rerank http client

### DIFF
--- a/litellm/llms/bedrock/rerank/handler.py
+++ b/litellm/llms/bedrock/rerank/handler.py
@@ -29,12 +29,13 @@ class BedrockRerankHandler(BaseAWSLLM):
     async def arerank(
         self,
         prepared_request: BedrockPreparedRequest,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[AsyncHTTPHandler] = None,
     ):
         if client is None:
             client = get_async_httpx_client(llm_provider=litellm.LlmProviders.BEDROCK)
         try:
-            response = await client.post(url=prepared_request["endpoint_url"], headers=dict(prepared_request["prepped"].headers), data=prepared_request["body"])
+            response = await client.post(url=prepared_request["endpoint_url"], headers=dict(prepared_request["prepped"].headers), data=prepared_request["body"], timeout=timeout)
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code = err.response.status_code
@@ -56,6 +57,7 @@ class BedrockRerankHandler(BaseAWSLLM):
         return_documents: Optional[bool] = True,
         max_chunks_per_doc: Optional[int] = None,
         _is_async: Optional[bool] = False,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
         api_base: Optional[str] = None,
         extra_headers: Optional[dict] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
@@ -89,12 +91,12 @@ class BedrockRerankHandler(BaseAWSLLM):
         )
 
         if _is_async:
-            return self.arerank(prepared_request, client=client if client is not None and isinstance(client, AsyncHTTPHandler) else None)  # type: ignore
+            return self.arerank(prepared_request, timeout=timeout, client=client if client is not None and isinstance(client, AsyncHTTPHandler) else None)  # type: ignore
 
         if client is None or not isinstance(client, HTTPHandler):
             client = _get_httpx_client()
         try:
-            response = client.post(url=prepared_request["endpoint_url"], headers=dict(prepared_request["prepped"].headers), data=prepared_request["body"])
+            response = client.post(url=prepared_request["endpoint_url"], headers=dict(prepared_request["prepped"].headers), data=prepared_request["body"], timeout=timeout)
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code = err.response.status_code

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -26555,65 +26555,124 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "perplexity/preset/fast-search": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_preset": true,
+        "supports_function_calling": true
+    },
     "perplexity/preset/pro-search": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_preset": true
+        "supports_preset": true,
+        "supports_function_calling": true
     },
-    "perplexity/openai/gpt-4o": {
+    "perplexity/preset/deep-research": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_preset": true,
+        "supports_function_calling": true
     },
-    "perplexity/openai/gpt-4o-mini": {
+    "perplexity/preset/advanced-deep-research": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_preset": true,
+        "supports_function_calling": true
     },
     "perplexity/openai/gpt-5.2": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": true
+        "supports_reasoning": true,
+        "supports_function_calling": true
     },
-    "perplexity/anthropic/claude-3-5-sonnet-20241022": {
+    "perplexity/openai/gpt-5.1": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
-    "perplexity/anthropic/claude-3-5-haiku-20241022": {
+    "perplexity/openai/gpt-5-mini": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
-    "perplexity/google/gemini-2.0-flash-exp": {
+    "perplexity/anthropic/claude-opus-4-6": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
-    "perplexity/google/gemini-2.0-flash-thinking-exp": {
+    "perplexity/anthropic/claude-opus-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": true
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
-    "perplexity/xai/grok-2-1212": {
+    "perplexity/anthropic/claude-sonnet-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
-    "perplexity/xai/grok-2-vision-1212": {
+    "perplexity/anthropic/claude-haiku-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/google/gemini-3-pro-preview": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/google/gemini-3-flash-preview": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/google/gemini-2.5-pro": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/google/gemini-2.5-flash": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/xai/grok-4-1-fast-non-reasoning": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/perplexity/sonar": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
     "publicai/aisingapore/Qwen-SEA-LION-v4-32B-IT": {
         "input_cost_per_token": 0.0,

--- a/litellm/rerank_api/main.py
+++ b/litellm/rerank_api/main.py
@@ -365,6 +365,7 @@ def rerank(  # noqa: PLR0915
                 max_chunks_per_doc=max_chunks_per_doc,
                 _is_async=_is_async,
                 optional_params=optional_params.model_dump(exclude_unset=True),
+                timeout=optional_params.timeout,
                 api_base=api_base,
                 extra_headers=merged_headers,
                 logging_obj=litellm_logging_obj,


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Bedrock rerank wasn't respecting the `timeout` parameter — setting `timeout=0.001` would still succeed because the value was never forwarded to the HTTP client.

All other rerank providers (Cohere, Jina AI, Voyage, NVIDIA NIM, etc.) go through `base_llm_http_handler.rerank()` which already passes timeout correctly. Bedrock uses its own handler and was missing it.

- Added `timeout` param to `BedrockRerankHandler.rerank()` and `arerank()`
- Pass `timeout` to `client.post()` in both sync and async paths
- Pass `optional_params.timeout` from `rerank_api/main.py` when calling the Bedrock handler
- Added two unit tests (`test_bedrock_rerank_timeout_sync`, `test_bedrock_rerank_timeout_async`) that verify the timeout value actually reaches `client.post()`