### PR TITLE
fix(router): emit x-litellm-overhead-duration-ms header for streaming requests

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -26555,65 +26555,124 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "perplexity/preset/fast-search": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_preset": true,
+        "supports_function_calling": true
+    },
     "perplexity/preset/pro-search": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_preset": true
+        "supports_preset": true,
+        "supports_function_calling": true
     },
-    "perplexity/openai/gpt-4o": {
+    "perplexity/preset/deep-research": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_preset": true,
+        "supports_function_calling": true
     },
-    "perplexity/openai/gpt-4o-mini": {
+    "perplexity/preset/advanced-deep-research": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_preset": true,
+        "supports_function_calling": true
     },
     "perplexity/openai/gpt-5.2": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": true
+        "supports_reasoning": true,
+        "supports_function_calling": true
     },
-    "perplexity/anthropic/claude-3-5-sonnet-20241022": {
+    "perplexity/openai/gpt-5.1": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
-    "perplexity/anthropic/claude-3-5-haiku-20241022": {
+    "perplexity/openai/gpt-5-mini": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
-    "perplexity/google/gemini-2.0-flash-exp": {
+    "perplexity/anthropic/claude-opus-4-6": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
-    "perplexity/google/gemini-2.0-flash-thinking-exp": {
+    "perplexity/anthropic/claude-opus-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": true
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
-    "perplexity/xai/grok-2-1212": {
+    "perplexity/anthropic/claude-sonnet-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
-    "perplexity/xai/grok-2-vision-1212": {
+    "perplexity/anthropic/claude-haiku-4-5": {
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_web_search": true,
-        "supports_reasoning": false
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/google/gemini-3-pro-preview": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/google/gemini-3-flash-preview": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/google/gemini-2.5-pro": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/google/gemini-2.5-flash": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/xai/grok-4-1-fast-non-reasoning": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
+    },
+    "perplexity/perplexity/sonar": {
+        "litellm_provider": "perplexity",
+        "mode": "responses",
+        "supports_web_search": true,
+        "supports_reasoning": false,
+        "supports_function_calling": true
     },
     "publicai/aisingapore/Qwen-SEA-LION-v4-32B-IT": {
         "input_cost_per_token": 0.0,

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1298,6 +1298,61 @@ async def test_acompletion_streaming_iterator_edge_cases():
 
 
 @pytest.mark.asyncio
+async def test_acompletion_streaming_iterator_preserves_hidden_params():
+    """
+    Regression test: FallbackStreamWrapper must copy _hidden_params from the
+    original CustomStreamWrapper so that x-litellm-overhead-duration-ms (and
+    other hidden params) are present in the proxy response headers for streaming.
+    """
+    from unittest.mock import MagicMock
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+    )
+
+    # Simulate a CustomStreamWrapper that already has timing metadata set by
+    # update_response_metadata (litellm_overhead_time_ms, _response_ms, etc.)
+    mock_response = MagicMock()
+    mock_response.model = "gpt-4"
+    mock_response.custom_llm_provider = "openai"
+    mock_response.logging_obj = MagicMock()
+    mock_response._hidden_params = {
+        "litellm_overhead_time_ms": 12.34,
+        "_response_ms": 500.0,
+        "litellm_call_id": "test-call-id",
+        "api_base": "https://api.openai.com",
+        "additional_headers": {},
+    }
+
+    # Make the mock iterable (yields nothing — we only care about hidden_params)
+    async def _empty():
+        return
+        yield  # make it an async generator
+
+    mock_response.__aiter__ = lambda self: _empty().__aiter__()
+
+    result = await router._acompletion_streaming_iterator(
+        model_response=mock_response,
+        messages=[{"role": "user", "content": "hi"}],
+        initial_kwargs={"model": "gpt-4", "stream": True},
+    )
+
+    # The returned FallbackStreamWrapper must carry the original _hidden_params
+    assert hasattr(result, "_hidden_params"), "result must have _hidden_params"
+    assert result._hidden_params.get("litellm_overhead_time_ms") == 12.34, (
+        "litellm_overhead_time_ms must be preserved — "
+        "this is what drives x-litellm-overhead-duration-ms in streaming responses"
+    )
+    assert result._hidden_params.get("litellm_call_id") == "test-call-id"
+    assert result._hidden_params.get("_response_ms") == 500.0
+
+
+@pytest.mark.asyncio
 async def test_async_function_with_fallbacks_common_utils():
     """Test the async_function_with_fallbacks_common_utils method"""
     # Create a basic router for testing
@@ -1858,7 +1913,7 @@ def test_get_deployment_credentials_with_provider_resolves_credential_name():
     litellm_credential_name to actual credential values (for UI-created models).
     """
     from litellm.types.utils import CredentialItem
-    
+
     # Setup credential list with a test credential
     litellm.credential_list = [
         CredentialItem(


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting \`@greptileai\` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

The `x-litellm-overhead-duration-ms` header was missing from streaming responses even though it worked correctly for non-streaming.

Root cause: when the Router handles a streaming response, `_acompletion` wraps the `CustomStreamWrapper` in a `FallbackStreamWrapper` (for mid-stream fallback support). The `FallbackStreamWrapper.__init__` called `super().__init__()` with a fresh async generator, which re-initialized `_hidden_params` to an empty dict — discarding `litellm_overhead_time_ms` that `update_response_metadata` had already set on the original stream wrapper.

Fix: copy `_hidden_params` from the original `model_response` into `FallbackStreamWrapper` after calling `super().__init__()`.

Before (streaming response headers):
```
x-litellm-call-id: ...
x-litellm-model-id: ...
x-litellm-version: 1.81.15
# x-litellm-overhead-duration-ms missing
```

After:
```
x-litellm-call-id: ...
x-litellm-overhead-duration-ms: 6.624
x-litellm-response-duration-ms: 1016.201
x-litellm-version: 1.81.15
```

Also fixes 5 pre-existing pyright type errors in `get_deployment_model_info` that were blocking commits.