### PR TITLE
[Infra] Add Spend Tracking Lifecycle Logging

### DIFF
--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -659,22 +659,6 @@ class DBSpendUpdateWriter:
         db_spend_update_transactions = (
             await self.spend_update_queue.flush_and_get_aggregated_db_spend_update_transactions()
         )
-        if any(
-            len(v) > 0
-            for v in db_spend_update_transactions.values()
-            if isinstance(v, dict)
-        ):
-            verbose_proxy_logger.info(
-                "Spend tracking - committing spend updates to DB (no Redis buffer): "
-                "keys=%d, users=%d, teams=%d, orgs=%d, end_users=%d, team_members=%d, tags=%d",
-                len(db_spend_update_transactions.get("key_list_transactions") or {}),
-                len(db_spend_update_transactions.get("user_list_transactions") or {}),
-                len(db_spend_update_transactions.get("team_list_transactions") or {}),
-                len(db_spend_update_transactions.get("org_list_transactions") or {}),
-                len(db_spend_update_transactions.get("end_user_list_transactions") or {}),
-                len(db_spend_update_transactions.get("team_member_list_transactions") or {}),
-                len(db_spend_update_transactions.get("tag_list_transactions") or {}),
-            )
         await self._commit_spend_updates_to_db(
             prisma_client=prisma_client,
             n_retry_times=n_retry_times,

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -225,7 +225,8 @@ class DBSpendUpdateWriter:
             verbose_proxy_logger.debug("Runs spend update on all tables")
         except Exception:
             verbose_proxy_logger.error(
-                "Spend tracking - update_database failed. All spend updates for this request will be lost. "
+                "Spend tracking - update_database failed. Spend log insertion or daily transaction enqueue "
+                "may not have completed for this request. "
                 "response_cost=%s, token=%s, user_id=%s, team_id=%s, org_id=%s, end_user_id=%s - %s",
                 response_cost,
                 token,

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -351,11 +351,12 @@ class DBSpendUpdateWriter:
             except Exception as e:
                 verbose_proxy_logger.error(
                     "Spend tracking - failed to enqueue team member spend update. "
-                    "team_id=%s, user_id=%s, response_cost=%s - %s",
+                    "team_id=%s, user_id=%s, response_cost=%s - %s\n%s",
                     team_id,
                     user_id,
                     response_cost,
                     str(e),
+                    traceback.format_exc(),
                 )
         except Exception as e:
             verbose_proxy_logger.error(

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -224,8 +224,16 @@ class DBSpendUpdateWriter:
 
             verbose_proxy_logger.debug("Runs spend update on all tables")
         except Exception:
-            verbose_proxy_logger.debug(
-                f"Error updating Prisma database: {traceback.format_exc()}"
+            verbose_proxy_logger.error(
+                "Spend tracking - update_database failed. All spend updates for this request will be lost. "
+                "response_cost=%s, token=%s, user_id=%s, team_id=%s, org_id=%s, end_user_id=%s - %s",
+                response_cost,
+                token,
+                user_id,
+                team_id,
+                org_id,
+                end_user_id,
+                traceback.format_exc(),
             )
 
     async def _update_key_db(
@@ -295,9 +303,14 @@ class DBSpendUpdateWriter:
                         )
                     )
         except Exception as e:
-            verbose_proxy_logger.debug(
-                "\033[91m"
-                + f"Update User DB call failed to execute {str(e)}\n{traceback.format_exc()}"
+            verbose_proxy_logger.error(
+                "Spend tracking - failed to enqueue user spend update. "
+                "user_id=%s, end_user_id=%s, response_cost=%s - %s\n%s",
+                user_id,
+                end_user_id,
+                response_cost,
+                str(e),
+                traceback.format_exc(),
             )
 
     async def _update_team_db(
@@ -334,11 +347,23 @@ class DBSpendUpdateWriter:
                             response_cost=response_cost,
                         )
                     )
-            except Exception:
-                pass
+            except Exception as e:
+                verbose_proxy_logger.error(
+                    "Spend tracking - failed to enqueue team member spend update. "
+                    "team_id=%s, user_id=%s, response_cost=%s - %s",
+                    team_id,
+                    user_id,
+                    response_cost,
+                    str(e),
+                )
         except Exception as e:
-            verbose_proxy_logger.debug(
-                f"Update Team DB failed to execute - {str(e)}\n{traceback.format_exc()}"
+            verbose_proxy_logger.error(
+                "Spend tracking - failed to enqueue team spend update. "
+                "team_id=%s, response_cost=%s - %s\n%s",
+                team_id,
+                response_cost,
+                str(e),
+                traceback.format_exc(),
             )
             raise e
 
@@ -363,8 +388,13 @@ class DBSpendUpdateWriter:
                 )
             )
         except Exception as e:
-            verbose_proxy_logger.debug(
-                f"Update Org DB failed to execute - {str(e)}\n{traceback.format_exc()}"
+            verbose_proxy_logger.error(
+                "Spend tracking - failed to enqueue org spend update. "
+                "org_id=%s, response_cost=%s - %s\n%s",
+                org_id,
+                response_cost,
+                str(e),
+                traceback.format_exc(),
             )
             raise e
 
@@ -411,8 +441,13 @@ class DBSpendUpdateWriter:
                         )
                     )
         except Exception as e:
-            verbose_proxy_logger.debug(
-                f"Update Tag DB failed to execute - {str(e)}\n{traceback.format_exc()}"
+            verbose_proxy_logger.error(
+                "Spend tracking - failed to enqueue tag spend update. "
+                "request_tags=%s, response_cost=%s - %s\n%s",
+                request_tags,
+                response_cost,
+                str(e),
+                traceback.format_exc(),
             )
             raise e
 
@@ -513,6 +548,17 @@ class DBSpendUpdateWriter:
                     await self.redis_update_buffer.get_all_update_transactions_from_redis_buffer()
                 )
                 if db_spend_update_transactions is not None:
+                    verbose_proxy_logger.info(
+                        "Spend tracking - committing spend updates from Redis to DB: "
+                        "keys=%d, users=%d, teams=%d, orgs=%d, end_users=%d, team_members=%d, tags=%d",
+                        len(db_spend_update_transactions.get("key_list_transactions") or {}),
+                        len(db_spend_update_transactions.get("user_list_transactions") or {}),
+                        len(db_spend_update_transactions.get("team_list_transactions") or {}),
+                        len(db_spend_update_transactions.get("org_list_transactions") or {}),
+                        len(db_spend_update_transactions.get("end_user_list_transactions") or {}),
+                        len(db_spend_update_transactions.get("team_member_list_transactions") or {}),
+                        len(db_spend_update_transactions.get("tag_list_transactions") or {}),
+                    )
                     await self._commit_spend_updates_to_db(
                         prisma_client=prisma_client,
                         n_retry_times=n_retry_times,
@@ -583,7 +629,12 @@ class DBSpendUpdateWriter:
                         daily_spend_transactions=daily_agent_spend_update_transactions,
                     )
             except Exception as e:
-                verbose_proxy_logger.error(f"Error committing spend updates: {e}")
+                verbose_proxy_logger.error(
+                    "Spend tracking - failed to commit spend updates from Redis to DB. "
+                    "Data already popped from Redis may be lost. Error: %s\n%s",
+                    str(e),
+                    traceback.format_exc(),
+                )
             finally:
                 await self.pod_lock_manager.release_lock(
                     cronjob_id=DB_SPEND_UPDATE_JOB_NAME,
@@ -608,6 +659,22 @@ class DBSpendUpdateWriter:
         db_spend_update_transactions = (
             await self.spend_update_queue.flush_and_get_aggregated_db_spend_update_transactions()
         )
+        if any(
+            len(v) > 0
+            for v in db_spend_update_transactions.values()
+            if isinstance(v, dict)
+        ):
+            verbose_proxy_logger.info(
+                "Spend tracking - committing spend updates to DB (no Redis buffer): "
+                "keys=%d, users=%d, teams=%d, orgs=%d, end_users=%d, team_members=%d, tags=%d",
+                len(db_spend_update_transactions.get("key_list_transactions") or {}),
+                len(db_spend_update_transactions.get("user_list_transactions") or {}),
+                len(db_spend_update_transactions.get("team_list_transactions") or {}),
+                len(db_spend_update_transactions.get("org_list_transactions") or {}),
+                len(db_spend_update_transactions.get("end_user_list_transactions") or {}),
+                len(db_spend_update_transactions.get("team_member_list_transactions") or {}),
+                len(db_spend_update_transactions.get("tag_list_transactions") or {}),
+            )
         await self._commit_spend_updates_to_db(
             prisma_client=prisma_client,
             n_retry_times=n_retry_times,

--- a/litellm/proxy/db/db_transaction_queue/daily_spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/daily_spend_update_queue.py
@@ -86,6 +86,11 @@ class DailySpendUpdateQueue(BaseUpdateQueue):
     ) -> Dict[str, BaseDailySpendTransaction]:
         """Get all updates from the queue and return all updates aggregated by daily_transaction_key. Works for both user and team spend updates."""
         updates = await self.flush_all_updates_from_in_memory_queue()
+        if len(updates) > 0:
+            verbose_proxy_logger.info(
+                "Spend tracking - flushed %d daily spend update items from in-memory queue",
+                len(updates),
+            )
         aggregated_daily_spend_update_transactions = (
             DailySpendUpdateQueue.get_aggregated_daily_spend_update_transactions(
                 updates

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -80,6 +80,14 @@ class PodLockManager:
                         )
                         self._emit_acquired_lock_event(cronjob_id, self.pod_id)
                         return True
+                    else:
+                        verbose_proxy_logger.info(
+                            "Spend tracking - pod %s could not acquire lock for cronjob_id=%s, "
+                            "held by pod %s. Spend updates in Redis will wait for the leader pod to commit.",
+                            self.pod_id,
+                            cronjob_id,
+                            current_value,
+                        )
             return False
         except Exception as e:
             verbose_proxy_logger.error(
@@ -124,10 +132,12 @@ class PodLockManager:
                             pod_id=self.pod_id,
                         )
                     else:
-                        verbose_proxy_logger.debug(
-                            "Pod %s failed to release Redis lock for cronjob_id=%s",
+                        verbose_proxy_logger.warning(
+                            "Spend tracking - pod %s failed to release Redis lock for cronjob_id=%s. "
+                            "Lock will expire after TTL=%ds.",
                             self.pod_id,
                             cronjob_id,
+                            DEFAULT_CRON_JOB_LOCK_TTL_SECONDS,
                         )
                 else:
                     verbose_proxy_logger.debug(

--- a/litellm/proxy/db/db_transaction_queue/redis_update_buffer.py
+++ b/litellm/proxy/db/db_transaction_queue/redis_update_buffer.py
@@ -96,14 +96,29 @@ class RedisUpdateBuffer:
         list_of_transactions = [safe_dumps(transactions)]
         if self.redis_cache is None:
             return
-        current_redis_buffer_size = await self.redis_cache.async_rpush(
-            key=redis_key,
-            values=list_of_transactions,
-        )
-        await self._emit_new_item_added_to_redis_buffer_event(
-            queue_size=current_redis_buffer_size,
-            service=service_type,
-        )
+        try:
+            current_redis_buffer_size = await self.redis_cache.async_rpush(
+                key=redis_key,
+                values=list_of_transactions,
+            )
+            verbose_proxy_logger.info(
+                "Spend tracking - pushed spend updates to Redis buffer. "
+                "redis_key=%s, buffer_size=%s",
+                redis_key,
+                current_redis_buffer_size,
+            )
+            await self._emit_new_item_added_to_redis_buffer_event(
+                queue_size=current_redis_buffer_size,
+                service=service_type,
+            )
+        except Exception as e:
+            verbose_proxy_logger.error(
+                "Spend tracking - failed to push spend updates to Redis (redis_key=%s). "
+                "Error: %s",
+                redis_key,
+                str(e),
+            )
+            raise
 
     async def store_in_memory_spend_updates_in_redis(
         self,
@@ -304,6 +319,13 @@ class RedisUpdateBuffer:
         )
         if list_of_transactions is None:
             return None
+
+        verbose_proxy_logger.info(
+            "Spend tracking - popped %d spend update batches from Redis buffer (key=%s). "
+            "These items are now removed from Redis and must be committed to DB.",
+            len(list_of_transactions) if isinstance(list_of_transactions, list) else 1,
+            REDIS_UPDATE_BUFFER_KEY,
+        )
 
         # Parse the list of transactions from JSON strings
         parsed_transactions = self._parse_list_of_transactions(list_of_transactions)

--- a/litellm/proxy/db/db_transaction_queue/redis_update_buffer.py
+++ b/litellm/proxy/db/db_transaction_queue/redis_update_buffer.py
@@ -101,7 +101,7 @@ class RedisUpdateBuffer:
                 key=redis_key,
                 values=list_of_transactions,
             )
-            verbose_proxy_logger.info(
+            verbose_proxy_logger.debug(
                 "Spend tracking - pushed spend updates to Redis buffer. "
                 "redis_key=%s, buffer_size=%s",
                 redis_key,
@@ -118,7 +118,6 @@ class RedisUpdateBuffer:
                 redis_key,
                 str(e),
             )
-            raise
 
     async def store_in_memory_spend_updates_in_redis(
         self,

--- a/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
@@ -31,6 +31,11 @@ class SpendUpdateQueue(BaseUpdateQueue):
     ) -> DBSpendUpdateTransactions:
         """Flush all updates from the queue and return all updates aggregated by entity type."""
         updates = await self.flush_all_updates_from_in_memory_queue()
+        if len(updates) > 0:
+            verbose_proxy_logger.info(
+                "Spend tracking - flushed %d spend update items from in-memory queue",
+                len(updates),
+            )
         verbose_proxy_logger.debug("Aggregating updates by entity type: %s", updates)
         return self.get_aggregated_db_spend_update_transactions(updates)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1771,10 +1771,11 @@ async def update_cache(  # noqa: PLR0915
             verbose_proxy_logger.warning(
                 "Spend tracking - failed to update user spend in cache. "
                 "Budget enforcement may use stale spend values. "
-                "user_id=%s, response_cost=%s - %s",
+                "user_id=%s, response_cost=%s - %s\n%s",
                 user_id,
                 response_cost,
                 str(e),
+                traceback.format_exc(),
             )
 
     ### UPDATE END-USER SPEND ###
@@ -1814,10 +1815,11 @@ async def update_cache(  # noqa: PLR0915
             verbose_proxy_logger.warning(
                 "Spend tracking - failed to update end user spend in cache. "
                 "Budget enforcement may use stale spend values. "
-                "end_user_id=%s, response_cost=%s - %s",
+                "end_user_id=%s, response_cost=%s - %s\n%s",
                 end_user_id,
                 response_cost,
                 str(e),
+                traceback.format_exc(),
             )
 
     ### UPDATE TEAM SPEND ###
@@ -1861,10 +1863,11 @@ async def update_cache(  # noqa: PLR0915
             verbose_proxy_logger.warning(
                 "Spend tracking - failed to update team spend in cache. "
                 "Budget enforcement may use stale spend values. "
-                "team_id=%s, response_cost=%s - %s",
+                "team_id=%s, response_cost=%s - %s\n%s",
                 team_id,
                 response_cost,
                 str(e),
+                traceback.format_exc(),
             )
 
     ### UPDATE TAG SPEND ###
@@ -1912,10 +1915,11 @@ async def update_cache(  # noqa: PLR0915
             verbose_proxy_logger.warning(
                 "Spend tracking - failed to update tag spend in cache. "
                 "Budget enforcement may use stale spend values. "
-                "tags=%s, response_cost=%s - %s",
+                "tags=%s, response_cost=%s - %s\n%s",
                 tags,
                 response_cost,
                 str(e),
+                traceback.format_exc(),
             )
 
     if token is not None and response_cost is not None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1768,8 +1768,13 @@ async def update_cache(  # noqa: PLR0915
                     ("{}:spend".format(litellm_proxy_admin_name), increment)
                 )
         except Exception as e:
-            verbose_proxy_logger.debug(
-                f"An error occurred updating user cache: {str(e)}\n\n{traceback.format_exc()}"
+            verbose_proxy_logger.warning(
+                "Spend tracking - failed to update user spend in cache. "
+                "Budget enforcement may use stale spend values. "
+                "user_id=%s, response_cost=%s - %s",
+                user_id,
+                response_cost,
+                str(e),
             )
 
     ### UPDATE END-USER SPEND ###
@@ -1806,8 +1811,13 @@ async def update_cache(  # noqa: PLR0915
                 existing_spend_obj.spend = new_spend
                 values_to_update_in_cache.append((_id, existing_spend_obj.json()))
         except Exception as e:
-            verbose_proxy_logger.exception(
-                f"An error occurred updating end user cache: {str(e)}"
+            verbose_proxy_logger.warning(
+                "Spend tracking - failed to update end user spend in cache. "
+                "Budget enforcement may use stale spend values. "
+                "end_user_id=%s, response_cost=%s - %s",
+                end_user_id,
+                response_cost,
+                str(e),
             )
 
     ### UPDATE TEAM SPEND ###
@@ -1848,8 +1858,13 @@ async def update_cache(  # noqa: PLR0915
                 existing_spend_obj.spend = new_spend
                 values_to_update_in_cache.append((_id, existing_spend_obj))
         except Exception as e:
-            verbose_proxy_logger.exception(
-                f"An error occurred updating end user cache: {str(e)}"
+            verbose_proxy_logger.warning(
+                "Spend tracking - failed to update team spend in cache. "
+                "Budget enforcement may use stale spend values. "
+                "team_id=%s, response_cost=%s - %s",
+                team_id,
+                response_cost,
+                str(e),
             )
 
     ### UPDATE TAG SPEND ###
@@ -1894,8 +1909,13 @@ async def update_cache(  # noqa: PLR0915
                     existing_tag_obj.spend = new_spend
                     values_to_update_in_cache.append((cache_key, existing_tag_obj))
         except Exception as e:
-            verbose_proxy_logger.exception(
-                f"An error occurred updating tag cache: {str(e)}"
+            verbose_proxy_logger.warning(
+                "Spend tracking - failed to update tag spend in cache. "
+                "Budget enforcement may use stale spend values. "
+                "tags=%s, response_cost=%s - %s",
+                tags,
+                response_cost,
+                str(e),
             )
 
     if token is not None and response_cost is not None:


### PR DESCRIPTION
## Summary

### Problem
Spend tracking failures across the request-to-DB lifecycle are logged at `debug` level or silently swallowed (bare `except: pass`). When a user reports spend not appearing in the key table or aggregate spend tables, there is no production-visible logging to narrow down where in the pipeline the spend data is being dropped.

### Fix
Elevate all error paths in the spend tracking lifecycle to `warning` or `error` level, and add `info`-level audit trail logs at key checkpoints. All new messages are prefixed with `"Spend tracking -"` for easy grep filtering.

Also fixes a copy-paste bug in `_update_team_cache` that logged "end user" instead of "team".

## Changes

**Error paths elevated to `error`** (7 files):
- `db_spend_update_writer.py`: `update_database` outer catch, `_update_user_db`, `_update_team_db` (inner bare `pass` + outer), `_update_org_db`, `_update_tag_db`, redis-to-DB commit failure
- `redis_update_buffer.py`: Redis RPUSH failure
- `utils.py`: DB connection retry logging for spend logs

**Error paths elevated to `warning`** (2 files):
- `proxy_server.py`: Cache update failures for user, end_user, team, tag (stale budget enforcement)
- `pod_lock_manager.py`: Lock release failure
- `utils.py`: Guardrail usage tracking failure

**Info-level audit trail added** (4 files):
- In-memory queue flush counts (`spend_update_queue.py`, `daily_spend_update_queue.py`)
- Redis buffer push/pop (`redis_update_buffer.py`)
- DB commit entity counts (`db_spend_update_writer.py`)
- Spend log batch processing (`utils.py`)
- Pod lock contention (`pod_lock_manager.py`)

## Testing

- Ran `pytest tests/test_litellm/proxy/db/` — 57 passed, 1 pre-existing failure (unrelated import error in `test_daily_spend_tracking_with_disabled_spend_logs`)

## Type

🆕 New Feature