### PR TITLE
docs: update v1.81.12-stable release notes to point to stable.1

### DIFF
--- a/docs/my-website/release_notes/v1.81.12.md
+++ b/docs/my-website/release_notes/v1.81.12.md
@@ -1,5 +1,5 @@
 ---
-title: "v1.81.12-stable - Guardrail Policy Templates & Action Builder"
+title: "v1.81.12-stable.1 - Guardrail Policy Templates & Action Builder"
 slug: "v1-81-12"
 date: 2026-02-14T00:00:00
 authors:
@@ -27,7 +27,7 @@ import Image from '@theme/IdealImage';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-ghcr.io/berriai/litellm:main-v1.81.12-stable
+ghcr.io/berriai/litellm:main-v1.81.12-stable.1
 ```
 
 </TabItem>


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

📖 Documentation

## Changes

Update the v1.81.12-stable release notes to reference `main-v1.81.12-stable.1` instead of `main-v1.81.12-stable`. We had a patch fix that went out as stable.1 and the docs should point users to the correct image.