### PR TITLE
[Fix] Enrich Failure Spend Logs With Key/Team Metadata

### DIFF
--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -263,7 +263,7 @@ class _ProxyDBLogger(CustomLogger):
     async def _enrich_failure_metadata_with_key_info(metadata: dict) -> dict:
         """
         Enriches failure spend log metadata by looking up the key object (and team object)
-        from cache when key fields are missing.
+        from cache/DB when key fields are missing.
 
         This handles two scenarios:
         1. Auth errors (401): UserAPIKeyAuth is created with only api_key set, all other
@@ -291,7 +291,6 @@ class _ProxyDBLogger(CustomLogger):
                     prisma_client=prisma_client,
                     user_api_key_cache=user_api_key_cache,
                     proxy_logging_obj=proxy_logging_obj,
-                    check_cache_only=True,
                 )
                 if metadata.get("user_api_key_alias") is None:
                     metadata["user_api_key_alias"] = key_obj.key_alias
@@ -316,7 +315,6 @@ class _ProxyDBLogger(CustomLogger):
                     prisma_client=prisma_client,
                     user_api_key_cache=user_api_key_cache,
                     proxy_logging_obj=proxy_logging_obj,
-                    check_cache_only=True,
                 )
                 if team_obj.team_alias is not None:
                     metadata["user_api_key_team_alias"] = team_obj.team_alias

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -12,7 +12,7 @@ from litellm.litellm_core_utils.core_helpers import (
 )
 from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
 from litellm.proxy._types import UserAPIKeyAuth
-from litellm.proxy.auth.auth_checks import log_db_metrics
+from litellm.proxy.auth.auth_checks import get_key_object, get_team_object, log_db_metrics
 from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.proxy.utils import ProxyUpdateSpend
 from litellm.types.utils import (
@@ -74,6 +74,10 @@ class _ProxyDBLogger(CustomLogger):
         ] = StandardLoggingPayloadSetup.get_error_information(
             original_exception=original_exception,
             traceback_str=traceback_str,
+        )
+
+        _metadata = await _ProxyDBLogger._enrich_failure_metadata_with_key_info(
+            metadata=_metadata,
         )
 
         existing_metadata: dict = request_data.get("metadata", None) or {}
@@ -254,6 +258,73 @@ class _ProxyDBLogger(CustomLogger):
             verbose_proxy_logger.exception(
                 "Error in tracking cost callback - %s", str(e)
             )
+
+    @staticmethod
+    async def _enrich_failure_metadata_with_key_info(metadata: dict) -> dict:
+        """
+        Enriches failure spend log metadata by looking up the key object (and team object)
+        from cache/DB when key fields are missing.
+
+        This handles two scenarios:
+        1. Auth errors (401): UserAPIKeyAuth is created with only api_key set, all other
+           fields are null. We look up the full key object to fill in alias, user_id,
+           team_id, etc.
+        2. Post-auth failures (provider errors, rate limits): key fields are populated
+           but team_alias is missing because LiteLLM_VerificationTokenView SQL view
+           doesn't include it. We look up the team object to fill in team_alias.
+        """
+        api_key_hash = metadata.get("user_api_key")
+        if not api_key_hash:
+            return metadata
+
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        # Step 1: If key fields are missing, look up the full key object
+        if metadata.get("user_api_key_alias") is None:
+            try:
+                key_obj = await get_key_object(
+                    hashed_token=api_key_hash,
+                    prisma_client=prisma_client,
+                    user_api_key_cache=user_api_key_cache,
+                    proxy_logging_obj=proxy_logging_obj,
+                )
+                if metadata.get("user_api_key_alias") is None:
+                    metadata["user_api_key_alias"] = key_obj.key_alias
+                if metadata.get("user_api_key_user_id") is None:
+                    metadata["user_api_key_user_id"] = key_obj.user_id
+                if metadata.get("user_api_key_team_id") is None:
+                    metadata["user_api_key_team_id"] = key_obj.team_id
+                if metadata.get("user_api_key_org_id") is None:
+                    metadata["user_api_key_org_id"] = key_obj.org_id
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "Failed to enrich failure metadata with key info for api_key=%s",
+                    api_key_hash,
+                )
+
+        # Step 2: If team_id is known but team_alias is missing, look up the team object
+        team_id = metadata.get("user_api_key_team_id")
+        if team_id and metadata.get("user_api_key_team_alias") is None:
+            try:
+                team_obj = await get_team_object(
+                    team_id=team_id,
+                    prisma_client=prisma_client,
+                    user_api_key_cache=user_api_key_cache,
+                    proxy_logging_obj=proxy_logging_obj,
+                    check_cache_only=True,
+                )
+                if team_obj.team_alias is not None:
+                    metadata["user_api_key_team_alias"] = team_obj.team_alias
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "Failed to enrich failure metadata with team_alias for team_id=%s",
+                    team_id,
+                )
+        return metadata
 
     @staticmethod
     def _should_track_errors_in_db():

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -263,7 +263,7 @@ class _ProxyDBLogger(CustomLogger):
     async def _enrich_failure_metadata_with_key_info(metadata: dict) -> dict:
         """
         Enriches failure spend log metadata by looking up the key object (and team object)
-        from cache/DB when key fields are missing.
+        from cache when key fields are missing.
 
         This handles two scenarios:
         1. Auth errors (401): UserAPIKeyAuth is created with only api_key set, all other

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -291,6 +291,7 @@ class _ProxyDBLogger(CustomLogger):
                     prisma_client=prisma_client,
                     user_api_key_cache=user_api_key_cache,
                     proxy_logging_obj=proxy_logging_obj,
+                    check_cache_only=True,
                 )
                 if metadata.get("user_api_key_alias") is None:
                     metadata["user_api_key_alias"] = key_obj.key_alias


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Summary

### Failure Path (Before Fix)

When a request fails, the spend log written to `LiteLLM_SpendLogs` is missing key metadata (`key_alias`, `user_id`, `team_id`, `team_alias`). This occurs in two scenarios:

1. **Auth errors (401)**: `auth_exception_handler.py` creates a minimal `UserAPIKeyAuth` with only `api_key` set — all other fields are null. For example, when `can_key_call_model` rejects a request because the key can't access the requested model.

2. **Post-auth failures (provider errors, rate limits)**: Key fields are populated but `team_alias` is always null because the `LiteLLM_VerificationTokenView` SQL view does not include `team_alias` from the team table.

### Fix

Added `_enrich_failure_metadata_with_key_info` in `async_post_call_failure_hook`. When key fields are missing, it uses the key hash (which is always present) to look up the full key object from cache/DB, then looks up the team object from cache to populate `team_alias`. Both lookups are non-fatal (wrapped in try/except).

## Testing

- `test_enrich_failure_metadata_with_team_alias` — team_alias populated from cache when key fields present but team_alias missing
- `test_enrich_failure_metadata_with_full_key_lookup` — all key fields populated from cache/DB when all are null (401 scenario)
- `test_enrich_failure_metadata_skips_when_team_alias_present` — no-op when fields already set
- `test_enrich_failure_metadata_skips_when_no_api_key` — no-op when no key hash available
- `test_async_post_call_failure_hook_enriches_auth_error_metadata` — end-to-end 401 scenario
- `test_async_post_call_failure_hook_enriches_missing_team_alias` — end-to-end missing team_alias scenario

## Type

🐛 Bug Fix
✅ Test

## Screenshots