### PR TITLE
[Feat]Add forward auth headers of provider

### DIFF
--- a/docs/my-website/docs/proxy/forward_client_headers.md
+++ b/docs/my-website/docs/proxy/forward_client_headers.md
@@ -21,7 +21,7 @@ sequenceDiagram
     
     Proxy->>Filter: Check forward_client_headers_to_llm_api<br/>setting for this model group
 
-    Note over Filter: Allowlist rules:<br/>1. Headers starting with "x-" <br/>2. "anthropic-beta" <br/>3. "x-stainless-*"  (blocked)<br/>4. All other headers  (blocked)
+    Note over Filter: Allowlist rules:<br/>1. Headers starting with "x-" ✅<br/>2. "anthropic-beta" ✅<br/>3. "x-stainless-*" ❌ (blocked)<br/>4. All other headers ❌ (blocked)
 
     Filter-->>Proxy: Return only allowed headers
 

--- a/docs/my-website/docs/proxy/forward_client_headers.md
+++ b/docs/my-website/docs/proxy/forward_client_headers.md
@@ -21,7 +21,7 @@ sequenceDiagram
     
     Proxy->>Filter: Check forward_client_headers_to_llm_api<br/>setting for this model group
 
-    Note over Filter: Allowlist rules:<br/>1. Headers starting with "x-" ✅<br/>2. "anthropic-beta" ✅<br/>3. "x-stainless-*" ❌ (blocked)<br/>4. All other headers ❌ (blocked)
+    Note over Filter: Allowlist rules:<br/>1. Headers starting with "x-" <br/>2. "anthropic-beta" <br/>3. "x-stainless-*"  (blocked)<br/>4. All other headers  (blocked)
 
     Filter-->>Proxy: Return only allowed headers
 
@@ -37,11 +37,11 @@ The following rules determine which headers are forwarded (see [`_get_forwardabl
 
 | Rule | Example | Forwarded? |
 |---|---|---|
-| Headers starting with `x-` | `x-trace-id`, `x-custom-header`, `x-request-source` | ✅ Yes |
-| `anthropic-beta` header | `anthropic-beta: prompt-caching-2024-07-31` | ✅ Yes |
-| Headers starting with `x-stainless-*` | `x-stainless-lang`, `x-stainless-arch` | ❌ No (causes OpenAI SDK issues) |
-| Standard HTTP headers | `Authorization`, `Content-Type`, `Host` | ❌ No |
-| Other provider headers | `Accept`, `User-Agent` | ❌ No |
+| Headers starting with `x-` | `x-trace-id`, `x-custom-header`, `x-request-source` |  Yes |
+| `anthropic-beta` header | `anthropic-beta: prompt-caching-2024-07-31` |  Yes |
+| Headers starting with `x-stainless-*` | `x-stainless-lang`, `x-stainless-arch` |  No (causes OpenAI SDK issues) |
+| Standard HTTP headers | `Authorization`, `Content-Type`, `Host` |  No |
+| Other provider headers | `Accept`, `User-Agent` |  No |
 
 ### Additional Header Mechanisms
 
@@ -152,16 +152,16 @@ curl -X POST "http://localhost:4000/v1/chat/completions" \
 
 ### Security Considerations
 
-⚠️ **When to Use This Feature:**
-- ✅ Internal tools where you trust all clients
-- ✅ Development/testing environments
-- ✅ Multi-tenant apps with proper client authentication
-- ✅ Scenarios where you want clients to use their own API keys
+**When to Use This Feature:**
+-  Internal tools where you trust all clients
+-  Development/testing environments
+-  Multi-tenant apps with proper client authentication
+-  Scenarios where you want clients to use their own API keys
 
-⚠️ **When NOT to Use:**
-- ❌ Public APIs where you don't trust all clients
-- ❌ When you want centralized billing/cost control
-- ❌ When you need to enforce rate limits at the proxy level
+**When NOT to Use:**
+-  Public APIs where you don't trust all clients
+-  When you want centralized billing/cost control
+-  When you need to enforce rate limits at the proxy level
 
 ### Backward Compatibility
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -251,10 +251,8 @@ def clean_headers(
     )    
     for header, value in headers.items():
         header_lower = header.lower()
-        verbose_proxy_logger.debug(f"header: {header}")
         
         if header_lower == "authorization" and is_anthropic_oauth_key(value):
-            verbose_proxy_logger.debug(f"Adding Anthropic OAuth header: {header}")
             clean_headers[header] = value
         elif forward_llm_provider_auth_headers and header_lower in _SPECIAL_HEADERS_CACHE:
             if litellm_key_lower and header_lower == litellm_key_lower:
@@ -266,7 +264,6 @@ def clean_headers(
         elif header_lower not in _SPECIAL_HEADERS_CACHE and (
             litellm_key_lower is None or header_lower != litellm_key_lower
         ):
-            verbose_proxy_logger.debug(f"Adding header and value: {header} {value}")
             clean_headers[header] = value
     return clean_headers
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -10,10 +10,15 @@ import litellm
 from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm._service_logger import ServiceLogging
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
-from litellm.proxy._types import (AddTeamCallback, CommonProxyErrors,
-                                  LitellmDataForBackendLLMCall,
-                                  LitellmUserRoles, SpecialHeaders,
-                                  TeamCallbackMetadata, UserAPIKeyAuth)
+from litellm.proxy._types import (
+    AddTeamCallback,
+    CommonProxyErrors,
+    LitellmDataForBackendLLMCall,
+    LitellmUserRoles,
+    SpecialHeaders,
+    TeamCallbackMetadata,
+    UserAPIKeyAuth,
+)
 from litellm.proxy.common_utils.http_parsing_utils import _safe_get_request_headers
 
 # Cache special headers as a frozenset for O(1) lookup performance
@@ -23,9 +28,12 @@ _SPECIAL_HEADERS_CACHE = frozenset(
 from litellm.router import Router
 from litellm.types.llms.anthropic import ANTHROPIC_API_HEADERS
 from litellm.types.services import ServiceTypes
-from litellm.types.utils import (LlmProviders, ProviderSpecificHeader,
-                                 StandardLoggingUserAPIKeyMetadata,
-                                 SupportedCacheControls)
+from litellm.types.utils import (
+    LlmProviders,
+    ProviderSpecificHeader,
+    StandardLoggingUserAPIKeyMetadata,
+    SupportedCacheControls,
+)
 
 service_logger_obj = ServiceLogging()  # used for tracking latency on OTEL
 
@@ -228,7 +236,9 @@ def _get_dynamic_logging_metadata(
 
 
 def clean_headers(
-    headers: Headers, litellm_key_header_name: Optional[str] = None
+    headers: Headers,
+    litellm_key_header_name: Optional[str] = None,
+    forward_llm_provider_auth_headers: bool = False,
 ) -> dict:
     """
     Removes litellm api key from headers
@@ -238,19 +248,25 @@ def clean_headers(
     clean_headers = {}
     litellm_key_lower = (
         litellm_key_header_name.lower() if litellm_key_header_name is not None else None
-    )
-
+    )    
     for header, value in headers.items():
         header_lower = header.lower()
-        # Preserve Authorization header if it contains Anthropic OAuth token (sk-ant-oat*)
-        # This allows OAuth tokens to be forwarded to Anthropic-compatible providers
-        # via add_provider_specific_headers_to_request()
+        verbose_proxy_logger.debug(f"header: {header}")
+        
         if header_lower == "authorization" and is_anthropic_oauth_key(value):
+            verbose_proxy_logger.debug(f"Adding Anthropic OAuth header: {header}")
+            clean_headers[header] = value
+        elif forward_llm_provider_auth_headers and header_lower in _SPECIAL_HEADERS_CACHE:
+            if litellm_key_lower and header_lower == litellm_key_lower:
+                continue
+            if header_lower == "authorization":
+                continue
             clean_headers[header] = value
         # Check if header should be excluded: either in special headers cache or matches custom litellm key
         elif header_lower not in _SPECIAL_HEADERS_CACHE and (
             litellm_key_lower is None or header_lower != litellm_key_lower
         ):
+            verbose_proxy_logger.debug(f"Adding header and value: {header} {value}")
             clean_headers[header] = value
     return clean_headers
 
@@ -654,7 +670,8 @@ class LiteLLMProxyRequestSetup:
             return data
         from litellm.proxy._types import (
             LiteLLM_ManagementEndpoint_MetadataFields,
-            LiteLLM_ManagementEndpoint_MetadataFields_Premium)
+            LiteLLM_ManagementEndpoint_MetadataFields_Premium,
+        )
 
         # ignore any special fields
         added_metadata = {}
@@ -826,6 +843,11 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     from litellm.types.proxy.litellm_pre_call_utils import SecretFields
 
     _raw_headers: Dict[str, str] = _safe_get_request_headers(request)
+    
+    forward_llm_auth = False
+    if general_settings:
+        forward_llm_auth = general_settings.get("forward_llm_provider_auth_headers", False)
+    
     _headers: Dict[str, str] = clean_headers(
         request.headers,
         litellm_key_header_name=(
@@ -833,7 +855,10 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
             if general_settings is not None
             else None
         ),
+        forward_llm_provider_auth_headers=forward_llm_auth,
     )
+    verbose_proxy_logger.debug(f"Request Headers: {_headers}")
+    verbose_proxy_logger.debug(f"Raw Headers: {_raw_headers}")
 
     ##########################################################
     # Init - Proxy Server Request
@@ -1479,8 +1504,7 @@ async def move_guardrails_to_metadata(
 
     # Only check policy engine if no local config (avoid import + registry lookup)
     if not (has_key_config or has_team_config or has_request_config):
-        from litellm.proxy.policy_engine.policy_registry import \
-            get_policy_registry
+        from litellm.proxy.policy_engine.policy_registry import get_policy_registry
 
         if not get_policy_registry().is_initialized():
             # Nothing configured anywhere - clean up request body fields and return
@@ -1544,16 +1568,14 @@ async def move_guardrails_to_metadata(
 
 def _is_policy_version_id(s: str) -> bool:
     """Return True if string is a policy version ID (starts with policy_<uuid> prefix)."""
-    from litellm.proxy.policy_engine.policy_registry import \
-        POLICY_VERSION_ID_PREFIX
+    from litellm.proxy.policy_engine.policy_registry import POLICY_VERSION_ID_PREFIX
 
     return isinstance(s, str) and s.startswith(POLICY_VERSION_ID_PREFIX)
 
 
 def _extract_policy_id(s: str) -> Optional[str]:
     """Extract raw UUID from policy_<uuid> string, or None if not a valid version ID."""
-    from litellm.proxy.policy_engine.policy_registry import \
-        POLICY_VERSION_ID_PREFIX
+    from litellm.proxy.policy_engine.policy_registry import POLICY_VERSION_ID_PREFIX
 
     if not _is_policy_version_id(s):
         return None
@@ -1574,9 +1596,10 @@ def _match_and_track_policies(
     """
     from litellm._logging import verbose_proxy_logger
     from litellm.proxy.common_utils.callback_utils import (
-        add_policy_sources_to_metadata, add_policy_to_applied_policies_header)
-    from litellm.proxy.policy_engine.attachment_registry import \
-        get_attachment_registry
+        add_policy_sources_to_metadata,
+        add_policy_to_applied_policies_header,
+    )
+    from litellm.proxy.policy_engine.attachment_registry import get_attachment_registry
     from litellm.proxy.policy_engine.policy_matcher import PolicyMatcher
 
     # Get matching policies via attachments (with match reasons for attribution)
@@ -1721,8 +1744,7 @@ async def add_guardrails_from_policy_engine(
         user_api_key_dict: The user's API key authentication info
     """
     from litellm._logging import verbose_proxy_logger
-    from litellm.proxy.common_utils.http_parsing_utils import \
-        get_tags_from_request_body
+    from litellm.proxy.common_utils.http_parsing_utils import get_tags_from_request_body
     from litellm.proxy.policy_engine.policy_registry import get_policy_registry
     from litellm.types.proxy.policy_engine import PolicyMatchContext
 

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -334,6 +334,81 @@ def test_chat_completion_forward_headers(
         pytest.fail(f"LiteLLM Proxy test failed. Exception - {str(e)}")
 
 
+@pytest.mark.parametrize("forward_llm_auth_headers", [True, False])
+@mock_patch_acompletion()
+def test_chat_completion_forward_llm_provider_auth_headers(
+    mock_acompletion, client_no_auth, forward_llm_auth_headers
+):
+    """
+    Test that LLM provider auth headers (x-api-key, x-goog-api-key) are forwarded
+    when forward_llm_provider_auth_headers=True.
+    
+    This allows clients to send their own LLM provider API keys through the proxy.
+    """
+    try:
+        # Configure general settings
+        gs = getattr(litellm.proxy.proxy_server, "general_settings")
+        gs["forward_client_headers_to_llm_api"] = True
+        gs["forward_llm_provider_auth_headers"] = forward_llm_auth_headers
+        setattr(litellm.proxy.proxy_server, "general_settings", gs)
+        
+        # Test data
+        test_data = {
+            "model": "gpt-3.5-turbo",
+            "messages": [
+                {"role": "user", "content": "hello"},
+            ],
+            "max_tokens": 10,
+        }
+        
+        # Headers including LLM provider auth
+        request_headers = {
+            "Authorization": "Bearer sk-proxy-auth-123",  # Proxy auth (should be stripped)
+            "x-api-key": "sk-ant-api03-test-anthropic-key",  # Anthropic API key
+            "x-goog-api-key": "google-api-key-123",  # Google API key
+            "X-Custom-Header": "custom-value",  # Custom header (should be forwarded)
+        }
+        
+        # Make request
+        response = client_no_auth.post(
+            "/v1/chat/completions", json=test_data, headers=request_headers
+        )
+        
+        assert response.status_code == 200
+        
+        # Check forwarded headers
+        forwarded_headers = mock_acompletion.call_args.kwargs.get("headers", {})
+        
+        if forward_llm_auth_headers:
+            # LLM provider auth headers should be forwarded
+            assert "x-api-key" in forwarded_headers
+            assert forwarded_headers["x-api-key"] == "sk-ant-api03-test-anthropic-key"
+            assert "x-goog-api-key" in forwarded_headers
+            assert forwarded_headers["x-goog-api-key"] == "google-api-key-123"
+        else:
+            # LLM provider auth headers should be stripped
+            assert "x-api-key" not in forwarded_headers
+            assert "x-goog-api-key" not in forwarded_headers
+        
+        # Custom headers should always be forwarded (when forward_client_headers_to_llm_api=True)
+        assert "x-custom-header" in forwarded_headers
+        assert forwarded_headers["x-custom-header"] == "custom-value"
+        
+        # Proxy Authorization should never be forwarded
+        assert "authorization" not in forwarded_headers
+        
+        print(f"✓ Test passed with forward_llm_provider_auth_headers={forward_llm_auth_headers}")
+        print(f"  Forwarded headers: {list(forwarded_headers.keys())}")
+        
+    except Exception as e:
+        pytest.fail(f"Test failed with forward_llm_auth_headers={forward_llm_auth_headers}: {str(e)}")
+    finally:
+        # Clean up
+        gs = getattr(litellm.proxy.proxy_server, "general_settings")
+        gs.pop("forward_llm_provider_auth_headers", None)
+        setattr(litellm.proxy.proxy_server, "general_settings", gs)
+
+
 @mock_patch_acompletion()
 @pytest.mark.asyncio
 async def test_team_disable_guardrails(mock_acompletion, client_no_auth):


### PR DESCRIPTION
## Relevant issues

User was using /login of claude with litellm. So when claude sent its api key in x-api-key, it would get stripped of and anthropic won't get the api key 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🆕 New Feature
🐛 Bug Fix


## Changes
<img width="891" height="252" alt="image" src="https://github.com/user-attachments/assets/abdb4c00-e626-4b20-b126-0a5397002f95" />
