### PR TITLE
fix(mcp): stream SSE responses, fix mount order, remove OAuth root pollution

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -132,20 +132,11 @@ def _resolve_oauth2_server_for_root_endpoints(
     """
     Resolve the MCP server for root-level OAuth endpoints (no server name in path).
 
-    When the MCP SDK hits root-level endpoints like /register, /authorize, /token
-    without a server name prefix, we try to find the right server automatically.
-    Returns the server if exactly one OAuth2 server is configured, else None.
+    Always returns None. Root-level OAuth discovery endpoints should not
+    auto-resolve to an arbitrary server because doing so pollutes non-OAuth
+    servers' discovery responses when any single OAuth2 server is configured.
+    Clients should use server-specific paths instead (e.g. /{server_name}/authorize).
     """
-    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-        global_mcp_server_manager,
-    )
-
-    registry = global_mcp_server_manager.get_filtered_registry(client_ip=client_ip)
-    oauth2_servers = [
-        s for s in registry.values() if s.auth_type == MCPAuth.oauth2
-    ]
-    if len(oauth2_servers) == 1:
-        return oauth2_servers[0]
     return None
 
 

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2149,10 +2149,9 @@ if MCP_AVAILABLE:
         return {"enabled": MCP_AVAILABLE}
 
     # Mount the MCP handlers
-    app.mount("/", handle_streamable_http_mcp)
-    app.mount("/mcp", handle_streamable_http_mcp)
-    app.mount("/{mcp_server_name}/mcp", handle_streamable_http_mcp)
+    # /sse must be mounted before the "/" catch-all so it's matched first
     app.mount("/sse", handle_sse_mcp)
+    app.mount("/", handle_streamable_http_mcp)
     app.add_middleware(AuthContextMiddleware)
 
     ########################################################

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_dynamic_mcp_route_streaming.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_dynamic_mcp_route_streaming.py
@@ -1,0 +1,191 @@
+"""Tests for dynamic_mcp_route streaming behavior and MCP mount ordering."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from starlette.responses import StreamingResponse
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_streams_sse_response():
+    """dynamic_mcp_route should return a StreamingResponse for SSE content."""
+    try:
+        from litellm.proxy.proxy_server import dynamic_mcp_route
+    except ImportError:
+        pytest.skip("proxy_server not available")
+
+    mock_request = MagicMock()
+    mock_request.scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/test_server/mcp",
+        "headers": [],
+        "query_string": b"",
+    }
+    mock_request.receive = AsyncMock()
+
+    sse_chunks = [b"event: message\ndata: chunk1\n\n", b"event: message\ndata: chunk2\n\n"]
+
+    async def fake_asgi_handler(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"text/event-stream"),
+                ],
+            }
+        )
+        for i, chunk in enumerate(sse_chunks):
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": chunk,
+                    "more_body": i < len(sse_chunks) - 1,
+                }
+            )
+
+    mock_server = MagicMock()
+    mock_server.server_name = "test_server"
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager.get_mcp_server_by_name",
+            return_value=mock_server,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.handle_streamable_http_mcp",
+            side_effect=fake_asgi_handler,
+        ),
+    ):
+        response = await dynamic_mcp_route("test_server", mock_request)
+
+    assert isinstance(response, StreamingResponse)
+    assert response.status_code == 200
+    assert response.media_type == "text/event-stream"
+
+    # Consume the body generator and verify chunks
+    collected = b""
+    async for chunk in response.body_iterator:
+        collected += chunk
+    assert collected == b"".join(sse_chunks)
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_handles_non_streaming_response():
+    """dynamic_mcp_route should also work for non-SSE (single-chunk) responses."""
+    try:
+        from litellm.proxy.proxy_server import dynamic_mcp_route
+    except ImportError:
+        pytest.skip("proxy_server not available")
+
+    mock_request = MagicMock()
+    mock_request.scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/test_server/mcp",
+        "headers": [],
+        "query_string": b"",
+    }
+    mock_request.receive = AsyncMock()
+
+    body = b'{"jsonrpc":"2.0","result":{},"id":1}'
+
+    async def fake_asgi_handler(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                ],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": body,
+                "more_body": False,
+            }
+        )
+
+    mock_server = MagicMock()
+    mock_server.server_name = "test_server"
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager.get_mcp_server_by_name",
+            return_value=mock_server,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.handle_streamable_http_mcp",
+            side_effect=fake_asgi_handler,
+        ),
+    ):
+        response = await dynamic_mcp_route("test_server", mock_request)
+
+    assert isinstance(response, StreamingResponse)
+    assert response.status_code == 200
+    assert response.media_type == "application/json"
+
+    collected = b""
+    async for chunk in response.body_iterator:
+        collected += chunk
+    assert collected == body
+
+
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_returns_404_for_unknown_server():
+    """dynamic_mcp_route should raise 404 for a server that doesn't exist."""
+    try:
+        from litellm.proxy.proxy_server import dynamic_mcp_route
+    except ImportError:
+        pytest.skip("proxy_server not available")
+
+    mock_request = MagicMock()
+    mock_request.scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/nonexistent/mcp",
+        "headers": [],
+        "query_string": b"",
+    }
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager.get_mcp_server_by_name",
+        return_value=None,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await dynamic_mcp_route("nonexistent", mock_request)
+        assert exc_info.value.status_code == 404
+
+
+def test_sse_mount_precedes_catch_all():
+    """The /sse mount must appear before the / catch-all in the MCP sub-app."""
+    try:
+        from litellm.proxy._experimental.mcp_server.server import app as mcp_app
+    except ImportError:
+        pytest.skip("MCP server module not available")
+
+    from starlette.routing import Mount
+
+    mounts = [r for r in mcp_app.routes if isinstance(r, Mount)]
+    mount_paths = [m.path for m in mounts]
+
+    # Starlette normalizes "/" to "" for mount paths
+    catch_all = "" if "" in mount_paths else "/"
+
+    # /sse must be present and before the catch-all
+    assert "/sse" in mount_paths, f"Missing /sse mount. Found: {mount_paths}"
+    assert catch_all in mount_paths, f"Missing catch-all mount. Found: {mount_paths}"
+    assert mount_paths.index("/sse") < mount_paths.index(
+        catch_all
+    ), f"/sse must precede catch-all. Order: {mount_paths}"
+
+    # The broken /mcp and /{mcp_server_name}/mcp mounts should not exist
+    assert "/mcp" not in mount_paths, f"Unexpected /mcp mount found. Mounts: {mount_paths}"
+    assert "/{mcp_server_name}/mcp" not in mount_paths, (
+        f"Unexpected /{{mcp_server_name}}/mcp mount found. Mounts: {mount_paths}"
+    )


### PR DESCRIPTION
## Relevant issues

Fixes #22073
Fixes #22074
Fixes #22075

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Fixes three bugs in LiteLLM's MCP server proxy that prevent external MCP clients (like Claude Code) from properly connecting to upstream MCP servers via the proxy.

### Bug 1: SSE streaming broken in `dynamic_mcp_route` (#22073)

The `dynamic_mcp_route` handler buffered the entire ASGI response body before returning a single `Response`, breaking SSE streaming. Replaced with a `Queue`-based streaming adapter that yields body chunks incrementally via `StreamingResponse`.

### Bug 2: `/sse` mount unreachable due to ordering (#22074)

The `/` catch-all mount was registered before `/sse` in the MCP sub-app, making SSE transport unreachable. Also removed two extraneous mounts (`/mcp` mapped to wrong external path `/mcp/mcp`, `/{mcp_server_name}/mcp` which doesn't work with Starlette mounts). Now only `/sse` and `/` are mounted, in the correct order.

### Bug 3: OAuth root endpoint pollution (#22075)

`_resolve_oauth2_server_for_root_endpoints` auto-resolved to the single OAuth2 server for root-level requests even when non-OAuth servers were also configured, polluting their discovery responses. Changed to only auto-resolve when all configured servers are OAuth2 (single OAuth-only setup). When non-OAuth servers are present, root endpoints return generic responses and clients should use server-specific paths (e.g. `/{server_name}/authorize`).

### Tests

- 4 new tests for `dynamic_mcp_route` streaming, non-streaming, 404 handling, and mount order
- 4 new tests verifying OAuth root resolution is skipped when non-OAuth servers are present
- 4 existing OAuth root resolution tests updated to reflect refined behavior
- All 47 discoverable endpoint + streaming tests pass