### PR TITLE
fix: convert Usage to dict in non-streaming /v1/responses to preserve…

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1689,7 +1689,16 @@ class Logging(LiteLLMLoggingBaseClass):
                     result.usage
                 )
             )
-            setattr(result, "usage", transformed_usage)
+            # Set as dict instead of Usage object so model_dump() serializes it correctly
+            setattr(
+                result,
+                "usage",
+                (
+                    transformed_usage.model_dump()
+                    if hasattr(transformed_usage, "model_dump")
+                    else dict(transformed_usage)
+                ),
+            )
             if (
                 standard_logging_payload := self.model_call_details.get(
                     "standard_logging_object"


### PR DESCRIPTION
In `_transform_usage_objects`, the non-streaming path was setting the transformed `Usage` Pydantic object directly on the `ResponsesAPIResponse`. When `model_dump()` serialized the response, Pydantic dropped `prompt_tokens` and `completion_tokens` because they don't match the `ResponseAPIUsage` schema — only `total_tokens` survived.

The streaming path already handled this correctly by converting the `Usage` object to a dict before setting it. This commit applies the same pattern to the non-streaming path.

Affected: all non-streaming `/v1/responses` calls that return usage data.

## Relevant issues

Fixes usage data loss on non-streaming `/v1/responses` — `prompt_tokens` and `completion_tokens` are silently dropped during Pydantic serialization.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

- **`litellm/litellm_core_utils/litellm_logging.py`** — In `_transform_usage_objects`, changed the non-streaming `ResponsesAPIResponse` path to convert the `Usage` object to a dict via `model_dump()` before setting it on the response, matching the existing streaming path (line ~3282). This prevents Pydantic from dropping `prompt_tokens` and `completion_tokens` during serialization.

- **`tests/test_litellm/litellm_core_utils/test_litellm_logging.py`** — Added `test_transform_usage_objects_non_streaming_preserves_prompt_and_completion_tokens` which builds a `ResponsesAPIResponse` with `ResponseAPIUsage`, runs `_transform_usage_objects`, and verifies that `prompt_tokens`, `completion_tokens`, and `total_tokens` are all preserved — both on the result object and after `model_dump()` serialization.
