### PR TITLE
fix(router): prevent NoneType errors and timedelta serialization in routing callbacks

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1969,8 +1969,8 @@ class PrometheusLogger(CustomLogger):
                 return
 
             api_base = standard_logging_payload["api_base"]
-            _litellm_params = request_kwargs.get("litellm_params", {}) or {}
-            _metadata = get_litellm_metadata_from_kwargs(request_kwargs)
+            _litellm_params = request_kwargs.get("litellm_params") or {}
+            _metadata = get_litellm_metadata_from_kwargs(request_kwargs) or {}
             litellm_model_name = request_kwargs.get("model", None)
             llm_provider = _litellm_params.get("custom_llm_provider", None)
             _model_info = _metadata.get("model_info") or {}

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -163,7 +163,7 @@ def get_litellm_metadata_from_kwargs(kwargs: dict):
 
     Return `litellm_metadata` if it exists, otherwise return `metadata`
     """
-    litellm_params = kwargs.get("litellm_params", {})
+    litellm_params = kwargs.get("litellm_params") or {}
     if litellm_params:
         metadata = litellm_params.get("metadata", {})
         litellm_metadata = litellm_params.get("litellm_metadata", {})

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -87,7 +87,11 @@ class LowestLatencyLoggingHandler(CustomLogger):
                         kwargs.get("completion_start_time", end_time) - start_time
                     )
 
-                final_value: Union[float, timedelta] = response_ms
+                # Always convert to float seconds for Redis JSON serialization
+                if isinstance(response_ms, timedelta):
+                    final_value: Union[float, timedelta] = response_ms.total_seconds()
+                else:
+                    final_value: Union[float, timedelta] = float(response_ms) if response_ms else 0.0
                 time_to_first_token: Optional[float] = None
                 total_tokens = 0
 
@@ -308,7 +312,11 @@ class LowestLatencyLoggingHandler(CustomLogger):
                         kwargs.get("completion_start_time", end_time) - start_time
                     )
 
-                final_value: Union[float, timedelta] = response_ms
+                # Always convert to float seconds for Redis JSON serialization
+                if isinstance(response_ms, timedelta):
+                    final_value: Union[float, timedelta] = response_ms.total_seconds()
+                else:
+                    final_value: Union[float, timedelta] = float(response_ms) if response_ms else 0.0
                 total_tokens = 0
                 time_to_first_token: Optional[float] = None
 


### PR DESCRIPTION
## Summary

Fixes three related bugs in the routing/metrics stack that cause `NoneType` errors and Redis serialization failures when using `latency-based-routing` strategy with Redis caching enabled.

### Bug 1: `get_litellm_metadata_from_kwargs` returns None (core_helpers.py)

`kwargs.get("litellm_params", {})` returns `None` (not `{}`) when the key exists but the value is explicitly `None`. Python's `.get(key, default)` only uses the default when the key is **missing**, not when the value is `None`.

**Fix**: `kwargs.get("litellm_params") or {}`

### Bug 2: timedelta not serializable for Redis cache (lowest_latency.py)

`end_time - start_time` returns a `datetime.timedelta`, which is assigned directly to `final_value`. When this value is written to Redis cache, JSON serialization fails because `timedelta` is not JSON-serializable. This affects both the sync (`log_success_event`) and async (`async_log_success_event`) code paths.

**Fix**: Convert to float seconds via `.total_seconds()` before storage.

### Bug 3: NoneType in Prometheus metrics (prometheus.py)

`set_llm_deployment_success_metrics` crashes when `_litellm_params` or `_metadata` is `None` (downstream of Bug 1). The existing `or {}` guard on `_litellm_params` doesn't help because `kwargs.get("litellm_params", {})` already returns `None` before `or {}` is evaluated.

**Fix**: Use `kwargs.get("litellm_params") or {}` pattern (same as Bug 1), and add `or {}` to `get_litellm_metadata_from_kwargs()` call.

## Reproduction

These bugs manifest when:
1. Using `routing_strategy: latency-based-routing` with Redis cache enabled
2. A non-`ModelResponse` object triggers the success callback (e.g., embedding responses)
3. `litellm_params` is set to `None` in kwargs by an upstream caller

## Test plan

- [x] Verified `py_compile` passes on all 3 files
- [x] Deployed and verified in production (LiteLLM v1.81.x equivalent)
- [ ] Unit tests for `get_litellm_metadata_from_kwargs` with `None` value
- [ ] Unit tests for timedelta conversion in `LowestLatencyLoggingHandler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)