### PR TITLE
fix(guardrails): prevent presidio crash on non-json responses

### DIFF
--- a/docs/my-website/docs/tutorials/presidio_pii_masking.md
+++ b/docs/my-website/docs/tutorials/presidio_pii_masking.md
@@ -592,6 +592,21 @@ def test_pii_masking_allows_normal_text():
 
 ## Part 7: Troubleshooting
 
+### Issue: Guardrail failure: non-JSON response from Presidio
+
+**Symptom:** You receive an error indicating `expected application/json Content-Type but received text/html` or similar.
+
+**Root cause:** Your ingress controller or reverse proxy might be routing the `/analyze` or `/anonymize` POST request to a health endpoint (like `/health` or `/presidio-analyzer/health`) which returns plain text instead of JSON.
+
+**Fix:** Ensure your `PRESIDIO_ANALYZER_API_BASE` and `PRESIDIO_ANONYMIZER_API_BASE` are correctly pointing directly to the Presidio API endpoints, or that your ingress routes the path correctly without stripping it and inadvertently forwarding to a plain-text health check endpoint.
+
+**Verification:** You can verify your endpoints using `curl`. It should return a JSON array, not `text/html`:
+```bash
+curl -sv -X POST http://your-analyzer-endpoint/analyze \
+  -H "Content-Type: application/json" \
+  -d '{"text":"test","language":"en"}'
+```
+
 ### Issue: Presidio Not Detecting PII
 
 **Check 1: Language Configuration**


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes Presidio guardrail failing with opaque `ContentTypeError` when the configured endpoint returns non-JSON responses (e.g., HTML from a `health` check route).

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
📖 Documentation
✅ Test

## Changes

<img width="1141" height="605" alt="image" src="https://github.com/user-attachments/assets/635163f8-a54d-4919-ac19-788af8f0245e" />



<img width="981" height="707" alt="image" src="https://github.com/user-attachments/assets/33e51239-e19c-4735-bf1f-db468ecc182d" />



1. **Defensive Validation in Presidio Guardrail**:
   - Added validation for HTTP status codes (`response.status >= 400`) in [analyze_text()](cci:1://file:///Users/harshitjain/litellm/litellm/proxy/guardrails/guardrail_hooks/presidio.py:284:4-397:87) and [anonymize_text()](cci:1://file:///Users/harshitjain/litellm/litellm/proxy/guardrails/guardrail_hooks/presidio.py:399:4-462:20).
   - Added `Content-Type` header verification to ensure the response contains `application/json` before calling `await response.json()`.
   - This prevents opaque `ContentTypeError` internal app crashes and instead surfaces a clean, descriptive error message (e.g. `expected application/json Content-Type but received text/html`).

2. **Explicit Content Negotiation**:
   - Proactively added the `Accept: application/json` header to outbound Presidio HTTP calls to prevent misconfigured load balancers from defaulting to non-JSON responses.

3. **Enhanced Testing Coverage**:
   - Expanded the [_make_mock_session_iterator](cci:1://file:///Users/harshitjain/litellm/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py:26:0-53:24) in [test_presidio.py](cci:7://file:///Users/harshitjain/litellm/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py:0:0-0:0) to support mocking HTTP status codes and `Content-Type` headers.
   - Added 5 new robust unit tests ([test_analyze_text_non_json_content_type_fail_closed](cci:1://file:///Users/harshitjain/litellm/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py:1466:0-1494:49), [test_analyze_text_non_json_content_type_fail_open](cci:1://file:///Users/harshitjain/litellm/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py:1497:0-1522:28), [test_analyze_text_http_error_status](cci:1://file:///Users/harshitjain/litellm/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py:1525:0-1551:48), [test_anonymize_text_non_json_content_type](cci:1://file:///Users/harshitjain/litellm/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py:1554:0-1581:13), [test_anonymize_text_http_error_status](cci:1://file:///Users/harshitjain/litellm/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py:1584:0-1609:13)) to strictly enforce validation logic.

4. **Updated Documentation**:
   - Appended a new "Guardrail failure: non-JSON response from Presidio" troubleshooting section to [presidio_pii_masking.md](cci:7://file:///Users/harshitjain/litellm/docs/my-website/docs/tutorials/presidio_pii_masking.md:0:0-0:0) giving users clear instructions and a `curl` testing command to identify when their loadbalancer incorrectly routes `/analyze` calls to a `/health` endpoint.
