### PR TITLE
fix(adapter): populate cache_read_input_tokens from prompt_tokens_details for OpenAI/Azure

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1106,19 +1106,19 @@ class LiteLLMAnthropicMessagesAdapter:
         # extract usage
         usage: Usage = getattr(response, "usage")
         uncached_input_tokens = usage.prompt_tokens or 0
+        cached_tokens = 0
         if hasattr(usage, "prompt_tokens_details") and usage.prompt_tokens_details:
             cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
             uncached_input_tokens -= cached_tokens
-        
+
         anthropic_usage = AnthropicUsage(
             input_tokens=uncached_input_tokens,
             output_tokens=usage.completion_tokens or 0,
         )
-        # Add cache tokens if available (for prompt caching support)
         if hasattr(usage, "_cache_creation_input_tokens") and usage._cache_creation_input_tokens > 0:
             anthropic_usage["cache_creation_input_tokens"] = usage._cache_creation_input_tokens
-        if hasattr(usage, "_cache_read_input_tokens") and usage._cache_read_input_tokens > 0:
-            anthropic_usage["cache_read_input_tokens"] = usage._cache_read_input_tokens
+        if cached_tokens > 0:
+            anthropic_usage["cache_read_input_tokens"] = cached_tokens
 
         translated_obj = AnthropicMessagesResponse(
             id=response.id,

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1271,19 +1271,19 @@ class LiteLLMAnthropicMessagesAdapter:
                 litellm_usage_chunk = None
             if litellm_usage_chunk is not None:
                 uncached_input_tokens = litellm_usage_chunk.prompt_tokens or 0
+                cached_tokens = 0
                 if hasattr(litellm_usage_chunk, "prompt_tokens_details") and litellm_usage_chunk.prompt_tokens_details:
                     cached_tokens = getattr(litellm_usage_chunk.prompt_tokens_details, "cached_tokens", 0) or 0
                     uncached_input_tokens -= cached_tokens
-                
+
                 usage_delta = UsageDelta(
                     input_tokens=uncached_input_tokens,
                     output_tokens=litellm_usage_chunk.completion_tokens or 0,
                 )
-                # Add cache tokens if available (for prompt caching support)
                 if hasattr(litellm_usage_chunk, "_cache_creation_input_tokens") and litellm_usage_chunk._cache_creation_input_tokens > 0:
                     usage_delta["cache_creation_input_tokens"] = litellm_usage_chunk._cache_creation_input_tokens
-                if hasattr(litellm_usage_chunk, "_cache_read_input_tokens") and litellm_usage_chunk._cache_read_input_tokens > 0:
-                    usage_delta["cache_read_input_tokens"] = litellm_usage_chunk._cache_read_input_tokens
+                if cached_tokens > 0:
+                    usage_delta["cache_read_input_tokens"] = cached_tokens
             else:
                 usage_delta = UsageDelta(input_tokens=0, output_tokens=0)
             return MessageBlockDelta(


### PR DESCRIPTION
## Relevant issues

Fixes #22089
Related: #19684, #20878

## Pre-Submission checklist

- [x] **Sign the Contributor License Agreement (CLA)** - [see details](#contributor-license-agreement-cla)
- [x] **Keep scope isolated** - Your changes should address 1 specific problem at a time
- [x] **Add testing** - Adding at least 1 test is a hard requirement - [see details](#adding-testing)
- [x] **Ensure your PR passes all checks**

## Type

🐛 Bug Fix

## Changes

`translate_openai_response_to_anthropic` already extracts `cached_tokens` from `prompt_tokens_details` (to subtract from `input_tokens`) but then discards the value. It only checked the private `_cache_read_input_tokens` attr when populating `cache_read_input_tokens` in the Anthropic response — which is never set for OpenAI/Azure providers.

This PR uses `prompt_tokens_details.cached_tokens` directly instead of the private attr, as @krrishdholakia suggested in #20878:

> shouldn't we just update the ui to use the openai compatible cached tokens instead? the private var seems like an older implementation which may break

This approach avoids depending on the private `_cache_read_input_tokens` attr for cache read tokens. `prompt_tokens_details.cached_tokens` is the standard field populated by all providers (OpenAI natively, Anthropic/DeepSeek via `Usage.__init__` mapping).

**Files changed:**
- `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py` — use `cached_tokens` from `prompt_tokens_details` directly
- `tests/test_litellm/.../test_anthropic_experimental_pass_through_adapters_transformation.py` — added test for OpenAI-style usage (only `prompt_tokens_details.cached_tokens`, no `cache_read_input_tokens` kwarg)