### PR TITLE
fix(proxy): improve auth exception logging levels and add structured context

### DIFF
--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -201,10 +201,10 @@ async def test_expected_auth_errors_log_at_warning_level():
             except Exception:
                 pass
 
-            mock_warning.assert_called_once(), (
+            assert mock_warning.call_count == 1, (
                 f"Expected warning log for {type(error).__name__}, got none"
             )
-            mock_exception.assert_not_called(), (
+            assert mock_exception.call_count == 0, (
                 f"Did not expect exception log for {type(error).__name__}"
             )
 

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -152,3 +152,199 @@ async def test_route_passed_to_post_call_failure_hook():
             mock_post_call_failure_hook.assert_called_once()
             call_args = mock_post_call_failure_hook.call_args[1]
             assert call_args["user_api_key_dict"].request_route == test_route
+
+
+@pytest.mark.asyncio
+async def test_expected_auth_errors_log_at_warning_level():
+    """
+    Expected auth failures (ProxyException, HTTPException < 500, BudgetExceededError)
+    should log at WARNING level, not ERROR, to reduce log noise.
+    """
+    handler = UserAPIKeyAuthExceptionHandler()
+
+    mock_request = MagicMock()
+    mock_request.method = "GET"
+    mock_request_data = {}
+    mock_route = "/schedule/model_cost_map_reload/status"
+    mock_span = None
+    mock_api_key = "sk-test1234"
+
+    expected_auth_errors = [
+        ProxyException(
+            message="Token not found",
+            type=ProxyErrorTypes.token_not_found_in_db,
+            param="key",
+            code=401,
+        ),
+        HTTPException(status_code=401, detail="Invalid API key"),
+        HTTPException(status_code=403, detail="Forbidden"),
+    ]
+
+    for error in expected_auth_errors:
+        with patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_requests_on_db_unavailable": False},
+        ), patch.object(
+            verbose_proxy_logger, "warning"
+        ) as mock_warning, patch.object(
+            verbose_proxy_logger, "exception"
+        ) as mock_exception:
+            try:
+                await handler._handle_authentication_error(
+                    error,
+                    mock_request,
+                    mock_request_data,
+                    mock_route,
+                    mock_span,
+                    mock_api_key,
+                )
+            except Exception:
+                pass
+
+            mock_warning.assert_called_once(), (
+                f"Expected warning log for {type(error).__name__}, got none"
+            )
+            mock_exception.assert_not_called(), (
+                f"Did not expect exception log for {type(error).__name__}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_unexpected_errors_log_at_error_level():
+    """
+    Unexpected exceptions (bare Exception, HTTPException with 500) should
+    still log at ERROR level with full traceback.
+    """
+    handler = UserAPIKeyAuthExceptionHandler()
+
+    mock_request = MagicMock()
+    mock_request.method = "POST"
+    mock_request_data = {}
+    mock_route = "/chat/completions"
+    mock_span = None
+    mock_api_key = "sk-test1234"
+
+    unexpected_errors = [
+        Exception("Something unexpected broke"),
+        HTTPException(status_code=500, detail="Master key type error"),
+    ]
+
+    for error in unexpected_errors:
+        with patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_requests_on_db_unavailable": False},
+        ), patch.object(
+            verbose_proxy_logger, "warning"
+        ) as mock_warning, patch.object(
+            verbose_proxy_logger, "exception"
+        ) as mock_exception:
+            try:
+                await handler._handle_authentication_error(
+                    error,
+                    mock_request,
+                    mock_request_data,
+                    mock_route,
+                    mock_span,
+                    mock_api_key,
+                )
+            except Exception:
+                pass
+
+            mock_exception.assert_called_once(), (
+                f"Expected exception log for {type(error).__name__}, got none"
+            )
+            mock_warning.assert_not_called(), (
+                f"Did not expect warning log for {type(error).__name__}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_auth_error_log_contains_structured_context():
+    """
+    Log messages should include route, HTTP method, masked API key, error type,
+    and error code for easier debugging.
+    """
+    handler = UserAPIKeyAuthExceptionHandler()
+
+    mock_request = MagicMock()
+    mock_request.method = "GET"
+    mock_request_data = {}
+    mock_route = "/schedule/model_cost_map_reload/status"
+    mock_span = None
+    mock_api_key = "sk-test1234"
+
+    error = ProxyException(
+        message="Token not found",
+        type=ProxyErrorTypes.token_not_found_in_db,
+        param="key",
+        code=401,
+    )
+
+    with patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"allow_requests_on_db_unavailable": False},
+    ), patch.object(verbose_proxy_logger, "warning") as mock_warning:
+        try:
+            await handler._handle_authentication_error(
+                error,
+                mock_request,
+                mock_request_data,
+                mock_route,
+                mock_span,
+                mock_api_key,
+            )
+        except Exception:
+            pass
+
+        mock_warning.assert_called_once()
+        log_message = mock_warning.call_args[0][0]
+        log_extra = mock_warning.call_args[1].get("extra", {})
+
+        # Verify structured fields are in the log message
+        assert mock_route in log_message
+        assert "GET" in log_message
+        assert "sk-...1234" in log_message
+
+        # Verify structured extra dict for log aggregation tools
+        assert log_extra["route"] == mock_route
+        assert log_extra["http_method"] == "GET"
+        assert log_extra["api_key"] == "sk-...1234"
+        assert log_extra["error_type"] == ProxyErrorTypes.token_not_found_in_db
+
+
+@pytest.mark.asyncio
+async def test_auth_error_log_handles_none_api_key():
+    """
+    When no API key is provided (None or empty), the log should show 'None'
+    instead of crashing.
+    """
+    handler = UserAPIKeyAuthExceptionHandler()
+
+    mock_request = MagicMock()
+    mock_request.method = "GET"
+    mock_request_data = {}
+    mock_route = "/test"
+    mock_span = None
+
+    error = Exception("No api key passed in.")
+
+    for empty_key in [None, ""]:
+        with patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_requests_on_db_unavailable": False},
+        ), patch.object(verbose_proxy_logger, "exception") as mock_exception:
+            try:
+                await handler._handle_authentication_error(
+                    error,
+                    mock_request,
+                    mock_request_data,
+                    mock_route,
+                    mock_span,
+                    empty_key,
+                )
+            except Exception:
+                pass
+
+            mock_exception.assert_called_once()
+            log_message = mock_exception.call_args[0][0]
+            assert "None" in log_message


### PR DESCRIPTION
## Relevant issues

Fixes #21293

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Problem

`_handle_authentication_error` in `auth_exception_handler.py` logs every auth failure at ERROR level with a full stack trace via `verbose_proxy_logger.exception()`. This includes routine rejections like missing/invalid API keys on polled endpoints (e.g. `/schedule/model_cost_map_reload/status`), producing noisy, alarming logs in production.

The log messages also lack context -- only `str(e)` and the requester IP are included, making it hard to debug which route was hit, what key was used, or what category of failure occurred.

### Fix

**Log level differentiation:**
- Expected auth failures (`ProxyException`, `HTTPException` with status < 500, `BudgetExceededError`) now log at WARNING without a traceback
- Unexpected exceptions and `HTTPException` with status >= 500 still log at ERROR with full traceback
- This preserves visibility into real server errors while eliminating noise from routine auth rejections

**Structured log context:**
- Log messages now include: route, HTTP method, masked API key (via existing `abbreviate_api_key`), error type, and error code
- All fields are also passed in the `extra` dict for log aggregation tools (Datadog, CloudWatch, etc.)
- None/empty API keys are handled gracefully (logged as "None")

**Before:**
```
ERROR - litellm.proxy.proxy_server.user_api_key_auth(): Exception occured -
Requester IP Address:10.90.83.128
Traceback (most recent call last):
  ...full traceback...
```

**After (expected auth failure):**
```
WARNING - Auth failed: error_type=token_not_found_in_db, error_code=401, route=GET /schedule/model_cost_map_reload/status, api_key=sk-...ab3f, ip=10.90.83.128 - Authentication Error, Invalid proxy server token passed...
```

### Tests added

4 new tests in `tests/test_litellm/proxy/auth/test_auth_exception_handler.py`:
- `test_expected_auth_errors_log_at_warning_level` -- verifies ProxyException and HTTPException < 500 log at WARNING
- `test_unexpected_errors_log_at_error_level` -- verifies bare Exception and HTTPException 500 log at ERROR
- `test_auth_error_log_contains_structured_context` -- verifies route, method, masked key, error type in log message and extra dict
- `test_auth_error_log_handles_none_api_key` -- verifies None/empty API keys don't crash and log as "None"
