### PR TITLE
fix(proxy): honor MAX_STRING_LENGTH_PROMPT_IN_DB from config env vars

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -11,6 +11,9 @@ from pydantic import BaseModel
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import (
+    MAX_STRING_LENGTH_PROMPT_IN_DB as DEFAULT_MAX_STRING_LENGTH_PROMPT_IN_DB,
+)
 from litellm.constants import REDACTED_BY_LITELM_STRING
 from litellm.litellm_core_utils.core_helpers import (
     get_litellm_metadata_from_kwargs,
@@ -36,14 +39,13 @@ def _get_max_string_length_prompt_in_db() -> int:
     Resolve prompt truncation threshold at runtime so values loaded later via
     proxy config environment_variables are honored.
     """
-    default_max = 2048
     max_length_str = os.getenv("MAX_STRING_LENGTH_PROMPT_IN_DB")
     if max_length_str is None:
-        return default_max
+        return DEFAULT_MAX_STRING_LENGTH_PROMPT_IN_DB
     try:
         return int(max_length_str)
     except (TypeError, ValueError):
-        return default_max
+        return DEFAULT_MAX_STRING_LENGTH_PROMPT_IN_DB
 
 
 def _is_master_key(api_key: str, _master_key: Optional[str]) -> bool:

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import secrets
 from datetime import datetime
 from datetime import datetime as dt
@@ -10,7 +11,7 @@ from pydantic import BaseModel
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.constants import MAX_STRING_LENGTH_PROMPT_IN_DB, REDACTED_BY_LITELM_STRING
+from litellm.constants import REDACTED_BY_LITELM_STRING
 from litellm.litellm_core_utils.core_helpers import (
     get_litellm_metadata_from_kwargs,
     reconstruct_model_name,
@@ -28,6 +29,21 @@ from litellm.types.utils import (
     VectorStoreSearchResponse,
 )
 from litellm.utils import get_end_user_id_for_cost_tracking
+
+
+def _get_max_string_length_prompt_in_db() -> int:
+    """
+    Resolve prompt truncation threshold at runtime so values loaded later via
+    proxy config environment_variables are honored.
+    """
+    default_max = 2048
+    max_length_str = os.getenv("MAX_STRING_LENGTH_PROMPT_IN_DB")
+    if max_length_str is None:
+        return default_max
+    try:
+        return int(max_length_str)
+    except (TypeError, ValueError):
+        return default_max
 
 
 def _is_master_key(api_key: str, _master_key: Optional[str]) -> bool:
@@ -599,6 +615,7 @@ def _get_messages_for_spend_logs_payload(
 def _sanitize_request_body_for_spend_logs_payload(
     request_body: dict,
     visited: Optional[set] = None,
+    max_string_length_prompt_in_db: Optional[int] = None,
 ) -> dict:
     """
     Recursively sanitize request body to prevent logging large base64 strings or other large values.
@@ -608,6 +625,8 @@ def _sanitize_request_body_for_spend_logs_payload(
 
     if visited is None:
         visited = set()
+    if max_string_length_prompt_in_db is None:
+        max_string_length_prompt_in_db = _get_max_string_length_prompt_in_db()
 
     # Get the object's memory address to track visited objects
     obj_id = id(request_body)
@@ -617,27 +636,29 @@ def _sanitize_request_body_for_spend_logs_payload(
 
     def _sanitize_value(value: Any) -> Any:
         if isinstance(value, dict):
-            return _sanitize_request_body_for_spend_logs_payload(value, visited)
+            return _sanitize_request_body_for_spend_logs_payload(
+                value, visited, max_string_length_prompt_in_db
+            )
         elif isinstance(value, list):
             return [_sanitize_value(item) for item in value]
         elif isinstance(value, str):
-            if len(value) > MAX_STRING_LENGTH_PROMPT_IN_DB:
+            if len(value) > max_string_length_prompt_in_db:
                 # Keep 35% from beginning and 65% from end (end is usually more important)
                 # This split ensures we keep more context from the end of conversations
                 start_ratio = 0.35
                 end_ratio = 0.65
 
                 # Calculate character distribution
-                start_chars = int(MAX_STRING_LENGTH_PROMPT_IN_DB * start_ratio)
-                end_chars = int(MAX_STRING_LENGTH_PROMPT_IN_DB * end_ratio)
+                start_chars = int(max_string_length_prompt_in_db * start_ratio)
+                end_chars = int(max_string_length_prompt_in_db * end_ratio)
 
                 # Ensure we don't exceed the total limit
                 total_keep = start_chars + end_chars
-                if total_keep > MAX_STRING_LENGTH_PROMPT_IN_DB:
-                    end_chars = MAX_STRING_LENGTH_PROMPT_IN_DB - start_chars
+                if total_keep > max_string_length_prompt_in_db:
+                    end_chars = max_string_length_prompt_in_db - start_chars
 
                 # If the string length is less than what we want to keep, just truncate normally
-                if len(value) <= MAX_STRING_LENGTH_PROMPT_IN_DB:
+                if len(value) <= max_string_length_prompt_in_db:
                     return value
 
                 # Calculate how many characters are being skipped

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -160,6 +160,21 @@ def test_sanitize_request_body_for_spend_logs_payload_mixed_types():
     assert len(sanitized["nested"]["dict"]["key"]) == expected_length
 
 
+def test_sanitize_request_body_for_spend_logs_payload_uses_runtime_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from litellm.constants import MAX_STRING_LENGTH_PROMPT_IN_DB
+
+    override_max = max(MAX_STRING_LENGTH_PROMPT_IN_DB + 1000, 6000)
+    test_string = "a" * (MAX_STRING_LENGTH_PROMPT_IN_DB + 500)
+
+    # Simulate config-loaded env var being set after module import.
+    monkeypatch.setenv("MAX_STRING_LENGTH_PROMPT_IN_DB", str(override_max))
+
+    sanitized = _sanitize_request_body_for_spend_logs_payload({"text": test_string})
+    assert sanitized["text"] == test_string
+
+
 def test_sanitize_request_body_for_spend_logs_payload_circular_reference():
     # Create a circular reference
     a: dict[str, Any] = {}
@@ -1232,8 +1247,6 @@ def test_get_logging_payload_handles_missing_retry_info_gracefully():
     assert (
         metadata.get("max_retries") is None
     ), "max_retries should be None when not provided"
-
-
 def test_get_request_duration_ms_normal():
     """Test that request duration is correctly computed in milliseconds."""
     start = datetime.datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
@@ -1279,4 +1292,3 @@ def test_get_logging_payload_includes_request_duration_ms():
         )
 
     assert payload["request_duration_ms"] == 3000
-

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -1247,6 +1247,8 @@ def test_get_logging_payload_handles_missing_retry_info_gracefully():
     assert (
         metadata.get("max_retries") is None
     ), "max_retries should be None when not provided"
+
+
 def test_get_request_duration_ms_normal():
     """Test that request duration is correctly computed in milliseconds."""
     start = datetime.datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
Fixes #22088

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: `<add link>`

- [ ] **CI run for the last commit**  
       Link: `<add link>`

- [ ] **Merge / cherry-pick CI run**  
       Links: `<add link(s)>`

## Type
🐛 Bug Fix  
✅ Test

## Changes

Issue #22088 root cause was import-time evaluation of `MAX_STRING_LENGTH_PROMPT_IN_DB` in spend-tracking sanitization paths. Proxy config `environment_variables` are loaded later via `_load_environment_variables()`, so the imported value could become stale.

1. Updated `litellm/proxy/spend_tracking/spend_tracking_utils.py`
- Resolve max prompt length at runtime from `os.environ`.
- Use fallback from `litellm.constants` default constant when env is missing or invalid.
- `_sanitize_request_body_for_spend_logs_payload()` resolves the limit once per call and threads it through recursive calls.
- Truncation behavior and formatting are unchanged. Only value resolution timing changed.

2. Added regression coverage in `tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py`
- Added test that sets `MAX_STRING_LENGTH_PROMPT_IN_DB` after import path setup.
- Verifies sanitization uses runtime env override, not stale import-time value.

3. Validation (targeted)
- `tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py` -> **32 passed**
- `tests/test_litellm/proxy/test_proxy_server.py -k load_environment_variables` -> **2 passed, 84 deselected**

4. Scope and impact
- Scope remains isolated to 2 files.
- No public API changes.
- No schema changes.
- Fix ensures config-loaded env overrides are honored for spend-log truncation threshold.
