### PR TITLE
[Docs] Credential Usage Tracking

### DIFF
--- a/docs/my-website/docs/proxy/credential_usage_tracking.md
+++ b/docs/my-website/docs/proxy/credential_usage_tracking.md
@@ -1,0 +1,19 @@
+# Credential Usage Tracking
+
+When a model is attached to a [reusable credential](./ui_credentials.md), LiteLLM automatically injects the credential name as a tag on every request that uses that model. This means credential-level spend and usage are tracked with zero extra configuration.
+
+## How It Works
+
+When you attach a model to a reusable credential via `litellm_credential_name`, each request routed through that model is tagged `Credential: <name>` (for example, `Credential: xAI`). This tag flows into `DailyTagSpend` and appears in the **Tag** view on the Usage page, where you can filter spend and usage by credential.
+
+If a model has no credential attached, behavior is unchanged—no credential tag is added.
+
+## Viewing Credential Usage
+
+In the Admin UI, go to **Usage → Tag** and look for tags with the `Credential: ` prefix. These represent aggregated spend and token usage across all requests that used that credential.
+
+## Related Documentation
+
+- [Adding LLM Credentials](./ui_credentials.md) - How to create and attach reusable credentials to models
+- [Tag Budgets](./tag_budgets.md) - Setting spend limits on tags
+- [Tag Routing](./tag_routing.md) - Routing requests based on tags

--- a/docs/my-website/docs/proxy/ui_credentials.md
+++ b/docs/my-website/docs/proxy/ui_credentials.md
@@ -46,6 +46,10 @@ Go to Add Model -> Existing Credentials -> Select your credential in the dropdow
 
 <Image img={require('../../img/use_model_cred.png')} />
 
+## Usage Tracking
+
+Models attached to a reusable credential are automatically tracked in the Usage page. Each request is tagged `Credential: <name>` and appears in the **Tag** view, so you can filter spend and usage by credential without any extra configuration. See [Credential Usage Tracking](./credential_usage_tracking.md) for details.
+
 ## Frequently Asked Questions
 
 


### PR DESCRIPTION
## Summary

Add documentation for automatic credential usage tracking. When models use reusable credentials, LiteLLM automatically injects a `Credential: <name>` tag on every request, enabling credential-level spend and usage tracking on the Usage page without additional configuration.

## Changes

- New doc: `credential_usage_tracking.md` explaining how credential usage is automatically tracked and tagged
- Updated: `ui_credentials.md` to reference the new doc in a new Usage Tracking section

## Type

📖 Documentation