### PR TITLE
fix(auth): remove hardcoded base64 string flagged by secret scanner

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -395,10 +395,8 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
                     endpoint.get("custom_auth_parser") is not None
                     and endpoint.get("custom_auth_parser") == "langfuse"
                 ):
-                    """
-                    - langfuse returns {'Authorization': 'Basic YW55dGhpbmc6YW55dGhpbmc'}
-                    - check the langfuse public key if it contains the litellm api key
-                    """
+                    # langfuse returns {'Authorization': 'Basic <base64(username:password)>'}
+                    # check the langfuse public key if it contains the litellm api key
                     import base64
 
                     api_key = api_key.replace("Basic ", "").strip()


### PR DESCRIPTION
## Summary
- Removed a literal Base64-encoded string (`YW55dGhpbmc6YW55dGhpbmc` = `anything:anything`) from a docstring in `litellm/proxy/auth/user_api_key_auth.py`
- Replaced it with a descriptive placeholder `<base64(username:password)>` that conveys the same information
- This fixes GitGuardian/ggshield container scan failures that flag the string as a "Base64 Basic Authentication" secret, which was blocking T-Mobile's compliance scanner on v1.81.14.rc.1

## Test plan
- [ ] Verify `make lint` passes
- [ ] Verify ggshield container scan no longer flags this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)