### PR TITLE
Fix: support file_search + vector_store with sync completion() and An…

### DIFF
--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -216,6 +216,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         prompt_version: Optional[int] = None,
         ignore_prompt_manager_model: Optional[bool] = False,
         ignore_prompt_manager_optional_params: Optional[bool] = False,
+        tools: Optional[List[Dict]] = None,
     ) -> Tuple[str, List[AllMessageValues], dict]:
         """
         Returns:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -636,6 +636,7 @@ class Logging(LiteLLMLoggingBaseClass):
         prompt_management_logger: Optional[CustomLogger] = None,
         prompt_label: Optional[str] = None,
         prompt_version: Optional[int] = None,
+        tools: Optional[List[Dict]] = None,
     ) -> Tuple[str, List[AllMessageValues], dict]:
         custom_logger = (
             prompt_management_logger
@@ -645,6 +646,7 @@ class Logging(LiteLLMLoggingBaseClass):
                 prompt_id=prompt_id,
                 prompt_spec=prompt_spec,
                 dynamic_callback_params=self.standard_callback_dynamic_params,
+                tools=tools,
             )
         )
 
@@ -663,6 +665,7 @@ class Logging(LiteLLMLoggingBaseClass):
                 dynamic_callback_params=self.standard_callback_dynamic_params,
                 prompt_label=prompt_label,
                 prompt_version=prompt_version,
+                tools=tools,
             )
         self.messages = messages
         return model, messages, non_default_params

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1262,7 +1262,9 @@ def completion(  # type: ignore # noqa: PLR0915
 
     if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and (
         litellm_logging_obj.should_run_prompt_management_hooks(
-            prompt_id=prompt_id, non_default_params=non_default_params
+            prompt_id=prompt_id,
+            non_default_params=non_default_params,
+            tools=tools,
         )
     ):
         (
@@ -1277,7 +1279,17 @@ def completion(  # type: ignore # noqa: PLR0915
             prompt_variables=prompt_variables,
             prompt_label=kwargs.get("prompt_label", None),
             prompt_version=kwargs.get("prompt_version", None),
+            tools=tools,
         )
+        #########################################################
+        # if the chat completion logging hook removed all tools,
+        # set tools to None
+        # eg. in certain cases when users send vector stores as tools
+        # we don't want the tools to go to the upstream llm
+        # relevant issue: https://github.com/BerriAI/litellm/issues/11404
+        #########################################################
+        if tools is not None and len(tools) == 0:
+            tools = None
 
     ### LITELLM SYSTEM PROMPT ###
     if litellm_system_prompt:


### PR DESCRIPTION
…thropic

- Pass tools into should_run_prompt_management_hooks and get_chat_completion_prompt in the sync completion path (main.py) so the vector store pre-call hook runs.
- Add tools parameter to get_chat_completion_prompt in Logging and CustomLogger.
- Implement sync get_chat_completion_prompt in VectorStorePreCallHook using pop_vector_stores_to_run and vector_stores.search() so file_search tools are stripped and context is injected before the request reaches Anthropic.
- After the hook, set tools to None when the list is empty (match async behavior).

Fixes: Unsupported tool type: file_search when using completion() with vector_store_ids and Anthropic models (e.g. https://github.com/BerriAI/litellm/issues/22124)

Made-with: Cursor

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
