### PR TITLE
Proxy request tags docs

### DIFF
--- a/docs/my-website/docs/proxy/cost_tracking.md
+++ b/docs/my-website/docs/proxy/cost_tracking.md
@@ -326,6 +326,10 @@ See our [Swagger API](https://litellm-api.up.railway.app/#/Budget%20%26%20Spend%
 
 ## Custom Tags
 
+:::tip See Full Request Tags Documentation
+For comprehensive documentation on all tag options including `x-litellm-tags` header, request body `tags`, and config-based tags, see the dedicated [Request Tags](./request_tags.md) page.
+:::
+
 Requirements:
 
 - Virtual Keys & a database should be set up, see [virtual keys](https://docs.litellm.ai/docs/proxy/virtual_keys)

--- a/docs/my-website/docs/proxy/request_tags.md
+++ b/docs/my-website/docs/proxy/request_tags.md
@@ -106,7 +106,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 The `tags` field must be an array of strings.
 
 :::info
-When tags are provided via header or request body, they override any tags configured in the model deployment.
+When tags are provided via header or request body, they override any tags configured in the model deployment. If both header and body tags are provided, body tags take precedence.
 :::
 
 ## Set Tags on Keys or Teams

--- a/docs/my-website/docs/proxy/request_tags.md
+++ b/docs/my-website/docs/proxy/request_tags.md
@@ -1,8 +1,15 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Request Tags for Spend Tracking
 
 Add tags to model deployments to track spend by environment, AWS account, or any custom label.
 
 Tags appear in the `request_tags` field of LiteLLM spend logs.
+
+:::info Requirements
+Virtual Keys & a database should be set up. See [Virtual Keys Setup](./virtual_keys.md).
+:::
 
 ## Config Setup
 
@@ -62,7 +69,10 @@ The header accepts:
 
 ### Option 3: Use Request Body `tags`
 
-Pass tags directly in the request body:
+Pass tags directly in the request body. Both formats are supported:
+
+<Tabs>
+<TabItem value="direct" label="Direct tags Field">
 
 ```bash
 curl -X POST 'http://0.0.0.0:4000/chat/completions' \
@@ -75,11 +85,84 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="metadata" label="Metadata Nested">
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/chat/completions' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-4",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "metadata": {
+      "tags": ["team-stripe", "production", "us-east-1"]
+    }
+  }'
+```
+
+</TabItem>
+</Tabs>
+
 The `tags` field must be an array of strings.
 
 :::info
 When tags are provided via header or request body, they override any tags configured in the model deployment.
 :::
+
+## Set Tags on Keys or Teams
+
+You can also set default tags at the API key or team level:
+
+<Tabs>
+<TabItem value="key" label="Set on Key">
+
+```bash
+curl -L -X POST 'http://0.0.0.0:4000/key/generate' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "metadata": {
+      "tags": ["customer-stripe", "tier-premium"]
+    }
+  }'
+```
+
+</TabItem>
+<TabItem value="team" label="Set on Team">
+
+```bash
+curl -L -X POST 'http://0.0.0.0:4000/team/new' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "metadata": {
+      "tags": ["team-engineering", "department-ai"]
+    }
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Advanced: Custom Header Tracking
+
+Track spend using any custom header by adding it to your config:
+
+```yaml
+litellm_settings:
+  extra_spend_tag_headers:
+    - "x-custom-header"
+    - "x-customer-id"
+```
+
+**Disable User-Agent tracking:**
+
+```yaml
+litellm_settings:
+  disable_add_user_agent_to_request_tags: true
+```
 
 ## Spend Logs
 
@@ -96,5 +179,6 @@ The tag from the model config appears in `LiteLLM_SpendLogs`:
 
 ## Related
 
-- [Spend Tracking Overview](cost_tracking.md)
+- [Spend Tracking Overview](cost_tracking.md) - Complete tutorial on tracking spend with tags
 - [Tag Budgets](tag_budgets.md) - Set budget limits per tag
+- [Virtual Keys Setup](virtual_keys.md) - Required for tag tracking

--- a/docs/my-website/docs/proxy/request_tags.md
+++ b/docs/my-website/docs/proxy/request_tags.md
@@ -50,7 +50,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 
 ### Option 2: Use `x-litellm-tags` Header
 
-Pass tags dynamically via the `x-litellm-tags` header:
+Pass tags dynamically via the `x-litellm-tags` header as a comma-separated string:
 
 ```bash
 curl -X POST 'http://0.0.0.0:4000/chat/completions' \
@@ -63,9 +63,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
   }'
 ```
 
-The header accepts:
-- **Comma-separated string**: `"tag1,tag2,tag3"` (spaces are trimmed)
-- **Array of strings**: `["tag1", "tag2", "tag3"]`
+Format: Comma-separated string (spaces are automatically trimmed): `"tag1,tag2,tag3"`
 
 ### Option 3: Use Request Body `tags`
 

--- a/docs/my-website/docs/proxy/request_tags.md
+++ b/docs/my-website/docs/proxy/request_tags.md
@@ -56,7 +56,7 @@ Pass tags dynamically via the `x-litellm-tags` header:
 curl -X POST 'http://0.0.0.0:4000/chat/completions' \
   -H 'Authorization: Bearer sk-1234' \
   -H 'Content-Type: application/json' \
-  -H 'x-litellm-tags: team-stripe,production,us-east-1' \
+  -H 'x-litellm-tags: team-api,production,us-east-1' \
   -d '{
     "model": "gpt-4",
     "messages": [{"role": "user", "content": "Hello"}]
@@ -81,7 +81,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
   -d '{
     "model": "gpt-4",
     "messages": [{"role": "user", "content": "Hello"}],
-    "tags": ["team-stripe", "production", "us-east-1"]
+    "tags": ["team-api", "production", "us-east-1"]
   }'
 ```
 
@@ -97,7 +97,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
     "model": "gpt-4",
     "messages": [{"role": "user", "content": "Hello"}],
     "metadata": {
-      "tags": ["team-stripe", "production", "us-east-1"]
+      "tags": ["team-api", "production", "us-east-1"]
     }
   }'
 ```
@@ -124,7 +124,7 @@ curl -L -X POST 'http://0.0.0.0:4000/key/generate' \
   -H 'Content-Type: application/json' \
   -d '{
     "metadata": {
-      "tags": ["customer-stripe", "tier-premium"]
+      "tags": ["customer-acme", "tier-premium"]
     }
   }'
 ```

--- a/docs/my-website/docs/proxy/request_tags.md
+++ b/docs/my-website/docs/proxy/request_tags.md
@@ -27,7 +27,9 @@ model_list:
 
 ## Make Request
 
-Requests just specify the model - tags are automatically applied:
+### Option 1: Use Config Tags (Automatic)
+
+Requests just specify the model - tags are automatically applied from config:
 
 ```bash
 curl -X POST 'http://0.0.0.0:4000/chat/completions' \
@@ -38,6 +40,46 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
     "messages": [{"role": "user", "content": "Hello"}]
   }'
 ```
+
+### Option 2: Use `x-litellm-tags` Header
+
+Pass tags dynamically via the `x-litellm-tags` header:
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/chat/completions' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -H 'x-litellm-tags: team-stripe,production,us-east-1' \
+  -d '{
+    "model": "gpt-4",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+The header accepts:
+- **Comma-separated string**: `"tag1,tag2,tag3"` (spaces are trimmed)
+- **Array of strings**: `["tag1", "tag2", "tag3"]`
+
+### Option 3: Use Request Body `tags`
+
+Pass tags directly in the request body:
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/chat/completions' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-4",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "tags": ["team-stripe", "production", "us-east-1"]
+  }'
+```
+
+The `tags` field must be an array of strings.
+
+:::info
+When tags are provided via header or request body, they override any tags configured in the model deployment.
+:::
 
 ## Spend Logs
 


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation

## Changes

This PR documents the existing `x-litellm-tags` header and the `tags` field in the request body for dynamic tag assignment. This is to officially document features currently in use by partners like Stripe, ensuring they are not removed as "undocumented".

The documentation now covers:
*   How to pass tags via the `x-litellm-tags` header (comma-separated string or array).
*   How to pass tags via the `tags` field in the request body (array of strings).
*   Clarification that dynamic tags (header or body) override tags defined in the model deployment configuration.

---
[Slack Thread](https://berriaillm.slack.com/archives/C09DYGJAVEU/p1772057608478219?thread_ts=1772057608.478219&cid=C09DYGJAVEU)

<p><a href="https://cursor.com/agents/bc-8056e4a9-e398-58a5-ad55-0b68a96bf584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8056e4a9-e398-58a5-ad55-0b68a96bf584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

