### PR TITLE
fix(streaming): prevent Vertex AI / Anthropic content truncation when finish_reason races content

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1082,7 +1082,18 @@ class CustomStreamWrapper:
                 and self.custom_llm_provider in litellm._custom_providers
             ):
                 if self.received_finish_reason is not None:
-                    if "provider_specific_fields" not in chunk:
+                    # Only skip/stop if there is no content in this chunk.
+                    # If the chunk carries text or tool_use data we must yield
+                    # it even though finish_reason was already recorded.
+                    # This prevents truncation when the last content_block_delta
+                    # arrives in the same iteration as (or just after) the
+                    # message_delta that sets finish_reason.
+                    # See: https://github.com/BerriAI/litellm/issues/22098
+                    _chunk_has_content = isinstance(chunk, dict) and (
+                        bool(chunk.get("text", ""))
+                        or chunk.get("tool_use") is not None
+                    )
+                    if not _chunk_has_content and "provider_specific_fields" not in chunk:
                         raise StopIteration
                 anthropic_response_obj: GChunk = cast(GChunk, chunk)
                 completion_obj["content"] = anthropic_response_obj["text"]
@@ -1591,7 +1602,7 @@ class CustomStreamWrapper:
     def _add_mcp_list_tools_to_first_chunk(self, chunk: ModelResponseStream) -> ModelResponseStream:
         """
         Add mcp_list_tools from _hidden_params to the first chunk's delta.provider_specific_fields.
-        
+
         This method checks if MCP metadata with mcp_list_tools is stored in _hidden_params
         and adds it to the first chunk's delta.provider_specific_fields.
         """
@@ -1599,16 +1610,16 @@ class CustomStreamWrapper:
             # Check if MCP metadata should be added to first chunk
             if not hasattr(self, "_hidden_params") or not self._hidden_params:
                 return chunk
-            
+
             mcp_metadata = self._hidden_params.get("mcp_metadata")
             if not mcp_metadata or not isinstance(mcp_metadata, dict):
                 return chunk
-            
+
             # Only add mcp_list_tools to first chunk (not tool_calls or tool_results)
             mcp_list_tools = mcp_metadata.get("mcp_list_tools")
             if not mcp_list_tools:
                 return chunk
-            
+
             # Add mcp_list_tools to delta.provider_specific_fields
             if hasattr(chunk, "choices") and chunk.choices:
                 for choice in chunk.choices:
@@ -1617,25 +1628,25 @@ class CustomStreamWrapper:
                         provider_fields = (
                             getattr(choice.delta, "provider_specific_fields", None) or {}
                         )
-                        
+
                         # Add only mcp_list_tools to first chunk
                         provider_fields["mcp_list_tools"] = mcp_list_tools
-                        
+
                         # Set the provider_specific_fields
                         setattr(choice.delta, "provider_specific_fields", provider_fields)
-        
+
         except Exception as e:
             from litellm._logging import verbose_logger
             verbose_logger.exception(
                 f"Error adding MCP list tools to first chunk: {str(e)}"
             )
-        
+
         return chunk
 
     def _add_mcp_metadata_to_final_chunk(self, chunk: ModelResponseStream) -> ModelResponseStream:
         """
         Add MCP metadata from _hidden_params to the final chunk's delta.provider_specific_fields.
-        
+
         This method checks if MCP metadata is stored in _hidden_params and adds it to
         the chunk's delta.provider_specific_fields, similar to how RAG adds search results.
         """
@@ -1643,11 +1654,11 @@ class CustomStreamWrapper:
             # Check if MCP metadata should be added to final chunk
             if not hasattr(self, "_hidden_params") or not self._hidden_params:
                 return chunk
-            
+
             mcp_metadata = self._hidden_params.get("mcp_metadata")
             if not mcp_metadata:
                 return chunk
-            
+
             # Add MCP metadata to delta.provider_specific_fields
             if hasattr(chunk, "choices") and chunk.choices:
                 for choice in chunk.choices:
@@ -1656,20 +1667,20 @@ class CustomStreamWrapper:
                         provider_fields = (
                             getattr(choice.delta, "provider_specific_fields", None) or {}
                         )
-                        
+
                         # Add MCP metadata
                         if isinstance(mcp_metadata, dict):
                             provider_fields.update(mcp_metadata)
-                        
+
                         # Set the provider_specific_fields
                         setattr(choice.delta, "provider_specific_fields", provider_fields)
-        
+
         except Exception as e:
             from litellm._logging import verbose_logger
             verbose_logger.exception(
                 f"Error adding MCP metadata to final chunk: {str(e)}"
             )
-        
+
         return chunk
 
     def cache_streaming_response(self, processed_chunk, cache_hit: bool):
@@ -1788,12 +1799,12 @@ class CustomStreamWrapper:
                     )
                     # HANDLE STREAM OPTIONS
                     self.chunks.append(response)
-                    
+
                     # Add mcp_list_tools to first chunk if present
                     if not self.sent_first_chunk:
                         response = self._add_mcp_list_tools_to_first_chunk(response)
                         self.sent_first_chunk = True
-                    
+
                     if hasattr(
                         response, "usage"
                     ):  # remove usage from chunk, only send on final chunk


### PR DESCRIPTION
## Relevant Issues
Fixes #22098
---

## Pre-Submission Checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory 2 new tests in [tests/test_litellm/litellm_core_utils/test_streaming_handler.py](cci:7://file:///Users/gaurav/Documents/litellm/tests/test_litellm/litellm_core_utils/test_streaming_handler.py:0:0-0:0)
- [x] My PR passes all unit tests on `make test-unit` 28/28 streaming handler tests pass
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory — 3 new tests in [tests/test_litellm/litellm_core_utils/test_streaming_handler.py](cci:7://file:///Users/gaurav/Documents/litellm/tests/test_litellm/litellm_core_utils/test_streaming_handler.py:0:0-0:0)
- [x] My PR passes all unit tests on `make test-unit` — 29/29 streaming handler tests pass
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review
---
## Type
🐛 Bug Fix
---

### What was broken

When streaming Claude models via Vertex AI, the **last piece of content is intermittently dropped** and never yielded to the caller. The bug manifests intermittently because it only surfaces when Vertex AI happens to deliver the [finish_reason](cci:1://file:///Users/gaurav/Documents/litellm/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py:1723:4-1738:25) in a way that causes `received_finish_reason` to already be set by the time the final content chunk arrives in [chunk_creator()](cci:1://file:///Users/gaurav/Documents/litellm/litellm/litellm_core_utils/streaming_handler.py:1064:4-1542:13).

At that point, the existing code unconditionally raised `StopIteration` silently discarding any remaining content and even when the incoming chunk still carried text.

### What was fixed

`CustomStreamWrapper.chunk_creator()` in [litellm/litellm_core_utils/streaming_handler.py](cci:7://file:///Users/gaurav/Documents/litellm/litellm/litellm_core_utils/streaming_handler.py:0:0-0:0) now checks whether the incoming chunk has content before deciding to stop iteration. `StopIteration` is only raised when the chunk has neither text nor tool output. Content-bearing chunks are always yielded, regardless of whether `received_finish_reason` has already been set.

Empty flush chunks continue to correctly terminate the stream existing behaviour is fully preserved.

### Files changed

| File | Description |
|------|-------------|
| [litellm/litellm_core_utils/streaming_handler.py](cci:7://file:///Users/gaurav/Documents/litellm/litellm/litellm_core_utils/streaming_handler.py:0:0-0:0) | Core fix in [chunk_creator()](cci:1://file:///Users/gaurav/Documents/litellm/litellm/litellm_core_utils/streaming_handler.py:1064:4-1542:13) |
| [tests/test_litellm/litellm_core_utils/test_streaming_handler.py](cci:7://file:///Users/gaurav/Documents/litellm/tests/test_litellm/litellm_core_utils/test_streaming_handler.py:0:0-0:0) | 2 regression tests |

### Tests added

| Test | What it verifies |
|------|-----------------|
| [test_content_not_dropped_when_finish_reason_already_set](cci:1://file:///Users/gaurav/Documents/litellm/tests/test_litellm/litellm_core_utils/test_streaming_handler.py:1229:0-1269:5) | Simulates the race condition: `received_finish_reason` is pre-set, a content chunk arrives - the content is returned and not dropped |
| [test_empty_chunk_still_stops_after_finish_reason_set](cci:1://file:///Users/gaurav/Documents/litellm/tests/test_litellm/litellm_core_utils/test_streaming_handler.py:1272:0-1292:74) | Asserts that empty chunks still correctly raise `StopIteration` after [finish_reason](cci:1://file:///Users/gaurav/Documents/litellm/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py:1723:4-1738:25) is set (existing behaviour preserved) |
| [test_tool_use_not_dropped_when_finish_reason_already_set](cci:1://file:///Users/gaurav/Documents/litellm/tests/test_litellm/litellm_core_utils/test_streaming_handler.py:1295:0-1328:5) | Asserts that a chunk carrying only [tool_use](cci:1://file:///Users/gaurav/Documents/litellm/tests/test_litellm/litellm_core_utils/test_streaming_handler.py:1295:0-1328:5) data (no text) is still yielded when `received_finish_reason` is set and covers the [tool_use](cci:1://file:///Users/gaurav/Documents/litellm/tests/test_litellm/litellm_core_utils/test_streaming_handler.py:1295:0-1328:5) branch of the content guard (added per Greptile review) |