### PR TITLE
feat: add Zaps.ai as a recognized provider

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -526,6 +526,13 @@ def _get_openai_compatible_provider_info(  # noqa: PLR0915
         ) = litellm.PerplexityChatConfig()._get_openai_compatible_provider_info(
             api_base, api_key
         )
+    elif custom_llm_provider == "zaps":
+        api_base = (
+            api_base
+            or get_secret("ZAPS_API_BASE")
+            or "https://api.zaps.ai/v1"
+        )
+        dynamic_api_key = api_key or get_secret_str("ZAPS_API_KEY")
     elif custom_llm_provider == "aiohttp_openai":
         return model, "aiohttp_openai", api_key, api_base
     elif custom_llm_provider == "anyscale":


### PR DESCRIPTION
## Summary

Adds `zaps` as a recognized provider in LiteLLM's OpenAI-compatible provider routing.

[Zaps.ai](https://zaps.ai) is a **privacy gateway** that automatically redacts PII from AI requests before forwarding them to upstream providers (OpenAI, Anthropic, etc.) and rehydrates PII in responses.

## Changes

**Modified:** `litellm/litellm_core_utils/get_llm_provider_logic.py`

Added `zaps` handler in `_get_openai_compatible_provider_info()`:

```python
elif custom_llm_provider == "zaps":
    api_base = (
        api_base
        or get_secret("ZAPS_API_BASE")
        or "https://api.zaps.ai/v1"
    )
    dynamic_api_key = api_key or get_secret_str("ZAPS_API_KEY")
```

## Configuration

| Env Variable | Description | Default |
|---|---|---|
| `ZAPS_API_KEY` | API key for Zaps.ai | (required) |
| `ZAPS_API_BASE` | Base URL | `https://api.zaps.ai/v1` |

## Usage

```python
import litellm
response = litellm.completion(
    model='zaps/gpt-4o',
    messages=[{'role': 'user', 'content': 'Hello!'}]
)
```

The `ZAPS` enum value is already auto-generated from `LlmProviders` — this PR just adds the routing logic.