### PR TITLE
feat(realtime): guardrails support for /v1/realtime WebSocket endpoint

### DIFF
--- a/docs/my-website/docs/realtime.md
+++ b/docs/my-website/docs/realtime.md
@@ -110,7 +110,88 @@ ws.on("error", function handleError(error) {
 });
 ```
 
-## Logging 
+## Guardrails
+
+You can apply [LiteLLM guardrails](https://docs.litellm.ai/docs/proxy/guardrails/quick_start) to realtime sessions.
+
+### Set guardrails on a key or team
+
+The easiest production setup — attach guardrails to a virtual key or team so they always apply automatically, without any client-side changes.
+
+See [Virtual Keys → Guardrails](https://docs.litellm.ai/docs/proxy/virtual_keys#guardrails) and [Teams → Guardrails](https://docs.litellm.ai/docs/proxy/team_budgets).
+
+### Pass guardrails dynamically (easy testing)
+
+Pass `guardrails` as a query param when opening the WebSocket.
+Useful for testing guardrails without modifying key/team config.
+
+```js
+// node test.js
+const WebSocket = require("ws");
+
+const guardrails = ["your-guardrail-name"]; // comma-separated list
+const url = `ws://0.0.0.0:4000/v1/realtime?model=openai-gpt-4o-realtime-audio&guardrails=${guardrails.join(",")}`;
+
+const ws = new WebSocket(url, {
+    headers: {
+        "Authorization": "Bearer sk-1234",
+    },
+});
+
+ws.on("open", function open() {
+    console.log("Connected — guardrails active:", guardrails);
+});
+
+ws.on("message", function incoming(message) {
+    const data = JSON.parse(message);
+    if (data.type === "error") {
+        // Guardrail block is sent as an error event before the connection closes
+        console.error("Guardrail error:", data.error.message);
+    }
+});
+
+ws.on("close", function close(code, reason) {
+    console.log("Closed:", code, reason.toString());
+    // code 1011 = blocked by guardrail at pre_call
+});
+```
+
+Or with Python:
+
+```python
+import asyncio
+import websockets
+
+async def main():
+    url = "ws://0.0.0.0:4000/v1/realtime?model=openai-gpt-4o-realtime-audio&guardrails=your-guardrail-name"
+    async with websockets.connect(
+        url,
+        additional_headers={"Authorization": "Bearer sk-1234"},
+    ) as ws:
+        print("Connected — guardrail active")
+        async for msg in ws:
+            import json
+            data = json.loads(msg)
+            if data["type"] == "error":
+                print("Guardrail blocked:", data["error"]["message"])
+                break
+
+asyncio.run(main())
+```
+
+When a guardrail blocks the request, the proxy sends an `error` event over the WebSocket and then closes the connection:
+
+```json
+{
+    "type": "error",
+    "error": {
+        "type": "guardrail_error",
+        "message": "Guardrail blocked this request: <reason>"
+    }
+}
+```
+
+## Logging
 
 To prevent requests from being dropped, by default LiteLLM just logs these event types:
 

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/ChatUI.tsx
@@ -1832,6 +1832,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                 accessToken={apiKeySource === "session" ? accessToken || "" : apiKey}
                 selectedModel={selectedModel || ""}
                 customProxyBaseUrl={customProxyBaseUrl || undefined}
+                selectedGuardrails={selectedGuardrails.length > 0 ? selectedGuardrails : undefined}
               />
             ) : (
             <>

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/RealtimePlayground.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/RealtimePlayground.tsx
@@ -24,12 +24,14 @@ interface RealtimePlaygroundProps {
   accessToken: string;
   selectedModel: string;
   customProxyBaseUrl?: string;
+  selectedGuardrails?: string[];
 }
 
 const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
   accessToken,
   selectedModel,
   customProxyBaseUrl,
+  selectedGuardrails,
 }) => {
   const [messages, setMessages] = useState<RealtimeMessage[]>([]);
   const [inputText, setInputText] = useState("");
@@ -107,7 +109,10 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
 
       const baseUrl = customProxyBaseUrl || getProxyBaseUrl();
       const wsBase = baseUrl.replace(/^http/, "ws");
-      const url = `${wsBase}/v1/realtime?model=${encodeURIComponent(selectedModel)}`;
+      let url = `${wsBase}/v1/realtime?model=${encodeURIComponent(selectedModel)}`;
+      if (selectedGuardrails && selectedGuardrails.length > 0) {
+        url += `&guardrails=${encodeURIComponent(selectedGuardrails.join(","))}`;
+      }
 
       const ws = new WebSocket(url, ["realtime", `openai-insecure-api-key.${accessToken}`]);
 
@@ -197,7 +202,7 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
       addMessage("status", `Connection failed: ${err.message}`);
       setIsConnecting(false);
     }
-  }, [accessToken, selectedModel, selectedVoice, customProxyBaseUrl, addMessage, appendAssistantText, playAudioChunk]);
+  }, [accessToken, selectedModel, selectedVoice, customProxyBaseUrl, selectedGuardrails, addMessage, appendAssistantText, playAudioChunk]);
 
   const disconnect = useCallback(() => {
     stopRecording();


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

Adds guardrail support to the `/v1/realtime` WebSocket endpoint so guardrails apply to realtime sessions, not just chat completions.

**Backend (`proxy_server.py`)**
- Added `guardrails` query param (comma-separated list) to `realtime_websocket_endpoint`
- Added `import websockets` / `import websockets.exceptions` at module level (was missing, caused a `NameError` in the existing `except websockets.exceptions.InvalidStatusCode` clause which silently swallowed errors)
- Split the single try/except into two phases:
  - Phase 1 (pre-call): if a guardrail blocks the request, sends `{"type": "error", "error": {"type": "guardrail_error", "message": "..."}}` back to the client before closing with code 1011
  - Phase 2 (upstream routing): upstream errors close with 1011 without a misleading guardrail label

**UI (`RealtimePlayground.tsx`, `ChatUI.tsx`)**
- `selectedGuardrails` from the playground sidebar now flows through to the WebSocket URL as `?guardrails=name1,name2`
- Previously the prop was never passed down to `RealtimePlayground`

**Docs (`docs/my-website/docs/realtime.md`)**
- Added `## Guardrails` section showing how to pass guardrails dynamically via query param (JS + Python examples) and links to key/team-level guardrail setup

**E2E tested locally:**
- Without guardrails: connects normally, close_code=None
- With `?guardrails=block-emails`: receives the error event then closes with code 1011