### PR TITLE
feat(vertex_ai): Vertex AI Gemini Live via unified /realtime endpoint

### DIFF
--- a/docs/my-website/docs/providers/vertex_realtime.md
+++ b/docs/my-website/docs/providers/vertex_realtime.md
@@ -1,0 +1,203 @@
+# Vertex AI Gemini Live - Realtime API
+
+Use Vertex AI's Gemini Live API (BidiGenerateContent) through LiteLLM's unified `/realtime` endpoint, which speaks the OpenAI Realtime protocol.
+
+| Feature | Supported |
+|---------|-----------|
+| Proxy (`/realtime`) | ✅ |
+| Voice in / Voice out | ✅ |
+| Text in / Text out | ✅ |
+| Server VAD | ✅ |
+| Output transcription | ✅ |
+
+## Setup
+
+### 1. Auth
+
+LiteLLM uses your Google Cloud credentials (OAuth2 Bearer token), not an API key.
+
+```bash
+gcloud auth application-default login
+```
+
+Or set a service-account key file:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa-key.json
+```
+
+### 2. Proxy config
+
+```yaml
+model_list:
+  - model_name: vertex-gemini-live
+    litellm_params:
+      model: vertex_ai/gemini-2.0-flash-live-001
+      vertex_project: your-gcp-project-id
+      vertex_location: us-east4   # or any supported region, or "global"
+
+general_settings:
+  master_key: sk-your-key
+```
+
+### 3. Start the proxy
+
+```bash
+litellm --config config.yaml --port 4000
+```
+
+## Usage
+
+### Python (websockets)
+
+```python
+import asyncio
+import json
+import websockets
+
+PROXY_URL = "ws://localhost:4000/realtime?model=vertex-gemini-live"
+API_KEY = "sk-your-key"
+
+async def main():
+    async with websockets.connect(
+        PROXY_URL,
+        additional_headers={"api-key": API_KEY},
+    ) as ws:
+        # Wait for session.created
+        event = json.loads(await ws.recv())
+        print(f"session.created: {event['session']['id']}")
+
+        # Send a text message
+        await ws.send(json.dumps({
+            "type": "conversation.item.create",
+            "item": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Say hello in one sentence."}],
+            },
+        }))
+
+        # Collect the response
+        async for raw in ws:
+            ev = json.loads(raw)
+            t = ev.get("type", "")
+            if t == "response.text.delta":
+                print(ev.get("delta", ""), end="", flush=True)
+            elif t == "response.done":
+                print("\n[done]")
+                break
+
+asyncio.run(main())
+```
+
+### Node.js
+
+```js
+const WebSocket = require("ws");
+
+const ws = new WebSocket(
+  "ws://localhost:4000/realtime?model=vertex-gemini-live",
+  { headers: { "api-key": "sk-your-key" } }
+);
+
+ws.on("open", () => {
+  ws.send(JSON.stringify({
+    type: "conversation.item.create",
+    item: {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "Say hello." }],
+    },
+  }));
+});
+
+ws.on("message", (data) => {
+  const ev = JSON.parse(data);
+  if (ev.type === "response.text.delta") process.stdout.write(ev.delta);
+  if (ev.type === "response.done") ws.close();
+});
+```
+
+### OpenAI SDK (Python)
+
+```python
+import asyncio
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI(
+    base_url="http://localhost:4000",
+    api_key="sk-your-key",
+)
+
+async def main():
+    async with client.beta.realtime.connect(
+        model="vertex-gemini-live"
+    ) as conn:
+        await conn.session.update(session={"modalities": ["text"]})
+
+        await conn.conversation.item.create(
+            item={
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Say hello."}],
+            }
+        )
+
+        async for event in conn:
+            if event.type == "response.text.delta":
+                print(event.delta, end="", flush=True)
+            elif event.type == "response.done":
+                print()
+                break
+
+asyncio.run(main())
+```
+
+## Voice in / Voice out
+
+For a complete voice example see [`voice_realtime_test.py`](https://github.com/BerriAI/litellm/blob/main/voice_realtime_test.py).
+
+Key settings for audio:
+- Microphone input: **16 kHz** PCM16 (`audio/pcm;rate=16000`)
+- Speaker output: **24 kHz** PCM16 (Vertex AI returns audio at 24 kHz)
+- Server VAD is enabled by default with 800 ms silence threshold
+
+```python
+# session.update with server VAD — the proxy ignores this for Vertex AI
+# because VAD is already configured in the initial setup message.
+await ws.send(json.dumps({
+    "type": "session.update",
+    "session": {
+        "modalities": ["audio"],
+        "turn_detection": {"type": "server_vad", "silence_duration_ms": 800},
+    },
+}))
+```
+
+## Supported OpenAI Realtime Events
+
+**Client → Proxy (→ Vertex AI)**
+
+| OpenAI event | Notes |
+|---|---|
+| `input_audio_buffer.append` | Forwarded as `realtime_input.audio` |
+| `conversation.item.create` | Forwarded as `realtime_input.text` |
+| `session.update` | Silently ignored — Vertex AI does not support mid-session reconfiguration |
+| `response.create` | Silently ignored — Vertex AI responds automatically after each turn |
+
+**Vertex AI → Proxy (→ Client)**
+
+| OpenAI event emitted | Vertex AI source |
+|---|---|
+| `session.created` | Synthesized after `setupComplete` |
+| `response.text.delta` | `serverContent.modelTurn.parts[].text` |
+| `response.audio.delta` | `serverContent.modelTurn.parts[].inlineData` |
+| `response.audio_transcript.delta` | `serverContent.outputTranscription.text` |
+| `conversation.item.input_audio_transcription.completed` | `serverContent.inputTranscription.text` |
+| `response.done` | `serverContent.turnComplete` |
+
+## Limitations
+
+- `session.update` is not forwarded (Vertex AI only accepts one setup message per connection).
+- Tool calling / function calling is not yet supported.
+- Audio transcription requires `outputAudioTranscription: {}` to be set in the initial setup (done automatically by LiteLLM).

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -758,6 +758,7 @@ const sidebars = {
             "providers/vertex_batch",
             "providers/vertex_ocr",
             "providers/vertex_ai_agent_engine",
+            "providers/vertex_realtime",
           ]
         },
         {

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -295,9 +295,9 @@ class RealTimeStreaming:
                     safe_msg = str(e) or "I'm sorry, that request was blocked by the content filter."
                 # Cancel any in-flight response before speaking the warning.
                 # This handles the race where create_response fired before we could intercept.
-                await self.backend_ws.send(json.dumps({"type": "response.cancel"}))
-                # Ask OpenAI to speak the warning — TTS audio plays naturally in the client
-                await self.backend_ws.send(
+                await self._send_to_backend(json.dumps({"type": "response.cancel"}))
+                # Ask the model to speak the warning — TTS audio plays naturally in the client
+                await self._send_to_backend(
                     json.dumps(
                         {
                             "type": "response.create",

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -312,9 +312,13 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         if _system_instruction is not None and isinstance(_system_instruction, str):
             session["instructions"] = _system_instruction
         if _model is not None and isinstance(_model, str):
-            session["model"] = _model.strip(
-                "models/"
-            )  # keep it consistent with how openai returns the model name
+            # Strip "models/" prefix if present to match OpenAI model name format.
+            # Use removeprefix (not strip) — strip removes individual chars, not a substring.
+            session["model"] = (
+                _model[len("models/"):]
+                if _model.startswith("models/")
+                else _model
+            )
 
         return OpenAIRealtimeStreamSessionEvents(
             type="session.created",

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -263,8 +263,9 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                 return []
             realtime_input_dict["text"] = text
         else:
-            # Pass through any other message types as raw text
-            realtime_input_dict["text"] = message
+            # Unknown/unsupported OpenAI event type — drop silently rather than
+            # forwarding raw JSON as text input to the model.
+            return []
 
         if len(realtime_input_dict) != 1:
             raise ValueError(

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -769,9 +769,14 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
             )
             returned_message = [transformed_content_done_event]
 
+            # Use IDs from the done event — transform_content_done_event may have
+            # generated UUID fallbacks when the originals were None.
+            resolved_item_id = transformed_content_done_event.get("item_id") or current_output_item_id
+            resolved_response_id = transformed_content_done_event.get("response_id") or current_response_id
+
             additional_items = self.return_additional_content_done_events(
-                current_output_item_id=current_output_item_id,
-                current_response_id=current_response_id,
+                current_output_item_id=resolved_item_id,
+                current_response_id=resolved_response_id,
                 delta_done_event=transformed_content_done_event,
                 delta_type=delta_type,
             )

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -522,10 +522,10 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         - return response.content_part.done
         - return response.output_item.done
         """
-        if current_output_item_id is None or current_response_id is None:
-            raise ValueError(
-                "current_output_item_id and current_response_id cannot be None for a 'done' event."
-            )
+        if current_output_item_id is None:
+            current_output_item_id = "item_{}".format(uuid.uuid4())
+        if current_response_id is None:
+            current_response_id = "resp_{}".format(uuid.uuid4())
         returned_items: List[OpenAIRealtimeEvents] = []
 
         delta_done_event_text = cast(Optional[str], delta_done_event.get("text"))

--- a/litellm/llms/vertex_ai/realtime/transformation.py
+++ b/litellm/llms/vertex_ai/realtime/transformation.py
@@ -15,9 +15,6 @@ import json
 from typing import List, Optional
 
 from litellm.llms.gemini.realtime.transformation import GeminiRealtimeConfig
-from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
-
-vertex_llm_base = VertexBase()
 
 
 class VertexAIRealtimeConfig(GeminiRealtimeConfig):

--- a/litellm/llms/vertex_ai/realtime/transformation.py
+++ b/litellm/llms/vertex_ai/realtime/transformation.py
@@ -1,0 +1,162 @@
+"""
+Vertex AI Realtime (BidiGenerateContent) config.
+
+Extends GeminiRealtimeConfig but adapts the WSS URL and auth header for the
+Vertex AI endpoint instead of Google AI Studio.
+
+URL pattern:
+  wss://{location}-aiplatform.googleapis.com/ws/
+      google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent
+
+Auth: OAuth2 Bearer token (not an API key).
+"""
+
+import json
+from typing import List, Optional
+
+from litellm.llms.gemini.realtime.transformation import GeminiRealtimeConfig
+from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
+
+vertex_llm_base = VertexBase()
+
+
+class VertexAIRealtimeConfig(GeminiRealtimeConfig):
+    """
+    Realtime config for Vertex AI (BidiGenerateContent).
+
+    ``access_token`` and ``project`` must be pre-resolved by the caller
+    (they require async I/O) and injected at construction time.
+    """
+
+    def __init__(self, access_token: str, project: str, location: str) -> None:
+        self._access_token = access_token
+        self._project = project
+        self._location = location
+
+    # ------------------------------------------------------------------
+    # URL
+    # ------------------------------------------------------------------
+
+    def get_complete_url(
+        self, api_base: Optional[str], model: str, api_key: Optional[str] = None  # noqa: ARG002
+    ) -> str:
+        """
+        Build the Vertex AI Live WSS endpoint URL.
+
+        If *api_base* is provided it overrides the default aiplatform host,
+        allowing enterprise / VPC-SC deployments to point at a custom gateway.
+        """
+        if api_base:
+            # Allow callers to supply a fully-qualified wss:// base URL.
+            base = api_base.rstrip("/")
+            base = base.replace("https://", "wss://").replace("http://", "ws://")
+            return f"{base}/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent"
+
+        location = self._location
+        if location == "global":
+            host = "aiplatform.googleapis.com"
+        else:
+            host = f"{location}-aiplatform.googleapis.com"
+
+        return f"wss://{host}/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent"
+
+    # ------------------------------------------------------------------
+    # Auth headers
+    # ------------------------------------------------------------------
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,  # noqa: ARG002
+        api_key: Optional[str] = None,  # noqa: ARG002
+    ) -> dict:
+        """
+        Return headers with a Bearer token for Vertex AI.
+
+        ``api_key`` is intentionally ignored — Vertex AI uses OAuth2 tokens,
+        not API keys.  The token was resolved at config-construction time.
+        """
+        headers = dict(headers)
+        headers["Authorization"] = f"Bearer {self._access_token}"
+        if self._project:
+            headers["x-goog-user-project"] = self._project
+        return headers
+
+    # ------------------------------------------------------------------
+    # Audio MIME type — Vertex AI needs the sample rate in the MIME string
+    # ------------------------------------------------------------------
+
+    def get_audio_mime_type(self, input_audio_format: str = "pcm16") -> str:
+        mime_types = {
+            "pcm16": "audio/pcm;rate=16000",
+            "g711_ulaw": "audio/pcmu",
+            "g711_alaw": "audio/pcma",
+        }
+        return mime_types.get(input_audio_format, "application/octet-stream")
+
+    # ------------------------------------------------------------------
+    # Session setup message
+    # ------------------------------------------------------------------
+
+    def session_configuration_request(self, model: str) -> str:
+        """
+        Return the JSON setup message for Vertex AI Live.
+
+        Vertex AI requires the fully-qualified model path:
+        ``projects/{project}/locations/{location}/publishers/google/models/{model}``
+
+        Also enables automatic activity detection (server VAD) and output
+        audio transcription so the proxy forwards transcript events.
+        """
+        from litellm.types.llms.gemini import BidiGenerateContentSetup
+        from litellm.types.llms.vertex_ai import GeminiResponseModalities
+
+        response_modalities: list[GeminiResponseModalities] = ["AUDIO"]
+        full_model_path = (
+            f"projects/{self._project}"
+            f"/locations/{self._location}"
+            f"/publishers/google/models/{model}"
+        )
+        setup_config: BidiGenerateContentSetup = {
+            "model": full_model_path,
+            "generationConfig": {"responseModalities": response_modalities},
+            # Enable server-side VAD with sensible defaults for voice sessions.
+            "realtimeInputConfig": {
+                "automaticActivityDetection": {
+                    "disabled": False,
+                    "silenceDurationMs": 800,
+                }
+            },
+            # Return output transcript so clients can read what the model said.
+            "outputAudioTranscription": {},
+        }
+        return json.dumps({"setup": setup_config})
+
+    # ------------------------------------------------------------------
+    # Request translation
+    # ------------------------------------------------------------------
+
+    def transform_realtime_request(
+        self,
+        message: str,
+        model: str,
+        session_configuration_request: Optional[str] = None,
+    ) -> List[str]:
+        """
+        Translate OpenAI realtime client messages to Vertex AI format.
+
+        ``session.update`` is intentionally ignored (returns []) because
+        Vertex AI only accepts a single ``setup`` message at the start of
+        the connection — sending a second one causes a 1007 close error.
+        The initial setup (sent automatically before bidirectional_forward)
+        already includes AUDIO modality and server VAD, so there is nothing
+        more to configure.
+        """
+        json_message = json.loads(message)
+        if json_message.get("type") == "session.update":
+            # Do not forward as a second setup — Vertex AI rejects it.
+            return []
+
+        return super().transform_realtime_request(
+            message, model, session_configuration_request
+        )

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1066,7 +1066,8 @@
         "fine_tuning": true,
         "rag_ingest": true,
         "rag_query": true,
-        "generateContent": true
+        "generateContent": true,
+        "realtime": true
       }
     },
     "gemini": {

--- a/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
@@ -1,0 +1,224 @@
+"""
+Unit tests for VertexAIRealtimeConfig.
+
+Validates:
+- URL construction (regional and global)
+- Auth headers (Bearer token + project header)
+- Session setup message format
+- Full text-in / text-out round-trip via RealTimeStreaming with a mocked
+  WebSocket pair (no real network calls)
+"""
+
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import websockets.exceptions  # registers websockets.exceptions on the websockets namespace
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.vertex_ai.realtime.transformation import VertexAIRealtimeConfig
+
+# ---------------------------------------------------------------------------
+# Config unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_complete_url_regional():
+    cfg = VertexAIRealtimeConfig(
+        access_token="tok", project="my-proj", location="us-central1"
+    )
+    url = cfg.get_complete_url(api_base=None, model="gemini-2.0-flash-live-001")
+    assert url == (
+        "wss://us-central1-aiplatform.googleapis.com"
+        "/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent"
+    )
+
+
+def test_get_complete_url_global():
+    cfg = VertexAIRealtimeConfig(
+        access_token="tok", project="my-proj", location="global"
+    )
+    url = cfg.get_complete_url(api_base=None, model="gemini-2.0-flash-live-001")
+    assert url == (
+        "wss://aiplatform.googleapis.com"
+        "/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent"
+    )
+
+
+def test_get_complete_url_custom_api_base():
+    cfg = VertexAIRealtimeConfig(
+        access_token="tok", project="my-proj", location="us-central1"
+    )
+    url = cfg.get_complete_url(
+        api_base="https://custom-gateway.example.com",
+        model="gemini-2.0-flash-live-001",
+    )
+    assert url.startswith("wss://custom-gateway.example.com")
+    assert "BidiGenerateContent" in url
+
+
+def test_validate_environment_sets_bearer_and_project():
+    cfg = VertexAIRealtimeConfig(
+        access_token="mytoken", project="proj-123", location="us-central1"
+    )
+    headers = cfg.validate_environment(
+        headers={}, model="gemini-2.0-flash-live-001", api_key=None
+    )
+    assert headers["Authorization"] == "Bearer mytoken"
+    assert headers["x-goog-user-project"] == "proj-123"
+
+
+def test_session_configuration_request_model_format():
+    cfg = VertexAIRealtimeConfig(
+        access_token="tok", project="my-proj", location="us-central1"
+    )
+    raw = cfg.session_configuration_request("gemini-2.0-flash-live-001")
+    parsed = json.loads(raw)
+    assert parsed["setup"]["model"] == (
+        "projects/my-proj/locations/us-central1/publishers/google/models/gemini-2.0-flash-live-001"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip test: text-in / text-out via RealTimeStreaming
+# ---------------------------------------------------------------------------
+
+# Minimal Gemini BidiGenerateContent message sequence:
+#   server → setupComplete
+#   client → conversation.item.create  (OpenAI format, translated by config)
+#   server → serverContent with modelTurn text delta
+#   server → serverContent with generationComplete
+
+SETUP_COMPLETE = json.dumps({"setupComplete": {}})
+
+SERVER_TEXT_DELTA = json.dumps(
+    {
+        "serverContent": {
+            "modelTurn": {
+                "parts": [{"text": "Hello from Vertex AI!"}]
+            }
+        }
+    }
+)
+
+# generationComplete fires RESPONSE_TEXT_DONE; turnComplete fires RESPONSE_DONE
+# They must be separate messages (the transformer processes one top-level key per message).
+SERVER_GENERATION_COMPLETE = json.dumps(
+    {"serverContent": {"generationComplete": True}}
+)
+
+SERVER_TURN_COMPLETE = json.dumps(
+    {"serverContent": {"turnComplete": True}}
+)
+
+# OpenAI-format text message the client sends
+CLIENT_TEXT_MESSAGE = json.dumps(
+    {
+        "type": "conversation.item.create",
+        "item": {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "Say hello"}],
+        },
+    }
+)
+
+
+@pytest.mark.asyncio
+async def test_vertex_realtime_text_in_text_out():
+    """
+    Simulate a full text-in / text-out session through RealTimeStreaming using
+    VertexAIRealtimeConfig for message translation.  All I/O is mocked.
+    """
+    from litellm.litellm_core_utils.realtime_streaming import RealTimeStreaming
+
+    cfg = VertexAIRealtimeConfig(
+        access_token="fake-token",
+        project="fake-project",
+        location="us-central1",
+    )
+
+    # --- mock client WebSocket (FastAPI side) ---
+    client_ws = MagicMock()
+    client_ws.exceptions = MagicMock()
+    client_ws.exceptions.ConnectionClosed = Exception
+
+    sent_to_client: list[str] = []
+
+    async def _client_send_text(data: str):
+        sent_to_client.append(data)
+
+    client_ws.send_text = AsyncMock(side_effect=_client_send_text)
+
+    # Client sends one text message then raises to end the loop
+    client_ws.receive_text = AsyncMock(
+        side_effect=[CLIENT_TEXT_MESSAGE, Exception("client done")]
+    )
+
+    # --- mock backend WebSocket (Vertex AI side) ---
+    backend_ws = MagicMock()
+
+    upstream_messages = [
+        SETUP_COMPLETE,
+        SERVER_TEXT_DELTA,
+        SERVER_GENERATION_COMPLETE,
+        SERVER_TURN_COMPLETE,
+    ]
+
+    async def _backend_recv(decode=True):  # noqa: ARG001
+        if not upstream_messages:
+            # Signal normal connection close so the loop exits cleanly
+            raise websockets.exceptions.ConnectionClosedOK(None, None)  # type: ignore[arg-type]
+        return upstream_messages.pop(0)
+
+    backend_ws.recv = AsyncMock(side_effect=_backend_recv)
+
+    sent_to_backend: list[str] = []
+
+    async def _backend_send(data: str):
+        sent_to_backend.append(data)
+
+    backend_ws.send = AsyncMock(side_effect=_backend_send)
+
+    logging_obj = MagicMock()
+    logging_obj.litellm_trace_id = "test-trace-id"
+    logging_obj.pre_call = MagicMock()
+    logging_obj.async_success_handler = AsyncMock()
+    logging_obj.success_handler = MagicMock()
+
+    streaming = RealTimeStreaming(
+        websocket=client_ws,
+        backend_ws=backend_ws,
+        logging_obj=logging_obj,
+        provider_config=cfg,
+        model="gemini-2.0-flash-live-001",
+    )
+
+    # Run backend→client forwarding for the three queued messages, then stop.
+    # We don't run client_ack_messages here to avoid the blocking receive loop.
+    await streaming.backend_to_client_send_messages()
+
+    # --- Assertions ---
+
+    # session.created should have been forwarded to client
+    session_created_msgs = [
+        m for m in sent_to_client if '"session.created"' in m
+    ]
+    assert session_created_msgs, "Expected session.created to be sent to client"
+
+    # At least one text delta should have been forwarded
+    text_delta_msgs = [
+        m for m in sent_to_client if '"response.text.delta"' in m
+    ]
+    assert text_delta_msgs, "Expected response.text.delta to be sent to client"
+
+    # Verify the delta contains the model's text
+    delta_obj = json.loads(text_delta_msgs[0])
+    assert "Hello from Vertex AI!" in delta_obj.get("delta", "")
+
+    # response.done should have been forwarded
+    done_msgs = [m for m in sent_to_client if '"response.done"' in m]
+    assert done_msgs, "Expected response.done to be sent to client"


### PR DESCRIPTION
## Relevant issues

Closes: N/A

## What this does

Adds Vertex AI Gemini Live (`gemini-2.0-flash-live-001`) support through LiteLLM's unified `/realtime` WebSocket endpoint. Clients use the standard OpenAI Realtime protocol — the proxy handles translation to/from Vertex AI's BidiGenerateContent format.

Tested end-to-end: text in/text out + voice in/voice out (mic → 16 kHz PCM16 → Vertex AI → 24 kHz PCM16 → speaker).

## Changes

**New: `litellm/llms/vertex_ai/realtime/transformation.py`** — `VertexAIRealtimeConfig`
- Builds correct `wss://{location}-aiplatform.googleapis.com/.../BidiGenerateContent` URL
- OAuth2 Bearer token auth (not API key)
- Full model path: `projects/{project}/locations/{location}/publishers/google/models/{model}`
- Ignores `session.update` — Vertex AI only accepts one `setup` message per connection; sending a second causes a 1007 disconnect
- Audio MIME type includes sample rate: `audio/pcm;rate=16000`

**`realtime_api/main.py`** — adds `vertex_ai` branch that resolves the OAuth token via `VertexBase._ensure_access_token_async` and constructs `VertexAIRealtimeConfig`

**`llm_http_handler.py`** — auto-sends the provider's session setup message before `bidirectional_forward()` when `requires_session_configuration()` returns True (needed for Gemini/Vertex AI Live)

**`gemini/realtime/transformation.py`** — fixes two crashes:
- `transform_response_done_event` raised `ValueError` when `turnComplete` arrived before any audio (IDs were None); now generates UUIDs instead
- Same fix in `transform_content_done_event`
- Silently drop `response.create` (Vertex AI responds automatically)
- Handle `conversation.item.create` to extract actual user text

**`realtime_streaming.py`** — try/except guard in backend loop so a single malformed message doesn't kill the whole session; also fix pre-existing Pyright type annotation errors on `_collect_tool_calls_from_response_done` / `_collect_user_input_from_backend_event`

**`proxy_server.py`** — add missing `import websockets.exceptions` (caused `NameError` on every WebSocket close)

**`provider_endpoints_support.json`** — mark `vertex_ai` with `"realtime": true`

**`docs/my-website/docs/providers/vertex_realtime.md`** — usage docs with Python, Node.js, and OpenAI SDK examples

## Pre-Submission checklist

- [x] Added tests (`tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py`) — 6 unit tests covering URL construction, auth headers, session config format, and full text-in/text-out round trip with mocked WebSockets
- [x] `make test-unit` passes

## Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Refactoring
- [ ] Documentation

## Changes

- `litellm/llms/vertex_ai/realtime/transformation.py`
- `litellm/llms/vertex_ai/realtime/__init__.py`
- `litellm/realtime_api/main.py`
- `litellm/llms/custom_httpx/llm_http_handler.py`
- `litellm/llms/gemini/realtime/transformation.py`
- `litellm/litellm_core_utils/realtime_streaming.py`
- `litellm/proxy/proxy_server.py`
- `provider_endpoints_support.json`
- `docs/my-website/docs/providers/vertex_realtime.md`