### PR TITLE
fix (model-map): gemini litellm_provider for gemini/gemini-2.5-flash-image

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16257,7 +16257,7 @@
         "cache_read_input_token_cost": 3e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
-        "litellm_provider": "vertex_ai-language-models",
+        "litellm_provider": "gemini",
         "max_audio_length_hours": 8.4,
         "max_audio_per_prompt": 1,
         "supports_reasoning": false,


### PR DESCRIPTION
The gemini/gemini-2.5-flash-image model is incorrectlymarked with the  litellm_provider set to vertex_ai-language-models.

This leads to a noisy error log on every request: "This model isn't mapped yet. model=gemini/gemini-2.5-flash-image, custom_llm_provider=gemini". The requests succeed regardless of this error, but this is not pretty.

A previous entry gemini/gemini-2.5-flash-image-preview correctly used the gemini provider, and so do 78 of 79 other gemini/ models. The vertex_ai/gemini-2.5-flash-image has its own separate entry.

Pre-Submission checklist

[N/A] I have Added testing in the [tests/litellm/](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, Adding at least 1 test is a hard requirement - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
[N/A] My PR passes all unit tests on [make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)
[N/A] My PR's scope is as isolated as possible, it only solves 1 specific problem
[N/A] I have requested a Greptile review by commenting @greptileai and received a Confidence Score of at least 4/5 before requesting a maintainer review
Type

🧹 Bug Fix