### PR TITLE
fix(realtime): guardrails with pre_call/post_call mode now work on realtime WebSocket

### DIFF
--- a/litellm/llms/azure/realtime/handler.py
+++ b/litellm/llms/azure/realtime/handler.py
@@ -6,13 +6,13 @@ This requires websockets, and is currently only supported on LiteLLM Proxy.
 
 from typing import Any, Optional, cast
 
+from litellm._logging import verbose_proxy_logger
 from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
 
 from ....litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from ....litellm_core_utils.realtime_streaming import RealTimeStreaming
 from ....llms.custom_httpx.http_handler import get_shared_realtime_ssl_context
 from ..azure import AzureChatCompletion
-from litellm._logging import verbose_proxy_logger
 
 # BACKEND_WS_URL = "ws://localhost:8080/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01"
 
@@ -77,6 +77,8 @@ class AzureOpenAIRealtime(AzureChatCompletion):
         client: Optional[Any] = None,
         timeout: Optional[float] = None,
         realtime_protocol: Optional[str] = None,
+        user_api_key_dict: Optional[Any] = None,
+        litellm_metadata: Optional[dict] = None,
     ):
         import websockets
         from websockets.asyncio.client import ClientConnection
@@ -101,7 +103,11 @@ class AzureOpenAIRealtime(AzureChatCompletion):
                 ssl=ssl_context,
             ) as backend_ws:
                 realtime_streaming = RealTimeStreaming(
-                    websocket, cast(ClientConnection, backend_ws), logging_obj
+                    websocket,
+                    cast(ClientConnection, backend_ws),
+                    logging_obj,
+                    user_api_key_dict=user_api_key_dict,
+                    request_data={"litellm_metadata": litellm_metadata or {}},
                 )
                 await realtime_streaming.bidirectional_forward()
 

--- a/litellm/llms/openai/realtime/handler.py
+++ b/litellm/llms/openai/realtime/handler.py
@@ -99,6 +99,7 @@ class OpenAIRealtime(OpenAIChatCompletion):
         timeout: Optional[float] = None,
         query_params: Optional[RealtimeQueryParams] = None,
         user_api_key_dict: Optional[Any] = None,
+        litellm_metadata: Optional[dict] = None,
         **kwargs: Any,
     ):
         import websockets
@@ -142,6 +143,7 @@ class OpenAIRealtime(OpenAIChatCompletion):
                     cast(ClientConnection, backend_ws),
                     logging_obj,
                     user_api_key_dict=user_api_key_dict,
+                    request_data={"litellm_metadata": litellm_metadata or {}},
                 )
                 await realtime_streaming.bidirectional_forward()
 

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -150,6 +150,11 @@ async def _arealtime(
             or get_secret_str("OPENAI_API_KEY")
         )
 
+        # Build metadata for guardrail checking.
+        _litellm_metadata: dict = {**(kwargs.get("litellm_metadata") or {})}
+        _guardrails = (kwargs.get("metadata") or {}).get("guardrails") or kwargs.get("guardrails") or []
+        if _guardrails:
+            _litellm_metadata["guardrails"] = _guardrails
         await openai_realtime.async_realtime(
             model=model,
             websocket=websocket,
@@ -160,6 +165,7 @@ async def _arealtime(
             timeout=timeout,
             query_params=query_params,
             user_api_key_dict=kwargs.get("user_api_key_dict"),
+            litellm_metadata=_litellm_metadata,
         )
     elif _custom_llm_provider == "bedrock":
         # Extract AWS parameters from kwargs

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -416,32 +416,32 @@ async def test_realtime_guardrail_blocks_prompt_injection():
     streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj)
     await streaming.backend_to_client_send_messages()
 
-    # ASSERT 1: no bare response.create was sent to backend (injection blocked).
-    # The only response.create allowed is the warning one (has "instructions" field).
+    # ASSERT 1: no response.create was sent to backend (injection blocked).
     sent_to_backend = [
         json.loads(c.args[0])
         for c in backend_ws.send.call_args_list
         if c.args
     ]
-    bare_response_creates = [
+    response_creates = [
         e for e in sent_to_backend
         if e.get("type") == "response.create"
-        and "instructions" not in e.get("response", {})
     ]
-    assert len(bare_response_creates) == 0, (
-        f"Guardrail should prevent bare response.create for injected content, "
-        f"but got: {bare_response_creates}"
+    assert len(response_creates) == 0, (
+        f"Guardrail should prevent response.create for injected content, "
+        f"but got: {response_creates}"
     )
 
-    # ASSERT 2: warning response.create was sent to backend (to speak the block message)
-    warning_creates = [
-        e for e in sent_to_backend
-        if e.get("type") == "response.create"
-        and "instructions" in e.get("response", {})
+    # ASSERT 2: error event was sent directly to the client WebSocket
+    sent_to_client = [
+        json.loads(c.args[0]) for c in client_ws.send_text.call_args_list
+        if c.args
     ]
-    assert len(warning_creates) > 0, (
-        f"Backend should receive a response.create with warning instructions, "
-        f"but got: {sent_to_backend}"
+    error_events = [e for e in sent_to_client if e.get("type") == "error"]
+    assert len(error_events) == 1, (
+        f"Expected one error event sent to client, got: {sent_to_client}"
+    )
+    assert error_events[0]["error"]["type"] == "guardrail_violation", (
+        f"Expected guardrail_violation error type, got: {error_events[0]}"
     )
 
     litellm.callbacks = []  # cleanup
@@ -514,11 +514,91 @@ async def test_realtime_guardrail_allows_clean_transcript():
 
 
 @pytest.mark.asyncio
-async def test_realtime_session_created_injects_create_response_false():
+async def test_realtime_text_input_guardrail_blocks_and_returns_error():
     """
-    Test that when session.created arrives from the backend and realtime guardrails
-    are registered, the proxy injects a session.update with create_response=False
-    so the LLM never auto-responds before the guardrail runs.
+    Test that when conversation.item.create arrives with text that triggers a guardrail,
+    the proxy blocks it (doesn't forward to backend) and returns an error event directly
+    to the client WebSocket.
+    """
+    from fastapi import HTTPException
+
+    import litellm
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.types.guardrails import GuardrailEventHooks
+
+    class BlockingGuardrail(CustomGuardrail):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
+            texts = inputs.get("texts", [])
+            for text in texts:
+                if "@" in text:
+                    raise HTTPException(
+                        status_code=403,
+                        detail={"error": "email address detected"},
+                    )
+            return inputs
+
+    guardrail = BlockingGuardrail(
+        guardrail_name="email-blocker",
+        event_hook=GuardrailEventHooks.pre_call,
+        default_on=True,
+    )
+    litellm.callbacks = [guardrail]
+
+    client_ws = MagicMock()
+    client_ws.send_text = AsyncMock()
+
+    backend_ws = MagicMock()
+    backend_ws.send = AsyncMock()
+    backend_ws.recv = AsyncMock(side_effect=ConnectionClosed(None, None))
+
+    logging_obj = MagicMock()
+    logging_obj.pre_call = MagicMock()
+
+    streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj)
+
+    item_create_msg = json.dumps({
+        "type": "conversation.item.create",
+        "item": {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "My email is test@example.com"}],
+        },
+    })
+
+    # Simulate the client sending a conversation.item.create with an email
+    client_ws.receive_text = AsyncMock(
+        side_effect=[
+            item_create_msg,
+            Exception("connection closed"),  # stop the loop
+        ]
+    )
+
+    await streaming.client_ack_messages()
+
+    # ASSERT: error event was sent to client
+    assert client_ws.send_text.called, "Expected error to be sent to client websocket"
+    sent_texts = [json.loads(c.args[0]) for c in client_ws.send_text.call_args_list]
+    error_events = [e for e in sent_texts if e.get("type") == "error"]
+    assert len(error_events) == 1, f"Expected one error event, got: {sent_texts}"
+    assert error_events[0]["error"]["type"] == "guardrail_violation"
+
+    # ASSERT: blocked item was NOT forwarded to the backend
+    sent_to_backend = [c.args[0] for c in backend_ws.send.call_args_list if c.args]
+    forwarded_items = [
+        json.loads(m) for m in sent_to_backend
+        if isinstance(m, str) and json.loads(m).get("type") == "conversation.item.create"
+    ]
+    assert len(forwarded_items) == 0, (
+        f"Blocked item should not be forwarded to backend, got: {forwarded_items}"
+    )
+
+    litellm.callbacks = []  # cleanup
+
+
+@pytest.mark.asyncio
+async def test_realtime_text_input_guardrail_uses_pre_call_mode():
+    """
+    Test that _has_realtime_guardrails returns True for a guardrail configured with
+    pre_call mode (not just realtime_input_transcription).
     """
     import litellm
     from litellm.integrations.custom_guardrail import CustomGuardrail
@@ -529,43 +609,19 @@ async def test_realtime_session_created_injects_create_response_false():
             return inputs
 
     guardrail = DummyGuardrail(
-        guardrail_name="dummy",
-        event_hook=GuardrailEventHooks.realtime_input_transcription,
+        guardrail_name="pre-call-guardrail",
+        event_hook=GuardrailEventHooks.pre_call,
         default_on=True,
     )
     litellm.callbacks = [guardrail]
 
     client_ws = MagicMock()
-    client_ws.send_text = AsyncMock()
-
-    session_created_event = json.dumps({"type": "session.created"}).encode()
-
     backend_ws = MagicMock()
-    backend_ws.recv = AsyncMock(
-        side_effect=[
-            session_created_event,
-            ConnectionClosed(None, None),
-        ]
-    )
-    backend_ws.send = AsyncMock()
-
     logging_obj = MagicMock()
-    logging_obj.async_success_handler = AsyncMock()
-    logging_obj.success_handler = MagicMock()
     streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj)
-    await streaming.backend_to_client_send_messages()
 
-    # ASSERT: proxy injected session.update with create_response=False to backend
-    sent_to_backend = [
-        json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args
-    ]
-    session_updates = [e for e in sent_to_backend if e.get("type") == "session.update"]
-    assert len(session_updates) == 1, (
-        f"Expected proxy to inject session.update, got: {sent_to_backend}"
-    )
-    td = session_updates[0]["session"]["turn_detection"]
-    assert td["create_response"] is False, (
-        f"Expected create_response=False, got: {td}"
+    assert streaming._has_realtime_guardrails() is True, (
+        "pre_call guardrail should be recognized as a realtime guardrail"
     )
 
     litellm.callbacks = []  # cleanup


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Guardrails configured with `mode: pre_call` or `mode: post_call` were silently ignored on the `/v1/realtime` WebSocket endpoint. Only guardrails with `mode: realtime_input_transcription` worked. This meant the standard content filter setup (e.g. email blocker with `mode: pre_call, default_on: true`) had no effect on realtime sessions.

**What changed:**

- `_has_realtime_guardrails()` and `run_realtime_guardrails()` now check `pre_call`, `post_call`, and `realtime_input_transcription` — so any guardrail mode works
- When a guardrail blocks text in `conversation.item.create`, the proxy now returns an `{"type": "error", "error": {"type": "guardrail_violation", ...}}` event directly to the WebSocket consumer, instead of asking the LLM to speak the error message via `response.create`
- The blocked item is not forwarded to the backend; the client's subsequent `response.create` is swallowed
- `RealTimeStreaming` takes an optional `request_data` param (passed from the OpenAI handler as `{"litellm_metadata": ...}`) so guardrail metadata (e.g. explicit guardrail lists) flows through correctly

**Tests added (`tests/test_litellm/litellm_core_utils/test_realtime_streaming.py`):**

- `test_realtime_text_input_guardrail_blocks_and_returns_error` — verifies that a `pre_call` guardrail blocks `conversation.item.create` text, sends an error event to the client, and does not forward the item to the backend
- `test_realtime_text_input_guardrail_uses_pre_call_mode` — verifies `_has_realtime_guardrails()` returns True for a `pre_call` guardrail
- Updated `test_realtime_guardrail_blocks_prompt_injection` to match the new direct-error behavior (was checking that the LLM was asked to speak the error)