### PR TITLE
[Feat] Make UI login session duration configurable via LITELLM_UI_SESSION_DURATION

### DIFF
--- a/docs/my-website/docs/proxy/cli_sso.md
+++ b/docs/my-website/docs/proxy/cli_sso.md
@@ -52,6 +52,10 @@ LITELLM_CLI_JWT_EXPIRATION_HOURS=48 EXPERIMENTAL_UI_LOGIN="True" litellm --confi
 - `LITELLM_CLI_JWT_EXPIRATION_HOURS=168` - Tokens expire after 7 days (168 hours)
 - `LITELLM_CLI_JWT_EXPIRATION_HOURS=720` - Tokens expire after 30 days (720 hours)
 
+:::note[Experimental UI Session]
+When `EXPERIMENTAL_UI_LOGIN` is enabled, the **browser UI login** session uses a fixed 10-minute expiry (not configurable). `LITELLM_UI_SESSION_DURATION` applies only to non-experimental flows.
+:::
+
 :::tip
 You can check your current token's age and expiration status using:
 ```bash

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -775,6 +775,7 @@ router_settings:
 | LITELLM_HOSTED_UI | URL of the hosted UI for LiteLLM
 | LITELLM_UI_API_DOC_BASE_URL | Optional override for the API Reference base URL (used in sample code/docs) when the admin UI runs on a different host than the proxy. Defaults to `PROXY_BASE_URL` when unset.
 | LITELLM_UI_PATH | Path to directory for Admin UI files. Used when running with read-only filesystem (e.g., Kubernetes). Default is `/var/lib/litellm/ui` in Docker.
+| LITELLM_UI_SESSION_DURATION | Duration for UI login session (username/password, SSO). Format: "30s", "30m", "24h", "7d". Applies to both default and EXPERIMENTAL_UI_LOGIN flows. Default is "24h"
 | LITELM_ENVIRONMENT | Environment of LiteLLM Instance, used by logging services. Currently only used by DeepEval.
 | LITELLM_KEY_ROTATION_ENABLED | Enable auto-key rotation for LiteLLM (boolean). Default is false.
 | LITELLM_KEY_ROTATION_CHECK_INTERVAL_SECONDS | Interval in seconds for how often to run job that auto-rotates keys. Default is 86400 (24 hours).

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -775,7 +775,7 @@ router_settings:
 | LITELLM_HOSTED_UI | URL of the hosted UI for LiteLLM
 | LITELLM_UI_API_DOC_BASE_URL | Optional override for the API Reference base URL (used in sample code/docs) when the admin UI runs on a different host than the proxy. Defaults to `PROXY_BASE_URL` when unset.
 | LITELLM_UI_PATH | Path to directory for Admin UI files. Used when running with read-only filesystem (e.g., Kubernetes). Default is `/var/lib/litellm/ui` in Docker.
-| LITELLM_UI_SESSION_DURATION | Duration for UI login session (username/password, SSO). Format: "30s", "30m", "24h", "7d". Applies to both default and EXPERIMENTAL_UI_LOGIN flows. Default is "24h"
+| LITELLM_UI_SESSION_DURATION | Duration for UI login session (username/password, SSO, invitation links). Format: "30s", "30m", "24h", "7d". Does not apply to EXPERIMENTAL_UI_LOGIN flow, which uses a fixed 10-minute expiry for security. Default is "24h"
 | LITELM_ENVIRONMENT | Environment of LiteLLM Instance, used by logging services. Currently only used by DeepEval.
 | LITELLM_KEY_ROTATION_ENABLED | Enable auto-key rotation for LiteLLM (boolean). Default is false.
 | LITELLM_KEY_ROTATION_CHECK_INTERVAL_SECONDS | Interval in seconds for how often to run job that auto-rotates keys. Default is 86400 (24 hours).

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -16,7 +16,8 @@ import os
 # Load .env before any other litellm imports so env vars (e.g. LITELLM_UI_SESSION_DURATION) are available
 import dotenv as _dotenv
 
-_dotenv.load_dotenv()
+if os.getenv("LITELLM_MODE", "DEV") == "DEV":
+    _dotenv.load_dotenv()
 
 from typing import (
     Callable,

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -12,6 +12,12 @@ warnings.filterwarnings(
 ### INIT VARIABLES #########################
 import threading
 import os
+
+# Load .env before any other litellm imports so env vars (e.g. LITELLM_UI_SESSION_DURATION) are available
+import dotenv as _dotenv
+
+_dotenv.load_dotenv()
+
 from typing import (
     Callable,
     List,
@@ -74,12 +80,9 @@ from litellm.constants import (
     DEFAULT_ALLOWED_FAILS,
 )
 import httpx
-import dotenv
 # register_async_client_cleanup is lazy-loaded and called on first access
 
 litellm_mode = os.getenv("LITELLM_MODE", "DEV")  # "PRODUCTION", "DEV"
-if litellm_mode == "DEV":
-    dotenv.load_dotenv()
 
 
 ####################################################

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1315,8 +1315,8 @@ CLI_JWT_EXPIRATION_HOURS = int(
 )
 
 ########################### UI SESSION DURATION ###########################
-# Duration for UI login session (username/password, SSO). Format: "30s", "30m", "24h", "7d"
-# Applies to default login flows (not EXPERIMENTAL_UI_LOGIN which uses its own 10-minute expiry)
+# Duration for UI login session (username/password, SSO, invitation links). Format: "30s", "30m", "24h", "7d"
+# Does NOT apply to EXPERIMENTAL_UI_LOGIN flow, which intentionally uses a fixed 10-minute expiry for security.
 LITELLM_UI_SESSION_DURATION = os.getenv("LITELLM_UI_SESSION_DURATION", "24h")
 
 ########################### DB CRON JOB NAMES ###########################

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1316,7 +1316,7 @@ CLI_JWT_EXPIRATION_HOURS = int(
 
 ########################### UI SESSION DURATION ###########################
 # Duration for UI login session (username/password, SSO). Format: "30s", "30m", "24h", "7d"
-# Applies to both default and EXPERIMENTAL_UI_LOGIN flows
+# Applies to default login flows (not EXPERIMENTAL_UI_LOGIN which uses its own 10-minute expiry)
 LITELLM_UI_SESSION_DURATION = os.getenv("LITELLM_UI_SESSION_DURATION", "24h")
 
 ########################### DB CRON JOB NAMES ###########################

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1314,6 +1314,11 @@ CLI_JWT_EXPIRATION_HOURS = int(
     or 24
 )
 
+########################### UI SESSION DURATION ###########################
+# Duration for UI login session (username/password, SSO). Format: "30s", "30m", "24h", "7d"
+# Applies to both default and EXPERIMENTAL_UI_LOGIN flows
+LITELLM_UI_SESSION_DURATION = os.getenv("LITELLM_UI_SESSION_DURATION", "24h")
+
 ########################### DB CRON JOB NAMES ###########################
 DB_SPEND_UPDATE_JOB_NAME = "db_spend_update_job"
 PROMETHEUS_EMIT_BUDGET_METRICS_JOB_NAME = "prometheus_emit_budget_metrics"

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -23,14 +23,12 @@ from litellm.caching.dual_cache import LimitedSizeOrderedDict
 from litellm.constants import (
     CLI_JWT_EXPIRATION_HOURS,
     CLI_JWT_TOKEN_NAME,
-    LITELLM_UI_SESSION_DURATION,
     DEFAULT_ACCESS_GROUP_CACHE_TTL,
     DEFAULT_IN_MEMORY_TTL,
     DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
     DEFAULT_MAX_RECURSE_DEPTH,
     EMAIL_BUDGET_ALERT_MAX_SPEND_ALERT_PERCENTAGE,
 )
-from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 from litellm.proxy._types import (
     RBAC_ROLES,
@@ -1886,9 +1884,8 @@ class ExperimentalUIJWTToken:
         if user_info.user_role is None:
             raise Exception("User role is required for experimental UI login")
 
-        # Calculate expiration time from LITELLM_UI_SESSION_DURATION (default 24h)
-        session_duration_seconds = duration_in_seconds(LITELLM_UI_SESSION_DURATION)
-        expiration_time = get_utc_datetime() + timedelta(seconds=session_duration_seconds)
+        # Experimental UI flow uses shorter 10-min expiry for security (experimental = shorter-lived tokens)
+        expiration_time = get_utc_datetime() + timedelta(minutes=10)
 
         # Format the expiration time as ISO 8601 string
         expires = expiration_time.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+00:00"

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -23,12 +23,14 @@ from litellm.caching.dual_cache import LimitedSizeOrderedDict
 from litellm.constants import (
     CLI_JWT_EXPIRATION_HOURS,
     CLI_JWT_TOKEN_NAME,
+    LITELLM_UI_SESSION_DURATION,
     DEFAULT_ACCESS_GROUP_CACHE_TTL,
     DEFAULT_IN_MEMORY_TTL,
     DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
     DEFAULT_MAX_RECURSE_DEPTH,
     EMAIL_BUDGET_ALERT_MAX_SPEND_ALERT_PERCENTAGE,
 )
+from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 from litellm.proxy._types import (
     RBAC_ROLES,
@@ -1884,8 +1886,9 @@ class ExperimentalUIJWTToken:
         if user_info.user_role is None:
             raise Exception("User role is required for experimental UI login")
 
-        # Calculate expiration time (10 minutes from now)
-        expiration_time = get_utc_datetime() + timedelta(minutes=10)
+        # Calculate expiration time from LITELLM_UI_SESSION_DURATION (default 24h)
+        session_duration_seconds = duration_in_seconds(LITELLM_UI_SESSION_DURATION)
+        expiration_time = get_utc_datetime() + timedelta(seconds=session_duration_seconds)
 
         # Format the expiration time as ISO 8601 string
         expires = expiration_time.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+00:00"

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1884,7 +1884,7 @@ class ExperimentalUIJWTToken:
         if user_info.user_role is None:
             raise Exception("User role is required for experimental UI login")
 
-        # Experimental UI flow uses shorter 10-min expiry for security (experimental = shorter-lived tokens)
+        # Experimental UI flow uses fixed 10-min expiry for security (does not use LITELLM_UI_SESSION_DURATION)
         expiration_time = get_utc_datetime() + timedelta(minutes=10)
 
         # Format the expiration time as ISO 8601 string

--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -12,7 +12,7 @@ from typing import Literal, Optional, cast
 from fastapi import HTTPException
 
 import litellm
-from litellm.constants import LITELLM_PROXY_ADMIN_NAME
+from litellm.constants import LITELLM_PROXY_ADMIN_NAME, LITELLM_UI_SESSION_DURATION
 from litellm.proxy._types import (
     LiteLLM_UserTable,
     LitellmUserRoles,
@@ -178,7 +178,7 @@ async def authenticate_user(  # noqa: PLR0915
                 request_type="key",
                 **{
                     "user_role": LitellmUserRoles.PROXY_ADMIN,
-                    "duration": "24hr",
+                    "duration": LITELLM_UI_SESSION_DURATION,
                     "key_max_budget": litellm.max_ui_session_budget,
                     "models": [],
                     "aliases": {},
@@ -264,7 +264,7 @@ async def authenticate_user(  # noqa: PLR0915
                     request_type="key",
                     **{  # type: ignore
                         "user_role": user_role,
-                        "duration": "24hr",
+                        "duration": LITELLM_UI_SESSION_DURATION,
                         "key_max_budget": litellm.max_ui_session_budget,
                         "models": [],
                         "aliases": {},

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -25,6 +25,7 @@ from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
 from litellm.caching import DualCache
 from litellm.constants import (
+    LITELLM_UI_SESSION_DURATION,
     MAX_SPENDLOG_ROWS_TO_QUERY,
     MICROSOFT_USER_DISPLAY_NAME_ATTRIBUTE,
     MICROSOFT_USER_EMAIL_ATTRIBUTE,
@@ -2237,7 +2238,7 @@ class SSOAuthenticationHandler:
         # User might not be already created on first generation of key
         # But if it is, we want their models preferences
         default_ui_key_values: Dict[str, Any] = {
-            "duration": "24hr",
+            "duration": LITELLM_UI_SESSION_DURATION,
             "key_max_budget": litellm.max_ui_session_budget,
             "aliases": {},
             "config": {},

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -50,6 +50,7 @@ from litellm.constants import (
     LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS,
     LITELLM_SETTINGS_SAFE_DB_OVERRIDES,
     LITELLM_UI_ALLOW_HEADERS,
+    LITELLM_UI_SESSION_DURATION,
 )
 from litellm.litellm_core_utils.litellm_logging import (
     _init_custom_logger_compatible_class,
@@ -10767,7 +10768,7 @@ async def onboarding(invite_link: str, request: Request):
         request_type="key",
         **{
             "user_role": user_obj.user_role,
-            "duration": "24hr",
+            "duration": LITELLM_UI_SESSION_DURATION,
             "key_max_budget": litellm.max_ui_session_budget,
             "models": [],
             "aliases": {},

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -136,6 +136,29 @@ def test_get_experimental_ui_login_jwt_auth_token_uses_10_min_expiry(
     assert expires <= now + timedelta(minutes=10, seconds=2)
 
 
+def test_experimental_ui_token_ignores_litellm_ui_session_duration(
+    valid_sso_user_defined_values,
+):
+    """Regression test: LITELLM_UI_SESSION_DURATION must NOT affect Experimental UI token expiry.
+    Experimental UI intentionally uses fixed 10-min expiry. If this test fails, the constant
+    was incorrectly wired to the experimental flow."""
+    # Default LITELLM_UI_SESSION_DURATION is "24h" - token must still expire in ~10 min
+    token = ExperimentalUIJWTToken.get_experimental_ui_login_jwt_auth_token(
+        valid_sso_user_defined_values
+    )
+    decrypted_token = decrypt_value_helper(
+        token, key="ui_hash_key", exception_type="debug"
+    )
+    assert decrypted_token is not None
+    token_data = json.loads(decrypted_token)
+    expires = datetime.fromisoformat(token_data["expires"].replace("Z", "+00:00"))
+    now = get_utc_datetime()
+    # Must be ~10 min, NOT 24h. If LITELLM_UI_SESSION_DURATION were incorrectly used, this would fail.
+    assert expires <= now + timedelta(minutes=11), (
+        "Experimental UI must use 10-min expiry, not LITELLM_UI_SESSION_DURATION"
+    )
+
+
 def test_get_experimental_ui_login_jwt_auth_token_invalid(
     invalid_sso_user_defined_values,
 ):


### PR DESCRIPTION
## Relevant issues
Add support for configuring the LiteLLM UI login session duration (username/password and SSO) via an environment variable instead of a fixed value. Supports formats like "30s", "30m", "24h", "7d" for easier testing and deployment.

Implementation Summary
litellm/constants.py – Added LITELLM_UI_SESSION_DURATION env var (default "24h").
litellm/__init__.py – Call load_dotenv() before any litellm imports so .env is loaded before litellm.constants is imported. Otherwise LITELLM_UI_SESSION_DURATION would stay at its default.
litellm/proxy/auth/login_utils.py – Pass LITELLM_UI_SESSION_DURATION as duration to generate_key_helper_fn for admin and DB user login.
litellm/proxy/auth/auth_checks.py – Use LITELLM_UI_SESSION_DURATION in ExperimentalUIJWTToken.get_experimental_ui_login_jwt_auth_token() for JWT expiry.
litellm/proxy/management_endpoints/ui_sso.py – Use LITELLM_UI_SESSION_DURATION for SSO login flows.
docs/my-website/docs/proxy/config_settings.md – Documented the new env var.
tests/test_litellm/proxy/auth/test_auth_checks.py – Added tests for the configurable duration.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
📖 Documentation
✅ Test
