### PR TITLE
fix: preserve usage/cached_tokens in Responses API streaming bridge

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1086,6 +1086,12 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
 
             finish_reason = "tool_calls" if has_function_calls else "stop"
 
+            usage = None
+            if response_data.get("usage"):
+                from litellm.responses.utils import ResponseAPILoggingUtils
+                usage = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+                    response_data.get("usage")
+                )
             return ModelResponseStream(
                 choices=[
                     StreamingChoices(
@@ -1093,7 +1099,8 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                         delta=Delta(content=""),
                         finish_reason=finish_reason,
                     )
-                ]
+                ],
+                usage=usage
             )
         else:
             pass


### PR DESCRIPTION
## Summary

Fixes #22192

The `response.completed` handler in `OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream()` was discarding the usage object from the event, causing `prompt_tokens_details` (and `cached_tokens`) to always be `None` when streaming with models that use the Responses API bridge (e.g. `gpt-5.2-codex`, `gpt-5.3-codex`).

## Changes

**`litellm/completion_extras/litellm_responses_transformation/transformation.py`**
- Extract `usage` from the `response.completed` event's `response` object
- Translate it via the existing `_transform_response_api_usage_to_chat_usage` helper
- Pass it to the returned `ModelResponseStream`

**`tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py`**
- Added `test_response_completed_preserves_usage_with_cached_tokens` regression test

## Verification

Tested with `gpt-5.2-codex` via OpenAI SDK directly — confirmed OpenAI returns `input_tokens_details.cached_tokens` correctly in both streaming and non-streaming. The issue was purely in litellm's streaming bridge translation.

**Before fix** (`stream=True`):
```
prompt_tokens_details=None
```

**After fix** (`stream=True`):
```
prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=1024, ...)
```

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix
✅ Test
