### PR TITLE
Add Anthropic to OpenAI format transformation for spend logs

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -744,6 +744,45 @@ def _convert_to_json_serializable_dict(
             visited.remove(obj_id)
 
 
+def _transform_anthropic_request_to_openai_format(request_body: dict) -> dict:
+    """
+    Transform Anthropic API request format to OpenAI-compatible format.
+    Anthropic uses a different format for system messages and tool definitions:
+    - System messages: separate 'system' field -> converted to system message in messages array
+    - Tools: Anthropic's input_schema -> OpenAI's function parameters
+    Args:
+        request_body: The request body from Anthropic /messages endpoint
+    Returns:
+        Transformed request body in OpenAI-compatible format
+    """
+    # Transform system message if present
+    request_body = dict(request_body)
+    system_content = request_body.pop("system", None)
+    if system_content:
+        request_body["messages"] = [
+            {"role": "system", "content": system_content}
+        ] + request_body.get("messages", [])
+
+    # Transform tools if present
+    if "tools" in request_body and request_body["tools"]:
+        request_body["tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": t["name"],
+                    "description": t.get("description", ""),
+                    "parameters": t.get(
+                        "input_schema", {}
+                    ),  # Anthropic-specific tools (e.g., computer_20241022) lack input_schema
+                },
+            }
+            for t in request_body.get("tools", [])
+            if "name" in t  # Valid tools should have a name
+        ]
+
+    return request_body
+
+
 def _get_proxy_server_request_for_spend_logs_payload(
     metadata: dict,
     litellm_params: dict,
@@ -786,6 +825,13 @@ def _get_proxy_server_request_for_spend_logs_payload(
                 if should_redact_message_logging(model_call_details=model_call_details):
                     _request_body = _convert_to_json_serializable_dict(_request_body)
                     perform_redaction(model_call_details=_request_body, result=None)
+
+            # Transform Anthropic format to OpenAI format if this is an Anthropic request
+            _request_uri = _proxy_server_request.get("url") or ""
+            if "/v1/messages" in _request_uri:
+                _request_body = _transform_anthropic_request_to_openai_format(
+                    _request_body
+                )
 
             _request_body = _sanitize_request_body_for_spend_logs_payload(_request_body)
             _request_body_json_str = json.dumps(_request_body, default=str)

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -806,6 +806,16 @@ def _get_proxy_server_request_for_spend_logs_payload(
                     _request_body = dict(_request_body)
                     _request_body["tools"] = realtime_tools
 
+            # Transform Anthropic format to OpenAI format if this is an Anthropic request
+            #
+            # Note that we normalize Anthropic requests first so redaction operates on the
+            # same OpenAI-style shape that gets serialized into spend logs.
+            _request_uri = _proxy_server_request.get("url") or ""
+            if "/v1/messages" in _request_uri:
+                _request_body = _transform_anthropic_request_to_openai_format(
+                    _request_body
+                )
+
             # Apply message redaction if turn_off_message_logging is enabled
             if kwargs is not None:
                 from litellm.litellm_core_utils.redact_messages import (
@@ -825,13 +835,6 @@ def _get_proxy_server_request_for_spend_logs_payload(
                 if should_redact_message_logging(model_call_details=model_call_details):
                     _request_body = _convert_to_json_serializable_dict(_request_body)
                     perform_redaction(model_call_details=_request_body, result=None)
-
-            # Transform Anthropic format to OpenAI format if this is an Anthropic request
-            _request_uri = _proxy_server_request.get("url") or ""
-            if "/v1/messages" in _request_uri:
-                _request_body = _transform_anthropic_request_to_openai_format(
-                    _request_body
-                )
 
             _request_body = _sanitize_request_body_for_spend_logs_payload(_request_body)
             _request_body_json_str = json.dumps(_request_body, default=str)

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -1103,7 +1103,85 @@ def test_spend_logs_redacts_request_and_response_when_turn_off_message_logging_e
     # perform_redaction redacts content in-place within the choices structure
     parsed_response = json.loads(response_result)
     assert parsed_response["choices"][0]["message"]["content"] == "redacted-by-litellm"
-    assert parsed_response["choices"][0]["message"]["role"] == "assistant"
+
+
+@patch(
+    "litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs"
+)
+def test_get_proxy_server_request_for_spend_logs_payload_redacts_anthropic_system_message(
+    mock_should_store,
+):
+    mock_should_store.return_value = True
+
+    litellm_params = {
+        "proxy_server_request": {
+            "url": "https://api.anthropic.com/v1/messages",
+            "body": {
+                "system": "secret system prompt",
+                "messages": [{"role": "user", "content": "secret user prompt"}],
+                "model": "claude-3-5-sonnet",
+            },
+        }
+    }
+    kwargs = {
+        "litellm_params": litellm_params,
+        "standard_callback_dynamic_params": {
+            "turn_off_message_logging": True,
+        },
+    }
+
+    request_result = _get_proxy_server_request_for_spend_logs_payload(
+        metadata={}, litellm_params=litellm_params, kwargs=kwargs
+    )
+
+    parsed_request = json.loads(request_result)
+    assert parsed_request["messages"] == [
+        {"role": "user", "content": "redacted-by-litellm"}
+    ]
+    assert "system" not in parsed_request
+    assert "secret system prompt" not in request_result
+    assert parsed_request["model"] == "claude-3-5-sonnet"
+
+
+@patch(
+    "litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs"
+)
+def test_get_proxy_server_request_for_spend_logs_payload_preserves_anthropic_system_message_without_redaction(
+    mock_should_store,
+):
+    mock_should_store.return_value = True
+
+    litellm_params = {
+        "proxy_server_request": {
+            "url": "https://api.anthropic.com/v1/messages",
+            "body": {
+                "system": "visible system prompt",
+                "messages": [{"role": "user", "content": "visible user prompt"}],
+                "model": "claude-3-5-sonnet",
+            },
+        }
+    }
+    kwargs = {
+        "litellm_params": litellm_params,
+        "standard_callback_dynamic_params": {
+            "turn_off_message_logging": False,
+        },
+    }
+
+    request_result = _get_proxy_server_request_for_spend_logs_payload(
+        metadata={}, litellm_params=litellm_params, kwargs=kwargs
+    )
+
+    parsed_request = json.loads(request_result)
+    assert parsed_request["messages"][0] == {
+        "role": "system",
+        "content": "visible system prompt",
+    }
+    assert parsed_request["messages"][1] == {
+        "role": "user",
+        "content": "visible user prompt",
+    }
+    assert "system" not in parsed_request
 
 
 @patch("litellm.secret_managers.main.get_secret_bool")

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -32,6 +32,7 @@ from litellm.proxy.spend_tracking.spend_tracking_utils import (
     _is_master_key,
     _sanitize_request_body_for_spend_logs_payload,
     _should_store_prompts_and_responses_in_spend_logs,
+    _transform_anthropic_request_to_openai_format,
     get_logging_payload,
 )
 from litellm.types.utils import (
@@ -1523,3 +1524,44 @@ class TestIsMasterKey:
         master = "sk-master-key-123"
         hashed = hash_token(master)
         assert _is_master_key(api_key=hashed, _master_key=master) is False
+
+
+def test_transform_anthropic_request_to_openai_format():
+    """Test Anthropic to OpenAI format transformation for system messages and tools."""
+    # Test with both system and tools
+    request_body = {
+        "model": "claude-3-opus-20240229",
+        "system": "You are a helpful assistant.",
+        "messages": [{"role": "user", "content": "What's the weather?"}],
+        "tools": [
+            {
+                "name": "get_weather",
+                "description": "Get weather information",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                },
+            }
+        ],
+    }
+
+    result = _transform_anthropic_request_to_openai_format(request_body)
+
+    # System field should be removed and converted to system message
+    assert "system" not in result
+    assert len(result["messages"]) == 2
+    assert result["messages"][0] == {
+        "role": "system",
+        "content": "You are a helpful assistant.",
+    }
+    assert result["messages"][1] == {"role": "user", "content": "What's the weather?"}
+
+    # Tools should be converted to OpenAI format
+    assert len(result["tools"]) == 1
+    assert result["tools"][0]["type"] == "function"
+    assert result["tools"][0]["function"]["name"] == "get_weather"
+    assert result["tools"][0]["function"]["description"] == "Get weather information"
+    assert result["tools"][0]["function"]["parameters"] == {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+    }


### PR DESCRIPTION
## Relevant issues

Fixes #22195

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

Transform Anthropic API requests to OpenAI-compatible format when logging
to spend logs. This ensures consistent format across different providers.

- Add _transform_anthropic_request_to_openai_format() function
- Convert Anthropic's system field to system message in messages array
- Transform Anthropic's tool input_schema to OpenAI function parameters
- Apply transformation for requests to /messages endpoint

<img width="1574" height="1490" alt="image" src="https://github.com/user-attachments/assets/e3de2bb8-5014-4503-a23d-2ff78685e80a" />

<img width="1596" height="1662" alt="image" src="https://github.com/user-attachments/assets/95ae16d0-0dbe-4f69-8ab1-42ee51a9c6f5" />
