### PR TITLE
fix: preserve interval_hours in model cost map reload config

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4608,7 +4608,7 @@ class ProxyConfig:
                                 }
                             ),
                         },
-                        "update": {"param_value": safe_dumps({"force_reload": False})},
+                        "update": {"param_value": safe_dumps({"interval_hours": interval_hours, "force_reload": False})},
                     },
                 )
 
@@ -4709,7 +4709,7 @@ class ProxyConfig:
                                 }
                             ),
                         },
-                        "update": {"param_value": safe_dumps({"force_reload": False})},
+                        "update": {"param_value": safe_dumps({"interval_hours": interval_hours, "force_reload": False})},
                     },
                 )
 
@@ -12229,7 +12229,14 @@ async def reload_model_cost_map(
         current_time = datetime.utcnow()
         last_model_cost_map_reload = current_time.isoformat()
 
-        # Set force reload flag in database for other pods
+        # Set force reload flag in database for other pods, preserving existing interval_hours
+        existing_config = await prisma_client.db.litellm_config.find_unique(
+            where={"param_name": "model_cost_map_reload_config"}
+        )
+        existing_interval = None
+        if existing_config and existing_config.param_value:
+            existing_interval = existing_config.param_value.get("interval_hours")
+
         await prisma_client.db.litellm_config.upsert(
             where={"param_name": "model_cost_map_reload_config"},
             data={
@@ -12239,7 +12246,7 @@ async def reload_model_cost_map(
                         {"interval_hours": None, "force_reload": True}
                     ),
                 },
-                "update": {"param_value": safe_dumps({"force_reload": True})},
+                "update": {"param_value": safe_dumps({"interval_hours": existing_interval, "force_reload": True})},
             },
         )
 
@@ -12568,7 +12575,14 @@ async def reload_anthropic_beta_headers(
         current_time = datetime.utcnow()
         last_anthropic_beta_headers_reload = current_time.isoformat()
 
-        # Set force reload flag in database for other pods
+        # Set force reload flag in database for other pods, preserving existing interval_hours
+        existing_beta_config = await prisma_client.db.litellm_config.find_unique(
+            where={"param_name": "anthropic_beta_headers_reload_config"}
+        )
+        existing_beta_interval = None
+        if existing_beta_config and existing_beta_config.param_value:
+            existing_beta_interval = existing_beta_config.param_value.get("interval_hours")
+
         await prisma_client.db.litellm_config.upsert(
             where={"param_name": "anthropic_beta_headers_reload_config"},
             data={
@@ -12578,7 +12592,7 @@ async def reload_anthropic_beta_headers(
                         {"interval_hours": None, "force_reload": True}
                     ),
                 },
-                "update": {"param_value": safe_dumps({"force_reload": True})},
+                "update": {"param_value": safe_dumps({"interval_hours": existing_beta_interval, "force_reload": True})},
             },
         )
 


### PR DESCRIPTION
## Summary

Fixes a bug where the scheduled model cost map reload **self-destructs after its first execution**. The `interval_hours` field is silently dropped from the database config, causing the schedule to appear disabled even though it was correctly set up.

## Steps to Reproduce

**1. Start the proxy with a database configured.**

**2. Schedule a periodic model cost map reload via the API:**

```bash
curl -X POST 'http://localhost:4000/schedule/model_cost_map_reload?hours=24' \
  -H 'Authorization: Bearer sk-master-key'
```

**3. Verify the schedule is active:**

```bash
curl 'http://localhost:4000/schedule/model_cost_map_reload/status' \
  -H 'Authorization: Bearer sk-master-key'
```

Expected response:
```json
{"scheduled": true, "interval_hours": 24, ...}
```

**4. Confirm the database has the correct config:**

```sql
SELECT param_name, param_value FROM "LiteLLM_Config"
WHERE param_name = 'model_cost_map_reload_config';
```

Expected: `{"interval_hours": 24, "force_reload": false}`

**5. Wait for the background job to execute** (it checks every 10 seconds via `_check_model_cost_map_reload`). Once the reload triggers and completes:

**6. Check the database again:**

```sql
SELECT param_name, param_value FROM "LiteLLM_Config"
WHERE param_name = 'model_cost_map_reload_config';
```

**Actual result:** `{"force_reload": false}` — the `interval_hours` field is gone.

**7. Check the schedule status again:**

```bash
curl 'http://localhost:4000/schedule/model_cost_map_reload/status' \
  -H 'Authorization: Bearer sk-master-key'
```

**Actual result:**
```json
{"scheduled": false, "interval_hours": null, "last_run": null, "next_run": null}
```

The schedule has been silently destroyed.

## Root Cause

Three locations in `proxy_server.py` perform upsert operations on the `model_cost_map_reload_config` record. In each case, the `update` branch overwrites the entire `param_value` without preserving `interval_hours`:

**Location 1 & 2** — `_check_model_cost_map_reload()` (background job, runs after successful reload):
```python
# After a successful reload, clears force_reload but DROPS interval_hours:
"update": {"param_value": safe_dumps({"force_reload": False})}
# Should be:
"update": {"param_value": safe_dumps({"interval_hours": interval_hours, "force_reload": False})}
```

**Location 3** — `reload_model_cost_map()` (manual reload endpoint):
```python
# Sets force_reload for other pods but DROPS interval_hours:
"update": {"param_value": safe_dumps({"force_reload": True})}
# Should be:
"update": {"param_value": safe_dumps({"interval_hours": existing_interval, "force_reload": True})}
```

Note: the `create` branches in all three locations correctly include both fields — it's only the `update` branches that are broken.

## Fix

- **Locations 1 & 2**: Added `interval_hours` to the `update` branch's `param_value` dict (the variable is already in scope from the config read earlier in the function)
- **Location 3**: Added a read of the existing config before the upsert to preserve the current `interval_hours` value

## Impact

- Scheduled model cost map reloads silently stop working after the first execution
- Manual reloads via the API also destroy any existing schedule
- The Admin UI shows no schedule even though one was configured
- Users must re-create the schedule after every reload, which defeats the purpose of scheduling

## Test plan

- [x] Verified `interval_hours` is preserved in the DB after the background reload job executes
- [x] Verified `interval_hours` is preserved when a manual reload is triggered
- [x] Verified the `create` branches (for new configs) still work correctly
- [x] Verified the status endpoint returns `scheduled: true` after a reload completes
