### PR TITLE
[Feat] Add control for setting upperbound on chunk processing time 

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -49,6 +49,14 @@ DEFAULT_REPLICATE_POLLING_DELAY_SECONDS = int(
 )
 DEFAULT_IMAGE_TOKEN_COUNT = int(os.getenv("DEFAULT_IMAGE_TOKEN_COUNT", 250))
 
+# Maximum wall-clock seconds a streaming response is allowed to run.
+# Streams exceeding this duration are terminated with a Timeout error.
+# None (default) = no limit.  Set env var to a number of seconds to enable globally.
+_max_stream_duration_env = os.getenv("LITELLM_MAX_STREAMING_DURATION_SECONDS", None)
+MAX_STREAMING_CHUNK_DURATION_S = (
+    float(_max_stream_duration_env) if _max_stream_duration_env is not None else None
+)
+
 # Maximum number of base64 characters to keep in logging payloads.
 # Data URIs exceeding this are replaced with a size placeholder.
 # Set to 0 to disable truncation.

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -53,7 +53,7 @@ DEFAULT_IMAGE_TOKEN_COUNT = int(os.getenv("DEFAULT_IMAGE_TOKEN_COUNT", 250))
 # Streams exceeding this duration are terminated with a Timeout error.
 # None (default) = no limit.  Set env var to a number of seconds to enable globally.
 _max_stream_duration_env = os.getenv("LITELLM_MAX_STREAMING_DURATION_SECONDS", None)
-MAX_STREAMING_CHUNK_DURATION_S = (
+MAX_STREAMING_DURATION_S = (
     float(_max_stream_duration_env) if _max_stream_duration_env is not None else None
 )
 

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -53,7 +53,7 @@ DEFAULT_IMAGE_TOKEN_COUNT = int(os.getenv("DEFAULT_IMAGE_TOKEN_COUNT", 250))
 # Streams exceeding this duration are terminated with a Timeout error.
 # None (default) = no limit.  Set env var to a number of seconds to enable globally.
 _max_stream_duration_env = os.getenv("LITELLM_MAX_STREAMING_DURATION_SECONDS", None)
-MAX_STREAMING_DURATION_S = (
+LITELLM_MAX_STREAMING_DURATION_SECONDS = (
     float(_max_stream_duration_env) if _max_stream_duration_env is not None else None
 )
 

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -96,6 +96,7 @@ class CustomStreamWrapper:
         self.completion_stream = completion_stream
         self.sent_first_chunk = False
         self.sent_last_chunk = False
+        self._stream_created_time: float = time.time()
 
         litellm_params: GenericLiteLLMParams = GenericLiteLLMParams(
             **self.logging_obj.model_call_details.get("litellm_params", {})
@@ -160,6 +161,20 @@ class CustomStreamWrapper:
         )  # keep track of the returned chunks - used for calculating the input/output tokens for stream options
         self.is_function_call = self.check_is_function_call(logging_obj=logging_obj)
         self.created: Optional[int] = None
+
+    def _check_max_streaming_duration(self) -> None:
+        """Raise litellm.Timeout if the stream has exceeded MAX_STREAMING_CHUNK_DURATION_S."""
+        from litellm.constants import MAX_STREAMING_CHUNK_DURATION_S
+
+        if MAX_STREAMING_CHUNK_DURATION_S is None:
+            return
+        elapsed = time.time() - self._stream_created_time
+        if elapsed > MAX_STREAMING_CHUNK_DURATION_S:
+            raise litellm.Timeout(
+                message=f"Stream exceeded max streaming duration of {MAX_STREAMING_CHUNK_DURATION_S}s (elapsed {elapsed:.1f}s)",
+                model=self.model or "",
+                llm_provider=self.custom_llm_provider or "",
+            )
 
     def __iter__(self) -> Iterator["ModelResponseStream"]:
         return self
@@ -1743,6 +1758,7 @@ class CustomStreamWrapper:
             and self.custom_llm_provider == "cached_response"
         ):
             cache_hit = True
+        self._check_max_streaming_duration()
         try:
             if self.completion_stream is None:
                 self.fetch_sync_stream()
@@ -1917,6 +1933,7 @@ class CustomStreamWrapper:
             and self.custom_llm_provider == "cached_response"
         ):
             cache_hit = True
+        self._check_max_streaming_duration()
         try:
             if self.completion_stream is None:
                 await self.fetch_stream()

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -163,15 +163,15 @@ class CustomStreamWrapper:
         self.created: Optional[int] = None
 
     def _check_max_streaming_duration(self) -> None:
-        """Raise litellm.Timeout if the stream has exceeded MAX_STREAMING_DURATION_S."""
-        from litellm.constants import MAX_STREAMING_DURATION_S
+        """Raise litellm.Timeout if the stream has exceeded LITELLM_MAX_STREAMING_DURATION_SECONDS."""
+        from litellm.constants import LITELLM_MAX_STREAMING_DURATION_SECONDS
 
-        if MAX_STREAMING_DURATION_S is None:
+        if LITELLM_MAX_STREAMING_DURATION_SECONDS is None:
             return
         elapsed = time.time() - self._stream_created_time
-        if elapsed > MAX_STREAMING_DURATION_S:
+        if elapsed > LITELLM_MAX_STREAMING_DURATION_SECONDS:
             raise litellm.Timeout(
-                message=f"Stream exceeded max streaming duration of {MAX_STREAMING_DURATION_S}s (elapsed {elapsed:.1f}s)",
+                message=f"Stream exceeded max streaming duration of {LITELLM_MAX_STREAMING_DURATION_SECONDS}s (elapsed {elapsed:.1f}s)",
                 model=self.model or "",
                 llm_provider=self.custom_llm_provider or "",
             )

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 import litellm
-from litellm.constants import MAX_STREAMING_DURATION_S, STREAM_SSE_DONE_STRING
+from litellm.constants import LITELLM_MAX_STREAMING_DURATION_SECONDS, STREAM_SSE_DONE_STRING
 from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.litellm_core_utils.core_helpers import process_response_headers
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -85,13 +85,13 @@ class BaseResponsesAPIStreamingIterator:
         )  # GUARANTEE OPENAI HEADERS IN RESPONSE
 
     def _check_max_streaming_duration(self) -> None:
-        """Raise litellm.Timeout if the stream has exceeded MAX_STREAMING_DURATION_S."""
-        if MAX_STREAMING_DURATION_S is None:
+        """Raise litellm.Timeout if the stream has exceeded LITELLM_MAX_STREAMING_DURATION_SECONDS."""
+        if LITELLM_MAX_STREAMING_DURATION_SECONDS is None:
             return
         elapsed = time.time() - self._stream_created_time
-        if elapsed > MAX_STREAMING_DURATION_S:
+        if elapsed > LITELLM_MAX_STREAMING_DURATION_SECONDS:
             raise litellm.Timeout(
-                message=f"Stream exceeded max streaming duration of {MAX_STREAMING_DURATION_S}s (elapsed {elapsed:.1f}s)",
+                message=f"Stream exceeded max streaming duration of {LITELLM_MAX_STREAMING_DURATION_SECONDS}s (elapsed {elapsed:.1f}s)",
                 model=self.model or "",
                 llm_provider=self.custom_llm_provider or "",
             )

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 import litellm
-from litellm.constants import MAX_STREAMING_CHUNK_DURATION_S, STREAM_SSE_DONE_STRING
+from litellm.constants import MAX_STREAMING_DURATION_S, STREAM_SSE_DONE_STRING
 from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.litellm_core_utils.core_helpers import process_response_headers
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -85,13 +85,13 @@ class BaseResponsesAPIStreamingIterator:
         )  # GUARANTEE OPENAI HEADERS IN RESPONSE
 
     def _check_max_streaming_duration(self) -> None:
-        """Raise litellm.Timeout if the stream has exceeded MAX_STREAMING_CHUNK_DURATION_S."""
-        if MAX_STREAMING_CHUNK_DURATION_S is None:
+        """Raise litellm.Timeout if the stream has exceeded MAX_STREAMING_DURATION_S."""
+        if MAX_STREAMING_DURATION_S is None:
             return
         elapsed = time.time() - self._stream_created_time
-        if elapsed > MAX_STREAMING_CHUNK_DURATION_S:
+        if elapsed > MAX_STREAMING_DURATION_S:
             raise litellm.Timeout(
-                message=f"Stream exceeded max streaming duration of {MAX_STREAMING_CHUNK_DURATION_S}s (elapsed {elapsed:.1f}s)",
+                message=f"Stream exceeded max streaming duration of {MAX_STREAMING_DURATION_S}s (elapsed {elapsed:.1f}s)",
                 model=self.model or "",
                 llm_provider=self.custom_llm_provider or "",
             )
@@ -476,6 +476,7 @@ class SyncResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
 
     def __next__(self):
         try:
+            self._check_max_streaming_duration()
             while True:
                 # Get the next chunk from the stream
                 try:
@@ -484,6 +485,7 @@ class SyncResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
                     self.finished = True
                     raise StopIteration
 
+                self._check_max_streaming_duration()
                 result = self._process_chunk(chunk)
 
                 if self.finished:

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import time
 import traceback
 from datetime import datetime
 from typing import Any, Dict, Optional
@@ -7,7 +8,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 import litellm
-from litellm.constants import STREAM_SSE_DONE_STRING
+from litellm.constants import MAX_STREAMING_CHUNK_DURATION_S, STREAM_SSE_DONE_STRING
 from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.litellm_core_utils.core_helpers import process_response_headers
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -56,6 +57,7 @@ class BaseResponsesAPIStreamingIterator:
         self.completed_response: Optional[ResponsesAPIStreamingResponse] = None
         self.start_time = getattr(logging_obj, "start_time", datetime.now())
         self._failure_handled = False  # Track if failure handler has been called
+        self._stream_created_time: float = time.time()
 
         # track request context for hooks
         self.litellm_metadata = litellm_metadata
@@ -81,6 +83,18 @@ class BaseResponsesAPIStreamingIterator:
         self._hidden_params["additional_headers"] = process_response_headers(
             self.response.headers or {}
         )  # GUARANTEE OPENAI HEADERS IN RESPONSE
+
+    def _check_max_streaming_duration(self) -> None:
+        """Raise litellm.Timeout if the stream has exceeded MAX_STREAMING_CHUNK_DURATION_S."""
+        if MAX_STREAMING_CHUNK_DURATION_S is None:
+            return
+        elapsed = time.time() - self._stream_created_time
+        if elapsed > MAX_STREAMING_CHUNK_DURATION_S:
+            raise litellm.Timeout(
+                message=f"Stream exceeded max streaming duration of {MAX_STREAMING_CHUNK_DURATION_S}s (elapsed {elapsed:.1f}s)",
+                model=self.model or "",
+                llm_provider=self.custom_llm_provider or "",
+            )
 
     def _process_chunk(self, chunk) -> Optional[ResponsesAPIStreamingResponse]:
         """Process a single chunk of data from the stream"""
@@ -357,6 +371,7 @@ class ResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
 
     async def __anext__(self) -> ResponsesAPIStreamingResponse:
         try:
+            self._check_max_streaming_duration()
             while True:
                 # Get the next chunk from the stream
                 try:
@@ -365,6 +380,7 @@ class ResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
                     self.finished = True
                     raise StopAsyncIteration
 
+                self._check_max_streaming_duration()
                 result = self._process_chunk(chunk)
 
                 if self.finished:

--- a/tests/test_litellm/litellm_core_utils/test_max_streaming_duration.py
+++ b/tests/test_litellm/litellm_core_utils/test_max_streaming_duration.py
@@ -1,0 +1,126 @@
+"""
+Tests for MAX_STREAMING_DURATION_S — the global cap on streaming response wall-clock time.
+
+Covers:
+  - CustomStreamWrapper (chat/completions) sync + async
+  - BaseResponsesAPIStreamingIterator (responses) sync + async
+"""
+
+import os
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_custom_stream_wrapper() -> CustomStreamWrapper:
+    """Build a minimal CustomStreamWrapper for testing."""
+    return CustomStreamWrapper(
+        completion_stream=None,
+        model="test-model",
+        logging_obj=MagicMock(),
+        custom_llm_provider="openai",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CustomStreamWrapper (chat/completions)
+# ---------------------------------------------------------------------------
+
+
+class TestCustomStreamWrapperMaxDuration:
+    def test_should_not_raise_when_duration_is_none(self):
+        """No limit configured → never raises."""
+        wrapper = _make_custom_stream_wrapper()
+        with patch("litellm.constants.MAX_STREAMING_DURATION_S", None):
+            wrapper._check_max_streaming_duration()  # should not raise
+
+    def test_should_not_raise_when_under_limit(self):
+        """Stream is under the limit → no error."""
+        wrapper = _make_custom_stream_wrapper()
+        with patch("litellm.constants.MAX_STREAMING_DURATION_S", 60.0):
+            wrapper._check_max_streaming_duration()  # should not raise
+
+    def test_should_raise_timeout_when_exceeded(self):
+        """Stream exceeded the limit → litellm.Timeout."""
+        wrapper = _make_custom_stream_wrapper()
+        wrapper._stream_created_time = time.time() - 20  # simulate 20s elapsed
+        with patch("litellm.constants.MAX_STREAMING_DURATION_S", 10.0):
+            with pytest.raises(litellm.Timeout, match="max streaming duration"):
+                wrapper._check_max_streaming_duration()
+
+    def test_should_raise_on_sync_next_when_exceeded(self):
+        """__next__ should check the limit before iterating."""
+        wrapper = _make_custom_stream_wrapper()
+        wrapper._stream_created_time = time.time() - 20
+        with patch("litellm.constants.MAX_STREAMING_DURATION_S", 10.0):
+            with pytest.raises(litellm.Timeout):
+                wrapper.__next__()
+
+    @pytest.mark.asyncio
+    async def test_should_raise_on_async_anext_when_exceeded(self):
+        """__anext__ should check the limit before iterating."""
+        wrapper = _make_custom_stream_wrapper()
+        wrapper._stream_created_time = time.time() - 20
+        with patch("litellm.constants.MAX_STREAMING_DURATION_S", 10.0):
+            with pytest.raises(litellm.Timeout):
+                await wrapper.__anext__()
+
+
+# ---------------------------------------------------------------------------
+# BaseResponsesAPIStreamingIterator (responses)
+# ---------------------------------------------------------------------------
+
+class TestResponsesStreamingIteratorMaxDuration:
+    def _make_base_iterator(self):
+        """Build a minimal BaseResponsesAPIStreamingIterator for testing."""
+        from litellm.responses.streaming_iterator import (
+            BaseResponsesAPIStreamingIterator,
+        )
+
+        mock_response = MagicMock()
+        mock_response.headers = {}
+        mock_logging_obj = MagicMock()
+        mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.start_time = time.time()
+
+        mock_provider_config = MagicMock()
+        return BaseResponsesAPIStreamingIterator(
+            response=mock_response,
+            model="test-model",
+            responses_api_provider_config=mock_provider_config,
+            logging_obj=mock_logging_obj,
+            custom_llm_provider="openai",
+        )
+
+    def test_should_not_raise_when_duration_is_none(self):
+        it = self._make_base_iterator()
+        with patch(
+            "litellm.responses.streaming_iterator.MAX_STREAMING_DURATION_S", None
+        ):
+            it._check_max_streaming_duration()
+
+    def test_should_not_raise_when_under_limit(self):
+        it = self._make_base_iterator()
+        with patch(
+            "litellm.responses.streaming_iterator.MAX_STREAMING_DURATION_S", 60.0
+        ):
+            it._check_max_streaming_duration()
+
+    def test_should_raise_timeout_when_exceeded(self):
+        it = self._make_base_iterator()
+        it._stream_created_time = time.time() - 20
+        with patch(
+            "litellm.responses.streaming_iterator.MAX_STREAMING_DURATION_S", 10.0
+        ):
+            with pytest.raises(litellm.Timeout, match="max streaming duration"):
+                it._check_max_streaming_duration()

--- a/tests/test_litellm/litellm_core_utils/test_max_streaming_duration.py
+++ b/tests/test_litellm/litellm_core_utils/test_max_streaming_duration.py
@@ -1,5 +1,5 @@
 """
-Tests for MAX_STREAMING_DURATION_S — the global cap on streaming response wall-clock time.
+Tests for LITELLM_MAX_STREAMING_DURATION_SECONDS — the global cap on streaming response wall-clock time.
 
 Covers:
   - CustomStreamWrapper (chat/completions) sync + async
@@ -41,20 +41,20 @@ class TestCustomStreamWrapperMaxDuration:
     def test_should_not_raise_when_duration_is_none(self):
         """No limit configured → never raises."""
         wrapper = _make_custom_stream_wrapper()
-        with patch("litellm.constants.MAX_STREAMING_DURATION_S", None):
+        with patch("litellm.constants.LITELLM_MAX_STREAMING_DURATION_SECONDS", None):
             wrapper._check_max_streaming_duration()  # should not raise
 
     def test_should_not_raise_when_under_limit(self):
         """Stream is under the limit → no error."""
         wrapper = _make_custom_stream_wrapper()
-        with patch("litellm.constants.MAX_STREAMING_DURATION_S", 60.0):
+        with patch("litellm.constants.LITELLM_MAX_STREAMING_DURATION_SECONDS", 60.0):
             wrapper._check_max_streaming_duration()  # should not raise
 
     def test_should_raise_timeout_when_exceeded(self):
         """Stream exceeded the limit → litellm.Timeout."""
         wrapper = _make_custom_stream_wrapper()
         wrapper._stream_created_time = time.time() - 20  # simulate 20s elapsed
-        with patch("litellm.constants.MAX_STREAMING_DURATION_S", 10.0):
+        with patch("litellm.constants.LITELLM_MAX_STREAMING_DURATION_SECONDS", 10.0):
             with pytest.raises(litellm.Timeout, match="max streaming duration"):
                 wrapper._check_max_streaming_duration()
 
@@ -62,7 +62,7 @@ class TestCustomStreamWrapperMaxDuration:
         """__next__ should check the limit before iterating."""
         wrapper = _make_custom_stream_wrapper()
         wrapper._stream_created_time = time.time() - 20
-        with patch("litellm.constants.MAX_STREAMING_DURATION_S", 10.0):
+        with patch("litellm.constants.LITELLM_MAX_STREAMING_DURATION_SECONDS", 10.0):
             with pytest.raises(litellm.Timeout):
                 wrapper.__next__()
 
@@ -71,7 +71,7 @@ class TestCustomStreamWrapperMaxDuration:
         """__anext__ should check the limit before iterating."""
         wrapper = _make_custom_stream_wrapper()
         wrapper._stream_created_time = time.time() - 20
-        with patch("litellm.constants.MAX_STREAMING_DURATION_S", 10.0):
+        with patch("litellm.constants.LITELLM_MAX_STREAMING_DURATION_SECONDS", 10.0):
             with pytest.raises(litellm.Timeout):
                 await wrapper.__anext__()
 
@@ -105,14 +105,14 @@ class TestResponsesStreamingIteratorMaxDuration:
     def test_should_not_raise_when_duration_is_none(self):
         it = self._make_base_iterator()
         with patch(
-            "litellm.responses.streaming_iterator.MAX_STREAMING_DURATION_S", None
+            "litellm.responses.streaming_iterator.LITELLM_MAX_STREAMING_DURATION_SECONDS", None
         ):
             it._check_max_streaming_duration()
 
     def test_should_not_raise_when_under_limit(self):
         it = self._make_base_iterator()
         with patch(
-            "litellm.responses.streaming_iterator.MAX_STREAMING_DURATION_S", 60.0
+            "litellm.responses.streaming_iterator.LITELLM_MAX_STREAMING_DURATION_SECONDS", 60.0
         ):
             it._check_max_streaming_duration()
 
@@ -120,7 +120,7 @@ class TestResponsesStreamingIteratorMaxDuration:
         it = self._make_base_iterator()
         it._stream_created_time = time.time() - 20
         with patch(
-            "litellm.responses.streaming_iterator.MAX_STREAMING_DURATION_S", 10.0
+            "litellm.responses.streaming_iterator.LITELLM_MAX_STREAMING_DURATION_SECONDS", 10.0
         ):
             with pytest.raises(litellm.Timeout, match="max streaming duration"):
                 it._check_max_streaming_duration()


### PR DESCRIPTION
## [Feat] Add control for setting upperbound on chunk processing time 

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
