### PR TITLE
feat: add tags in project

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2280,6 +2280,9 @@ class LiteLLM_VerificationTokenView(LiteLLM_VerificationToken):
     organization_rpm_limit: Optional[int] = None
     organization_metadata: Optional[dict] = None
 
+    # Project Params
+    project_metadata: Optional[dict] = None
+
     # Time stamps
     last_refreshed_at: Optional[float] = None  # last time joint view was pulled from db
 
@@ -2581,6 +2584,7 @@ class NewProjectRequest(LiteLLM_BudgetTable):
     team_id: str
     budget_id: Optional[str] = None
     metadata: Optional[dict] = None
+    tags: Optional[List[str]] = None
     models: List[str] = []
     model_rpm_limit: Optional[dict] = None
     model_tpm_limit: Optional[dict] = None
@@ -2590,7 +2594,15 @@ class NewProjectRequest(LiteLLM_BudgetTable):
     @model_validator(mode="before")
     @classmethod
     def set_model_info(cls, values):
-        for field in LiteLLM_ManagementEndpoint_MetadataFields:
+        if "tags" in values and values["tags"] is not None:
+            if not isinstance(values["tags"], list):
+                raise ValueError(
+                    f"tags must be a list of strings, got {type(values['tags']).__name__}"
+                )
+        for field in (
+            LiteLLM_ManagementEndpoint_MetadataFields
+            + LiteLLM_ManagementEndpoint_MetadataFields_Premium
+        ):
             if values.get(field) is not None:
                 if values.get("metadata") is None:
                     values.update({"metadata": {}})
@@ -2607,6 +2619,7 @@ class UpdateProjectRequest(LiteLLM_BudgetTable):
     description: Optional[str] = None
     team_id: Optional[str] = None
     metadata: Optional[dict] = None
+    tags: Optional[List[str]] = None
     models: Optional[List[str]] = None
     model_rpm_limit: Optional[dict] = None
     model_tpm_limit: Optional[dict] = None
@@ -2617,7 +2630,15 @@ class UpdateProjectRequest(LiteLLM_BudgetTable):
     @model_validator(mode="before")
     @classmethod
     def set_model_info(cls, values):
-        for field in LiteLLM_ManagementEndpoint_MetadataFields:
+        if "tags" in values and values["tags"] is not None:
+            if not isinstance(values["tags"], list):
+                raise ValueError(
+                    f"tags must be a list of strings, got {type(values['tags']).__name__}"
+                )
+        for field in (
+            LiteLLM_ManagementEndpoint_MetadataFields
+            + LiteLLM_ManagementEndpoint_MetadataFields_Premium
+        ):
             if values.get(field) is not None:
                 if values.get("metadata") is None:
                     values.update({"metadata": {}})

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2599,10 +2599,7 @@ class NewProjectRequest(LiteLLM_BudgetTable):
                 raise ValueError(
                     f"tags must be a list of strings, got {type(values['tags']).__name__}"
                 )
-        for field in (
-            LiteLLM_ManagementEndpoint_MetadataFields
-            + LiteLLM_ManagementEndpoint_MetadataFields_Premium
-        ):
+        for field in LiteLLM_ManagementEndpoint_MetadataFields:
             if values.get(field) is not None:
                 if values.get("metadata") is None:
                     values.update({"metadata": {}})
@@ -2635,10 +2632,7 @@ class UpdateProjectRequest(LiteLLM_BudgetTable):
                 raise ValueError(
                     f"tags must be a list of strings, got {type(values['tags']).__name__}"
                 )
-        for field in (
-            LiteLLM_ManagementEndpoint_MetadataFields
-            + LiteLLM_ManagementEndpoint_MetadataFields_Premium
-        ):
+        for field in LiteLLM_ManagementEndpoint_MetadataFields:
             if values.get(field) is not None:
                 if values.get("metadata") is None:
                     values.update({"metadata": {}})

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -212,10 +212,12 @@ async def user_api_key_auth_websocket(websocket: WebSocket):
         api_key = websocket.headers.get("api-key")
         if not api_key:
             # Try extracting from WebSocket subprotocol (browser clients)
-            for protocol in websocket.headers.get("sec-websocket-protocol", "").split(","):
+            for protocol in websocket.headers.get("sec-websocket-protocol", "").split(
+                ","
+            ):
                 protocol = protocol.strip()
                 if protocol.startswith("openai-insecure-api-key."):
-                    api_key = protocol[len("openai-insecure-api-key."):]
+                    api_key = protocol[len("openai-insecure-api-key.") :]
                     break
         if not api_key:
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
@@ -704,6 +706,8 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                         user_api_key_cache=user_api_key_cache,
                         proxy_logging_obj=proxy_logging_obj,
                     )
+                    if _jwt_project_obj is not None:
+                        valid_token.project_metadata = _jwt_project_obj.metadata
 
                 # run through common checks
                 _ = await common_checks(
@@ -1294,6 +1298,8 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     user_api_key_cache=user_api_key_cache,
                     proxy_logging_obj=proxy_logging_obj,
                 )
+                if _project_obj is not None:
+                    valid_token.project_metadata = _project_obj.metadata
 
             global_proxy_spend = None
             if (
@@ -1743,6 +1749,8 @@ async def _run_post_custom_auth_checks(
             user_api_key_cache=user_api_key_cache,
             proxy_logging_obj=proxy_logging_obj,
         )
+        if _project_obj is not None:
+            valid_token.project_metadata = _project_obj.metadata
 
     _ = await common_checks(
         request=request,

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -248,13 +248,15 @@ def clean_headers(
     clean_headers = {}
     litellm_key_lower = (
         litellm_key_header_name.lower() if litellm_key_header_name is not None else None
-    )    
+    )
     for header, value in headers.items():
         header_lower = header.lower()
-        
+
         if header_lower == "authorization" and is_anthropic_oauth_key(value):
             clean_headers[header] = value
-        elif forward_llm_provider_auth_headers and header_lower in _SPECIAL_HEADERS_CACHE:
+        elif (
+            forward_llm_provider_auth_headers and header_lower in _SPECIAL_HEADERS_CACHE
+        ):
             if litellm_key_lower and header_lower == litellm_key_lower:
                 continue
             if header_lower == "authorization":
@@ -840,11 +842,13 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     from litellm.types.proxy.litellm_pre_call_utils import SecretFields
 
     _raw_headers: Dict[str, str] = _safe_get_request_headers(request)
-    
+
     forward_llm_auth = False
     if general_settings:
-        forward_llm_auth = general_settings.get("forward_llm_provider_auth_headers", False)
-    
+        forward_llm_auth = general_settings.get(
+            "forward_llm_provider_auth_headers", False
+        )
+
     _headers: Dict[str, str] = clean_headers(
         request.headers,
         litellm_key_header_name=(
@@ -1018,6 +1022,14 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
             data[_metadata_variable_name]["spend_logs_metadata"] = team_metadata[
                 "spend_logs_metadata"
             ]
+
+    ## PROJECT-LEVEL SPEND LOGS/TAGS
+    project_metadata = user_api_key_dict.project_metadata or {}
+    if "tags" in project_metadata and project_metadata["tags"] is not None:
+        data[_metadata_variable_name]["tags"] = LiteLLMProxyRequestSetup._merge_tags(
+            request_tags=data[_metadata_variable_name].get("tags"),
+            tags_to_add=project_metadata["tags"],
+        )
 
     ## TEAM-LEVEL METADATA
     data = (

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1023,7 +1023,7 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
                 "spend_logs_metadata"
             ]
 
-    ## PROJECT-LEVEL SPEND LOGS/TAGS
+    ## PROJECT-LEVEL TAGS
     project_metadata = user_api_key_dict.project_metadata or {}
     if "tags" in project_metadata and project_metadata["tags"] is not None:
         data[_metadata_variable_name]["tags"] = LiteLLMProxyRequestSetup._merge_tags(

--- a/litellm/proxy/management_endpoints/project_endpoints.py
+++ b/litellm/proxy/management_endpoints/project_endpoints.py
@@ -358,6 +358,16 @@ async def new_project(
                 },
             )
 
+        # ADD METADATA FIELDS
+        for field in LiteLLM_ManagementEndpoint_MetadataFields_Premium:
+            if getattr(data, field, None) is not None:
+                _set_object_metadata_field(
+                    object_data=data,
+                    field_name=field,
+                    value=getattr(data, field),
+                )
+                delattr(data, field)
+
         if prisma_client is None:
             raise HTTPException(
                 status_code=500,
@@ -473,7 +483,7 @@ async def new_project(
     response_model=LiteLLM_ProjectTable,
 )
 @management_endpoint_wrapper
-async def update_project(
+async def update_project(  # noqa: PLR0915
     data: UpdateProjectRequest,
     http_request: Request,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
@@ -542,6 +552,16 @@ async def update_project(
                     + CommonProxyErrors.not_premium_user.value
                 },
             )
+
+        # ADD METADATA FIELDS
+        for field in LiteLLM_ManagementEndpoint_MetadataFields_Premium:
+            if getattr(data, field, None) is not None:
+                _set_object_metadata_field(
+                    object_data=data,
+                    field_name=field,
+                    value=getattr(data, field),
+                )
+                delattr(data, field)
 
         if prisma_client is None:
             raise HTTPException(

--- a/litellm/proxy/management_endpoints/project_endpoints.py
+++ b/litellm/proxy/management_endpoints/project_endpoints.py
@@ -284,6 +284,7 @@ async def new_project(
     - model_tpm_limit: *Optional[dict]* - TPM limits per model. Example: {"gpt-4": 50000, "gpt-3.5-turbo": 100000}
     - budget_duration: *Optional[str]* - Frequency of reseting project budget
     - metadata: *Optional[dict]* - Metadata for project, store information for project. Example metadata - {"use_case_id": "SNOW-12345", "responsible_ai_id": "RAI-67890"}
+    - tags: *Optional[list]* - Tags for the project. Example: ["production", "api"]
     - blocked: *bool* - Flag indicating if the project is blocked or not - will stop all calls from keys with this project_id.
     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - project-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"]}. IF null or {} then no object permission.
 
@@ -339,6 +340,15 @@ async def new_project(
     )
 
     try:
+        if getattr(data, "tags", None) is not None and not premium_user:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "Only premium users can add tags to projects. "
+                    + CommonProxyErrors.not_premium_user.value
+                },
+            )
+
         if not premium_user:
             raise HTTPException(
                 status_code=403,
@@ -485,6 +495,7 @@ async def update_project(
     - model_rpm_limit: *Optional[dict]* - Updated RPM limits per model
     - model_tpm_limit: *Optional[dict]* - Updated TPM limits per model
     - budget_duration: *Optional[str]* - Updated budget duration
+    - tags: *Optional[list]* - Updated list of tags for the project
     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - Updated object permission
 
     Example:
@@ -514,6 +525,15 @@ async def update_project(
     )
 
     try:
+        if getattr(data, "tags", None) is not None and not premium_user:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "Only premium users can add tags to projects. "
+                    + CommonProxyErrors.not_premium_user.value
+                },
+            )
+
         if not premium_user:
             raise HTTPException(
                 status_code=403,

--- a/tests/test_litellm/test_project_tags_pydantic.py
+++ b/tests/test_litellm/test_project_tags_pydantic.py
@@ -1,0 +1,37 @@
+import pytest
+from litellm.proxy._types import NewProjectRequest, UpdateProjectRequest
+
+
+def test_new_project_request_tags():
+    # Test tags are correctly moved to metadata["tags"]
+    req = NewProjectRequest(
+        project_id="test_proj", team_id="team_1", tags=["tag1", "tag2"]
+    )
+
+    # After validation, tags should be inside metadata
+    assert req.metadata is not None
+    assert "tags" in req.metadata
+    assert req.metadata["tags"] == ["tag1", "tag2"]
+    assert req.tags is None  # Or removed dependending on pydantic version
+
+
+def test_update_project_request_tags():
+    # Test tags are correctly moved to metadata["tags"]
+    req = UpdateProjectRequest(project_id="test_proj", tags=["new_tag"])
+
+    assert req.metadata is not None
+    assert "tags" in req.metadata
+    assert req.metadata["tags"] == ["new_tag"]
+    assert req.tags is None
+
+
+def test_new_project_request_invalid_tags_type():
+    # tags must be a list — a string should raise a ValidationError
+    with pytest.raises(Exception):
+        NewProjectRequest(project_id="test_proj", team_id="team_1", tags="not-a-list")
+
+
+def test_update_project_request_invalid_tags_type():
+    # tags must be a list — a string should raise a ValidationError
+    with pytest.raises(Exception):
+        UpdateProjectRequest(project_id="test_proj", tags="not-a-list")

--- a/tests/test_litellm/test_project_tags_pydantic.py
+++ b/tests/test_litellm/test_project_tags_pydantic.py
@@ -3,26 +3,20 @@ from litellm.proxy._types import NewProjectRequest, UpdateProjectRequest
 
 
 def test_new_project_request_tags():
-    # Test tags are correctly moved to metadata["tags"]
+    # Test tags correctly stay top level initially
     req = NewProjectRequest(
         project_id="test_proj", team_id="team_1", tags=["tag1", "tag2"]
     )
 
-    # After validation, tags should be inside metadata
-    assert req.metadata is not None
-    assert "tags" in req.metadata
-    assert req.metadata["tags"] == ["tag1", "tag2"]
-    assert req.tags is None  # Or removed dependending on pydantic version
+    # tags should be top level initially
+    assert req.tags == ["tag1", "tag2"]
 
 
 def test_update_project_request_tags():
-    # Test tags are correctly moved to metadata["tags"]
+    # Test tags correctly stay top level initially
     req = UpdateProjectRequest(project_id="test_proj", tags=["new_tag"])
 
-    assert req.metadata is not None
-    assert "tags" in req.metadata
-    assert req.metadata["tags"] == ["new_tag"]
-    assert req.tags is None
+    assert req.tags == ["new_tag"]
 
 
 def test_new_project_request_invalid_tags_type():


### PR DESCRIPTION
## Relevant issues

add tags on project

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes
This PR adds support for **Project-Level Tags** similar to how tags are handled for keys and teams. Project tags are correctly set to `metadata["tags"]` and will seamlessly sync to upstream telemetry, alerting, and spend logs dynamically. 

<img width="961" height="682" alt="image" src="https://github.com/user-attachments/assets/7b206837-6dac-4c34-ae9b-a8d5b149f0f2" />


**Summary of Changes**:
- **[litellm/proxy/_types.py](cci:7://file:///Users/harshitjain/litellm/litellm/proxy/_types.py:0:0-0:0):** Added `tags: Optional[List[str]] = None` to [NewProjectRequest](cci:2://file:///Users/harshitjain/litellm/litellm/proxy/_types.py:2577:0-2610:21) and [UpdateProjectRequest](cci:2://file:///Users/harshitjain/litellm/litellm/proxy/_types.py:2613:0-2646:21). Updated [LiteLLM_VerificationTokenView](cci:2://file:///Users/harshitjain/litellm/litellm/proxy/_types.py:2245:0-2312:34) parameter to store `project_metadata`. Ensures [tags](cci:1://file:///Users/harshitjain/litellm/litellm/proxy/litellm_pre_call_utils.py:748:4-770:25) moves seamlessly inside the `"tags"` key via Pydantic model validators mapping iterating across `LiteLLM_ManagementEndpoint_MetadataFields_Premium`.
- **[litellm/proxy/auth/user_api_key_auth.py](cci:7://file:///Users/harshitjain/litellm/litellm/proxy/auth/user_api_key_auth.py:0:0-0:0):** Handled appending `project_metadata` across various key extraction functions (`valid_token.project_metadata = _project_obj.metadata`).
- **[litellm/proxy/litellm_pre_call_utils.py](cci:7://file:///Users/harshitjain/litellm/litellm/proxy/litellm_pre_call_utils.py:0:0-0:0):** Added `project-level` tag merging logic beneath team-level tag logic to embed project tags seamlessly within `spend_logs_metadata["tags"]`.
- **[litellm/proxy/management_endpoints/project_endpoints.py](cci:7://file:///Users/harshitjain/litellm/litellm/proxy/management_endpoints/project_endpoints.py:0:0-0:0):** Added premium user checking logic inside of `/project/new` and `/project/update` if [tags](cci:1://file:///Users/harshitjain/litellm/litellm/proxy/litellm_pre_call_utils.py:748:4-770:25) are supplied.
- **[tests/test_litellm/test_project_tags_pydantic.py](cci:7://file:///Users/harshitjain/litellm/tests/test_litellm/test_project_tags_pydantic.py:0:0-0:0)**: Added unit tests to ensure pydantic mappings of tags directly to the `req.metadata["tags"]` dictionary during Project endpoint parsing.

