### PR TITLE
feat(apm): correlate LiteLLM call IDs with Datadog APM spans

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -29,7 +29,7 @@ from litellm.constants import (
     MAX_PAYLOAD_SIZE_FOR_DEBUG_LOG,
     STREAM_SSE_DATA_PREFIX,
 )
-from litellm.litellm_core_utils.dd_tracing import tracer
+from litellm.litellm_core_utils.dd_tracing import set_active_span_tag, tracer
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.llm_response_utils.get_headers import (
     get_response_headers,
@@ -243,6 +243,26 @@ async def create_response(
         headers=headers,
         status_code=final_status_code,
     )
+
+
+def _add_dd_apm_tags_for_litellm_call_id(litellm_call_id: Optional[str]) -> None:
+    """
+    Attach LiteLLM call id to the active Datadog APM span.
+
+    This enables searching APM traces by LiteLLM call id returned in
+    `x-litellm-call-id`.
+    """
+    if not litellm_call_id:
+        return
+
+    try:
+        set_active_span_tag("litellm.call_id", str(litellm_call_id))
+    except Exception:
+        # Tagging is best-effort and should never impact request processing.
+        verbose_proxy_logger.debug(
+            "Failed to tag active ddtrace span with litellm.call_id",
+            exc_info=True,
+        )
 
 
 def _override_openai_response_model(
@@ -642,6 +662,7 @@ class ProxyBaseLLMRequestProcessing:
         self.data["litellm_call_id"] = request.headers.get(
             "x-litellm-call-id", str(uuid.uuid4())
         )
+        _add_dd_apm_tags_for_litellm_call_id(self.data.get("litellm_call_id"))
 
         ### AUTO STREAM USAGE TRACKING ###
         # If always_include_stream_usage is enabled and this is a streaming request
@@ -658,7 +679,6 @@ class ProxyBaseLLMRequestProcessing:
                 and "include_usage" not in self.data["stream_options"]
             ):
                 self.data["stream_options"]["include_usage"] = True
-
         ### CALL HOOKS ### - modify/reject incoming data before calling the model
 
         ## LOGGING OBJECT ## - initialize logging object for logging success/failure events for call


### PR DESCRIPTION
## Summary
- add reusable Datadog tracing helpers in `litellm_core_utils/dd_tracing.py` to resolve the active span and set tags safely
- tag active DD APM spans with `litellm.call_id` in proxy pre-call request processing when `litellm_call_id` is assigned
- add unit coverage for proxy tagging behavior and helper delegation

## Test plan
- [x] `poetry run pytest tests/test_litellm/proxy/test_common_request_processing.py -q`
- [x] pre-commit checks passed during cherry-pick (`pyright`, `isort`, `flake8`)

Made with [Cursor](https://cursor.com)