### PR TITLE
fix(anthropic): map reasoning_effort to output_config for Claude 4.6 models

### DIFF
--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -4,6 +4,8 @@ import TabItem from '@theme/TabItem';
 # Anthropic
 LiteLLM supports all anthropic models.
 
+- `claude-opus-4-6` (`claude-opus-4-6-20260205`)
+- `claude-sonnet-4-6`
 - `claude-sonnet-4-5-20250929`
 - `claude-opus-4-5-20251101`
 - `claude-opus-4-1-20250805`
@@ -50,7 +52,7 @@ Check this in code, [here](../completion/input.md#translated-openai-params)
 **Notes:**
 - Anthropic API fails requests when `max_tokens` are not passed. Due to this litellm passes `max_tokens=4096` when no `max_tokens` are passed.
 - `response_format` is fully supported for Claude Sonnet 4.5 and Opus 4.1 models (see [Structured Outputs](#structured-outputs) section)
-- `reasoning_effort` is automatically mapped to `output_config={"effort": ...}` for Claude Opus 4.5 models (see [Effort Parameter](./anthropic_effort.md))
+- `reasoning_effort` is automatically mapped to `output_config={"effort": ...}` for Claude 4.6 and Opus 4.5 models (see [Effort Parameter](./anthropic_effort.md))
 
 :::
 

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -169,24 +169,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         return tool_call
 
     @staticmethod
-    def _is_claude_4_6_model(model: str) -> bool:
-        """Check if the model is a Claude 4.6 model that uses adaptive thinking."""
-        model_lower = model.lower()
-        return any(
-            model_variant in model_lower
-            for model_variant in (
-                "opus-4-6",
-                "opus_4_6",
-                "opus-4.6",
-                "opus_4.6",
-                "sonnet-4-6",
-                "sonnet_4_6",
-                "sonnet-4.6",
-                "sonnet_4.6",
-            )
-        )
-
-    @staticmethod
     def _is_opus_4_6_model(model: str) -> bool:
         """Check if the model is specifically Claude Opus 4.6."""
         model_lower = model.lower()
@@ -1017,9 +999,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 )
                 if AnthropicConfig._is_claude_4_6_model(model):
                     # Map reasoning_effort to Anthropic's output_config for 4.6 models
-                    # "minimal" has no Anthropic equivalent → map to "low"
-                    anthropic_effort = value if value != "minimal" else "low"
-                    optional_params["output_config"] = {"effort": anthropic_effort}
+                    effort_map = {"minimal": "low", "low": "low", "medium": "medium", "high": "high", "max": "max"}
+                    anthropic_effort = effort_map.get(value)
+                    if anthropic_effort is not None:
+                        optional_params["output_config"] = {"effort": anthropic_effort}
             elif param == "web_search_options" and isinstance(value, dict):
                 hosted_web_search_tool = self.map_web_search_tool(
                     cast(OpenAIWebSearchOptions, value)

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -224,6 +224,18 @@ class AnthropicModelInfo(BaseLLMModelInfo):
 
         return False
 
+    @staticmethod
+    def _is_claude_4_6_model(model: str) -> bool:
+        """Check if the model is a Claude 4.6 model (Opus 4.6 or Sonnet 4.6)."""
+        model_lower = model.lower()
+        return any(
+            v in model_lower
+            for v in (
+                "opus-4-6", "opus_4_6", "opus-4.6", "opus_4.6",
+                "sonnet-4-6", "sonnet_4_6", "sonnet-4.6", "sonnet_4.6",
+            )
+        )
+
     def is_effort_used(
         self, optional_params: Optional[dict], model: Optional[str] = None
     ) -> bool:
@@ -238,17 +250,8 @@ class AnthropicModelInfo(BaseLLMModelInfo):
             return False
 
         # Claude 4.6 models use output_config as a stable API feature — no beta header needed
-        if model:
-            model_lower = model.lower()
-            is_4_6 = any(
-                v in model_lower
-                for v in (
-                    "opus-4-6", "opus_4_6", "opus-4.6", "opus_4.6",
-                    "sonnet-4-6", "sonnet_4_6", "sonnet-4.6", "sonnet_4.6",
-                )
-            )
-            if is_4_6:
-                return False
+        if model and self._is_claude_4_6_model(model):
+            return False
 
         # Check if reasoning_effort is provided for Claude Opus 4.5
         if model and ("opus-4-5" in model.lower() or "opus_4_5" in model.lower()):


### PR DESCRIPTION
## Relevant issues

Fixes #22212
Fixes #22213
Fixes #22214

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix
📖 Documentation

## Changes

Claude 4.6 models (Opus 4.6, Sonnet 4.6) use `output_config: {"effort": "..."}` as a **stable** API parameter, separate from the beta `thinking` config. Three related bugs are fixed:

1. **`reasoning_effort` → `output_config` mapping** (#22212): When `reasoning_effort` is set on a 4.6 model, LiteLLM now also generates `output_config={"effort": ...}` alongside the adaptive thinking config. `"minimal"` maps to `"low"` since it has no Anthropic equivalent.

2. **`effort="max"` restricted to Opus 4.6** (#22214): Previously any 4.6 model accepted `max`. Now only Claude Opus 4.6 accepts it; Sonnet 4.6 raises a `ValueError`.

3. **No beta header for 4.6 models** (#22213): `is_effort_used()` now returns `False` for 4.6 models, preventing injection of the `effort-2025-11-24` beta header which is only needed for Opus 4.5.

Documentation updated to reflect Claude 4.6 support, `max` effort level, and stable vs beta distinction.