### PR TITLE
feat(vertex): add gemini-3.1-flash-image-preview to model DB

### DIFF
--- a/litellm/llms/gemini/image_generation/cost_calculator.py
+++ b/litellm/llms/gemini/image_generation/cost_calculator.py
@@ -2,10 +2,71 @@
 Google AI Image Generation Cost Calculator
 """
 
-from typing import Any
+from typing import Any, Optional
 
 import litellm
-from litellm.types.utils import ImageResponse
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+from litellm.types.utils import (
+    CompletionTokensDetailsWrapper,
+    ImageResponse,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
+
+
+def _calculate_token_based_cost(model: str, image_response: ImageResponse) -> Optional[float]:
+    """
+    Calculate token-based image generation cost when usage metadata is available.
+
+    Falls back to None when usage metadata is missing/incomplete.
+    """
+    usage = image_response.usage
+    if usage is None:
+        return None
+
+    prompt_tokens = usage.input_tokens
+    completion_tokens = usage.output_tokens
+    total_tokens = usage.total_tokens
+
+    if (
+        prompt_tokens is None
+        or completion_tokens is None
+        or total_tokens is None
+    ):
+        return None
+    # ImageResponse may carry a default zeroed usage object even when provider
+    # usage metadata is absent. Treat this as missing usage and fall back.
+    if prompt_tokens == 0 and completion_tokens == 0 and total_tokens == 0:
+        return None
+
+    input_tokens_details = getattr(usage, "input_tokens_details", None)
+    prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
+    if input_tokens_details is not None:
+        prompt_tokens_details = PromptTokensDetailsWrapper(
+            text_tokens=getattr(input_tokens_details, "text_tokens", None),
+            image_tokens=getattr(input_tokens_details, "image_tokens", None),
+            cached_tokens=0,
+        )
+
+    normalized_usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        prompt_tokens_details=prompt_tokens_details,
+        completion_tokens_details=CompletionTokensDetailsWrapper(
+            text_tokens=0,
+            image_tokens=completion_tokens,
+            reasoning_tokens=0,
+            audio_tokens=0,
+        ),
+    )
+
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model=model,
+        usage=normalized_usage,
+        custom_llm_provider="gemini",
+    )
+    return prompt_cost + completion_cost
 
 
 def cost_calculator(
@@ -19,6 +80,13 @@ def cost_calculator(
         model=model,
         custom_llm_provider="gemini",
     )
+
+    if isinstance(image_response, ImageResponse):
+        token_based_cost = _calculate_token_based_cost(
+            model=model, image_response=image_response
+        )
+        if token_based_cost is not None:
+            return token_based_cost
 
     output_cost_per_image: float = _model_info.get("output_cost_per_image") or 0.0
     num_images: int = 0

--- a/litellm/llms/gemini/image_generation/cost_calculator.py
+++ b/litellm/llms/gemini/image_generation/cost_calculator.py
@@ -2,71 +2,13 @@
 Google AI Image Generation Cost Calculator
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import litellm
-from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
-from litellm.types.utils import (
-    CompletionTokensDetailsWrapper,
-    ImageResponse,
-    PromptTokensDetailsWrapper,
-    Usage,
+from litellm.litellm_core_utils.llm_cost_calc.utils import (
+    calculate_image_response_cost_from_usage,
 )
-
-
-def _calculate_token_based_cost(model: str, image_response: ImageResponse) -> Optional[float]:
-    """
-    Calculate token-based image generation cost when usage metadata is available.
-
-    Falls back to None when usage metadata is missing/incomplete.
-    """
-    usage = image_response.usage
-    if usage is None:
-        return None
-
-    prompt_tokens = usage.input_tokens
-    completion_tokens = usage.output_tokens
-    total_tokens = usage.total_tokens
-
-    if (
-        prompt_tokens is None
-        or completion_tokens is None
-        or total_tokens is None
-    ):
-        return None
-    # ImageResponse may carry a default zeroed usage object even when provider
-    # usage metadata is absent. Treat this as missing usage and fall back.
-    if prompt_tokens == 0 and completion_tokens == 0 and total_tokens == 0:
-        return None
-
-    input_tokens_details = getattr(usage, "input_tokens_details", None)
-    prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
-    if input_tokens_details is not None:
-        prompt_tokens_details = PromptTokensDetailsWrapper(
-            text_tokens=getattr(input_tokens_details, "text_tokens", None),
-            image_tokens=getattr(input_tokens_details, "image_tokens", None),
-            cached_tokens=0,
-        )
-
-    normalized_usage = Usage(
-        prompt_tokens=prompt_tokens,
-        completion_tokens=completion_tokens,
-        total_tokens=total_tokens,
-        prompt_tokens_details=prompt_tokens_details,
-        completion_tokens_details=CompletionTokensDetailsWrapper(
-            text_tokens=0,
-            image_tokens=completion_tokens,
-            reasoning_tokens=0,
-            audio_tokens=0,
-        ),
-    )
-
-    prompt_cost, completion_cost = generic_cost_per_token(
-        model=model,
-        usage=normalized_usage,
-        custom_llm_provider="gemini",
-    )
-    return prompt_cost + completion_cost
+from litellm.types.utils import ImageResponse
 
 
 def cost_calculator(
@@ -74,7 +16,7 @@ def cost_calculator(
     image_response: Any,
 ) -> float:
     """
-    Vertex AI Image Generation Cost Calculator
+    Google AI Image Generation Cost Calculator
     """
     _model_info = litellm.get_model_info(
         model=model,
@@ -82,8 +24,10 @@ def cost_calculator(
     )
 
     if isinstance(image_response, ImageResponse):
-        token_based_cost = _calculate_token_based_cost(
-            model=model, image_response=image_response
+        token_based_cost = calculate_image_response_cost_from_usage(
+            model=model,
+            image_response=image_response,
+            custom_llm_provider="gemini",
         )
         if token_based_cost is not None:
             return token_based_cost

--- a/litellm/llms/vertex_ai/image_generation/cost_calculator.py
+++ b/litellm/llms/vertex_ai/image_generation/cost_calculator.py
@@ -2,71 +2,11 @@
 Vertex AI Image Generation Cost Calculator
 """
 
-from typing import Optional
-
 import litellm
-from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
-from litellm.types.utils import (
-    CompletionTokensDetailsWrapper,
-    ImageResponse,
-    PromptTokensDetailsWrapper,
-    Usage,
+from litellm.litellm_core_utils.llm_cost_calc.utils import (
+    calculate_image_response_cost_from_usage,
 )
-
-
-def _calculate_token_based_cost(model: str, image_response: ImageResponse) -> Optional[float]:
-    """
-    Calculate token-based image generation cost when usage metadata is available.
-
-    Falls back to None when usage metadata is missing/incomplete.
-    """
-    usage = image_response.usage
-    if usage is None:
-        return None
-
-    prompt_tokens = usage.input_tokens
-    completion_tokens = usage.output_tokens
-    total_tokens = usage.total_tokens
-
-    if (
-        prompt_tokens is None
-        or completion_tokens is None
-        or total_tokens is None
-    ):
-        return None
-    # ImageResponse may carry a default zeroed usage object even when provider
-    # usage metadata is absent. Treat this as missing usage and fall back.
-    if prompt_tokens == 0 and completion_tokens == 0 and total_tokens == 0:
-        return None
-
-    input_tokens_details = getattr(usage, "input_tokens_details", None)
-    prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
-    if input_tokens_details is not None:
-        prompt_tokens_details = PromptTokensDetailsWrapper(
-            text_tokens=getattr(input_tokens_details, "text_tokens", None),
-            image_tokens=getattr(input_tokens_details, "image_tokens", None),
-            cached_tokens=0,
-        )
-
-    normalized_usage = Usage(
-        prompt_tokens=prompt_tokens,
-        completion_tokens=completion_tokens,
-        total_tokens=total_tokens,
-        prompt_tokens_details=prompt_tokens_details,
-        completion_tokens_details=CompletionTokensDetailsWrapper(
-            text_tokens=0,
-            image_tokens=completion_tokens,
-            reasoning_tokens=0,
-            audio_tokens=0,
-        ),
-    )
-
-    prompt_cost, completion_cost = generic_cost_per_token(
-        model=model,
-        usage=normalized_usage,
-        custom_llm_provider="vertex_ai",
-    )
-    return prompt_cost + completion_cost
+from litellm.types.utils import ImageResponse
 
 
 def cost_calculator(
@@ -81,8 +21,10 @@ def cost_calculator(
         custom_llm_provider="vertex_ai",
     )
 
-    token_based_cost = _calculate_token_based_cost(
-        model=model, image_response=image_response
+    token_based_cost = calculate_image_response_cost_from_usage(
+        model=model,
+        image_response=image_response,
+        custom_llm_provider="vertex_ai",
     )
     if token_based_cost is not None:
         return token_based_cost

--- a/litellm/llms/vertex_ai/image_generation/cost_calculator.py
+++ b/litellm/llms/vertex_ai/image_generation/cost_calculator.py
@@ -2,8 +2,71 @@
 Vertex AI Image Generation Cost Calculator
 """
 
+from typing import Optional
+
 import litellm
-from litellm.types.utils import ImageResponse
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+from litellm.types.utils import (
+    CompletionTokensDetailsWrapper,
+    ImageResponse,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
+
+
+def _calculate_token_based_cost(model: str, image_response: ImageResponse) -> Optional[float]:
+    """
+    Calculate token-based image generation cost when usage metadata is available.
+
+    Falls back to None when usage metadata is missing/incomplete.
+    """
+    usage = image_response.usage
+    if usage is None:
+        return None
+
+    prompt_tokens = usage.input_tokens
+    completion_tokens = usage.output_tokens
+    total_tokens = usage.total_tokens
+
+    if (
+        prompt_tokens is None
+        or completion_tokens is None
+        or total_tokens is None
+    ):
+        return None
+    # ImageResponse may carry a default zeroed usage object even when provider
+    # usage metadata is absent. Treat this as missing usage and fall back.
+    if prompt_tokens == 0 and completion_tokens == 0 and total_tokens == 0:
+        return None
+
+    input_tokens_details = getattr(usage, "input_tokens_details", None)
+    prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
+    if input_tokens_details is not None:
+        prompt_tokens_details = PromptTokensDetailsWrapper(
+            text_tokens=getattr(input_tokens_details, "text_tokens", None),
+            image_tokens=getattr(input_tokens_details, "image_tokens", None),
+            cached_tokens=0,
+        )
+
+    normalized_usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        prompt_tokens_details=prompt_tokens_details,
+        completion_tokens_details=CompletionTokensDetailsWrapper(
+            text_tokens=0,
+            image_tokens=completion_tokens,
+            reasoning_tokens=0,
+            audio_tokens=0,
+        ),
+    )
+
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model=model,
+        usage=normalized_usage,
+        custom_llm_provider="vertex_ai",
+    )
+    return prompt_cost + completion_cost
 
 
 def cost_calculator(
@@ -17,6 +80,12 @@ def cost_calculator(
         model=model,
         custom_llm_provider="vertex_ai",
     )
+
+    token_based_cost = _calculate_token_based_cost(
+        model=model, image_response=image_response
+    )
+    if token_based_cost is not None:
+        return token_based_cost
 
     output_cost_per_image: float = _model_info.get("output_cost_per_image") or 0.0
     num_images: int = 0

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14194,6 +14194,38 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "gemini-3.1-flash-image-preview": {
+        "input_cost_per_image": 0.00056,
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0672,
+        "output_cost_per_image_token": 6e-05,
+        "output_cost_per_token": 3e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "deep-research-pro-preview-12-2025": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
@@ -31544,6 +31576,19 @@
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_batches": 6e-06,
         "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
+    },
+    "vertex_ai/gemini-3.1-flash-image-preview": {
+        "input_cost_per_image": 0.00056,
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0672,
+        "output_cost_per_image_token": 6e-05,
+        "output_cost_per_token": 3e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models"
     },
     "vertex_ai/deep-research-pro-preview-12-2025": {
         "input_cost_per_image": 0.0011,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14194,6 +14194,38 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "gemini-3.1-flash-image-preview": {
+        "input_cost_per_image": 0.00056,
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0672,
+        "output_cost_per_image_token": 6e-05,
+        "output_cost_per_token": 3e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "deep-research-pro-preview-12-2025": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
@@ -31544,6 +31576,19 @@
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_batches": 6e-06,
         "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
+    },
+    "vertex_ai/gemini-3.1-flash-image-preview": {
+        "input_cost_per_image": 0.00056,
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0672,
+        "output_cost_per_image_token": 6e-05,
+        "output_cost_per_token": 3e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models"
     },
     "vertex_ai/deep-research-pro-preview-12-2025": {
         "input_cost_per_image": 0.0011,


### PR DESCRIPTION
## Summary
- add `gemini-3.1-flash-image-preview` to the model DB for Vertex
- add `vertex_ai/gemini-3.1-flash-image-preview` alias entry
- mirror both entries in `litellm/model_prices_and_context_window_backup.json`
- fix `image_generation()` spend calculation for Vertex/Gemini to use token usage metadata when available
- keep backward-compatible fallback to flat `output_cost_per_image` when usage metadata is missing

## Pricing Applied (Gemini 3.1 Flash Image Preview)
- Input (text,image): `$0.50 / 1M tokens` (`input_cost_per_token: 5e-07`)
- Text output (response/reasoning): `$3 / 1M tokens` (`output_cost_per_token: 3e-06`)
- Image output: `$60 / 1M tokens` (`output_cost_per_image_token: 6e-05`)
- Input image token charge: `1120 tokens / image` (`input_cost_per_image: 0.00056`)
- Default flat output image cost set to 1K tier (`1120 tokens`): `0.0672`

## Calculation Changes (Why Needed)
Before this PR, Vertex/Gemini `image_generation()` cost calculators always used:
- `num_images * output_cost_per_image`

That meant token-level image pricing (`output_cost_per_image_token`) was not used in that path even when the provider returned usage token metadata.

This PR changes the calculators to:
1. Use token-based costing when usage metadata is present on `ImageResponse`:
   - map `ImageUsage` -> `Usage`
   - set output token breakdown as image tokens
   - reuse `generic_cost_per_token()` so `input_cost_per_token` + `output_cost_per_image_token` are applied consistently
2. Fall back to `output_cost_per_image * num_images` when usage metadata is missing
3. Treat default zeroed usage objects as missing metadata (to avoid incorrectly returning zero cost)

This keeps current behavior safe for providers/responses without usage data, while enabling accurate token-based billing where usage details are available.

## Validation
- `python -m json.tool model_prices_and_context_window.json`
- `python -m json.tool litellm/model_prices_and_context_window_backup.json`
- `poetry run pytest tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py -k "gemini_image_generation_cost_with_zero_text_tokens or image_generation_cost_prefers_token_usage_metadata or image_generation_cost_falls_back_to_flat_image_pricing" -q`
- `poetry run pytest tests/test_litellm/test_utils.py -k aaamodel_prices_and_context_window_json_is_valid -q`

All checks passed locally.
