### PR TITLE
[Fix] Enhance MidStreamFallbackError to preserve original status code and attributes

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -955,7 +955,8 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
         generated_content: str = "",
         is_pre_first_chunk: bool = False,
     ):
-        self.status_code = 503  # Service Unavailable
+        original_status = getattr(original_exception, "status_code", None)
+        self.status_code = int(original_status) if original_status is not None else 503
         self.message = f"litellm.MidStreamFallbackError: {message}"
         self.model = model
         self.llm_provider = llm_provider
@@ -978,7 +979,14 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
         else:
             self.response = response
 
-        # Call the parent constructor
+        # Save the original attributes before they are overridden by ServiceUnavailableError
+        _saved_response = self.response
+        _saved_request = getattr(self.response, "request", None) or httpx.Request(
+            method="POST", url=f"https://{llm_provider}.com/v1/"
+        )
+        _saved_message = self.message
+
+        # Call the parent constructor (which hardcodes status_code=503 and modifies the response object)
         super().__init__(
             message=self.message,
             llm_provider=llm_provider,
@@ -988,6 +996,14 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
             max_retries=self.max_retries,
             num_retries=self.num_retries,
         )
+        
+        # Restore the propagated status and original response/request objects
+        self.status_code = int(original_status) if original_status is not None else 503
+        self.response = _saved_response
+        self.request = _saved_request
+        self.message = _saved_message
+        self.args = (_saved_message,)
+        self.args = (_saved_message,)
 
     def __str__(self):
         _message = self.message

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -1003,7 +1003,6 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
         self.request = _saved_request
         self.message = _saved_message
         self.args = (_saved_message,)
-        self.args = (_saved_message,)
 
     def __str__(self):
         _message = self.message

--- a/tests/local_testing/test_exceptions.py
+++ b/tests/local_testing/test_exceptions.py
@@ -1422,4 +1422,46 @@ async def test_exception_bubbling_up(sync_mode, stream_mode, model):
     assert exc_info.value.type == "invalid_request_error"
 
 
+def test_midstream_fallback_error_status_code_propagation():
+    """
+    MidStreamFallbackError should preserve the original status code and keep
+    message/request/response fields consistent after super().__init__().
+    """
+    import litellm
+    from httpx import Request, Response
 
+    # 1) Wrapping a 429 should preserve the 429 status
+    original_req = Request("POST", "https://api.openai.com/v1/chat/completions")
+    original_resp = Response(status_code=429, request=original_req)
+
+    rate_limit_error = litellm.RateLimitError(
+        message="Rate limit exceeded",
+        llm_provider="openai",
+        model="gpt-4o-mini",
+        response=original_resp,
+    )
+
+    midstream_error = litellm.exceptions.MidStreamFallbackError(
+        message="stream broke",
+        model="gpt-4o-mini",
+        llm_provider="openai",
+        original_exception=rate_limit_error,
+    )
+
+    assert midstream_error.status_code == 429
+    assert midstream_error.response.status_code == 429
+    assert str(midstream_error.response.request.url) == "https://openai.com/v1/"
+    assert midstream_error.message == "litellm.MidStreamFallbackError: stream broke"
+    assert midstream_error.args == ("litellm.MidStreamFallbackError: stream broke",)
+
+    # 2) With no original exception, should default to 503
+    midstream_fallback = litellm.exceptions.MidStreamFallbackError(
+        message="stream broke without original",
+        model="gpt-4o-mini",
+        llm_provider="openai",
+        original_exception=None,
+    )
+
+    assert midstream_fallback.status_code == 503
+    assert midstream_fallback.response.status_code == 503
+    assert str(midstream_fallback.response.request.url) == "https://openai.com/v1/"


### PR DESCRIPTION


- Updated MidStreamFallbackError to retrieve and maintain the original status code from the wrapped exception.
- Ensured that message, request, and response fields remain consistent after calling the parent constructor.
- Added unit tests to verify the correct propagation of status codes and attributes in various scenarios.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
