### PR TITLE
fix(openai): pass extra_headers to image generation API calls

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -483,6 +483,7 @@ def image_generation(  # noqa: PLR0915
                 organization=organization,
                 aimg_generation=aimg_generation,
                 client=client,
+                headers=headers,
             )
         elif custom_llm_provider == "bedrock":
             if model is None:

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1401,6 +1401,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         client=None,
         max_retries=None,
         organization: Optional[str] = None,
+        headers: Optional[dict] = None,
     ):
         response = None
         try:
@@ -1413,6 +1414,9 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 organization=organization,
                 client=client,
             )
+
+            if headers:
+                data["extra_headers"] = headers
 
             response = await openai_aclient.images.generate(**data, timeout=timeout)  # type: ignore
             stringified_response = response.model_dump()
@@ -1446,6 +1450,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         client=None,
         aimg_generation=None,
         organization: Optional[str] = None,
+        headers: Optional[dict] = None,
     ) -> ImageResponse:
         data = {}
         try:
@@ -1455,7 +1460,10 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 raise OpenAIError(status_code=422, message="max retries must be an int")
 
             if aimg_generation is True:
-                return self.aimage_generation(data=data, prompt=prompt, logging_obj=logging_obj, model_response=model_response, api_base=api_base, api_key=api_key, timeout=timeout, client=client, max_retries=max_retries, organization=organization)  # type: ignore
+                return self.aimage_generation(data=data, prompt=prompt, logging_obj=logging_obj, model_response=model_response, api_base=api_base, api_key=api_key, timeout=timeout, client=client, max_retries=max_retries, organization=organization, headers=headers)  # type: ignore
+
+            if headers:
+                data["extra_headers"] = headers
 
             openai_client: OpenAI = self._get_openai_client(  # type: ignore
                 is_async=False,

--- a/tests/test_litellm/llms/openai/image_generation/test_openai_image_generation_extra_headers.py
+++ b/tests/test_litellm/llms/openai/image_generation/test_openai_image_generation_extra_headers.py
@@ -1,0 +1,222 @@
+"""
+Unit tests for extra_headers support in OpenAI image generation.
+
+Verifies that extra_headers passed to litellm.image_generation() are forwarded
+through to the OpenAI SDK's images.generate() call as `extra_headers`.
+
+Ref: https://github.com/BerriAI/litellm/issues/22025
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.openai.openai import OpenAIChatCompletion
+from litellm.types.utils import ImageResponse
+
+
+class TestOpenAIImageGenerationExtraHeaders:
+    """Test that extra_headers are passed through to the OpenAI SDK image generation call."""
+
+    def test_image_generation_passes_extra_headers_sync(self):
+        """
+        Test that headers dict is injected as extra_headers into the
+        data dict used for the sync images.generate() call.
+        """
+        openai_chat_completions = OpenAIChatCompletion()
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "created": 1589478378,
+            "data": [{"url": "https://example.com/image.png", "revised_prompt": "test"}],
+        }
+
+        mock_openai_client = MagicMock()
+        mock_openai_client.images.generate.return_value = mock_response
+        mock_openai_client.api_key = "test-key"
+        mock_openai_client._base_url = MagicMock()
+        mock_openai_client._base_url._uri_reference = "https://api.openai.com"
+
+        extra_headers = {"X-Custom-Header": "custom-value", "X-Another": "another-value"}
+
+        with patch.object(
+            openai_chat_completions,
+            "_get_openai_client",
+            return_value=mock_openai_client,
+        ):
+            openai_chat_completions.image_generation(
+                model="dall-e-3",
+                prompt="a white siamese cat",
+                timeout=600,
+                optional_params={"n": 1, "size": "1024x1024"},
+                logging_obj=MagicMock(),
+                api_key="test-key",
+                api_base="https://api.openai.com",
+                model_response=ImageResponse(),
+                headers=extra_headers,
+            )
+
+        # Verify that images.generate was called with extra_headers in the kwargs
+        call_kwargs = mock_openai_client.images.generate.call_args[1]
+        assert call_kwargs.get("extra_headers") == extra_headers
+
+    def test_image_generation_no_headers_no_extra_headers(self):
+        """
+        Test that when headers is None, extra_headers is NOT injected into
+        the data dict.
+        """
+        openai_chat_completions = OpenAIChatCompletion()
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "created": 1589478378,
+            "data": [{"url": "https://example.com/image.png", "revised_prompt": "test"}],
+        }
+
+        mock_openai_client = MagicMock()
+        mock_openai_client.images.generate.return_value = mock_response
+        mock_openai_client.api_key = "test-key"
+        mock_openai_client._base_url = MagicMock()
+        mock_openai_client._base_url._uri_reference = "https://api.openai.com"
+
+        with patch.object(
+            openai_chat_completions,
+            "_get_openai_client",
+            return_value=mock_openai_client,
+        ):
+            openai_chat_completions.image_generation(
+                model="dall-e-3",
+                prompt="a white siamese cat",
+                timeout=600,
+                optional_params={"n": 1, "size": "1024x1024"},
+                logging_obj=MagicMock(),
+                api_key="test-key",
+                api_base="https://api.openai.com",
+                model_response=ImageResponse(),
+                headers=None,
+            )
+
+        # Verify that extra_headers was NOT passed
+        call_kwargs = mock_openai_client.images.generate.call_args[1]
+        assert "extra_headers" not in call_kwargs
+
+    def test_image_generation_empty_headers_no_extra_headers(self):
+        """
+        Test that when headers is an empty dict, extra_headers is NOT
+        injected into the data dict.
+        """
+        openai_chat_completions = OpenAIChatCompletion()
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "created": 1589478378,
+            "data": [{"url": "https://example.com/image.png", "revised_prompt": "test"}],
+        }
+
+        mock_openai_client = MagicMock()
+        mock_openai_client.images.generate.return_value = mock_response
+        mock_openai_client.api_key = "test-key"
+        mock_openai_client._base_url = MagicMock()
+        mock_openai_client._base_url._uri_reference = "https://api.openai.com"
+
+        with patch.object(
+            openai_chat_completions,
+            "_get_openai_client",
+            return_value=mock_openai_client,
+        ):
+            openai_chat_completions.image_generation(
+                model="dall-e-3",
+                prompt="a white siamese cat",
+                timeout=600,
+                optional_params={"n": 1, "size": "1024x1024"},
+                logging_obj=MagicMock(),
+                api_key="test-key",
+                api_base="https://api.openai.com",
+                model_response=ImageResponse(),
+                headers={},
+            )
+
+        # Verify that extra_headers was NOT passed (empty dict is falsy)
+        call_kwargs = mock_openai_client.images.generate.call_args[1]
+        assert "extra_headers" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_aimage_generation_passes_extra_headers(self):
+        """
+        Test that headers dict is injected as extra_headers into the
+        data dict used for the async images.generate() call.
+        """
+        openai_chat_completions = OpenAIChatCompletion()
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "created": 1589478378,
+            "data": [{"url": "https://example.com/image.png", "revised_prompt": "test"}],
+        }
+
+        mock_openai_aclient = MagicMock()
+        mock_openai_aclient.images.generate = AsyncMock(return_value=mock_response)
+        mock_openai_aclient.api_key = "test-key"
+        mock_openai_aclient._base_url = MagicMock()
+        mock_openai_aclient._base_url._uri_reference = "https://api.openai.com"
+
+        extra_headers = {"X-Custom-Header": "custom-value"}
+
+        with patch.object(
+            openai_chat_completions,
+            "_get_openai_client",
+            return_value=mock_openai_aclient,
+        ):
+            await openai_chat_completions.aimage_generation(
+                prompt="a white siamese cat",
+                data={"model": "dall-e-3", "prompt": "a white siamese cat", "n": 1},
+                model_response=ImageResponse(),
+                timeout=600,
+                logging_obj=MagicMock(),
+                api_key="test-key",
+                api_base="https://api.openai.com",
+                headers=extra_headers,
+            )
+
+        # Verify that images.generate was called with extra_headers
+        call_kwargs = mock_openai_aclient.images.generate.call_args[1]
+        assert call_kwargs.get("extra_headers") == extra_headers
+
+
+class TestImageGenerationMainExtraHeaders:
+    """
+    Test that litellm.image_generation() passes extra_headers through
+    to the OpenAI provider path.
+    """
+
+    @patch("litellm.images.main.openai_chat_completions")
+    def test_image_generation_main_passes_headers_to_openai(
+        self, mock_openai_chat_completions
+    ):
+        """
+        Test that the OpenAI branch in images/main.py passes the merged
+        headers (including extra_headers) to the OpenAI image_generation call.
+        """
+        import litellm
+
+        mock_openai_chat_completions.image_generation.return_value = ImageResponse(
+            created=1589478378,
+            data=[],
+        )
+
+        extra_headers = {"X-Custom-Header": "custom-value"}
+
+        litellm.image_generation(
+            model="dall-e-3",
+            prompt="a white siamese cat",
+            extra_headers=extra_headers,
+        )
+
+        # Verify the OpenAI provider's image_generation was called with headers
+        call_kwargs = mock_openai_chat_completions.image_generation.call_args[1]
+        assert "headers" in call_kwargs
+        assert call_kwargs["headers"]["X-Custom-Header"] == "custom-value"


### PR DESCRIPTION
## Summary
- Fixes #22025
- `extra_headers` were correctly prepared in `images/main.py` but never forwarded to the OpenAI image generation API call
- Added `headers` parameter to `OpenAIChatCompletion.image_generation()` and `aimage_generation()` methods
- Inject headers as `extra_headers` in the request data dict (matching the pattern used by `completion()`)
- Pass `headers` from the OpenAI branch in `images/main.py`

## Changes
- **`litellm/llms/openai/openai.py`**: Added `headers: Optional[dict] = None` parameter to both `image_generation()` and `aimage_generation()`. When headers are present, they are injected as `data["extra_headers"]` which the OpenAI SDK passes as HTTP headers on the request. Also forward `headers` from `image_generation()` to `aimage_generation()` for the async path.
- **`litellm/images/main.py`**: Pass the merged `headers` dict (which includes `extra_headers`) to `openai_chat_completions.image_generation()` in the OpenAI provider branch.
- **`tests/test_litellm/llms/openai/image_generation/test_openai_image_generation_extra_headers.py`**: Added 5 unit tests covering sync, async, None headers, empty headers, and end-to-end flow from `litellm.image_generation()`.

## Test plan
- [x] `test_image_generation_passes_extra_headers_sync` - verifies sync path injects extra_headers
- [x] `test_image_generation_no_headers_no_extra_headers` - verifies None headers are not injected
- [x] `test_image_generation_empty_headers_no_extra_headers` - verifies empty dict headers are not injected
- [x] `test_aimage_generation_passes_extra_headers` - verifies async path injects extra_headers
- [x] `test_image_generation_main_passes_headers_to_openai` - verifies end-to-end from litellm.image_generation()

🤖 Generated with [Claude Code](https://claude.com/claude-code)