### PR TITLE
fix: preserve anthropic-beta headers for ARN-based Bedrock inference profiles

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1355,7 +1355,7 @@ class AmazonConverseConfig(BaseConfig):
         # Set anthropic_beta in additional_request_params if we have any beta features
         # ONLY apply to Anthropic/Claude models - other models (e.g., Qwen, Llama) don't support this field
         base_model = BedrockModelInfo.get_base_model(model)
-        if anthropic_beta_list and base_model.startswith("anthropic"):
+        if anthropic_beta_list and (base_model.startswith("anthropic") or "arn:aws:bedrock" in model.lower()):
             additional_request_params["anthropic_beta"] = anthropic_beta_list
 
         return bedrock_tools, anthropic_beta_list

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -3479,3 +3479,101 @@ class TestBedrockMinThinkingBudgetTokens:
             drop_params=False,
         )
         assert "thinking" not in result or result.get("thinking") is None
+
+
+class TestProcessToolsAndBetaARN:
+    """
+    Tests for _process_tools_and_beta with ARN-based Bedrock inference profiles.
+
+    Verifies fix for https://github.com/BerriAI/litellm/issues/22016
+    where anthropic-beta headers were dropped for ARN-based inference profiles
+    because get_base_model() returns an opaque profile ID instead of 'anthropic.claude-*'.
+    """
+
+    def _make_tool(self):
+        return {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                },
+            },
+        }
+
+    def test_arn_model_preserves_anthropic_beta_headers(self):
+        """
+        ARN-based inference profiles should still get anthropic_beta headers
+        even though get_base_model() does not return an 'anthropic.*' string.
+        """
+        config = AmazonConverseConfig()
+        headers = {"anthropic-beta": "prompt-caching-2024-07-31"}
+        additional_request_params: dict = {}
+
+        bedrock_tools, beta_list = config._process_tools_and_beta(
+            original_tools=[self._make_tool()],
+            model="arn:aws:bedrock:us-east-1:123456789012:inference-profile/some-opaque-profile-id",
+            headers=headers,
+            additional_request_params=additional_request_params,
+        )
+
+        assert "prompt-caching-2024-07-31" in beta_list
+        assert "anthropic_beta" in additional_request_params
+        assert "prompt-caching-2024-07-31" in additional_request_params["anthropic_beta"]
+
+    def test_standard_anthropic_model_preserves_anthropic_beta_headers(self):
+        """
+        Standard anthropic.claude-* models should continue to receive anthropic_beta headers.
+        """
+        config = AmazonConverseConfig()
+        headers = {"anthropic-beta": "prompt-caching-2024-07-31"}
+        additional_request_params: dict = {}
+
+        bedrock_tools, beta_list = config._process_tools_and_beta(
+            original_tools=[self._make_tool()],
+            model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+            headers=headers,
+            additional_request_params=additional_request_params,
+        )
+
+        assert "prompt-caching-2024-07-31" in beta_list
+        assert "anthropic_beta" in additional_request_params
+
+    def test_non_anthropic_model_does_not_get_anthropic_beta_headers(self):
+        """
+        Non-Anthropic models (e.g. meta.llama) should NOT receive anthropic_beta headers
+        even if the header is present in the request.
+        """
+        config = AmazonConverseConfig()
+        headers = {"anthropic-beta": "prompt-caching-2024-07-31"}
+        additional_request_params: dict = {}
+
+        bedrock_tools, beta_list = config._process_tools_and_beta(
+            original_tools=[self._make_tool()],
+            model="meta.llama3-2-11b-instruct-v1:0",
+            headers=headers,
+            additional_request_params=additional_request_params,
+        )
+
+        assert "prompt-caching-2024-07-31" in beta_list
+        assert "anthropic_beta" not in additional_request_params
+
+    def test_arn_model_with_bedrock_prefix_preserves_anthropic_beta(self):
+        """
+        ARN models passed with a 'bedrock/' prefix should still get anthropic_beta headers.
+        """
+        config = AmazonConverseConfig()
+        headers = {"anthropic-beta": "prompt-caching-2024-07-31"}
+        additional_request_params: dict = {}
+
+        bedrock_tools, beta_list = config._process_tools_and_beta(
+            original_tools=[self._make_tool()],
+            model="bedrock/converse/arn:aws:bedrock:us-west-2:123456789012:inference-profile/my-profile",
+            headers=headers,
+            additional_request_params=additional_request_params,
+        )
+
+        assert "prompt-caching-2024-07-31" in beta_list
+        assert "anthropic_beta" in additional_request_params


### PR DESCRIPTION
## Summary

Fixes #22016

- `_process_tools_and_beta()` in `converse_transformation.py` checked `base_model.startswith("anthropic")` to decide whether to apply `anthropic_beta` headers
- For ARN-based Bedrock inference profiles, `get_base_model()` returns an opaque profile ID (e.g. `some-opaque-profile-id`) instead of `anthropic.claude-*`, causing the headers to be silently dropped
- Added a fallback check for `"arn:aws:bedrock"` in the raw model string so ARN-based profiles still receive the `anthropic_beta` headers

## Test plan

- [x] Added 4 unit tests in `TestProcessToolsAndBetaARN` covering:
  - ARN model preserves anthropic-beta headers
  - Standard `anthropic.claude-*` model still works (regression)
  - Non-Anthropic model (e.g. `meta.llama`) does NOT get anthropic-beta headers (regression)
  - ARN model with `bedrock/converse/` prefix preserves headers
- [x] All tests pass locally via `pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py::TestProcessToolsAndBetaARN -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)