### PR TITLE
fix: stop injecting effort beta header for output_config (#22213)

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -241,13 +241,6 @@ class AnthropicModelInfo(BaseLLMModelInfo):
             if reasoning_effort and isinstance(reasoning_effort, str):
                 return True
 
-        # Check if output_config is directly provided
-        output_config = optional_params.get("output_config")
-        if output_config and isinstance(output_config, dict):
-            effort = output_config.get("effort")
-            if effort and isinstance(effort, str):
-                return True
-
         return False
 
     def is_code_execution_tool_used(self, tools: Optional[List]) -> bool:


### PR DESCRIPTION
## Summary
- Remove the `output_config` check from `AnthropicModelInfo.is_effort_used()` so the `effort-2025-11-24` beta header is only injected for Opus 4.5's `reasoning_effort` parameter, not for the `output_config.effort` parameter used by Claude 4.6 models
- Update `test_effort_beta_header_injection` to assert the corrected behavior (output_config does not trigger the header, reasoning_effort on Opus 4.5 does)
- Add `test_output_config_effort_no_beta_header_for_claude_46` to verify multiple 4.6 model names are unaffected

Fixes #22213

## Test plan
- [x] `test_effort_beta_header_injection` -- verifies output_config.effort returns `is_effort_used=False` and Opus 4.5 reasoning_effort returns `True`
- [x] `test_output_config_effort_no_beta_header_for_claude_46` -- verifies multiple 4.6 model strings do not trigger the beta header
- [x] All 11 existing effort-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)