### PR TITLE
fix(anthropic): restrict effort='max' to Opus 4.6 only

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -186,6 +186,23 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             )
         )
 
+    @staticmethod
+    def _is_opus_4_6_model(model: str) -> bool:
+        """Check if the model is specifically Claude Opus 4.6.
+
+        Used for features exclusive to Opus 4.6 (e.g. effort='max').
+        """
+        model_lower = model.lower()
+        return any(
+            model_variant in model_lower
+            for model_variant in (
+                "opus-4-6",
+                "opus_4_6",
+                "opus-4.6",
+                "opus_4.6",
+            )
+        )
+
     def get_supported_openai_params(self, model: str):
         params = [
             "stream",
@@ -1392,9 +1409,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     raise ValueError(
                         f"Invalid effort value: {effort}. Must be one of: 'high', 'medium', 'low', 'max'"
                     )
-                if effort == "max" and not self._is_claude_4_6_model(model):
+                if effort == "max" and not self._is_opus_4_6_model(model):
                     raise ValueError(
-                        f"effort='max' is only supported by Claude 4.6 models (Opus 4.6, Sonnet 4.6). Got model: {model}"
+                        f"effort='max' is only supported by Claude Opus 4.6. Got model: {model}"
                     )
                 data["output_config"] = output_config
 

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1662,7 +1662,7 @@ def test_max_effort_rejected_for_opus_45():
 
     messages = [{"role": "user", "content": "Test"}]
 
-    with pytest.raises(ValueError, match="effort='max' is only supported by Claude 4.6 models"):
+    with pytest.raises(ValueError, match="effort='max' is only supported by Claude Opus 4.6"):
         optional_params = {"output_config": {"effort": "max"}}
         config.transform_request(
             model="claude-opus-4-5-20251101",
@@ -1671,6 +1671,61 @@ def test_max_effort_rejected_for_opus_45():
             litellm_params={},
             headers={}
         )
+
+
+def test_max_effort_rejected_for_sonnet_46():
+    """Test that effort='max' is rejected for Sonnet 4.6 -- max is Opus 4.6 only.
+
+    Fixes https://github.com/BerriAI/litellm/issues/22214
+    """
+    config = AnthropicConfig()
+
+    messages = [{"role": "user", "content": "Test"}]
+
+    sonnet_variants = [
+        "claude-sonnet-4-6-20260205",
+        "claude-sonnet-4.6",
+        "claude-sonnet_4_6",
+    ]
+    for model in sonnet_variants:
+        with pytest.raises(
+            ValueError,
+            match="effort='max' is only supported by Claude Opus 4.6",
+        ):
+            optional_params = {"output_config": {"effort": "max"}}
+            config.transform_request(
+                model=model,
+                messages=messages,
+                optional_params=optional_params,
+                litellm_params={},
+                headers={},
+            )
+
+
+def test_max_effort_accepted_for_opus_46():
+    """Test that effort='max' is accepted for all Opus 4.6 name variants.
+
+    Fixes https://github.com/BerriAI/litellm/issues/22214
+    """
+    config = AnthropicConfig()
+
+    messages = [{"role": "user", "content": "Test"}]
+
+    opus_variants = [
+        "claude-opus-4-6-20260205",
+        "claude-opus-4.6",
+        "claude-opus_4_6",
+    ]
+    for model in opus_variants:
+        optional_params = {"output_config": {"effort": "max"}}
+        result = config.transform_request(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+        assert result["output_config"]["effort"] == "max"
 
 
 def test_effort_with_other_features():


### PR DESCRIPTION
## Relevant issues

Fixes #22214

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The `effort="max"` client-side guard in `AnthropicConfig.transform_request()` was using `_is_claude_4_6_model()`, which matches **both** Sonnet 4.6 and Opus 4.6. Per the [Anthropic API docs](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#adaptive-thinking), `effort='max'` is **Opus 4.6 only**.

### What changed

- **Added** `_is_opus_4_6_model()` static method that checks only for Opus 4.6 model name variants (`opus-4-6`, `opus_4_6`, `opus-4.6`, `opus_4.6`)
- **Changed** the `effort='max'` guard (line ~1395) to use the new Opus-only check instead of `_is_claude_4_6_model()`
- **Updated** error message to: `"effort='max' is only supported by Claude Opus 4.6. Got model: {model}"`
- **Added tests** verifying:
  - `effort="max"` with Opus 4.6 model variants does NOT raise
  - `effort="max"` with Sonnet 4.6 model variants DOES raise `ValueError`