### PR TITLE
fix: prevent root-level OAuth endpoints from auto-resolving to unrelated MCP servers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -132,20 +132,16 @@ def _resolve_oauth2_server_for_root_endpoints(
     """
     Resolve the MCP server for root-level OAuth endpoints (no server name in path).
 
-    When the MCP SDK hits root-level endpoints like /register, /authorize, /token
-    without a server name prefix, we try to find the right server automatically.
-    Returns the server if exactly one OAuth2 server is configured, else None.
-    """
-    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-        global_mcp_server_manager,
-    )
+    Root-level endpoints (e.g., /register, /authorize, /token) should NOT
+    auto-resolve to any server. Clients must use server-specific paths
+    (e.g., /{server_name}/authorize) to avoid returning OAuth metadata from
+    an unrelated server, which pollutes non-OAuth server responses.
 
-    registry = global_mcp_server_manager.get_filtered_registry(client_ip=client_ip)
-    oauth2_servers = [
-        s for s in registry.values() if s.auth_type == MCPAuth.oauth2
-    ]
-    if len(oauth2_servers) == 1:
-        return oauth2_servers[0]
+    Always returns None. Callers fall through to the appropriate default
+    behaviour (404 or dummy response) when no server name is present.
+
+    See: https://github.com/BerriAI/litellm/issues/22075
+    """
     return None
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1259,7 +1259,7 @@ def _create_oauth2_server(
 
 @pytest.mark.asyncio
 async def test_authorize_root_resolves_single_oauth2_server():
-    """When /authorize is hit without server name and exactly 1 OAuth2 server exists, resolve it."""
+    """When /authorize is hit without server name, return 404 even if 1 OAuth2 server exists (fixes #22075)."""
     try:
         from fastapi import Request
 
@@ -1281,25 +1281,17 @@ async def test_authorize_root_resolves_single_oauth2_server():
     mock_request.headers = {}
 
     try:
-        with patch(
-            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper"
-        ) as mock_encrypt:
-            mock_encrypt.return_value = "mocked_encrypted_state"
-
-            # Call /authorize WITHOUT mcp_server_name, with dummy_client as client_id
-            response = await authorize(
+        # Call /authorize WITHOUT mcp_server_name -- should NOT auto-resolve
+        with pytest.raises(HTTPException) as exc_info:
+            await authorize(
                 request=mock_request,
                 client_id="dummy_client",
                 mcp_server_name=None,
                 redirect_uri="http://localhost:62646/callback",
                 state="test_state",
             )
-
-        # Should resolve to the single OAuth2 server and redirect
-        assert response.status_code == 307
-        location = response.headers["location"]
-        assert "https://provider.com/oauth/authorize" in location
-        assert "client_id=test_client_id" in location
+        assert exc_info.value.status_code == 404
+        assert "MCP server not found" in str(exc_info.value.detail)
     finally:
         global_mcp_server_manager.registry.clear()
 
@@ -1350,7 +1342,7 @@ async def test_authorize_root_fails_with_multiple_oauth2_servers():
 
 @pytest.mark.asyncio
 async def test_token_root_resolves_single_oauth2_server():
-    """When /token is hit without server name and exactly 1 OAuth2 server exists, resolve it."""
+    """When /token is hit without server name, return 404 even if 1 OAuth2 server exists (fixes #22075)."""
     try:
         from fastapi import Request
 
@@ -1371,25 +1363,10 @@ async def test_token_root_resolves_single_oauth2_server():
     mock_request.base_url = "https://llm.example.com/"
     mock_request.headers = {}
 
-    mock_response = MagicMock()
-    mock_response.json.return_value = {
-        "access_token": "ya29.test_token",
-        "token_type": "Bearer",
-        "expires_in": 3599,
-    }
-    mock_response.raise_for_status = MagicMock()
-
-    mock_async_client = MagicMock()
-    mock_async_client.post = AsyncMock(return_value=mock_response)
-
     try:
-        with patch(
-            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client"
-        ) as mock_get_client:
-            mock_get_client.return_value = mock_async_client
-
-            # Call /token WITHOUT mcp_server_name
-            response = await token_endpoint(
+        # Call /token WITHOUT mcp_server_name -- should NOT auto-resolve
+        with pytest.raises(HTTPException) as exc_info:
+            await token_endpoint(
                 request=mock_request,
                 grant_type="authorization_code",
                 code="test_auth_code",
@@ -1399,23 +1376,15 @@ async def test_token_root_resolves_single_oauth2_server():
                 client_secret=None,
                 code_verifier="test_verifier",
             )
-
-        # Should resolve and exchange token with the upstream server
-        import json
-
-        token_data = json.loads(response.body)
-        assert token_data["access_token"] == "ya29.test_token"
-
-        # Verify it called the correct upstream token URL
-        call_args = mock_async_client.post.call_args
-        assert call_args.args[0] == "https://provider.com/oauth/token"
+        assert exc_info.value.status_code == 404
+        assert "MCP server not found" in str(exc_info.value.detail)
     finally:
         global_mcp_server_manager.registry.clear()
 
 
 @pytest.mark.asyncio
 async def test_register_root_resolves_single_oauth2_server():
-    """When /register is hit without server name and exactly 1 OAuth2 server exists, resolve it."""
+    """When /register is hit without server name, return dummy even if 1 OAuth2 server exists (fixes #22075)."""
     try:
         from fastapi import Request
 
@@ -1443,8 +1412,9 @@ async def test_register_root_resolves_single_oauth2_server():
         ):
             result = await register_client(request=mock_request, mcp_server_name=None)
 
-        # Should resolve to the single server and return its name as client_id
-        assert result["client_id"] == "test_oauth"
+        # Should NOT resolve to any server; returns dummy response
+        assert result["client_id"] == "dummy_client"
+        assert result["client_secret"] == "dummy"
         assert "redirect_uris" in result
     finally:
         global_mcp_server_manager.registry.clear()
@@ -1452,7 +1422,7 @@ async def test_register_root_resolves_single_oauth2_server():
 
 @pytest.mark.asyncio
 async def test_discovery_root_includes_server_name_prefix():
-    """When root discovery is hit and exactly 1 OAuth2 server exists, include server name in URLs."""
+    """When root discovery is hit, do NOT auto-resolve even if 1 OAuth2 server exists (fixes #22075)."""
     try:
         from fastapi import Request
 
@@ -1480,11 +1450,11 @@ async def test_discovery_root_includes_server_name_prefix():
             mcp_server_name=None,
         )
 
-        # Should resolve to the single server and include its name in endpoint URLs
-        assert "/test_oauth/authorize" in response["authorization_endpoint"]
-        assert "/test_oauth/token" in response["token_endpoint"]
-        assert "/test_oauth/register" in response["registration_endpoint"]
-        assert response["scopes_supported"] == ["read", "write"]
+        # Should NOT resolve to any server -- endpoints use generic root paths
+        assert response["authorization_endpoint"] == "https://llm.example.com/authorize"
+        assert response["token_endpoint"] == "https://llm.example.com/token"
+        assert response["registration_endpoint"] == "https://llm.example.com/register"
+        assert response["scopes_supported"] == []
     finally:
         global_mcp_server_manager.registry.clear()
 
@@ -1664,5 +1634,97 @@ async def test_oauth_authorize_prefers_request_scope_over_server_config():
         # Should use the explicit scope, not server config
         assert response.status_code in (307, 302)
         redirect_url = response.headers["location"]
-        assert "scope=custom_scope1+custom_scope2" in redirect_url or "scope=custom_scope1%20custom_scope2" in redirect_url
+        assert (
+            "scope=custom_scope1+custom_scope2" in redirect_url
+            or "scope=custom_scope1%20custom_scope2" in redirect_url
+        )
         assert "default_scope" not in redirect_url
+
+
+# -------------------------------------------------------------------
+# Tests for _resolve_oauth2_server_for_root_endpoints always returning None
+# (fixes #22075 - root-level endpoints should not auto-resolve)
+# -------------------------------------------------------------------
+
+
+def test_resolve_oauth2_server_for_root_endpoints_returns_none_with_single_server():
+    """
+    _resolve_oauth2_server_for_root_endpoints must return None even when
+    exactly one OAuth2 server is registered, to prevent root-level OAuth
+    discovery from leaking metadata of an unrelated server.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/22075
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            _resolve_oauth2_server_for_root_endpoints,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    global_mcp_server_manager.registry.clear()
+    oauth2_server = _create_oauth2_server()
+    global_mcp_server_manager.registry[oauth2_server.server_id] = oauth2_server
+
+    try:
+        result = _resolve_oauth2_server_for_root_endpoints(client_ip=None)
+        assert result is None, (
+            "_resolve_oauth2_server_for_root_endpoints should always return None "
+            "so that root-level endpoints do not leak OAuth metadata from unrelated servers"
+        )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+
+def test_resolve_oauth2_server_for_root_endpoints_returns_none_with_no_servers():
+    """
+    _resolve_oauth2_server_for_root_endpoints returns None when no servers exist.
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            _resolve_oauth2_server_for_root_endpoints,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    global_mcp_server_manager.registry.clear()
+
+    result = _resolve_oauth2_server_for_root_endpoints(client_ip=None)
+    assert result is None
+
+
+def test_resolve_oauth2_server_for_root_endpoints_returns_none_with_multiple_servers():
+    """
+    _resolve_oauth2_server_for_root_endpoints returns None when multiple OAuth2 servers exist.
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            _resolve_oauth2_server_for_root_endpoints,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    global_mcp_server_manager.registry.clear()
+    server1 = _create_oauth2_server(
+        server_id="s1", name="s1", server_name="s1", alias="s1"
+    )
+    server2 = _create_oauth2_server(
+        server_id="s2", name="s2", server_name="s2", alias="s2"
+    )
+    global_mcp_server_manager.registry[server1.server_id] = server1
+    global_mcp_server_manager.registry[server2.server_id] = server2
+
+    try:
+        result = _resolve_oauth2_server_for_root_endpoints(client_ip=None)
+        assert result is None
+    finally:
+        global_mcp_server_manager.registry.clear()


### PR DESCRIPTION
## Summary
- `_resolve_oauth2_server_for_root_endpoints` previously auto-resolved to the single OAuth2 server when no server name was in the URL path, causing root-level OAuth discovery endpoints to return metadata from an unrelated server
- Changed the function to always return `None` so root-level endpoints fall through to their default behavior (404 for `/authorize` and `/token`; dummy response for `/register`)
- Clients must now use server-specific paths (e.g., `/{server_name}/authorize`) instead of root-level endpoints

Fixes #22075

## Test plan
- [x] Updated 4 existing tests that expected auto-resolution to now assert correct 404/dummy behavior
- [x] Added 3 new unit tests for `_resolve_oauth2_server_for_root_endpoints` covering single server, no servers, and multiple servers scenarios
- [x] All 42 tests in `test_discoverable_endpoints.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)