### PR TITLE
fix(types): normalize null top_logprobs to [] in ChatCompletionTokenLogprob

### DIFF
--- a/tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
+++ b/tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
@@ -1497,3 +1497,95 @@ def test_convert_to_model_response_object_default_usage_overwritten():
     assert result.usage.prompt_tokens == 15
     assert result.usage.completion_tokens == 7
     assert result.usage.total_tokens == 22
+
+
+def test_convert_to_model_response_object_with_null_top_logprobs():
+    """
+    Test that convert_to_model_response_object handles null top_logprobs
+    without raising a Pydantic validation error.
+
+    Some providers return null for top_logprobs when logprobs=true but
+    top_logprobs is unset/0. The OpenAI spec requires top_logprobs to be
+    an array, so litellm should normalize null to [].
+
+    Regression test for https://github.com/BerriAI/litellm/issues/21932
+    """
+    response_object = {
+        "id": "chatcmpl-a21e454401074fd8814736d84dcbb1e4",
+        "object": "chat.completion",
+        "created": 1771632698,
+        "model": "my-model",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Silent light above.",
+                },
+                "finish_reason": "stop",
+                "logprobs": {
+                    "content": [
+                        {
+                            "token": "Sil",
+                            "bytes": [83, 105, 108],
+                            "logprob": -2.1518118381500244,
+                            "top_logprobs": None,
+                        },
+                        {
+                            "token": "ent",
+                            "bytes": [101, 110, 116],
+                            "logprob": -0.13957086205482483,
+                            "top_logprobs": None,
+                        },
+                        {
+                            "token": " light",
+                            "bytes": [32, 108, 105, 103, 104, 116],
+                            "logprob": -1.3923776149749756,
+                            "top_logprobs": None,
+                        },
+                        {
+                            "token": " above",
+                            "bytes": [32, 97, 98, 111, 118, 101],
+                            "logprob": -1.137486219406128,
+                            "top_logprobs": None,
+                        },
+                        {
+                            "token": ".",
+                            "bytes": [46],
+                            "logprob": -0.1709611415863037,
+                            "top_logprobs": None,
+                        },
+                    ],
+                    "refusal": None,
+                },
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 73,
+            "completion_tokens": 5,
+            "total_tokens": 78,
+        },
+    }
+
+    result = convert_to_model_response_object(
+        model_response_object=ModelResponse(),
+        response_object=response_object,
+        stream=False,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+        hidden_params=None,
+        _response_headers=None,
+        convert_tool_call_to_json_mode=False,
+    )
+
+    assert isinstance(result, ModelResponse)
+    assert len(result.choices) == 1
+
+    choice = result.choices[0]
+    assert choice.logprobs is not None
+    assert len(choice.logprobs.content) == 5
+
+    # Verify all null top_logprobs were normalized to empty lists
+    for token_logprob in choice.logprobs.content:
+        assert token_logprob.top_logprobs == []
+        assert isinstance(token_logprob.top_logprobs, list)


### PR DESCRIPTION
## Relevant issues

Fixes #21932

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

Bug Fix

## Summary

Some OpenAI-compatible providers return `null` for `top_logprobs` when `logprobs=true` but `top_logprobs` is unset or 0. The OpenAI spec requires `top_logprobs` to be `Array<TopLogprob>` (never null), so this triggers Pydantic validation errors (19 errors per response) while parsing responses through the proxy.

The official OpenAI Python SDK also types this field as `List[TopLogprob]` (non-optional), so it would crash too. Since LiteLLM is a multi-provider abstraction layer, it should be defensive against non-conforming providers.

## Changes

Added a Pydantic v2 `field_validator` on `ChatCompletionTokenLogprob.top_logprobs` (in `litellm/types/utils.py`) that normalizes `None` -> `[]` before type validation. This preserves the typed `List[TopLogprob]` contract for downstream consumers while remaining narrowly scoped to null only (other invalid types are still rejected by Pydantic).

The fix is applied at the Pydantic model level rather than in the conversion layer, so it covers all code paths: the main `convert_to_model_response_object` path, the streaming path (`StreamingChoices.__init__`), and any direct construction.

### Files changed

- `litellm/types/utils.py` - added `field_validator` import and null -> [] normalizer on `ChatCompletionTokenLogprob.top_logprobs`
- `tests/test_litellm/types/test_types_utils.py` - 4 new tests (null normalization, valid array passthrough, nested ChoiceLogprobs parsing, invalid type rejection)
- `tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py` - 1 new end-to-end test through `convert_to_model_response_object` with null top_logprobs payload

## Testing

- 37 tests pass (32 existing + 5 new), zero regressions
- Black and Ruff pass on the source file
- Uses Pydantic v2 `field_validator`, consistent with existing `model_validator` usage in the same module