### PR TITLE
[Infra] Add prisma_schema_sync step as prerequisite for e2e UI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4100,6 +4100,63 @@ jobs:
           path: playwright-report
           destination: playwright-report
 
+  prisma_schema_sync:
+    machine:
+      image: ubuntu-2204:2023.10.1
+    resource_class: xlarge
+    working_directory: ~/project
+    steps:
+      - checkout
+      - setup_google_dns
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Load Docker Database Image
+          command: |
+            gunzip -c litellm-docker-database.tar.gz | docker load
+            docker images | grep litellm-docker-database
+      - run:
+          name: Install Neon CLI
+          command: |
+            npm i -g neonctl
+      - run:
+          name: Install curl and dockerize
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y curl
+            sudo wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz
+            sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz
+            sudo rm dockerize-linux-amd64-v0.6.1.tar.gz
+      - run:
+          name: Sync schema on base e2e database
+          command: |
+            BASE_DATABASE_URL=$(neon connection-string \
+              --project-id $NEON_PROJECT_ID \
+              --api-key $NEON_API_KEY \
+              --branch br-fancy-paper-ad1olsb3 \
+              --database-name yuneng-trial-db \
+              --role neondb_owner)
+            docker run -d \
+              -p 4000:4000 \
+              -e DATABASE_URL=$BASE_DATABASE_URL \
+              -e LITELLM_MASTER_KEY="sk-1234" \
+              --name schema-sync \
+              -v $(pwd)/litellm/proxy/example_config_yaml/simple_config.yaml:/app/config.yaml \
+              litellm-docker-database:ci \
+              --config /app/config.yaml \
+              --port 4000 \
+              --use_prisma_db_push
+      - run:
+          name: Start outputting logs
+          command: docker logs -f schema-sync
+          background: true
+      - run:
+          name: Wait for proxy to be ready (schema sync complete)
+          command: dockerize -wait http://localhost:4000 -timeout 5m
+      - run:
+          name: Stop schema sync container
+          command: docker stop schema-sync
+
   test_nonroot_image:
     machine:
       image: ubuntu-2204:2023.10.1
@@ -4298,6 +4355,15 @@ workflows:
               only:
                 - main
                 - /litellm_.*/
+      - prisma_schema_sync:
+          context: e2e_ui_tests
+          requires:
+            - build_docker_database_image
+          filters:
+            branches:
+              only:
+                - main
+                - /litellm_.*/
       - e2e_ui_testing:
           name: e2e_ui_testing_chromium
           browser: chromium
@@ -4305,6 +4371,7 @@ workflows:
           requires:
             - ui_build
             - build_docker_database_image
+            - prisma_schema_sync
           filters:
             branches:
               only:
@@ -4317,6 +4384,7 @@ workflows:
           requires:
             - ui_build
             - build_docker_database_image
+            - prisma_schema_sync
           filters:
             branches:
               only:


### PR DESCRIPTION
## Summary

The e2e UI tests create ephemeral Neon branches from a shared parent branch (`br-fancy-paper-ad1olsb3`). If the parent branch's schema is out of sync, those child branches inherit the stale schema and tests fail.

### Fix

Adds a new `prisma_schema_sync` CircleCI job that runs the proxy with `--use_prisma_db_push` against the parent Neon branch before the e2e UI tests run. This forces a `prisma db push --accept-data-loss` on the parent, ensuring all child branches created by `e2e_ui_testing_chromium` and `e2e_ui_testing_firefox` start with a synced schema.

## Changes

- New `prisma_schema_sync` job: loads Docker database image, gets parent Neon branch connection string, starts proxy with `--use_prisma_db_push`, waits for health, stops container.
- `prisma_schema_sync` is added to the workflow requiring `build_docker_database_image` (with `context: e2e_ui_tests`).
- Both `e2e_ui_testing_chromium` and `e2e_ui_testing_firefox` now require `prisma_schema_sync` to complete first.

## Testing

This is a CI infrastructure change. It will be validated when the pipeline runs on `main` or a `litellm_*` branch.

## Type

🚄 Infrastructure