### PR TITLE
fix: reserve cache_control in DashScopeChatConfig._transform_messages

### DIFF
--- a/litellm/llms/dashscope/chat/transformation.py
+++ b/litellm/llms/dashscope/chat/transformation.py
@@ -5,12 +5,23 @@ Translates from OpenAI's `/v1/chat/completions` to DashScope's `/v1/chat/complet
 from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
 
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.llms.openai import AllMessageValues
+from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
 
 class DashScopeChatConfig(OpenAIGPTConfig):
+    def remove_cache_control_flag_from_messages_and_tools(
+        self,
+        model: str,
+        messages: List[AllMessageValues],
+        tools: Optional[List[ChatCompletionToolParam]] = None,
+    ) -> Tuple[List[AllMessageValues], Optional[List[ChatCompletionToolParam]]]:
+        """
+        DashScope supports cache_control - don't strip it.
+        """
+        return messages, tools
+
     @overload
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: Literal[True]


### PR DESCRIPTION
## Relevant issues

Fixes: DashScope provider strips `cache_control` from messages and tools, causing prompt caching to never take effect.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### Problem

`DashScopeChatConfig` inherits from `OpenAIGPTConfig`, which calls `remove_cache_control_flag_from_messages_and_tools` during `transform_request`. This method recursively strips all `cache_control` fields from messages and tools via `filter_value_from_dict`.

DashScope **does** support `cache_control` for prompt caching, but because the config class did not override this method, `cache_control` was silently removed before the request was sent to the DashScope API — making prompt caching impossible.

Ref: https://help.aliyun.com/zh/model-studio/context-cache#11dae6102439j

### Fix

Override `remove_cache_control_flag_from_messages_and_tools` in `DashScopeChatConfig` to return messages and tools unchanged, preserving `cache_control`. This follows the same pattern used by other providers that support prompt caching:

- `ZAIChatConfig` (`litellm/llms/zai/chat/transformation.py`)
- `MiniMaxChatConfig` (`litellm/llms/minimax/chat/transformation.py`)
- `OpenRouterChatConfig` (`litellm/llms/openrouter/chat/transformation.py`)
- `DatabricksChatConfig` (`litellm/llms/databricks/chat/transformation.py`)

### Files changed

| File | Change |
|------|--------|
| `litellm/llms/dashscope/chat/transformation.py` | Added `remove_cache_control_flag_from_messages_and_tools` override to preserve `cache_control` |
| `tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py` | Added 2 unit tests: one for `cache_control` in messages, one for `cache_control` in tools |

### Testing

- `test_dashscope_preserves_cache_control_in_messages` — verifies `cache_control` is preserved in both top-level message fields and nested content list items
- `test_dashscope_preserves_cache_control_in_tools` — verifies `cache_control` is preserved in tool definitions

All 5 tests pass:

poetry run pytest tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py -v
# 5 passed in 1.03s
