### PR TITLE
fix: base_model cost calculation fails when base_model provider differs from deployment provider

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1093,6 +1093,19 @@ def completion_cost(  # noqa: PLR0915
             router_model_id=router_model_id,
         )
 
+        # When base_model is used and its provider differs from custom_llm_provider,
+        # update custom_llm_provider to match the base_model's provider.
+        # e.g. model="anthropic/gemini-3-flash" (provider=anthropic) with
+        # base_model="gemini/gemini-3-flash-preview" should use provider=gemini
+        # for cost lookup.
+        if base_model is not None and selected_model == base_model:
+            _base_model_provider_prefix = base_model.split("/")[0]
+            if (
+                _base_model_provider_prefix in LlmProvidersSet
+                and _base_model_provider_prefix != custom_llm_provider
+            ):
+                custom_llm_provider = _base_model_provider_prefix
+
         potential_model_names = [
             selected_model,
             _get_response_model(completion_response),

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -17,6 +17,7 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     PassthroughStandardLoggingPayload,
 )
 from litellm.types.utils import LiteLLMBatch, ModelResponse, TextCompletionResponse
+from litellm.utils import _get_base_model_from_metadata
 
 if TYPE_CHECKING:
     from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
@@ -124,10 +125,15 @@ class AnthropicPassthroughLoggingHandler:
             if custom_llm_provider and not model.startswith(f"{custom_llm_provider}/"):
                 model_for_cost = f"{custom_llm_provider}/{model}"
 
+            base_model = _get_base_model_from_metadata(
+                model_call_details=logging_obj.model_call_details
+            )
+
             response_cost = litellm.completion_cost(
                 completion_response=litellm_model_response,
                 model=model_for_cost,
                 custom_llm_provider=custom_llm_provider,
+                base_model=base_model,
             )
 
             kwargs["response_cost"] = response_cost


### PR DESCRIPTION
## Relevant issues

Fixes #22257

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

After `_select_model_name_for_cost_calc()` returns, check if `base_model` was used and its provider differs from `custom_llm_provider`. If so, update `custom_llm_provider`:

```python
selected_model = _select_model_name_for_cost_calc(...)

# When base_model is used and its provider differs from custom_llm_provider,
# update custom_llm_provider to match the base_model's provider.
if base_model is not None and selected_model == base_model:
    _base_model_provider_prefix = base_model.split("/")[0]
    if (
        _base_model_provider_prefix in LlmProvidersSet
        and _base_model_provider_prefix != custom_llm_provider
    ):
        custom_llm_provider = _base_model_provider_prefix
```