### PR TITLE
Fix/claude code plugin schema

### DIFF
--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -1106,7 +1106,7 @@ model LiteLLM_ClaudeCodePluginTable {
   files_json    String?   @default("{}")
   enabled       Boolean   @default(true)
   created_at    DateTime? @default(now())
-  updated_at    DateTime? @default(now())
+  updated_at    DateTime? @default(now()) @updatedAt
   created_by    String?
 
   @@map("LiteLLM_ClaudeCodePluginTable")

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -1096,3 +1096,18 @@ model LiteLLM_AccessGroupTable {
   updated_at         DateTime @default(now()) @updatedAt
   updated_by         String?
 }
+// Claude Code Plugin Marketplace table
+model LiteLLM_ClaudeCodePluginTable {
+  id            String    @id @default(uuid())
+  name          String    @unique
+  version       String?
+  description   String?
+  manifest_json String?
+  files_json    String?   @default("{}")
+  enabled       Boolean   @default(true)
+  created_at    DateTime? @default(now())
+  updated_at    DateTime? @default(now())
+  created_by    String?
+
+  @@map("LiteLLM_ClaudeCodePluginTable")
+}

--- a/schema.prisma
+++ b/schema.prisma
@@ -1106,7 +1106,7 @@ model LiteLLM_ClaudeCodePluginTable {
   files_json    String?   @default("{}")
   enabled       Boolean   @default(true)
   created_at    DateTime? @default(now())
-  updated_at    DateTime? @default(now())
+  updated_at    DateTime? @default(now()) @updatedAt
   created_by    String?
 
   @@map("LiteLLM_ClaudeCodePluginTable")

--- a/schema.prisma
+++ b/schema.prisma
@@ -1096,3 +1096,18 @@ model LiteLLM_AccessGroupTable {
   updated_at         DateTime @default(now()) @updatedAt
   updated_by         String?
 }
+// Claude Code Plugin Marketplace table
+model LiteLLM_ClaudeCodePluginTable {
+  id            String    @id @default(uuid())
+  name          String    @unique
+  version       String?
+  description   String?
+  manifest_json String?
+  files_json    String?   @default("{}")
+  enabled       Boolean   @default(true)
+  created_at    DateTime? @default(now())
+  updated_at    DateTime? @default(now())
+  created_by    String?
+
+  @@map("LiteLLM_ClaudeCodePluginTable")
+}

--- a/tests/litellm/proxy/test_claude_code_marketplace.py
+++ b/tests/litellm/proxy/test_claude_code_marketplace.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.mark.asyncio
+async def test_claude_code_plugin_table_schema_exists():
+    """
+    Test that LiteLLM_ClaudeCodePluginTable is defined in schema.prisma.
+    Regression test for https://github.com/BerriAI/litellm/issues/21310
+    """
+    with open("schema.prisma", "r") as f:
+        schema = f.read()
+    assert "LiteLLM_ClaudeCodePluginTable" in schema, (
+        "LiteLLM_ClaudeCodePluginTable model missing from schema.prisma - "
+        "this causes AttributeError on all /claude-code/plugins endpoints"
+    )
+
+    with open("litellm/proxy/schema.prisma", "r") as f:
+        proxy_schema = f.read()
+    assert "LiteLLM_ClaudeCodePluginTable" in proxy_schema, (
+        "LiteLLM_ClaudeCodePluginTable model missing from litellm/proxy/schema.prisma"
+    )

--- a/tests/litellm/proxy/test_claude_code_marketplace.py
+++ b/tests/litellm/proxy/test_claude_code_marketplace.py
@@ -1,13 +1,9 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 
 @pytest.mark.asyncio
 async def test_claude_code_plugin_table_schema_exists():
-    """
-    Test that LiteLLM_ClaudeCodePluginTable is defined in schema.prisma.
-    Regression test for https://github.com/BerriAI/litellm/issues/21310
-    """
+
     with open("schema.prisma", "r") as f:
         schema = f.read()
     assert "LiteLLM_ClaudeCodePluginTable" in schema, (


### PR DESCRIPTION
## Relevant issues
Fixes #22250

## Problem
- Claude Code Plugin Marketplace endpoints (`/claude-code/marketplace.json`, `/claude-code/plugins`) were returning 500 errors because `LiteLLM_ClaudeCodePluginTable` model was missing from both `schema.prisma` files
- Prisma client was generated without this table causing `AttributeError: 'Prisma' object has no attribute 'litellm_claudecodeplugintable'`

## Fix
- Added missing model definition to root `schema.prisma` and `litellm/proxy/schema.prisma`

## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [ x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type
🐛 Bug Fix

## Changes
- Added `LiteLLM_ClaudeCodePluginTable` Prisma model to `schema.prisma` (root)
- Added `LiteLLM_ClaudeCodePluginTable` Prisma model to `litellm/proxy/schema.prisma`

## Testing
Reproduced and verified fix locally with Postgres + LiteLLM proxy v1.81.12

**Before fix:**
```json
{"detail": {"error": "Failed to generate marketplace: 'Prisma' object has no attribute 'litellm_claudecodeplugintable'"}}
```

**After fix:**
```json
{
  "status": "success",
  "action": "created",
  "plugin": {
    "id": "1c0237fd-7070-4e05-8e76-e3ac63b9e48f",
    "name": "test-plugin",
    "version": "1.0.0",
    "description": "Test plugin",
    "source": {"source": "github", "repo": "org/test"},
    "enabled": true
  }
}
```