### PR TITLE
Fix: Restrict MCP server/access group assignment for non-admins in view_all mode

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -63,6 +63,7 @@ from litellm.proxy.management_helpers.object_permission_utils import (
     _set_object_permission,
     attach_object_permission_to_dict,
     handle_update_object_permission_common,
+    validate_mcp_object_permission_for_key,
 )
 from litellm.proxy.management_helpers.team_member_permission_checks import (
     TeamMemberPermissionChecks,
@@ -619,6 +620,12 @@ async def _common_key_generation_helper(  # noqa: PLR0915
             data_json["metadata"]["tags"] = data_json["tags"]
 
         data_json.pop("tags")
+
+    await validate_mcp_object_permission_for_key(
+        user_api_key_dict=user_api_key_dict,
+        object_permission=data_json.get("object_permission"),
+        prisma_client=prisma_client,
+    )
 
     data_json = await _set_object_permission(
         data_json=data_json,
@@ -1926,6 +1933,13 @@ async def update_key_fn(
             )
 
             # Set Management Endpoint Metadata Fields
+
+        if "object_permission" in data_json:
+            await validate_mcp_object_permission_for_key(
+                user_api_key_dict=user_api_key_dict,
+                object_permission=data_json.get("object_permission"),
+                prisma_client=prisma_client,
+            )
 
         non_default_values = await prepare_key_update_data(
             data=data, existing_key_row=existing_key_row

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -5,12 +5,14 @@ organizations, teams, and keys.
 
 import json
 from litellm._uuid import uuid
-from typing import Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
+if TYPE_CHECKING:
+    from litellm.proxy._types import UserAPIKeyAuth
 
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy.utils import PrismaClient
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
-        
 
 
 async def attach_object_permission_to_dict(
@@ -178,3 +180,154 @@ async def _set_object_permission(
     data_json["object_permission_id"] = created_permission.object_permission_id
     data_json.pop("object_permission")
     return data_json
+
+
+async def get_allowed_mcp_access_groups_for_user(
+    user_api_key_dict: "UserAPIKeyAuth",
+    prisma_client: Optional[PrismaClient],
+) -> Optional[set]:
+    """
+    Return the set of MCP access group IDs the user can assign (via teams or key).
+    Returns None if user is admin (can assign any) or if MCP modules are unavailable.
+    """
+    from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
+
+    if _user_has_admin_view(user_api_key_dict):
+        return None  # Admin can assign any
+
+    try:
+        from litellm.proxy._experimental.mcp_server.ui_session_utils import (
+            build_effective_auth_contexts,
+        )
+        from litellm.proxy.auth.auth_checks import get_team_object
+        from litellm.proxy.proxy_server import user_api_key_cache, proxy_logging_obj
+    except ImportError:
+        return set()  # No MCP - user has no access
+
+    if prisma_client is None or user_api_key_cache is None:
+        return set()
+
+    allowed_access_group_ids: set = set()
+    auth_contexts = await build_effective_auth_contexts(user_api_key_dict)
+
+    for auth_context in auth_contexts:
+        if auth_context.team_id:
+            team_obj = await get_team_object(
+                team_id=auth_context.team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=getattr(
+                    user_api_key_dict, "parent_otel_span", None
+                ),
+                proxy_logging_obj=proxy_logging_obj,
+            )
+            if team_obj and team_obj.object_permission:
+                groups = team_obj.object_permission.mcp_access_groups or []
+                allowed_access_group_ids.update(groups)
+
+    if user_api_key_dict.object_permission:
+        key_groups = user_api_key_dict.object_permission.mcp_access_groups or []
+        allowed_access_group_ids.update(key_groups)
+
+    return allowed_access_group_ids
+
+
+async def validate_mcp_object_permission_for_key(
+    user_api_key_dict: "UserAPIKeyAuth",
+    object_permission: Optional[Union[Dict[str, Any], Any]],
+    prisma_client: Optional[PrismaClient],
+) -> None:
+    """
+    Validate that a non-admin user can only assign MCP servers and access groups
+    they have access to (via their teams or key). With view_all mode, users see
+    all servers but must not be able to assign servers/groups they lack access to.
+
+    Raises:
+        HTTPException: 403 if user tries to assign MCP servers or access groups
+            they do not have access to.
+    """
+    from fastapi import HTTPException, status
+
+    from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
+
+    if object_permission is None:
+        return
+
+    # Admins can assign any MCP servers/groups
+    if _user_has_admin_view(user_api_key_dict):
+        return
+
+    # Extract mcp_servers and mcp_access_groups from object_permission
+    mcp_servers: list = []
+    mcp_access_groups: list = []
+    if isinstance(object_permission, dict):
+        mcp_servers = object_permission.get("mcp_servers") or []
+        mcp_access_groups = object_permission.get("mcp_access_groups") or []
+    else:
+        mcp_servers = getattr(object_permission, "mcp_servers", None) or []
+        mcp_access_groups = getattr(object_permission, "mcp_access_groups", None) or []
+
+    if not mcp_servers and not mcp_access_groups:
+        return
+
+    try:
+        from litellm.proxy._experimental.mcp_server.ui_session_utils import (
+            build_effective_auth_contexts,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+        from litellm.proxy.proxy_server import user_api_key_cache
+    except ImportError:
+        verbose_proxy_logger.debug(
+            "MCP modules not available, skipping MCP object permission validation"
+        )
+        return
+
+    if prisma_client is None or user_api_key_cache is None:
+        return
+
+    allowed_server_ids: set = set()
+    auth_contexts = await build_effective_auth_contexts(user_api_key_dict)
+    for auth_context in auth_contexts:
+        server_ids = await global_mcp_server_manager.get_allowed_mcp_servers(
+            auth_context
+        )
+        allowed_server_ids.update(server_ids)
+
+    allowed_access_group_ids = await get_allowed_mcp_access_groups_for_user(
+        user_api_key_dict=user_api_key_dict,
+        prisma_client=prisma_client,
+    )
+    if allowed_access_group_ids is None:
+        allowed_access_group_ids = set()
+
+    # Validate requested mcp_servers
+    disallowed_servers = [
+        s for s in mcp_servers if s not in allowed_server_ids
+    ]
+    if disallowed_servers:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": (
+                    f"You do not have access to assign the following MCP servers to this key: {disallowed_servers}. "
+                    "You can only assign MCP servers that your teams have access to."
+                )
+            },
+        )
+
+    # Validate requested mcp_access_groups
+    disallowed_groups = [
+        g for g in mcp_access_groups if g not in allowed_access_group_ids
+    ]
+    if disallowed_groups:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": (
+                    f"You do not have access to assign the following MCP access groups to this key: {disallowed_groups}. "
+                    "You can only assign MCP access groups that your teams have access to."
+                )
+            },
+        )


### PR DESCRIPTION
## Relevant issues
With user_mcp_management_mode: view_all, non-admin users could see all MCP servers and access groups in the UI and assign ones they did not have access to when creating or updating keys. For example, a user in a team with no MCP access could still see and select sensitive_group or sensitive_server for a new key.

Cause:

- Assignment validation: Key creation and update did not check that the user’s teams or key had access to the requested mcp_servers and mcp_access_groups before saving.
- Access groups API: GET /v1/mcp/access_groups returned all access groups from config and DB, without filtering by the user’s access.
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
- Validation: Added validate_mcp_object_permission_for_key() to ensure non-admins can only assign MCP servers and access groups they have access to (via teams or key). This runs before key creation and update.
- Filtered access groups: Added get_allowed_mcp_access_groups_for_user() and updated GET /v1/mcp/access_groups so non-admins only receive access groups they can use.
- Admins unchanged: Proxy admins still see and can assign all MCP servers and access groups.