### PR TITLE
feature: support end_user_budget alerts to slack

### DIFF
--- a/litellm/integrations/SlackAlerting/budget_alert_types.py
+++ b/litellm/integrations/SlackAlerting/budget_alert_types.py
@@ -82,6 +82,14 @@ class ProjectBudgetAlert(BaseBudgetAlertType):
         return user_info.token or "default_id"
 
 
+class EndUserBudgetAlert(BaseBudgetAlertType):
+    def get_event_message(self) -> str:
+        return "Customer Budget: "
+
+    def get_id(self, user_info: CallInfo) -> str:
+        return user_info.customer_id or "default_id"
+
+
 def get_budget_alert_type(
     type: Literal[
         "token_budget",
@@ -93,6 +101,7 @@ def get_budget_alert_type(
         "proxy_budget",
         "projected_limit_exceeded",
         "project_budget",
+        "end_user_budget",
     ],
 ) -> BaseBudgetAlertType:
     """Factory function to get the appropriate budget alert type class"""
@@ -107,6 +116,7 @@ def get_budget_alert_type(
         "token_budget": TokenBudgetAlert(),
         "projected_limit_exceeded": ProjectedLimitExceededAlert(),
         "project_budget": ProjectBudgetAlert(),
+        "end_user_budget": EndUserBudgetAlert(),
     }
 
     if type in alert_types:

--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -552,6 +552,7 @@ class SlackAlerting(CustomBatchLogger):
             "proxy_budget",
             "projected_limit_exceeded",
             "project_budget",
+            "end_user_budget",
         ],
         user_info: CallInfo,
     ):

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -928,8 +928,6 @@ async def get_end_user_object(
         return _response
 
     except Exception as e:
-        if isinstance(e, litellm.BudgetExceededError):
-            raise e
         return None
 
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -928,6 +928,11 @@ async def get_end_user_object(
         return _response
 
     except Exception as e:
+        verbose_proxy_logger.exception(
+            "Error getting end user object for end_user_id: %s",
+            end_user_id,
+            e,
+        )
         return None
 
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -363,6 +363,7 @@ async def common_checks(
             await _check_end_user_budget(
                 end_user_obj=end_user_object,
                 route=route,
+                valid_token=valid_token,
                 proxy_logging_obj=proxy_logging_obj,
             )
 
@@ -774,6 +775,7 @@ async def _apply_default_budget_to_end_user(
 async def _check_end_user_budget(
     end_user_obj: LiteLLM_EndUserTable,
     route: str,
+    valid_token: Optional[UserAPIKeyAuth] = None,
     proxy_logging_obj: Optional[ProxyLogging] = None,
 ) -> None:
     """
@@ -786,6 +788,7 @@ async def _check_end_user_budget(
     Args:
         end_user_obj: The end user object to check
         route: The request route
+        valid_token: Optional token for the current request
         proxy_logging_obj: Optional proxy logging object for budget alerts
 
     Raises:
@@ -803,8 +806,9 @@ async def _check_end_user_budget(
 
     # Max budget check — alert + block
     if end_user_budget is not None and end_user_obj.spend > end_user_budget:
-        if proxy_logging_obj is not None:
+        if proxy_logging_obj is not None and valid_token is not None:
             call_info = CallInfo(
+                token=valid_token.token,
                 spend=end_user_obj.spend,
                 max_budget=end_user_budget,
                 soft_budget=end_user_soft_budget,
@@ -828,8 +832,10 @@ async def _check_end_user_budget(
         end_user_soft_budget is not None
         and end_user_obj.spend >= end_user_soft_budget
         and proxy_logging_obj is not None
+        and valid_token is not None
     ):
         call_info = CallInfo(
+            token=valid_token.token,
             spend=end_user_obj.spend,
             max_budget=end_user_budget,
             soft_budget=end_user_soft_budget,

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -927,11 +927,10 @@ async def get_end_user_object(
 
         return _response
 
-    except Exception as e:
+    except Exception:
         verbose_proxy_logger.exception(
             "Error getting end user object for end_user_id: %s",
             end_user_id,
-            e,
         )
         return None
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -359,17 +359,12 @@ async def common_checks(
         )
 
         # 5. If end_user ('user' passed to /chat/completions, /embeddings endpoint) is in budget
-        if (
-            end_user_object is not None
-            and end_user_object.litellm_budget_table is not None
-        ):
-            end_user_budget = end_user_object.litellm_budget_table.max_budget
-            if end_user_budget is not None and end_user_object.spend > end_user_budget:
-                raise litellm.BudgetExceededError(
-                    current_cost=end_user_object.spend,
-                    max_budget=end_user_budget,
-                    message=f"ExceededBudget: End User={end_user_object.user_id} over budget. Spend={end_user_object.spend}, Budget={end_user_budget}",
-                )
+        if end_user_object is not None:
+            await _check_end_user_budget(
+                end_user_obj=end_user_object,
+                route=route,
+                proxy_logging_obj=proxy_logging_obj,
+            )
 
     # 6. [OPTIONAL] If 'enforce_user_param' enabled - did developer pass in 'user' param for openai endpoints
     if (
@@ -776,19 +771,25 @@ async def _apply_default_budget_to_end_user(
     return end_user_obj
 
 
-def _check_end_user_budget(
+async def _check_end_user_budget(
     end_user_obj: LiteLLM_EndUserTable,
     route: str,
+    proxy_logging_obj: Optional[ProxyLogging] = None,
 ) -> None:
     """
     Check if end user is within their budget limit.
 
+    Fires a budget alert (via Slack/webhook) when the max or soft budget is
+    crossed, following the same pattern used by ``_team_max_budget_check`` and
+    ``_team_soft_budget_check``.
+
     Args:
         end_user_obj: The end user object to check
         route: The request route
+        proxy_logging_obj: Optional proxy logging object for budget alerts
 
     Raises:
-        litellm.BudgetExceededError: If end user has exceeded their budget
+        litellm.BudgetExceededError: If end user has exceeded their max budget
     """
     if route in LiteLLMRoutes.info_routes.value:
         return
@@ -796,12 +797,50 @@ def _check_end_user_budget(
     if end_user_obj.litellm_budget_table is None:
         return
 
-    end_user_budget = end_user_obj.litellm_budget_table.max_budget
+    budget_table = end_user_obj.litellm_budget_table
+    end_user_budget = budget_table.max_budget
+    end_user_soft_budget = budget_table.soft_budget
+
+    # Max budget check — alert + block
     if end_user_budget is not None and end_user_obj.spend > end_user_budget:
+        if proxy_logging_obj is not None:
+            call_info = CallInfo(
+                spend=end_user_obj.spend,
+                max_budget=end_user_budget,
+                soft_budget=end_user_soft_budget,
+                customer_id=end_user_obj.user_id,
+                event_group=Litellm_EntityType.END_USER,
+            )
+            asyncio.create_task(
+                proxy_logging_obj.budget_alerts(
+                    type="end_user_budget",
+                    user_info=call_info,
+                )
+            )
         raise litellm.BudgetExceededError(
             current_cost=end_user_obj.spend,
             max_budget=end_user_budget,
             message=f"ExceededBudget: End User={end_user_obj.user_id} over budget. Spend={end_user_obj.spend}, Budget={end_user_budget}",
+        )
+
+    # Soft budget check — alert only, does not block
+    if (
+        end_user_soft_budget is not None
+        and end_user_obj.spend >= end_user_soft_budget
+        and proxy_logging_obj is not None
+    ):
+        call_info = CallInfo(
+            spend=end_user_obj.spend,
+            max_budget=end_user_budget,
+            soft_budget=end_user_soft_budget,
+            customer_id=end_user_obj.user_id,
+            event_group=Litellm_EntityType.END_USER,
+        )
+        asyncio.create_task(
+            proxy_logging_obj.budget_alerts(
+                type="end_user_budget",
+                user_info=call_info,
+            )
         )
 
 
@@ -852,9 +891,6 @@ async def get_end_user_object(
             parent_otel_span=parent_otel_span,
         )
 
-        # Check budget limits
-        _check_end_user_budget(end_user_obj=return_obj, route=route)
-
         return return_obj
 
     # Fetch from database
@@ -882,9 +918,6 @@ async def get_end_user_object(
         await user_api_key_cache.async_set_cache(
             key="end_user_id:{}".format(end_user_id), value=_response.dict()
         )
-
-        # Check budget limits
-        _check_end_user_budget(end_user_obj=_response, route=route)
 
         return _response
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1500,6 +1500,7 @@ class ProxyLogging:
             "proxy_budget",
             "projected_limit_exceeded",
             "project_budget",
+            "end_user_budget",
         ],
         user_info: CallInfo,
     ):

--- a/tests/test_litellm/integrations/SlackAlerting/test_budget_alert_types.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_budget_alert_types.py
@@ -1,4 +1,7 @@
-from litellm.integrations.SlackAlerting.budget_alert_types import SoftBudgetAlert
+from litellm.integrations.SlackAlerting.budget_alert_types import (
+    EndUserBudgetAlert,
+    SoftBudgetAlert,
+)
 from litellm.proxy._types import CallInfo, Litellm_EntityType
 
 
@@ -36,6 +39,46 @@ class TestSoftBudgetAlert:
             token="",
             event_group=Litellm_EntityType.KEY,
         )
-        
+
+        result = alert.get_id(user_info)
+        assert result == "default_id"
+
+
+class TestEndUserBudgetAlert:
+    def test_get_event_message(self):
+        """Test that get_event_message returns the correct customer budget message"""
+        alert = EndUserBudgetAlert()
+        assert alert.get_event_message() == "Customer Budget: "
+
+    def test_get_id_with_customer_id(self):
+        """Test that get_id returns user_info.customer_id when customer_id is provided"""
+        alert = EndUserBudgetAlert()
+        user_info = CallInfo(
+            spend=50.0,
+            customer_id="customer_123",
+            event_group=Litellm_EntityType.END_USER,
+        )
+        result = alert.get_id(user_info)
+        assert result == "customer_123"
+
+    def test_get_id_without_customer_id(self):
+        """Test that get_id returns 'default_id' when customer_id is None"""
+        alert = EndUserBudgetAlert()
+        user_info = CallInfo(
+            spend=50.0,
+            customer_id=None,
+            event_group=Litellm_EntityType.END_USER,
+        )
+        result = alert.get_id(user_info)
+        assert result == "default_id"
+
+    def test_get_id_with_empty_customer_id(self):
+        """Test that get_id returns 'default_id' when customer_id is empty string"""
+        alert = EndUserBudgetAlert()
+        user_info = CallInfo(
+            spend=50.0,
+            customer_id="",
+            event_group=Litellm_EntityType.END_USER,
+        )
         result = alert.get_id(user_info)
         assert result == "default_id"

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1585,6 +1585,7 @@ class TestCheckEndUserBudget:
             spend=150.0,
             litellm_budget_table=LiteLLM_BudgetTable(max_budget=100.0),
         )
+        valid_token = UserAPIKeyAuth(token="hashed-token-123")
         mock_proxy_logging = AsyncMock()
         mock_proxy_logging.budget_alerts = AsyncMock()
 
@@ -1592,6 +1593,7 @@ class TestCheckEndUserBudget:
             await _check_end_user_budget(
                 end_user_obj=end_user_obj,
                 route="/chat/completions",
+                valid_token=valid_token,
                 proxy_logging_obj=mock_proxy_logging,
             )
 
@@ -1602,6 +1604,7 @@ class TestCheckEndUserBudget:
         call_kwargs = mock_proxy_logging.budget_alerts.call_args
         assert call_kwargs.kwargs["type"] == "end_user_budget"
         user_info = call_kwargs.kwargs["user_info"]
+        assert user_info.token == "hashed-token-123"
         assert user_info.spend == 150.0
         assert user_info.max_budget == 100.0
         assert user_info.customer_id == "customer_abc"
@@ -1616,12 +1619,14 @@ class TestCheckEndUserBudget:
             spend=50.0,
             litellm_budget_table=LiteLLM_BudgetTable(max_budget=100.0),
         )
+        valid_token = UserAPIKeyAuth(token="hashed-token-123")
         mock_proxy_logging = AsyncMock()
 
         # Should not raise
         await _check_end_user_budget(
             end_user_obj=end_user_obj,
             route="/chat/completions",
+            valid_token=valid_token,
             proxy_logging_obj=mock_proxy_logging,
         )
 
@@ -1687,6 +1692,7 @@ class TestCheckEndUserBudget:
                 max_budget=200.0, soft_budget=50.0
             ),
         )
+        valid_token = UserAPIKeyAuth(token="hashed-token-123")
         mock_proxy_logging = AsyncMock()
         mock_proxy_logging.budget_alerts = AsyncMock()
 
@@ -1694,6 +1700,7 @@ class TestCheckEndUserBudget:
         await _check_end_user_budget(
             end_user_obj=end_user_obj,
             route="/chat/completions",
+            valid_token=valid_token,
             proxy_logging_obj=mock_proxy_logging,
         )
 
@@ -1704,6 +1711,7 @@ class TestCheckEndUserBudget:
         call_kwargs = mock_proxy_logging.budget_alerts.call_args
         assert call_kwargs.kwargs["type"] == "end_user_budget"
         user_info = call_kwargs.kwargs["user_info"]
+        assert user_info.token == "hashed-token-123"
         assert user_info.spend == 80.0
         assert user_info.soft_budget == 50.0
         assert user_info.max_budget == 200.0
@@ -1721,11 +1729,13 @@ class TestCheckEndUserBudget:
                 max_budget=200.0, soft_budget=50.0
             ),
         )
+        valid_token = UserAPIKeyAuth(token="hashed-token-123")
         mock_proxy_logging = AsyncMock()
 
         await _check_end_user_budget(
             end_user_obj=end_user_obj,
             route="/chat/completions",
+            valid_token=valid_token,
             proxy_logging_obj=mock_proxy_logging,
         )
 
@@ -1742,6 +1752,7 @@ class TestCheckEndUserBudget:
                 max_budget=200.0, soft_budget=100.0
             ),
         )
+        valid_token = UserAPIKeyAuth(token="hashed-token-123")
         mock_proxy_logging = AsyncMock()
         mock_proxy_logging.budget_alerts = AsyncMock()
 
@@ -1749,6 +1760,7 @@ class TestCheckEndUserBudget:
             await _check_end_user_budget(
                 end_user_obj=end_user_obj,
                 route="/chat/completions",
+                valid_token=valid_token,
                 proxy_logging_obj=mock_proxy_logging,
             )
 

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -16,6 +16,8 @@ import pytest
 import litellm
 from litellm.proxy._types import (
     CallInfo,
+    LiteLLM_BudgetTable,
+    LiteLLM_EndUserTable,
     Litellm_EntityType,
     LiteLLM_ObjectPermissionTable,
     LiteLLM_TeamTable,
@@ -29,6 +31,7 @@ from litellm.proxy._types import (
 from litellm.proxy.auth.auth_checks import (
     ExperimentalUIJWTToken,
     _can_object_call_vector_stores,
+    _check_end_user_budget,
     _get_fuzzy_user_object,
     _get_team_db_check,
     _log_budget_lookup_failure,
@@ -59,9 +62,9 @@ def reset_constants_module():
     # Reload modules before test
     importlib.reload(constants)
     importlib.reload(auth_checks)
-    
+
     yield
-    
+
     # Reload modules after test to clean up
     importlib.reload(constants)
     importlib.reload(auth_checks)
@@ -290,12 +293,12 @@ def test_get_cli_jwt_auth_token_custom_expiration(
 
     # Set custom expiration to 48 hours
     monkeypatch.setenv("LITELLM_CLI_JWT_EXPIRATION_HOURS", "48")
-    
+
     # Reload the constants module to pick up the new env var
     importlib.reload(constants)
     # Also reload auth_checks to pick up the new constant value
     importlib.reload(auth_checks)
-    
+
     token = auth_checks.ExperimentalUIJWTToken.get_cli_jwt_auth_token(valid_sso_user_defined_values)
 
     # Decrypt and verify token contents
@@ -1571,3 +1574,188 @@ async def test_common_checks_skip_route_check_for_custom_auth():
     )
 
     assert result is True
+
+class TestCheckEndUserBudget:
+    @pytest.mark.asyncio
+    async def test_budget_alert_fired_when_spend_exceeds_max(self):
+        """Test that budget_alerts is called with type='end_user_budget' when spend > max_budget"""
+        end_user_obj = LiteLLM_EndUserTable(
+            user_id="customer_abc",
+            blocked=False,
+            spend=150.0,
+            litellm_budget_table=LiteLLM_BudgetTable(max_budget=100.0),
+        )
+        mock_proxy_logging = AsyncMock()
+        mock_proxy_logging.budget_alerts = AsyncMock()
+
+        with pytest.raises(litellm.BudgetExceededError):
+            await _check_end_user_budget(
+                end_user_obj=end_user_obj,
+                route="/chat/completions",
+                proxy_logging_obj=mock_proxy_logging,
+            )
+
+        # Allow the asyncio.create_task to run
+        await asyncio.sleep(0.1)
+
+        mock_proxy_logging.budget_alerts.assert_called_once()
+        call_kwargs = mock_proxy_logging.budget_alerts.call_args
+        assert call_kwargs.kwargs["type"] == "end_user_budget"
+        user_info = call_kwargs.kwargs["user_info"]
+        assert user_info.spend == 150.0
+        assert user_info.max_budget == 100.0
+        assert user_info.customer_id == "customer_abc"
+        assert user_info.event_group == Litellm_EntityType.END_USER
+
+    @pytest.mark.asyncio
+    async def test_no_alert_when_under_budget(self):
+        """Test that no alert is fired when spend is under max_budget"""
+        end_user_obj = LiteLLM_EndUserTable(
+            user_id="customer_abc",
+            blocked=False,
+            spend=50.0,
+            litellm_budget_table=LiteLLM_BudgetTable(max_budget=100.0),
+        )
+        mock_proxy_logging = AsyncMock()
+
+        # Should not raise
+        await _check_end_user_budget(
+            end_user_obj=end_user_obj,
+            route="/chat/completions",
+            proxy_logging_obj=mock_proxy_logging,
+        )
+
+        mock_proxy_logging.budget_alerts.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_alert_when_no_proxy_logging_obj(self):
+        """Test that BudgetExceededError is raised even without proxy_logging_obj"""
+        end_user_obj = LiteLLM_EndUserTable(
+            user_id="customer_abc",
+            blocked=False,
+            spend=150.0,
+            litellm_budget_table=LiteLLM_BudgetTable(max_budget=100.0),
+        )
+
+        with pytest.raises(litellm.BudgetExceededError):
+            await _check_end_user_budget(
+                end_user_obj=end_user_obj,
+                route="/chat/completions",
+                proxy_logging_obj=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_skips_check_for_info_routes(self):
+        """Test that budget check is skipped for info routes"""
+        end_user_obj = LiteLLM_EndUserTable(
+            user_id="customer_abc",
+            blocked=False,
+            spend=150.0,
+            litellm_budget_table=LiteLLM_BudgetTable(max_budget=100.0),
+        )
+
+        # Should not raise for info routes
+        await _check_end_user_budget(
+            end_user_obj=end_user_obj,
+            route="/key/info",
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_check_when_no_budget_table(self):
+        """Test that budget check is skipped when litellm_budget_table is None"""
+        end_user_obj = LiteLLM_EndUserTable(
+            user_id="customer_abc",
+            blocked=False,
+            spend=150.0,
+            litellm_budget_table=None,
+        )
+
+        # Should not raise when no budget table
+        await _check_end_user_budget(
+            end_user_obj=end_user_obj,
+            route="/chat/completions",
+        )
+
+    @pytest.mark.asyncio
+    async def test_soft_budget_alert_fired_when_spend_exceeds_soft(self):
+        """Test that a soft budget alert is fired when spend >= soft_budget but under max_budget"""
+        end_user_obj = LiteLLM_EndUserTable(
+            user_id="customer_abc",
+            blocked=False,
+            spend=80.0,
+            litellm_budget_table=LiteLLM_BudgetTable(
+                max_budget=200.0, soft_budget=50.0
+            ),
+        )
+        mock_proxy_logging = AsyncMock()
+        mock_proxy_logging.budget_alerts = AsyncMock()
+
+        # Should not raise (under max_budget)
+        await _check_end_user_budget(
+            end_user_obj=end_user_obj,
+            route="/chat/completions",
+            proxy_logging_obj=mock_proxy_logging,
+        )
+
+        # Allow the asyncio.create_task to run
+        await asyncio.sleep(0.1)
+
+        mock_proxy_logging.budget_alerts.assert_called_once()
+        call_kwargs = mock_proxy_logging.budget_alerts.call_args
+        assert call_kwargs.kwargs["type"] == "end_user_budget"
+        user_info = call_kwargs.kwargs["user_info"]
+        assert user_info.spend == 80.0
+        assert user_info.soft_budget == 50.0
+        assert user_info.max_budget == 200.0
+        assert user_info.customer_id == "customer_abc"
+        assert user_info.event_group == Litellm_EntityType.END_USER
+
+    @pytest.mark.asyncio
+    async def test_no_soft_budget_alert_when_under_soft_budget(self):
+        """Test that no alert is fired when spend is under soft_budget"""
+        end_user_obj = LiteLLM_EndUserTable(
+            user_id="customer_abc",
+            blocked=False,
+            spend=30.0,
+            litellm_budget_table=LiteLLM_BudgetTable(
+                max_budget=200.0, soft_budget=50.0
+            ),
+        )
+        mock_proxy_logging = AsyncMock()
+
+        await _check_end_user_budget(
+            end_user_obj=end_user_obj,
+            route="/chat/completions",
+            proxy_logging_obj=mock_proxy_logging,
+        )
+
+        mock_proxy_logging.budget_alerts.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_max_budget_alert_includes_soft_budget(self):
+        """Test that the max budget alert CallInfo includes soft_budget when set"""
+        end_user_obj = LiteLLM_EndUserTable(
+            user_id="customer_abc",
+            blocked=False,
+            spend=250.0,
+            litellm_budget_table=LiteLLM_BudgetTable(
+                max_budget=200.0, soft_budget=100.0
+            ),
+        )
+        mock_proxy_logging = AsyncMock()
+        mock_proxy_logging.budget_alerts = AsyncMock()
+
+        with pytest.raises(litellm.BudgetExceededError):
+            await _check_end_user_budget(
+                end_user_obj=end_user_obj,
+                route="/chat/completions",
+                proxy_logging_obj=mock_proxy_logging,
+            )
+
+        await asyncio.sleep(0.1)
+
+        # Only the max budget alert fires (raises before reaching soft check)
+        mock_proxy_logging.budget_alerts.assert_called_once()
+        user_info = mock_proxy_logging.budget_alerts.call_args.kwargs["user_info"]
+        assert user_info.soft_budget == 100.0
+        assert user_info.max_budget == 200.0


### PR DESCRIPTION
## Relevant issues

Expected to see slack alerts when my `end_users` are exceeding spend limit when they have a budget attached. But nothing happened, so went into the code to see if we already support alerting for `end_users`. No support for alerting currently, this addresses this. 

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
🐛 Bug Fix


## Changes

Introducing a `end_user_budget` alert to slack for alerting.

Decoupled `_check_end_user_budget` from `get_end_user_object` as they serve different functionality