### PR TITLE
fix(router): sync model name changes across replicas

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6768,7 +6768,12 @@ class Router:
             )
             if _deployment_on_router is not None:
                 # deployment with this model_id exists on the router
-                if deployment.litellm_params == _deployment_on_router.litellm_params:
+                if (
+                    deployment.litellm_params
+                    == _deployment_on_router.litellm_params
+                    and deployment.model_name
+                    == _deployment_on_router.model_name
+                ):
                     # No need to update
                     return None
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6777,7 +6777,7 @@ class Router:
                     # No need to update
                     return None
 
-                # if there is a new litellm param -> then update the deployment
+                # if there is a new litellm param or model name -> then update the deployment
                 # remove the previous deployment
                 removal_idx: Optional[int] = None
                 deployment_id = deployment.model_info.id

--- a/tests/litellm/test_router_upsert_deployment.py
+++ b/tests/litellm/test_router_upsert_deployment.py
@@ -1,0 +1,138 @@
+"""
+Tests for router.upsert_deployment() model name change detection.
+
+Regression tests for https://github.com/BerriAI/litellm/issues/22190
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm.types.router import Deployment, LiteLLM_Params
+
+
+def test_upsert_deployment_detects_model_name_change():
+    """
+    Test that upsert_deployment updates a deployment when model_name changes
+    but litellm_params stay the same.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/22190
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "original-name",
+                "litellm_params": {
+                    "model": "openai/fake-model",
+                    "api_key": "fake-key",
+                    "api_base": "https://example.com",
+                },
+            },
+        ],
+    )
+
+    # Get the deployment to find its model_id
+    deployment = router.get_deployment_by_model_group_name(
+        model_group_name="original-name"
+    )
+    model_id = deployment.model_info.id
+
+    # Upsert with same litellm_params but different model_name
+    result = router.upsert_deployment(
+        deployment=Deployment(
+            model_name="updated-name",
+            litellm_params=deployment.litellm_params,
+            model_info={"id": model_id},
+        )
+    )
+
+    # Should return the deployment (not None) since the name changed
+    assert result is not None
+
+    # Router should still have exactly 1 deployment
+    assert len(router.model_list) == 1
+
+    # The deployment should have the updated name
+    updated = router.get_deployment(model_id=model_id)
+    assert updated is not None
+    assert updated.model_name == "updated-name"
+
+
+def test_upsert_deployment_skips_when_nothing_changed():
+    """
+    Test that upsert_deployment returns None when neither model_name
+    nor litellm_params have changed.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "my-model",
+                "litellm_params": {
+                    "model": "openai/fake-model",
+                    "api_key": "fake-key",
+                    "api_base": "https://example.com",
+                },
+            },
+        ],
+    )
+
+    deployment = router.get_deployment_by_model_group_name(
+        model_group_name="my-model"
+    )
+    model_id = deployment.model_info.id
+
+    # Upsert with identical name and params
+    result = router.upsert_deployment(
+        deployment=Deployment(
+            model_name="my-model",
+            litellm_params=deployment.litellm_params,
+            model_info={"id": model_id},
+        )
+    )
+
+    # Should return None since nothing changed
+    assert result is None
+    assert len(router.model_list) == 1
+
+
+def test_upsert_deployment_detects_litellm_params_change():
+    """
+    Test that upsert_deployment updates a deployment when litellm_params
+    change but model_name stays the same.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "my-model",
+                "litellm_params": {
+                    "model": "openai/fake-model",
+                    "api_key": "old-key",
+                    "api_base": "https://example.com",
+                },
+            },
+        ],
+    )
+
+    deployment = router.get_deployment_by_model_group_name(
+        model_group_name="my-model"
+    )
+    model_id = deployment.model_info.id
+
+    # Upsert with same name but different api_key
+    result = router.upsert_deployment(
+        deployment=Deployment(
+            model_name="my-model",
+            litellm_params=LiteLLM_Params(
+                model="openai/fake-model",
+                api_key="new-key",
+                api_base="https://example.com",
+            ),
+            model_info={"id": model_id},
+        )
+    )
+
+    # Should return the deployment since params changed
+    assert result is not None
+    assert len(router.model_list) == 1


### PR DESCRIPTION
## Relevant issues

Fixes #22190

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
      Link:

- [ ] **CI run for the last commit**  
      Link:

- [ ] **Merge / cherry-pick CI run**  
      Links:

## Type

🐛 Bug Fix

## Changes

`upsert_deployment()` in `router.py` only compared `litellm_params` when deciding whether to update an existing deployment during the 30s polling cycle. If only `model_name` was changed (e.g. via `PATCH /model/{id}/update`), the comparison returned equal and the update was skipped. This caused model name changes to never propagate to other replicas — only a full restart would fix it.

**Fix:** Added `model_name` to the equality check in `upsert_deployment()` so that name-only changes are detected and the deployment is replaced during the next poll.

**Tests added** (`tests/litellm/test_router_upsert_deployment.py`):
- `test_upsert_deployment_detects_model_name_change` — verifies upsert updates when only model_name changes
- `test_upsert_deployment_skips_when_nothing_changed` — verifies no unnecessary updates when nothing changed
- `test_upsert_deployment_detects_litellm_params_change` — verifies existing behavior (param changes) is preserved