### PR TITLE
[Fix] Pass MCP auth headers from request into tool fetch for /v1/responses and chat completions

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -177,6 +177,19 @@ async def aresponses_api_with_mcp(
         "litellm_metadata", {}
     ).get("user_api_key_auth")
 
+    # Extract MCP auth headers from request (for dynamic auth when fetching tools)
+    mcp_auth_header: Optional[str] = None
+    mcp_server_auth_headers: Optional[Dict[str, Dict[str, str]]] = None
+    secret_fields = kwargs.get("secret_fields")
+    if secret_fields and isinstance(secret_fields, dict):
+        from litellm.responses.utils import ResponsesAPIRequestUtils
+
+        mcp_auth_header, mcp_server_auth_headers, _, _ = (
+            ResponsesAPIRequestUtils.extract_mcp_headers_from_request(
+                secret_fields=secret_fields, tools=tools
+            )
+        )
+
     # Get original MCP tools (for events) and OpenAI tools (for LLM) by reusing existing methods
     (
         original_mcp_tools,
@@ -185,6 +198,8 @@ async def aresponses_api_with_mcp(
         user_api_key_auth=user_api_key_auth,
         mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy,
         litellm_trace_id=kwargs.get("litellm_trace_id"),
+        mcp_auth_header=mcp_auth_header,
+        mcp_server_auth_headers=mcp_server_auth_headers,
     )
     openai_tools = LiteLLM_Proxy_MCP_Handler._transform_mcp_tools_to_openai(
         original_mcp_tools
@@ -370,6 +385,8 @@ async def aresponses_api_with_mcp(
                     ) = await LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform(
                         user_api_key_auth=user_api_key_auth,
                         mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy,
+                        mcp_auth_header=mcp_auth_header,
+                        mcp_server_auth_headers=mcp_server_auth_headers,
                     )
                     final_response = (
                         LiteLLM_Proxy_MCP_Handler._add_mcp_output_elements_to_response(

--- a/litellm/responses/mcp/chat_completions_handler.py
+++ b/litellm/responses/mcp/chat_completions_handler.py
@@ -120,7 +120,18 @@ async def acompletion_with_mcp(  # noqa: PLR0915
         (kwargs.get("metadata", {}) or {}).get("user_api_key_auth")
     )
 
-    # Process MCP tools
+    # Extract MCP auth headers before fetching tools (needed for dynamic auth)
+    (
+        mcp_auth_header,
+        mcp_server_auth_headers,
+        oauth2_headers,
+        raw_headers,
+    ) = ResponsesAPIRequestUtils.extract_mcp_headers_from_request(
+        secret_fields=kwargs.get("secret_fields"),
+        tools=tools,
+    )
+
+    # Process MCP tools (pass auth headers for dynamic auth)
     (
         deduplicated_mcp_tools,
         tool_server_map,
@@ -128,6 +139,8 @@ async def acompletion_with_mcp(  # noqa: PLR0915
         user_api_key_auth=user_api_key_auth,
         mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy,
         litellm_trace_id=kwargs.get("litellm_trace_id"),
+        mcp_auth_header=mcp_auth_header,
+        mcp_server_auth_headers=mcp_server_auth_headers,
     )
 
     openai_tools = LiteLLM_Proxy_MCP_Handler._transform_mcp_tools_to_openai(
@@ -141,17 +154,6 @@ async def acompletion_with_mcp(  # noqa: PLR0915
     # Determine if we should auto-execute tools
     should_auto_execute = LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools(
         mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy
-    )
-
-    # Extract MCP auth headers
-    (
-        mcp_auth_header,
-        mcp_server_auth_headers,
-        oauth2_headers,
-        raw_headers,
-    ) = ResponsesAPIRequestUtils.extract_mcp_headers_from_request(
-        secret_fields=kwargs.get("secret_fields"),
-        tools=tools,
     )
 
     # Prepare call parameters

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -130,10 +130,10 @@ class LiteLLM_Proxy_MCP_Handler:
                 server_url = (
                     _tool.get("server_url", "") if isinstance(_tool, dict) else ""
                 )
-        if isinstance(server_url, str) and server_url.startswith(
-            LITELLM_PROXY_MCP_SERVER_URL_PREFIX
-        ):
-            mcp_servers.append(server_url.split("/")[-1])
+                if isinstance(server_url, str) and server_url.startswith(
+                    LITELLM_PROXY_MCP_SERVER_URL_PREFIX
+                ):
+                    mcp_servers.append(server_url.split("/")[-1])
 
         tools = await _get_tools_from_mcp_servers(
             user_api_key_auth=user_api_key_auth,

--- a/tests/mcp_tests/test_aresponses_api_with_mcp.py
+++ b/tests/mcp_tests/test_aresponses_api_with_mcp.py
@@ -3,6 +3,7 @@ import os
 import sys
 import pytest
 from typing import List, Any, cast
+from unittest.mock import AsyncMock, patch
 
 sys.path.insert(0, os.path.abspath("../../.."))
 
@@ -252,6 +253,76 @@ async def test_aresponses_api_with_mcp_mock_integration():
     print(f"Auto-execute enabled: {should_auto_execute}")
     print(f"MCP tools parsed: {len(mcp_parsed)}")
     print(f"Other tools parsed: {len(other_parsed)}")
+
+
+@pytest.mark.asyncio
+async def test_aresponses_api_with_mcp_passes_mcp_server_auth_headers_to_process_tools():
+    """
+    Test that MCP auth headers from secret_fields (e.g. x-mcp-linear_config-authorization)
+    are passed to _process_mcp_tools_without_openai_transform when using the responses API.
+    """
+    from litellm.responses.main import aresponses_api_with_mcp
+
+    captured_process_kwargs = {}
+
+    async def mock_process(**kwargs):
+        captured_process_kwargs.update(kwargs)
+        return ([], {})
+
+    mock_response = ResponsesAPIResponse(
+        **{
+            "id": "resp_test",
+            "object": "response",
+            "created_at": 1234567890,
+            "status": "completed",
+            "error": None,
+            "incomplete_details": None,
+            "instructions": None,
+            "max_output_tokens": None,
+            "model": "gpt-4o",
+            "output": [{"type": "message", "id": "msg_1", "status": "completed", "role": "assistant", "content": []}],
+            "parallel_tool_calls": True,
+            "previous_response_id": None,
+            "reasoning": {"effort": None, "summary": None},
+            "store": True,
+            "temperature": 1.0,
+            "text": {"format": {"type": "text"}},
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": 1.0,
+            "truncation": "disabled",
+            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            "user": None,
+            "metadata": {},
+        }
+    )
+
+    mcp_tools = [{"type": "mcp", "server_url": "litellm_proxy"}]
+    secret_fields = {
+        "raw_headers": {"x-mcp-linear_config-authorization": "Bearer linear-token"},
+    }
+
+    with patch.object(
+        LiteLLM_Proxy_MCP_Handler,
+        "_process_mcp_tools_without_openai_transform",
+        mock_process,
+    ), patch(
+        "litellm.responses.main.aresponses",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        await aresponses_api_with_mcp(
+            input=[{"role": "user", "type": "message", "content": "hi"}],
+            model="gpt-4o",
+            tools=mcp_tools,
+            secret_fields=secret_fields,
+        )
+
+    assert "mcp_server_auth_headers" in captured_process_kwargs
+    mcp_server_auth_headers = captured_process_kwargs["mcp_server_auth_headers"]
+    assert mcp_server_auth_headers is not None
+    assert "linear_config" in mcp_server_auth_headers
+    assert mcp_server_auth_headers["linear_config"]["Authorization"] == "Bearer linear-token"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues
When calling /v1/responses or /chat/completions with MCP tools and auth sent via headers (e.g. x-mcp-linear_config-authorization: Bearer <token>), the model received an empty tools list. MCP servers that rely on dynamic auth from headers (e.g. Linear) returned no tools because auth was not forwarded to the tool fetch.

mcp_server_auth_headers were read from secret_fields via extract_mcp_headers_from_request, but were never passed into _process_mcp_tools_without_openai_transform. The tool fetch always used mcp_server_auth_headers=None, so MCP servers without auth_value in config (e.g. linear_config) got no auth and returned 0 tools.
## Pre-Submission checklist
Before:
<img width="1076" height="648" alt="Screenshot 2026-02-27 at 7 09 34 AM" src="https://github.com/user-attachments/assets/03a96ba1-de9b-4a01-8037-439bcac87e5a" />


After:
<img width="1062" height="638" alt="Screenshot 2026-02-27 at 6 55 51 AM" src="https://github.com/user-attachments/assets/04e3fc0d-10f7-4d57-a838-7daa7bf3e58b" />

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
Extract MCP auth headers from secret_fields before fetching tools and pass mcp_auth_header and mcp_server_auth_headers into _process_mcp_tools_without_openai_transform in both litellm/responses/main.py (responses API) and litellm/responses/mcp/chat_completions_handler.py (chat completions). This applies to the initial tool fetch and to the auto-execute output-element fetch. The handler already supported these parameters; the missing step was wiring them through from the request.