### PR TITLE
fix: allow 429 to trigger MidStreamFallbackError for deferred-HTTP providers in async streaming

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2156,9 +2156,12 @@ class CustomStreamWrapper:
             mapped_status_code = _normalize_status_code(mapped_exception)
             original_status_code = _normalize_status_code(e)
 
-            if mapped_status_code is not None and 400 <= mapped_status_code < 500:
+            # Raise non-retriable client errors directly (skip fallback).
+            # Exception: 429 (rate-limit) IS retriable/transient — allow it
+            # through so the Router can switch to a different model group.
+            if mapped_status_code is not None and 400 <= mapped_status_code < 500 and mapped_status_code != 429:
                 raise mapped_exception
-            if original_status_code is not None and 400 <= original_status_code < 500:
+            if original_status_code is not None and 400 <= original_status_code < 500 and original_status_code != 429:
                 raise mapped_exception
 
             from litellm.exceptions import MidStreamFallbackError


### PR DESCRIPTION
## Summary

Some LiteLLM providers (Vertex AI, Bedrock, Predibase, Codestral) use a deferred HTTP pattern where the streaming HTTP request is not made during `litellm.completion()`/`acompletion()`, but lazily on the first iteration of the stream. This is intentional — PR #3944 introduced it to prevent HTTP client lifecycle issues during parallel streaming on singleton provider handlers.

A consequence is that a 429 rate-limit rejection from these providers surfaces during stream iteration (inside `__anext__`), which is outside the Router's normal retry/fallback machinery. PR #18698 then introduced a blanket 4xx filter in `__anext__()` that raises all 400-499 errors directly, preventing them from being wrapped in `MidStreamFallbackError`. While correct for non-retriable errors (400, 401, 403, 404), this also blocked 429 — which is transient and should trigger the Router's fallback system.

**This does not affect eager-HTTP providers (OpenAI, Anthropic, etc.)** where the HTTP request is made inline during `completion()`/`acompletion()`. For those providers, a 429 is thrown during the initial call and caught by the Router's existing retry/fallback logic — no `MidStreamFallbackError` involvement needed.

```python
# Deferred-HTTP providers (Vertex AI, Bedrock, etc.):
# 429 surfaces during __anext__() → needs MidStreamFallbackError wrapping

# Eager-HTTP providers (OpenAI, Anthropic, etc.):
# 429 surfaces during completion()/acompletion() → Router retry/fallback handles it
```

## Changes

- **`streaming_handler.py`**: Exclude 429 from the 4xx filter in `__anext__()` so rate-limit errors raise `MidStreamFallbackError` instead of `RateLimitError` directly. Other 4xx errors (400, 401, 403, 404) still raised directly as before.
- **`router.py`**: When `MidStreamFallbackError` has `is_pre_first_chunk=True` or empty `generated_content` (e.g. 429 before any tokens), skip the continuation prompt and retry with original messages. Previously this always appended a "continue from this text:" system message with empty content, wasting ~100 tokens.
- **Tests**: Added `test_vertex_streaming_rate_limit_triggers_midstream_fallback` (streaming handler) and `test_acompletion_streaming_iterator_pre_first_chunk_skips_continuation` (router). Updated existing edge case test for new empty-content behavior.

## Scope and limitations

- **Affected providers**: Only those using the deferred `make_call=partial(...)` pattern — Vertex AI/Gemini, Bedrock, Predibase, Codestral.
- **Async streaming only**: The fix works through `__anext__` → `MidStreamFallbackError` → `_acompletion_streaming_iterator`. Sync streaming (`__next__`) has no `MidStreamFallbackError` wrapping and no Router-level stream fallback wrapper — this is a pre-existing feature gap, not a regression from this PR.
- **Eager providers unaffected**: OpenAI, Anthropic, and others that make the HTTP call inline already handle 429 through the Router's normal retry/fallback path.

Fixes #22296
Relates to #20870, #18229, #8648, #6532