### PR TITLE
Litellm health check tokens

### DIFF
--- a/docs/my-website/docs/proxy/health.md
+++ b/docs/my-website/docs/proxy/health.md
@@ -330,6 +330,22 @@ model_list:
       health_check_timeout: 10 # 👈 OVERRIDE HEALTH CHECK TIMEOUT
 ```
 
+## Health Check Max Tokens
+
+By default, health checks use `max_tokens=1` to minimize cost and latency. For wildcard models, the default is `max_tokens=10`.
+
+You can override this per-model by setting `health_check_max_tokens` in the `model_info` section of your config.yaml.
+
+```yaml
+model_list:
+  - model_name: openai/gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      health_check_max_tokens: 5 # 👈 OVERRIDE HEALTH CHECK MAX TOKENS
+```
+
 ## `/health/readiness`
 
 Unprotected endpoint for checking if proxy is ready to accept requests

--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -14,7 +14,6 @@ TEST_PDF_URL = "data:application/pdf;base64,JVBERi0xLjQKJeLjz9MKMyAwIG9iago8PC9U
 
 
 class HealthCheckHelpers:
-
     @staticmethod
     async def ahealth_check_wildcard_models(
         model: str,
@@ -132,7 +131,7 @@ class HealthCheckHelpers:
         Callable,
     ]:
         """
-        Returns a dictionary of mode handlers for health check calls. 
+        Returns a dictionary of mode handlers for health check calls.
 
         Mode Handlers are Callables that need to be run for execution of the health check call.
 

--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -44,7 +44,9 @@ class HealthCheckHelpers:
         model_params["model"] = cheapest_models[0]
         model_params["litellm_logging_obj"] = litellm_logging_obj
         model_params["fallbacks"] = fallback_models
-        model_params["max_tokens"] = 10  # gpt-5-nano throws errors for max_tokens=1
+        model_params["max_tokens"] = model_params.get(
+            "max_tokens", 10
+        )  # gpt-5-nano throws errors for max_tokens=1
         await acompletion(**model_params)
         return {}
 

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -329,7 +329,9 @@ async def perform_health_check(
 
     # Filter by model_id first so a single deployment is checked when id is specified
     if model_id is not None:
-        _by_id = [x for x in model_list if (x.get("model_info") or {}).get("id") == model_id]
+        _by_id = [
+            x for x in model_list if (x.get("model_info") or {}).get("id") == model_id
+        ]
         if _by_id:
             model_list = _by_id
     elif model is not None:

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -234,6 +234,14 @@ def _update_litellm_params_for_health_check(
     - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID
     """
     litellm_params["messages"] = _get_random_llm_message()
+    _health_check_max_tokens = model_info.get("health_check_max_tokens", None)
+    if _health_check_max_tokens is not None:
+        litellm_params["max_tokens"] = _health_check_max_tokens
+    elif "*" not in (
+        model_info.get("health_check_model") or litellm_params.get("model") or ""
+    ):
+        litellm_params["max_tokens"] = 1
+
     _health_check_model = model_info.get("health_check_model", None)
     if _health_check_model is not None:
         litellm_params["model"] = _health_check_model

--- a/poetry.lock
+++ b/poetry.lock
@@ -3222,15 +3222,15 @@ files = [
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.48"
+version = "0.4.49"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 optional = true
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 groups = ["main"]
 markers = "extra == \"proxy\""
 files = [
-    {file = "litellm_proxy_extras-0.4.48-py3-none-any.whl", hash = "sha256:097001fccec5dbf4cffd902114898a9cfeba62673202447d55d2d0286cf93126"},
-    {file = "litellm_proxy_extras-0.4.48.tar.gz", hash = "sha256:5d5d8acf31b92d0cd6738555fb4a2411819755155438de9fb23c724c356400a2"},
+    {file = "litellm_proxy_extras-0.4.49-py3-none-any.whl", hash = "sha256:aeb0e08b4705c19fdc5b75a43c608a82fc36032f6d83be509dbf37baea62f2cd"},
+    {file = "litellm_proxy_extras-0.4.49.tar.gz", hash = "sha256:d9bdae54d1e3398f2e2025c9d8b98a19e226874337d540d5415922d7dbbc97bb"},
 ]
 
 [[package]]
@@ -7989,4 +7989,4 @@ utils = ["numpydoc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "b9b1e47b3b84748c0053be6a544c2399bf2601746a4f88dcb1be7c5e4eeab359"
+content-hash = "bbc7d43f5484af4c8877fe66e34f8283069528379af49d573036ba144cc2eb7a"

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -1,8 +1,8 @@
-
 import pytest
 from litellm.proxy.health_check import _update_litellm_params_for_health_check
 from litellm.litellm_core_utils.health_check_helpers import HealthCheckHelpers
 from unittest.mock import AsyncMock, patch, MagicMock
+
 
 @pytest.mark.asyncio
 async def test_update_litellm_params_max_tokens_default():
@@ -11,10 +11,11 @@ async def test_update_litellm_params_max_tokens_default():
     """
     model_info = {}
     litellm_params = {"model": "gpt-4"}
-    
+
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    
+
     assert updated_params["max_tokens"] == 1
+
 
 @pytest.mark.asyncio
 async def test_update_litellm_params_max_tokens_custom():
@@ -23,10 +24,11 @@ async def test_update_litellm_params_max_tokens_custom():
     """
     model_info = {"health_check_max_tokens": 5}
     litellm_params = {"model": "gpt-4"}
-    
+
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    
+
     assert updated_params["max_tokens"] == 5
+
 
 @pytest.mark.asyncio
 async def test_update_litellm_params_max_tokens_wildcard():
@@ -35,11 +37,12 @@ async def test_update_litellm_params_max_tokens_wildcard():
     """
     model_info = {}
     litellm_params = {"model": "openai/*"}
-    
+
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    
+
     # Should not be set to 1
     assert "max_tokens" not in updated_params or updated_params["max_tokens"] != 1
+
 
 @pytest.mark.asyncio
 async def test_ahealth_check_wildcard_models_respects_max_tokens():
@@ -47,25 +50,26 @@ async def test_ahealth_check_wildcard_models_respects_max_tokens():
     Test that ahealth_check_wildcard_models respects max_tokens if passed,
     otherwise defaults to 10.
     """
-    with patch("litellm.litellm_core_utils.llm_request_utils.pick_cheapest_chat_models_from_llm_provider", return_value=["gpt-4o-mini"]), \
-         patch("litellm.acompletion", new_callable=AsyncMock) as mock_acompletion:
-        
+    with patch(
+        "litellm.litellm_core_utils.llm_request_utils.pick_cheapest_chat_models_from_llm_provider",
+        return_value=["gpt-4o-mini"],
+    ), patch("litellm.acompletion", new_callable=AsyncMock):
         # Test Case 1: No max_tokens passed, should default to 10
         model_params = {}
         await HealthCheckHelpers.ahealth_check_wildcard_models(
             model="openai/*",
             custom_llm_provider="openai",
             model_params=model_params,
-            litellm_logging_obj=MagicMock()
+            litellm_logging_obj=MagicMock(),
         )
         assert model_params["max_tokens"] == 10
-        
+
         # Test Case 2: Custom health_check_max_tokens passed via model_params, should be respected
         model_params = {"max_tokens": 3}
         await HealthCheckHelpers.ahealth_check_wildcard_models(
             model="openai/*",
             custom_llm_provider="openai",
             model_params=model_params,
-            litellm_logging_obj=MagicMock()
+            litellm_logging_obj=MagicMock(),
         )
         assert model_params["max_tokens"] == 3

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -1,0 +1,71 @@
+
+import pytest
+from litellm.proxy.health_check import _update_litellm_params_for_health_check
+from litellm.litellm_core_utils.health_check_helpers import HealthCheckHelpers
+from unittest.mock import AsyncMock, patch, MagicMock
+
+@pytest.mark.asyncio
+async def test_update_litellm_params_max_tokens_default():
+    """
+    Test that max_tokens defaults to 1 for non-wildcard models.
+    """
+    model_info = {}
+    litellm_params = {"model": "gpt-4"}
+    
+    updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
+    
+    assert updated_params["max_tokens"] == 1
+
+@pytest.mark.asyncio
+async def test_update_litellm_params_max_tokens_custom():
+    """
+    Test that max_tokens respects health_check_max_tokens from model_info.
+    """
+    model_info = {"health_check_max_tokens": 5}
+    litellm_params = {"model": "gpt-4"}
+    
+    updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
+    
+    assert updated_params["max_tokens"] == 5
+
+@pytest.mark.asyncio
+async def test_update_litellm_params_max_tokens_wildcard():
+    """
+    Test that max_tokens does NOT default to 1 for wildcard models.
+    """
+    model_info = {}
+    litellm_params = {"model": "openai/*"}
+    
+    updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
+    
+    # Should not be set to 1
+    assert "max_tokens" not in updated_params or updated_params["max_tokens"] != 1
+
+@pytest.mark.asyncio
+async def test_ahealth_check_wildcard_models_respects_max_tokens():
+    """
+    Test that ahealth_check_wildcard_models respects max_tokens if passed,
+    otherwise defaults to 10.
+    """
+    with patch("litellm.litellm_core_utils.llm_request_utils.pick_cheapest_chat_models_from_llm_provider", return_value=["gpt-4o-mini"]), \
+         patch("litellm.acompletion", new_callable=AsyncMock) as mock_acompletion:
+        
+        # Test Case 1: No max_tokens passed, should default to 10
+        model_params = {}
+        await HealthCheckHelpers.ahealth_check_wildcard_models(
+            model="openai/*",
+            custom_llm_provider="openai",
+            model_params=model_params,
+            litellm_logging_obj=MagicMock()
+        )
+        assert model_params["max_tokens"] == 10
+        
+        # Test Case 2: Custom health_check_max_tokens passed via model_params, should be respected
+        model_params = {"max_tokens": 3}
+        await HealthCheckHelpers.ahealth_check_wildcard_models(
+            model="openai/*",
+            custom_llm_provider="openai",
+            model_params=model_params,
+            litellm_logging_obj=MagicMock()
+        )
+        assert model_params["max_tokens"] == 3


### PR DESCRIPTION
## Relevant issues

Address health check token overconsumption by introducing a configurable limit and a sensible default for non-wildcard models.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory (Added [tests/test_litellm/proxy/test_health_check_max_tokens.py](cci:7://file:///Users/harshitjain/conductor/workspaces/litellm-v1/pattaya/tests/test_litellm/proxy/test_health_check_max_tokens.py:0:0-0:0))
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` 

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:
- [ ] **CI run for the last commit**  
       Link:
- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

- **Optimization**: Updated [litellm/proxy/health_check.py](cci:7://file:///Users/harshitjain/conductor/workspaces/litellm-v1/pattaya/litellm/proxy/health_check.py:0:0-0:0) to default `max_tokens: 1` for standard health checks. This prevents health checks (like Azure OpenAI) from generating long responses, saving cost and reducing latency.
- **New Config Setting**: Introduced `health_check_max_tokens` in `model_info`. Users can now explicitly set the token limit for health checks in their `config.yaml`.
- **Wildcard Alignment**: Updated [litellm/litellm_core_utils/health_check_helpers.py](cci:7://file:///Users/harshitjain/conductor/workspaces/litellm-v1/pattaya/litellm/litellm_core_utils/health_check_helpers.py:0:0-0:0) to respect the configurable token limit while maintaining a safe default of `10` for wildcard-route models.
- **Testing**: Added unit tests in [tests/test_litellm/proxy/test_health_check_max_tokens.py](cci:7://file:///Users/harshitjain/conductor/workspaces/litellm-v1/pattaya/tests/test_litellm/proxy/test_health_check_max_tokens.py:0:0-0:0) covering default behavior, custom overrides, and wildcard routing safety.
