### PR TITLE
fix(count_tokens): include system and tools in token counting API requests

### DIFF
--- a/litellm/llms/anthropic/count_tokens/handler.py
+++ b/litellm/llms/anthropic/count_tokens/handler.py
@@ -31,6 +31,8 @@ class AnthropicCountTokensHandler(AnthropicCountTokensConfig):
         api_key: str,
         api_base: Optional[str] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Handle a CountTokens request using httpx.
@@ -60,6 +62,8 @@ class AnthropicCountTokensHandler(AnthropicCountTokensConfig):
             request_body = self.transform_request_to_count_tokens(
                 model=model,
                 messages=messages,
+                tools=tools,
+                system=system,
             )
 
             verbose_logger.debug(f"Transformed request: {request_body}")

--- a/litellm/llms/anthropic/count_tokens/token_counter.py
+++ b/litellm/llms/anthropic/count_tokens/token_counter.py
@@ -30,6 +30,8 @@ class AnthropicTokenCounter(BaseTokenCounter):
         contents: Optional[List[Dict[str, Any]]],
         deployment: Optional[Dict[str, Any]] = None,
         request_model: str = "",
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[Any] = None,
     ) -> Optional[TokenCountResponse]:
         """
         Count tokens using Anthropic's CountTokens API.
@@ -66,6 +68,8 @@ class AnthropicTokenCounter(BaseTokenCounter):
                 model=model_to_use,
                 messages=messages,
                 api_key=api_key,
+                tools=tools,
+                system=system,
             )
 
             if result is not None:

--- a/litellm/llms/anthropic/count_tokens/transformation.py
+++ b/litellm/llms/anthropic/count_tokens/transformation.py
@@ -4,7 +4,7 @@ Anthropic CountTokens API transformation logic.
 This module handles the transformation of requests to Anthropic's CountTokens API format.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from litellm.constants import ANTHROPIC_TOKEN_COUNTING_BETA_VERSION
 
@@ -32,26 +32,26 @@ class AnthropicCountTokensConfig:
         self,
         model: str,
         messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Transform request to Anthropic CountTokens format.
 
-        Input:
-        {
-            "model": "claude-3-5-sonnet-20241022",
-            "messages": [{"role": "user", "content": "Hello!"}]
-        }
-
-        Output (Anthropic CountTokens format):
-        {
-            "model": "claude-3-5-sonnet-20241022",
-            "messages": [{"role": "user", "content": "Hello!"}]
-        }
+        Includes optional system and tools fields for accurate token counting.
         """
-        return {
+        request: Dict[str, Any] = {
             "model": model,
             "messages": messages,
         }
+
+        if system is not None:
+            request["system"] = system
+
+        if tools is not None:
+            request["tools"] = tools
+
+        return request
 
     def get_required_headers(self, api_key: str) -> Dict[str, str]:
         """

--- a/litellm/llms/azure_ai/anthropic/count_tokens/handler.py
+++ b/litellm/llms/azure_ai/anthropic/count_tokens/handler.py
@@ -32,6 +32,8 @@ class AzureAIAnthropicCountTokensHandler(AzureAIAnthropicCountTokensConfig):
         api_base: str,
         litellm_params: Optional[Dict[str, Any]] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Handle a CountTokens request using httpx with Azure authentication.
@@ -62,6 +64,8 @@ class AzureAIAnthropicCountTokensHandler(AzureAIAnthropicCountTokensConfig):
             request_body = self.transform_request_to_count_tokens(
                 model=model,
                 messages=messages,
+                tools=tools,
+                system=system,
             )
 
             verbose_logger.debug(f"Transformed request: {request_body}")

--- a/litellm/llms/azure_ai/anthropic/count_tokens/token_counter.py
+++ b/litellm/llms/azure_ai/anthropic/count_tokens/token_counter.py
@@ -32,6 +32,8 @@ class AzureAIAnthropicTokenCounter(BaseTokenCounter):
         contents: Optional[List[Dict[str, Any]]],
         deployment: Optional[Dict[str, Any]] = None,
         request_model: str = "",
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[Any] = None,
     ) -> Optional[TokenCountResponse]:
         """
         Count tokens using Azure AI Anthropic's CountTokens API.
@@ -79,6 +81,8 @@ class AzureAIAnthropicTokenCounter(BaseTokenCounter):
                 api_key=api_key,
                 api_base=api_base,
                 litellm_params=litellm_params,
+                tools=tools,
+                system=system,
             )
 
             if result is not None:

--- a/litellm/llms/base_llm/base_utils.py
+++ b/litellm/llms/base_llm/base_utils.py
@@ -24,6 +24,8 @@ class BaseTokenCounter(ABC):
         contents: Optional[List[Dict[str, Any]]],
         deployment: Optional[Dict[str, Any]] = None,
         request_model: str = "",
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[Any] = None,
     ) -> Optional[TokenCountResponse]:
         pass
 

--- a/litellm/llms/bedrock/count_tokens/bedrock_token_counter.py
+++ b/litellm/llms/bedrock/count_tokens/bedrock_token_counter.py
@@ -30,6 +30,8 @@ class BedrockTokenCounter(BaseTokenCounter):
         contents: Optional[List[Dict[str, Any]]],
         deployment: Optional[Dict[str, Any]] = None,
         request_model: str = "",
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[Any] = None,
     ) -> Optional[TokenCountResponse]:
         """
         Count tokens using AWS Bedrock's CountTokens API.
@@ -54,10 +56,16 @@ class BedrockTokenCounter(BaseTokenCounter):
         litellm_params = deployment.get("litellm_params", {})
 
         # Build request data in the format expected by BedrockCountTokensHandler
-        request_data = {
+        request_data: Dict[str, Any] = {
             "model": model_to_use,
             "messages": messages,
         }
+
+        if tools:
+            request_data["tools"] = tools
+
+        if system:
+            request_data["system"] = system
 
         # Get the resolved model (strip prefixes like bedrock/, converse/, etc.)
         resolved_model = get_bedrock_base_model(model_to_use)

--- a/litellm/llms/gemini/common_utils.py
+++ b/litellm/llms/gemini/common_utils.py
@@ -166,6 +166,7 @@ class GoogleAIStudioTokenCounter(BaseTokenCounter):
         contents: Optional[List[Dict[str, Any]]],
         deployment: Optional[Dict[str, Any]] = None,
         request_model: str = "",
+        **kwargs,
     ) -> Optional[TokenCountResponse]:
         import copy
 

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -1042,6 +1042,7 @@ class VertexAITokenCounter(BaseTokenCounter):
         contents: Optional[List[Dict[str, Any]]],
         deployment: Optional[Dict[str, Any]] = None,
         request_model: str = "",
+        **kwargs,
     ) -> Optional[TokenCountResponse]:
         import copy
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2832,6 +2832,9 @@ class TokenCountRequest(LiteLLMPydanticObjectBase):
     Google /countTokens endpoint expects contents to be a list of dicts with the following structure:
     """
 
+    tools: Optional[List[dict]] = None
+    system: Optional[Any] = None
+
 
 class CallInfo(LiteLLMPydanticObjectBase):
     """Used for slack budget alerting"""

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -204,7 +204,12 @@ async def count_tokens(
         # Create TokenCountRequest for the internal endpoint
         from litellm.proxy._types import TokenCountRequest
 
-        token_request = TokenCountRequest(model=model_name, messages=messages)
+        token_request = TokenCountRequest(
+            model=model_name,
+            messages=messages,
+            tools=data.get("tools"),
+            system=data.get("system"),
+        )
 
         # Call the internal token counter function with direct request flag set to False
         token_response = await internal_token_counter(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8321,6 +8321,8 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
     prompt = request.prompt
     messages = request.messages
     contents = request.contents
+    tools = request.tools
+    system = request.system
 
     #########################################################
     # Validate request
@@ -8381,6 +8383,8 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
                 contents=contents,
                 deployment=deployment,
                 request_model=request.model,
+                tools=tools,
+                system=system,
             )
             #########################################################
             # Transfrom the Response to the well known format

--- a/tests/test_litellm/llms/anthropic/test_anthropic_count_tokens_transformation.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_count_tokens_transformation.py
@@ -1,0 +1,92 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+from litellm.llms.anthropic.count_tokens.transformation import (
+    AnthropicCountTokensConfig,
+)
+
+
+def test_transform_basic_request():
+    """Test basic request with only model and messages."""
+    config = AnthropicCountTokensConfig()
+
+    result = config.transform_request_to_count_tokens(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+    assert result == {
+        "model": "claude-3-5-sonnet",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+
+def test_transform_includes_system():
+    """Test that system prompt is included when provided."""
+    config = AnthropicCountTokensConfig()
+
+    result = config.transform_request_to_count_tokens(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Hello"}],
+        system="You are a helpful assistant.",
+    )
+
+    assert result["system"] == "You are a helpful assistant."
+    assert result["model"] == "claude-3-5-sonnet"
+    assert result["messages"] == [{"role": "user", "content": "Hello"}]
+
+
+def test_transform_includes_tools():
+    """Test that tools are included when provided."""
+    config = AnthropicCountTokensConfig()
+
+    tools = [
+        {
+            "name": "read_file",
+            "description": "Read a file",
+            "input_schema": {"type": "object", "properties": {"path": {"type": "string"}}},
+        }
+    ]
+
+    result = config.transform_request_to_count_tokens(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Hello"}],
+        tools=tools,
+    )
+
+    assert result["tools"] == tools
+
+
+def test_transform_includes_system_and_tools():
+    """Test that both system and tools are included together."""
+    config = AnthropicCountTokensConfig()
+
+    result = config.transform_request_to_count_tokens(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Hello"}],
+        system="Be helpful",
+        tools=[{"name": "my_tool", "input_schema": {"type": "object"}}],
+    )
+
+    assert "system" in result
+    assert "tools" in result
+    assert "messages" in result
+    assert "model" in result
+
+
+def test_transform_no_system_no_tools():
+    """Test that None system/tools are not included."""
+    config = AnthropicCountTokensConfig()
+
+    result = config.transform_request_to_count_tokens(
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "Hello"}],
+        system=None,
+        tools=None,
+    )
+
+    assert "system" not in result
+    assert "tools" not in result

--- a/tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py
+++ b/tests/test_litellm/llms/bedrock/count_tokens/test_bedrock_count_tokens_transformation.py
@@ -34,3 +34,123 @@ def test_transform_anthropic_to_bedrock_request():
     assert "input" in result
     assert "converse" in result["input"]
     assert "messages" in result["input"]["converse"]
+
+
+def test_transform_includes_system_prompt():
+    """Test that system prompt is included in Bedrock converse format."""
+    config = BedrockCountTokensConfig()
+
+    request = {
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "system": "You are a helpful assistant.",
+    }
+
+    result = config.transform_anthropic_to_bedrock_count_tokens(request)
+
+    converse = result["input"]["converse"]
+    assert "system" in converse
+    assert converse["system"] == [{"text": "You are a helpful assistant."}]
+
+
+def test_transform_includes_system_prompt_as_list():
+    """Test that system prompt as list of blocks is handled."""
+    config = BedrockCountTokensConfig()
+
+    request = {
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "system": [{"type": "text", "text": "Block 1"}, {"type": "text", "text": "Block 2"}],
+    }
+
+    result = config.transform_anthropic_to_bedrock_count_tokens(request)
+
+    converse = result["input"]["converse"]
+    assert converse["system"] == [{"text": "Block 1"}, {"text": "Block 2"}]
+
+
+def test_transform_includes_tools():
+    """Test that tools are transformed to Bedrock toolConfig format."""
+    config = BedrockCountTokensConfig()
+
+    request = {
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "tools": [
+            {
+                "name": "read_file",
+                "description": "Read a file",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            }
+        ],
+    }
+
+    result = config.transform_anthropic_to_bedrock_count_tokens(request)
+
+    converse = result["input"]["converse"]
+    assert "toolConfig" in converse
+    tools = converse["toolConfig"]["tools"]
+    assert len(tools) == 1
+    assert tools[0]["toolSpec"]["name"] == "read_file"
+    assert tools[0]["toolSpec"]["description"] == "Read a file"
+    assert tools[0]["toolSpec"]["inputSchema"]["json"]["type"] == "object"
+
+
+def test_transform_includes_system_and_tools_together():
+    """Test that both system and tools are included together."""
+    config = BedrockCountTokensConfig()
+
+    request = {
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "system": "Be helpful",
+        "tools": [
+            {"name": "my_tool", "description": "A tool", "input_schema": {"type": "object", "properties": {}}},
+        ],
+    }
+
+    result = config.transform_anthropic_to_bedrock_count_tokens(request)
+
+    converse = result["input"]["converse"]
+    assert "system" in converse
+    assert "toolConfig" in converse
+    assert "messages" in converse
+
+
+def test_transform_no_system_no_tools():
+    """Test that missing system and tools don't add extra keys."""
+    config = BedrockCountTokensConfig()
+
+    request = {
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+    result = config.transform_anthropic_to_bedrock_count_tokens(request)
+
+    converse = result["input"]["converse"]
+    assert "system" not in converse
+    assert "toolConfig" not in converse
+
+
+def test_tool_name_sanitization():
+    """Test that tool names are sanitized for Bedrock requirements."""
+    config = BedrockCountTokensConfig()
+
+    request = {
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "tools": [
+            {"name": "my-tool!", "description": "A tool", "input_schema": {"type": "object", "properties": {}}},
+        ],
+    }
+
+    result = config.transform_anthropic_to_bedrock_count_tokens(request)
+
+    tool_name = result["input"]["converse"]["toolConfig"]["tools"][0]["toolSpec"]["name"]
+    # Should be sanitized: only [a-zA-Z0-9_]
+    assert tool_name == "my_tool_"


### PR DESCRIPTION
## Relevant issues

Fixes context overflow issues for Claude Code users on Bedrock — the `/v1/messages/count_tokens` proxy endpoint was discarding `system` and `tools`, returning artificially low token counts (e.g. 10 instead of 531 with 3 tools).

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The proxy's `/v1/messages/count_tokens` endpoint and all provider token counters (Bedrock, Anthropic, Azure AI) only passed `messages` to the token counting APIs, silently discarding `system` prompts and `tools`. This caused clients like Claude Code to receive incorrect token counts, preventing proper context window management and leading to context overflow errors.

**Example:** A request with 1 message + system prompt + 3 MCP tools returns **10 tokens** (bug) instead of **531 tokens** (correct).

### Fix

Pass `system` and `tools` through the full token counting chain:

1. **`TokenCountRequest`** — added `tools` and `system` fields
2. **`proxy/anthropic_endpoints/endpoints.py`** — extract `tools`/`system` from request body
3. **`proxy/proxy_server.py`** — pass them to provider counters
4. **`BaseTokenCounter` interface** — added `tools`/`system` parameters
5. **Bedrock** — transform tools to `toolConfig` format, system to text blocks
6. **Anthropic / Azure AI** — pass through directly (same API format)
7. **Gemini / Vertex AI** — accept `**kwargs` for forward compatibility

### Tests

- 8 new Bedrock transformation tests (system as string/list, tools, combined, sanitization)
- 5 new Anthropic transformation tests (system, tools, combined, none)
- All 19 count_tokens tests passing