### PR TITLE
feat(models): add gpt-audio-1.5 to model cost map

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -19085,6 +19085,42 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "gpt-audio-1.5": {
+        "input_cost_per_audio_token": 3.2e-05,
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_audio_token": 6.4e-05,
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/realtime",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "gpt-audio-2025-08-28": {
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_token": 2.5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -19096,10 +19096,7 @@
         "output_cost_per_audio_token": 6.4e-05,
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses",
-            "/v1/realtime",
-            "/v1/batch"
+            "/v1/chat/completions"
         ],
         "supported_modalities": [
             "text",


### PR DESCRIPTION
## Relevant issues

Fixes #22269

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - N/A (pure JSON data update, no code logic changed)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

Adds `gpt-audio-1.5` to the model cost map. This is a new OpenAI audio model released on 2026-02-23 with:

- 128K context window, 16K max output tokens
- Text input/output: $2.50 / $10.00 per 1M tokens
- Audio input/output: $32.00 / $64.00 per 1M tokens
- Supports: Chat Completions, Responses, Realtime, Batch endpoints
- Supports: function calling, audio I/O, streaming

Reference: https://developers.openai.com/api/docs/models/gpt-audio-1.5