### PR TITLE
feat(models): add gpt-realtime-1.5 to model cost map

### DIFF
--- a/litellm/llms/openai/chat/gpt_audio_transformation.py
+++ b/litellm/llms/openai/chat/gpt_audio_transformation.py
@@ -29,7 +29,9 @@ class OpenAIGPTAudioConfig(OpenAIGPTConfig):
         return all_openai_params + audio_specific_params
 
     def is_model_gpt_audio_model(self, model: str) -> bool:
-        if model in litellm.open_ai_chat_completion_models and "audio" in model:
+        if model in litellm.open_ai_chat_completion_models and (
+            "audio" in model or "realtime" in model
+        ):
             return True
         return False
 

--- a/litellm/llms/openai/chat/gpt_audio_transformation.py
+++ b/litellm/llms/openai/chat/gpt_audio_transformation.py
@@ -29,9 +29,7 @@ class OpenAIGPTAudioConfig(OpenAIGPTConfig):
         return all_openai_params + audio_specific_params
 
     def is_model_gpt_audio_model(self, model: str) -> bool:
-        if model in litellm.open_ai_chat_completion_models and (
-            "audio" in model or "realtime" in model
-        ):
+        if model in litellm.open_ai_chat_completion_models and "audio" in model:
             return True
         return False
 

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20816,8 +20816,6 @@
         "output_cost_per_audio_token": 6.4e-05,
         "output_cost_per_token": 1.6e-05,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses",
             "/v1/realtime"
         ],
         "supported_modalities": [

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20802,6 +20802,40 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "gpt-realtime-1.5": {
+        "cache_creation_input_audio_token_cost": 4e-07,
+        "cache_read_input_token_cost": 4e-07,
+        "input_cost_per_audio_token": 3.2e-05,
+        "input_cost_per_image": 5e-06,
+        "input_cost_per_token": 4e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_audio_token": 6.4e-05,
+        "output_cost_per_token": 1.6e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "gpt-realtime-mini": {
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_audio_token_cost": 3e-07,


### PR DESCRIPTION
## Relevant issues

Fixes #22266

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - N/A (pure JSON data update, no code logic changed)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

Adds `gpt-realtime-1.5` to the model cost map. This is a new OpenAI realtime model released on 2026-02-23 with:

- 32K context window, 4K max output tokens
- Text input/output: $4.00 / $16.00 per 1M tokens
- Audio input/output: $32.00 / $64.00 per 1M tokens
- Image input: $5.00 per 1M tokens
- Cached input: $0.40 per 1M tokens
- Supports: **Chat Completions, Responses, and Realtime** endpoints (unlike `gpt-realtime` which only supports Realtime)
- Supports: function calling, audio I/O, image input, streaming

Key difference from `gpt-realtime`: this model works via regular HTTP (Chat Completions/Responses) without requiring WebSocket.

Reference: https://developers.openai.com/api/docs/models/gpt-realtime-1.5