### PR TITLE
fix(images): pass model_info/metadata in image_edit for custom pricing

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -873,10 +873,10 @@ def image_edit(  # noqa: PLR0915
             user=user,
             optional_params=dict(image_edit_request_params),
             litellm_params={
+                **image_edit_request_params,
                 "litellm_call_id": litellm_call_id,
                 "model_info": model_info,
                 "metadata": metadata,
-                **image_edit_request_params,
             },
             custom_llm_provider=custom_llm_provider,
         )

--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -763,6 +763,8 @@ def image_edit(  # noqa: PLR0915
         }  # model-specific params - pass them straight to the model/provider
         litellm_logging_obj: LiteLLMLoggingObj = kwargs.get("litellm_logging_obj")  # type: ignore
         litellm_call_id: Optional[str] = kwargs.get("litellm_call_id", None)
+        model_info = kwargs.get("model_info", None)
+        metadata = kwargs.get("metadata", {})
         _is_async = kwargs.pop("async_call", False) is True
 
         # add images / or return a single image
@@ -872,6 +874,8 @@ def image_edit(  # noqa: PLR0915
             optional_params=dict(image_edit_request_params),
             litellm_params={
                 "litellm_call_id": litellm_call_id,
+                "model_info": model_info,
+                "metadata": metadata,
                 **image_edit_request_params,
             },
             custom_llm_provider=custom_llm_provider,


### PR DESCRIPTION
## Relevant issues

Fixes #22244

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`image_edit()` was not extracting `model_info` and `metadata` from kwargs and not passing them in `litellm_params` to `update_environment_variables()`. This meant `custom_pricing` was never set to `True` for image edit calls.

After PR #20679 stripped custom pricing fields (like `input_cost_per_image`) from the shared backend model key in `litellm.model_cost`, the cost calculator fell back to the shared key — which no longer had pricing info — resulting in cost = 0.

`image_generation()` already did this correctly, so it was unaffected.

### Fix

- Extract `model_info` and `metadata` from `kwargs` in `image_edit()` (matching `image_generation()`)
- Pass them in `litellm_params` to `update_environment_variables()`

### Tests

Added 3 tests to `tests/test_litellm/images/test_image_edit_utils.py`:
- `test_image_edit_passes_model_info_to_logging` — verifies model_info/metadata are forwarded
- `test_custom_pricing_detected_from_model_info_in_metadata` — verifies detection logic
- `test_custom_pricing_not_detected_without_model_info` — verifies no false positives