### PR TITLE
fix: apply server root path to mapped passthrough route matching

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -2062,7 +2062,8 @@ class InitPassThroughEndpointHelpers:
         """
         ## CHECK IF MAPPED PASS THROUGH ENDPOINT
         for mapped_route in LiteLLMRoutes.mapped_pass_through_routes.value:
-            if route.startswith(mapped_route):
+            full_mapped_route = InitPassThroughEndpointHelpers._build_full_path_with_root(mapped_route)
+            if route.startswith(full_mapped_route):
                 return True
 
         # Fast path: check if any registered route key contains this path


### PR DESCRIPTION
mapped passthrough routes (vertex_ai, bedrock, etc) were compared against the raw request path without prepending SERVER_ROOT_PATH. db-registered routes already used _build_full_path_with_root for this — the mapped routes branch was missed.

when a reverse proxy forwards `/litellm/vertex_ai/...` and `SERVER_ROOT_PATH=/litellm`, the route check fell through because it compared `/litellm/vertex_ai/...` against bare `/vertex_ai`.

one-line fix: run `_build_full_path_with_root` on each mapped route before the startswith check — same pattern already used 15 lines below for db routes.

test added covering prefixed and bare routes with a custom root.

fixes #22272