### PR TITLE
fix: include mcp_tool_permissions server ids in allowed mcp servers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -649,8 +649,13 @@ class MCPRequestHandler:
                 )
             )
 
-            # Combine both lists
-            all_servers = direct_mcp_servers + access_group_servers
+            # servers referenced in tool permissions should also be accessible
+            tool_perm_servers = list(
+                (key_object_permission.mcp_tool_permissions or {}).keys()
+            )
+
+            # Combine all lists
+            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
             return list(set(all_servers))
         except Exception as e:
             verbose_logger.warning(
@@ -686,8 +691,13 @@ class MCPRequestHandler:
                 )
             )
 
-            # Combine both lists
-            all_servers = direct_mcp_servers + access_group_servers
+            # servers referenced in tool permissions should also be accessible
+            tool_perm_servers = list(
+                (object_permissions.mcp_tool_permissions or {}).keys()
+            )
+
+            # Combine all lists
+            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
             return list(set(all_servers))
         except Exception as e:
             verbose_logger.warning(
@@ -737,8 +747,6 @@ class MCPRequestHandler:
             # Get direct MCP servers
             direct_mcp_servers = end_user_obj.object_permission.mcp_servers or []
 
-
-
             # Get MCP servers from access groups
             access_group_servers = (
                 await MCPRequestHandler._get_mcp_servers_from_access_groups(
@@ -746,8 +754,13 @@ class MCPRequestHandler:
                 )
             )
 
-            # Combine both lists
-            all_servers = direct_mcp_servers + access_group_servers
+            # servers referenced in tool permissions should also be accessible
+            tool_perm_servers = list(
+                (end_user_obj.object_permission.mcp_tool_permissions or {}).keys()
+            )
+
+            # Combine all lists
+            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
             return list(set(all_servers))
         except Exception as e:
             verbose_logger.warning(


### PR DESCRIPTION
when a key/team/end-user has mcp_tool_permissions for a server but that server isn't in mcp_servers, the server was excluded from the allowed list — making the tool permissions useless.

now we union the keys from mcp_tool_permissions into the allowed server set in all three functions: _get_allowed_mcp_servers_for_key, _get_allowed_mcp_servers_for_team, _get_allowed_mcp_servers_for_end_user.

test verifies that a server appearing only in tool_permissions is returned in the allowed list.

fixes #21954