### PR TITLE
[Fix] Redact JWT bearer tokens in debug logs

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -221,6 +221,7 @@ verbose_proxy_logger.addHandler(handler)
 verbose_proxy_logger.addFilter(_sensitive_filter)
 verbose_logger.addHandler(handler)
 verbose_logger.addFilter(_sensitive_filter)
+logging.getLogger().addFilter(_sensitive_filter)
 
 
 def _suppress_loggers():


### PR DESCRIPTION
## Relevant issues
With --detailed_debug, JWT bearer tokens from the Authorization header were logged in full. This exposed credentials in server output, log files, and any log aggregation systems.

The proxy stores raw request headers (including Authorization) in data["secret_fields"] for MCP and response forwarding. Several debug log calls (e.g. print_args_passed_to_litellm in utils.py and the "receiving data" logs in litellm_pre_call_utils.py and proxy_server.py) logged the full data or kwargs without redacting these fields.
<img width="324" height="145" alt="Screenshot 2026-02-27 at 1 17 32 PM" src="https://github.com/user-attachments/assets/ecda2cf1-2a05-4f6f-940c-59dd8850dc32" />

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes
A SensitiveLogFilter was added in litellm/_logging.py and attached to all three LiteLLM loggers. It runs before any handler and redacts Bearer tokens in the formatted log message using a regex, replacing them with Bearer [REDACTED]. This centralizes redaction so new log sites are covered without per-call changes.
