### PR TITLE
fix: normalize non-compliant tool call IDs for strict OpenAI-compatible providers (e.g. Mistral)

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -2,11 +2,14 @@
 Support for gpt model family
 """
 
+import hashlib
+import re
 from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
     Coroutine,
+    Dict,
     Iterator,
     List,
     Literal,
@@ -431,6 +434,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             dict: The transformed request. Sent as the body of the API call.
         """
         messages = self._transform_messages(messages=messages, model=model)
+        messages = self._normalize_tool_call_ids(messages)
         messages, tools = self.remove_cache_control_flag_from_messages_and_tools(
             model=model, messages=messages, tools=optional_params.get("tools", [])
         )
@@ -476,6 +480,76 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             return self.transform_request(
                 model, messages, optional_params, litellm_params, headers
             )
+
+    def _normalize_tool_call_ids(
+        self, messages: List[AllMessageValues]
+    ) -> List[AllMessageValues]:
+        """
+        Normalize non-compliant tool call IDs in message history to satisfy strict
+        OpenAI-compatible providers (e.g. Mistral) that require IDs matching
+        ^[a-zA-Z0-9]{1,64}$.
+
+        Some providers (e.g. MiniMax via OpenRouter) return IDs like
+        ``call_function_jlv0n7uyomle_1`` which contain underscores and are longer
+        than 9 characters.  When those IDs are forwarded in a subsequent request to
+        a strict provider the request is rejected with a 400 BadRequestError.
+
+        This method scans the message list once, collects every non-compliant ID,
+        builds a stable deterministic remapping using an MD5 hash (truncated to 9
+        characters), and then rewrites:
+
+        * ``tool_calls[].id`` on assistant messages
+        * ``tool_call_id`` on tool/function result messages
+
+        IDs that already satisfy ``^[a-zA-Z0-9]{1,64}$`` are left unchanged so
+        there is zero overhead for well-behaved providers.
+        """
+        _VALID_TOOL_CALL_ID = re.compile(r"^[a-zA-Z0-9]{1,64}$")
+
+        def _remap_id(original: str, mapping: Dict[str, str]) -> str:
+            if original not in mapping:
+                digest = hashlib.md5(original.encode()).hexdigest()[:9]
+                mapping[original] = digest
+            return mapping[original]
+
+        # First pass: collect all non-compliant IDs that appear in assistant messages.
+        id_mapping: Dict[str, str] = {}
+        for message in messages:
+            role = message.get("role")
+            if role == "assistant":
+                tool_calls = message.get("tool_calls")  # type: ignore[union-attr]
+                if tool_calls:
+                    for tc in tool_calls:
+                        tc_id = (
+                            tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                        )
+                        if tc_id and not _VALID_TOOL_CALL_ID.match(tc_id):
+                            _remap_id(tc_id, id_mapping)
+
+        if not id_mapping:
+            return messages
+
+        # Second pass: rewrite IDs in-place.
+        for message in messages:
+            role = message.get("role")
+            if role == "assistant":
+                tool_calls = message.get("tool_calls")  # type: ignore[union-attr]
+                if tool_calls:
+                    for tc in tool_calls:
+                        if isinstance(tc, dict):
+                            tc_id = tc.get("id")
+                            if tc_id and tc_id in id_mapping:
+                                tc["id"] = id_mapping[tc_id]
+                        else:
+                            tc_id = getattr(tc, "id", None)
+                            if tc_id and tc_id in id_mapping:
+                                tc.id = id_mapping[tc_id]  # type: ignore[union-attr]
+            elif role in ("tool", "function"):
+                tc_id = message.get("tool_call_id")  # type: ignore[union-attr]
+                if tc_id and tc_id in id_mapping:
+                    message["tool_call_id"] = id_mapping[tc_id]  # type: ignore[index]
+
+        return messages
 
     def _passed_in_tools(self, optional_params: dict) -> bool:
         return optional_params.get("tools", None) is not None


### PR DESCRIPTION
## Summary

Fixes #22317

Some OpenAI-compatible providers (e.g. **MiniMax via OpenRouter**) return tool call IDs in non-standard formats like `call_function_jlv0n7uyomle_1` — using the function name and a numeric suffix. When the router forwards a subsequent turn of that conversation to a **strict** provider (e.g. **Mistral**), the request is rejected:

```
litellm.BadRequestError: OpenAIException - Tool call id was call_function_jlv0n7uyomle_1
but must be a-z, A-Z, 0-9, with a length of 9.
```

Because this is a 400 `BadRequestError`, the router does **not** retry or fall back — the error surfaces directly to the caller.

## Fix

Adds `_normalize_tool_call_ids()` to `OpenAIGPTConfig`, called from `transform_request()`. It:

1. Scans the message list **once** for assistant messages with non-compliant `tool_calls[].id` values (anything not matching `^[a-zA-Z0-9]{1,64}$`)
2. Builds a **stable deterministic mapping** (MD5 hash, truncated to 9 chars) for each offending ID
3. Rewrites **both** the assistant message `tool_calls[].id` **and** the matching tool result `tool_call_id` in a second pass — keeping the pair in sync
4. **No-ops** when all IDs are already compliant (zero overhead for well-behaved providers)

This is analogous to the existing `_sanitize_anthropic_tool_use_id()` in `factory.py`, but generalised for the OpenAI-to-OpenAI routing case where both sides of the ID pair must match.

## Test plan

- [x] `test_compliant_ids_unchanged` — valid IDs are not modified
- [x] `test_non_compliant_id_is_remapped` — bad ID is replaced with a valid 9-char alphanumeric ID
- [x] `test_remapping_is_deterministic` — same input always produces same output
- [x] `test_multiple_tool_calls_each_remapped_consistently` — distinct IDs get distinct mappings; both assistant and tool messages updated
- [x] `test_messages_without_tool_calls_unaffected` — plain messages pass through unchanged
- [x] `test_transform_request_normalizes_ids` — end-to-end through `transform_request()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)