### PR TITLE
feat: add in_flight_requests metric to /health/backlog + prometheus

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -19210,6 +19210,39 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "gpt-audio-1.5": {
+        "input_cost_per_audio_token": 3.2e-05,
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_audio_token": 6.4e-05,
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "gpt-audio-2025-08-28": {
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_token": 2.5e-06,
@@ -20896,6 +20929,38 @@
         ]
     },
     "gpt-realtime": {
+        "cache_creation_input_audio_token_cost": 4e-07,
+        "cache_read_input_token_cost": 4e-07,
+        "input_cost_per_audio_token": 3.2e-05,
+        "input_cost_per_image": 5e-06,
+        "input_cost_per_token": 4e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_audio_token": 6.4e-05,
+        "output_cost_per_token": 1.6e-05,
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "gpt-realtime-1.5": {
         "cache_creation_input_audio_token_cost": 4e-07,
         "cache_read_input_token_cost": 4e-07,
         "input_cost_per_audio_token": 3.2e-05,
@@ -26650,8 +26715,8 @@
         "mode": "chat",
         "output_cost_per_token": 0.0,
         "source": "https://platform.publicai.co/docs",
-        "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_function_calling": false,
+        "supports_tool_choice": false
     },
     "publicai/swiss-ai/apertus-70b-instruct": {
         "input_cost_per_token": 0.0,
@@ -26662,8 +26727,8 @@
         "mode": "chat",
         "output_cost_per_token": 0.0,
         "source": "https://platform.publicai.co/docs",
-        "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_function_calling": false,
+        "supports_tool_choice": false
     },
     "publicai/aisingapore/Gemma-SEA-LION-v4-27B-IT": {
         "input_cost_per_token": 0.0,
@@ -32991,6 +33056,7 @@
         "supports_web_search": true
     },
     "xai/grok-2-vision-1212": {
+        "deprecation_date": "2026-02-28",
         "input_cost_per_image": 2e-06,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "xai",
@@ -33095,6 +33161,7 @@
     },
     "xai/grok-3-mini": {
         "cache_read_input_token_cost": 7.5e-08,
+        "deprecation_date": "2026-02-28",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -33111,6 +33178,7 @@
     },
     "xai/grok-3-mini-beta": {
         "cache_read_input_token_cost": 7.5e-08,
+        "deprecation_date": "2026-02-28",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,

--- a/litellm/proxy/middleware/in_flight_requests_middleware.py
+++ b/litellm/proxy/middleware/in_flight_requests_middleware.py
@@ -10,49 +10,25 @@ from typing import Optional
 
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-_in_flight: int = 0
-
-# Lazily created on first request so PROMETHEUS_MULTIPROC_DIR is already set
-# by the time we register the metric.
-_gauge: Optional[object] = None
-
-
-def _get_gauge() -> Optional[object]:
-    global _gauge
-    if _gauge is not None:
-        return _gauge
-    try:
-        from prometheus_client import Gauge
-
-        kwargs = {}
-        if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
-            # livesum aggregates across all worker processes in the scrape response
-            kwargs["multiprocess_mode"] = "livesum"
-        _gauge = Gauge(
-            "litellm_in_flight_requests",
-            "Number of HTTP requests currently in-flight on this uvicorn worker",
-            **kwargs,
-        )
-    except Exception:
-        pass
-    return _gauge
-
-
-def get_in_flight_requests() -> int:
-    return _in_flight
-
 
 class InFlightRequestsMiddleware:
     """
-    ASGI middleware that increments a counter when a request arrives
-    and decrements it when the response is sent (or an error occurs).
+    ASGI middleware that increments a counter when a request arrives and
+    decrements it when the response is sent (or an error occurs).
 
-    The counter is module-level and therefore scoped to a single uvicorn
-    worker process — exactly the per-pod granularity we want.
+    The counter is class-level and therefore scoped to a single uvicorn worker
+    process — exactly the per-pod granularity we want.
 
     Also updates the `litellm_in_flight_requests` Prometheus gauge if
-    prometheus_client is installed.
+    prometheus_client is installed. The gauge is lazily initialised on the
+    first request so that PROMETHEUS_MULTIPROC_DIR is already set by the time
+    we register the metric. Initialisation is attempted only once — if
+    prometheus_client is absent the class remembers and never retries.
     """
+
+    _in_flight: int = 0
+    _gauge: Optional[object] = None
+    _gauge_init_attempted: bool = False
 
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
@@ -62,14 +38,44 @@ class InFlightRequestsMiddleware:
             await self.app(scope, receive, send)
             return
 
-        global _in_flight
-        _in_flight += 1
-        gauge = _get_gauge()
+        InFlightRequestsMiddleware._in_flight += 1
+        gauge = InFlightRequestsMiddleware._get_gauge()
         if gauge is not None:
             gauge.inc()  # type: ignore[union-attr]
         try:
             await self.app(scope, receive, send)
         finally:
-            _in_flight -= 1
+            InFlightRequestsMiddleware._in_flight -= 1
             if gauge is not None:
                 gauge.dec()  # type: ignore[union-attr]
+
+    @staticmethod
+    def get_count() -> int:
+        """Return the number of HTTP requests currently in-flight."""
+        return InFlightRequestsMiddleware._in_flight
+
+    @staticmethod
+    def _get_gauge() -> Optional[object]:
+        if InFlightRequestsMiddleware._gauge_init_attempted:
+            return InFlightRequestsMiddleware._gauge
+        InFlightRequestsMiddleware._gauge_init_attempted = True
+        try:
+            from prometheus_client import Gauge
+
+            kwargs = {}
+            if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+                # livesum aggregates across all worker processes in the scrape response
+                kwargs["multiprocess_mode"] = "livesum"
+            InFlightRequestsMiddleware._gauge = Gauge(
+                "litellm_in_flight_requests",
+                "Number of HTTP requests currently in-flight on this uvicorn worker",
+                **kwargs,
+            )
+        except Exception:
+            InFlightRequestsMiddleware._gauge = None
+        return InFlightRequestsMiddleware._gauge
+
+
+def get_in_flight_requests() -> int:
+    """Module-level convenience wrapper used by the /health/backlog endpoint."""
+    return InFlightRequestsMiddleware.get_count()

--- a/litellm/proxy/middleware/in_flight_requests_middleware.py
+++ b/litellm/proxy/middleware/in_flight_requests_middleware.py
@@ -1,0 +1,75 @@
+"""
+Tracks the number of HTTP requests currently in-flight on this uvicorn worker.
+
+Used by /health/backlog to expose per-pod queue depth, and emitted as the
+Prometheus gauge `litellm_in_flight_requests`.
+"""
+
+import os
+from typing import Optional
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+_in_flight: int = 0
+
+# Lazily created on first request so PROMETHEUS_MULTIPROC_DIR is already set
+# by the time we register the metric.
+_gauge: Optional[object] = None
+
+
+def _get_gauge() -> Optional[object]:
+    global _gauge
+    if _gauge is not None:
+        return _gauge
+    try:
+        from prometheus_client import Gauge
+
+        kwargs = {}
+        if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+            # livesum aggregates across all worker processes in the scrape response
+            kwargs["multiprocess_mode"] = "livesum"
+        _gauge = Gauge(
+            "litellm_in_flight_requests",
+            "Number of HTTP requests currently in-flight on this uvicorn worker",
+            **kwargs,
+        )
+    except Exception:
+        pass
+    return _gauge
+
+
+def get_in_flight_requests() -> int:
+    return _in_flight
+
+
+class InFlightRequestsMiddleware:
+    """
+    ASGI middleware that increments a counter when a request arrives
+    and decrements it when the response is sent (or an error occurs).
+
+    The counter is module-level and therefore scoped to a single uvicorn
+    worker process — exactly the per-pod granularity we want.
+
+    Also updates the `litellm_in_flight_requests` Prometheus gauge if
+    prometheus_client is installed.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        global _in_flight
+        _in_flight += 1
+        gauge = _get_gauge()
+        if gauge is not None:
+            gauge.inc()  # type: ignore[union-attr]
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            _in_flight -= 1
+            if gauge is not None:
+                gauge.dec()  # type: ignore[union-attr]

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -424,6 +424,9 @@ from litellm.proxy.management_endpoints.user_agent_analytics_endpoints import (
     router as user_agent_analytics_router,
 )
 from litellm.proxy.management_helpers.audit_logs import create_audit_log_for_update
+from litellm.proxy.middleware.in_flight_requests_middleware import (
+    InFlightRequestsMiddleware,
+)
 from litellm.proxy.middleware.prometheus_auth_middleware import PrometheusAuthMiddleware
 from litellm.proxy.ocr_endpoints.endpoints import router as ocr_router
 from litellm.proxy.openai_evals_endpoints.endpoints import router as evals_router
@@ -1404,6 +1407,7 @@ app.add_middleware(
 )
 
 app.add_middleware(PrometheusAuthMiddleware)
+app.add_middleware(InFlightRequestsMiddleware)
 
 
 def mount_swagger_ui():

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -237,6 +237,7 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_remaining_api_key_tokens_for_model",
     "litellm_llm_api_failed_requests_metric",
     "litellm_callback_logging_failures_metric",
+    "litellm_in_flight_requests",
 ]
 
 

--- a/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_in_flight_requests_middleware.py
@@ -1,0 +1,98 @@
+"""
+Tests for InFlightRequestsMiddleware.
+
+Verifies that in_flight_requests is incremented during a request and
+decremented after it completes, including on errors.
+"""
+import asyncio
+
+import pytest
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from litellm.proxy.middleware.in_flight_requests_middleware import (
+    InFlightRequestsMiddleware,
+    get_in_flight_requests,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Reset class-level state between tests."""
+    InFlightRequestsMiddleware._in_flight = 0
+    yield
+    InFlightRequestsMiddleware._in_flight = 0
+
+
+def _make_app(handler):
+    from starlette.applications import Starlette
+
+    app = Starlette(routes=[Route("/", handler)])
+    app.add_middleware(InFlightRequestsMiddleware)
+    return app
+
+
+# ── Structure ─────────────────────────────────────────────────────────────────
+
+
+def test_is_not_base_http_middleware():
+    """Must be pure ASGI — BaseHTTPMiddleware causes streaming degradation."""
+    assert not issubclass(InFlightRequestsMiddleware, BaseHTTPMiddleware)
+
+
+def test_has_asgi_call_protocol():
+    assert "__call__" in InFlightRequestsMiddleware.__dict__
+
+
+# ── Counter behaviour ─────────────────────────────────────────────────────────
+
+
+def test_counter_zero_at_start():
+    assert get_in_flight_requests() == 0
+
+
+def test_counter_increments_inside_handler():
+    captured = []
+
+    async def handler(request: Request) -> Response:
+        captured.append(InFlightRequestsMiddleware.get_count())
+        return JSONResponse({})
+
+    TestClient(_make_app(handler)).get("/")
+    assert captured == [1]
+
+
+def test_counter_returns_to_zero_after_request():
+    async def handler(request: Request) -> Response:
+        return JSONResponse({})
+
+    TestClient(_make_app(handler)).get("/")
+    assert get_in_flight_requests() == 0
+
+
+def test_counter_decrements_after_error():
+    """Counter must reach 0 even when the handler raises."""
+
+    async def handler(request: Request) -> Response:
+        return Response("boom", status_code=500)
+
+    TestClient(_make_app(handler)).get("/")
+    assert get_in_flight_requests() == 0
+
+
+def test_non_http_scopes_not_counted():
+    """Lifespan / websocket scopes must not touch the counter."""
+
+    class _InnerApp:
+        async def __call__(self, scope, receive, send):
+            pass
+
+    mw = InFlightRequestsMiddleware(_InnerApp())
+
+    asyncio.get_event_loop().run_until_complete(
+        mw({"type": "lifespan"}, None, None)  # type: ignore[arg-type]
+    )
+    assert get_in_flight_requests() == 0


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run** Link:
- [ ] **CI run for the last commit** Link:
- [ ] **Merge / cherry-pick CI run** Links:

## Type

🆕 New Feature

## Changes

### Problem

Users were reporting 20s total latency while LiteLLM only logged 10s. The missing 10s was the request sitting in uvicorn's event loop waiting to be dispatched — LiteLLM's clock doesn't start until its handler runs, so that queue wait is completely invisible.

```
T=0   Request arrives at ALB / uvicorn
      [10s gap — LiteLLM never sees this]
T=10  LiteLLM handler starts → starts its own timer
T=20  Response sent

LiteLLM logs: 10s   User experiences: 20s
```

### What this adds

**`GET /health/backlog`** — new per-pod endpoint returning the number of HTTP requests currently in-flight on this uvicorn worker:

```json
{"in_flight_requests": 47}
```

**`litellm_in_flight_requests`** Prometheus gauge — same value, scraped at `/metrics`. Uses `multiprocess_mode="livesum"` so it aggregates correctly when running with multiple workers.

### Implementation

- `litellm/proxy/middleware/in_flight_requests_middleware.py` — pure ASGI middleware (not `BaseHTTPMiddleware`). Increments a class-level counter on request start, decrements in `finally` so errors never leak. Prometheus gauge is lazily initialised on first request (so `PROMETHEUS_MULTIPROC_DIR` is already set), with a sentinel flag so the import is attempted exactly once.
- `litellm/proxy/proxy_server.py` — `InFlightRequestsMiddleware` registered as the outermost middleware (wraps everything, including CORS and Prometheus auth).
- `litellm/proxy/health_endpoints/_health_endpoints.py` — `/health/backlog` endpoint, protected by `user_api_key_auth`.
- `litellm/types/integrations/prometheus.py` — `litellm_in_flight_requests` added to `DEFINED_PROMETHEUS_METRICS`.

### POC results

```
start — no traffic                          0
low  — +5  requests fired                   5  █████
med  — +5  more (10 total)                 10  ██████████
high — +10 more (20 total)                 20  ████████████████████
peak — +10 more (30 total)                 30  ██████████████████████████████
peak — holding                             30  ██████████████████████████████
drained — all requests done                 0
```

### How SREs use this

| `in_flight_requests` | ALB `TargetResponseTime` | What it means |
|---|---|---|
| High | High | Pod overloaded → scale out |
| Low | High | Delay is pre-ASGI (network, event loop blocking) |
| High | Normal | Pod is busy but healthy |

Works out of the box with AWS ALB — no nginx header injection needed.