### PR TITLE
fix(vertex_ai): Set anthropic-beta as HTTP header for Vertex AI rawPredict

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py
@@ -144,6 +144,7 @@ class VertexAIAnthropicConfig(AnthropicConfig):
 
         if beta_set:
             data["anthropic_beta"] = list(beta_set)
+            headers["anthropic-beta"] = ",".join(beta_set)
 
         return data
 


### PR DESCRIPTION
## Relevant issues

Related: context_management and compact beta headers fail on Vertex AI via
the legacy VertexAIAnthropicConfig handler.

Possibly related: #20418

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai`

## Type

Bug Fix

## Changes

`VertexAIAnthropicConfig.transform_request()` sets beta values in the request
body (`data["anthropic_beta"]`) but does not set them as HTTP headers. Vertex
AI's rawPredict endpoint requires `anthropic-beta` as an HTTP header for
certain features to be recognized. Without the header, Vertex rejects request
body fields that depend on it with:

invalid_request_error: context_management: Extra inputs are not permitted

(We were experiencing this with the `compact-2026-01-12` beta header)

Verified with direct curl calls to Vertex AI rawPredict:
- `anthropic_beta` body field alone: 400 (context_management rejected)
- `anthropic-beta` HTTP header: 200 (context_management accepted)
- Both body field and HTTP header: 200

The fix adds a single line to also set `headers["anthropic-beta"]` alongside
the existing body field. The `headers` dict is mutable and propagates to the
HTTP POST call in the Anthropic chat handler.

The experimental pass-through handler
(`VertexAIPartnerModelsAnthropicMessagesConfig`) already sets beta values as
HTTP headers in `validate_anthropic_messages_environment()`. This fix aligns
the legacy handler behavior.

### Test plan

- [x] Updated existing context_management tests to verify HTTP header is set
- [x] Updated extra_headers propagation test to verify HTTP header
- [x] Updated no-headers test to verify HTTP header is absent when no betas
- [x] All 13 tests in test file pass