### PR TITLE
Add Prometheus child_exit cleanup for gunicorn workers

### DIFF
--- a/litellm/proxy/prometheus_cleanup.py
+++ b/litellm/proxy/prometheus_cleanup.py
@@ -28,3 +28,20 @@ def wipe_directory(directory: str) -> None:
         verbose_proxy_logger.info(
             f"Prometheus cleanup: wiped {deleted} stale .db files from {directory}"
         )
+
+
+def mark_worker_exit(worker_pid: int) -> None:
+    """Remove prometheus .db files for a dead worker. Called by gunicorn child_exit hook."""
+    if not os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        return
+    try:
+        from prometheus_client import multiprocess
+
+        multiprocess.mark_process_dead(worker_pid)
+        verbose_proxy_logger.info(
+            f"Prometheus cleanup: marked worker {worker_pid} as dead"
+        )
+    except Exception as e:
+        verbose_proxy_logger.warning(
+            f"Failed to mark prometheus worker {worker_pid} as dead: {e}"
+        )


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type


## Changes

For those running gunicorn we can hook into when child workers die and on that we clean up (using [prometheus](https://prometheus.github.io/client_python/)' `mark_process_dead`) all the stale live tracking files for that worker. 