### PR TITLE
fix(lint): suppress PLR0915 in complex transform methods

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -64,7 +64,7 @@ class AnthropicResponsesStreamWrapper:
         self._current_block_index += 1
         return self._current_block_index
 
-    def _process_event(self, event: Any) -> None:
+    def _process_event(self, event: Any) -> None:  # noqa: PLR0915
         """Convert one Responses API event into zero or more Anthropic chunks queued for emission."""
         event_type = getattr(event, "type", None)
         if event_type is None and isinstance(event, dict):

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -48,7 +48,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             return source.get("url")
         return None
 
-    def translate_messages_to_responses_input(
+    def translate_messages_to_responses_input(  # noqa: PLR0915
         self,
         messages: List[
             Union[

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -829,7 +829,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
             raise ValueError(f"Unknown openai event: {key}, value: {value}")
         return openai_event
 
-    def transform_realtime_response(
+    def transform_realtime_response(  # noqa: PLR0915
         self,
         message: Union[str, bytes],
         model: str,


### PR DESCRIPTION
## Summary
- Suppress Ruff PLR0915 (too-many-statements) on 3 methods that legitimately need many statements for event/message transformation logic
- `streaming_iterator.py::_process_event` (84 statements)
- `transformation.py::translate_messages_to_responses_input` (51 statements)
- `transformation.py::transform_realtime_response` (54 statements)

These are complex transformation methods where splitting would reduce readability. Suppressing the lint warning is the appropriate fix.

## Test plan
- [x] `ruff check` passes with no PLR0915 errors
- [ ] CI lint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)