### PR TITLE
fix(mcp): default available_on_public_internet to true

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -300,7 +300,7 @@ model LiteLLM_MCPServerTable {
   token_url          String?
   registration_url   String?
   allow_all_keys Boolean @default(false)
-  available_on_public_internet Boolean @default(false)
+  available_on_public_internet Boolean @default(true)
 }
 
 // Generate Tokens for Proxy

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -19210,6 +19210,39 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "gpt-audio-1.5": {
+        "input_cost_per_audio_token": 3.2e-05,
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_audio_token": 6.4e-05,
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "gpt-audio-2025-08-28": {
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_token": 2.5e-06,
@@ -20896,6 +20929,38 @@
         ]
     },
     "gpt-realtime": {
+        "cache_creation_input_audio_token_cost": 4e-07,
+        "cache_read_input_token_cost": 4e-07,
+        "input_cost_per_audio_token": 3.2e-05,
+        "input_cost_per_image": 5e-06,
+        "input_cost_per_token": 4e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_audio_token": 6.4e-05,
+        "output_cost_per_token": 1.6e-05,
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "gpt-realtime-1.5": {
         "cache_creation_input_audio_token_cost": 4e-07,
         "cache_read_input_token_cost": 4e-07,
         "input_cost_per_audio_token": 3.2e-05,
@@ -25092,6 +25157,25 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 159
     },
+    "openrouter/anthropic/claude-opus-4.6": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346
+    },
     "openrouter/anthropic/claude-sonnet-4.5": {
         "input_cost_per_image": 0.0048,
         "cache_creation_input_token_cost": 3.75e-06,
@@ -26104,6 +26188,42 @@
         "supports_prompt_caching": true,
         "supports_computer_use": false
     },
+    "openrouter/openrouter/auto": {
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 2000000,
+        "max_tokens": 2000000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_audio_input": true,
+        "supports_video_input": true
+    },
+    "openrouter/openrouter/free": {
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 200000,
+        "max_tokens": 200000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
+    "openrouter/openrouter/bodybuilder": {
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat"
+    },
     "ovhcloud/DeepSeek-R1-Distill-Llama-70B": {
         "input_cost_per_token": 6.7e-07,
         "litellm_provider": "ovhcloud",
@@ -26650,8 +26770,8 @@
         "mode": "chat",
         "output_cost_per_token": 0.0,
         "source": "https://platform.publicai.co/docs",
-        "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_function_calling": false,
+        "supports_tool_choice": false
     },
     "publicai/swiss-ai/apertus-70b-instruct": {
         "input_cost_per_token": 0.0,
@@ -26662,8 +26782,8 @@
         "mode": "chat",
         "output_cost_per_token": 0.0,
         "source": "https://platform.publicai.co/docs",
-        "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_function_calling": false,
+        "supports_tool_choice": false
     },
     "publicai/aisingapore/Gemma-SEA-LION-v4-27B-IT": {
         "input_cost_per_token": 0.0,
@@ -32991,6 +33111,7 @@
         "supports_web_search": true
     },
     "xai/grok-2-vision-1212": {
+        "deprecation_date": "2026-02-28",
         "input_cost_per_image": 2e-06,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "xai",
@@ -33095,6 +33216,7 @@
     },
     "xai/grok-3-mini": {
         "cache_read_input_token_cost": 7.5e-08,
+        "deprecation_date": "2026-02-28",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -33111,6 +33233,7 @@
     },
     "xai/grok-3-mini-beta": {
         "cache_read_input_token_cost": 7.5e-08,
+        "deprecation_date": "2026-02-28",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -331,7 +331,7 @@ class MCPServerManager:
                 static_headers=server_config.get("static_headers", None),
                 allow_all_keys=bool(server_config.get("allow_all_keys", False)),
                 available_on_public_internet=bool(
-                    server_config.get("available_on_public_internet", False)
+                    server_config.get("available_on_public_internet", True)
                 ),
             )
             self.config_mcp_servers[server_id] = new_server
@@ -634,7 +634,7 @@ class MCPServerManager:
             disallowed_tools=getattr(mcp_server, "disallowed_tools", None),
             allow_all_keys=mcp_server.allow_all_keys,
             available_on_public_internet=bool(
-                getattr(mcp_server, "available_on_public_internet", False)
+                getattr(mcp_server, "available_on_public_internet", True)
             ),
             updated_at=getattr(mcp_server, "updated_at", None),
         )

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1092,7 +1092,7 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
     token_url: Optional[str] = None
     registration_url: Optional[str] = None
     allow_all_keys: bool = False
-    available_on_public_internet: bool = False
+    available_on_public_internet: bool = True
 
     @model_validator(mode="before")
     @classmethod
@@ -1146,7 +1146,7 @@ class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
     token_url: Optional[str] = None
     registration_url: Optional[str] = None
     allow_all_keys: bool = False
-    available_on_public_internet: bool = False
+    available_on_public_internet: bool = True
 
     @model_validator(mode="before")
     @classmethod
@@ -1203,7 +1203,7 @@ class LiteLLM_MCPServerTable(LiteLLMPydanticObjectBase):
     token_url: Optional[str] = None
     registration_url: Optional[str] = None
     allow_all_keys: bool = False
-    available_on_public_internet: bool = False
+    available_on_public_internet: bool = True
 
 
 class MakeMCPServersPublicRequest(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -300,7 +300,7 @@ model LiteLLM_MCPServerTable {
   token_url          String?
   registration_url   String?
   allow_all_keys Boolean @default(false)
-  available_on_public_internet Boolean @default(false)
+  available_on_public_internet Boolean @default(true)
 }
 
 // Generate Tokens for Proxy

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -52,7 +52,7 @@ class MCPServer(BaseModel):
     env: Optional[Dict[str, str]] = None
     access_groups: Optional[List[str]] = None
     allow_all_keys: bool = False
-    available_on_public_internet: bool = False
+    available_on_public_internet: bool = True
     updated_at: Optional[datetime] = None
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -300,7 +300,7 @@ model LiteLLM_MCPServerTable {
   token_url          String?
   registration_url   String?
   allow_all_keys Boolean @default(false)
-  available_on_public_internet Boolean @default(false)
+  available_on_public_internet Boolean @default(true)
 }
 
 // Generate Tokens for Proxy

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.tsx
@@ -90,17 +90,19 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
           <div className="flex items-start justify-between gap-4">
             <div>
               <span className="text-sm font-medium text-gray-700 flex items-center">
-                Available on Public Internet
-                <Tooltip title="When enabled, this MCP server is accessible from external/public IPs (e.g., ChatGPT). When disabled, only callers from internal/private networks can access it.">
+                Internal network only
+                <Tooltip title="When on, only requests from within your internal network are accepted. Turn off to allow external clients (other clusters, ChatGPT, etc). API key authentication is always required regardless of this setting.">
                   <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
                 </Tooltip>
               </span>
-              <p className="text-sm text-gray-600 mt-1">Enable if this server should be reachable from the public internet.</p>
+              <p className="text-sm text-gray-600 mt-1">Turn on to restrict access to callers within your internal network only.</p>
             </div>
             <Form.Item
               name="available_on_public_internet"
               valuePropName="checked"
-              initialValue={mcpServer?.available_on_public_internet ?? true}
+              getValueProps={(value) => ({ checked: !value })}
+              getValueFromEvent={(checked: boolean) => !checked}
+              initialValue={true}
               className="mb-0"
             >
               <Switch />

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.tsx
@@ -46,7 +46,7 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
       }
     } else {
       form.setFieldValue("allow_all_keys", false);
-      form.setFieldValue("available_on_public_internet", false);
+      form.setFieldValue("available_on_public_internet", true);
     }
   }, [mcpServer, form]);
 
@@ -99,7 +99,7 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
             <Form.Item
               name="available_on_public_internet"
               valuePropName="checked"
-              initialValue={mcpServer?.available_on_public_internet ?? false}
+              initialValue={mcpServer?.available_on_public_internet ?? true}
               className="mb-0"
             >
               <Switch />

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.tsx
@@ -64,6 +64,7 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
         }
         key="permissions"
         className="border-0"
+        forceRender
       >
         <div className="space-y-6 pt-4">
           <div className="flex items-start justify-between gap-4">

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_columns.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_columns.tsx
@@ -157,9 +157,9 @@ export const mcpServerColumns = (
     cell: ({ row }) => {
       const isPublic = row.original.available_on_public_internet;
       return isPublic ? (
-        <span className="px-2 py-0.5 bg-green-50 text-green-700 rounded text-xs font-medium">Public</span>
+        <span className="px-2 py-0.5 bg-green-50 text-green-700 rounded text-xs font-medium">All networks</span>
       ) : (
-        <span className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded text-xs font-medium">Internal</span>
+        <span className="px-2 py-0.5 bg-orange-50 text-orange-700 rounded text-xs font-medium">Internal only</span>
       );
     },
   },

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
@@ -251,20 +251,20 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
                     </div>
                   </div>
                   <div>
-                    <Text className="font-medium">Available on Public Internet</Text>
+                    <Text className="font-medium">Network Access</Text>
                     <div className="flex items-center gap-2">
                       {mcpServer.available_on_public_internet ? (
                         <span className="px-2 py-1 bg-green-50 text-green-700 rounded-md text-sm">
-                          Public
+                          All networks
                         </span>
                       ) : (
-                        <span className="px-2 py-1 bg-gray-100 text-gray-600 rounded-md text-sm">
-                          Internal
+                        <span className="px-2 py-1 bg-orange-50 text-orange-700 rounded-md text-sm">
+                          Internal only
                         </span>
                       )}
-                      {mcpServer.available_on_public_internet && (
+                      {!mcpServer.available_on_public_internet && (
                         <Text className="text-xs text-gray-500">
-                          Accessible from external/public IPs
+                          Restricted to internal network
                         </Text>
                       )}
                     </div>


### PR DESCRIPTION
## Relevant issues

## Default Toggle
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/f5426050-0e2c-45f4-89ce-8ea4e4bedb95" />


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

`available_on_public_internet` was defaulting to `false`, making all new MCP servers private by default. This was a breaking change — servers created via the UI or YAML config would silently be invisible to external callers.

Changed the default to `true` in:
- `_types.py` — `AddMCPServerRequest`, `UpdateMCPServerRequest`, `LiteLLM_MCPServerTable`
- `schema.prisma` — `@default(false)` → `@default(true)` for new DB rows
- `mcp_server_manager.py` — YAML config fallback and DB loading fallback
- `MCPPermissionManagement.tsx` — form `initialValue` and `setFieldValue` defaults