### PR TITLE
fix(test): update realtime guardrail test assertions for voice violation behavior

### DIFF
--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -430,19 +430,36 @@ async def test_realtime_guardrail_blocks_prompt_injection():
     streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj)
     await streaming.backend_to_client_send_messages()
 
-    # ASSERT 1: no response.create was sent to backend (injection blocked).
+    # ASSERT 1: the guardrail blocked the normal auto-response and instead
+    # injected a conversation.item.create + response.create to voice the
+    # violation message.  There should be exactly ONE response.create (the
+    # guardrail-triggered one), preceded by a response.cancel and a
+    # conversation.item.create carrying the violation text.
     sent_to_backend = [
         json.loads(c.args[0])
         for c in backend_ws.send.call_args_list
         if c.args
     ]
-    response_creates = [
-        e for e in sent_to_backend
-        if e.get("type") == "response.create"
+    response_cancels = [
+        e for e in sent_to_backend if e.get("type") == "response.cancel"
     ]
-    assert len(response_creates) == 0, (
-        f"Guardrail should prevent response.create for injected content, "
-        f"but got: {response_creates}"
+    assert len(response_cancels) == 1, (
+        f"Guardrail should send response.cancel, got: {response_cancels}"
+    )
+    guardrail_items = [
+        e for e in sent_to_backend
+        if e.get("type") == "conversation.item.create"
+    ]
+    assert len(guardrail_items) == 1, (
+        f"Guardrail should inject a conversation.item.create with violation message, "
+        f"got: {guardrail_items}"
+    )
+    response_creates = [
+        e for e in sent_to_backend if e.get("type") == "response.create"
+    ]
+    assert len(response_creates) == 1, (
+        f"Guardrail should send exactly one response.create to voice the violation, "
+        f"got: {response_creates}"
     )
 
     # ASSERT 2: error event was sent directly to the client WebSocket
@@ -595,14 +612,26 @@ async def test_realtime_text_input_guardrail_blocks_and_returns_error():
     assert len(error_events) == 1, f"Expected one error event, got: {sent_texts}"
     assert error_events[0]["error"]["type"] == "guardrail_violation"
 
-    # ASSERT: blocked item was NOT forwarded to the backend
+    # ASSERT: the original blocked item was NOT forwarded to the backend.
+    # The guardrail handler injects its own conversation.item.create with
+    # the violation message — only that one should be present, not the
+    # original user message.
     sent_to_backend = [c.args[0] for c in backend_ws.send.call_args_list if c.args]
     forwarded_items = [
         json.loads(m) for m in sent_to_backend
         if isinstance(m, str) and json.loads(m).get("type") == "conversation.item.create"
     ]
-    assert len(forwarded_items) == 0, (
-        f"Blocked item should not be forwarded to backend, got: {forwarded_items}"
+    # Filter out guardrail-injected items (contain "Say exactly the following message")
+    original_items = [
+        item for item in forwarded_items
+        if not any(
+            "Say exactly the following message" in c.get("text", "")
+            for c in item.get("item", {}).get("content", [])
+            if isinstance(c, dict)
+        )
+    ]
+    assert len(original_items) == 0, (
+        f"Blocked item should not be forwarded to backend, got: {original_items}"
     )
 
     litellm.callbacks = []  # cleanup

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -379,7 +379,8 @@ async def test_realtime_guardrail_blocks_prompt_injection():
     """
     Test that when a transcription event containing prompt injection arrives from the
     backend, a registered guardrail blocks it — sending a warning to the client
-    and NOT sending response.create to the backend.
+    and voicing the guardrail violation message via response.cancel +
+    conversation.item.create + response.create.
     """
     import litellm
     from litellm.integrations.custom_guardrail import CustomGuardrail


### PR DESCRIPTION
## Summary
- Two realtime streaming guardrail tests were asserting that **no** `response.create` / `conversation.item.create` messages are sent to the backend when a guardrail blocks
- But the implementation at `realtime_streaming.py:348-363` intentionally sends these to have the LLM **voice the guardrail violation message** to the user in audio sessions
- Updated test assertions to match the actual (correct) behavior:
  - `test_realtime_guardrail_blocks_prompt_injection`: Now verifies the full guardrail flow — `response.cancel` + guardrail `conversation.item.create` + `response.create`
  - `test_realtime_text_input_guardrail_blocks_and_returns_error`: Now filters out guardrail-injected items and only asserts the **original** blocked message wasn't forwarded

## Test plan
- [x] Both previously failing tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)