### PR TITLE
fix(db): add missing migration for LiteLLM_ClaudeCodePluginTable

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260228000000_add_claude_code_plugin_table/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260228000000_add_claude_code_plugin_table/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "LiteLLM_ClaudeCodePluginTable" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "version" TEXT,
+    "description" TEXT,
+    "manifest_json" TEXT,
+    "files_json" TEXT DEFAULT '{}',
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT,
+
+    CONSTRAINT "LiteLLM_ClaudeCodePluginTable_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LiteLLM_ClaudeCodePluginTable_name_key" ON "LiteLLM_ClaudeCodePluginTable"("name");


### PR DESCRIPTION
## Summary
- PR #22271 added `LiteLLM_ClaudeCodePluginTable` to `schema.prisma` but did not include a migration file
- This causes `test_aaaasschema_migration_check` to fail with "Schema changes detected - new migration required"
- Adds the missing migration to create the `LiteLLM_ClaudeCodePluginTable` table with all columns matching the schema definition

## Test plan
- [x] Migration SQL matches schema.prisma model definition
- [x] Migration follows existing conventions (TIMESTAMP(3), CURRENT_TIMESTAMP defaults, etc.)
- [ ] CI `test_aaaasschema_migration_check` should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)