### PR TITLE
fix: update custom_llm_provider when base_model provider differs from deployment

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1192,6 +1192,19 @@ def completion_cost(  # noqa: PLR0915
                                 service_tier = _map_traffic_type_to_service_tier(
                                     raw_traffic_type
                                 )
+                    # When base_model is used and its provider differs
+                    # from the deployment provider, override
+                    # custom_llm_provider so cost_per_token dispatches
+                    # to the correct provider-specific function.
+                    # Must run after hidden_params extraction above.
+                    if (
+                        base_model is not None
+                        and model == base_model
+                        and _model_contains_known_llm_provider(base_model)
+                    ):
+                        _base_provider = base_model.split("/")[0]
+                        if _base_provider != custom_llm_provider:
+                            custom_llm_provider = _base_provider
                 else:
                     if model is None:
                         raise ValueError(


### PR DESCRIPTION
## Summary

When `base_model` is set with a different provider than the deployment model (e.g., `base_model='gemini/gemini-2.0-flash'` on deployment `anthropic/gemini-3-flash`), cost calculation returns `0.0` because `cost_per_token()` dispatches to the wrong provider.

## Root Cause

`_select_model_name_for_cost_calc()` correctly resolves model name to the `base_model`, but `custom_llm_provider` stays as the deployment provider (e.g., `anthropic`). The `cost_per_token()` function then dispatches to `anthropic_cost_per_token()` which can't find `anthropic/gemini-2.0-flash` in the cost map.

## Fix

After `hidden_params` extraction (which sets `custom_llm_provider` to deployment provider), check if the current iteration model matches `base_model` and the `base_model` contains a known LLM provider prefix. If so, override `custom_llm_provider` with the `base_model`'s provider.

## Test

Added `test_base_model_provider_mismatch_cost_calc` that:
- Sets `_hidden_params = {"custom_llm_provider": "anthropic"}` to simulate production conditions
- Verifies `completion_cost()` returns > 0 when `base_model` provider differs from deployment

Fixes #22257