### PR TITLE
perf: use deque for streaming event queues to avoid O(n) pop(0)

### DIFF
--- a/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
@@ -257,7 +257,7 @@ def test_tool_call_delta_without_id_uses_index_mapping():
 
     all_events = []
     while iterator._pending_tool_events:
-        all_events.append(iterator._pending_tool_events.pop(0))
+        all_events.append(iterator._pending_tool_events.popleft())
 
     delta_events = [
         evt
@@ -310,7 +310,7 @@ def test_parallel_tool_calls_without_ids_use_index_mapping():
 
     all_events = []
     while iterator._pending_tool_events:
-        all_events.append(iterator._pending_tool_events.pop(0))
+        all_events.append(iterator._pending_tool_events.popleft())
 
     output_item_added_events = [
         evt
@@ -374,7 +374,7 @@ def test_reused_index_with_new_call_id_marks_fallback_ambiguous():
 
     all_events = []
     while iterator._pending_tool_events:
-        all_events.append(iterator._pending_tool_events.pop(0))
+        all_events.append(iterator._pending_tool_events.popleft())
 
     delta_events = [
         evt


### PR DESCRIPTION
## Problem

`LiteLLMCompletionTransformationStreamingIterator` uses `list.pop(0)` (10 call-sites) to dequeue pending tool, response and annotation events during streaming. `list.pop(0)` is **O(n)** because CPython must shift every remaining element left by one slot.

On long streaming responses with many queued events, this becomes a measurable bottleneck.

## Solution

Replace the three internal lists (`_pending_tool_events`, `_pending_response_events`, `_pending_annotation_events`) with `collections.deque` and change all `.pop(0)` calls to `.popleft()`, which is **O(1)** amortised.

`.append()`, `.extend()`, boolean truthiness checks, and iteration all work identically on `deque`, so no other API surface changes.

## Testing

All 6 tests in `test_tool_call_streaming_transformation.py` pass (updated the test file to use `.popleft()` too).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>