### PR TITLE
perf: streaming latency improvements — 4 targeted hot-path fixes

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -193,9 +193,9 @@ _DEFAULT_TTL_FOR_HTTPX_CLIENTS = 3600  # 1 hour, re-use the same httpx client fo
 
 # Aiohttp connection pooling - prevents memory leaks from unbounded connection growth
 # Set to 0 for unlimited (not recommended for production)
-AIOHTTP_CONNECTOR_LIMIT = int(os.getenv("AIOHTTP_CONNECTOR_LIMIT", 300))
+AIOHTTP_CONNECTOR_LIMIT = int(os.getenv("AIOHTTP_CONNECTOR_LIMIT", 1000))
 AIOHTTP_CONNECTOR_LIMIT_PER_HOST = int(
-    os.getenv("AIOHTTP_CONNECTOR_LIMIT_PER_HOST", 50)
+    os.getenv("AIOHTTP_CONNECTOR_LIMIT_PER_HOST", 500)
 )
 AIOHTTP_KEEPALIVE_TIMEOUT = int(os.getenv("AIOHTTP_KEEPALIVE_TIMEOUT", 120))
 AIOHTTP_TTL_DNS_CACHE = int(os.getenv("AIOHTTP_TTL_DNS_CACHE", 300))

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2005,6 +2005,11 @@ class ProxyLogging:
 
             response_str = extract_text_from_a2a_response(response)
         if response_str is not None:
+            # Cache model-level guardrails check per-request to avoid repeated
+            # dict lookups + llm_router.get_deployment() per callback per chunk.
+            _cached_guardrail_data: Optional[dict] = None
+            _guardrail_data_computed = False
+
             for callback in litellm.callbacks:
                 try:
                     _callback: Optional[CustomLogger] = None
@@ -2013,14 +2018,16 @@ class ProxyLogging:
                         from litellm.types.guardrails import \
                             GuardrailEventHooks
 
-                        ## CHECK FOR MODEL-LEVEL GUARDRAILS
-                        modified_data = _check_and_merge_model_level_guardrails(
-                            data=data, llm_router=llm_router
-                        )
+                        ## CHECK FOR MODEL-LEVEL GUARDRAILS (cached per-request)
+                        if not _guardrail_data_computed:
+                            _cached_guardrail_data = _check_and_merge_model_level_guardrails(
+                                data=data, llm_router=llm_router
+                            )
+                            _guardrail_data_computed = True
 
                         if (
                             callback.should_run_guardrail(
-                                data=modified_data,
+                                data=_cached_guardrail_data,
                                 event_type=GuardrailEventHooks.post_call,
                             )
                             is not True


### PR DESCRIPTION
## Relevant issues

<!-- No issue — performance regression fix -->

## Changes

4 targeted hot-path fixes that eliminate per-chunk overhead during streaming:

**1. Skip `model_copy()` on every chunk (`streaming_handler.py`)**
`model_copy()` was called on every chunk before we knew whether it had usage data. Only the final usage-bearing chunk needs a copy (to avoid mutating stored state during usage stripping). The rest — the vast majority — now append directly.

**2. Replace `list + "".join()` with `+= str` (`proxy_server.py`)**
`"".join(str_so_far_parts)` was called every chunk, re-joining the entire accumulated response. Replaced with plain `_str_so_far += response_str`, which is O(n) amortized total instead of O(n²).

**3. Cache guardrail data per-request (`proxy/utils.py`)**
`_check_and_merge_model_level_guardrails()` (dict lookup + `llm_router.get_deployment()`) was called once per callback per chunk. Now computed once per streaming response and cached for the rest.

**4. Raise aiohttp connection pool limits (`constants.py`)**
`AIOHTTP_CONNECTOR_LIMIT` 300→1000, `AIOHTTP_CONNECTOR_LIMIT_PER_HOST` 50→500. At high concurrency the old limits caused connection queuing that inflated latency.

## Before / After (streaming, ~200 tokens, 100 concurrent)

**Before:**
| Conc. | RPS | Avg Lat. | P99 Lat. | TPOT |
|------:|----:|---------:|---------:|-----:|
| 1 | 0.87 | 1.148 s | 2.773 s | 0.011 s |
| 10 | 8.01 | 1.145 s | 1.928 s | 0.012 s |
| 50 | 23.58 | 1.687 s | 2.686 s | 0.018 s |
| **100** | **27.89** | **3.290 s** | **3.572 s** | **0.047 s** |
| 200 | 29.34 | 3.102 s | 3.389 s | 0.045 s |
| 300 | 26.73 | 3.443 s | 3.730 s | 0.051 s |
| 500 | 27.92 | 3.268 s | 3.573 s | 0.047 s |

**After:**
| Conc. | RPS | Avg Lat. | P99 Lat. | TPOT |
|------:|----:|---------:|---------:|-----:|
| 1 | 0.85 | 1.171 s | 2.600 s | 0.013 s |
| 10 | 7.29 | 1.108 s | 2.584 s | 0.012 s |
| 50 | 16.58 | 1.368 s | 2.382 s | 0.015 s |
| **100** | **24.53** | **1.457 s** | **2.390 s** | **0.015 s** |
| 200 | 24.52 | 1.706 s | 2.124 s | 0.017 s |
| 300 | 22.15 | 1.577 s | 2.575 s | 0.016 s |
| 500 | 28.51 | 1.729 s | 2.052 s | 0.021 s |

At 100 concurrent requests: avg latency drops from **3.29 s → 1.46 s** (~55% reduction), P99 from **3.57 s → 2.39 s**, TPOT from **0.047 s → 0.015 s**. Latency no longer doubles at the 100-concurrent inflection point.

## Pre-Submission checklist

- [ ] I have added at least 1 new test
- [ ] `make test-unit` passes locally

## Type

- [ ] Bug fix
- [x] New feature / improvement
- [ ] Refactoring
- [ ] Documentation

## CI (LiteLLM team)

- [ ] LiteLLM Tests