### PR TITLE
feat: add include_litellm_headers setting to strip x-litellm-* response_headers

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -351,6 +351,7 @@ anthropic_beta_headers_url: str = os.getenv(
     "https://raw.githubusercontent.com/BerriAI/litellm/main/litellm/anthropic_beta_headers_config.json",
 )
 suppress_debug_info = False
+include_litellm_headers: bool = True
 dynamodb_table_name: Optional[str] = None
 s3_callback_params: Optional[Dict] = None
 datadog_llm_observability_params: Optional[Union[DatadogLLMObsInitParams, Dict]] = None

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -395,6 +395,10 @@ class ProxyBaseLLMRequestProcessing:
         litellm_logging_obj: Optional[LiteLLMLoggingObj] = None,
         **kwargs,
     ) -> dict:
+        # When include_litellm_headers is False, skip all x-litellm-* headers
+        if litellm.include_litellm_headers is False:
+            return {}
+
         exclude_values = {"", None, "None"}
         hidden_params = hidden_params or {}
 


### PR DESCRIPTION
Add `include_litellm_headers` setting (`litellm_settings`) that allows disabling all `x-litellm-*` response headers. When set to `false`, `get_custom_headers()` returns an empty dict, stripping headers like `x-litellm-call-id`, `x-litellm-model-id`, `x-litellm-version`, `x-litellm-response-cost`, etc.

## Relevant issues

Relates to proxy users who need to hide the LiteLLM proxy layer from downstream clients.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

- **`litellm/__init__.py`** — Add `include_litellm_headers: bool = True` module-level setting
- **`litellm/proxy/common_request_processing.py`** — Early return `{}` in `get_custom_headers()` when `litellm.include_litellm_headers is False`
- **`tests/test_litellm/proxy/test_common_request_processing.py`** — Add 2 tests: headers included by default, headers excluded when disabled

## Usage

```yaml
# config.yaml
litellm_settings:
  include_litellm_headers: false
```