### PR TITLE
fix(video): use DEFAULT_VIDEO_ENDPOINT_MODEL in avideo_list provider resolution

### DIFF
--- a/litellm/videos/main.py
+++ b/litellm/videos/main.py
@@ -699,7 +699,7 @@ async def avideo_list(
         # get custom llm provider so we can use this for mapping exceptions
         if custom_llm_provider is None:
             _, custom_llm_provider, _, _ = litellm.get_llm_provider(
-                model="", api_base=local_vars.get("api_base", None)
+                model=DEFAULT_VIDEO_ENDPOINT_MODEL, api_base=local_vars.get("api_base", None)
             )
 
         func = partial(

--- a/tests/test_litellm/test_video_generation.py
+++ b/tests/test_litellm/test_video_generation.py
@@ -1256,6 +1256,35 @@ class TestVideoListTransformation:
         assert params["after"] == "video_bbb"
 
 
+class TestAvideListProviderFallback:
+    """Regression test for https://github.com/BerriAI/litellm/issues/22130.
+
+    avideo_list must not raise BadRequestError when custom_llm_provider is
+    omitted.  It should fall back to DEFAULT_VIDEO_ENDPOINT_MODEL instead of
+    passing model="" to get_llm_provider.
+    """
+
+    @pytest.mark.asyncio
+    async def test_avideo_list_no_provider_does_not_raise(self):
+        """avideo_list with custom_llm_provider=None should resolve the
+        provider via DEFAULT_VIDEO_ENDPOINT_MODEL, not fail on model=""."""
+        mock_videos = [
+            {
+                "id": "video_123",
+                "object": "video",
+                "model": "sora-2",
+                "status": "completed",
+                "created_at": 1700000000,
+            }
+        ]
+        from litellm.videos.main import avideo_list
+
+        # Patch the sync video_list that avideo_list delegates to
+        with patch("litellm.videos.main.video_list", return_value=mock_videos):
+            result = await avideo_list(custom_llm_provider=None)
+            assert result == mock_videos
+
+
 class TestVideoEndpointsProxyLitellmParams:
     """Test that video proxy endpoints (status, content, remix) respect litellm_params from proxy config."""
 


### PR DESCRIPTION
## Summary

Fixes #22130 — `avideo_list()` raises `BadRequestError: LLM Provider NOT provided` when `custom_llm_provider` is not explicitly passed.

## Root Cause

In `litellm/videos/main.py`, the async wrapper `avideo_list()` attempts to resolve the LLM provider by calling:

```python
litellm.get_llm_provider(model="", ...)
```

An empty model string cannot be resolved to any provider, causing the `BadRequestError`.

The sync `video_list()` function already handles this correctly by defaulting to `"openai"` when `custom_llm_provider` is `None`. The async `avideo_generation()` function also handles this correctly by using `model or DEFAULT_VIDEO_ENDPOINT_MODEL`.

## Fix

Replace `model=""` with `model=DEFAULT_VIDEO_ENDPOINT_MODEL` (`"sora-2"`) in `avideo_list()`, consistent with how `avideo_generation()` resolves the provider when no model is provided.

## Changes

- **`litellm/videos/main.py`**: One-line fix — use `DEFAULT_VIDEO_ENDPOINT_MODEL` instead of empty string
- **`tests/test_litellm/test_video_generation.py`**: Added regression test `TestAvideListProviderFallback`

## Testing

- New regression test passes ✅
- All 17 existing video generation tests pass ✅