### PR TITLE
[Feature] Key list endpoint: Add project_id and access_group_id filters

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6071,6 +6071,121 @@ async def test_build_key_filter_admin_all_member_overlap():
 
 
 @pytest.mark.asyncio
+async def test_build_key_filter_project_id():
+    """
+    Test that project_id is applied as a global AND condition, narrowing all results
+    to keys that belong to the specified project.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    user_id = "user-123"
+    project_id = "proj-abc"
+
+    where = _build_key_filter_conditions(
+        user_id=user_id,
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=None,
+        member_team_ids=None,
+        include_created_by_keys=False,
+        project_id=project_id,
+    )
+
+    # Should be wrapped in a top-level AND for the project_id filter
+    assert "AND" in where
+    and_parts = where["AND"]
+    assert len(and_parts) == 2
+
+    # Second part of AND should be the project_id filter
+    assert {"project_id": project_id} in and_parts
+
+
+@pytest.mark.asyncio
+async def test_build_key_filter_access_group_id():
+    """
+    Test that access_group_id is applied as a global AND condition using hasSome,
+    narrowing results to keys whose access_group_ids array contains the given ID.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    user_id = "user-123"
+    access_group_id = "ag-xyz"
+
+    where = _build_key_filter_conditions(
+        user_id=user_id,
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=None,
+        member_team_ids=None,
+        include_created_by_keys=False,
+        access_group_id=access_group_id,
+    )
+
+    # Should be wrapped in a top-level AND for the access_group_id filter
+    assert "AND" in where
+    and_parts = where["AND"]
+    assert len(and_parts) == 2
+
+    # Second part of AND should use hasSome for the array field
+    assert {"access_group_ids": {"hasSome": [access_group_id]}} in and_parts
+
+
+@pytest.mark.asyncio
+async def test_build_key_filter_project_id_and_access_group_id():
+    """
+    Test that project_id and access_group_id stack correctly when both are provided.
+    Both should be applied as AND conditions, narrowing results to keys that match both.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    user_id = "user-123"
+    project_id = "proj-abc"
+    access_group_id = "ag-xyz"
+
+    where = _build_key_filter_conditions(
+        user_id=user_id,
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=None,
+        member_team_ids=None,
+        include_created_by_keys=False,
+        project_id=project_id,
+        access_group_id=access_group_id,
+    )
+
+    # After project_id: {"AND": [visibility_where, {"project_id": ...}]}
+    # After access_group_id: {"AND": [above, {"access_group_ids": ...}]}
+    assert "AND" in where
+    outer_and = where["AND"]
+    assert len(outer_and) == 2
+
+    # The access_group_ids filter is the outermost AND
+    access_group_filter = outer_and[1]
+    assert access_group_filter == {"access_group_ids": {"hasSome": [access_group_id]}}
+
+    # The project_id filter is nested one level in
+    inner = outer_and[0]
+    assert "AND" in inner
+    inner_and = inner["AND"]
+    assert {"project_id": project_id} in inner_and
+
+
+@pytest.mark.asyncio
 async def test_get_member_team_ids():
     """
     Test that get_member_team_ids returns all teams where user is a member


### PR DESCRIPTION
## Summary

Added `project_id` and `access_group_id` filtering parameters to the `/key/list` endpoint. Both filters are applied as global AND conditions that narrow results across all visibility rules (user keys, team keys, etc.) and work with existing sort/pagination parameters. The `access_group_id` filter uses Prisma's `hasSome` operator to check if a key's `access_group_ids` array contains the specified ID.

## Testing

Added 3 unit tests:
- `test_build_key_filter_project_id`: Verifies project_id creates proper AND condition
- `test_build_key_filter_access_group_id`: Verifies access_group_id uses hasSome for array filtering
- `test_build_key_filter_project_id_and_access_group_id`: Verifies both filters stack correctly

All existing tests pass with no regressions.

## Type

🆕 New Feature
✅ Test