### PR TITLE
fix: set mock status_code in JWT OIDC discovery tests

### DIFF
--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -1559,6 +1559,7 @@ async def test_resolve_jwks_url_caches_resolved_jwks_uri():
     jwks_url = "https://login.microsoftonline.com/tenant/discovery/keys"
 
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {"jwks_uri": jwks_url}
 
     with patch.object(handler.http_handler, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
@@ -1587,6 +1588,7 @@ async def test_resolve_jwks_url_raises_if_no_jwks_uri_in_discovery_doc():
 
     discovery_url = "https://example.com/.well-known/openid-configuration"
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {"issuer": "https://example.com"}  # no jwks_uri
 
     with patch.object(handler.http_handler, "get", new_callable=AsyncMock, return_value=mock_response):


### PR DESCRIPTION
## Relevant issues

Fixes `proxy-core` CI failure: `test_resolve_jwks_url_caches_resolved_jwks_uri` and `test_resolve_jwks_url_raises_if_no_jwks_uri_in_discovery_doc`

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`_resolve_jwks_url` checks `response.status_code != 200` (line 486 in `handle_jwt.py`), but the test mocks use `MagicMock()` without setting `status_code`. Since `MagicMock().status_code` returns another `MagicMock` object (which is `!= 200`), the method raises an exception before reaching `json()`.

Fix: explicitly set `mock_response.status_code = 200` in both tests.