### PR TITLE
fix(ui): Display newlines correctly in tool descriptions

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/ToolsSection/FormattedToolView.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/ToolsSection/FormattedToolView.tsx
@@ -58,7 +58,14 @@ export function FormattedToolView({ tool }: FormattedToolViewProps) {
       {/* Description */}
       {tool.description && (
         <div style={{ marginBottom: 16 }}>
-          <Text style={{ lineHeight: 1.6 }}>{tool.description}</Text>
+          <Text
+            style={{
+              lineHeight: 1.6,
+              whiteSpace: 'pre-wrap',
+            }}
+          >
+            {tool.description}
+          </Text>
         </div>
       )}
 


### PR DESCRIPTION
## Relevant issues

Fixes #22362

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Add `whiteSpace: 'pre-wrap'` to tool description rendering to preserve newlines.

After this change:

<img width="1652" height="1570" alt="image" src="https://github.com/user-attachments/assets/5d7047b8-7d3a-494f-bd55-77ba9fa8a9e1" />
