### PR TITLE
feat: pass request_data to custom_auth when function accepts it

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -8,6 +8,7 @@ Returns a UserAPIKeyAuth object if the API key is valid
 """
 
 import asyncio
+import inspect
 import re
 import secrets
 from datetime import datetime, timezone
@@ -605,7 +606,19 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 api_key = response
                 custom_auth_api_key = True
         elif user_custom_auth is not None:
-            response = await user_custom_auth(request=request, api_key=api_key)  # type: ignore
+            # Pass request_data if the custom_auth function accepts it (backwards compatible)
+            _custom_auth_kwargs: dict = {"request": request, "api_key": api_key}
+            try:
+                _sig = inspect.signature(user_custom_auth)
+                _accepts_request_data = "request_data" in _sig.parameters or any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD
+                    for p in _sig.parameters.values()
+                )
+                if _accepts_request_data:
+                    _custom_auth_kwargs["request_data"] = request_data
+            except (ValueError, TypeError):
+                pass
+            response = await user_custom_auth(**_custom_auth_kwargs)  # type: ignore
             validated = UserAPIKeyAuth.model_validate(response)
             validated = await _run_post_custom_auth_checks(
                 valid_token=validated,

--- a/tests/test_litellm/proxy/auth/test_custom_auth_request_data.py
+++ b/tests/test_litellm/proxy/auth/test_custom_auth_request_data.py
@@ -1,0 +1,179 @@
+"""
+Tests for custom_auth receiving request_data parameter.
+
+Verifies that when a custom_auth function accepts a `request_data` parameter,
+the parsed request body is passed to it. Also verifies backwards compatibility
+with custom_auth functions that only accept (request, api_key).
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import Request
+from starlette.datastructures import URL
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+
+def _make_request(path: str) -> Request:
+    """Create a mock Request with the given URL path."""
+    request = Request(scope={"type": "http"})
+    request._url = URL(url=path)
+    return request
+
+
+def _set_proxy_server_attrs(proxy_mod, overrides: dict) -> dict:
+    """Set attributes on the proxy_server module and return originals."""
+    defaults = {
+        "prisma_client": None,
+        "user_api_key_cache": MagicMock(),
+        "proxy_logging_obj": MagicMock(),
+        "master_key": "sk-master-key",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    defaults.update(overrides)
+    original_values = {attr: getattr(proxy_mod, attr, None) for attr in defaults}
+    for attr, val in defaults.items():
+        setattr(proxy_mod, attr, val)
+    return original_values
+
+
+def _restore_proxy_server_attrs(proxy_mod, original_values: dict) -> None:
+    """Restore original values on the proxy_server module."""
+    for attr, val in original_values.items():
+        setattr(proxy_mod, attr, val)
+
+
+@pytest.mark.asyncio
+@patch("litellm.proxy.auth.user_api_key_auth.enterprise_custom_auth", None)
+async def test_custom_auth_receives_request_data():
+    """
+    When a custom_auth function has a `request_data` parameter,
+    it should receive the parsed request body dict.
+    """
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    received_kwargs = {}
+
+    async def custom_auth_with_request_data(request, api_key, request_data):
+        received_kwargs["request"] = request
+        received_kwargs["api_key"] = api_key
+        received_kwargs["request_data"] = request_data
+        return UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER)
+
+    overrides = {"user_custom_auth": custom_auth_with_request_data}
+    original_values = _set_proxy_server_attrs(_proxy_server_mod, overrides)
+
+    try:
+        request = _make_request("/chat/completions")
+        test_request_data = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+
+        await _user_api_key_auth_builder(
+            request=request,
+            api_key="Bearer sk-test",
+            azure_api_key_header="",
+            anthropic_api_key_header=None,
+            google_ai_studio_api_key_header=None,
+            azure_apim_header=None,
+            request_data=test_request_data,
+        )
+
+        assert "request_data" in received_kwargs
+        assert received_kwargs["request_data"] == test_request_data
+        assert received_kwargs["request_data"]["model"] == "gpt-4"
+    finally:
+        _restore_proxy_server_attrs(_proxy_server_mod, original_values)
+
+
+@pytest.mark.asyncio
+@patch("litellm.proxy.auth.user_api_key_auth.enterprise_custom_auth", None)
+async def test_custom_auth_backwards_compatible_without_request_data():
+    """
+    When a custom_auth function does NOT have a `request_data` parameter
+    (old-style 2-arg signature), it should still work without errors.
+    """
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    received_kwargs = {}
+
+    async def custom_auth_legacy(request, api_key):
+        received_kwargs["request"] = request
+        received_kwargs["api_key"] = api_key
+        return UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER)
+
+    overrides = {"user_custom_auth": custom_auth_legacy}
+    original_values = _set_proxy_server_attrs(_proxy_server_mod, overrides)
+
+    try:
+        request = _make_request("/chat/completions")
+
+        result = await _user_api_key_auth_builder(
+            request=request,
+            api_key="Bearer sk-test",
+            azure_api_key_header="",
+            anthropic_api_key_header=None,
+            google_ai_studio_api_key_header=None,
+            azure_apim_header=None,
+            request_data={"model": "gpt-4"},
+        )
+
+        assert isinstance(result, UserAPIKeyAuth)
+        # request_data should NOT be in received kwargs (not in signature)
+        assert "request_data" not in received_kwargs
+        assert "request" in received_kwargs
+        assert "api_key" in received_kwargs
+    finally:
+        _restore_proxy_server_attrs(_proxy_server_mod, original_values)
+
+
+@pytest.mark.asyncio
+@patch("litellm.proxy.auth.user_api_key_auth.enterprise_custom_auth", None)
+async def test_custom_auth_with_kwargs_receives_request_data():
+    """
+    When a custom_auth function accepts **kwargs, it should receive
+    request_data since kwargs implies any parameter is accepted.
+    """
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    received_kwargs = {}
+
+    async def custom_auth_with_kwargs(request, api_key, **kwargs):
+        received_kwargs.update(kwargs)
+        return UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER)
+
+    overrides = {"user_custom_auth": custom_auth_with_kwargs}
+    original_values = _set_proxy_server_attrs(_proxy_server_mod, overrides)
+
+    try:
+        request = _make_request("/chat/completions")
+        test_data = {"model": "gpt-4"}
+
+        await _user_api_key_auth_builder(
+            request=request,
+            api_key="Bearer sk-test",
+            azure_api_key_header="",
+            anthropic_api_key_header=None,
+            google_ai_studio_api_key_header=None,
+            azure_apim_header=None,
+            request_data=test_data,
+        )
+
+        # **kwargs should capture request_data
+        assert "request_data" in received_kwargs
+        assert received_kwargs["request_data"] == test_data
+    finally:
+        _restore_proxy_server_attrs(_proxy_server_mod, original_values)


### PR DESCRIPTION
## Relevant issues

Relates to proxy users who need access to the request body (e.g., model name) inside `custom_auth` without manually parsing `request.body()`.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

Pass the parsed `request_data` dict to `custom_auth` functions that accept it, using `inspect.signature` for backwards-compatible detection. Functions with the old `(request, api_key)` signature continue to work unchanged.

- **`litellm/proxy/auth/user_api_key_auth.py`** — Use `inspect.signature` to detect if `user_custom_auth` accepts `request_data` (explicit parameter or `**kwargs`), and pass it when supported. Falls back to `(request, api_key)` for existing functions.
- **`tests/test_litellm/proxy/auth/test_custom_auth_request_data.py`** — 3 tests:
  - `test_custom_auth_receives_request_data` — explicit `request_data` parameter
  - `test_custom_auth_backwards_compatible_without_request_data` — old 2-arg signature
  - `test_custom_auth_with_kwargs_receives_request_data` — `**kwargs` signature

### Usage

```python
# New-style custom_auth (receives request_data)
async def my_custom_auth(request, api_key, request_data):
    model = request_data.get("model", "")
    # ... auth logic based on model
    return UserAPIKeyAuth(...)

# Old-style custom_auth (still works)
async def my_custom_auth(request, api_key):
    return UserAPIKeyAuth(...)
```