### PR TITLE
fix(anthropic): remove spurious effort beta header for output_config and restrict effort=max to Opus 4.6

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -186,6 +186,20 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             )
         )
 
+    @staticmethod
+    def _is_claude_opus_4_6_model(model: str) -> bool:
+        """Check if the model is specifically Claude Opus 4.6 (required for effort='max')."""
+        model_lower = model.lower()
+        return any(
+            model_variant in model_lower
+            for model_variant in (
+                "opus-4-6",
+                "opus_4_6",
+                "opus-4.6",
+                "opus_4.6",
+            )
+        )
+
     def get_supported_openai_params(self, model: str):
         params = [
             "stream",
@@ -1392,9 +1406,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     raise ValueError(
                         f"Invalid effort value: {effort}. Must be one of: 'high', 'medium', 'low', 'max'"
                     )
-                if effort == "max" and not self._is_claude_4_6_model(model):
+                if effort == "max" and not self._is_claude_opus_4_6_model(model):
                     raise ValueError(
-                        f"effort='max' is only supported by Claude 4.6 models (Opus 4.6, Sonnet 4.6). Got model: {model}"
+                        f"effort='max' is only supported by Claude Opus 4.6. Got model: {model}"
                     )
                 data["output_config"] = output_config
 

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -228,24 +228,21 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         self, optional_params: Optional[dict], model: Optional[str] = None
     ) -> bool:
         """
-        Check if effort parameter is being used.
+        Check if effort parameter is being used in a way that requires the
+        effort-2025-11-24 beta header.
 
-        Returns True if effort-related parameters are present.
+        Returns True only for reasoning_effort on Claude Opus 4.5, which is
+        the only path that requires the beta header. The output_config.effort
+        parameter used with Claude 4.6 models does NOT require a beta header
+        per the Anthropic docs.
         """
         if not optional_params:
             return False
 
-        # Check if reasoning_effort is provided for Claude Opus 4.5
+        # Only Opus 4.5 reasoning_effort needs the beta header
         if model and ("opus-4-5" in model.lower() or "opus_4_5" in model.lower()):
             reasoning_effort = optional_params.get("reasoning_effort")
             if reasoning_effort and isinstance(reasoning_effort, str):
-                return True
-
-        # Check if output_config is directly provided
-        output_config = optional_params.get("output_config")
-        if output_config and isinstance(output_config, dict):
-            effort = output_config.get("effort")
-            if effort and isinstance(effort, str):
                 return True
 
         return False


### PR DESCRIPTION
## Summary

Fixes #22213 and #22226

Two fixes for Anthropic adaptive thinking parameters:

### 1. Spurious `effort-2025-11-24` beta header (#22213)

`is_effort_used()` returns `True` whenever `output_config` contains an `effort` key, causing the `effort-2025-11-24` beta header to be injected. Per the [Anthropic docs](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking):

> No beta header is required [for adaptive thinking].

**Fix:** Remove the `output_config` check from `is_effort_used()`. The beta header is now only injected for `reasoning_effort` on Opus 4.5 (the legitimate use case).

### 2. `effort="max"` guard too loose (#22226)

`_is_claude_4_6_model()` matches both Opus 4.6 and Sonnet 4.6, but per the Anthropic docs:

> **`max`** — Claude always thinks with no constraints on thinking depth. **Opus 4.6 only.**

**Fix:** Added `_is_claude_opus_4_6_model()` helper that only matches Opus 4.6 variants. The `effort="max"` guard now correctly rejects Sonnet 4.6.

## Testing

- Updated `test_effort_beta_header_injection` to verify no beta header for `output_config.effort`, and that `reasoning_effort` on Opus 4.5 still triggers the header
- Added `test_max_effort_rejected_for_sonnet_46`
- All 11 effort-related tests pass (2 consecutive clean runs)

## Type

🐛 Bug Fix