### PR TITLE
fix(moonshot): validate reasoning_content in multi-turn tool calling

### DIFF
--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -94,7 +94,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
             if (
                 message.get("role") == "assistant"
                 and message.get("tool_calls")
-                and not message.get("reasoning_content")
+                and message.get("reasoning_content") is None
             ):
                 raise litellm.BadRequestError(
                     message=(

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -94,7 +94,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
             reasoning_content = message.get("reasoning_content")
             if (
                 message.get("role") == "assistant"
-                and message.get("reasoning_content") is None
+                and message.get("tool_calls")
                 and (
                     reasoning_content is None
                     or (isinstance(reasoning_content, str) and not reasoning_content.strip())

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -94,7 +94,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
             if (
                 message.get("role") == "assistant"
                 and message.get("tool_calls")
-                and message.get("reasoning_content") is None
+                and not message.get("reasoning_content")
             ):
                 raise litellm.BadRequestError(
                     message=(

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -94,13 +94,13 @@ class MoonshotChatConfig(OpenAIGPTConfig):
             reasoning_content = message.get("reasoning_content")
             if (
                 message.get("role") == "assistant"
-                and message.get("tool_calls")
+                and message.get("reasoning_content") is None
                 and (
                     reasoning_content is None
                     or (isinstance(reasoning_content, str) and not reasoning_content.strip())
                 )
             ):
-                raise litellm.BadRequestError(
+                raise BadRequestError(
                     message=(
                         f"Moonshot reasoning model '{model}' requires "
                         f"'reasoning_content' in assistant messages that contain "

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -10,6 +10,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 )
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
+from litellm.utils import supports_reasoning
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
@@ -66,13 +67,6 @@ class MoonshotChatConfig(OpenAIGPTConfig):
                 messages=messages, model=model, is_async=False
             )
 
-    @staticmethod
-    def _is_reasoning_model(model: str) -> bool:
-        """Check if a Moonshot model has thinking/reasoning enabled by default."""
-        reasoning_indicators = ["k2.5", "k2-5", "reasoning", "thinking"]
-        model_lower = model.lower()
-        return any(indicator in model_lower for indicator in reasoning_indicators)
-
     def _validate_reasoning_content_in_messages(
         self, messages: List[AllMessageValues], model: str
     ) -> None:
@@ -87,7 +81,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
         Raises:
             litellm.BadRequestError when reasoning_content is missing.
         """
-        if not self._is_reasoning_model(model):
+        if not supports_reasoning(model=model, custom_llm_provider="moonshot"):
             return
 
         for i, message in enumerate(messages):
@@ -97,7 +91,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
                 and message.get("tool_calls")
                 and (
                     reasoning_content is None
-                    or (isinstance(reasoning_content, str) and not reasoning_content.strip())
+                    or (isinstance(reasoning_content, str) and not reasoning_content.strip())  # Moonshot rejects empty/whitespace-only reasoning_content
                 )
             ):
                 raise BadRequestError(

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -4,6 +4,7 @@ Translates from OpenAI's `/v1/chat/completions` to Moonshot AI's `/v1/chat/compl
 
 from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
 
+import litellm
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     handle_messages_with_content_list_to_str_conversion,
 )
@@ -40,6 +41,9 @@ class MoonshotChatConfig(OpenAIGPTConfig):
 
         If any message contains a non-text content part, skip flattening
         so the multimodal payload is preserved.
+
+        Also validates that reasoning_content is preserved in assistant messages
+        with tool_calls for reasoning models (e.g. kimi-k2.5).
         """
         has_non_text = False
         for m in messages:
@@ -52,6 +56,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
         if not has_non_text:
             messages = handle_messages_with_content_list_to_str_conversion(messages)
 
+        self._validate_reasoning_content_in_messages(messages, model)
         if is_async:
             return super()._transform_messages(
                 messages=messages, model=model, is_async=True
@@ -60,6 +65,50 @@ class MoonshotChatConfig(OpenAIGPTConfig):
             return super()._transform_messages(
                 messages=messages, model=model, is_async=False
             )
+
+    @staticmethod
+    def _is_reasoning_model(model: str) -> bool:
+        """Check if a Moonshot model has thinking/reasoning enabled by default."""
+        reasoning_indicators = ["k2.5", "k2-5", "reasoning", "thinking"]
+        model_lower = model.lower()
+        return any(indicator in model_lower for indicator in reasoning_indicators)
+
+    def _validate_reasoning_content_in_messages(
+        self, messages: List[AllMessageValues], model: str
+    ) -> None:
+        """
+        Validate that assistant messages with tool_calls include reasoning_content
+        when using a Moonshot reasoning model.
+
+        Moonshot reasoning models (e.g. kimi-k2.5) require reasoning_content to be
+        preserved in assistant tool-call messages during multi-turn conversations.
+        See: https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart#tool-use-compatibility
+
+        Raises:
+            litellm.BadRequestError when reasoning_content is missing.
+        """
+        if not self._is_reasoning_model(model):
+            return
+
+        for i, message in enumerate(messages):
+            if (
+                message.get("role") == "assistant"
+                and message.get("tool_calls")
+                and not message.get("reasoning_content")
+            ):
+                raise litellm.BadRequestError(
+                    message=(
+                        f"Moonshot reasoning model '{model}' requires "
+                        f"'reasoning_content' in assistant messages that contain "
+                        f"tool_calls (message at index {i}). "
+                        f"When building your conversation history, preserve the "
+                        f"reasoning_content from the model's response, e.g.: "
+                        f"messages.append(response.choices[0].message.model_dump(exclude_none=True)). "
+                        f"Ref: https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart#tool-use-compatibility"
+                    ),
+                    model=model,
+                    llm_provider="moonshot",
+                )
 
     def _get_openai_compatible_provider_info(
         self, api_base: Optional[str], api_key: Optional[str]

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -4,7 +4,7 @@ Translates from OpenAI's `/v1/chat/completions` to Moonshot AI's `/v1/chat/compl
 
 from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
 
-import litellm
+from litellm.exceptions import BadRequestError
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     handle_messages_with_content_list_to_str_conversion,
 )
@@ -91,10 +91,14 @@ class MoonshotChatConfig(OpenAIGPTConfig):
             return
 
         for i, message in enumerate(messages):
+            reasoning_content = message.get("reasoning_content")
             if (
                 message.get("role") == "assistant"
                 and message.get("tool_calls")
-                and message.get("reasoning_content") is None
+                and (
+                    reasoning_content is None
+                    or (isinstance(reasoning_content, str) and not reasoning_content.strip())
+                )
             ):
                 raise litellm.BadRequestError(
                     message=(

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -67,8 +67,9 @@ class MoonshotChatConfig(OpenAIGPTConfig):
                 messages=messages, model=model, is_async=False
             )
 
+    @staticmethod
     def _validate_reasoning_content_in_messages(
-        self, messages: List[AllMessageValues], model: str
+        messages: List[AllMessageValues], model: str
     ) -> None:
         """
         Validate that assistant messages with tool_calls include reasoning_content

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -24186,6 +24186,7 @@
         "output_cost_per_token": 3e-06,
         "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
@@ -24256,6 +24257,7 @@
         "mode": "chat",
         "output_cost_per_token": 2.5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "moonshot/kimi-k2-thinking": {
@@ -24269,6 +24271,7 @@
         "output_cost_per_token": 2.5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
@@ -24283,6 +24286,7 @@
         "output_cost_per_token": 8e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -24186,6 +24186,7 @@
         "output_cost_per_token": 3e-06,
         "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
@@ -24256,6 +24257,7 @@
         "mode": "chat",
         "output_cost_per_token": 2.5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "moonshot/kimi-k2-thinking": {
@@ -24269,6 +24271,7 @@
         "output_cost_per_token": 2.5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
@@ -24283,6 +24286,7 @@
         "output_cost_per_token": 8e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -16,7 +16,6 @@ import pytest
 
 import litellm
 import litellm.utils
-from litellm import completion
 from litellm.llms.moonshot.chat.transformation import MoonshotChatConfig
 
 

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -299,7 +299,7 @@ class TestMoonshotConfig:
             {"role": "tool", "content": '{"temp": 25}', "tool_call_id": "call_1"},
         ]
 
-        with pytest.raises(litellm.BadRequestError) as exc_info:
+        with pytest.raises(litellm.BadRequestError, match=r"reasoning_content.*index 1"):
             config.transform_request(
                 model="kimi-k2.5",
                 messages=messages,
@@ -307,9 +307,6 @@ class TestMoonshotConfig:
                 litellm_params={},
                 headers={},
             )
-
-        assert "reasoning_content" in str(exc_info.value)
-        assert "index 1" in str(exc_info.value)
 
     def test_reasoning_content_validation_passes_when_present(self):
         """Test that reasoning_content present in messages passes validation."""
@@ -412,7 +409,7 @@ class TestMoonshotConfig:
             {"role": "tool", "content": "result", "tool_call_id": "call_1"},
         ]
 
-        with pytest.raises(litellm.BadRequestError):
+        with pytest.raises(litellm.BadRequestError, match=r"reasoning_content"):
             config.transform_request(
                 model="kimi-k2.5",
                 messages=messages,

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -17,6 +17,7 @@ import pytest
 import litellm
 import litellm.utils
 from litellm.llms.moonshot.chat.transformation import MoonshotChatConfig
+from litellm.utils import supports_reasoning
 
 
 class TestMoonshotConfig:
@@ -418,15 +419,14 @@ class TestMoonshotConfig:
                 headers={},
             )
 
-    def test_is_reasoning_model_detection(self):
-        """Test _is_reasoning_model detects reasoning models correctly."""
-        assert MoonshotChatConfig._is_reasoning_model("kimi-k2.5") is True
-        assert MoonshotChatConfig._is_reasoning_model("kimi-k2.5-0514") is True
-        assert MoonshotChatConfig._is_reasoning_model("moonshot-v1-auto-8k-reasoning-v4") is True
-        assert MoonshotChatConfig._is_reasoning_model("kimi-thinking-preview") is True
-        assert MoonshotChatConfig._is_reasoning_model("kimi-k2-5") is True
-        assert MoonshotChatConfig._is_reasoning_model("moonshot-v1-8k") is False
-        assert MoonshotChatConfig._is_reasoning_model("moonshot-v1-32k") is False
+    def test_supports_reasoning_model_detection(self):
+        """Test supports_reasoning detects moonshot reasoning models correctly via JSON config."""
+        assert supports_reasoning(model="moonshot/kimi-k2.5", custom_llm_provider="moonshot") is True
+        assert supports_reasoning(model="moonshot/kimi-thinking-preview", custom_llm_provider="moonshot") is True
+        assert supports_reasoning(model="moonshot/kimi-k2-thinking", custom_llm_provider="moonshot") is True
+        assert supports_reasoning(model="moonshot/kimi-k2-thinking-turbo", custom_llm_provider="moonshot") is True
+        assert supports_reasoning(model="moonshot/moonshot-v1-8k", custom_llm_provider="moonshot") is False
+        assert supports_reasoning(model="moonshot/moonshot-v1-32k", custom_llm_provider="moonshot") is False
 
     def test_tool_choice_non_required_preserved(self):
         """Test that non-'required' tool_choice values are preserved"""


### PR DESCRIPTION
## Summary

Fixes #21672

Moonshot reasoning models (e.g. `kimi-k2.5`) require `reasoning_content` to be preserved in assistant messages with `tool_calls` during multi-turn conversations. Without it, the Moonshot API returns a 400 Bad Request error:

```
MoonshotException - thinking is enabled but reasoning_content is missing in assistant tool call message at index 2
```

This is architecturally the same issue as Anthropic's `thinking_blocks` — the API is stateless and requires reasoning content from the previous turn to be echoed back.

## Root Cause

When users construct conversation history for multi-turn tool calling, they often build assistant message dicts without including `reasoning_content`:

```python
messages.append({"role": "assistant", "content": None, "tool_calls": [...]})
# Missing reasoning_content → Moonshot API rejects the request
```

## Fix

Add validation in `MoonshotChatConfig._transform_messages()` that detects assistant messages with `tool_calls` but missing `reasoning_content` on reasoning models, and raises a clear `litellm.BadRequestError` with:

- The exact message index that is missing the field
- A code example showing the correct pattern (`model_dump(exclude_none=True)`)
- A link to the official Moonshot documentation

This provides an **actionable error message before the API call** instead of letting users hit a cryptic 400 from the Moonshot API.

### Changes

- `litellm/llms/moonshot/chat/transformation.py`:
  - Added `_is_reasoning_model()` static method to detect Moonshot models with thinking enabled (kimi-k2.5, kimi-k2-5, etc.)
  - Added `_validate_reasoning_content_in_messages()` that checks for missing/falsy `reasoning_content` in assistant tool-call messages
  - Integrated validation into `_transform_messages()`

- `tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py`:
  - 6 new tests covering: missing field raises, present field passes, None value rejected, non-reasoning models skip, no tool_calls skip, model detection accuracy

## Test Results

All 18 Moonshot tests pass. Pre-existing Bedrock Moonshot test failures are unrelated (confirmed on main).

Ref: https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart#tool-use-compatibility