### PR TITLE
fix: add sync streaming fallback + fix 429 for all streaming paths

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -13,6 +13,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    NoReturn,
     Optional,
     Union,
     cast,
@@ -1899,14 +1900,7 @@ class CustomStreamWrapper:
             threading.Thread(
                 target=self.logging_obj.failure_handler, args=(e, traceback_exception)
             ).start()
-            if isinstance(e, OpenAIError):
-                raise e
-            else:
-                raise exception_type(
-                    model=self.model,
-                    original_exception=e,
-                    custom_llm_provider=self.custom_llm_provider,
-                )
+            self._handle_stream_fallback_error(e)
 
     def fetch_sync_stream(self):
         if self.completion_stream is None and self.make_call is not None:
@@ -2119,7 +2113,25 @@ class CustomStreamWrapper:
                 asyncio.create_task(
                     self.logging_obj.async_failure_handler(e, traceback_exception)  # type: ignore
                 )
-            ## Map to OpenAI Exception
+            self._handle_stream_fallback_error(e)
+
+    def _handle_stream_fallback_error(self, e: Exception) -> "NoReturn":
+        """
+        Common error handling for both __next__ and __anext__.
+
+        Maps the raw exception to an OpenAI-compatible type, then decides
+        whether to raise it directly (non-retriable 4xx) or wrap it in
+        MidStreamFallbackError so the Router can trigger a fallback.
+
+        429 (rate-limit) is explicitly exempted from the 4xx filter because
+        it is transient and the Router should switch to another model group.
+        """
+        from litellm.exceptions import MidStreamFallbackError
+
+        # Map to OpenAI exception format
+        if isinstance(e, OpenAIError):
+            mapped_exception: Exception = e
+        else:
             try:
                 mapped_exception = exception_type(
                     model=self.model,
@@ -2131,46 +2143,44 @@ class CustomStreamWrapper:
             except Exception as mapping_error:
                 mapped_exception = mapping_error
 
-            def _normalize_status_code(exc: Exception) -> Optional[int]:
-                """
-                Best-effort status_code extraction.
-                Uses status_code on the exception, then falls back to the response.
-                """
+        def _normalize_status_code(exc: Exception) -> Optional[int]:
+            """Best-effort status_code extraction."""
+            try:
+                code = getattr(exc, "status_code", None)
+                if code is not None:
+                    return int(code)
+            except Exception:
+                pass
+
+            response = getattr(exc, "response", None)
+            if response is not None:
                 try:
-                    code = getattr(exc, "status_code", None)
-                    if code is not None:
-                        return int(code)
+                    status_code = getattr(response, "status_code", None)
+                    if status_code is not None:
+                        return int(status_code)
                 except Exception:
                     pass
+            return None
 
-                response = getattr(exc, "response", None)
-                if response is not None:
-                    try:
-                        status_code = getattr(response, "status_code", None)
-                        if status_code is not None:
-                            return int(status_code)
-                    except Exception:
-                        pass
-                return None
+        mapped_status_code = _normalize_status_code(mapped_exception)
+        original_status_code = _normalize_status_code(e)
 
-            mapped_status_code = _normalize_status_code(mapped_exception)
-            original_status_code = _normalize_status_code(e)
+        # Raise non-retriable client errors directly (skip fallback).
+        # Exception: 429 (rate-limit) IS retriable/transient — allow it
+        # through so the Router can switch to a different model group.
+        if mapped_status_code is not None and 400 <= mapped_status_code < 500 and mapped_status_code != 429:
+            raise mapped_exception
+        if original_status_code is not None and 400 <= original_status_code < 500 and original_status_code != 429:
+            raise mapped_exception
 
-            if mapped_status_code is not None and 400 <= mapped_status_code < 500:
-                raise mapped_exception
-            if original_status_code is not None and 400 <= original_status_code < 500:
-                raise mapped_exception
-
-            from litellm.exceptions import MidStreamFallbackError
-
-            raise MidStreamFallbackError(
-                message=str(mapped_exception),
-                model=self.model,
-                llm_provider=self.custom_llm_provider or "anthropic",
-                original_exception=mapped_exception,
-                generated_content=self.response_uptil_now,
-                is_pre_first_chunk=not self.sent_first_chunk,
-            )
+        raise MidStreamFallbackError(
+            message=str(mapped_exception),
+            model=self.model,
+            llm_provider=self.custom_llm_provider or "anthropic",
+            original_exception=mapped_exception,
+            generated_content=self.response_uptil_now,
+            is_pre_first_chunk=not self.sent_first_chunk,
+        )
 
     @staticmethod
     def _strip_sse_data_from_chunk(chunk: Optional[str]) -> Optional[str]:

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1486,10 +1486,9 @@ def test_completion_streaming_iterator_fallback_on_429():
         assert mock_fallback.called
         call_kwargs = mock_fallback.call_args
         # Pre-first-chunk: should use original messages, no continuation prompt
-        assert call_kwargs.kwargs.get("messages", call_kwargs[1].get("messages")) is None or True
+        assert call_kwargs.kwargs.get("messages") == messages
         # Verify original_function is _completion (sync)
-        passed_kwargs = {**call_kwargs.kwargs}
-        assert passed_kwargs.get("original_function") == router._completion
+        assert call_kwargs.kwargs.get("original_function") == router._completion
 
 
 def test_completion_streaming_iterator_preserves_hidden_params():


### PR DESCRIPTION
## Summary

LiteLLM providers that use deferred HTTP (Vertex AI, Bedrock, Predibase, Codestral) make the streaming HTTP request lazily on first iteration (`__next__`/`__anext__`), not during `completion()`/`acompletion()`. This means errors surface during stream iteration — outside the Router's retry/fallback machinery.

Two gaps existed:

1. **`__anext__` blocked 429 from fallback** (PR #18698): A blanket 4xx filter raised all 400–499 errors directly, preventing `MidStreamFallbackError` wrapping. 429 is transient and should trigger fallback.
2. **`__next__` had zero fallback support**: No `MidStreamFallbackError` wrapping, and no Router-level sync streaming fallback wrapper (`_completion_streaming_iterator`). All errors — 429, 5xx, network drops — surfaced directly to the caller.

Eager-HTTP providers (OpenAI, Anthropic) are unaffected — their HTTP requests happen inline during `completion()`/`acompletion()`, so the Router's normal retry/fallback handles errors.

```python
# Deferred-HTTP providers (Vertex AI, Bedrock, etc.):
# Error surfaces during __next__()/__anext__() → needs MidStreamFallbackError + Router wrapper

# Eager-HTTP providers (OpenAI, Anthropic, etc.):
# Error surfaces during completion()/acompletion() → Router retry/fallback handles it directly
```

## Changes

### `streaming_handler.py`
- **Extract `_handle_stream_fallback_error()`**: Shared method used by both `__next__` and `__anext__`. Maps exceptions to OpenAI format, filters non-retriable 4xx (excluding 429), wraps everything else in `MidStreamFallbackError` with `generated_content` and `is_pre_first_chunk`.
- **`__next__` now raises `MidStreamFallbackError`**: Previously just re-raised `OpenAIError` or called `exception_type()`. Now uses the shared handler — same semantics as `__anext__`.
- **429 exempted from 4xx filter**: `and mapped_status_code != 429` in the shared helper. Applies to both sync and async paths.

### `router.py`
- **Add `_completion_streaming_iterator()`**: Sync mirror of `_acompletion_streaming_iterator`. Wraps `CustomStreamWrapper` in a `SyncFallbackStreamWrapper` that catches `MidStreamFallbackError` during iteration and dispatches to `function_with_fallbacks()`.
- **Modify `_completion()`**: Captures `input_kwargs_for_streaming_fallback` before deployment selection (mirrors `_acompletion`). Wraps streaming responses through `_completion_streaming_iterator`.
- **Pre-first-chunk optimization** (both iterators): When `is_pre_first_chunk=True` or `generated_content` is empty (e.g. 429 before any tokens), skip the continuation prompt and retry with original messages.

### Tests
- `test_sync_streaming_rate_limit_triggers_midstream_fallback` — `__next__` 429 → `MidStreamFallbackError`
- `test_sync_streaming_bad_request_not_midstream` — `__next__` 400 → `BadRequestError` (no fallback)
- `test_vertex_streaming_rate_limit_triggers_midstream_fallback` — `__anext__` 429 → `MidStreamFallbackError`
- `test_completion_streaming_iterator_fallback_on_429` — Router sync streaming fallback dispatch
- `test_completion_streaming_iterator_preserves_hidden_params` — Sync wrapper preserves `_hidden_params`
- `test_acompletion_streaming_iterator_pre_first_chunk_skips_continuation` — Pre-first-chunk uses original messages
- Updated `test_acompletion_streaming_iterator_edge_cases` — Empty content now uses original messages (no continuation prompt)

## What this fixes (by mode)

| Mode | Before | After |
|------|--------|-------|
| Async streaming + deferred provider + 429 | 4xx filter blocks fallback | **Fixed** — 429 exempted, fallback triggers |
| Sync streaming + deferred provider + 429 | No `MidStreamFallbackError` in `__next__`, no Router wrapper | **Fixed** — both added |
| Sync streaming + any provider + 5xx/network | No `MidStreamFallbackError` in `__next__`, no Router wrapper | **Fixed** — both added |
| Async streaming + any provider + 5xx/network | Already worked | Unchanged |
| Non-streaming (any provider) | Already worked | Unchanged |

## Scope

- **Supersedes** PR #22297 (async-only fix, now closed)
- **Affected providers**: Deferred-HTTP only (Vertex AI/Gemini, Bedrock, Predibase, Codestral) for 429. All providers benefit from the new sync streaming fallback support for 5xx/network errors.
- **No behavioral change** for eager-HTTP providers (OpenAI, Anthropic) or non-streaming calls.

Fixes #22296
Relates to #20870, #18229, #8648, #6532, #6957