### PR TITLE
fix(anthropic): populate output_config when reasoning_effort is used with Claude 4.6

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1006,6 +1006,8 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
                     reasoning_effort=value, model=model
                 )
+                if AnthropicConfig._is_claude_4_6_model(model) and value != "none":
+                    optional_params.setdefault("output_config", {})["effort"] = value
             elif param == "web_search_options" and isinstance(value, dict):
                 hosted_web_search_tool = self.map_web_search_tool(
                     cast(OpenAIWebSearchOptions, value)

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2011,7 +2011,7 @@ def test_reasoning_effort_maps_to_adaptive_thinking_for_claude_4_6_models():
     Test that reasoning_effort maps to adaptive thinking type for Claude 4.6 models.
 
     For Claude Opus 4.6 and Claude Sonnet 4.6, reasoning_effort should map to {"type": "adaptive"}
-    regardless of the effort level specified.
+    and also populate output_config with the effort level.
     """
     config = AnthropicConfig()
 
@@ -2035,6 +2035,9 @@ def test_reasoning_effort_maps_to_adaptive_thinking_for_claude_4_6_models():
             assert "budget_tokens" not in result["thinking"]
             # reasoning_effort should not be in the result (it's transformed to thinking)
             assert "reasoning_effort" not in result
+            # output_config should carry the effort level
+            assert "output_config" in result, f"output_config missing for {model} effort={effort}"
+            assert result["output_config"]["effort"] == effort
 
 
 def test_get_supported_params_includes_reasoning_for_sonnet_4_6_alias():
@@ -2081,6 +2084,7 @@ def test_sonnet_4_6_reasoning_effort_to_transform_request_payload():
     assert "thinking" in result
     assert result["thinking"]["type"] == "adaptive"
     assert "budget_tokens" not in result["thinking"]
+    assert result.get("output_config", {}).get("effort") == "high"
 
 
 def test_reasoning_effort_maps_to_budget_thinking_for_non_opus_4_6():


### PR DESCRIPTION
## Summary

Fixes #22212

When `reasoning_effort` is passed for Claude 4.6 models, the effort level is silently discarded. The `thinking` param correctly becomes `{'type': 'adaptive'}`, but without `output_config` the effort guidance is never sent to the API.

## Root Cause

`_map_reasoning_effort()` returns `AnthropicThinkingParam(type='adaptive')` for all 4.6 models regardless of effort level. The caller in `map_openai_params()` only sets `optional_params['thinking']` from the return value, never populating `output_config`.

Per the [Anthropic docs](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking), effort on 4.6 models is controlled via `output_config`, not `thinking`:
```python
thinking={'type': 'adaptive'}
output_config={'effort': 'low'}  # ← this was missing
```

## Fix

After calling `_map_reasoning_effort()` in `map_openai_params()`, also set `output_config.effort` for 4.6 models:
```python
if AnthropicConfig._is_claude_4_6_model(model) and value != 'none':
    optional_params.setdefault('output_config', {})['effort'] = value
```

## Tests

- Updated `test_reasoning_effort_maps_to_adaptive_thinking_for_claude_4_6_models` to verify `output_config.effort` is populated
- Updated `test_sonnet_4_6_reasoning_effort_to_transform_request_payload` to verify `output_config` in final request
- 10/10 effort and reasoning_effort tests pass, 2 consecutive clean runs