### PR TITLE
fix(proxy): apply SERVER_ROOT_PATH to mapped passthrough route matching

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -2062,7 +2062,12 @@ class InitPassThroughEndpointHelpers:
         """
         ## CHECK IF MAPPED PASS THROUGH ENDPOINT
         for mapped_route in LiteLLMRoutes.mapped_pass_through_routes.value:
-            if route.startswith(mapped_route):
+            full_mapped_route = (
+                InitPassThroughEndpointHelpers._build_full_path_with_root(
+                    mapped_route
+                )
+            )
+            if route.startswith(full_mapped_route):
                 return True
 
         # Fast path: check if any registered route key contains this path


### PR DESCRIPTION
## Problem

All built-in LLM passthrough routes (`/vertex_ai`, `/bedrock`, `/anthropic`, `/gemini`, `/cohere`, `/azure`, `/openai`, `/mistral`, `/vllm`, etc.) return 404 when `SERVER_ROOT_PATH` is set:

```json
{"detail": "Pass-through endpoint v1/projects/.../models/...:generateContent not found."}
```

### Root Cause

`is_registered_pass_through_route()` checks `request.url.path` (which includes the root prefix, e.g. `/litellm/vertex_ai/...`) against raw mapped routes (e.g. `/vertex_ai`). The prefix mismatch causes `startswith()` to fail.

PR #19383 fixed the same issue for **DB-registered** routes using `_build_full_path_with_root()`, but the **mapped routes** branch was not updated.

## Fix

Apply `_build_full_path_with_root()` to mapped routes, consistent with the existing pattern for DB-registered routes:

```python
for mapped_route in LiteLLMRoutes.mapped_pass_through_routes.value:
    full_mapped_route = InitPassThroughEndpointHelpers._build_full_path_with_root(mapped_route)
    if route.startswith(full_mapped_route):
        return True
```

When `SERVER_ROOT_PATH` is not set (or is `/`), `_build_full_path_with_root` returns the path unchanged, so existing behavior is fully preserved.

## Test

Added `test_is_registered_pass_through_route_mapped_routes_with_root` that verifies:
- Mapped routes match with root prefix (`/litellm/vertex_ai/...`)
- Mapped routes don't match without prefix when root is set
- Mapped routes match without prefix when root is `/`

All tests pass (2 consecutive clean runs).

Fixes #22272