### PR TITLE
fix(ui): render newlines in tool descriptions in log viewer

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/ToolsSection/FormattedToolView.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/ToolsSection/FormattedToolView.tsx
@@ -49,7 +49,7 @@ export function FormattedToolView({ tool }: FormattedToolViewProps) {
       title: "Description",
       dataIndex: "description",
       key: "description",
-      render: (desc: string) => <Text type="secondary">{desc}</Text>,
+      render: (desc: string) => <Text type="secondary" style={{ whiteSpace: "pre-line" }}>{desc}</Text>,
     },
   ];
 
@@ -58,7 +58,7 @@ export function FormattedToolView({ tool }: FormattedToolViewProps) {
       {/* Description */}
       {tool.description && (
         <div style={{ marginBottom: 16 }}>
-          <Text style={{ lineHeight: 1.6 }}>{tool.description}</Text>
+          <Text style={{ lineHeight: 1.6, whiteSpace: "pre-line" }}>{tool.description}</Text>
         </div>
       )}
 


### PR DESCRIPTION
## Problem

Tool descriptions containing `\n` characters were displayed as continuous text without line breaks in the log viewer's tool section.


## Fix

Add `whiteSpace: 'pre-line'` CSS to both:
- The tool description text (`tool.description`)
- The parameter description column

`pre-line` collapses multiple spaces but preserves explicit `\n` newline characters, rendering them as line breaks.

## Files Changed

- `ui/litellm-dashboard/src/components/view_logs/ToolsSection/FormattedToolView.tsx`

Fixes #22362