### PR TITLE
fix: update custom_llm_provider when base_model has a different provider

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1093,6 +1093,19 @@ def completion_cost(  # noqa: PLR0915
             router_model_id=router_model_id,
         )
 
+        # When base_model was used and its provider differs from custom_llm_provider,
+        # update custom_llm_provider to match the base_model's provider so
+        # cost_per_token dispatches to the correct provider cost function.
+        if base_model is not None and selected_model == base_model:
+            _base_model_parts = base_model.split("/", 1)
+            if len(_base_model_parts) > 1:
+                _base_model_provider = _base_model_parts[0]
+                if (
+                    _base_model_provider in LlmProvidersSet
+                    and _base_model_provider != custom_llm_provider
+                ):
+                    custom_llm_provider = _base_model_provider
+
         potential_model_names = [
             selected_model,
             _get_response_model(completion_response),

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -2747,6 +2747,27 @@ def test_cost_calculator_with_base_model():
     assert resp._hidden_params["response_cost"] > 0
 
 
+def test_cost_calculator_with_base_model_cross_provider():
+    """
+    When base_model provider differs from deployment provider, cost should
+    still be calculated correctly using the base_model's provider pricing.
+    Regression test for #22257.
+    """
+    from litellm import completion_cost
+    from litellm.types.utils import Usage
+
+    cost = completion_cost(
+        model="anthropic/gemini-3-flash",
+        custom_llm_provider="anthropic",
+        base_model="gemini/gemini-2.5-flash-preview-05-20",
+        call_type="completion",
+        completion_response={
+            "usage": Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150),
+        },
+    )
+    assert cost > 0, "Cost should be non-zero when base_model has valid pricing"
+
+
 @pytest.fixture
 def model_item():
     return {


### PR DESCRIPTION
## Problem

When using `base_model` in `model_info` to specify pricing lookup for a model deployed under a different provider (e.g., `model: anthropic/gemini-3-flash` with `base_model: gemini/gemini-3-flash-preview`), the cost calculation silently returns `spend: 0`.

### Root Cause

1. `_select_model_name_for_cost_calc()` correctly resolves the model to `gemini/gemini-3-flash-preview`
2. But `custom_llm_provider` stays as `anthropic` (from the deployment)
3. `cost_per_token()` dispatches to `anthropic_cost_per_token()` which looks up `anthropic/gemini-3-flash-preview` — doesn't exist
4. Cost silently falls back to `0.0`

## Fix

After `_select_model_name_for_cost_calc()` returns, check if `base_model` was used and its provider prefix differs from `custom_llm_provider`. If so, update `custom_llm_provider` to match:

```python
if base_model is not None and selected_model == base_model:
    _base_model_parts = base_model.split('/', 1)
    if len(_base_model_parts) > 1:
        _base_model_provider = _base_model_parts[0]
        if _base_model_provider in LlmProvidersSet and _base_model_provider != custom_llm_provider:
            custom_llm_provider = _base_model_provider
```

Only applies when the prefix is a known LLM provider in `LlmProvidersSet`.

## Test

Added `test_cost_calculator_with_base_model_cross_provider` that verifies cost is non-zero when `base_model` provider differs from deployment provider.

All tests pass (2 consecutive clean runs).

Fixes #22257