### PR TITLE
fix(ui): parse and save blocked words from uploaded YAML file

### DIFF
--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -55,6 +55,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/babel__traverse": "^7.28.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/lodash": "^4.17.15",
     "@types/node": "^20",
     "@types/react": "18.2.48",


### PR DESCRIPTION
## Problem

When uploading a YAML blocked words file in the Content Filter guardrail configuration, the file is validated successfully but the keywords are silently discarded. The guardrail is saved with an empty `blocked_words: []` list.

### Root Cause

The `onFileUpload` callback in `ContentFilterManager.tsx` was:

```tsx
onFileUpload={(content: string) => {
  console.log('File uploaded:', content);  // <-- logs and discards
}}
```

The file content was logged to console but never parsed or added to the `blockedWords` state.

## Fix

Parse the YAML content using `js-yaml` (already a project dependency) and append the blocked words to the existing state:

```tsx
onFileUpload={(content: string) => {
  const data = yaml.load(content);
  if (data?.blocked_words && Array.isArray(data.blocked_words)) {
    const newWords = data.blocked_words.map(...);
    setBlockedWords([...blockedWords, ...newWords]);
  }
}}
```

The validation endpoint already confirms the YAML is valid before `onFileUpload` is called, so parsing here is safe.

Fixes #22227