### PR TITLE
[Feature] Add Gemini 3.1 Flash Image Preview pricing details

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16422,8 +16422,8 @@
         "supports_web_search": true
     },
     "gemini/gemini-3.1-flash-image-preview": {
-        "input_cost_per_image": 0.0001375,
         "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_batches": 1.25e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 65536,
         "max_output_tokens": 32768,
@@ -16431,13 +16431,16 @@
         "mode": "image_generation",
         "output_cost_per_image": 0.045,
         "output_cost_per_image_token": 6e-05,
+        "output_cost_per_image_token_batches": 3e-05,
         "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token_batches": 7.5e-07,
         "rpm": 1000,
         "tpm": 4000000,
         "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-image-preview",
         "supported_endpoints": [
             "/v1/chat/completions",
-            "/v1/completions"
+            "/v1/completions",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16421,6 +16421,39 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "gemini/gemini-3.1-flash-image-preview": {
+        "input_cost_per_image": 0.0001375,
+        "input_cost_per_token": 2.5e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.045,
+        "output_cost_per_image_token": 6e-05,
+        "output_cost_per_token": 1.5e-06,
+        "rpm": 1000,
+        "tpm": 4000000,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-image-preview",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "gemini/deep-research-pro-preview-12-2025": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,


### PR DESCRIPTION
## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
_Not making any backend nor frontend contribution, so no test needed_
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🆕 New Feature

## Changes

Add pricing and metadata for `gemini/gemini-3.1-flash-image-preview` to `model_prices_and_context_window.json`.

**Pricing sourced from:** https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-image-preview

**Standard tab:**

| Field | Value | Source |
|---|---|---|
| `input_cost_per_token` | `2.5e-07` | $0.25 / 1M tokens (text + image, unified) |
| `output_cost_per_token` | `1.5e-06` | $1.50 / 1M tokens (text + thinking) |
| `output_cost_per_image` | `0.045` | $0.045 per 512px image (747 tokens × $60/1M) |
| `output_cost_per_image_token` | `6e-05` | $60 / 1M image output tokens |
| `supports_web_search` | `true` | Grounding with Google Search listed in pricing |
| `mode` | `image_generation` | Model generates images |
| `supported_modalities` | `["text", "image"]` | Text/image input listed in pricing |
| `supported_output_modalities` | `["text", "image"]` | Text and image output listed in pricing |

**Batch tab:**

| Field | Value | Source |
|---|---|---|
| `input_cost_per_token_batches` | `1.25e-07` | $0.125 / 1M tokens (50% discount) |
| `output_cost_per_token_batches` | `7.5e-07` | $0.75 / 1M tokens (50% discount) |
| `output_cost_per_image_token_batches` | `3e-05` | $30 / 1M image output tokens (50% discount) |

**Note on `input_cost_per_image`:** Not included. Unlike the Pro model which has separate per-image input pricing, the Flash model uses a unified per-token rate for both text and image input (`$0.25/1M tokens`). This is consistent with the existing `gemini/gemini-2.5-flash-image` entry in this repo, which also omits `input_cost_per_image`.
