### PR TITLE
fix: add empty block check for the user message

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2366,10 +2366,13 @@ def anthropic_messages_pt(  # noqa: PLR0915
                             user_content.append(_anthropic_content_element)
                         elif m.get("type", "") == "text":
                             m = cast(ChatCompletionTextObject, m)
+                            text_value = cast(str, m.get("text", ""))
+                            if not text_value:  # don't pass empty text blocks. anthropic api raises errors.
+                                continue
                             _anthropic_text_content_element = (
                                 AnthropicMessagesTextParam(
                                     type="text",
-                                    text=m["text"],
+                                    text=text_value,
                                 )
                             )
                             _content_element = add_cache_control_to_content(


### PR DESCRIPTION
## Summary
Fixes #22312 , the first suggested bug
The user message text block handler in anthropic_messages_pt was missing the empty-string guard
  that already existed for assistant messages, causing empty `{"type": "text", "text": ""}` blocks to  
  be forwarded to the Anthropic API which rejects them.
## Fix
Added an early continue that skips any text block whose text value is falsy before constructing the
   AnthropicMessagesTextParam, mirroring the existing guard in the assistant message path.
```
m = cast(ChatCompletionTextObject, m)
text_value = cast(str, m.get("text", ""))
if not text_value:  # don't pass empty text blocks. anthropic api raises errors.
    continue
```
## Test
Added `test_anthropic_messages_pt_skips_empty_user_text_blocks` in `test_anthropic_chat_transformation`

1 test passed