### PR TITLE
fix(anthropic): set output_config.effort when reasoning_effort maps to adaptive for 4.6 models

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1009,7 +1009,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 # For Claude 4.6 models, effort is controlled via output_config,
                 # not thinking budget_tokens. Map reasoning_effort to output_config.
                 if AnthropicConfig._is_claude_4_6_model(model) and value != "none":
-                    optional_params["output_config"] = {"effort": value}
+                    # output_config.effort accepts: high, medium, low, max
+                    # Map "minimal" → "low" since Anthropic has no "minimal" level
+                    effort_value = "low" if value == "minimal" else value
+                    optional_params["output_config"] = {"effort": effort_value}
             elif param == "web_search_options" and isinstance(value, dict):
                 hosted_web_search_tool = self.map_web_search_tool(
                     cast(OpenAIWebSearchOptions, value)

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1006,6 +1006,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
                     reasoning_effort=value, model=model
                 )
+                # For Claude 4.6 models, effort is controlled via output_config,
+                # not thinking budget_tokens. Map reasoning_effort to output_config.
+                if AnthropicConfig._is_claude_4_6_model(model) and value != "none":
+                    optional_params["output_config"] = {"effort": value}
             elif param == "web_search_options" and isinstance(value, dict):
                 hosted_web_search_tool = self.map_web_search_tool(
                     cast(OpenAIWebSearchOptions, value)

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2033,6 +2033,9 @@ def test_reasoning_effort_maps_to_adaptive_thinking_for_claude_4_6_models():
             assert result["thinking"]["type"] == "adaptive"
             # Should not have budget_tokens for adaptive type
             assert "budget_tokens" not in result["thinking"]
+            # Should set output_config with the effort level
+            assert "output_config" in result, f"output_config missing for {model} with effort={effort}"
+            assert result["output_config"]["effort"] == effort
             # reasoning_effort should not be in the result (it's transformed to thinking)
             assert "reasoning_effort" not in result
 
@@ -2081,6 +2084,9 @@ def test_sonnet_4_6_reasoning_effort_to_transform_request_payload():
     assert "thinking" in result
     assert result["thinking"]["type"] == "adaptive"
     assert "budget_tokens" not in result["thinking"]
+    # output_config should be set in the final payload
+    assert "output_config" in result
+    assert result["output_config"]["effort"] == "high"
 
 
 def test_reasoning_effort_maps_to_budget_thinking_for_non_opus_4_6():
@@ -2115,6 +2121,8 @@ def test_reasoning_effort_maps_to_budget_thinking_for_non_opus_4_6():
         assert "thinking" in result
         assert result["thinking"]["type"] == "enabled"
         assert result["thinking"]["budget_tokens"] == expected_budget
+        # Non-4.6 models should NOT get output_config from reasoning_effort
+        assert "output_config" not in result
         # reasoning_effort should not be in the result (it's transformed to thinking)
         assert "reasoning_effort" not in result
 

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2034,8 +2034,10 @@ def test_reasoning_effort_maps_to_adaptive_thinking_for_claude_4_6_models():
             # Should not have budget_tokens for adaptive type
             assert "budget_tokens" not in result["thinking"]
             # Should set output_config with the effort level
+            # "minimal" maps to "low" since Anthropic output_config has no "minimal" level
+            expected_effort = "low" if effort == "minimal" else effort
             assert "output_config" in result, f"output_config missing for {model} with effort={effort}"
-            assert result["output_config"]["effort"] == effort
+            assert result["output_config"]["effort"] == expected_effort
             # reasoning_effort should not be in the result (it's transformed to thinking)
             assert "reasoning_effort" not in result
 


### PR DESCRIPTION
## Problem

When using `reasoning_effort` with Claude 4.6 models (Opus 4.6, Sonnet 4.6), the effort level is **silently lost**.

`_map_reasoning_effort()` correctly returns `{"type": "adaptive"}` for 4.6 models, but never sets `output_config.effort`. Since Anthropic's 4.6 models use `output_config.effort` (not `thinking.budget_tokens`) to control effort level, the model always runs at the default effort regardless of what the user specifies.

## Fix

In `map_openai_params()`, when `reasoning_effort` is set for a 4.6 model, also set:
```python
optional_params["output_config"] = {"effort": value}
```

This ensures the effort level flows through to the final API request alongside the adaptive thinking config.

## Tests

Updated existing tests to verify:
- 4.6 models get `output_config.effort` set when `reasoning_effort` is provided
- Non-4.6 models do NOT get `output_config` from `reasoning_effort`
- Full `transform_request` pipeline includes `output_config` in final payload

Fixes #22212