### PR TITLE
fix(minimax): map reasoning_details to reasoning_content for streaming and non-streaming

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1206,7 +1206,15 @@ def _extract_reasoning_content(message: dict) -> Tuple[Optional[str], Optional[s
     elif "reasoning" in message:
         return message["reasoning"], message_content
     elif "reasoning_details" in message:
-        return message["reasoning_details"], message_content
+        details = message["reasoning_details"]
+        if isinstance(details, str):
+            return details, message_content
+        if isinstance(details, list):
+            text = "".join(
+                item.get("text", "") for item in details if isinstance(item, dict)
+            )
+            return text, message_content
+        return None, message_content
     elif isinstance(message_content, str):
         return _parse_content_for_reasoning(message_content)
     return None, message_content

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1205,6 +1205,8 @@ def _extract_reasoning_content(message: dict) -> Tuple[Optional[str], Optional[s
         return message["reasoning_content"], message_content
     elif "reasoning" in message:
         return message["reasoning"], message_content
+    elif "reasoning_details" in message:
+        return message["reasoning_details"], message_content
     elif isinstance(message_content, str):
         return _parse_content_for_reasoning(message_content)
     return None, message_content

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -20,6 +20,7 @@ class MinimaxChatConfig(OpenAIGPTConfig):
     - MiniMax-M2.1
     - MiniMax-M2.1-lightning
     - MiniMax-M2
+    - MiniMax-M2.5
     """
 
     @staticmethod
@@ -103,4 +104,19 @@ class MinimaxChatConfig(OpenAIGPTConfig):
             pass
         
         return base_params + additional_params
+
+    def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
+        """
+        Map MiniMax's 'reasoning_details' and 'reasoning' fields to 'reasoning_content'.
+
+        MiniMax returns reasoning content in delta.reasoning_details when
+        reasoning_split=True is passed. LiteLLM expects delta.reasoning_content.
+        """
+        for choice in choices:
+            delta = choice.get("delta", {})
+            if "reasoning_details" in delta:
+                delta["reasoning_content"] = delta.pop("reasoning_details")
+            elif "reasoning" in delta:
+                delta["reasoning_content"] = delta.pop("reasoning")
+        return choices
 

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -1,12 +1,31 @@
 """
 MiniMax OpenAI transformation config - extends OpenAI chat config for MiniMax's OpenAI-compatible API
 """
-from typing import List, Optional, Tuple
+from typing import Any, AsyncIterator, Iterator, List, Optional, Tuple, Union
 
 import litellm
-from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+from litellm.llms.openai.chat.gpt_transformation import (
+    OpenAIChatCompletionStreamingHandler,
+    OpenAIGPTConfig,
+)
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
+from litellm.types.utils import ModelResponse
+
+
+def _extract_reasoning_text(reasoning_details: Any) -> Optional[str]:
+    """Extract reasoning text from MiniMax's reasoning_details field.
+
+    MiniMax returns reasoning_details as a list of objects like
+    ``[{"text": "..."}]``.  This helper converts it to a plain string.
+    """
+    if isinstance(reasoning_details, str):
+        return reasoning_details
+    if isinstance(reasoning_details, list):
+        return "".join(
+            item.get("text", "") for item in reasoning_details if isinstance(item, dict)
+        )
+    return None
 
 
 class MinimaxChatConfig(OpenAIGPTConfig):
@@ -105,17 +124,29 @@ class MinimaxChatConfig(OpenAIGPTConfig):
         
         return base_params + additional_params
 
-    def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
-        """
-        Map MiniMax's 'reasoning_details' and 'reasoning' fields to 'reasoning_content'.
+    def get_model_response_iterator(
+        self,
+        streaming_response: Union[Iterator[str], AsyncIterator[str], ModelResponse],
+        sync_stream: bool,
+        json_mode: Optional[bool] = False,
+    ) -> Any:
+        return MinimaxChatCompletionStreamingHandler(
+            streaming_response=streaming_response,
+            sync_stream=sync_stream,
+            json_mode=json_mode,
+        )
 
-        MiniMax returns reasoning content in delta.reasoning_details when
-        reasoning_split=True is passed. LiteLLM expects delta.reasoning_content.
-        """
+
+class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler):
+    """Streaming handler that maps MiniMax reasoning fields to reasoning_content."""
+
+    def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
         for choice in choices:
             delta = choice.get("delta", {})
             if "reasoning_details" in delta:
-                delta["reasoning_content"] = delta.pop("reasoning_details")
+                delta["reasoning_content"] = _extract_reasoning_text(
+                    delta.pop("reasoning_details")
+                )
             elif "reasoning" in delta:
                 delta["reasoning_content"] = delta.pop("reasoning")
         return choices


### PR DESCRIPTION
## Summary

Fixes #22392 

MiniMax returns reasoning content in `delta.reasoning_details` when `reasoning_split=True` is used (e.g., MiniMax-M2.5). LiteLLM currently only handles `reasoning_content` and `reasoning` fields, causing MiniMax reasoning details to be silently lost in both streaming and non-streaming responses.

## Changes

### Streaming (`MinimaxChatConfig._map_reasoning_to_reasoning_content`)
Override the parent method to also map `reasoning_details` → `reasoning_content` in streaming deltas, in addition to the standard `reasoning` → `reasoning_content` mapping.

### Non-streaming (`_extract_reasoning_content`)
Add `reasoning_details` as a recognized field in `_extract_reasoning_content()` in `common_utils.py`, so non-streaming responses also correctly extract reasoning content from MiniMax.

## Testing

- Added 4 new unit tests covering:
  - `reasoning_details` → `reasoning_content` streaming mapping
  - Standard `reasoning` field still works  
  - Chunks without reasoning fields are unchanged
  - Non-streaming `_extract_reasoning_content` with `reasoning_details`
- All 8 tests pass (4 skipped = API key required tests)
- 2 consecutive clean runs with 0 errors, 0 warnings

## Reproduction

```python
import litellm

# With reasoning_split=True, reasoning details are lost in streaming
response = litellm.completion(
    model="minimax/MiniMax-M2.5",
    messages=[{"role": "user", "content": "Solve 2+2"}],
    stream=True,
    extra_body={"reasoning_split": True}
)
for chunk in response:
    # Before fix: chunk.choices[0].delta.reasoning_content is None
    # After fix: chunk.choices[0].delta.reasoning_content contains reasoning
    pass
```