### PR TITLE
feat: add 0.5K resolution support for GeminiImageSize

### DIFF
--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -176,7 +176,7 @@ GeminiResponseModalities = Literal["TEXT", "IMAGE", "AUDIO", "VIDEO"]
 
 GeminiImageAspectRatio = Literal["1:1", "2:3", "3:2", "3:4", "4:3", "9:16", "16:9", "21:9"]
 
-GeminiImageSize = Literal["1K", "2K", "4K"]
+GeminiImageSize = Literal["0.5K", "1K", "2K", "4K"]
 
 
 class GeminiImageConfig(TypedDict, total=False):


### PR DESCRIPTION
## Relevant issues

Gemini 3.1 Flash Image Preview now supports 0.5K resolution for image generation. Without this change, passing `imageSize: "0.5K"` results in "Request contains an invalid argument."

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

- Added `"0.5K"` to the `GeminiImageSize` Literal type in `litellm/types/llms/vertex_ai.py`
- This enables the new 0.5K resolution option supported by `gemini-3.1-flash-image-preview`