### PR TITLE
fix(proxy): preserve master_key set by initialize() during lifespan startup

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -765,7 +765,13 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
         premium_user = _license_check.is_premium()
 
     ## CHECK MASTER KEY IN ENVIRONMENT ##
-    master_key = get_secret_str("LITELLM_MASTER_KEY")
+    # Only overwrite master_key from env var if it is actually set.
+    # initialize() may have already configured master_key from a config file;
+    # unconditionally assigning None here would discard that value when the
+    # LITELLM_MASTER_KEY env var is absent (e.g. programmatic startup, tests).
+    _env_master_key = get_secret_str("LITELLM_MASTER_KEY")
+    if _env_master_key:
+        master_key = _env_master_key
     ### LOAD CONFIG ###
     worker_config: Optional[Union[str, dict]] = get_secret("WORKER_CONFIG")  # type: ignore
     env_config_yaml: Optional[str] = get_secret_str("CONFIG_FILE_PATH")


### PR DESCRIPTION
## Summary
Fixes #22330

## Root Cause
`proxy_startup_event()` unconditionally overwrites `master_key` with `get_secret_str("LITELLM_MASTER_KEY")`, discarding a valid `master_key` already configured by `initialize()` from the YAML config.

When neither `CONFIG_FILE_PATH` nor `WORKER_CONFIG` env vars are set (e.g. programmatic startup or test harnesses), the config is not reloaded during the ASGI lifespan, so `master_key` stays `None`.

This causes `user_api_key_auth()` to return `INTERNAL_USER` for **every** request — including the admin key — resulting in 403 errors for MCP tool calls and list_tools.

## Fix
Only overwrite `master_key` from the environment variable when it has a truthy value, preserving any previously configured value from `initialize()`.

```python
# Before (always overwrites, even with None)
master_key = get_secret_str("LITELLM_MASTER_KEY")

# After (preserves config-provided value)
_env_master_key = get_secret_str("LITELLM_MASTER_KEY")
if _env_master_key:
    master_key = _env_master_key
```

## How I found it
The issue description attributes the 403 errors to ContextVar propagation failing when `StreamableHTTPSessionManager` spawns tasks. **I proved this is incorrect** — ContextVar propagation works correctly (anyio 4.x on asyncio backend copies context for `create_task`). The actual root cause is the master_key being wiped during lifespan startup.

## Testing
- The 3 MCP e2e tests that exercise streamable HTTP now pass (they all fail with 403 on `main`)
- The 4th test (`test_independent_clients_no_shared_session`) also fails on `main` due to a separate stdio connection issue — not affected by this change