### PR TITLE
fix(ci): replace default CodeQL with custom workflow to unblock CI

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,15 @@
+name: "LiteLLM CodeQL config"
+
+# Exclude queries that produce result sets > 2 GiB on this codebase,
+# causing 49+ minute runs that fail and block CI resources.
+query-filters:
+  - exclude:
+      id: py/clear-text-logging-sensitive-data  # CWE-312/CleartextLogging.ql — result set > 2 GiB
+  - exclude:
+      id: py/polynomial-redos                   # CWE-730/PolynomialReDoS.ql — result set > 2 GiB
+
+paths-ignore:
+  - tests
+  - docs
+  - "**/*.md"
+  - litellm/proxy/_experimental/out

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Sundays at 04:00 UTC
+    - cron: "0 4 * * 0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: ruby
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- The default CodeQL Python analysis takes 49+ minutes and fails — 2 queries produce result sets exceeding 2 GiB:
  - `py/clear-text-logging-sensitive-data` (CWE-312) — 38m51s
  - `py/polynomial-redos` (CWE-730) — 45m24s
- This consumes a full runner slot and blocks CI pipeline resources
- Adds a custom CodeQL workflow with:
  - **30-minute timeout** (hard cap instead of unlimited)
  - **Concurrency group** with `cancel-in-progress: true` to prevent piling up
  - **Query exclusions** for the 2 problematic queries via `.github/codeql/codeql-config.yml`
  - **Path ignores** for `tests/`, `docs/`, `**/*.md`, and UI build output
  - Same 4 languages as the current default setup: `actions`, `javascript-typescript`, `python`, `ruby`

## Before merging
> **Important**: Disable the Default Setup in repo **Settings > Code security > Code scanning** before merging. Otherwise both the default and custom workflows will run simultaneously, doubling resource usage.

## Test plan
- [ ] Disable Default Setup in repo settings
- [ ] Merge this PR
- [ ] Verify CodeQL runs complete in <15 minutes with the custom config
- [ ] Verify security alerts still appear for the remaining 43 Python queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)