### PR TITLE
fix(anthropic): restrict effort='max' to Opus 4.6 only

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -186,6 +186,15 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             )
         )
 
+    @staticmethod
+    def _is_opus_4_6_model(model: str) -> bool:
+        """Check if the model is specifically Claude Opus 4.6 (required for effort='max')."""
+        model_lower = model.lower()
+        return any(
+            variant in model_lower
+            for variant in ("opus-4-6", "opus_4_6", "opus-4.6", "opus_4.6")
+        )
+
     def get_supported_openai_params(self, model: str):
         params = [
             "stream",
@@ -1392,9 +1401,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     raise ValueError(
                         f"Invalid effort value: {effort}. Must be one of: 'high', 'medium', 'low', 'max'"
                     )
-                if effort == "max" and not self._is_claude_4_6_model(model):
+                if effort == "max" and not self._is_opus_4_6_model(model):
                     raise ValueError(
-                        f"effort='max' is only supported by Claude 4.6 models (Opus 4.6, Sonnet 4.6). Got model: {model}"
+                        f"effort='max' is only supported by Claude Opus 4.6. Got model: {model}"
                     )
                 data["output_config"] = output_config
 

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1662,10 +1662,27 @@ def test_max_effort_rejected_for_opus_45():
 
     messages = [{"role": "user", "content": "Test"}]
 
-    with pytest.raises(ValueError, match="effort='max' is only supported by Claude 4.6 models"):
+    with pytest.raises(ValueError, match="effort='max' is only supported by Claude Opus 4.6"):
         optional_params = {"output_config": {"effort": "max"}}
         config.transform_request(
             model="claude-opus-4-5-20251101",
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params={},
+            headers={}
+        )
+
+
+def test_max_effort_rejected_for_sonnet_46():
+    """Test that effort='max' is rejected for Sonnet 4.6 (Opus 4.6 only)."""
+    config = AnthropicConfig()
+
+    messages = [{"role": "user", "content": "Test"}]
+
+    with pytest.raises(ValueError, match="effort='max' is only supported by Claude Opus 4.6"):
+        optional_params = {"output_config": {"effort": "max"}}
+        config.transform_request(
+            model="claude-sonnet-4-6-20260205",
             messages=messages,
             optional_params=optional_params,
             litellm_params={},


### PR DESCRIPTION
## Summary

Per [Anthropic docs](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking):

> **`max`** — Claude always thinks with no constraints on thinking depth. **Opus 4.6 only.** Requests using `max` on other models will return an error.

The existing client-side guard uses `_is_claude_4_6_model()` which matches **both** Sonnet 4.6 and Opus 4.6, so `effort='max'` with Sonnet 4.6 passes validation but fails with 400 server-side.

## Changes

- Add `_is_opus_4_6_model()` static method that matches only Opus 4.6 variants
- Use it for the `effort='max'` guard instead of the broader `_is_claude_4_6_model()`
- Update error message to clarify Opus 4.6 specifically
- Add test for Sonnet 4.6 being correctly rejected with `effort='max'`

## Test Results

```
4 passed in 0.15s
- test_effort_validation_with_opus_46 ✅ (all 4 effort levels accepted)
- test_max_effort_rejected_for_opus_45 ✅ (Opus 4.5 rejected)
- test_max_effort_rejected_for_sonnet_46 ✅ (NEW: Sonnet 4.6 rejected)
- test_effort_with_other_features ✅ (effort works with tools/thinking)
```

Fixes #22214