### PR TITLE
fix(ci): remove duplicate env key in scan_duplicate_issues workflow

### DIFF
--- a/.github/workflows/scan_duplicate_issues.yml
+++ b/.github/workflows/scan_duplicate_issues.yml
@@ -33,8 +33,6 @@ jobs:
       - name: Scan for duplicate issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_THRESHOLD: ${{ inputs.threshold }}
           INPUT_CLOSE: ${{ inputs.close }}
         run: |


### PR DESCRIPTION
## Summary

The `scan_duplicate_issues.yml` workflow has been broken since #22034 — a greptile suggestion was applied without removing the original `env:` block, leaving a duplicate key that makes the YAML invalid. 

 ### Docs reference                                                                          
                                                                                         
  - [YamlDotNet](https://github.com/aaubry/YamlDotNet) — the YAML parser used by [GitHub Actions runner](https://github.com/actions/runner), does not allow duplicate mapping keys ([#407](https://github.com/aaubry/YamlDotNet/issues/407))
  - [PyYAML #165](https://github.com/yaml/pyyaml/issues/165) — Python's parser accepts duplicates

Fix: remove the duplicate `env:` block (2 lines deleted).