### PR TITLE
fix(ui): preserve newlines in tool descriptions on logs page

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/ToolsSection/FormattedToolView.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/ToolsSection/FormattedToolView.tsx
@@ -49,7 +49,7 @@ export function FormattedToolView({ tool }: FormattedToolViewProps) {
       title: "Description",
       dataIndex: "description",
       key: "description",
-      render: (desc: string) => <Text type="secondary">{desc}</Text>,
+      render: (desc: string) => <Text type="secondary" style={{ whiteSpace: "pre-wrap" }}>{desc}</Text>,
     },
   ];
 
@@ -58,7 +58,7 @@ export function FormattedToolView({ tool }: FormattedToolViewProps) {
       {/* Description */}
       {tool.description && (
         <div style={{ marginBottom: 16 }}>
-          <Text style={{ lineHeight: 1.6 }}>{tool.description}</Text>
+          <Text style={{ lineHeight: 1.6, whiteSpace: "pre-wrap" }}>{tool.description}</Text>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Tool descriptions containing `\n` characters are displayed as continuous text without line breaks in the logs tool view.

## Root Cause

The `<Text>` components in `FormattedToolView.tsx` use default `whiteSpace` ("normal"), which collapses consecutive whitespace and newlines into a single space.

## Fix

Add `whiteSpace: 'pre-wrap'` to both:
- Tool-level description text (line 61)
- Parameter-level description column (line 52)

This preserves `\n` characters while still wrapping long lines.

## Before / After

**Before:** Description rendered as one continuous line  
**After:** Newlines in descriptions are preserved and rendered as line breaks

Fixes #22362