### PR TITLE
fix(cost): extract provider from base_model for cross-provider cost calculation

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1093,6 +1093,13 @@ def completion_cost(  # noqa: PLR0915
             router_model_id=router_model_id,
         )
 
+        # When base_model is used and contains a provider prefix (e.g. "gemini/gemini-3-flash"),
+        # extract the provider from base_model so cost lookup uses the correct provider
+        # instead of the deployment provider (e.g. "anthropic").
+        if base_model is not None and _model_contains_known_llm_provider(base_model):
+            base_model_provider = base_model.split("/")[0]
+            custom_llm_provider = base_model_provider
+
         potential_model_names = [
             selected_model,
             _get_response_model(completion_response),


### PR DESCRIPTION
## Summary

When `base_model` has a different provider prefix than the deployment model (e.g. deployed as `anthropic/gemini-3-flash` with `base_model: gemini/gemini-3-flash-preview`), the cost calculation silently returns `spend: 0`.

## Root Cause

`completion_cost()` calls `_select_model_name_for_cost_calc()` which correctly resolves to the `base_model` name. However, `custom_llm_provider` remains the deployment's provider (`anthropic`), not the base model's provider (`gemini`).

When `cost_per_token()` runs, it constructs `model_with_provider = 'anthropic/gemini/gemini-3-flash-preview'` which doesn't exist in `model_cost`, causing all cost lookups to fail.

## Fix

After selecting the model name, if `base_model` contains a known provider prefix, extract that provider and use it as `custom_llm_provider` for cost calculation.

## Tests

Added `test_cost_calculator_base_model_cross_provider` that verifies:
1. `_select_model_name_for_cost_calc` returns the base_model as-is
2. `completion_cost` returns `response_cost > 0` for a cross-provider base_model

```
2 passed in 0.19s
```

Fixes #22257