### PR TITLE
fix(anthropic): remove spurious effort-2025-11-24 beta header for Claude 4.6 models

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -228,24 +228,19 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         self, optional_params: Optional[dict], model: Optional[str] = None
     ) -> bool:
         """
-        Check if effort parameter is being used.
+        Check if the effort-2025-11-24 beta header is needed.
 
-        Returns True if effort-related parameters are present.
+        Only required for Claude Opus 4.5 reasoning_effort.
+        Claude 4.6 models use output_config/effort natively without a beta header.
+        See: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
         """
         if not optional_params:
             return False
 
-        # Check if reasoning_effort is provided for Claude Opus 4.5
+        # Only Opus 4.5 reasoning_effort needs the beta header
         if model and ("opus-4-5" in model.lower() or "opus_4_5" in model.lower()):
             reasoning_effort = optional_params.get("reasoning_effort")
             if reasoning_effort and isinstance(reasoning_effort, str):
-                return True
-
-        # Check if output_config is directly provided
-        output_config = optional_params.get("output_config")
-        if output_config and isinstance(output_config, dict):
-            effort = output_config.get("effort")
-            if effort and isinstance(effort, str):
                 return True
 
         return False


### PR DESCRIPTION
## Summary

The `effort-2025-11-24` beta header is injected for all Anthropic requests containing `output_config` with an `effort` key, including Claude 4.6 models. Per the [Anthropic docs](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking):

> No beta header is required [for adaptive thinking].

The beta header should only be injected for Claude Opus 4.5 `reasoning_effort`.

## Root Cause

`is_effort_used()` in `common_utils.py` had two code paths:
1. `reasoning_effort` on Opus 4.5 → correctly triggers the beta header
2. `output_config.effort` on any model → **incorrectly** triggers the beta header for 4.6 models

## Fix

Removed the `output_config` check from `is_effort_used()`. The function now only returns `True` for Opus 4.5 `reasoning_effort`, which is the only case requiring the beta header.

## Tests

Updated `test_effort_beta_header_injection` to verify:
- `output_config` with `effort` on Sonnet 4.6 → `is_effort_used` returns `False`
- `reasoning_effort` on Opus 4.5 → `is_effort_used` returns `True`, beta header present

```
2 passed in 0.12s
```

Fixes #22213