### PR TITLE
fix(anthropic): populate output_config when reasoning_effort is used on Claude 4.6

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1006,6 +1006,18 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
                     reasoning_effort=value, model=model
                 )
+                # For Claude 4.6 models, effort is controlled via output_config,
+                # not thinking budget_tokens. Map reasoning_effort to output_config.
+                if AnthropicConfig._is_claude_4_6_model(model):
+                    effort_map = {
+                        "low": "low",
+                        "minimal": "low",
+                        "medium": "medium",
+                        "high": "high",
+                        "max": "max",
+                    }
+                    mapped_effort = effort_map.get(value, value)
+                    optional_params["output_config"] = {"effort": mapped_effort}
             elif param == "web_search_options" and isinstance(value, dict):
                 hosted_web_search_tool = self.map_web_search_tool(
                     cast(OpenAIWebSearchOptions, value)

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2008,12 +2008,17 @@ def test_calculate_usage_completion_tokens_details_with_reasoning():
 
 def test_reasoning_effort_maps_to_adaptive_thinking_for_claude_4_6_models():
     """
-    Test that reasoning_effort maps to adaptive thinking type for Claude 4.6 models.
-
-    For Claude Opus 4.6 and Claude Sonnet 4.6, reasoning_effort should map to {"type": "adaptive"}
-    regardless of the effort level specified.
+    Test that reasoning_effort maps to adaptive thinking type for Claude 4.6 models,
+    and also sets output_config with the effort level.
     """
     config = AnthropicConfig()
+
+    effort_map = {
+        "low": "low",
+        "minimal": "low",
+        "medium": "medium",
+        "high": "high",
+    }
 
     # Test with different reasoning_effort values - all should map to adaptive
     for model in ["claude-opus-4-6-20250514", "claude-sonnet-4-6-20260219"]:
@@ -2035,6 +2040,9 @@ def test_reasoning_effort_maps_to_adaptive_thinking_for_claude_4_6_models():
             assert "budget_tokens" not in result["thinking"]
             # reasoning_effort should not be in the result (it's transformed to thinking)
             assert "reasoning_effort" not in result
+            # Should set output_config with the mapped effort value
+            assert "output_config" in result, f"output_config missing for {model} with effort={effort}"
+            assert result["output_config"]["effort"] == effort_map[effort]
 
 
 def test_get_supported_params_includes_reasoning_for_sonnet_4_6_alias():

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2018,11 +2018,12 @@ def test_reasoning_effort_maps_to_adaptive_thinking_for_claude_4_6_models():
         "minimal": "low",
         "medium": "medium",
         "high": "high",
+        "max": "max",
     }
 
     # Test with different reasoning_effort values - all should map to adaptive
     for model in ["claude-opus-4-6-20250514", "claude-sonnet-4-6-20260219"]:
-        for effort in ["low", "medium", "high", "minimal"]:
+        for effort in ["low", "medium", "high", "minimal", "max"]:
             non_default_params = {"reasoning_effort": effort}
             optional_params = {}
 


### PR DESCRIPTION
## Summary

When `reasoning_effort` is passed for Claude 4.6 models (`claude-sonnet-4-6`, `claude-opus-4-6`), the effort level is silently discarded. `_map_reasoning_effort` returns `{"type": "adaptive"}` regardless of the effort value, and no `output_config` is set.

## Root Cause

`_map_reasoning_effort` for 4.6 models returns only `AnthropicThinkingParam(type="adaptive")` without forwarding the effort level. Per the [Anthropic docs](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking), effort on 4.6 models is controlled via `output_config`, not `thinking.budget_tokens`.

## Fix

In `map_openai_params`, after calling `_map_reasoning_effort` for 4.6 models, also set `optional_params["output_config"] = {"effort": mapped_effort}` to forward the effort guidance.

Effort mapping:
- `low` → `low`
- `minimal` → `low`  
- `medium` → `medium`
- `high` → `high`
- `max` → `max`

## Tests

Updated `test_reasoning_effort_maps_to_adaptive_thinking_for_claude_4_6_models` to verify `output_config` is populated with the correct effort value.

```
3 passed in 0.12s
```

Fixes #22212