### PR TITLE
[Feature] UI - Projects: Add delete project action

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useDeleteProject.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useDeleteProject.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getProxyBaseUrl,
+  getGlobalLitellmHeaderName,
+  deriveErrorMessage,
+  handleError,
+} from "@/components/networking";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { projectKeys } from "./useProjects";
+
+// ── Fetch function ───────────────────────────────────────────────────────────
+
+const deleteProjects = async (
+  accessToken: string,
+  projectIds: string[],
+): Promise<void> => {
+  const baseUrl = getProxyBaseUrl();
+  const url = `${baseUrl}/project/delete`;
+
+  const response = await fetch(url, {
+    method: "DELETE",
+    headers: {
+      [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ project_ids: projectIds }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    const errorMessage = deriveErrorMessage(errorData);
+    handleError(errorMessage);
+    throw new Error(errorMessage);
+  }
+};
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+export const useDeleteProject = () => {
+  const { accessToken } = useAuthorized();
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string[]>({
+    mutationFn: async (projectIds) => {
+      if (!accessToken) {
+        throw new Error("Access token is required");
+      }
+      return deleteProjects(accessToken, projectIds);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: projectKeys.all });
+    },
+  });
+};


### PR DESCRIPTION
## Summary

### Problem
There was no way to delete projects from the Projects list page in the UI.

### Fix
Added a delete action to the projects table using the existing `TableIconActionButton` and `DeleteResourceModal` components, backed by a new `useDeleteProject` hook that calls `DELETE /project/delete`.

## Changes
- New `useDeleteProject` mutation hook
- Actions column in the projects table with a delete button
- `DeleteResourceModal` with project name confirmation required
- Alert warns that keys must be unlinked before deletion

## Testing
- Manual testing of delete flow
- Verified correct HTTP method (DELETE) matches backend endpoint

## Type

🆕 New Feature