### PR TITLE
fix(mcp): set LITELLM_MASTER_KEY env var in e2e tests

### DIFF
--- a/tests/mcp_tests/test_proxy_mcp_e2e.py
+++ b/tests/mcp_tests/test_proxy_mcp_e2e.py
@@ -35,6 +35,10 @@ def _clear_proxy_database_env() -> typing.Iterator[None]:
     """Ensure local proxy DB settings don't leak into tests."""
     mp = pytest.MonkeyPatch()
     mp.delenv("DATABASE_URL", raising=False)
+    # The FastAPI lifespan event (proxy_startup_event) re-reads master_key from
+    # the LITELLM_MASTER_KEY env var, overriding whatever initialize() set from
+    # the config file. We must set it here so the lifespan doesn't reset it to None.
+    mp.setenv("LITELLM_MASTER_KEY", "sk-1234")
     try:
         yield
     finally:


### PR DESCRIPTION
## Summary
- Fixes MCP e2e test failures where all tests fail with "User not allowed to call this tool"
- Root cause: The FastAPI lifespan event (`proxy_startup_event`) re-reads `master_key` from the `LITELLM_MASTER_KEY` env var, overriding whatever `initialize()` set from the YAML config. Without this env var set, `master_key` becomes `None`, causing all users to be treated as `INTERNAL_USER` with no MCP server access.
- Fix: Set `LITELLM_MASTER_KEY=sk-1234` in the session-scoped test fixture so the lifespan event preserves the master key.

## Root Cause Analysis
1. `_initialize_proxy()` calls `initialize(config=config_path)` which sets `master_key = "sk-1234"` from the YAML config
2. `uvicorn.Server.serve()` triggers the FastAPI lifespan handler `proxy_startup_event`
3. `proxy_startup_event` at line 768 does `master_key = get_secret_str("LITELLM_MASTER_KEY")` — since the env var isn't set, this returns `None`, wiping out the previously configured master key
4. All subsequent requests see `master_key is None` → auth returns `user_role=INTERNAL_USER` → `get_allowed_mcp_servers()` returns `[]` → 403 error

## Test plan
- [x] All 4 MCP e2e tests pass locally (`pytest tests/mcp_tests/test_proxy_mcp_e2e.py`)

Closes #22330

🤖 Generated with [Claude Code](https://claude.com/claude-code)