### PR TITLE
fix: bump litellm-proxy-extras to 0.4.50 and fix 3 failing tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3886,7 +3886,7 @@ jobs:
           command: |
             cd ~/project
             # Check pyproject.toml
-            CURRENT_VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['tool']['poetry']['dependencies']['litellm-proxy-extras'].split('\"')[1])")
+            CURRENT_VERSION=$(python -c "import toml; dep = toml.load('pyproject.toml')['tool']['poetry']['dependencies']['litellm-proxy-extras']; print(dep['version'] if isinstance(dep, dict) else dep)")
             if [ "$CURRENT_VERSION" != "$NEW_VERSION" ]; then
               echo "Error: Version in pyproject.toml ($CURRENT_VERSION) doesn't match new version ($NEW_VERSION)"
               exit 1

--- a/poetry.lock
+++ b/poetry.lock
@@ -3222,15 +3222,15 @@ files = [
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.49"
+version = "0.4.50"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 optional = true
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 groups = ["main"]
 markers = "extra == \"proxy\""
 files = [
-    {file = "litellm_proxy_extras-0.4.49-py3-none-any.whl", hash = "sha256:aeb0e08b4705c19fdc5b75a43c608a82fc36032f6d83be509dbf37baea62f2cd"},
-    {file = "litellm_proxy_extras-0.4.49.tar.gz", hash = "sha256:d9bdae54d1e3398f2e2025c9d8b98a19e226874337d540d5415922d7dbbc97bb"},
+    {file = "litellm_proxy_extras-0.4.50-py3-none-any.whl", hash = "sha256:598f5da91cc830a8da341a0c75ae12da01c4b8eb44f933429244cf066151b079"},
+    {file = "litellm_proxy_extras-0.4.50.tar.gz", hash = "sha256:0db0b8d81d382993d47f054ca973859beb111271f08e9eba6ab12f5c9163877e"},
 ]
 
 [[package]]
@@ -7989,4 +7989,4 @@ utils = ["numpydoc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "bbc7d43f5484af4c8877fe66e34f8283069528379af49d573036ba144cc2eb7a"
+content-hash = "ea52d80526c0d55b8972e4ba1742b4b72c7cf6ecaac1865605b638a4634c4f60"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ boto3 = { version = "1.40.76", optional = true }
 redisvl = {version = "^0.4.1", optional = true, markers = "python_version >= '3.9' and python_version < '3.14'"}
 mcp = {version = ">=1.25.0,<2.0.0", optional = true, python = ">=3.10"}
 a2a-sdk = {version = "^0.3.22", optional = true, python = ">=3.10"}
-litellm-proxy-extras = {version = "0.4.49", optional = true}
+litellm-proxy-extras = {version = "0.4.50", optional = true}
 rich = {version = "13.7.1", optional = true}
 litellm-enterprise = {version = "0.1.32", optional = true}
 diskcache = {version = "^5.6.1", optional = true}

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ grpcio>=1.75.0; python_version >= "3.14"
 sentry_sdk==2.21.0 # for sentry error handling
 detect-secrets==1.5.0 # Enterprise - secret detection / masking in LLM requests
 tzdata==2025.1 # IANA time zone database
-litellm-proxy-extras==0.4.49 # for proxy extras - e.g. prisma migrations
+litellm-proxy-extras==0.4.50 # for proxy extras - e.g. prisma migrations
 llm-sandbox==0.3.31 # for skill execution in sandbox
 ### LITELLM PACKAGE DEPENDENCIES
 python-dotenv==1.0.1 # for env

--- a/tests/guardrails_tests/test_presidio_pii.py
+++ b/tests/guardrails_tests/test_presidio_pii.py
@@ -286,8 +286,6 @@ async def test_output_parsing():
         }
     ]
 
-    pii_masking.pii_tokens = {"<PERSON>": "Jane Doe", "<PHONE_NUMBER>": "034453334"}
-
     response = mock_completion(
         model="gpt-3.5-turbo",
         messages=filtered_message,
@@ -296,7 +294,8 @@ async def test_output_parsing():
     new_response = await pii_masking.async_post_call_success_hook(
         user_api_key_dict=UserAPIKeyAuth(),
         data={
-            "messages": [{"role": "system", "content": "You are an helpfull assistant"}]
+            "messages": [{"role": "system", "content": "You are an helpfull assistant"}],
+            "pii_tokens": {"<PERSON>": "Jane Doe", "<PHONE_NUMBER>": "034453334"},
         },
         response=response,
     )

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -1559,6 +1559,7 @@ async def test_resolve_jwks_url_caches_resolved_jwks_uri():
     jwks_url = "https://login.microsoftonline.com/tenant/discovery/keys"
 
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {"jwks_uri": jwks_url}
 
     with patch.object(handler.http_handler, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
@@ -1587,6 +1588,7 @@ async def test_resolve_jwks_url_raises_if_no_jwks_uri_in_discovery_doc():
 
     discovery_url = "https://example.com/.well-known/openid-configuration"
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.json.return_value = {"issuer": "https://example.com"}  # no jwks_uri
 
     with patch.object(handler.http_handler, "get", new_callable=AsyncMock, return_value=mock_response):


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Two fixes:

**1. Bump litellm-proxy-extras to 0.4.50** (`pyproject.toml`, `requirements.txt`, `poetry.lock`)

The version in `litellm-proxy-extras/pyproject.toml` was bumped to 0.4.50 but the root `pyproject.toml` and `requirements.txt` still referenced 0.4.49. The `publish_proxy_extras` CI job was catching this mismatch and failing. Package has already been published to PyPI manually.

**2. Fix 3 failing tests**

- `test_resolve_jwks_url_caches_resolved_jwks_uri` / `test_resolve_jwks_url_raises_if_no_jwks_uri_in_discovery_doc` — mocks were missing `status_code = 200`, so the implementation's status check triggered the wrong exception before reaching jwks_uri logic
- `test_output_parsing` (presidio) — test was setting `pii_tokens` on the instance but the hook reads it from `request_data`; fixed by passing `pii_tokens` through the `data` dict