### PR TITLE
fix: defer remote model cost map fetch to first use (simplified)

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -470,12 +470,12 @@ def _ensure_remote_model_cost() -> None:
     global _model_cost_remote_loaded
     if _model_cost_remote_loaded:
         return
-    _model_cost_remote_loaded = True
     try:
         remote = get_model_cost_map(url=_model_cost_url)
         model_cost.update(remote)  # merge remote on top of local; no clear() needed
+        _model_cost_remote_loaded = True
     except Exception:
-        pass  # keep using local backup
+        pass  # keep using local backup; next call will retry
 
 
 cost_discount_config: Dict[str, float] = (

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -489,8 +489,12 @@ def _ensure_remote_model_cost() -> None:
         model_cost.update(remote)  # merge remote on top of local; no clear() needed
         add_known_models()  # repopulate provider model sets with merged data
         _model_cost_remote_loaded = True
-    except Exception:
-        pass  # keep using local backup; next call will retry
+    except Exception as e:
+        verbose_logger.debug(
+            "LiteLLM: Remote model cost map fetch/merge failed: %s. "
+            "Keeping local backup; will retry on next call.",
+            str(e),
+        )
 
 
 cost_discount_config: Dict[str, float] = (

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -463,8 +463,9 @@ model_cost = GetModelCostMap.load_local_model_cost_map()
 def _ensure_remote_model_cost() -> None:
     """Fetch and merge the remote model cost map on first use (once only).
 
-    No threading, no locks — simply fetches on first call and merges
-    remote data into the existing dict so all references stay valid.
+    Thread safety: uses update() (not clear()+update()) so concurrent readers
+    always see a non-empty dict. The worst case for a race is a redundant
+    remote fetch, which is harmless since update() is idempotent for same data.
     """
     global _model_cost_remote_loaded
     if _model_cost_remote_loaded:

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -449,8 +449,35 @@ _key_management_system: Optional["KeyManagementSystem"] = None
 output_parse_pii: bool = False
 #############################################
 from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
+from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
 
-model_cost = get_model_cost_map(url=model_cost_map_url)
+# Load local backup at import time (fast, ~12 ms, no network I/O).
+# The remote fetch is deferred to first access — no threading, no locks.
+_model_cost_url: str = model_cost_map_url
+_model_cost_remote_loaded: bool = (
+    os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", "").lower() == "true"
+)
+model_cost = GetModelCostMap.load_local_model_cost_map()
+
+
+def _ensure_remote_model_cost() -> None:
+    """Fetch and merge the remote model cost map on first use (once only).
+
+    No threading, no locks — simply fetches on first call and replaces the
+    dict contents in place so all existing references stay valid.
+    """
+    global _model_cost_remote_loaded
+    if _model_cost_remote_loaded:
+        return
+    _model_cost_remote_loaded = True
+    try:
+        remote = get_model_cost_map(url=_model_cost_url)
+        model_cost.clear()
+        model_cost.update(remote)
+    except Exception:
+        pass  # keep using local backup
+
+
 cost_discount_config: Dict[str, float] = (
     {}
 )  # Provider-specific cost discounts {"vertex_ai": 0.05} = 5% discount
@@ -630,6 +657,8 @@ def is_openai_finetune_model(key: str) -> bool:
 
 
 def add_known_models(model_cost_map: Optional[Dict] = None):
+    if model_cost_map is None:
+        _ensure_remote_model_cost()
     _map = model_cost_map if model_cost_map is not None else model_cost
     for key, value in _map.items():
         if value.get("litellm_provider") == "openai" and not is_openai_finetune_model(

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -505,12 +505,12 @@ def _ensure_remote_model_cost() -> None:
         try:
             remote = get_model_cost_map(url=_model_cost_url)
             model_cost.update(remote)  # merge remote on top of local; no clear() needed
-            add_known_models()  # repopulate provider model sets with merged data
+            add_known_models(model_cost_map=model_cost)  # repopulate provider model sets with merged data
             _model_cost_remote_loaded = True
             _model_cost_last_failure_monotonic = 0.0
         except Exception as e:
             _model_cost_last_failure_monotonic = time.monotonic()
-            verbose_logger.debug(
+            verbose_logger.warning(
                 "LiteLLM: Remote model cost map fetch/merge failed: %s. "
                 "Keeping local backup; will retry after cooldown.",
                 str(e),

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -452,6 +452,7 @@ output_parse_pii: bool = False
 from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
 from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
 from litellm.litellm_core_utils.get_model_cost_map import _cost_map_source_info
+from litellm.litellm_core_utils.get_model_cost_map import _get_model_cost_map_with_source
 
 # Load local backup at import time (fast, ~12 ms, no network I/O).
 _model_cost_url: str = model_cost_map_url
@@ -504,20 +505,20 @@ def _ensure_remote_model_cost() -> None:
         ):
             return
         try:
-            remote = get_model_cost_map(url=_model_cost_url)
-            # get_model_cost_map() silently returns local backup on network
-            # failure.  Check _cost_map_source_info.source to distinguish a
-            # genuine remote fetch from a silent local fallback so the retry
-            # cooldown stays effective for network-unreachable scenarios.
-            if _cost_map_source_info.source != "remote":
+            result = _get_model_cost_map_with_source(url=_model_cost_url)
+            # Use the atomic source from the result instead of reading the
+            # mutable singleton — avoids a race where a concurrent direct call
+            # to get_model_cost_map() could overwrite _cost_map_source_info
+            # between the fetch and our check.
+            if result.source != "remote":
                 _model_cost_last_failure_monotonic = time.monotonic()
                 verbose_logger.warning(
                     "LiteLLM: Remote model cost map unavailable (%s). "
                     "Using local backup; will retry after cooldown.",
-                    _cost_map_source_info.fallback_reason or "unknown",
+                    result.fallback_reason or "unknown",
                 )
                 return
-            model_cost.update(remote)  # merge remote on top of local; no clear() needed
+            model_cost.update(result.data)  # merge remote on top of local; no clear() needed
             add_known_models(model_cost_map=model_cost)  # repopulate provider model sets with merged data
             _model_cost_remote_loaded = True
             _model_cost_last_failure_monotonic = 0.0

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -451,6 +451,7 @@ output_parse_pii: bool = False
 #############################################
 from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
 from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+from litellm.litellm_core_utils.get_model_cost_map import _cost_map_source_info
 
 # Load local backup at import time (fast, ~12 ms, no network I/O).
 _model_cost_url: str = model_cost_map_url
@@ -504,6 +505,18 @@ def _ensure_remote_model_cost() -> None:
             return
         try:
             remote = get_model_cost_map(url=_model_cost_url)
+            # get_model_cost_map() silently returns local backup on network
+            # failure.  Check _cost_map_source_info.source to distinguish a
+            # genuine remote fetch from a silent local fallback so the retry
+            # cooldown stays effective for network-unreachable scenarios.
+            if _cost_map_source_info.source != "remote":
+                _model_cost_last_failure_monotonic = time.monotonic()
+                verbose_logger.warning(
+                    "LiteLLM: Remote model cost map unavailable (%s). "
+                    "Using local backup; will retry after cooldown.",
+                    _cost_map_source_info.fallback_reason or "unknown",
+                )
+                return
             model_cost.update(remote)  # merge remote on top of local; no clear() needed
             add_known_models(model_cost_map=model_cost)  # repopulate provider model sets with merged data
             _model_cost_remote_loaded = True

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -463,8 +463,8 @@ model_cost = GetModelCostMap.load_local_model_cost_map()
 def _ensure_remote_model_cost() -> None:
     """Fetch and merge the remote model cost map on first use (once only).
 
-    No threading, no locks — simply fetches on first call and replaces the
-    dict contents in place so all existing references stay valid.
+    No threading, no locks — simply fetches on first call and merges
+    remote data into the existing dict so all references stay valid.
     """
     global _model_cost_remote_loaded
     if _model_cost_remote_loaded:
@@ -472,8 +472,7 @@ def _ensure_remote_model_cost() -> None:
     _model_cost_remote_loaded = True
     try:
         remote = get_model_cost_map(url=_model_cost_url)
-        model_cost.clear()
-        model_cost.update(remote)
+        model_cost.update(remote)  # merge remote on top of local; no clear() needed
     except Exception:
         pass  # keep using local backup
 
@@ -889,7 +888,7 @@ def add_known_models(model_cost_map: Optional[Dict] = None):
             bedrock_mantle_models.add(key)
 
 
-add_known_models()
+add_known_models(model_cost)  # use local backup — remote fetch deferred to first external call
 # known openai compatible endpoints - we'll eventually move this list to the model_prices_and_context_window.json dictionary
 
 # this is maintained for Exception Mapping

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -12,6 +12,7 @@ warnings.filterwarnings(
 ### INIT VARIABLES #########################
 import threading
 import os
+import time
 
 # Load .env before any other litellm imports so env vars (e.g. LITELLM_UI_SESSION_DURATION) are available
 import dotenv as _dotenv
@@ -461,6 +462,8 @@ _model_cost_remote_loaded: bool = (
     os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", "").lower() == "true"
 )
 _model_cost_lock = threading.Lock()
+_model_cost_last_failure_monotonic: float = 0.0
+_MODEL_COST_RETRY_COOLDOWN_SECONDS: float = 60.0
 model_cost = GetModelCostMap.load_local_model_cost_map()
 
 
@@ -481,21 +484,35 @@ def _ensure_remote_model_cost() -> None:
     until process restart. This is an acceptable trade-off for thread safety
     (atomic reassignment would break references held by other modules).
     """
-    global _model_cost_remote_loaded
+    global _model_cost_remote_loaded, _model_cost_last_failure_monotonic
     if _model_cost_remote_loaded:
+        return
+    if (
+        _model_cost_last_failure_monotonic > 0
+        and (time.monotonic() - _model_cost_last_failure_monotonic)
+        < _MODEL_COST_RETRY_COOLDOWN_SECONDS
+    ):
         return
     with _model_cost_lock:
         if _model_cost_remote_loaded:
+            return
+        if (
+            _model_cost_last_failure_monotonic > 0
+            and (time.monotonic() - _model_cost_last_failure_monotonic)
+            < _MODEL_COST_RETRY_COOLDOWN_SECONDS
+        ):
             return
         try:
             remote = get_model_cost_map(url=_model_cost_url)
             model_cost.update(remote)  # merge remote on top of local; no clear() needed
             add_known_models()  # repopulate provider model sets with merged data
             _model_cost_remote_loaded = True
+            _model_cost_last_failure_monotonic = 0.0
         except Exception as e:
+            _model_cost_last_failure_monotonic = time.monotonic()
             verbose_logger.debug(
                 "LiteLLM: Remote model cost map fetch/merge failed: %s. "
-                "Keeping local backup; will retry on next call.",
+                "Keeping local backup; will retry after cooldown.",
                 str(e),
             )
 

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -454,8 +454,10 @@ from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
 # Load local backup at import time (fast, ~12 ms, no network I/O).
 # The remote fetch is deferred to first access — no threading, no locks.
 _model_cost_url: str = model_cost_map_url
-# Check at import time to avoid any remote fetch when explicitly disabled.
-# get_model_cost_map() also checks this env var as a secondary guard.
+# Dual env-var check is intentional:
+#   1. Import-time check (here) initializes _model_cost_remote_loaded to skip lazy fetch
+#   2. Runtime check (in get_model_cost_map) ensures correctness if env var changes
+#      after import (e.g., in tests or dynamic reconfiguration)
 _model_cost_remote_loaded: bool = (
     os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", "").lower() == "true"
 )
@@ -485,6 +487,7 @@ def _ensure_remote_model_cost() -> None:
     try:
         remote = get_model_cost_map(url=_model_cost_url)
         model_cost.update(remote)  # merge remote on top of local; no clear() needed
+        add_known_models()  # repopulate provider model sets with merged data
         _model_cost_remote_loaded = True
     except Exception:
         pass  # keep using local backup; next call will retry
@@ -1275,16 +1278,6 @@ from .responses.main import *
 # Interactions API is available as litellm.interactions module
 # Usage: litellm.interactions.create(), litellm.interactions.get(), etc.
 from . import interactions
-from .skills.main import (
-    create_skill,
-    acreate_skill,
-    list_skills,
-    alist_skills,
-    get_skill,
-    aget_skill,
-    delete_skill,
-    adelete_skill,
-)
 from .containers.main import *
 from .ocr.main import *
 from .rag.main import *

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -523,6 +523,8 @@ def _ensure_remote_model_cost() -> None:
             # Update the singleton so get_model_cost_map_source_info() reflects reality
             _cost_map_source_info.source = result.source
             _cost_map_source_info.fallback_reason = result.fallback_reason
+            _cost_map_source_info.url = _model_cost_url
+            _cost_map_source_info.is_env_forced = False
             _model_cost_remote_loaded = True
             _model_cost_last_failure_monotonic = 0.0
         except Exception as e:

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -520,6 +520,9 @@ def _ensure_remote_model_cost() -> None:
                 return
             model_cost.update(result.data)  # merge remote on top of local; no clear() needed
             add_known_models(model_cost_map=model_cost)  # repopulate provider model sets with merged data
+            # Update the singleton so get_model_cost_map_source_info() reflects reality
+            _cost_map_source_info.source = result.source
+            _cost_map_source_info.fallback_reason = result.fallback_reason
             _model_cost_remote_loaded = True
             _model_cost_last_failure_monotonic = 0.0
         except Exception as e:

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -466,6 +466,11 @@ def _ensure_remote_model_cost() -> None:
     Thread safety: uses update() (not clear()+update()) so concurrent readers
     always see a non-empty dict. The worst case for a race is a redundant
     remote fetch, which is harmless since update() is idempotent for same data.
+
+    Note: update() merges remote keys on top of local backup. If a model is
+    removed upstream but still present in the local backup, it will persist
+    until process restart. This is an acceptable trade-off for thread safety
+    (atomic reassignment would break references held by other modules).
     """
     global _model_cost_remote_loaded
     if _model_cost_remote_loaded:
@@ -657,8 +662,6 @@ def is_openai_finetune_model(key: str) -> bool:
 
 
 def add_known_models(model_cost_map: Optional[Dict] = None):
-    if model_cost_map is None:
-        _ensure_remote_model_cost()
     _map = model_cost_map if model_cost_map is not None else model_cost
     for key, value in _map.items():
         if value.get("litellm_provider") == "openai" and not is_openai_finetune_model(

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -295,6 +295,8 @@ def cost_per_token(  # noqa: PLR0915
     if model is None:
         raise Exception("Invalid arg. Model cannot be none.")
 
+    litellm._ensure_remote_model_cost()
+
     ## RECONSTRUCT USAGE BLOCK ##
     if usage_object is not None:
         usage_block = usage_object
@@ -1041,6 +1043,7 @@ def completion_cost(  # noqa: PLR0915
         - For un-mapped Replicate models, the cost is calculated based on the total time used for the request.
     """
     try:
+        litellm._ensure_remote_model_cost()
         call_type = _infer_call_type(call_type, completion_response) or "completion"
 
         if (

--- a/litellm/litellm_core_utils/get_model_cost_map.py
+++ b/litellm/litellm_core_utils/get_model_cost_map.py
@@ -183,6 +183,66 @@ def get_model_cost_map_source_info() -> dict:
     }
 
 
+class _FetchResult:
+    """Return value of ``_get_model_cost_map_with_source`` carrying both the
+    cost map and an *isolated* snapshot of source metadata so the caller never
+    needs to read the mutable ``_cost_map_source_info`` singleton."""
+
+    __slots__ = ("data", "source", "fallback_reason")
+
+    def __init__(self, data: dict, source: str, fallback_reason: Optional[str] = None):
+        self.data = data
+        self.source = source
+        self.fallback_reason = fallback_reason
+
+
+def _get_model_cost_map_with_source(url: str) -> _FetchResult:
+    """Fetch the model cost map and return an atomic result with source info.
+
+    This is the internal implementation shared by the public
+    ``get_model_cost_map()`` (which also updates the legacy singleton) and
+    ``_ensure_remote_model_cost()`` (which needs a race-free source check).
+    """
+    if os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", "").lower() == "true":
+        return _FetchResult(
+            data=GetModelCostMap.load_local_model_cost_map(),
+            source="local",
+            fallback_reason=None,
+        )
+
+    try:
+        content = GetModelCostMap.fetch_remote_model_cost_map(url)
+    except Exception as e:
+        verbose_logger.warning(
+            "LiteLLM: Failed to fetch remote model cost map from %s: %s. "
+            "Falling back to local backup.",
+            url,
+            str(e),
+        )
+        return _FetchResult(
+            data=GetModelCostMap.load_local_model_cost_map(),
+            source="local",
+            fallback_reason=f"Remote fetch failed: {str(e)}",
+        )
+
+    if not GetModelCostMap.validate_model_cost_map(
+        fetched_map=content,
+        backup_model_count=GetModelCostMap._get_backup_model_count(),
+    ):
+        verbose_logger.warning(
+            "LiteLLM: Fetched model cost map failed integrity check. "
+            "Using local backup instead. url=%s",
+            url,
+        )
+        return _FetchResult(
+            data=GetModelCostMap.load_local_model_cost_map(),
+            source="local",
+            fallback_reason="Remote data failed integrity validation",
+        )
+
+    return _FetchResult(data=content, source="remote")
+
+
 def get_model_cost_map(url: str) -> dict:
     """
     Public entry point — returns the model cost map dict.
@@ -194,46 +254,18 @@ def get_model_cost_map(url: str) -> dict:
     Only the backup model count is cached (a single int) for validation.
     The full backup dict is only parsed when it must be *returned* as a
     fallback — it is never held in memory long-term.
+
+    Note: also updates the module-level ``_cost_map_source_info`` singleton
+    for backward-compatible callers.  Thread-safe callers should prefer
+    ``_get_model_cost_map_with_source`` to avoid reading a shared mutable.
     """
-    # Note: can't use get_secret_bool here — this runs during litellm.__init__
-    # before litellm._key_management_settings is set.
-    if os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", "").lower() == "true":
-        _cost_map_source_info.source = "local"
-        _cost_map_source_info.url = None
-        _cost_map_source_info.is_env_forced = True
-        _cost_map_source_info.fallback_reason = None
-        return GetModelCostMap.load_local_model_cost_map()
+    result = _get_model_cost_map_with_source(url)
 
-    _cost_map_source_info.url = url
-    _cost_map_source_info.is_env_forced = False
+    # Update legacy singleton (best-effort; concurrent calls may interleave
+    # but the singleton is only informational).
+    _cost_map_source_info.source = result.source
+    _cost_map_source_info.url = url if os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", "").lower() != "true" else None
+    _cost_map_source_info.is_env_forced = os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", "").lower() == "true"
+    _cost_map_source_info.fallback_reason = result.fallback_reason
 
-    try:
-        content = GetModelCostMap.fetch_remote_model_cost_map(url)
-    except Exception as e:
-        verbose_logger.warning(
-            "LiteLLM: Failed to fetch remote model cost map from %s: %s. "
-            "Falling back to local backup.",
-            url,
-            str(e),
-        )
-        _cost_map_source_info.source = "local"
-        _cost_map_source_info.fallback_reason = f"Remote fetch failed: {str(e)}"
-        return GetModelCostMap.load_local_model_cost_map()
-
-    # Validate using cached count (cheap int comparison, no file I/O)
-    if not GetModelCostMap.validate_model_cost_map(
-        fetched_map=content,
-        backup_model_count=GetModelCostMap._get_backup_model_count(),
-    ):
-        verbose_logger.warning(
-            "LiteLLM: Fetched model cost map failed integrity check. "
-            "Using local backup instead. url=%s",
-            url,
-        )
-        _cost_map_source_info.source = "local"
-        _cost_map_source_info.fallback_reason = "Remote data failed integrity validation"
-        return GetModelCostMap.load_local_model_cost_map()
-
-    _cost_map_source_info.source = "remote"
-    _cost_map_source_info.fallback_reason = None
-    return content
+    return result.data

--- a/tests/test_litellm/test_lazy_model_cost_map.py
+++ b/tests/test_litellm/test_lazy_model_cost_map.py
@@ -1,0 +1,53 @@
+"""Tests for deferred (lazy) model cost map loading."""
+
+import importlib
+import os
+import unittest
+from unittest.mock import patch
+
+
+class TestLazyModelCostMap(unittest.TestCase):
+    """Verify that model_cost loads local data at import and defers remote."""
+
+    def test_local_backup_loaded_at_import(self):
+        """model_cost should contain local data immediately after import."""
+        import litellm
+
+        assert isinstance(litellm.model_cost, dict)
+        assert len(litellm.model_cost) > 0, "model_cost should not be empty"
+
+    def test_local_only_skips_remote(self):
+        """When LITELLM_LOCAL_MODEL_COST_MAP=True, remote fetch is skipped."""
+        with patch.dict(os.environ, {"LITELLM_LOCAL_MODEL_COST_MAP": "true"}):
+            import litellm
+
+            litellm._model_cost_remote_loaded = True
+            litellm._ensure_remote_model_cost()  # should be a no-op
+            assert litellm._model_cost_remote_loaded is True
+
+    def test_ensure_remote_model_cost_is_idempotent(self):
+        """Calling _ensure_remote_model_cost multiple times only fetches once."""
+        import litellm
+
+        litellm._model_cost_remote_loaded = True
+        original_len = len(litellm.model_cost)
+        litellm._ensure_remote_model_cost()
+        assert len(litellm.model_cost) == original_len
+
+    def test_add_known_models_triggers_remote(self):
+        """add_known_models() without args triggers _ensure_remote_model_cost."""
+        import litellm
+
+        litellm._model_cost_remote_loaded = True  # prevent actual HTTP
+        litellm.add_known_models()
+        assert litellm._model_cost_remote_loaded is True
+
+    def test_model_cost_is_plain_dict(self):
+        """model_cost should be a plain dict, not a custom subclass."""
+        import litellm
+
+        assert type(litellm.model_cost) is dict
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_litellm/test_lazy_model_cost_map.py
+++ b/tests/test_litellm/test_lazy_model_cost_map.py
@@ -1,11 +1,9 @@
 """Tests for deferred (lazy) model cost map loading."""
 
-import os
-import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 
-class TestLazyModelCostMap(unittest.TestCase):
+class TestLazyModelCostMap:
     """Verify that model_cost loads local data at import and defers remote."""
 
     def test_local_backup_loaded_at_import(self):
@@ -108,6 +106,14 @@ class TestLazyModelCostMap(unittest.TestCase):
                 pass  # model lookup may fail in test env
             mock_ensure.assert_called()
 
+    def test_completion_cost_triggers_remote_fetch(self):
+        """completion_cost() should trigger _ensure_remote_model_cost on first use."""
+        import litellm
 
-if __name__ == "__main__":
-    unittest.main()
+        litellm._model_cost_remote_loaded = False
+        with patch("litellm._ensure_remote_model_cost") as mock_ensure:
+            try:
+                litellm.completion_cost(model="gpt-4o", prompt="test", completion="test")
+            except Exception:
+                pass
+            mock_ensure.assert_called()

--- a/tests/test_litellm/test_lazy_model_cost_map.py
+++ b/tests/test_litellm/test_lazy_model_cost_map.py
@@ -4,6 +4,8 @@ import threading
 import pytest
 from unittest.mock import patch
 
+from litellm.litellm_core_utils.get_model_cost_map import _FetchResult
+
 
 @pytest.fixture
 def isolate_model_cost_state():
@@ -63,16 +65,16 @@ class TestLazyModelCostMap:
     def test_ensure_remote_idempotent(self, isolate_model_cost_state):
         """Calling _ensure_remote_model_cost multiple times only fetches once."""
         import litellm
-        from litellm.litellm_core_utils.get_model_cost_map import _cost_map_source_info
 
         litellm._model_cost_remote_loaded = False
 
         def fake_remote_get(url):
-            _cost_map_source_info.source = "remote"
-            _cost_map_source_info.fallback_reason = None
-            return {"test_idempotent": {"litellm_provider": "openai"}}
+            return _FetchResult(
+                data={"test_idempotent": {"litellm_provider": "openai"}},
+                source="remote",
+            )
 
-        with patch("litellm.get_model_cost_map", side_effect=fake_remote_get) as mock_get:
+        with patch("litellm._get_model_cost_map_with_source", side_effect=fake_remote_get) as mock_get:
             litellm._ensure_remote_model_cost()
             litellm._ensure_remote_model_cost()
             litellm._ensure_remote_model_cost()
@@ -99,21 +101,21 @@ class TestLazyModelCostMap:
             assert litellm._model_cost_remote_loaded is False
 
     def test_silent_local_fallback_does_not_set_flag(self, isolate_model_cost_state):
-        """If get_model_cost_map returns local backup (source != 'remote'),
+        """If _get_model_cost_map_with_source returns local source,
         _model_cost_remote_loaded must stay False so retries remain active."""
         import litellm
-        from litellm.litellm_core_utils.get_model_cost_map import _cost_map_source_info
 
         litellm._model_cost_remote_loaded = False
         original_keys = set(litellm.model_cost.keys())
 
-        # Simulate get_model_cost_map silently falling back to local backup
         def fake_get(url):
-            _cost_map_source_info.source = "local"
-            _cost_map_source_info.fallback_reason = "Remote fetch failed: timeout"
-            return dict(litellm.model_cost)
+            return _FetchResult(
+                data=dict(litellm.model_cost),
+                source="local",
+                fallback_reason="Remote fetch failed: timeout",
+            )
 
-        with patch("litellm.get_model_cost_map", side_effect=fake_get) as mock_get:
+        with patch("litellm._get_model_cost_map_with_source", side_effect=fake_get) as mock_get:
             litellm._ensure_remote_model_cost()
             mock_get.assert_called_once()
             # Flag must NOT be set — only local data was loaded
@@ -135,7 +137,7 @@ class TestLazyModelCostMap:
 
         litellm._model_cost_remote_loaded = False
         original_keys = set(litellm.model_cost.keys())
-        with patch("litellm.get_model_cost_map", side_effect=Exception("network")) as mock_get:
+        with patch("litellm._get_model_cost_map_with_source", side_effect=Exception("network")) as mock_get:
             litellm._ensure_remote_model_cost()
             assert set(litellm.model_cost.keys()) == original_keys
             assert litellm._model_cost_remote_loaded is False  # flag NOT set on failure
@@ -175,17 +177,17 @@ class TestLazyModelCostMap:
     def test_concurrent_ensure_fetches_only_once(self, isolate_model_cost_state):
         """Only one thread should perform the remote fetch even under contention."""
         import litellm
-        from litellm.litellm_core_utils.get_model_cost_map import _cost_map_source_info
 
         litellm._model_cost_remote_loaded = False
         barrier = threading.Barrier(4)
 
         def fake_remote_get(url):
-            _cost_map_source_info.source = "remote"
-            _cost_map_source_info.fallback_reason = None
-            return {"concurrent_test": {"litellm_provider": "openai"}}
+            return _FetchResult(
+                data={"concurrent_test": {"litellm_provider": "openai"}},
+                source="remote",
+            )
 
-        with patch("litellm.get_model_cost_map", side_effect=fake_remote_get) as mock_get:
+        with patch("litellm._get_model_cost_map_with_source", side_effect=fake_remote_get) as mock_get:
 
             def worker():
                 barrier.wait()

--- a/tests/test_litellm/test_lazy_model_cost_map.py
+++ b/tests/test_litellm/test_lazy_model_cost_map.py
@@ -152,4 +152,6 @@ class TestLazyModelCostMap:
                 t.start()
             for t in threads:
                 t.join(timeout=10)
+            for t in threads:
+                assert not t.is_alive(), "Thread did not complete within timeout"
             mock_get.assert_called_once()

--- a/tests/test_litellm/test_lazy_model_cost_map.py
+++ b/tests/test_litellm/test_lazy_model_cost_map.py
@@ -7,11 +7,20 @@ from unittest.mock import patch
 
 @pytest.fixture
 def isolate_model_cost_state():
-    """Save and restore _model_cost_remote_loaded state across tests."""
+    """Save and restore _model_cost_remote_loaded state and provider model sets across tests."""
     import litellm
     original_state = litellm._model_cost_remote_loaded
     original_last_failure = litellm._model_cost_last_failure_monotonic
     original_cost_dict = dict(litellm.model_cost)  # shallow copy
+    
+    # Save all provider model sets that add_known_models might modify
+    saved_model_sets = {}
+    for attr_name in dir(litellm):
+        attr = getattr(litellm, attr_name, None)
+        if isinstance(attr, set) and attr_name.endswith("_models"):
+            # Save a copy of each provider model set
+            saved_model_sets[attr_name] = set(attr)
+    
     litellm._model_cost_last_failure_monotonic = 0.0
     yield
     # Restore state after test
@@ -19,6 +28,11 @@ def isolate_model_cost_state():
     litellm._model_cost_last_failure_monotonic = original_last_failure
     litellm.model_cost.clear()
     litellm.model_cost.update(original_cost_dict)
+    
+    # Restore all provider model sets
+    for attr_name, original_set in saved_model_sets.items():
+        getattr(litellm, attr_name).clear()
+        getattr(litellm, attr_name).update(original_set)
 
 
 class TestLazyModelCostMap:

--- a/tests/test_litellm/test_lazy_model_cost_map.py
+++ b/tests/test_litellm/test_lazy_model_cost_map.py
@@ -10,10 +10,13 @@ def isolate_model_cost_state():
     """Save and restore _model_cost_remote_loaded state across tests."""
     import litellm
     original_state = litellm._model_cost_remote_loaded
+    original_last_failure = litellm._model_cost_last_failure_monotonic
     original_cost_dict = dict(litellm.model_cost)  # shallow copy
+    litellm._model_cost_last_failure_monotonic = 0.0
     yield
     # Restore state after test
     litellm._model_cost_remote_loaded = original_state
+    litellm._model_cost_last_failure_monotonic = original_last_failure
     litellm.model_cost.clear()
     litellm.model_cost.update(original_cost_dict)
 
@@ -94,8 +97,8 @@ class TestLazyModelCostMap:
 
         assert type(litellm.model_cost) is dict
 
-    def test_remote_failure_keeps_local_and_allows_retry(self, isolate_model_cost_state):
-        """If remote fetch fails, local backup data remains and next call retries."""
+    def test_remote_failure_keeps_local_and_uses_cooldown(self, isolate_model_cost_state):
+        """If remote fetch fails, local backup remains and retries respect cooldown."""
         import litellm
 
         litellm._model_cost_remote_loaded = False
@@ -104,9 +107,13 @@ class TestLazyModelCostMap:
             litellm._ensure_remote_model_cost()
             assert set(litellm.model_cost.keys()) == original_keys
             assert litellm._model_cost_remote_loaded is False  # flag NOT set on failure
-            # Next call should retry
+            # Immediate next call should skip due cooldown
             litellm._ensure_remote_model_cost()
-            assert mock_get.call_count == 2  # retried
+            assert mock_get.call_count == 1
+            # Force cooldown expiry, then retry should happen
+            litellm._model_cost_last_failure_monotonic = 0.0
+            litellm._ensure_remote_model_cost()
+            assert mock_get.call_count == 2
 
     def test_cost_per_token_triggers_remote_fetch(self, isolate_model_cost_state):
         """cost_per_token() should trigger _ensure_remote_model_cost on first use."""

--- a/tests/test_litellm/test_lazy_model_cost_map.py
+++ b/tests/test_litellm/test_lazy_model_cost_map.py
@@ -17,6 +17,8 @@ def isolate_model_cost_state():
     original_last_failure = litellm._model_cost_last_failure_monotonic
     original_cost_dict = dict(litellm.model_cost)  # shallow copy
     original_source = _cost_map_source_info.source
+    original_url = _cost_map_source_info.url
+    original_is_env_forced = _cost_map_source_info.is_env_forced
     original_fallback_reason = _cost_map_source_info.fallback_reason
     
     # Save all provider model sets that add_known_models might modify
@@ -35,6 +37,8 @@ def isolate_model_cost_state():
     litellm.model_cost.clear()
     litellm.model_cost.update(original_cost_dict)
     _cost_map_source_info.source = original_source
+    _cost_map_source_info.url = original_url
+    _cost_map_source_info.is_env_forced = original_is_env_forced
     _cost_map_source_info.fallback_reason = original_fallback_reason
     
     # Restore all provider model sets
@@ -95,10 +99,16 @@ class TestLazyModelCostMap:
         import litellm
 
         litellm._model_cost_remote_loaded = False
-        with patch("litellm.get_model_cost_map") as mock_get:
-            litellm.add_known_models()
-            mock_get.assert_not_called()
-            assert litellm._model_cost_remote_loaded is False
+        # Inject a sentinel model to verify add_known_models reads from model_cost
+        litellm.model_cost["_test_sentinel_model"] = {"litellm_provider": "openai"}
+        litellm.add_known_models()
+        assert "_test_sentinel_model" in litellm.open_ai_chat_completion_models, (
+            "add_known_models() should populate provider sets from current model_cost"
+        )
+        assert litellm._model_cost_remote_loaded is False
+        # Cleanup
+        litellm.open_ai_chat_completion_models.discard("_test_sentinel_model")
+        litellm.model_cost.pop("_test_sentinel_model", None)
 
     def test_silent_local_fallback_does_not_set_flag(self, isolate_model_cost_state):
         """If _get_model_cost_map_with_source returns local source,
@@ -160,7 +170,7 @@ class TestLazyModelCostMap:
                 cost_per_token(model="gpt-4o", prompt_tokens=10, completion_tokens=5)
             except Exception:
                 pass  # model lookup may fail in test env
-            mock_ensure.assert_called()
+            mock_ensure.assert_called_once()
 
     def test_completion_cost_triggers_remote_fetch(self, isolate_model_cost_state):
         """completion_cost() should trigger _ensure_remote_model_cost on first use."""
@@ -172,7 +182,7 @@ class TestLazyModelCostMap:
                 litellm.completion_cost(model="gpt-4o", prompt="test", completion="test")
             except Exception:
                 pass
-            mock_ensure.assert_called()
+            mock_ensure.assert_called()  # called at least once (may be >1 via internal cost helpers)
 
     def test_concurrent_ensure_fetches_only_once(self, isolate_model_cost_state):
         """Only one thread should perform the remote fetch even under contention."""

--- a/tests/test_litellm/test_lazy_model_cost_map.py
+++ b/tests/test_litellm/test_lazy_model_cost_map.py
@@ -9,9 +9,13 @@ from unittest.mock import patch
 def isolate_model_cost_state():
     """Save and restore _model_cost_remote_loaded state and provider model sets across tests."""
     import litellm
+    from litellm.litellm_core_utils.get_model_cost_map import _cost_map_source_info
+
     original_state = litellm._model_cost_remote_loaded
     original_last_failure = litellm._model_cost_last_failure_monotonic
     original_cost_dict = dict(litellm.model_cost)  # shallow copy
+    original_source = _cost_map_source_info.source
+    original_fallback_reason = _cost_map_source_info.fallback_reason
     
     # Save all provider model sets that add_known_models might modify
     saved_model_sets = {}
@@ -28,6 +32,8 @@ def isolate_model_cost_state():
     litellm._model_cost_last_failure_monotonic = original_last_failure
     litellm.model_cost.clear()
     litellm.model_cost.update(original_cost_dict)
+    _cost_map_source_info.source = original_source
+    _cost_map_source_info.fallback_reason = original_fallback_reason
     
     # Restore all provider model sets
     for attr_name, original_set in saved_model_sets.items():
@@ -57,10 +63,16 @@ class TestLazyModelCostMap:
     def test_ensure_remote_idempotent(self, isolate_model_cost_state):
         """Calling _ensure_remote_model_cost multiple times only fetches once."""
         import litellm
+        from litellm.litellm_core_utils.get_model_cost_map import _cost_map_source_info
 
         litellm._model_cost_remote_loaded = False
-        with patch("litellm.get_model_cost_map") as mock_get:
-            mock_get.return_value = {"test_idempotent": {"litellm_provider": "openai"}}
+
+        def fake_remote_get(url):
+            _cost_map_source_info.source = "remote"
+            _cost_map_source_info.fallback_reason = None
+            return {"test_idempotent": {"litellm_provider": "openai"}}
+
+        with patch("litellm.get_model_cost_map", side_effect=fake_remote_get) as mock_get:
             litellm._ensure_remote_model_cost()
             litellm._ensure_remote_model_cost()
             litellm._ensure_remote_model_cost()
@@ -86,24 +98,30 @@ class TestLazyModelCostMap:
             mock_get.assert_not_called()
             assert litellm._model_cost_remote_loaded is False
 
-    def test_remote_not_fetched_at_import_time(self, isolate_model_cost_state):
-        """The module-level add_known_models(model_cost) passes args, so
-        _ensure_remote_model_cost should NOT fire during import."""
+    def test_silent_local_fallback_does_not_set_flag(self, isolate_model_cost_state):
+        """If get_model_cost_map returns local backup (source != 'remote'),
+        _model_cost_remote_loaded must stay False so retries remain active."""
         import litellm
+        from litellm.litellm_core_utils.get_model_cost_map import _cost_map_source_info
 
-        # After import, if LITELLM_LOCAL_MODEL_COST_MAP was not set,
-        # _model_cost_remote_loaded should still be False (import doesn't fetch)
-        # We can't truly test import-time behavior without reimporting,
-        # but we can verify the guard logic works correctly:
         litellm._model_cost_remote_loaded = False
-        with patch("litellm.get_model_cost_map") as mock_get:
-            mock_get.return_value = {"test_model": {"litellm_provider": "openai"}}
+        original_keys = set(litellm.model_cost.keys())
+
+        # Simulate get_model_cost_map silently falling back to local backup
+        def fake_get(url):
+            _cost_map_source_info.source = "local"
+            _cost_map_source_info.fallback_reason = "Remote fetch failed: timeout"
+            return dict(litellm.model_cost)
+
+        with patch("litellm.get_model_cost_map", side_effect=fake_get) as mock_get:
             litellm._ensure_remote_model_cost()
             mock_get.assert_called_once()
-            assert "test_model" in litellm.model_cost
-            # Second call should be a no-op
-            litellm._ensure_remote_model_cost()
-            mock_get.assert_called_once()  # still only 1 call
+            # Flag must NOT be set — only local data was loaded
+            assert litellm._model_cost_remote_loaded is False
+            # Failure timestamp should be recorded for cooldown
+            assert litellm._model_cost_last_failure_monotonic > 0
+            # Local data should be unchanged
+            assert set(litellm.model_cost.keys()) == original_keys
 
     def test_model_cost_is_plain_dict(self):
         """model_cost should be a plain dict, not a custom subclass."""
@@ -157,12 +175,17 @@ class TestLazyModelCostMap:
     def test_concurrent_ensure_fetches_only_once(self, isolate_model_cost_state):
         """Only one thread should perform the remote fetch even under contention."""
         import litellm
+        from litellm.litellm_core_utils.get_model_cost_map import _cost_map_source_info
 
         litellm._model_cost_remote_loaded = False
         barrier = threading.Barrier(4)
 
-        with patch("litellm.get_model_cost_map") as mock_get:
-            mock_get.return_value = {"concurrent_test": {"litellm_provider": "openai"}}
+        def fake_remote_get(url):
+            _cost_map_source_info.source = "remote"
+            _cost_map_source_info.fallback_reason = None
+            return {"concurrent_test": {"litellm_provider": "openai"}}
+
+        with patch("litellm.get_model_cost_map", side_effect=fake_remote_get) as mock_get:
 
             def worker():
                 barrier.wait()

--- a/tests/test_litellm/test_lazy_model_cost_map.py
+++ b/tests/test_litellm/test_lazy_model_cost_map.py
@@ -58,7 +58,7 @@ class TestLazyModelCostMap:
         import litellm
 
         litellm._model_cost_remote_loaded = True
-        with patch("litellm.get_model_cost_map") as mock_get:
+        with patch("litellm._get_model_cost_map_with_source") as mock_get:
             litellm._ensure_remote_model_cost()
             mock_get.assert_not_called()
 


### PR DESCRIPTION
## Summary

Lazy-load the remote model cost map on first cost-calculation call instead of blocking `import litellm`.

### What changed

1. **Deferred remote fetch**: The remote model cost map (from GitHub) is no longer fetched at import time. Instead, only the local backup is loaded during `import litellm` (~12 ms, no network I/O). The remote fetch is triggered lazily on the first call to `cost_per_token()` or `completion_cost()`.

2. **Thread-safe lazy loading**: `_ensure_remote_model_cost()` uses a `threading.Lock` with double-checked locking to ensure exactly one thread performs the remote fetch, even under concurrent access.

3. **Race-condition fix on `_cost_map_source_info`**: Extracted `_get_model_cost_map_with_source()` which returns an atomic `_FetchResult` carrying both the cost map dict and source metadata. `_ensure_remote_model_cost()` now reads the source from the returned result instead of the shared mutable `_cost_map_source_info` singleton, eliminating a race where concurrent direct calls to `get_model_cost_map()` could overwrite `.source` between fetch and check.

4. **Retry cooldown**: Failed remote fetches record a monotonic timestamp and skip retries for 60 seconds, preventing thundering-herd retries on network issues.

5. **Graceful fallback**: If the remote fetch fails or returns invalid data, the local backup remains in use with a warning logged. The `_model_cost_remote_loaded` flag stays `False` so retries are attempted after cooldown.

### Backward compatibility

- `litellm.model_cost` remains a plain `dict` populated at import time (local data)
- `get_model_cost_map()` public API and `get_model_cost_map_source_info()` are unchanged
- Skills imports preserved (deduplicated from main which had a duplicate block)

### Testing

- 11 dedicated tests covering: idempotency, concurrent access, cooldown behavior, silent fallback detection, cost_per_token/completion_cost trigger paths, provider model set isolation