### PR TITLE
[Fix] UI - resolve flaky tests from leaked @tremor/react Tooltip timer

### DIFF
--- a/ui/litellm-dashboard/src/components/router_settings/RouterSettingsForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/router_settings/RouterSettingsForm.test.tsx
@@ -24,21 +24,6 @@ vi.mock("antd", () => ({
   ),
 }));
 
-vi.mock("@tremor/react", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@tremor/react")>();
-  return {
-    ...actual,
-    Switch: ({ checked, onChange }: any) => (
-      <input
-        type="checkbox"
-        role="switch"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-      />
-    ),
-  };
-});
-
 const defaultValue: RouterSettingsFormValue = {
   routerSettings: {},
   selectedStrategy: null,

--- a/ui/litellm-dashboard/src/components/router_settings/TagFilteringToggle.test.tsx
+++ b/ui/litellm-dashboard/src/components/router_settings/TagFilteringToggle.test.tsx
@@ -3,24 +3,6 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TagFilteringToggle from "./TagFilteringToggle";
 
-// setupTests.ts mocks @tremor/react but leaves Switch as the real implementation.
-// Re-mock Switch as a plain checkbox so toggle interactions are trivially testable.
-vi.mock("@tremor/react", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@tremor/react")>();
-  return {
-    ...actual,
-    Switch: ({ checked, onChange, className }: any) => (
-      <input
-        type="checkbox"
-        role="switch"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        className={className}
-      />
-    ),
-  };
-});
-
 const baseMetadata = {
   enable_tag_filtering: {
     ui_field_name: "Tag Filtering",

--- a/ui/litellm-dashboard/src/components/router_settings/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/router_settings/index.test.tsx
@@ -22,21 +22,6 @@ vi.mock("antd", () => ({
   ),
 }));
 
-vi.mock("@tremor/react", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@tremor/react")>();
-  return {
-    ...actual,
-    Switch: ({ checked, onChange }: any) => (
-      <input
-        type="checkbox"
-        role="switch"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-      />
-    ),
-  };
-});
-
 vi.mock("@/components/networking", () => ({
   getCallbacksCall: vi.fn(),
   getRouterSettingsCall: vi.fn(),

--- a/ui/litellm-dashboard/tests/setupTests.ts
+++ b/ui/litellm-dashboard/tests/setupTests.ts
@@ -30,6 +30,15 @@ vi.mock("@tremor/react", async (importOriginal) => {
       // This avoids issues with hover states, positioning, and DOM queries in tests
       return React.createElement(React.Fragment, null, children);
     },
+    // Render as a plain checkbox so toggle interactions are testable without Tremor internals
+    Switch: ({ checked, onChange, className }: { checked?: boolean; onChange?: (v: boolean) => void; className?: string }) =>
+      React.createElement("input", {
+        type: "checkbox",
+        role: "switch",
+        checked,
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => onChange?.(e.target.checked),
+        className,
+      }),
   };
 });
 


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Summary

### Problem

Three `router_settings` test files (`index.test.tsx`, `RouterSettingsForm.test.tsx`, `TagFilteringToggle.test.tsx`) each had a local `vi.mock("@tremor/react", async (importOriginal) => { ...actual, Switch })`. This local mock overrode the global `setupTests.ts` mock, which properly stubs `Tooltip` to a no-op. By spreading `...actual`, the real `@tremor/react` `Tooltip` was reintroduced. The real Tooltip schedules a `setTimeout` internally that fires after jsdom is torn down, causing `ReferenceError: window is not defined`. Vitest flags this as "may cause false positive tests," and the corrupted state caused the `create_mcp_server` test to time out in CI.

### Fix

Added `Switch` to the global `@tremor/react` mock in `setupTests.ts` — the only reason the local overrides existed. Removed the three local `vi.mock("@tremor/react")` blocks so all test files inherit the global mock with properly stubbed `Button`, `Tooltip`, and `Switch`.

## Testing

- All `router_settings` tests pass (45 tests across 6 files)
- All `create_mcp_server` tests pass including the previously-flaky "should successfully create a server when auth value is provided"
- No unhandled errors or leaked timers in combined run (60 tests, 7 files)

## Type

🐛 Bug Fix
✅ Test