### PR TITLE
fix(mypy): fix 3 mypy/pyright errors in presidio.py and _health_endpoints.py

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -300,6 +300,7 @@ async def health_services_endpoint(  # noqa: PLR0915
                 datadog_metrics_logger = DatadogMetricsLogger(
                     start_periodic_flush=False
                 )
+            assert isinstance(datadog_metrics_logger, DatadogMetricsLogger)
             response = await datadog_metrics_logger.async_health_check()
             return {
                 "status": response["status"],


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🐛 Bug Fix

## Changes

Fixes 3 mypy errors that were failing CI:

1. `presidio.py:555` — `entity_type` is `str | None` so `entity_type.value` fails type checking when `entity_type` is `None`. Switched to `getattr(entity_type, "value", entity_type)` with a None guard.

2. `presidio.py:1138` — `ModelResponse` doesn't have `usage` as a declared class field, so direct attribute assignment fails type checking. Used `getattr`/`setattr` for dynamic attribute access. Also moved `all_chunks` and `remaining_chunks` declarations before their `try` blocks to fix "possibly unbound" errors in the `except` handlers.

3. `_health_endpoints.py:303` — `get_custom_logger_compatible_class` returns `CustomLogger | None`, which doesn't have `async_health_check`. Added `assert isinstance(datadog_metrics_logger, DatadogMetricsLogger)` after the None check to narrow the type.