### PR TITLE
Fix plaintext JWTs leaking in debug logs

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -839,9 +839,14 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     """
 
     from litellm.proxy.proxy_server import llm_router, premium_user
-    from litellm.types.proxy.litellm_pre_call_utils import SecretFields
+    from litellm.types.proxy.litellm_pre_call_utils import (
+        RedactedDict,
+        SecretFields,
+    )
 
-    _raw_headers: Dict[str, str] = _safe_get_request_headers(request)
+    _raw_headers: Dict[str, str] = RedactedDict(
+        _safe_get_request_headers(request)
+    )
 
     forward_llm_auth = False
     if general_settings:
@@ -938,9 +943,7 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     add_provider_specific_headers_to_request(data=data, headers=_headers)
 
     ## Cache Controls
-    headers = request.headers
-    verbose_proxy_logger.debug("Request Headers: %s", headers)
-    cache_control_header = headers.get("Cache-Control", None)
+    cache_control_header = _headers.get("Cache-Control", None)
     if cache_control_header:
         cache_dict = parse_cache_control(cache_control_header)
         data["ttl"] = cache_dict.get("s-maxage")

--- a/litellm/types/proxy/litellm_pre_call_utils.py
+++ b/litellm/types/proxy/litellm_pre_call_utils.py
@@ -1,6 +1,16 @@
 from typing_extensions import TypedDict
 
 
+class RedactedDict(dict):
+    """Dict subclass with redacted str/repr to prevent leaking in logs."""
+
+    def __repr__(self) -> str:
+        return "RedactedDict(REDACTED)"
+
+    def __str__(self) -> str:
+        return "RedactedDict(REDACTED)"
+
+
 class SecretFields(TypedDict):
     """
     Stored in data["secret_fields"]

--- a/litellm/types/proxy/litellm_pre_call_utils.py
+++ b/litellm/types/proxy/litellm_pre_call_utils.py
@@ -10,6 +10,9 @@ class RedactedDict(dict):
     def __str__(self) -> str:
         return "RedactedDict(REDACTED)"
 
+    def copy(self) -> "RedactedDict":
+        return RedactedDict(super().copy())
+
 
 class SecretFields(TypedDict):
     """


### PR DESCRIPTION
## Type

🐛 Bug Fix

## Changes

Wrapped raw request headers in RedactedDict (dict subclass with redacted str/repr) at the single entry point where they enter the system. This prevents any downstream logging path from exposing Bearer tokens.

Also remove a redundant log that re-read request.headers directly, not using the already cleaned _headers.

