### PR TITLE
fix(logging): preserve all provider response headers in StandardLoggingPayload

### DIFF
--- a/docs/my-website/docs/proxy/logging_spec.md
+++ b/docs/my-website/docs/proxy/logging_spec.md
@@ -108,6 +108,10 @@ Inherits from `StandardLoggingUserAPIKeyMetadata` and adds:
 
 ## StandardLoggingAdditionalHeaders
 
+`additional_headers` contains **all** provider response headers (e.g., `llm_provider-request-id`, `llm_provider-openai-organization`, `llm_provider-openai-processing-ms`), not just rate-limit fields.
+
+The following 4 rate-limit headers are also normalized to underscore keys with `int` values for backward compatibility:
+
 | Field | Type | Description |
 |-------|------|-------------|
 | `x_ratelimit_limit_requests` | `int` | Rate limit for requests |
@@ -123,7 +127,7 @@ Inherits from `StandardLoggingUserAPIKeyMetadata` and adds:
 | `cache_key` | `Optional[str]` | Optional cache key |
 | `api_base` | `Optional[str]` | Optional API base URL |
 | `response_cost` | `Optional[str]` | Optional response cost |
-| `additional_headers` | `Optional[StandardLoggingAdditionalHeaders]` | Additional headers |
+| `additional_headers` | `Optional[Dict[str, Any]]` | All provider response headers |
 | `batch_models` | `Optional[List[str]]` | Only set for Batches API. Lists the models used for cost calculation |
 | `litellm_model_name` | `Optional[str]` | Model name sent in request |
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2563,7 +2563,7 @@ class StandardLoggingHiddenParams(TypedDict):
     api_base: Optional[str]
     response_cost: Optional[str]
     litellm_overhead_time_ms: Optional[float]
-    additional_headers: Optional[StandardLoggingAdditionalHeaders]
+    additional_headers: Optional[Dict[str, Any]]
     batch_models: Optional[List[str]]
     litellm_model_name: Optional[str]  # the model name sent to the provider by litellm
     usage_object: Optional[dict]

--- a/tests/test_litellm/litellm_core_utils/test_additional_headers.py
+++ b/tests/test_litellm/litellm_core_utils/test_additional_headers.py
@@ -1,0 +1,77 @@
+"""
+Unit tests for get_additional_headers() in StandardLoggingPayloadSetup.
+
+Verifies that all provider response headers are preserved in the
+StandardLoggingPayload, while maintaining backward compatibility for
+the 4 standard rate-limit headers (underscore aliases with int conversion).
+"""
+
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+
+def test_get_additional_headers_preserves_provider_headers():
+    """Verify that llm_provider-* headers are not dropped."""
+    headers = {
+        "x-ratelimit-limit-requests": "100",
+        "llm_provider-request-id": "req_abc123",
+        "llm_provider-cf-ray": "8da71bdbc9b57abb-SJC",
+        "llm_provider-openai-organization": "org-test",
+        "llm_provider-openai-processing-ms": "250",
+    }
+    result = StandardLoggingPayloadSetup.get_additional_headers(headers)
+
+    assert result is not None
+    assert result["llm_provider-request-id"] == "req_abc123"
+    assert result["llm_provider-cf-ray"] == "8da71bdbc9b57abb-SJC"
+    assert result["llm_provider-openai-organization"] == "org-test"
+    assert result["llm_provider-openai-processing-ms"] == "250"
+
+
+def test_get_additional_headers_rate_limit_backward_compat():
+    """Verify underscore aliases and int conversion still work for rate-limit headers."""
+    headers = {
+        "x-ratelimit-limit-requests": "2000",
+        "x-ratelimit-remaining-requests": "1999",
+        "x-ratelimit-limit-tokens": "160000",
+        "x-ratelimit-remaining-tokens": "159000",
+    }
+    result = StandardLoggingPayloadSetup.get_additional_headers(headers)
+
+    assert result is not None
+    # Underscore aliases with int values
+    assert result["x_ratelimit_limit_requests"] == 2000
+    assert result["x_ratelimit_remaining_requests"] == 1999
+    assert result["x_ratelimit_limit_tokens"] == 160000
+    assert result["x_ratelimit_remaining_tokens"] == 159000
+
+    # Original dashed keys also present (as strings)
+    assert result["x-ratelimit-limit-requests"] == "2000"
+    assert result["x-ratelimit-remaining-requests"] == "1999"
+
+
+def test_get_additional_headers_none_input():
+    """Returns None when input is None."""
+    result = StandardLoggingPayloadSetup.get_additional_headers(None)
+    assert result is None
+
+
+def test_get_additional_headers_empty_input():
+    """Returns empty dict when input is empty dict."""
+    result = StandardLoggingPayloadSetup.get_additional_headers({})
+    assert result == {}
+
+
+def test_get_additional_headers_non_integer_values():
+    """Non-integer rate-limit values are stored as-is instead of being dropped."""
+    headers = {
+        "x-ratelimit-limit-requests": "not-a-number",
+        "x-ratelimit-remaining-tokens": "unlimited",
+    }
+    result = StandardLoggingPayloadSetup.get_additional_headers(headers)
+
+    assert result is not None
+    # Non-integer values stored as-is under underscore keys (not dropped)
+    assert result["x_ratelimit_limit_requests"] == "not-a-number"
+    assert result["x_ratelimit_remaining_tokens"] == "unlimited"


### PR DESCRIPTION
## Relevant issues

Fixes #22341

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

Bug Fix

## Changes

### Problem

`get_additional_headers()` in `StandardLoggingPayloadSetup` iterates only over the 4 keys defined in `StandardLoggingAdditionalHeaders.__annotations__`, silently dropping all other provider response headers (e.g., `llm_provider-request-id`, `llm_provider-openai-organization`, `llm_provider-openai-processing-ms`). These headers are critical for filing support tickets with providers and for observability, but they never reach logging backends like S3, SpendLogs, or GCS.

### Solution

- Changed `get_additional_headers()` to pass through all headers from `process_response_headers()` instead of filtering to only 4 rate-limit fields
- The 4 standard rate-limit headers (`x_ratelimit_limit_requests`, etc.) still get their underscore-key aliases with int conversion for backward compatibility with consumers like Prometheus
- Non-integer rate-limit values are now stored as-is instead of being silently dropped
- Updated `StandardLoggingHiddenParams.additional_headers` type from `Optional[StandardLoggingAdditionalHeaders]` to `Optional[Dict[str, Any]]` to reflect the open-ended nature of provider headers

### Files changed

- `litellm/litellm_core_utils/litellm_logging.py` - Updated `get_additional_headers()` to preserve all headers
- `litellm/types/utils.py` - Changed `additional_headers` type annotation in `StandardLoggingHiddenParams`
- `tests/test_litellm/litellm_core_utils/test_additional_headers.py` - New unit tests (5 tests)
- `tests/logging_callback_tests/test_standard_logging_payload.py` - Updated existing tests for new behavior
- `docs/my-website/docs/proxy/logging_spec.md` - Updated documentation

## Testing

- 5 new unit tests in `tests/test_litellm/litellm_core_utils/test_additional_headers.py`:
  - `test_get_additional_headers_preserves_provider_headers` - verifies `llm_provider-*` headers are not dropped
  - `test_get_additional_headers_rate_limit_backward_compat` - verifies underscore aliases and int conversion still work
  - `test_get_additional_headers_none_input` - returns None
  - `test_get_additional_headers_empty_input` - returns empty dict
  - `test_get_additional_headers_non_integer_values` - non-int values stored as-is
- Updated 2 existing tests in `tests/logging_callback_tests/test_standard_logging_payload.py`

@greptileai @shin-bot-litellm