### PR TITLE
fix(cost): aimage_edit custom pricing not detected via litellm_metadata

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4446,15 +4446,18 @@ def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
         if litellm_params.get(key) is not None:
             return True
 
-    # Check model_info
-    metadata: dict = litellm_params.get("metadata", {}) or {}
-    model_info: dict = metadata.get("model_info", {}) or {}
+    # Check model_info from metadata or litellm_metadata
+    # litellm_metadata is used by generic API calls (e.g. aimage_edit)
+    # routed via _ageneric_api_call_with_fallbacks
+    for meta_key in ("metadata", "litellm_metadata"):
+        metadata: dict = litellm_params.get(meta_key, {}) or {}
+        model_info: dict = metadata.get("model_info", {}) or {}
 
-    if model_info:
-        matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
-        for key in matching_keys:
-            if model_info.get(key) is not None:
-                return True
+        if model_info:
+            matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
+            for key in matching_keys:
+                if model_info.get(key) is not None:
+                    return True
 
     return False
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1149,7 +1149,10 @@ def function_setup(  # noqa: PLR0915
             # model_info (injected by router for generic API calls like
             # aimage_edit) is visible for cost calculation.
             if "metadata" not in litellm_params:
-                litellm_params["metadata"] = {**kwargs["litellm_metadata"]}
+                litellm_metadata = kwargs["litellm_metadata"]
+                litellm_params["metadata"] = (
+                    {**litellm_metadata} if isinstance(litellm_metadata, dict) else {}
+                )
 
         logging_obj.update_environment_variables(
             model=model,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1143,6 +1143,13 @@ def function_setup(  # noqa: PLR0915
         litellm_params: Dict[str, Any] = {"api_base": ""}
         if "metadata" in kwargs:
             litellm_params["metadata"] = kwargs["metadata"]
+        if "litellm_metadata" in kwargs:
+            litellm_params["litellm_metadata"] = kwargs["litellm_metadata"]
+            # Also use litellm_metadata as metadata fallback so that
+            # model_info (injected by router for generic API calls like
+            # aimage_edit) is visible for cost calculation.
+            if "metadata" not in litellm_params:
+                litellm_params["metadata"] = kwargs["litellm_metadata"]
 
         logging_obj.update_environment_variables(
             model=model,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1149,7 +1149,7 @@ def function_setup(  # noqa: PLR0915
             # model_info (injected by router for generic API calls like
             # aimage_edit) is visible for cost calculation.
             if "metadata" not in litellm_params:
-                litellm_params["metadata"] = kwargs["litellm_metadata"]
+                litellm_params["metadata"] = {**kwargs["litellm_metadata"]}
 
         logging_obj.update_environment_variables(
             model=model,

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3679,3 +3679,45 @@ class TestValidateAndFixThinkingParam:
         validate_and_fix_thinking_param(thinking=thinking)
         assert "budgetTokens" in thinking
         assert "budget_tokens" not in thinking
+
+
+def test_function_setup_litellm_metadata():
+    """
+    Test that function_setup picks up litellm_metadata (used by generic API
+    calls like aimage_edit) and includes it in litellm_params so that
+    custom pricing is correctly detected.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/22244
+    """
+    import time
+
+    from litellm.utils import function_setup, Rules
+
+    rules_obj = Rules()
+    start_time = time.time()
+
+    kwargs = {
+        "model": "openai/flux-2-klein-4b",
+        "litellm_call_id": "test-call-id-123",
+        "litellm_metadata": {
+            "model_info": {
+                "input_cost_per_image": 0.00676128,
+                "mode": "image_generation",
+            },
+        },
+    }
+
+    logging_obj, result_kwargs = function_setup(
+        original_function="aimage_edit",
+        rules_obj=rules_obj,
+        start_time=start_time,
+        **kwargs,
+    )
+
+    # litellm_metadata should be included in litellm_params
+    assert "litellm_metadata" in logging_obj.litellm_params
+    assert logging_obj.litellm_params["litellm_metadata"]["model_info"]["input_cost_per_image"] == 0.00676128
+
+    # metadata should also be set (fallback from litellm_metadata)
+    assert "metadata" in logging_obj.litellm_params
+    assert logging_obj.litellm_params["metadata"]["model_info"]["input_cost_per_image"] == 0.00676128


### PR DESCRIPTION
## Relevant issues
Fixes #22244

## Problem
When  is routed through `_ageneric_api_call_with_fallbacks`, the router stores `model_info` under `litellm_metadata` (not `metadata`). However, `function_setup()` and `use_custom_pricing_for_model()` only checked the `metadata` key, causing custom pricing fields (e.g. `input_cost_per_image`) to be invisible for image edit cost calculation.

This was exposed by #20679 which strips custom pricing fields from the shared backend model key. After that change, only the per-deployment `model_id` key retains custom pricing — and it's only used when `custom_pricing=True`. Since `aimage_edit` never had `custom_pricing` detected as True, cost calculation fell back to the shared key which no longer had `input_cost_per_image`.

### Root Cause
- `aimage_generation` has a dedicated router method (`_aimage_generation`) that calls `_update_kwargs_with_deployment(function_name=None)` → stores `model_info` under `kwargs["metadata"]` ✅
- `aimage_edit` goes through the generic `_ageneric_api_call_with_fallbacks` path → stores `model_info` under `kwargs["litellm_metadata"]` ❌ not picked up by cost calculator

### Fix
1. **`function_setup()`**: Also include `litellm_metadata` in `litellm_params`, and use it as `metadata` fallback when `metadata` is not present
2. **`use_custom_pricing_for_model()`**: Check both `metadata` and `litellm_metadata` for `model_info` with custom pricing keys

## Pre-Submission checklist
- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix

## Changes
- `litellm/utils.py`: `function_setup()` now picks up `litellm_metadata` from kwargs
- `litellm/litellm_core_utils/litellm_logging.py`: `use_custom_pricing_for_model()` checks both `metadata` and `litellm_metadata` for model_info
- Added 2 unit tests covering the regression scenario
- Added 1 integration test for `function_setup` with `litellm_metadata`