### PR TITLE
fix(proxy): catch GuardrailInterventionNormalStringError in apply_guardrail

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -1451,16 +1451,15 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             # When disable_exception_on_block is True, use the guardrail's
             # blocked output text as the masked text instead of raising.
             # This mirrors the behavior of async_pre_call_hook (line ~805).
-            masked_texts = [e.message] if e.message else texts
-            inputs["texts"] = masked_texts
+            blocked_message = e.message or "Content blocked by Bedrock guardrail"
+            inputs["texts"] = [blocked_message]
             # Set mock_response to short-circuit the LLM call, matching
             # the async_pre_call_hook path which also sets data["mock_response"].
             # Without this, the guardrail's blocked text would be sent as
             # input to the LLM instead of being returned as the response.
-            if e.message:
-                request_data["mock_response"] = self.create_guardrail_blocked_response(
-                    response=e.message
-                )
+            request_data["mock_response"] = self.create_guardrail_blocked_response(
+                response=blocked_message
+            )
             return inputs
         except HTTPException:
             # Let HTTP exceptions propagate so the proxy returns the

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -1388,7 +1388,13 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             GenericGuardrailAPIInputs - processed_texts may be masked, images unchanged
 
         Raises:
-            Exception: If content is blocked by Bedrock guardrail
+            HTTPException: If content is blocked and disable_exception_on_block is False.
+            Exception: If the Bedrock guardrail API call fails unexpectedly.
+
+        Note:
+            When disable_exception_on_block is True, GuardrailInterventionNormalStringError
+            is handled internally: inputs["texts"] is set to the blocked message and
+            request_data["mock_response"] is set to short-circuit the LLM call.
         """
         texts = inputs.get("texts", [])
         try:

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
@@ -346,11 +346,15 @@ async def test_bedrock_apply_guardrail_blocked_with_disable_exception_on_block()
             message="Sorry, your question in its current format is unable to be answered."
         )
 
+        request_data = {}
         result = await guardrail.apply_guardrail(
             inputs={"texts": ["harmful prompt content"]},
-            request_data={},
+            request_data=request_data,
             input_type="request",
         )
 
         # The blocked text should be returned as the guardrailed output
         assert "unable to be answered" in result["texts"][0]
+        # mock_response should be set to short-circuit the LLM call,
+        # matching the async_pre_call_hook behavior
+        assert "mock_response" in request_data

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
@@ -324,10 +324,11 @@ def test_bedrock_guardrail_filters_latest_user_message_when_enabled():
 @pytest.mark.asyncio
 async def test_bedrock_apply_guardrail_blocked_with_disable_exception_on_block():
     """
-    Regression test for issue #20045: when disable_exception_on_block=True,
+    Regression test for issue #22183: when disable_exception_on_block=True,
     make_bedrock_api_request raises GuardrailInterventionNormalStringError.
-    apply_guardrail must let it propagate as-is so the proxy can handle it
-    properly instead of wrapping it in a generic Exception.
+    apply_guardrail must catch it and return the guardrail's blocked output
+    text as a normal response, instead of letting the exception propagate
+    (which would cause a 500 error at the proxy level).
     """
     from litellm.exceptions import GuardrailInterventionNormalStringError
 
@@ -345,11 +346,11 @@ async def test_bedrock_apply_guardrail_blocked_with_disable_exception_on_block()
             message="Sorry, your question in its current format is unable to be answered."
         )
 
-        with pytest.raises(GuardrailInterventionNormalStringError) as exc_info:
-            await guardrail.apply_guardrail(
-                inputs={"texts": ["harmful prompt content"]},
-                request_data={},
-                input_type="request",
-            )
+        result = await guardrail.apply_guardrail(
+            inputs={"texts": ["harmful prompt content"]},
+            request_data={},
+            input_type="request",
+        )
 
-        assert "unable to be answered" in str(exc_info.value.message)
+        # The blocked text should be returned as the guardrailed output
+        assert "unable to be answered" in result["texts"][0]


### PR DESCRIPTION
## Summary

Fixes #22183

When `disable_exception_on_block=True` is configured for Bedrock guardrails, the unified guardrail path (`apply_guardrail` → `process_input_messages` → `async_pre_call_hook`) lets `GuardrailInterventionNormalStringError` propagate unhandled, causing a **500 error** at the proxy level instead of returning the guardrail's blocked output as a normal response.

## Root Cause

The old `async_pre_call_hook` (line ~805) correctly catches `GuardrailInterventionNormalStringError` and converts it to a normal response text:

```python
except GuardrailInterventionNormalStringError as e:
    bedrock_guardrail_response = e.message
```

However, the newer `apply_guardrail` method (used by the unified guardrail path) was re-raising this exception alongside `HTTPException`, instead of handling it:

```python
except (HTTPException, GuardrailInterventionNormalStringError):
    raise  # This lets the normal-string error propagate as a 500
```

## Fix

Split the exception handlers:
- **`GuardrailInterventionNormalStringError`**: Catch it and use its `.message` as the guardrailed output text (matching the old path's behavior)
- **`HTTPException`**: Continue to re-raise so the proxy returns the correct HTTP 400 status

## Test Plan

- Updated existing regression test `test_bedrock_apply_guardrail_blocked_with_disable_exception_on_block` to verify the new behavior (returns guardrailed text instead of raising)
- All 28 existing bedrock guardrail tests pass (2 consecutive runs, 0 errors, 0 warnings)