### PR TITLE
fix: skip effort beta header for Claude 4.6 models

### DIFF
--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1560,19 +1560,19 @@ def test_effort_output_config_preservation():
 
 
 def test_effort_beta_header_injection():
-    """Test that effort beta header is automatically added when output_config is detected."""
+    """Test that effort beta header is automatically added for non-4.6 models."""
     from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 
     model_info = AnthropicModelInfo()
 
-    # Test with effort parameter
+    # Test with effort parameter on non-4.6 model (should inject header)
     optional_params = {
         "output_config": {
             "effort": "low"
         }
     }
 
-    effort_used = model_info.is_effort_used(optional_params=optional_params)
+    effort_used = model_info.is_effort_used(optional_params=optional_params, model="claude-opus-4-5-20251101")
     assert effort_used is True
 
     headers = model_info.get_anthropic_headers(
@@ -1582,6 +1582,24 @@ def test_effort_beta_header_injection():
 
     assert "anthropic-beta" in headers
     assert "effort-2025-11-24" in headers["anthropic-beta"]
+
+
+def test_no_effort_beta_header_for_46_models():
+    """Test that effort beta header is NOT injected for Claude 4.6 models."""
+    from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+    model_info = AnthropicModelInfo()
+
+    # output_config.effort on a 4.6 model should NOT trigger the beta header
+    optional_params = {
+        "output_config": {
+            "effort": "high"
+        }
+    }
+
+    for model in ["claude-sonnet-4-6-20260514", "claude-opus-4-6-20260205"]:
+        effort_used = model_info.is_effort_used(optional_params=optional_params, model=model)
+        assert effort_used is False, f"Beta header should not be injected for {model}"
 
 
 def test_effort_validation():


### PR DESCRIPTION
## Summary

Fixes #22213

The `effort-2025-11-24` beta header was spuriously injected for Claude 4.6 models when `output_config.effort` was present. Per the [Anthropic docs](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking), no beta header is required for adaptive thinking on 4.6 models.

## Root Cause

`is_effort_used()` in `common_utils.py` returned `True` whenever `output_config.effort` was present, regardless of the model. This caused `get_anthropic_beta_list` to append `effort-2025-11-24` for all models.

## Changes

- **`common_utils.py`**: Updated `is_effort_used()` to detect Claude 4.6 models and skip the beta header for `output_config.effort` on those models. The header is still injected for `reasoning_effort` on Opus 4.5 (the legitimate use case).
- **Tests**: Updated `test_effort_beta_header_injection` to specify a non-4.6 model. Added `test_no_effort_beta_header_for_46_models` verifying both Sonnet 4.6 and Opus 4.6 skip the beta header.