### PR TITLE
fix(anthropic): filter unsupported JSON Schema constraints for structured outputs

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -352,9 +352,9 @@ class Logging(LiteLLMLoggingBaseClass):
         )
         self.function_id = function_id
         self.streaming_chunks: List[Any] = []  # for generating complete stream response
-        self.sync_streaming_chunks: List[
-            Any
-        ] = []  # for generating complete stream response
+        self.sync_streaming_chunks: List[Any] = (
+            []
+        )  # for generating complete stream response
         self.log_raw_request_response = log_raw_request_response
 
         # Initialize dynamic callbacks
@@ -746,9 +746,9 @@ class Logging(LiteLLMLoggingBaseClass):
                         prompt_spec=prompt_spec,
                         dynamic_callback_params=dynamic_callback_params,
                     ):
-                        self.model_call_details[
-                            "prompt_integration"
-                        ] = logger.__class__.__name__
+                        self.model_call_details["prompt_integration"] = (
+                            logger.__class__.__name__
+                        )
                         return logger
                 except Exception:
                     # If check fails, continue to next logger
@@ -816,9 +816,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if anthropic_cache_control_logger := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(
             non_default_params
         ):
-            self.model_call_details[
-                "prompt_integration"
-            ] = anthropic_cache_control_logger.__class__.__name__
+            self.model_call_details["prompt_integration"] = (
+                anthropic_cache_control_logger.__class__.__name__
+            )
             return anthropic_cache_control_logger
 
         #########################################################
@@ -830,9 +830,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 internal_usage_cache=None,
                 llm_router=None,
             )
-            self.model_call_details[
-                "prompt_integration"
-            ] = vector_store_custom_logger.__class__.__name__
+            self.model_call_details["prompt_integration"] = (
+                vector_store_custom_logger.__class__.__name__
+            )
             # Add to global callbacks so post-call hooks are invoked
             if (
                 vector_store_custom_logger
@@ -892,9 +892,9 @@ class Logging(LiteLLMLoggingBaseClass):
             model
         ):  # if model name was changes pre-call, overwrite the initial model call name with the new one
             self.model_call_details["model"] = model
-        self.model_call_details["litellm_params"][
-            "api_base"
-        ] = self._get_masked_api_base(additional_args.get("api_base", ""))
+        self.model_call_details["litellm_params"]["api_base"] = (
+            self._get_masked_api_base(additional_args.get("api_base", ""))
+        )
 
     def pre_call(self, input, api_key, model=None, additional_args={}):  # noqa: PLR0915
         # Log the exact input to the LLM API
@@ -923,10 +923,10 @@ class Logging(LiteLLMLoggingBaseClass):
                 try:
                     # [Non-blocking Extra Debug Information in metadata]
                     if turn_off_message_logging is True:
-                        _metadata[
-                            "raw_request"
-                        ] = "redacted by litellm. \
+                        _metadata["raw_request"] = (
+                            "redacted by litellm. \
                             'litellm.turn_off_message_logging=True'"
+                        )
                     else:
                         curl_command = self._get_request_curl_command(
                             api_base=additional_args.get("api_base", ""),
@@ -937,34 +937,34 @@ class Logging(LiteLLMLoggingBaseClass):
 
                         _metadata["raw_request"] = str(curl_command)
                         # split up, so it's easier to parse in the UI
-                        self.model_call_details[
-                            "raw_request_typed_dict"
-                        ] = RawRequestTypedDict(
-                            raw_request_api_base=str(
-                                additional_args.get("api_base") or ""
-                            ),
-                            raw_request_body=self._get_raw_request_body(
-                                additional_args.get("complete_input_dict", {})
-                            ),
-                            # NOTE: setting ignore_sensitive_headers to True will cause
-                            # the Authorization header to be leaked when calls to the health
-                            # endpoint are made and fail.
-                            raw_request_headers=self._get_masked_headers(
-                                additional_args.get("headers", {}) or {},
-                            ),
-                            error=None,
+                        self.model_call_details["raw_request_typed_dict"] = (
+                            RawRequestTypedDict(
+                                raw_request_api_base=str(
+                                    additional_args.get("api_base") or ""
+                                ),
+                                raw_request_body=self._get_raw_request_body(
+                                    additional_args.get("complete_input_dict", {})
+                                ),
+                                # NOTE: setting ignore_sensitive_headers to True will cause
+                                # the Authorization header to be leaked when calls to the health
+                                # endpoint are made and fail.
+                                raw_request_headers=self._get_masked_headers(
+                                    additional_args.get("headers", {}) or {},
+                                ),
+                                error=None,
+                            )
                         )
                 except Exception as e:
-                    self.model_call_details[
-                        "raw_request_typed_dict"
-                    ] = RawRequestTypedDict(
-                        error=str(e),
+                    self.model_call_details["raw_request_typed_dict"] = (
+                        RawRequestTypedDict(
+                            error=str(e),
+                        )
                     )
-                    _metadata[
-                        "raw_request"
-                    ] = "Unable to Log \
+                    _metadata["raw_request"] = (
+                        "Unable to Log \
                         raw request: {}".format(
-                        str(e)
+                            str(e)
+                        )
                     )
             if getattr(self, "logger_fn", None) and callable(self.logger_fn):
                 try:
@@ -1265,13 +1265,13 @@ class Logging(LiteLLMLoggingBaseClass):
         for callback in callbacks:
             try:
                 if isinstance(callback, CustomLogger):
-                    response: Optional[
-                        MCPPostCallResponseObject
-                    ] = await callback.async_post_mcp_tool_call_hook(
-                        kwargs=kwargs,
-                        response_obj=post_mcp_tool_call_response_obj,
-                        start_time=start_time,
-                        end_time=end_time,
+                    response: Optional[MCPPostCallResponseObject] = (
+                        await callback.async_post_mcp_tool_call_hook(
+                            kwargs=kwargs,
+                            response_obj=post_mcp_tool_call_response_obj,
+                            start_time=start_time,
+                            end_time=end_time,
+                        )
                     )
                     ######################################################################
                     # if any of the callbacks modify the response, use the modified response
@@ -1466,9 +1466,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details[
-                "response_cost_failure_debug_information"
-            ] = debug_info
+            self.model_call_details["response_cost_failure_debug_information"] = (
+                debug_info
+            )
             return None
 
         try:
@@ -1494,9 +1494,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details[
-                "response_cost_failure_debug_information"
-            ] = debug_info
+            self.model_call_details["response_cost_failure_debug_information"] = (
+                debug_info
+            )
 
         return None
 
@@ -1652,9 +1652,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 result=logging_result
             )
 
-        self.model_call_details[
-            "standard_logging_object"
-        ] = self._build_standard_logging_payload(logging_result, start_time, end_time)
+        self.model_call_details["standard_logging_object"] = (
+            self._build_standard_logging_payload(logging_result, start_time, end_time)
+        )
 
         if (
             standard_logging_payload := self.model_call_details.get(
@@ -1732,9 +1732,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 end_time = datetime.datetime.now()
             if self.completion_start_time is None:
                 self.completion_start_time = end_time
-                self.model_call_details[
-                    "completion_start_time"
-                ] = self.completion_start_time
+                self.model_call_details["completion_start_time"] = (
+                    self.completion_start_time
+                )
 
             self.model_call_details["log_event_type"] = "successful_api_call"
             self.model_call_details["end_time"] = end_time
@@ -1771,10 +1771,10 @@ class Logging(LiteLLMLoggingBaseClass):
                         end_time=end_time,
                     )
                 elif isinstance(result, dict) or isinstance(result, list):
-                    self.model_call_details[
-                        "standard_logging_object"
-                    ] = self._build_standard_logging_payload(
-                        result, start_time, end_time
+                    self.model_call_details["standard_logging_object"] = (
+                        self._build_standard_logging_payload(
+                            result, start_time, end_time
+                        )
                     )
                     if (
                         standard_logging_payload := self.model_call_details.get(
@@ -1783,9 +1783,9 @@ class Logging(LiteLLMLoggingBaseClass):
                     ) is not None:
                         emit_standard_logging_payload(standard_logging_payload)
             elif standard_logging_object is not None:
-                self.model_call_details[
-                    "standard_logging_object"
-                ] = standard_logging_object
+                self.model_call_details["standard_logging_object"] = (
+                    standard_logging_object
+                )
             else:
                 self.model_call_details["response_cost"] = None
 
@@ -1943,17 +1943,17 @@ class Logging(LiteLLMLoggingBaseClass):
                 verbose_logger.debug(
                     "Logging Details LiteLLM-Success Call streaming complete"
                 )
-                self.model_call_details[
-                    "complete_streaming_response"
-                ] = complete_streaming_response
-                self.model_call_details[
-                    "response_cost"
-                ] = self._response_cost_calculator(result=complete_streaming_response)
+                self.model_call_details["complete_streaming_response"] = (
+                    complete_streaming_response
+                )
+                self.model_call_details["response_cost"] = (
+                    self._response_cost_calculator(result=complete_streaming_response)
+                )
                 ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details[
-                    "standard_logging_object"
-                ] = self._build_standard_logging_payload(
-                    complete_streaming_response, start_time, end_time
+                self.model_call_details["standard_logging_object"] = (
+                    self._build_standard_logging_payload(
+                        complete_streaming_response, start_time, end_time
+                    )
                 )
                 if (
                     standard_logging_payload := self.model_call_details.get(
@@ -2287,10 +2287,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details[
-                                    "complete_response"
-                                ] = self.model_call_details.get(
-                                    "complete_streaming_response", {}
+                                self.model_call_details["complete_response"] = (
+                                    self.model_call_details.get(
+                                        "complete_streaming_response", {}
+                                    )
                                 )
                                 result = self.model_call_details["complete_response"]
                             openMeterLogger.log_success_event(
@@ -2314,10 +2314,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details[
-                                    "complete_response"
-                                ] = self.model_call_details.get(
-                                    "complete_streaming_response", {}
+                                self.model_call_details["complete_response"] = (
+                                    self.model_call_details.get(
+                                        "complete_streaming_response", {}
+                                    )
                                 )
                                 result = self.model_call_details["complete_response"]
 
@@ -2456,9 +2456,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if complete_streaming_response is not None:
             print_verbose("Async success callbacks: Got a complete streaming response")
 
-            self.model_call_details[
-                "async_complete_streaming_response"
-            ] = complete_streaming_response
+            self.model_call_details["async_complete_streaming_response"] = (
+                complete_streaming_response
+            )
 
             try:
                 if self.model_call_details.get("cache_hit", False) is True:
@@ -2469,10 +2469,10 @@ class Logging(LiteLLMLoggingBaseClass):
                         model_call_details=self.model_call_details
                     )
                     # base_model defaults to None if not set on model_info
-                    self.model_call_details[
-                        "response_cost"
-                    ] = self._response_cost_calculator(
-                        result=complete_streaming_response
+                    self.model_call_details["response_cost"] = (
+                        self._response_cost_calculator(
+                            result=complete_streaming_response
+                        )
                     )
 
                 verbose_logger.debug(
@@ -2485,10 +2485,10 @@ class Logging(LiteLLMLoggingBaseClass):
                 self.model_call_details["response_cost"] = None
 
             ## STANDARDIZED LOGGING PAYLOAD
-            self.model_call_details[
-                "standard_logging_object"
-            ] = self._build_standard_logging_payload(
-                complete_streaming_response, start_time, end_time
+            self.model_call_details["standard_logging_object"] = (
+                self._build_standard_logging_payload(
+                    complete_streaming_response, start_time, end_time
+                )
             )
 
             # print standard logging payload
@@ -2515,9 +2515,9 @@ class Logging(LiteLLMLoggingBaseClass):
             # _success_handler_helper_fn
             if self.model_call_details.get("standard_logging_object") is None:
                 ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details[
-                    "standard_logging_object"
-                ] = self._build_standard_logging_payload(result, start_time, end_time)
+                self.model_call_details["standard_logging_object"] = (
+                    self._build_standard_logging_payload(result, start_time, end_time)
+                )
 
                 # print standard logging payload
                 if (
@@ -2760,18 +2760,18 @@ class Logging(LiteLLMLoggingBaseClass):
 
         ## STANDARDIZED LOGGING PAYLOAD
 
-        self.model_call_details[
-            "standard_logging_object"
-        ] = get_standard_logging_object_payload(
-            kwargs=self.model_call_details,
-            init_response_obj={},
-            start_time=start_time,
-            end_time=end_time,
-            logging_obj=self,
-            status="failure",
-            error_str=str(exception),
-            original_exception=exception,
-            standard_built_in_tools_params=self.standard_built_in_tools_params,
+        self.model_call_details["standard_logging_object"] = (
+            get_standard_logging_object_payload(
+                kwargs=self.model_call_details,
+                init_response_obj={},
+                start_time=start_time,
+                end_time=end_time,
+                logging_obj=self,
+                status="failure",
+                error_str=str(exception),
+                original_exception=exception,
+                standard_built_in_tools_params=self.standard_built_in_tools_params,
+            )
         )
         return start_time, end_time
 
@@ -3735,9 +3735,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 service_name=arize_config.project_name,
             )
 
-            os.environ[
-                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
-            ] = f"space_id={arize_config.space_key or arize_config.space_id},api_key={arize_config.api_key}"
+            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
+                f"space_id={arize_config.space_key or arize_config.space_id},api_key={arize_config.api_key}"
+            )
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, ArizeLogger)
@@ -3763,13 +3763,13 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
                 # Add openinference.project.name attribute
                 if existing_attrs:
-                    os.environ[
-                        "OTEL_RESOURCE_ATTRIBUTES"
-                    ] = f"{existing_attrs},openinference.project.name={arize_phoenix_config.project_name}"
+                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
+                        f"{existing_attrs},openinference.project.name={arize_phoenix_config.project_name}"
+                    )
                 else:
-                    os.environ[
-                        "OTEL_RESOURCE_ATTRIBUTES"
-                    ] = f"openinference.project.name={arize_phoenix_config.project_name}"
+                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
+                        f"openinference.project.name={arize_phoenix_config.project_name}"
+                    )
 
             # Set Phoenix project name from environment variable
             phoenix_project_name = os.environ.get("PHOENIX_PROJECT_NAME", None)
@@ -3777,19 +3777,19 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
                 # Add openinference.project.name attribute
                 if existing_attrs:
-                    os.environ[
-                        "OTEL_RESOURCE_ATTRIBUTES"
-                    ] = f"{existing_attrs},openinference.project.name={phoenix_project_name}"
+                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
+                        f"{existing_attrs},openinference.project.name={phoenix_project_name}"
+                    )
                 else:
-                    os.environ[
-                        "OTEL_RESOURCE_ATTRIBUTES"
-                    ] = f"openinference.project.name={phoenix_project_name}"
+                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
+                        f"openinference.project.name={phoenix_project_name}"
+                    )
 
             # auth can be disabled on local deployments of arize phoenix
             if arize_phoenix_config.otlp_auth_headers is not None:
-                os.environ[
-                    "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
-                ] = arize_phoenix_config.otlp_auth_headers
+                os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
+                    arize_phoenix_config.otlp_auth_headers
+                )
 
             for callback in _in_memory_loggers:
                 if (
@@ -3965,9 +3965,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 exporter="otlp_http",
                 endpoint="https://langtrace.ai/api/trace",
             )
-            os.environ[
-                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
-            ] = f"api_key={os.getenv('LANGTRACE_API_KEY')}"
+            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
+                f"api_key={os.getenv('LANGTRACE_API_KEY')}"
+            )
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, OpenTelemetry)
@@ -4446,15 +4446,17 @@ def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
         if litellm_params.get(key) is not None:
             return True
 
-    # Check model_info
-    metadata: dict = litellm_params.get("metadata", {}) or {}
-    model_info: dict = metadata.get("model_info", {}) or {}
+    # Check model_info from metadata or litellm_metadata (generic_api_call routes
+    # like /responses and /messages store model_info under litellm_metadata)
+    for metadata_key in ("metadata", "litellm_metadata"):
+        metadata: dict = litellm_params.get(metadata_key, {}) or {}
+        model_info: dict = metadata.get("model_info", {}) or {}
 
-    if model_info:
-        matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
-        for key in matching_keys:
-            if model_info.get(key) is not None:
-                return True
+        if model_info:
+            matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
+            for key in matching_keys:
+                if model_info.get(key) is not None:
+                    return True
 
     return False
 
@@ -4881,10 +4883,10 @@ class StandardLoggingPayloadSetup:
             for key in StandardLoggingHiddenParams.__annotations__.keys():
                 if key in hidden_params:
                     if key == "additional_headers":
-                        clean_hidden_params[
-                            "additional_headers"
-                        ] = StandardLoggingPayloadSetup.get_additional_headers(
-                            hidden_params[key]
+                        clean_hidden_params["additional_headers"] = (
+                            StandardLoggingPayloadSetup.get_additional_headers(
+                                hidden_params[key]
+                            )
                         )
                     else:
                         clean_hidden_params[key] = hidden_params[key]  # type: ignore
@@ -5523,9 +5525,9 @@ def scrub_sensitive_keys_in_metadata(litellm_params: Optional[dict]):
     ):
         for k, v in metadata["user_api_key_metadata"].items():
             if k == "logging":  # prevent logging user logging keys
-                cleaned_user_api_key_metadata[
-                    k
-                ] = "scrubbed_by_litellm_for_sensitive_keys"
+                cleaned_user_api_key_metadata[k] = (
+                    "scrubbed_by_litellm_for_sensitive_keys"
+                )
             else:
                 cleaned_user_api_key_metadata[k] = v
 

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -77,6 +77,23 @@ if TYPE_CHECKING:
 else:
     LoggingClass = Any
 
+# String formats natively supported by Anthropic's structured output API.
+# See: https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/_parse/_transform.py
+_ANTHROPIC_SUPPORTED_STRING_FORMATS = frozenset(
+    {
+        "date-time",
+        "time",
+        "date",
+        "duration",
+        "email",
+        "hostname",
+        "uri",
+        "ipv4",
+        "ipv6",
+        "uuid",
+    }
+)
+
 
 class AnthropicConfig(AnthropicModelInfo, BaseConfig):
     """
@@ -209,8 +226,12 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         return params
 
+
     @staticmethod
-    def filter_anthropic_output_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
+    def filter_anthropic_output_schema(
+        schema: Dict[str, Any],
+        enforce_additional_properties: bool = True,
+    ) -> Dict[str, Any]:
         """
         Filter out unsupported fields from JSON schema for Anthropic's output_format API.
 
@@ -218,16 +239,26 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         - maxItems/minItems: Not supported for array types
         - minimum/maximum: Not supported for numeric types
         - minLength/maxLength: Not supported for string types
+        - pattern: Not supported for string types
 
         This mirrors the transformation done by the Anthropic Python SDK.
         See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#how-sdk-transformation-works
+        See: https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/_parse/_transform.py
 
         The SDK approach:
         1. Remove unsupported constraints from schema
         2. Add constraint info to description (e.g., "Must be at least 100")
-        3. Validate responses against original schema
+        3. Force additionalProperties: false on all object schemas
+        4. Filter string formats to supported list only
+        5. Validate responses against original schema (with all constraints)
+
         Args:
             schema: The JSON schema dictionary to filter
+            enforce_additional_properties: When True (default), forces
+                additionalProperties: false on object schemas that don't already
+                have it set (SDK behavior).
+                Set to False for regular tool schemas where users may
+                intentionally allow additional properties.
 
         Returns:
             A new dictionary with unsupported fields removed and descriptions updated
@@ -248,10 +279,11 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "exclusiveMaximum",  # numeric constraints
             "minLength",
             "maxLength",  # string constraints
+            "pattern",  # string constraints
         }
 
         # Build description additions from removed constraints
-        constraint_descriptions: list = []
+        constraint_descriptions: List[str] = []
         constraint_labels = {
             "minItems": "minimum number of items: {}",
             "maxItems": "maximum number of items: {}",
@@ -261,12 +293,25 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "exclusiveMaximum": "exclusive maximum value: {}",
             "minLength": "minimum length: {}",
             "maxLength": "maximum length: {}",
+            "pattern": "pattern: {}",
         }
-        for field in unsupported_fields:
+        # Sort fields for deterministic iteration order
+        for field in sorted(unsupported_fields):
             if field in schema:
                 constraint_descriptions.append(
                     constraint_labels[field].format(schema[field])
                 )
+
+        # Filter unsupported string format values → move to description
+        # Use ``"format" in schema`` (not ``schema.get("format") is not None``)
+        # to correctly handle explicit ``"format": None`` (valid JSON Schema).
+        if (
+            "format" in schema
+            and schema.get("type") == "string"
+            and schema["format"] is not None
+            and schema["format"] not in _ANTHROPIC_SUPPORTED_STRING_FORMATS
+        ):
+            constraint_descriptions.append(f"format: {schema['format']}")
 
         result: Dict[str, Any] = {}
 
@@ -286,39 +331,93 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 # Already handled above
                 continue
 
+            # Filter unsupported string formats (format: null means "no
+            # constraint" which is equivalent to omitting the key entirely)
+            if (
+                key == "format"
+                and schema.get("type") == "string"
+                and value not in _ANTHROPIC_SUPPORTED_STRING_FORMATS
+            ):
+                continue
+
             if key == "properties" and isinstance(value, dict):
                 result[key] = {
-                    k: AnthropicConfig.filter_anthropic_output_schema(v)
+                    k: AnthropicConfig.filter_anthropic_output_schema(
+                        v, enforce_additional_properties
+                    )
                     for k, v in value.items()
                 }
-            elif key == "items" and isinstance(value, dict):
-                result[key] = AnthropicConfig.filter_anthropic_output_schema(value)
+            elif key == "items":
+                # items can be a schema (dict) or tuple validation (list of schemas)
+                if isinstance(value, dict):
+                    result[key] = AnthropicConfig.filter_anthropic_output_schema(
+                        value, enforce_additional_properties
+                    )
+                elif isinstance(value, list):
+                    result[key] = [
+                        AnthropicConfig.filter_anthropic_output_schema(
+                            item, enforce_additional_properties
+                        )
+                        for item in value
+                    ]
+                else:
+                    result[key] = value
+            elif key == "prefixItems" and isinstance(value, list):
+                # prefixItems: list of schemas for tuple validation
+                result[key] = [
+                    AnthropicConfig.filter_anthropic_output_schema(
+                        item, enforce_additional_properties
+                    )
+                    for item in value
+                ]
             elif key == "$defs" and isinstance(value, dict):
                 result[key] = {
-                    k: AnthropicConfig.filter_anthropic_output_schema(v)
+                    k: AnthropicConfig.filter_anthropic_output_schema(
+                        v, enforce_additional_properties
+                    )
                     for k, v in value.items()
                 }
             elif key == "anyOf" and isinstance(value, list):
                 result[key] = [
-                    AnthropicConfig.filter_anthropic_output_schema(item)
+                    AnthropicConfig.filter_anthropic_output_schema(
+                        item, enforce_additional_properties
+                    )
                     for item in value
                 ]
             elif key == "allOf" and isinstance(value, list):
                 result[key] = [
-                    AnthropicConfig.filter_anthropic_output_schema(item)
+                    AnthropicConfig.filter_anthropic_output_schema(
+                        item, enforce_additional_properties
+                    )
                     for item in value
                 ]
             elif key == "oneOf" and isinstance(value, list):
                 result[key] = [
-                    AnthropicConfig.filter_anthropic_output_schema(item)
+                    AnthropicConfig.filter_anthropic_output_schema(
+                        item, enforce_additional_properties
+                    )
                     for item in value
                 ]
+            elif key == "additionalProperties" and isinstance(value, dict):
+                # additionalProperties can be a schema (dict) — recurse into it
+                result[key] = AnthropicConfig.filter_anthropic_output_schema(
+                    value, enforce_additional_properties
+                )
             else:
+                # All other keys (including ``type``, ``default``, ``const``,
+                # ``enum``, ``$ref``, ``title``, ``required``, etc.) are
+                # preserved as-is.  In particular ``type`` is NOT dropped
+                # when composition keywords (``anyOf``, ``allOf``, ``oneOf``)
+                # are also present.
                 result[key] = value
 
-        # Anthropic requires additionalProperties=false for object schemas
-        # See: https://docs.anthropic.com/en/docs/build-with-claude/structured-outputs
-        if result.get("type") == "object" and "additionalProperties" not in result:
+        # Ensure additionalProperties: false on object schemas.
+        # When enforce_additional_properties is True (response_format schemas),
+        # force false even if the schema explicitly set true — Anthropic requires
+        # additionalProperties: false for structured outputs.
+        # When enforce_additional_properties is False (regular tool schemas),
+        # leave the schema as-is to respect user intent.
+        if enforce_additional_properties and result.get("type") == "object":
             result["additionalProperties"] = False
 
         return result
@@ -409,6 +508,13 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 if "properties" not in _input_schema:
                     _input_schema["properties"] = {}
 
+            # Recursively filter unsupported constraints (minimum, maximum, etc.)
+            # from nested schemas within properties, items, anyOf, etc.
+            # Done BEFORE top-level key restriction so constraint-to-description
+            # propagation happens on the full schema.
+            _input_schema = self.filter_anthropic_output_schema(
+                _input_schema, enforce_additional_properties=False
+            )
             _allowed_properties = set(AnthropicInputSchema.__annotations__.keys())
             input_schema_filtered = {
                 k: v for k, v in _input_schema.items() if k in _allowed_properties
@@ -1098,7 +1204,11 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             _input_schema["additionalProperties"] = True
             _input_schema["properties"] = {}
         else:
-            _input_schema.update(cast(AnthropicInputSchema, json_schema))
+            # Filter out unsupported constraints (minimum, maximum, etc.) before
+            # sending to Anthropic API. Mirrors SDK transformation behavior.
+            # See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#how-sdk-transformation-works
+            filtered_schema = self.filter_anthropic_output_schema(json_schema)
+            _input_schema.update(cast(AnthropicInputSchema, filtered_schema))
 
         _tool = AnthropicMessagesTool(
             name=RESPONSE_FORMAT_TOOL_NAME, input_schema=_input_schema

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -22,9 +22,7 @@ import litellm.litellm_core_utils
 import litellm.types
 import litellm.types.utils
 from litellm._logging import verbose_logger
-from litellm.anthropic_beta_headers_manager import (
-    update_headers_with_filtered_beta,
-)
+from litellm.anthropic_beta_headers_manager import update_headers_with_filtered_beta
 from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
 from litellm.litellm_core_utils.realtime_streaming import RealTimeStreaming
 from litellm.llms.base_llm.anthropic_messages.transformation import (
@@ -1889,6 +1887,7 @@ class BaseLLMHTTPHandler:
             optional_params=dict(anthropic_messages_optional_request_params),
             litellm_params={
                 "metadata": kwargs.get("metadata", {}),
+                "litellm_metadata": kwargs.get("litellm_metadata", {}),
                 "preset_cache_key": None,
                 "stream_response": {},
                 **anthropic_messages_optional_request_params,

--- a/tests/litellm/llms/anthropic/test_anthropic_schema_filter.py
+++ b/tests/litellm/llms/anthropic/test_anthropic_schema_filter.py
@@ -4,7 +4,6 @@ Tests for Anthropic JSON schema filtering.
 Related to: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#how-sdk-transformation-works
 """
 
-import pytest
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
 
@@ -153,3 +152,597 @@ class TestFilterAnthropicOutputSchema:
         result = AnthropicConfig.filter_anthropic_output_schema(schema)
         
         assert result == schema  # Should be unchanged
+
+
+class TestToolBasedResponseFormatFiltering:
+    """Test that tool-based response_format path also filters unsupported constraints.
+
+    When using older Anthropic models that don't support native output_format,
+    LiteLLM falls back to tool-based JSON mode. The tool's input_schema must
+    also have unsupported constraints stripped.
+    """
+
+    def test_tool_response_format_filters_minimum_maximum(self):
+        """Tool-based response_format should strip minimum/maximum from nested schemas."""
+        config = AnthropicConfig()
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "age": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 150,
+                    "description": "Person's age",
+                },
+                "score": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 100.0,
+                },
+            },
+            "required": ["age", "score"],
+        }
+
+        tool = config._create_json_tool_call_for_response_format(
+            json_schema=json_schema
+        )
+
+        input_schema = tool["input_schema"]
+        assert "minimum" not in input_schema["properties"]["age"]
+        assert "maximum" not in input_schema["properties"]["age"]
+        assert "minimum" not in input_schema["properties"]["score"]
+        assert "maximum" not in input_schema["properties"]["score"]
+        # Descriptions should contain constraint info
+        assert "minimum value: 0" in input_schema["properties"]["age"]["description"]
+        assert "maximum value: 150" in input_schema["properties"]["age"]["description"]
+
+    def test_tool_response_format_filters_string_constraints(self):
+        """Tool-based response_format should strip minLength/maxLength."""
+        config = AnthropicConfig()
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                }
+            },
+            "required": ["name"],
+        }
+
+        tool = config._create_json_tool_call_for_response_format(
+            json_schema=json_schema
+        )
+
+        input_schema = tool["input_schema"]
+        assert "minLength" not in input_schema["properties"]["name"]
+        assert "maxLength" not in input_schema["properties"]["name"]
+
+    def test_tool_response_format_filters_array_constraints(self):
+        """Tool-based response_format should strip minItems/maxItems."""
+        config = AnthropicConfig()
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "maxItems": 10,
+                }
+            },
+            "required": ["tags"],
+        }
+
+        tool = config._create_json_tool_call_for_response_format(
+            json_schema=json_schema
+        )
+
+        input_schema = tool["input_schema"]
+        assert "minItems" not in input_schema["properties"]["tags"]
+        assert "maxItems" not in input_schema["properties"]["tags"]
+
+    def test_tool_response_format_preserves_valid_fields(self):
+        """Tool-based response_format should preserve valid schema fields."""
+        config = AnthropicConfig()
+        json_schema = {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["active", "inactive"],
+                    "description": "Current status",
+                }
+            },
+            "required": ["status"],
+        }
+
+        tool = config._create_json_tool_call_for_response_format(
+            json_schema=json_schema
+        )
+
+        input_schema = tool["input_schema"]
+        assert input_schema["properties"]["status"]["type"] == "string"
+        assert input_schema["properties"]["status"]["enum"] == ["active", "inactive"]
+        assert input_schema["properties"]["status"]["description"] == "Current status"
+
+
+class TestRegularToolSchemaFiltering:
+    """Test that regular tool schemas also filter unsupported constraints.
+
+    When tools are mapped via _map_tool_helper, nested schemas within
+    properties should have unsupported constraints stripped.
+    """
+
+    def _make_openai_tool(self, name, parameters):
+        """Helper to create an OpenAI-format tool definition."""
+        return {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"Test tool {name}",
+                "parameters": parameters,
+            },
+        }
+
+    def test_tool_filters_nested_numeric_constraints(self):
+        """Regular tools should strip minimum/maximum from nested property schemas."""
+        config = AnthropicConfig()
+        tool = self._make_openai_tool(
+            "create_user",
+            {
+                "type": "object",
+                "properties": {
+                    "age": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 150,
+                        "description": "User age",
+                    }
+                },
+                "required": ["age"],
+            },
+        )
+
+        result, _ = config._map_tool_helper(tool)
+        assert result is not None
+        props = result["input_schema"]["properties"]
+        assert "minimum" not in props["age"]
+        assert "maximum" not in props["age"]
+        assert "User age" in props["age"]["description"]
+        assert "minimum value: 0" in props["age"]["description"]
+
+    def test_tool_filters_nested_string_constraints(self):
+        """Regular tools should strip minLength/maxLength from nested property schemas."""
+        config = AnthropicConfig()
+        tool = self._make_openai_tool(
+            "search",
+            {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 500,
+                    }
+                },
+                "required": ["query"],
+            },
+        )
+
+        result, _ = config._map_tool_helper(tool)
+        assert result is not None
+        props = result["input_schema"]["properties"]
+        assert "minLength" not in props["query"]
+        assert "maxLength" not in props["query"]
+
+    def test_tool_filters_deeply_nested_constraints(self):
+        """Regular tools should strip constraints from deeply nested schemas."""
+        config = AnthropicConfig()
+        tool = self._make_openai_tool(
+            "create_order",
+            {
+                "type": "object",
+                "properties": {
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "quantity": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 1000,
+                                }
+                            },
+                        },
+                        "minItems": 1,
+                        "maxItems": 50,
+                    }
+                },
+                "required": ["items"],
+            },
+        )
+
+        result, _ = config._map_tool_helper(tool)
+        assert result is not None
+        items_schema = result["input_schema"]["properties"]["items"]
+        assert "minItems" not in items_schema
+        assert "maxItems" not in items_schema
+        nested_props = items_schema["items"]["properties"]
+        assert "minimum" not in nested_props["quantity"]
+        assert "maximum" not in nested_props["quantity"]
+
+    def test_tool_preserves_valid_nested_fields(self):
+        """Regular tools should preserve valid schema fields in nested schemas."""
+        config = AnthropicConfig()
+        tool = self._make_openai_tool(
+            "set_status",
+            {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": ["on", "off"],
+                        "description": "Device status",
+                    }
+                },
+                "required": ["status"],
+            },
+        )
+
+        result, _ = config._map_tool_helper(tool)
+        assert result is not None
+        props = result["input_schema"]["properties"]
+        assert props["status"]["type"] == "string"
+        assert props["status"]["enum"] == ["on", "off"]
+        assert props["status"]["description"] == "Device status"
+
+
+class TestAdditionalSDKTransformations:
+    """Test additional SDK transformations: additionalProperties, string formats, pattern.
+
+    Mirrors the Anthropic Python SDK's transform_schema() behavior:
+    - Add additionalProperties: false to all object schemas
+    - Filter string format to supported values only
+    - Strip pattern constraint (move to description)
+    See: https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/_parse/_transform.py
+    """
+
+    def test_adds_additional_properties_false_to_objects(self):
+        """Object schemas should get additionalProperties: false."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "required": ["name"],
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result["additionalProperties"] is False
+
+    def test_overrides_additional_properties_true(self):
+        """additionalProperties: true should be overridden to false for objects."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "additionalProperties": True,
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result["additionalProperties"] is False
+
+    def test_preserves_additional_properties_false(self):
+        """additionalProperties: false should remain false."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "additionalProperties": False,
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result["additionalProperties"] is False
+
+    def test_no_additional_properties_for_non_object(self):
+        """Non-object schemas should NOT get additionalProperties."""
+        schema = {"type": "string"}
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "additionalProperties" not in result
+
+    def test_additional_properties_on_nested_objects(self):
+        """Nested object schemas should also get additionalProperties: false."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"},
+                    },
+                }
+            },
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result["additionalProperties"] is False
+        assert result["properties"]["address"]["additionalProperties"] is False
+
+    def test_preserves_supported_string_format(self):
+        """Supported string formats (date-time, email, uuid, etc.) should be preserved."""
+        for fmt in ["date-time", "date", "time", "email", "uri", "uuid", "ipv4", "ipv6", "hostname", "duration"]:
+            schema = {"type": "string", "format": fmt}
+            result = AnthropicConfig.filter_anthropic_output_schema(schema)
+            assert result.get("format") == fmt, f"Format {fmt} should be preserved"
+
+    def test_strips_unsupported_string_format(self):
+        """Unsupported string formats should be removed and added to description."""
+        schema = {
+            "type": "string",
+            "format": "phone-number",
+            "description": "Contact phone",
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "format" not in result
+        assert "phone-number" in result["description"]
+        assert "Contact phone" in result["description"]
+
+    def test_strips_unsupported_format_no_existing_description(self):
+        """Unsupported format stripped without existing description."""
+        schema = {"type": "string", "format": "binary"}
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "format" not in result
+        assert "binary" in result["description"]
+
+    def test_format_preserved_for_non_string_types(self):
+        """Format on non-string types should pass through unchanged."""
+        schema = {"type": "integer", "format": "int64"}
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result.get("format") == "int64"
+
+    def test_strips_pattern_constraint(self):
+        """pattern constraint should be stripped and moved to description."""
+        schema = {
+            "type": "string",
+            "pattern": "^[A-Z]{2}\\d{4}$",
+            "description": "Product code",
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "pattern" not in result
+        assert "Product code" in result["description"]
+        assert "pattern:" in result["description"]
+
+    def test_combined_transformations(self):
+        """Test all transformations together on a complex schema."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "format": "email",
+                    "minLength": 5,
+                },
+                "phone": {
+                    "type": "string",
+                    "format": "phone-number",
+                    "pattern": "^\\+\\d+$",
+                },
+                "age": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 150,
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string", "maxLength": 50},
+                    "minItems": 1,
+                    "maxItems": 10,
+                },
+            },
+            "required": ["email", "phone", "age", "tags"],
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        # Object gets additionalProperties: false
+        assert result["additionalProperties"] is False
+
+        # email: supported format preserved, minLength stripped
+        assert result["properties"]["email"]["format"] == "email"
+        assert "minLength" not in result["properties"]["email"]
+        assert "minimum length: 5" in result["properties"]["email"]["description"]
+
+        # phone: unsupported format and pattern stripped
+        assert "format" not in result["properties"]["phone"]
+        assert "pattern" not in result["properties"]["phone"]
+        assert "phone-number" in result["properties"]["phone"]["description"]
+
+        # age: numeric constraints stripped
+        assert "minimum" not in result["properties"]["age"]
+        assert "maximum" not in result["properties"]["age"]
+
+        # tags: array constraints stripped, nested string constraint stripped
+        assert "minItems" not in result["properties"]["tags"]
+        assert "maxItems" not in result["properties"]["tags"]
+        assert "maxLength" not in result["properties"]["tags"]["items"]
+
+
+class TestTupleAndPrefixItemsFiltering:
+    """Tests for tuple-style items (list) and prefixItems filtering."""
+
+    def test_tuple_style_items_list_filtered(self):
+        """Tuple-style items (list of schemas) should be recursively filtered."""
+        schema = {
+            "type": "array",
+            "items": [
+                {"type": "number", "minimum": -90, "maximum": 90},
+                {"type": "number", "minimum": -180, "maximum": 180},
+            ],
+        }
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+        for item in result["items"]:
+            assert "minimum" not in item
+            assert "maximum" not in item
+            assert "description" in item
+
+    def test_prefix_items_filtered(self):
+        """prefixItems (JSON Schema 2020-12) should be recursively filtered."""
+        schema = {
+            "type": "array",
+            "prefixItems": [
+                {"type": "string", "minLength": 1, "maxLength": 10},
+                {"type": "integer", "minimum": 0},
+            ],
+        }
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+        for item in result["prefixItems"]:
+            assert "minLength" not in item
+            assert "maxLength" not in item
+            assert "minimum" not in item
+
+
+class TestEnforceAdditionalPropertiesFlag:
+    """Test the enforce_additional_properties parameter."""
+
+    def test_enforce_false_preserves_additional_properties_true(self):
+        """When enforce_additional_properties=False, user's additionalProperties: true is preserved."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "additionalProperties": True,
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(
+            schema, enforce_additional_properties=False
+        )
+
+        assert result["additionalProperties"] is True
+
+    def test_enforce_false_does_not_add_additional_properties(self):
+        """When enforce_additional_properties=False, additionalProperties is NOT injected."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(
+            schema, enforce_additional_properties=False
+        )
+
+        assert "additionalProperties" not in result
+
+    def test_enforce_false_still_filters_constraints(self):
+        """Constraint filtering still works when enforce_additional_properties=False."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "age": {"type": "integer", "minimum": 0, "maximum": 150}
+            },
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(
+            schema, enforce_additional_properties=False
+        )
+
+        assert "minimum" not in result["properties"]["age"]
+        assert "maximum" not in result["properties"]["age"]
+        assert "additionalProperties" not in result
+
+    def test_enforce_false_nested_objects(self):
+        """Nested objects also respect enforce_additional_properties=False."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"}
+                    },
+                    "additionalProperties": True,
+                }
+            },
+            "additionalProperties": True,
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(
+            schema, enforce_additional_properties=False
+        )
+
+        assert result["additionalProperties"] is True
+        assert result["properties"]["address"]["additionalProperties"] is True
+
+    def test_enforce_true_is_default(self):
+        """Default behavior (enforce_additional_properties=True) forces false."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "additionalProperties": True,
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result["additionalProperties"] is False
+
+    def test_type_preserved_with_composition_keywords(self):
+        """``type`` is preserved even when ``anyOf``/``oneOf``/``allOf`` are present.
+
+        The filter iterates per-key; ``type`` falls through to the ``else``
+        branch and is copied to the result regardless of composition keywords.
+        """
+        schema = {
+            "type": "object",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"},
+            ],
+            "properties": {"name": {"type": "string"}},
+        }
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+        assert result["type"] == "object"
+        assert "anyOf" in result
+        assert "properties" in result
+
+    def test_default_none_preserved(self):
+        """``"default": None`` (Pydantic Optional fields) is preserved."""
+        schema = {
+            "type": "string",
+            "default": None,
+        }
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+        assert "default" in result
+        assert result["default"] is None
+
+    def test_const_none_preserved(self):
+        """``"const": None`` is preserved (valid JSON Schema)."""
+        schema = {
+            "type": "string",
+            "const": None,
+        }
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+        assert "const" in result
+        assert result["const"] is None

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -148,6 +148,38 @@ def test_use_custom_pricing_for_model():
     assert use_custom_pricing_for_model(litellm_params) == True
 
 
+def test_use_custom_pricing_for_model_via_litellm_metadata():
+    """Pricing in litellm_metadata.model_info must be detected.
+
+    Generic API call routes (/messages, /responses) store model_info
+    under litellm_metadata, not metadata. Regression test for #23185.
+    """
+    from litellm.litellm_core_utils.litellm_logging import use_custom_pricing_for_model
+
+    litellm_params = {
+        "litellm_metadata": {
+            "model_info": {
+                "id": "claude-sonnet-4-custom",
+                "input_cost_per_token": 0.0003,
+                "output_cost_per_token": 0.0015,
+            },
+        },
+    }
+    assert use_custom_pricing_for_model(litellm_params) is True
+
+
+def test_use_custom_pricing_not_detected_litellm_metadata_no_pricing():
+    """Should return False when litellm_metadata.model_info has no pricing keys."""
+    from litellm.litellm_core_utils.litellm_logging import use_custom_pricing_for_model
+
+    litellm_params = {
+        "litellm_metadata": {
+            "model_info": {"id": "some-id", "db_model": False},
+        },
+    }
+    assert use_custom_pricing_for_model(litellm_params) is False
+
+
 def test_logging_prevent_double_logging(logging_obj):
     """
     When using a bridge, log only once from the underlying bridge call.

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -155,6 +155,80 @@ async def test_async_anthropic_messages_handler_extra_headers():
 
 
 @pytest.mark.asyncio
+async def test_async_anthropic_messages_handler_passes_litellm_metadata():
+    """Ensure litellm_metadata from kwargs is included in litellm_params
+    passed to update_environment_variables.
+
+    Routes like /messages store model_info under kwargs['litellm_metadata'].
+    The handler must forward this into litellm_params so that
+    use_custom_pricing_for_model can detect custom pricing. Regression test for #23185.
+    """
+    handler = BaseLLMHTTPHandler()
+
+    mock_config = Mock()
+    mock_config.validate_anthropic_messages_environment = Mock(
+        return_value=({"x-api-key": "test-key"}, "https://api.anthropic.com")
+    )
+    mock_config.transform_anthropic_messages_request = Mock(
+        return_value={"model": "claude-sonnet-4-20250514", "messages": []}
+    )
+
+    mock_client = AsyncMock()
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "id": "msg_123",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello!"}],
+        "model": "claude-sonnet-4-20250514",
+        "stop_reason": "end_turn",
+    }
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    mock_logging_obj = Mock()
+    mock_logging_obj.update_environment_variables = Mock()
+    mock_logging_obj.model_call_details = {}
+    mock_logging_obj.stream = False
+
+    custom_model_info = {
+        "id": "claude-sonnet-4-custom-pricing",
+        "input_cost_per_token": 0.0003,
+        "output_cost_per_token": 0.0015,
+    }
+    kwargs = {
+        "litellm_metadata": {
+            "model_info": custom_model_info,
+            "deployment": "anthropic/claude-sonnet-4-20250514",
+        },
+    }
+
+    try:
+        await handler.async_anthropic_messages_handler(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "Hello"}],
+            anthropic_messages_provider_config=mock_config,
+            anthropic_messages_optional_request_params={},
+            custom_llm_provider="anthropic",
+            litellm_params=GenericLiteLLMParams(),
+            logging_obj=mock_logging_obj,
+            client=mock_client,
+            kwargs=kwargs,
+        )
+    except Exception:
+        pass
+
+    mock_logging_obj.update_environment_variables.assert_called_once()
+    call_kwargs = mock_logging_obj.update_environment_variables.call_args
+    litellm_params_arg = call_kwargs.kwargs.get(
+        "litellm_params", call_kwargs[1].get("litellm_params", {})
+    ) if call_kwargs.kwargs else call_kwargs[1].get("litellm_params", {})
+
+    assert "litellm_metadata" in litellm_params_arg
+    assert litellm_params_arg["litellm_metadata"]["model_info"] == custom_model_info
+
+
+@pytest.mark.asyncio
 async def test_async_anthropic_messages_handler_header_priority():
     """
     Test that async_anthropic_messages_handler respects header priority:

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -332,6 +332,62 @@ def test_custom_pricing_with_router_model_id():
     assert model_info["cache_read_input_token_cost"] == 0.0000006
 
 
+def test_custom_pricing_cost_calc_uses_router_model_id_from_litellm_metadata():
+    """When custom pricing is in litellm_metadata.model_info,
+    use_custom_pricing_for_model should return True and
+    _select_model_name_for_cost_calc should use router_model_id.
+
+    This tests the full chain that was broken for /messages and /responses
+    endpoints. Regression test for #23185.
+    """
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+    from litellm.litellm_core_utils.litellm_logging import use_custom_pricing_for_model
+
+    custom_model_id = "claude-sonnet-4-custom-pricing-test"
+    custom_pricing_info = {
+        "input_cost_per_token": 0.0003,
+        "output_cost_per_token": 0.0015,
+        "max_tokens": 8192,
+        "litellm_provider": "anthropic",
+    }
+    litellm.register_model(model_cost={custom_model_id: custom_pricing_info})
+
+    litellm_params = {
+        "litellm_metadata": {
+            "model_info": {
+                "id": custom_model_id,
+                "input_cost_per_token": 0.0003,
+                "output_cost_per_token": 0.0015,
+            },
+        },
+    }
+
+    custom_pricing = use_custom_pricing_for_model(litellm_params)
+    assert custom_pricing is True
+
+    # _select_model_name_for_cost_calc appends provider prefix to the
+    # selected router_model_id, so the result is "anthropic/<model_id>"
+    selected_model = _select_model_name_for_cost_calc(
+        model="anthropic/claude-sonnet-4-20250514",
+        completion_response=None,
+        custom_pricing=custom_pricing,
+        custom_llm_provider="anthropic",
+        router_model_id=custom_model_id,
+    )
+    assert selected_model is not None
+    assert custom_model_id in selected_model
+
+    # Without custom_pricing, the router_model_id is NOT selected
+    selected_model_no_custom = _select_model_name_for_cost_calc(
+        model="anthropic/claude-sonnet-4-20250514",
+        completion_response=None,
+        custom_pricing=False,
+        custom_llm_provider="anthropic",
+        router_model_id=custom_model_id,
+    )
+    assert custom_model_id not in (selected_model_no_custom or "")
+
+
 def test_azure_realtime_cost_calculator():
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
@@ -365,11 +421,7 @@ def test_azure_audio_output_cost_calculation():
     Audio tokens should be charged at output_cost_per_audio_token rate,
     not at the text token rate (output_cost_per_token).
     """
-    from litellm.types.utils import (
-        Choices,
-        CompletionTokensDetailsWrapper,
-        Message,
-    )
+    from litellm.types.utils import Choices, CompletionTokensDetailsWrapper, Message
 
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
@@ -471,11 +523,7 @@ def test_default_image_cost_calculator(monkeypatch):
 
 def test_cost_calculator_with_cache_creation():
     from litellm import completion_cost
-    from litellm.types.utils import (
-        Choices,
-        Message,
-        Usage,
-    )
+    from litellm.types.utils import Choices, Message, Usage
 
     litellm_model_response = ModelResponse(
         id="chatcmpl-cc5638bc-fdfe-48e4-8884-57c8f4fb7c63",
@@ -896,10 +944,7 @@ def test_azure_ai_cache_cost_calculation():
     applied correctly.
     """
     from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
-    from litellm.types.utils import (
-        PromptTokensDetailsWrapper,
-        Usage,
-    )
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -2735,6 +2735,81 @@ def test_credential_name_not_injected_when_absent():
     assert kwargs["metadata"]["tags"] == ["A.101"]
 
 
+def test_update_kwargs_with_deployment_model_info_in_litellm_metadata():
+    """For generic_api_call, model_info with pricing must go to litellm_metadata.
+
+    Routes like /messages and /responses use generic_api_call which stores
+    model_info under litellm_metadata. Regression test for #23185.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "claude-sonnet-4",
+                "litellm_params": {
+                    "model": "anthropic/claude-sonnet-4-20250514",
+                    "api_key": "fake-key",
+                },
+                "model_info": {
+                    "id": "custom-pricing-id",
+                    "input_cost_per_token": 0.0003,
+                    "output_cost_per_token": 0.0015,
+                },
+            },
+        ],
+    )
+
+    kwargs: dict = {}
+    deployment = router.get_deployment_by_model_group_name(
+        model_group_name="claude-sonnet-4"
+    )
+    router._update_kwargs_with_deployment(
+        deployment=deployment, kwargs=kwargs, function_name="generic_api_call"
+    )
+
+    assert "litellm_metadata" in kwargs
+    model_info = kwargs["litellm_metadata"]["model_info"]
+    assert model_info["id"] == "custom-pricing-id"
+    assert model_info["input_cost_per_token"] == 0.0003
+    assert model_info["output_cost_per_token"] == 0.0015
+
+
+def test_update_kwargs_with_deployment_model_info_in_metadata():
+    """For acompletion (function_name=None), model_info goes to metadata.
+
+    /chat/completions uses acompletion which stores model_info under metadata.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "claude-sonnet-4",
+                "litellm_params": {
+                    "model": "anthropic/claude-sonnet-4-20250514",
+                    "api_key": "fake-key",
+                },
+                "model_info": {
+                    "id": "custom-pricing-id",
+                    "input_cost_per_token": 0.0003,
+                    "output_cost_per_token": 0.0015,
+                },
+            },
+        ],
+    )
+
+    kwargs: dict = {}
+    deployment = router.get_deployment_by_model_group_name(
+        model_group_name="claude-sonnet-4"
+    )
+    router._update_kwargs_with_deployment(
+        deployment=deployment, kwargs=kwargs, function_name=None
+    )
+
+    assert "metadata" in kwargs
+    model_info = kwargs["metadata"]["model_info"]
+    assert model_info["id"] == "custom-pricing-id"
+    assert model_info["input_cost_per_token"] == 0.0003
+    assert model_info["output_cost_per_token"] == 0.0015
+
+
 def test_combine_fallback_usage():
     """Test that _combine_fallback_usage merges partial and fallback usage."""
     from litellm.router import Router

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
@@ -235,6 +235,24 @@ vi.mock("../common_components/ProjectDropdown", () => ({
       onChange={(e) => onChange?.(e.target.value)}
     />
   ),
+
+vi.mock("../agent_management/AgentSelector", () => ({ default: () => null }));
+vi.mock("../common_components/budget_duration_dropdown", () => ({ default: () => null }));
+vi.mock("../common_components/check_openapi_schema", () => ({ default: () => null }));
+vi.mock("../common_components/KeyLifecycleSettings", () => ({ default: () => null }));
+vi.mock("../common_components/ModelAliasManager", () => ({ default: () => null }));
+vi.mock("../common_components/PassThroughRoutesSelector", () => ({ default: () => null }));
+vi.mock("../common_components/PremiumLoggingSettings", () => ({ default: () => null }));
+vi.mock("../common_components/RateLimitTypeFormItem", () => ({ default: () => null }));
+vi.mock("../common_components/RouterSettingsAccordion", () => ({ default: () => null }));
+vi.mock("../common_components/team_dropdown", () => ({ default: () => null }));
+vi.mock("../CreateUserButton", () => ({ CreateUserButton: () => null }));
+vi.mock("../mcp_server_management/MCPServerSelector", () => ({ default: () => null }));
+vi.mock("../mcp_server_management/MCPToolPermissions", () => ({ default: () => null }));
+vi.mock("../shared/numerical_input", () => ({ default: () => null }));
+vi.mock("../vector_store_management/VectorStoreSelector", () => ({ default: () => null }));
+vi.mock("../key_team_helpers/fetch_available_models_team_key", () => ({
+  getModelDisplayName: (model: string) => model,
 }));
 
 vi.mock("../common_components/AccessGroupSelector", () => ({


### PR DESCRIPTION
## Summary

When using Anthropic models (first-party or Azure) via `litellm.completion` with structured outputs containing `minimum`/`maximum`/`minLength`/`maxLength`/`pattern`, the Anthropic API returns a 400 error because these JSON Schema keywords are not supported by constrained decoding.

This PR mirrors the [Anthropic SDK's `transform_schema()`](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/_parse/_transform.py) behavior to strip unsupported constraints and encode them into field descriptions.

## Changes (3 incremental commits)

### Commit A: Filter tool-based response_format path
`filter_anthropic_output_schema()` was only applied for native `output_format` (newer models: sonnet-4.5+, opus-4.1+). For older models using the tool-based JSON mode fallback (`_create_json_tool_call_for_response_format`), the schema was sent unfiltered → 400 errors.

### Commit B: Filter regular tool schemas
Regular tool schemas mapped via `_map_tool_helper` only had top-level key filtering. Nested schemas inside `properties`, `items`, `anyOf`, etc. still contained unsupported constraints.

### Commit C: Additional SDK transformations
Enhanced `filter_anthropic_output_schema()` to fully mirror the Anthropic SDK:
- Add `additionalProperties: false` to all object schemas
- Filter string `format` to supported values only (`date-time`, `time`, `date`, `duration`, `email`, `hostname`, `uri`, `ipv4`, `ipv6`, `uuid`)
- Strip `pattern` constraint (moved to description)

## Test Results
25 unit tests added/updated, all passing.

## References
- Anthropic SDK: https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/_parse/_transform.py
- Anthropic docs: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#how-sdk-transformation-works
- Fixes #19444