### PR TITLE
fix(mcp): semantic tool filter matches prefixed tool names

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -207,7 +207,9 @@ class SemanticMCPToolFilter:
 
         return []
 
-    def _get_tools_by_names(self, tool_names: List[str], available_tools: List[Any]) -> List[Any]:
+    def _get_tools_by_names(
+        self, tool_names: List[str], available_tools: List[Any]
+    ) -> List[Any]:
         """Get tools from available_tools by their names, preserving order.
 
         Handles the case where the semantic router indexes tools with raw MCP

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -214,9 +214,13 @@ class SemanticMCPToolFilter:
 
         Handles the case where the semantic router indexes tools with raw MCP
         names (e.g. ``get_transcript``) but the expanded OpenAI-format tools
-        carry a server-name prefix (e.g. ``youtube-get_transcript``).  When an
-        exact match is not found the method falls back to suffix matching so
-        that ``get_transcript`` matches ``youtube-get_transcript``.
+        carry a server-name prefix (e.g. ``youtube<sep>get_transcript`` where
+        ``<sep>`` is ``MCP_TOOL_PREFIX_SEPARATOR``).  When an exact match is
+        not found the method falls back to suffix matching so that
+        ``get_transcript`` matches ``youtube<sep>get_transcript``.
+
+        The separator is **not** hardcoded — ``split_server_prefix_from_name``
+        uses the configurable ``MCP_TOOL_PREFIX_SEPARATOR`` constant.
         """
         tool_name_set = set(tool_names)
 

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -226,8 +226,8 @@ class SemanticMCPToolFilter:
 
         # Build a map from matched router name → available tool
         matched: Dict[str, Any] = {}
-                suffix, _ = split_server_prefix_from_name(tool_name)
-                if suffix and suffix in tool_name_set and suffix not in matched:
+        for tool in available_tools:
+            tool_name, _ = self._extract_tool_info(tool)
             if tool_name in tool_name_set:
                 # Exact match (unprefixed name or already matching)
                 matched[tool_name] = tool

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -226,17 +226,22 @@ class SemanticMCPToolFilter:
 
         # Build a map from matched router name → available tool
         matched: Dict[str, Any] = {}
+        exact_matched: set = set()  # names resolved via exact match
         for tool in available_tools:
             tool_name, _ = self._extract_tool_info(tool)
             if tool_name in tool_name_set:
                 # Exact match (unprefixed name or already matching)
                 matched[tool_name] = tool
+                exact_matched.add(tool_name)
             else:
                 # Suffix match: tool_name may be "server<sep>raw_name"
                 raw_name, server_prefix = split_server_prefix_from_name(tool_name)
                 suffix = raw_name if server_prefix else None
                 if suffix and suffix in tool_name_set:
-                    if suffix in matched:
+                    if suffix in exact_matched:
+                        # An exact match already won — skip silently
+                        pass
+                    elif suffix in matched:
                         verbose_logger.warning(
                             "MCP suffix collision: tool '%s' (server '%s') "
                             "collides with already-matched suffix '%s' — "

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -235,8 +235,18 @@ class SemanticMCPToolFilter:
                 # Suffix match: tool_name may be "server<sep>raw_name"
                 raw_name, server_prefix = split_server_prefix_from_name(tool_name)
                 suffix = raw_name if server_prefix else None
-                if suffix and suffix in tool_name_set and suffix not in matched:
-                    matched[suffix] = tool
+                if suffix and suffix in tool_name_set:
+                    if suffix in matched:
+                        verbose_logger.warning(
+                            "MCP suffix collision: tool '%s' (server '%s') "
+                            "collides with already-matched suffix '%s' — "
+                            "keeping first match",
+                            tool_name,
+                            server_prefix,
+                            suffix,
+                        )
+                    else:
+                        matched[suffix] = tool
 
         return [matched[name] for name in tool_names if name in matched]
 

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -226,8 +226,8 @@ class SemanticMCPToolFilter:
 
         # Build a map from matched router name → available tool
         matched: Dict[str, Any] = {}
-        for tool in available_tools:
-            tool_name, _ = self._extract_tool_info(tool)
+                suffix, _ = split_server_prefix_from_name(tool_name)
+                if suffix and suffix in tool_name_set and suffix not in matched:
             if tool_name in tool_name_set:
                 # Exact match (unprefixed name or already matching)
                 matched[tool_name] = tool

--- a/litellm/proxy/guardrails/guardrail_hooks/mcp_end_user_permission/mcp_end_user_permission.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/mcp_end_user_permission/mcp_end_user_permission.py
@@ -17,6 +17,7 @@ from litellm.integrations.custom_guardrail import (
     CustomGuardrail,
     log_guardrail_information,
 )
+from litellm.proxy._experimental.mcp_server.utils import MCP_TOOL_PREFIX_SEPARATOR
 from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.utils import GenericGuardrailAPIInputs
@@ -238,11 +239,11 @@ class MCPEndUserPermissionGuardrail(CustomGuardrail):
     def _extract_mcp_server_name(tool_name: str) -> Optional[str]:
         """
         Split "github-create_issue" → "github".
-        Returns None if the tool name has no '-' prefix (not an MCP tool).
+        Returns None if the tool name has no prefix separator (not an MCP tool).
         """
-        if not tool_name or "-" not in tool_name:
+        if not tool_name or MCP_TOOL_PREFIX_SEPARATOR not in tool_name:
             return None
-        return tool_name.split("-", 1)[0]
+        return tool_name.split(MCP_TOOL_PREFIX_SEPARATOR, 1)[0]
 
     @staticmethod
     def _get_tool_name_from_definition(tool: Any) -> Optional[str]:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -15,6 +15,8 @@ sys.path.insert(0, os.path.abspath("../.."))
 
 from mcp.types import Tool as MCPTool
 
+from litellm.proxy._experimental.mcp_server.utils import MCP_TOOL_PREFIX_SEPARATOR
+
 
 @pytest.mark.asyncio
 async def test_semantic_filter_basic_filtering():
@@ -419,20 +421,21 @@ def test_get_tools_by_names_with_prefixed_names():
     # Router matched these raw names
     matched_names = ["get_transcript", "perplexity_ask"]
 
-    # Expanded tools carry a server-name prefix
+    # Expanded tools carry a server-name prefix using the configurable separator
+    sep = MCP_TOOL_PREFIX_SEPARATOR
     available_tools = [
-        {"name": "youtube-get_transcript", "description": "Get transcript"},
-        {"name": "fetch-fetch", "description": "Fetch URL"},
-        {"name": "perplexity-perplexity_ask", "description": "Ask Perplexity"},
-        {"name": "github-search_issues", "description": "Search issues"},
+        {"name": f"youtube{sep}get_transcript", "description": "Get transcript"},
+        {"name": f"fetch{sep}fetch", "description": "Fetch URL"},
+        {"name": f"perplexity{sep}perplexity_ask", "description": "Ask Perplexity"},
+        {"name": f"github{sep}search_issues", "description": "Search issues"},
     ]
 
     result = filter_instance._get_tools_by_names(matched_names, available_tools)
 
     assert len(result) == 2, f"Expected 2 matched tools, got {len(result)}"
     result_names = [t["name"] for t in result]
-    assert result_names[0] == "youtube-get_transcript"
-    assert result_names[1] == "perplexity-perplexity_ask"
+    assert result_names[0] == f"youtube{sep}get_transcript"
+    assert result_names[1] == f"perplexity{sep}perplexity_ask"
 
 
 def test_get_tools_by_names_exact_match_preferred():
@@ -452,9 +455,10 @@ def test_get_tools_by_names_exact_match_preferred():
     )
 
     # If a tool's name exactly matches, that takes priority
+    sep = MCP_TOOL_PREFIX_SEPARATOR
     available_tools = [
         {"name": "get_transcript", "description": "Get transcript (unprefixed)"},
-        {"name": "youtube-get_transcript", "description": "Get transcript (prefixed)"},
+        {"name": f"youtube{sep}get_transcript", "description": "Get transcript (prefixed)"},
     ]
 
     result = filter_instance._get_tools_by_names(["get_transcript"], available_tools)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -394,8 +394,7 @@ async def test_semantic_filter_hook_skips_no_tools():
 
 
 
-@pytest.mark.asyncio
-async def test_get_tools_by_names_with_prefixed_names():
+def test_get_tools_by_names_with_prefixed_names():
     """
     Test that _get_tools_by_names matches prefixed tool names.
 
@@ -436,8 +435,7 @@ async def test_get_tools_by_names_with_prefixed_names():
     assert result_names[1] == "perplexity-perplexity_ask"
 
 
-@pytest.mark.asyncio
-async def test_get_tools_by_names_exact_match_preferred():
+def test_get_tools_by_names_exact_match_preferred():
     """
     Exact name match is preferred over suffix match.
     """

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -392,3 +392,75 @@ async def test_semantic_filter_hook_skips_no_tools():
     assert result is None, "Hook should skip requests without tools"
     print("✅ Hook correctly skips requests without tools")
 
+
+
+@pytest.mark.asyncio
+async def test_get_tools_by_names_with_prefixed_names():
+    """
+    Test that _get_tools_by_names matches prefixed tool names.
+
+    When MCP tools are expanded for OpenAI format they receive a server-name
+    prefix (e.g. "youtube-get_transcript").  The semantic router indexes raw
+    names ("get_transcript").  _get_tools_by_names must handle this mismatch.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/22445
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=5,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    # Router matched these raw names
+    matched_names = ["get_transcript", "perplexity_ask"]
+
+    # Expanded tools carry a server-name prefix
+    available_tools = [
+        {"name": "youtube-get_transcript", "description": "Get transcript"},
+        {"name": "fetch-fetch", "description": "Fetch URL"},
+        {"name": "perplexity-perplexity_ask", "description": "Ask Perplexity"},
+        {"name": "github-search_issues", "description": "Search issues"},
+    ]
+
+    result = filter_instance._get_tools_by_names(matched_names, available_tools)
+
+    assert len(result) == 2, f"Expected 2 matched tools, got {len(result)}"
+    result_names = [t["name"] for t in result]
+    assert result_names[0] == "youtube-get_transcript"
+    assert result_names[1] == "perplexity-perplexity_ask"
+
+
+@pytest.mark.asyncio
+async def test_get_tools_by_names_exact_match_preferred():
+    """
+    Exact name match is preferred over suffix match.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=5,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    # If a tool's name exactly matches, that takes priority
+    available_tools = [
+        {"name": "get_transcript", "description": "Get transcript (unprefixed)"},
+        {"name": "youtube-get_transcript", "description": "Get transcript (prefixed)"},
+    ]
+
+    result = filter_instance._get_tools_by_names(["get_transcript"], available_tools)
+
+    assert len(result) == 1
+    # Exact match should win
+    assert result[0]["name"] == "get_transcript"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -466,3 +466,33 @@ def test_get_tools_by_names_exact_match_preferred():
     assert len(result) == 1
     # Exact match should win
     assert result[0]["name"] == "get_transcript"
+
+
+def test_get_tools_by_names_exact_match_preferred_reversed_order():
+    """
+    Exact name match is preferred even when the prefixed tool appears first.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=5,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    # Prefixed tool appears BEFORE the unprefixed (exact) match
+    sep = MCP_TOOL_PREFIX_SEPARATOR
+    available_tools = [
+        {"name": f"youtube{sep}get_transcript", "description": "Get transcript (prefixed)"},
+        {"name": "get_transcript", "description": "Get transcript (unprefixed)"},
+    ]
+
+    result = filter_instance._get_tools_by_names(["get_transcript"], available_tools)
+
+    assert len(result) == 1
+    # Exact match should still win even though it appears second
+    assert result[0]["name"] == "get_transcript"


### PR DESCRIPTION
## Summary

Fixes #22445

The MCP Semantic Tool Filter (`mcp_semantic_tool_filter`) consistently filters **all** tools to 0, regardless of query relevance.

## Root Cause

The semantic router indexes tools at startup using **raw MCP tool names** from the registry (e.g., `get_transcript`, `perplexity_ask`). However, at request time, the expanded OpenAI-format tools have **server-name-prefixed names** (e.g., `youtube-get_transcript`, `perplexity-perplexity_ask`).

When `_get_tools_by_names()` tries to match the raw router names against the prefixed available tools, no names match, resulting in an empty list.

## Fix

Added **suffix matching as a fallback** in `_get_tools_by_names()`:

1. First try **exact match** (handles unprefixed or already-matching names)  
2. If no exact match, strip the server prefix via `rsplit('-', 1)` and try matching the suffix
3. Exact matches are **always preferred** over suffix matches (no overwrites)

## Tests

Added 2 new tests:
- `test_get_tools_by_names_with_prefixed_names` — verifies suffix matching works for prefixed tools
- `test_get_tools_by_names_exact_match_preferred` — verifies exact match takes priority over suffix match