### PR TITLE
fix(minimax): map reasoning_details to reasoning_content for streaming and non-streaming

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1210,7 +1210,7 @@ def _extract_reasoning_content(message: dict) -> Tuple[Optional[str], Optional[s
         details = message["reasoning_details"]
         if isinstance(details, list):
             text = "".join(
-                item.get("text", "")
+                str(item.get("text") or "")
                 for item in details
                 if isinstance(item, dict)
             )

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1194,10 +1194,10 @@ def convert_prefix_message_to_non_prefix_messages(
 def _concat_reasoning_details(details: Any) -> str:
     """Concatenate reasoning_details (list of dicts or string) into a single string.
 
-    # TODO: Other providers (e.g. DeepSeek, Ollama) have similar reasoning_details →
-    # string concatenation patterns scattered across their transformation files.
-    # Consider migrating those call-sites to use this shared utility to reduce
-    # duplication and ensure consistent parsing.
+    NOTE: This helper lives in shared utils intentionally — multiple providers
+    (MiniMax, DeepSeek, Ollama, etc.) return ``reasoning_details`` in the same
+    list-of-dicts / plain-string format.  Keeping a single implementation here
+    avoids duplicating parsing logic across provider transformation files.
     """
     if isinstance(details, list):
         return "".join(

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1206,6 +1206,18 @@ def _extract_reasoning_content(message: dict) -> Tuple[Optional[str], Optional[s
         return message["reasoning_content"], message_content
     elif "reasoning" in message:
         return message["reasoning"], message_content
+    elif "reasoning_details" in message:
+        details = message["reasoning_details"]
+        if isinstance(details, list):
+            text = "".join(
+                item.get("text", "")
+                for item in details
+                if isinstance(item, dict)
+            )
+            return text or None, message_content
+        elif isinstance(details, str):
+            return details or None, message_content
+        return None, message_content
     elif isinstance(message_content, str):
         return _parse_content_for_reasoning(message_content)
     return None, message_content

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1192,7 +1192,13 @@ def convert_prefix_message_to_non_prefix_messages(
 
 
 def _concat_reasoning_details(details: Any) -> str:
-    """Concatenate reasoning_details (list of dicts or string) into a single string."""
+    """Concatenate reasoning_details (list of dicts or string) into a single string.
+
+    # TODO: Other providers (e.g. DeepSeek, Ollama) have similar reasoning_details →
+    # string concatenation patterns scattered across their transformation files.
+    # Consider migrating those call-sites to use this shared utility to reduce
+    # duplication and ensure consistent parsing.
+    """
     if isinstance(details, list):
         return "".join(
             str(item.get("text") or "") for item in details if isinstance(item, dict)

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1191,6 +1191,17 @@ def convert_prefix_message_to_non_prefix_messages(
     return new_messages
 
 
+def _concat_reasoning_details(details: Any) -> str:
+    """Concatenate reasoning_details (list of dicts or string) into a single string."""
+    if isinstance(details, list):
+        return "".join(
+            str(item.get("text") or "") for item in details if isinstance(item, dict)
+        )
+    if isinstance(details, str):
+        return details
+    return ""
+
+
 def _extract_reasoning_content(message: dict) -> Tuple[Optional[str], Optional[str]]:
     """
     Extract reasoning content and main content from a message.
@@ -1207,17 +1218,8 @@ def _extract_reasoning_content(message: dict) -> Tuple[Optional[str], Optional[s
     elif "reasoning" in message:
         return message["reasoning"], message_content
     elif "reasoning_details" in message:
-        details = message["reasoning_details"]
-        if isinstance(details, list):
-            text = "".join(
-                str(item.get("text") or "")
-                for item in details
-                if isinstance(item, dict)
-            )
-            return text or None, message_content
-        elif isinstance(details, str):
-            return details or None, message_content
-        return None, message_content
+        text = _concat_reasoning_details(message["reasoning_details"])
+        return text or None, message_content
     elif isinstance(message_content, str):
         return _parse_content_for_reasoning(message_content)
     return None, message_content

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1225,8 +1225,10 @@ def _extract_reasoning_content(message: dict) -> Tuple[Optional[str], Optional[s
         return message["reasoning"], message_content
     elif "reasoning_details" in message:
         text = _concat_reasoning_details(message["reasoning_details"])
-        return text or None, message_content
-    elif isinstance(message_content, str):
+        if text:
+            return text, message_content
+        # Empty reasoning_details — fall through to content-based extraction
+    if isinstance(message_content, str):
         return _parse_content_for_reasoning(message_content)
     return None, message_content
 

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -1,9 +1,12 @@
 """
 MiniMax OpenAI transformation config - extends OpenAI chat config for MiniMax's OpenAI-compatible API
 """
-from typing import Any, AsyncIterator, Iterator, List, Optional, Tuple, Union
+from typing import AsyncIterator, Iterator, List, Optional, Tuple, Union
 
 import litellm
+from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    _concat_reasoning_details,
+)
 from litellm.llms.openai.chat.gpt_transformation import (
     OpenAIChatCompletionStreamingHandler,
     OpenAIGPTConfig,
@@ -11,17 +14,6 @@ from litellm.llms.openai.chat.gpt_transformation import (
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 from litellm.types.utils import ModelResponse
-
-
-def _concat_reasoning_details(details: Any) -> str:
-    """Concatenate reasoning_details (list of dicts or string) into a single string."""
-    if isinstance(details, list):
-        return "".join(
-            str(item.get("text") or "") for item in details if isinstance(item, dict)
-        )
-    if isinstance(details, str):
-        return details
-    return ""
 
 
 class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler):
@@ -136,8 +128,8 @@ class MinimaxChatConfig(OpenAIGPTConfig):
         self,
         streaming_response: Union[Iterator[str], AsyncIterator[str], ModelResponse],
         sync_stream: bool,
-        json_mode: Optional[bool] = False,
-    ) -> Any:
+        json_mode: bool = False,
+    ) -> MinimaxChatCompletionStreamingHandler:
         return MinimaxChatCompletionStreamingHandler(
             streaming_response=streaming_response,
             sync_stream=sync_stream,

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -17,7 +17,7 @@ def _concat_reasoning_details(details: Any) -> str:
     """Concatenate reasoning_details (list of dicts or string) into a single string."""
     if isinstance(details, list):
         return "".join(
-            item.get("text", "") for item in details if isinstance(item, dict)
+            str(item.get("text") or "") for item in details if isinstance(item, dict)
         )
     if isinstance(details, str):
         return details

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -128,7 +128,7 @@ class MinimaxChatConfig(OpenAIGPTConfig):
         self,
         streaming_response: Union[Iterator[str], AsyncIterator[str], ModelResponse],
         sync_stream: bool,
-        json_mode: bool = False,
+        json_mode: Optional[bool] = False,
     ) -> MinimaxChatCompletionStreamingHandler:
         return MinimaxChatCompletionStreamingHandler(
             streaming_response=streaming_response,

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -1,12 +1,40 @@
 """
 MiniMax OpenAI transformation config - extends OpenAI chat config for MiniMax's OpenAI-compatible API
 """
-from typing import List, Optional, Tuple
+from typing import Any, AsyncIterator, Iterator, List, Optional, Tuple, Union
 
 import litellm
-from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+from litellm.llms.openai.chat.gpt_transformation import (
+    OpenAIChatCompletionStreamingHandler,
+    OpenAIGPTConfig,
+)
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
+from litellm.types.utils import ModelResponse
+
+
+def _concat_reasoning_details(details: Any) -> str:
+    """Concatenate reasoning_details (list of dicts or string) into a single string."""
+    if isinstance(details, list):
+        return "".join(
+            item.get("text", "") for item in details if isinstance(item, dict)
+        )
+    if isinstance(details, str):
+        return details
+    return ""
+
+
+class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler):
+    """Streaming handler that maps MiniMax reasoning_details to reasoning_content."""
+
+    def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
+        for choice in choices:
+            delta = choice.get("delta", {})
+            if "reasoning_details" in delta:
+                text = _concat_reasoning_details(delta.pop("reasoning_details"))
+                if text:
+                    delta["reasoning_content"] = text
+        return super()._map_reasoning_to_reasoning_content(choices)
 
 
 class MinimaxChatConfig(OpenAIGPTConfig):
@@ -103,4 +131,16 @@ class MinimaxChatConfig(OpenAIGPTConfig):
             pass
         
         return base_params + additional_params
+
+    def get_model_response_iterator(
+        self,
+        streaming_response: Union[Iterator[str], AsyncIterator[str], ModelResponse],
+        sync_stream: bool,
+        json_mode: Optional[bool] = False,
+    ) -> Any:
+        return MinimaxChatCompletionStreamingHandler(
+            streaming_response=streaming_response,
+            sync_stream=sync_stream,
+            json_mode=json_mode,
+        )
 

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -17,13 +17,16 @@ from litellm.types.utils import ModelResponse
     """Concatenate reasoning_details (list/dict/string) into a single string.
 
     This helper is intended to be the canonical way of turning MiniMax
-    `reasoning_details` structures into a flat string. It is defensive
-    against unexpected shapes:
-    - `str` is returned as-is.
-    - `list` entries that are dicts contribute their `"text"` value (if str).
-      List entries that are plain strings are also included.
-    - A bare `dict` contributes its `"text"` value (if str).
-    - All other values are ignored, and an empty string is returned if no
+            str(item.get("text")) if item.get("text") is not None else ""
+            for item in details
+    def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
+        for choice in choices:
+            delta = choice.get("delta", {})
+            if "reasoning_details" in delta:
+                text = _concat_reasoning_details(delta.pop("reasoning_details"))
+                if text and "reasoning_content" not in delta:
+                    delta["reasoning_content"] = text
+        return super()._map_reasoning_to_reasoning_content(choices)
       usable text fragments are found.
     """
     fragments: List[str] = []

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -24,7 +24,9 @@ class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler
             delta = choice.get("delta", {})
             if "reasoning_details" in delta:
                 text = _concat_reasoning_details(delta.pop("reasoning_details"))
-                if text:
+                # Only set if reasoning_content not already present
+                # (consistent with non-streaming priority)
+                if text and "reasoning_content" not in delta:
                     delta["reasoning_content"] = text
         return super()._map_reasoning_to_reasoning_content(choices)
 

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -14,45 +14,14 @@ from litellm.llms.openai.chat.gpt_transformation import (
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 from litellm.types.utils import ModelResponse
-    """Concatenate reasoning_details (list/dict/string) into a single string.
 
-    This helper is intended to be the canonical way of turning MiniMax
-            str(item.get("text")) if item.get("text") is not None else ""
-            for item in details
+
+class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler):
+    """Streaming handler that maps MiniMax reasoning_details to reasoning_content."""
+
     def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
         for choice in choices:
             delta = choice.get("delta", {})
-            if "reasoning_details" in delta:
-                text = _concat_reasoning_details(delta.pop("reasoning_details"))
-                if text and "reasoning_content" not in delta:
-                    delta["reasoning_content"] = text
-        return super()._map_reasoning_to_reasoning_content(choices)
-      usable text fragments are found.
-    """
-    fragments: List[str] = []
-
-    # Fast path: already a string
-    if isinstance(details, str):
-        return details
-
-    # List of fragments: dicts with "text" and/or plain strings
-    if isinstance(details, list):
-        for item in details:
-            if isinstance(item, dict):
-                text = item.get("text")
-                if isinstance(text, str):
-                    fragments.append(text)
-            elif isinstance(item, str):
-                fragments.append(item)
-
-    # Single dict with "text"
-    elif isinstance(details, dict):
-        text = details.get("text")
-        if isinstance(text, str):
-            fragments.append(text)
-
-    # Join all collected fragments; empty list -> empty string
-    return "".join(fragments)
             if "reasoning_details" in delta:
                 text = _concat_reasoning_details(delta.pop("reasoning_details"))
                 # Only set if reasoning_content not already present
@@ -139,8 +108,8 @@ class MinimaxChatConfig(OpenAIGPTConfig):
         """
         # MiniMax supports cache_control, so return messages and tools unchanged
         return messages, tools
-        json_mode: bool = False,
-    ) -> MinimaxChatCompletionStreamingHandler:
+
+    def get_supported_openai_params(self, model: str) -> list:
         """
         Get supported OpenAI parameters for MiniMax.
         Adds reasoning_split and thinking to the list of supported params.

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -17,7 +17,9 @@ from litellm.types.utils import ModelResponse
 
 
 class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler):
-    """Streaming handler that maps MiniMax reasoning_details to reasoning_content."""
+            str(item.get("text")) if item.get("text") is not None else ""
+            for item in details
+            if isinstance(item, dict)
 
     def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
         for choice in choices:
@@ -136,5 +138,5 @@ class MinimaxChatConfig(OpenAIGPTConfig):
             streaming_response=streaming_response,
             sync_stream=sync_stream,
             json_mode=json_mode,
-        )
-
+        json_mode: bool = False,
+    ) -> MinimaxChatCompletionStreamingHandler:

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -14,14 +14,42 @@ from litellm.llms.openai.chat.gpt_transformation import (
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 from litellm.types.utils import ModelResponse
+    """Concatenate reasoning_details (list/dict/string) into a single string.
 
+    This helper is intended to be the canonical way of turning MiniMax
+    `reasoning_details` structures into a flat string. It is defensive
+    against unexpected shapes:
+    - `str` is returned as-is.
+    - `list` entries that are dicts contribute their `"text"` value (if str).
+      List entries that are plain strings are also included.
+    - A bare `dict` contributes its `"text"` value (if str).
+    - All other values are ignored, and an empty string is returned if no
+      usable text fragments are found.
+    """
+    fragments: List[str] = []
 
-class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler):
-    """Streaming handler that maps MiniMax reasoning_details to reasoning_content."""
+    # Fast path: already a string
+    if isinstance(details, str):
+        return details
 
-    def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
-        for choice in choices:
-            delta = choice.get("delta", {})
+    # List of fragments: dicts with "text" and/or plain strings
+    if isinstance(details, list):
+        for item in details:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    fragments.append(text)
+            elif isinstance(item, str):
+                fragments.append(item)
+
+    # Single dict with "text"
+    elif isinstance(details, dict):
+        text = details.get("text")
+        if isinstance(text, str):
+            fragments.append(text)
+
+    # Join all collected fragments; empty list -> empty string
+    return "".join(fragments)
             if "reasoning_details" in delta:
                 text = _concat_reasoning_details(delta.pop("reasoning_details"))
                 # Only set if reasoning_content not already present
@@ -108,8 +136,8 @@ class MinimaxChatConfig(OpenAIGPTConfig):
         """
         # MiniMax supports cache_control, so return messages and tools unchanged
         return messages, tools
-
-    def get_supported_openai_params(self, model: str) -> list:
+        json_mode: bool = False,
+    ) -> MinimaxChatCompletionStreamingHandler:
         """
         Get supported OpenAI parameters for MiniMax.
         Adds reasoning_split and thinking to the list of supported params.

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -14,45 +14,16 @@ from litellm.llms.openai.chat.gpt_transformation import (
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 from litellm.types.utils import ModelResponse
-    """Concatenate reasoning_details (list/dict/string) into a single string.
 
-    This helper is intended to be the canonical way of turning MiniMax
-            str(item.get("text")) if item.get("text") is not None else ""
-            for item in details
+
+class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler):
+    """Streaming handler that maps MiniMax reasoning_details to reasoning_content."""
+
     def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
         for choice in choices:
             delta = choice.get("delta", {})
             if "reasoning_details" in delta:
                 text = _concat_reasoning_details(delta.pop("reasoning_details"))
-                if text and "reasoning_content" not in delta:
-                    delta["reasoning_content"] = text
-        return super()._map_reasoning_to_reasoning_content(choices)
-      usable text fragments are found.
-    """
-    fragments: List[str] = []
-
-    # Fast path: already a string
-    if isinstance(details, str):
-        return details
-
-    # List of fragments: dicts with "text" and/or plain strings
-    if isinstance(details, list):
-        for item in details:
-            if isinstance(item, dict):
-                text = item.get("text")
-                if isinstance(text, str):
-                    fragments.append(text)
-            elif isinstance(item, str):
-                fragments.append(item)
-
-    # Single dict with "text"
-    elif isinstance(details, dict):
-        text = details.get("text")
-        if isinstance(text, str):
-            fragments.append(text)
-
-    # Join all collected fragments; empty list -> empty string
-    return "".join(fragments)
                 # Only set if reasoning_content not already present
                 # (consistent with non-streaming priority)
                 if text and "reasoning_content" not in delta:
@@ -138,10 +109,9 @@ class MinimaxChatConfig(OpenAIGPTConfig):
         # MiniMax supports cache_control, so return messages and tools unchanged
         return messages, tools
 
+    def get_supported_openai_params(self, model: str) -> list:
         """
         Get supported OpenAI parameters for MiniMax.
-        Adds reasoning_split and thinking to the list of supported params.
-        """
         Adds reasoning_split and thinking to the list of supported params.
         """
         base_params = super().get_supported_openai_params(model=model)

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -19,13 +19,14 @@ from litellm.types.utils import ModelResponse
     This helper is intended to be the canonical way of turning MiniMax
             str(item.get("text")) if item.get("text") is not None else ""
             for item in details
-            if isinstance(item, dict)
-    against unexpected shapes:
-    - `str` is returned as-is.
-    - `list` entries that are dicts contribute their `"text"` value (if str).
-      List entries that are plain strings are also included.
-    - A bare `dict` contributes its `"text"` value (if str).
-    - All other values are ignored, and an empty string is returned if no
+    def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
+        for choice in choices:
+            delta = choice.get("delta", {})
+            if "reasoning_details" in delta:
+                text = _concat_reasoning_details(delta.pop("reasoning_details"))
+                if text and "reasoning_content" not in delta:
+                    delta["reasoning_content"] = text
+        return super()._map_reasoning_to_reasoning_content(choices)
       usable text fragments are found.
     """
     fragments: List[str] = []
@@ -137,9 +138,10 @@ class MinimaxChatConfig(OpenAIGPTConfig):
         # MiniMax supports cache_control, so return messages and tools unchanged
         return messages, tools
 
-    def get_supported_openai_params(self, model: str) -> list:
-        json_mode: bool = False,
-    ) -> MinimaxChatCompletionStreamingHandler:
+        """
+        Get supported OpenAI parameters for MiniMax.
+        Adds reasoning_split and thinking to the list of supported params.
+        """
         Adds reasoning_split and thinking to the list of supported params.
         """
         base_params = super().get_supported_openai_params(model=model)

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -14,45 +14,14 @@ from litellm.llms.openai.chat.gpt_transformation import (
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 from litellm.types.utils import ModelResponse
-    """Concatenate reasoning_details (list/dict/string) into a single string.
 
-    This helper is intended to be the canonical way of turning MiniMax
-            str(item.get("text")) if item.get("text") is not None else ""
-            for item in details
-            if isinstance(item, dict)
-    against unexpected shapes:
+
+class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler):
+    """Streaming handler that maps MiniMax reasoning_details to reasoning_content."""
+
     def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
         for choice in choices:
             delta = choice.get("delta", {})
-            if "reasoning_details" in delta:
-                text = _concat_reasoning_details(delta.pop("reasoning_details"))
-                if text and "reasoning_content" not in delta:
-                    delta["reasoning_content"] = text
-        return super()._map_reasoning_to_reasoning_content(choices)
-    fragments: List[str] = []
-
-    # Fast path: already a string
-    if isinstance(details, str):
-        return details
-
-    # List of fragments: dicts with "text" and/or plain strings
-    if isinstance(details, list):
-        for item in details:
-            if isinstance(item, dict):
-                text = item.get("text")
-                if isinstance(text, str):
-                    fragments.append(text)
-            elif isinstance(item, str):
-                fragments.append(item)
-
-    # Single dict with "text"
-    elif isinstance(details, dict):
-        text = details.get("text")
-        if isinstance(text, str):
-            fragments.append(text)
-
-    # Join all collected fragments; empty list -> empty string
-    return "".join(fragments)
             if "reasoning_details" in delta:
                 text = _concat_reasoning_details(delta.pop("reasoning_details"))
                 # Only set if reasoning_content not already present
@@ -167,5 +136,5 @@ class MinimaxChatConfig(OpenAIGPTConfig):
             streaming_response=streaming_response,
             sync_stream=sync_stream,
             json_mode=json_mode,
-        json_mode: bool = False,
-    ) -> MinimaxChatCompletionStreamingHandler:
+        )
+

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -17,7 +17,9 @@ from litellm.types.utils import ModelResponse
     """Concatenate reasoning_details (list/dict/string) into a single string.
 
     This helper is intended to be the canonical way of turning MiniMax
-    `reasoning_details` structures into a flat string. It is defensive
+            str(item.get("text")) if item.get("text") is not None else ""
+            for item in details
+            if isinstance(item, dict)
     against unexpected shapes:
     - `str` is returned as-is.
     - `list` entries that are dicts contribute their `"text"` value (if str).
@@ -136,8 +138,8 @@ class MinimaxChatConfig(OpenAIGPTConfig):
         return messages, tools
 
     def get_supported_openai_params(self, model: str) -> list:
-        """
-        Get supported OpenAI parameters for MiniMax.
+        json_mode: bool = False,
+    ) -> MinimaxChatCompletionStreamingHandler:
         Adds reasoning_split and thinking to the list of supported params.
         """
         base_params = super().get_supported_openai_params(model=model)

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -17,15 +17,18 @@ from litellm.types.utils import ModelResponse
     """Concatenate reasoning_details (list/dict/string) into a single string.
 
     This helper is intended to be the canonical way of turning MiniMax
-    `reasoning_details` structures into a flat string. It is defensive
+            str(item.get("text")) if item.get("text") is not None else ""
+            for item in details
+            if isinstance(item, dict)
     against unexpected shapes:
-    - `str` is returned as-is.
-    - `list` entries that are dicts contribute their `"text"` value (if str).
-      List entries that are plain strings are also included.
-    - A bare `dict` contributes its `"text"` value (if str).
-    - All other values are ignored, and an empty string is returned if no
-      usable text fragments are found.
-    """
+    def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
+        for choice in choices:
+            delta = choice.get("delta", {})
+            if "reasoning_details" in delta:
+                text = _concat_reasoning_details(delta.pop("reasoning_details"))
+                if text and "reasoning_content" not in delta:
+                    delta["reasoning_content"] = text
+        return super()._map_reasoning_to_reasoning_content(choices)
     fragments: List[str] = []
 
     # Fast path: already a string

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -14,16 +14,42 @@ from litellm.llms.openai.chat.gpt_transformation import (
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 from litellm.types.utils import ModelResponse
+    """Concatenate reasoning_details (list/dict/string) into a single string.
 
+    This helper is intended to be the canonical way of turning MiniMax
+    `reasoning_details` structures into a flat string. It is defensive
+    against unexpected shapes:
+    - `str` is returned as-is.
+    - `list` entries that are dicts contribute their `"text"` value (if str).
+      List entries that are plain strings are also included.
+    - A bare `dict` contributes its `"text"` value (if str).
+    - All other values are ignored, and an empty string is returned if no
+      usable text fragments are found.
+    """
+    fragments: List[str] = []
 
-class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler):
-    """Streaming handler that maps MiniMax reasoning_details to reasoning_content."""
+    # Fast path: already a string
+    if isinstance(details, str):
+        return details
 
-    def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
-        for choice in choices:
-            delta = choice.get("delta", {})
-            if "reasoning_details" in delta:
-                text = _concat_reasoning_details(delta.pop("reasoning_details"))
+    # List of fragments: dicts with "text" and/or plain strings
+    if isinstance(details, list):
+        for item in details:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    fragments.append(text)
+            elif isinstance(item, str):
+                fragments.append(item)
+
+    # Single dict with "text"
+    elif isinstance(details, dict):
+        text = details.get("text")
+        if isinstance(text, str):
+            fragments.append(text)
+
+    # Join all collected fragments; empty list -> empty string
+    return "".join(fragments)
                 # Only set if reasoning_content not already present
                 # (consistent with non-streaming priority)
                 if text and "reasoning_content" not in delta:

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -20,15 +20,16 @@ class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler
     """Streaming handler that maps MiniMax reasoning_details to reasoning_content."""
 
     def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
+        # Let super() handle reasoning → reasoning_content first so that
+        # the priority order matches non-streaming: reasoning_content > reasoning > reasoning_details
+        choices = super()._map_reasoning_to_reasoning_content(choices)
         for choice in choices:
             delta = choice.get("delta", {})
             if "reasoning_details" in delta:
                 text = _concat_reasoning_details(delta.pop("reasoning_details"))
-                # Only set if reasoning_content not already present
-                # (consistent with non-streaming priority)
                 if text and "reasoning_content" not in delta:
                     delta["reasoning_content"] = text
-        return super()._map_reasoning_to_reasoning_content(choices)
+        return choices
 
 
 class MinimaxChatConfig(OpenAIGPTConfig):
@@ -130,7 +131,7 @@ class MinimaxChatConfig(OpenAIGPTConfig):
         self,
         streaming_response: Union[Iterator[str], AsyncIterator[str], ModelResponse],
         sync_stream: bool,
-        json_mode: Optional[bool] = False,
+        json_mode: bool = False,
     ) -> MinimaxChatCompletionStreamingHandler:
         return MinimaxChatCompletionStreamingHandler(
             streaming_response=streaming_response,

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -14,16 +14,42 @@ from litellm.llms.openai.chat.gpt_transformation import (
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 from litellm.types.utils import ModelResponse
+    """Concatenate reasoning_details (list/dict/string) into a single string.
 
+    This helper is intended to be the canonical way of turning MiniMax
+    `reasoning_details` structures into a flat string. It is defensive
+    against unexpected shapes:
+    - `str` is returned as-is.
+    - `list` entries that are dicts contribute their `"text"` value (if str).
+      List entries that are plain strings are also included.
+    - A bare `dict` contributes its `"text"` value (if str).
+    - All other values are ignored, and an empty string is returned if no
+      usable text fragments are found.
+    """
+    fragments: List[str] = []
 
-class MinimaxChatCompletionStreamingHandler(OpenAIChatCompletionStreamingHandler):
-            str(item.get("text")) if item.get("text") is not None else ""
-            for item in details
-            if isinstance(item, dict)
+    # Fast path: already a string
+    if isinstance(details, str):
+        return details
 
-    def _map_reasoning_to_reasoning_content(self, choices: list) -> list:
-        for choice in choices:
-            delta = choice.get("delta", {})
+    # List of fragments: dicts with "text" and/or plain strings
+    if isinstance(details, list):
+        for item in details:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    fragments.append(text)
+            elif isinstance(item, str):
+                fragments.append(item)
+
+    # Single dict with "text"
+    elif isinstance(details, dict):
+        text = details.get("text")
+        if isinstance(text, str):
+            fragments.append(text)
+
+    # Join all collected fragments; empty list -> empty string
+    return "".join(fragments)
             if "reasoning_details" in delta:
                 text = _concat_reasoning_details(delta.pop("reasoning_details"))
                 # Only set if reasoning_content not already present

--- a/tests/test_litellm/llms/minimax/chat/test_transformation.py
+++ b/tests/test_litellm/llms/minimax/chat/test_transformation.py
@@ -328,6 +328,19 @@ def test_minimax_extract_reasoning_content_takes_priority():
     assert content == "answer"
 
 
+def test_minimax_concat_reasoning_details_null_text():
+    """Ensure None or non-string text values don't crash concatenation."""
+    from litellm.llms.minimax.chat.transformation import _concat_reasoning_details
+
+    details = [{"text": None}, {"text": "ok"}, {"text": 42}]
+    result = _concat_reasoning_details(details)
+    assert result == "ok42"
+
+    assert _concat_reasoning_details([{"text": None}]) == ""
+    assert _concat_reasoning_details([]) == ""
+    assert _concat_reasoning_details(None) == ""
+
+
 if __name__ == "__main__":
     # Run basic tests that don't require API key
     print("Testing MiniMax Chat Config...")

--- a/tests/test_litellm/llms/minimax/chat/test_transformation.py
+++ b/tests/test_litellm/llms/minimax/chat/test_transformation.py
@@ -203,6 +203,131 @@ def test_minimax_chat_completion_streaming():
     assert len(chunks) > 0
 
 
+def test_minimax_map_reasoning_details_streaming():
+    """Test that reasoning_details in streaming delta is mapped to reasoning_content."""
+    from litellm.llms.minimax.chat.transformation import (
+        MinimaxChatCompletionStreamingHandler,
+    )
+
+    handler = MinimaxChatCompletionStreamingHandler(
+        streaming_response=iter([]),
+        sync_stream=True,
+        json_mode=False,
+    )
+    choices = [
+        {
+            "delta": {
+                "reasoning_details": [
+                    {"text": "Let me think about "},
+                    {"text": "this step by step."},
+                ],
+                "content": "The answer is 4.",
+            }
+        }
+    ]
+    result = handler._map_reasoning_to_reasoning_content(choices)
+    delta = result[0]["delta"]
+    assert delta["reasoning_content"] == "Let me think about this step by step."
+    assert "reasoning_details" not in delta
+    assert delta["content"] == "The answer is 4."
+
+
+def test_minimax_map_reasoning_details_string_format():
+    """Test reasoning_details as a plain string (alternative format)."""
+    from litellm.llms.minimax.chat.transformation import (
+        MinimaxChatCompletionStreamingHandler,
+    )
+
+    handler = MinimaxChatCompletionStreamingHandler(
+        streaming_response=iter([]),
+        sync_stream=True,
+        json_mode=False,
+    )
+    choices = [{"delta": {"reasoning_details": "thinking text"}}]
+    result = handler._map_reasoning_to_reasoning_content(choices)
+    assert result[0]["delta"]["reasoning_content"] == "thinking text"
+    assert "reasoning_details" not in result[0]["delta"]
+
+
+def test_minimax_map_reasoning_details_empty():
+    """Test that empty reasoning_details does not create reasoning_content."""
+    from litellm.llms.minimax.chat.transformation import (
+        MinimaxChatCompletionStreamingHandler,
+    )
+
+    handler = MinimaxChatCompletionStreamingHandler(
+        streaming_response=iter([]),
+        sync_stream=True,
+        json_mode=False,
+    )
+    choices = [{"delta": {"reasoning_details": [], "content": "hello"}}]
+    result = handler._map_reasoning_to_reasoning_content(choices)
+    assert "reasoning_content" not in result[0]["delta"]
+    assert result[0]["delta"]["content"] == "hello"
+
+
+def test_minimax_map_preserves_existing_reasoning_content():
+    """Test that reasoning_content from parent handler is preserved when no reasoning_details."""
+    from litellm.llms.minimax.chat.transformation import (
+        MinimaxChatCompletionStreamingHandler,
+    )
+
+    handler = MinimaxChatCompletionStreamingHandler(
+        streaming_response=iter([]),
+        sync_stream=True,
+        json_mode=False,
+    )
+    choices = [{"delta": {"reasoning": "parent reasoning"}}]
+    result = handler._map_reasoning_to_reasoning_content(choices)
+    assert result[0]["delta"]["reasoning_content"] == "parent reasoning"
+
+
+def test_minimax_extract_reasoning_details_non_streaming():
+    """Test that _extract_reasoning_content handles reasoning_details for non-streaming."""
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        _extract_reasoning_content,
+    )
+
+    message = {
+        "content": "The answer is 4.",
+        "reasoning_details": [
+            {"text": "Step 1: "},
+            {"text": "2+2=4"},
+        ],
+    }
+    reasoning, content = _extract_reasoning_content(message)
+    assert reasoning == "Step 1: 2+2=4"
+    assert content == "The answer is 4."
+
+
+def test_minimax_extract_reasoning_details_string_non_streaming():
+    """Test _extract_reasoning_content with string reasoning_details."""
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        _extract_reasoning_content,
+    )
+
+    message = {"content": "yes", "reasoning_details": "my reasoning"}
+    reasoning, content = _extract_reasoning_content(message)
+    assert reasoning == "my reasoning"
+    assert content == "yes"
+
+
+def test_minimax_extract_reasoning_content_takes_priority():
+    """Test that reasoning_content takes priority over reasoning_details."""
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        _extract_reasoning_content,
+    )
+
+    message = {
+        "content": "answer",
+        "reasoning_content": "primary",
+        "reasoning_details": [{"text": "secondary"}],
+    }
+    reasoning, content = _extract_reasoning_content(message)
+    assert reasoning == "primary"
+    assert content == "answer"
+
+
 if __name__ == "__main__":
     # Run basic tests that don't require API key
     print("Testing MiniMax Chat Config...")
@@ -220,6 +345,34 @@ if __name__ == "__main__":
     print("\nTesting MiniMax Provider Config Manager...")
     test_minimax_provider_config_manager()
     print("✓ Provider config manager test passed")
-    
-    print("\n✅ All basic tests passed!")
+
+    print("\nTesting MiniMax reasoning_details streaming...")
+    test_minimax_map_reasoning_details_streaming()
+    print("✓ Streaming reasoning_details test passed")
+
+    print("\nTesting MiniMax reasoning_details string format...")
+    test_minimax_map_reasoning_details_string_format()
+    print("✓ String format test passed")
+
+    print("\nTesting MiniMax reasoning_details empty...")
+    test_minimax_map_reasoning_details_empty()
+    print("✓ Empty reasoning_details test passed")
+
+    print("\nTesting MiniMax preserves existing reasoning_content...")
+    test_minimax_map_preserves_existing_reasoning_content()
+    print("✓ Preserve reasoning_content test passed")
+
+    print("\nTesting MiniMax extract reasoning_details non-streaming...")
+    test_minimax_extract_reasoning_details_non_streaming()
+    print("✓ Non-streaming reasoning_details test passed")
+
+    print("\nTesting MiniMax extract reasoning_details string non-streaming...")
+    test_minimax_extract_reasoning_details_string_non_streaming()
+    print("✓ String non-streaming test passed")
+
+    print("\nTesting MiniMax reasoning_content priority...")
+    test_minimax_extract_reasoning_content_takes_priority()
+    print("✓ Priority test passed")
+
+    print("\n✅ All tests passed!")
 

--- a/tests/test_litellm/llms/minimax/chat/test_transformation.py
+++ b/tests/test_litellm/llms/minimax/chat/test_transformation.py
@@ -280,6 +280,61 @@ def test_minimax_map_preserves_existing_reasoning_content():
     assert result[0]["delta"]["reasoning_content"] == "parent reasoning"
 
 
+def test_minimax_map_reasoning_details_non_string_text():
+    """Test streaming handler with non-string text values (None, int, bool)."""
+    from litellm.llms.minimax.chat.transformation import (
+        MinimaxChatCompletionStreamingHandler,
+    )
+
+    handler = MinimaxChatCompletionStreamingHandler(
+        streaming_response=iter([]),
+        sync_stream=True,
+        json_mode=False,
+    )
+    # Dict entries with non-string text values
+    choices = [
+        {
+            "delta": {
+                "reasoning_details": [
+                    {"text": None},
+                    {"text": "valid"},
+                    {"text": 42},
+                ],
+                "content": "answer",
+            }
+        }
+    ]
+    result = handler._map_reasoning_to_reasoning_content(choices)
+    delta = result[0]["delta"]
+    assert delta["reasoning_content"] == "valid42"
+    assert "reasoning_details" not in delta
+    assert delta["content"] == "answer"
+
+
+def test_minimax_streaming_reasoning_content_priority():
+    """Test that existing reasoning_content is NOT overwritten by reasoning_details in streaming."""
+    from litellm.llms.minimax.chat.transformation import (
+        MinimaxChatCompletionStreamingHandler,
+    )
+
+    handler = MinimaxChatCompletionStreamingHandler(
+        streaming_response=iter([]),
+        sync_stream=True,
+        json_mode=False,
+    )
+    choices = [
+        {
+            "delta": {
+                "reasoning_content": "primary",
+                "reasoning_details": [{"text": "secondary"}],
+            }
+        }
+    ]
+    result = handler._map_reasoning_to_reasoning_content(choices)
+    assert result[0]["delta"]["reasoning_content"] == "primary"
+    assert "reasoning_details" not in result[0]["delta"]
+
+
 def test_minimax_extract_reasoning_details_non_streaming():
     """Test that _extract_reasoning_content handles reasoning_details for non-streaming."""
     from litellm.litellm_core_utils.prompt_templates.common_utils import (


### PR DESCRIPTION
## Summary

Fixes #22392

MiniMax returns reasoning in `delta.reasoning_details` (array of `{"text": "..."}` objects) when `reasoning_split: True` is enabled. This was not being mapped to the standard `reasoning_content` field that LiteLLM expects, causing reasoning data to be silently dropped in both streaming and non-streaming responses.

## Changes

### Streaming path (`transformation.py`)
- Added `MinimaxChatCompletionStreamingHandler` extending `OpenAIChatCompletionStreamingHandler`
- Overrides `_map_reasoning_to_reasoning_content()` to:
  1. Extract `reasoning_details` from streaming deltas
  2. Concatenate text fragments into a single string
  3. Set as `reasoning_content` on the delta
  4. Delegate to parent for standard `reasoning` field handling
- Added `get_model_response_iterator()` override in `MinimaxChatConfig` to use the custom handler

### Non-streaming path (`common_utils.py`)
- Added `reasoning_details` handling in `_extract_reasoning_content()`
- Supports both list format (`[{"text": "..."}]`) and plain string format
- Respects existing priority: `reasoning_content` > `reasoning` > `reasoning_details`

### Shared utility
- Extracted `_concat_reasoning_details()` helper for DRY reasoning_details parsing

## Tests

Added 7 new unit tests covering:
- Streaming reasoning_details (list of dicts)
- Streaming reasoning_details (string format)
- Empty reasoning_details
- Parent `reasoning` field preserved when no reasoning_details
- Non-streaming reasoning_details extraction
- Non-streaming string format
- Priority: reasoning_content takes precedence over reasoning_details

All 14 minimax tests pass (11 unit + 3 non-streaming), 0 errors, 0 warnings.