### PR TITLE
fix(logging): persist provider response headers in StandardLoggingAdditionalHeaders

### DIFF
--- a/docs/my-website/docs/proxy/logging_spec.md
+++ b/docs/my-website/docs/proxy/logging_spec.md
@@ -108,16 +108,18 @@ Inherits from `StandardLoggingUserAPIKeyMetadata` and adds:
 
 ## StandardLoggingAdditionalHeaders
 
+All fields are optional — only fields present in the provider's response headers are included.
+
 | Field | Type | Description |
 |-------|------|-------------|
 | `x_ratelimit_limit_requests` | `int` | Rate limit for requests |
 | `x_ratelimit_limit_tokens` | `int` | Rate limit for tokens |
 | `x_ratelimit_remaining_requests` | `int` | Remaining requests in rate limit |
 | `x_ratelimit_remaining_tokens` | `int` | Remaining tokens in rate limit |
-| `llm_provider_x_request_id` | `str` | LLM provider's `x-request-id` response header |
-| `llm_provider_request_id` | `str` | LLM provider's `request-id` response header |
-| `llm_provider_openai_organization` | `str` | OpenAI organization from response headers |
-| `llm_provider_openai_processing_ms` | `int` | OpenAI processing time in milliseconds from response headers |
+| `llm_provider_x_request_id` | `str` | LLM provider's `x-request-id` response header (e.g., OpenAI, Anthropic) |
+| `llm_provider_request_id` | `str` | LLM provider's `request-id` response header (e.g., Anthropic) |
+| `llm_provider_openai_organization` | `str` | OpenAI `openai-organization` response header |
+| `llm_provider_openai_processing_ms` | `int` | OpenAI `openai-processing-ms` response header (milliseconds) |
 
 ## StandardLoggingHiddenParams
 

--- a/docs/my-website/docs/proxy/logging_spec.md
+++ b/docs/my-website/docs/proxy/logging_spec.md
@@ -114,6 +114,10 @@ Inherits from `StandardLoggingUserAPIKeyMetadata` and adds:
 | `x_ratelimit_limit_tokens` | `int` | Rate limit for tokens |
 | `x_ratelimit_remaining_requests` | `int` | Remaining requests in rate limit |
 | `x_ratelimit_remaining_tokens` | `int` | Remaining tokens in rate limit |
+| `llm_provider_x_request_id` | `str` | LLM provider's `x-request-id` response header |
+| `llm_provider_request_id` | `str` | LLM provider's `request-id` response header |
+| `llm_provider_openai_organization` | `str` | OpenAI organization from response headers |
+| `llm_provider_openai_processing_ms` | `int` | OpenAI processing time in milliseconds from response headers |
 
 ## StandardLoggingHiddenParams
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4877,6 +4877,11 @@ class StandardLoggingPayloadSetup:
                 try:
                     _value = int(_value)
                 except (ValueError, TypeError):
+                    verbose_logger.debug(
+                        "Skipping non-numeric value %r for int-typed header field %s",
+                        _value,
+                        key,
+                    )
                     continue
             else:
                 _value = str(_value)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4871,15 +4871,7 @@ class StandardLoggingPayloadSetup:
             if _value is None:
                 continue
 
-            _annotation = StandardLoggingAdditionalHeaders.__annotations__.get(key)
-            _is_str_field = _annotation is Optional[str]
-            if _is_str_field:
-                additional_logging_headers[key] = str(_value)  # type: ignore
-            else:
-                try:
-                    additional_logging_headers[key] = int(_value)  # type: ignore
-                except (ValueError, TypeError):
-                    additional_logging_headers[key] = str(_value)  # type: ignore
+            additional_logging_headers[key] = str(_value)  # type: ignore
         return additional_logging_headers
 
     @staticmethod

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4877,7 +4877,7 @@ class StandardLoggingPayloadSetup:
                 try:
                     _value = int(_value)
                 except (ValueError, TypeError):
-                    continue
+                    _value = str(_value)
             else:
                 _value = str(_value)
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4851,15 +4851,30 @@ class StandardLoggingPayloadSetup:
         additional_logging_headers: StandardLoggingAdditionalHeaders = {}
 
         for key in StandardLoggingAdditionalHeaders.__annotations__.keys():
-            _key = key.lower()
-            _key = _key.replace("_", "-")
-            if _key in additiona_headers:
-                try:
-                    additional_logging_headers[key] = int(additiona_headers[_key])  # type: ignore
-                except (ValueError, TypeError):
-                    verbose_logger.debug(
-                        f"Could not convert {additiona_headers[_key]} to int for key {key}."
-                    )
+            _key = key.lower().replace("_", "-")
+
+            # For llm_provider-prefixed annotation keys, look up the header
+            # using the canonical llm_provider-{rest} format (underscore
+            # before "provider", hyphens in the rest of the name).
+            if _key.startswith("llm-provider-"):
+                suffix = _key[len("llm-provider-"):]
+                lookup_keys = [f"llm_provider-{suffix}", _key]
+            else:
+                lookup_keys = [_key, f"llm_provider-{_key}"]
+
+            _value = None
+            for lk in lookup_keys:
+                if lk in additiona_headers:
+                    _value = additiona_headers[lk]
+                    break
+
+            if _value is None:
+                continue
+
+            try:
+                additional_logging_headers[key] = int(_value)  # type: ignore
+            except (ValueError, TypeError):
+                additional_logging_headers[key] = str(_value)  # type: ignore
         return additional_logging_headers
 
     @staticmethod

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4877,7 +4877,7 @@ class StandardLoggingPayloadSetup:
                 try:
                     _value = int(_value)
                 except (ValueError, TypeError):
-                    _value = str(_value)
+                    continue
             else:
                 _value = str(_value)
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4871,10 +4871,15 @@ class StandardLoggingPayloadSetup:
             if _value is None:
                 continue
 
-            try:
-                additional_logging_headers[key] = int(_value)  # type: ignore
-            except (ValueError, TypeError):
+            _annotation = StandardLoggingAdditionalHeaders.__annotations__.get(key)
+            _is_str_field = _annotation is Optional[str]
+            if _is_str_field:
                 additional_logging_headers[key] = str(_value)  # type: ignore
+            else:
+                try:
+                    additional_logging_headers[key] = int(_value)  # type: ignore
+                except (ValueError, TypeError):
+                    additional_logging_headers[key] = str(_value)  # type: ignore
         return additional_logging_headers
 
     @staticmethod

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4871,7 +4871,17 @@ class StandardLoggingPayloadSetup:
             if _value is None:
                 continue
 
-            additional_logging_headers[key] = str(_value)  # type: ignore
+            # Coerce to the annotated type (int fields stay int, str fields stay str)
+            annotation = StandardLoggingAdditionalHeaders.__annotations__.get(key, str)
+            if annotation is int:
+                try:
+                    _value = int(_value)
+                except (ValueError, TypeError):
+                    continue
+            else:
+                _value = str(_value)
+
+            additional_logging_headers[key] = _value  # type: ignore
         return additional_logging_headers
 
     @staticmethod

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2565,14 +2565,14 @@ class StandardLoggingMetadata(StandardLoggingUserAPIKeyMetadata):
 
 
 class StandardLoggingAdditionalHeaders(TypedDict, total=False):
-    x_ratelimit_limit_requests: int
-    x_ratelimit_limit_tokens: int
-    x_ratelimit_remaining_requests: int
-    x_ratelimit_remaining_tokens: int
+    x_ratelimit_limit_requests: Optional[str]
+    x_ratelimit_limit_tokens: Optional[str]
+    x_ratelimit_remaining_requests: Optional[str]
+    x_ratelimit_remaining_tokens: Optional[str]
     llm_provider_x_request_id: Optional[str]
     llm_provider_request_id: Optional[str]
     llm_provider_openai_organization: Optional[str]
-    llm_provider_openai_processing_ms: Optional[int]
+    llm_provider_openai_processing_ms: Optional[str]
 
 
 class StandardLoggingHiddenParams(TypedDict):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2565,14 +2565,14 @@ class StandardLoggingMetadata(StandardLoggingUserAPIKeyMetadata):
 
 
 class StandardLoggingAdditionalHeaders(TypedDict, total=False):
-    x_ratelimit_limit_requests: Optional[str]
-    x_ratelimit_limit_tokens: Optional[str]
-    x_ratelimit_remaining_requests: Optional[str]
-    x_ratelimit_remaining_tokens: Optional[str]
-    llm_provider_x_request_id: Optional[str]
-    llm_provider_request_id: Optional[str]
-    llm_provider_openai_organization: Optional[str]
-    llm_provider_openai_processing_ms: Optional[str]
+    x_ratelimit_limit_requests: int
+    x_ratelimit_limit_tokens: int
+    x_ratelimit_remaining_requests: int
+    x_ratelimit_remaining_tokens: int
+    llm_provider_x_request_id: str
+    llm_provider_request_id: str
+    llm_provider_openai_organization: str
+    llm_provider_openai_processing_ms: int
 
 
 class StandardLoggingHiddenParams(TypedDict):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2569,6 +2569,10 @@ class StandardLoggingAdditionalHeaders(TypedDict, total=False):
     x_ratelimit_limit_tokens: int
     x_ratelimit_remaining_requests: int
     x_ratelimit_remaining_tokens: int
+    llm_provider_x_request_id: Optional[str]
+    llm_provider_request_id: Optional[str]
+    llm_provider_openai_organization: Optional[str]
+    llm_provider_openai_processing_ms: Optional[str]
 
 
 class StandardLoggingHiddenParams(TypedDict):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2572,7 +2572,7 @@ class StandardLoggingAdditionalHeaders(TypedDict, total=False):
     llm_provider_x_request_id: Optional[str]
     llm_provider_request_id: Optional[str]
     llm_provider_openai_organization: Optional[str]
-    llm_provider_openai_processing_ms: Optional[str]
+    llm_provider_openai_processing_ms: Optional[int]
 
 
 class StandardLoggingHiddenParams(TypedDict):

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -202,6 +202,19 @@ def test_get_additional_headers_only_prefixed_ratelimit():
     assert result["x_ratelimit_remaining_tokens"] == 49999
 
 
+def test_get_additional_headers_numeric_request_id_stays_string():
+    """String-typed fields must remain strings even when values are numeric."""
+    additional_headers = {
+        "llm_provider-x-request-id": "12345",
+        "llm_provider-request-id": "67890",
+    }
+    result = StandardLoggingPayloadSetup.get_additional_headers(additional_headers)
+    assert result["llm_provider_x_request_id"] == "12345"
+    assert isinstance(result["llm_provider_x_request_id"], str)
+    assert result["llm_provider_request_id"] == "67890"
+    assert isinstance(result["llm_provider_request_id"], str)
+
+
 def all_fields_present(standard_logging_metadata: StandardLoggingMetadata):
     for field in StandardLoggingMetadata.__annotations__.keys():
         assert field in standard_logging_metadata

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -159,10 +159,10 @@ def test_get_additional_headers():
         additional_headers
     )
     assert additional_logging_headers == {
-        "x_ratelimit_limit_requests": 2000,
-        "x_ratelimit_remaining_requests": 1999,
-        "x_ratelimit_limit_tokens": 160000,
-        "x_ratelimit_remaining_tokens": 160000,
+        "x_ratelimit_limit_requests": "2000",
+        "x_ratelimit_remaining_requests": "1999",
+        "x_ratelimit_limit_tokens": "160000",
+        "x_ratelimit_remaining_tokens": "160000",
         "llm_provider_request_id": "req_01F6CycZZPSHKRCCctcS1Vto",
     }
 
@@ -182,8 +182,8 @@ def test_get_additional_headers_openai_x_request_id():
     assert result is not None
     assert result["llm_provider_x_request_id"] == "req_abc123"
     assert result["llm_provider_openai_organization"] == "org-test"
-    assert result["llm_provider_openai_processing_ms"] == 42
-    assert result["x_ratelimit_limit_requests"] == 5000
+    assert result["llm_provider_openai_processing_ms"] == "42"
+    assert result["x_ratelimit_limit_requests"] == "5000"
 
 
 def test_get_additional_headers_only_prefixed_ratelimit():
@@ -196,10 +196,10 @@ def test_get_additional_headers_only_prefixed_ratelimit():
     }
     result = StandardLoggingPayloadSetup.get_additional_headers(additional_headers)
     assert result is not None
-    assert result["x_ratelimit_limit_requests"] == 1000
-    assert result["x_ratelimit_remaining_requests"] == 999
-    assert result["x_ratelimit_limit_tokens"] == 50000
-    assert result["x_ratelimit_remaining_tokens"] == 49999
+    assert result["x_ratelimit_limit_requests"] == "1000"
+    assert result["x_ratelimit_remaining_requests"] == "999"
+    assert result["x_ratelimit_limit_tokens"] == "50000"
+    assert result["x_ratelimit_remaining_tokens"] == "49999"
 
 
 def test_get_additional_headers_numeric_request_id_stays_string():

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -163,7 +163,43 @@ def test_get_additional_headers():
         "x_ratelimit_remaining_requests": 1999,
         "x_ratelimit_limit_tokens": 160000,
         "x_ratelimit_remaining_tokens": 160000,
+        "llm_provider_request_id": "req_01F6CycZZPSHKRCCctcS1Vto",
     }
+
+
+def test_get_additional_headers_openai_x_request_id():
+    """Test that OpenAI x-request-id is extracted via llm_provider- prefix."""
+    additional_headers = {
+        "llm_provider-x-request-id": "req_abc123",
+        "llm_provider-openai-organization": "org-test",
+        "llm_provider-openai-processing-ms": "42",
+        "x-ratelimit-limit-requests": "5000",
+        "x-ratelimit-remaining-requests": "4999",
+        "x-ratelimit-limit-tokens": "300000",
+        "x-ratelimit-remaining-tokens": "299990",
+    }
+    result = StandardLoggingPayloadSetup.get_additional_headers(additional_headers)
+    assert result is not None
+    assert result["llm_provider_x_request_id"] == "req_abc123"
+    assert result["llm_provider_openai_organization"] == "org-test"
+    assert result["llm_provider_openai_processing_ms"] == 42
+    assert result["x_ratelimit_limit_requests"] == 5000
+
+
+def test_get_additional_headers_only_prefixed_ratelimit():
+    """Test extraction when only llm_provider-prefixed rate-limit headers exist."""
+    additional_headers = {
+        "llm_provider-x-ratelimit-limit-requests": "1000",
+        "llm_provider-x-ratelimit-remaining-requests": "999",
+        "llm_provider-x-ratelimit-limit-tokens": "50000",
+        "llm_provider-x-ratelimit-remaining-tokens": "49999",
+    }
+    result = StandardLoggingPayloadSetup.get_additional_headers(additional_headers)
+    assert result is not None
+    assert result["x_ratelimit_limit_requests"] == 1000
+    assert result["x_ratelimit_remaining_requests"] == 999
+    assert result["x_ratelimit_limit_tokens"] == 50000
+    assert result["x_ratelimit_remaining_tokens"] == 49999
 
 
 def all_fields_present(standard_logging_metadata: StandardLoggingMetadata):

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -159,10 +159,10 @@ def test_get_additional_headers():
         additional_headers
     )
     assert additional_logging_headers == {
-        "x_ratelimit_limit_requests": "2000",
-        "x_ratelimit_remaining_requests": "1999",
-        "x_ratelimit_limit_tokens": "160000",
-        "x_ratelimit_remaining_tokens": "160000",
+        "x_ratelimit_limit_requests": 2000,
+        "x_ratelimit_remaining_requests": 1999,
+        "x_ratelimit_limit_tokens": 160000,
+        "x_ratelimit_remaining_tokens": 160000,
         "llm_provider_request_id": "req_01F6CycZZPSHKRCCctcS1Vto",
     }
 
@@ -182,8 +182,8 @@ def test_get_additional_headers_openai_x_request_id():
     assert result is not None
     assert result["llm_provider_x_request_id"] == "req_abc123"
     assert result["llm_provider_openai_organization"] == "org-test"
-    assert result["llm_provider_openai_processing_ms"] == "42"
-    assert result["x_ratelimit_limit_requests"] == "5000"
+    assert result["llm_provider_openai_processing_ms"] == 42
+    assert result["x_ratelimit_limit_requests"] == 5000
 
 
 def test_get_additional_headers_only_prefixed_ratelimit():
@@ -196,10 +196,10 @@ def test_get_additional_headers_only_prefixed_ratelimit():
     }
     result = StandardLoggingPayloadSetup.get_additional_headers(additional_headers)
     assert result is not None
-    assert result["x_ratelimit_limit_requests"] == "1000"
-    assert result["x_ratelimit_remaining_requests"] == "999"
-    assert result["x_ratelimit_limit_tokens"] == "50000"
-    assert result["x_ratelimit_remaining_tokens"] == "49999"
+    assert result["x_ratelimit_limit_requests"] == 1000
+    assert result["x_ratelimit_remaining_requests"] == 999
+    assert result["x_ratelimit_limit_tokens"] == 50000
+    assert result["x_ratelimit_remaining_tokens"] == 49999
 
 
 def test_get_additional_headers_numeric_request_id_stays_string():

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -215,6 +215,23 @@ def test_get_additional_headers_numeric_request_id_stays_string():
     assert isinstance(result["llm_provider_request_id"], str)
 
 
+def test_get_additional_headers_non_numeric_int_field_skipped():
+    """Non-numeric values for int-typed fields are gracefully skipped (not silently lost)."""
+    additional_headers = {
+        "x-ratelimit-limit-requests": "not-a-number",
+        "x-ratelimit-remaining-requests": "1999",
+        "llm_provider-x-request-id": "req_ok",
+    }
+    result = StandardLoggingPayloadSetup.get_additional_headers(additional_headers)
+    assert result is not None
+    # The non-numeric value is skipped
+    assert "x_ratelimit_limit_requests" not in result
+    # Valid int field is still present
+    assert result["x_ratelimit_remaining_requests"] == 1999
+    # String field unaffected
+    assert result["llm_provider_x_request_id"] == "req_ok"
+
+
 def all_fields_present(standard_logging_metadata: StandardLoggingMetadata):
     for field in StandardLoggingMetadata.__annotations__.keys():
         assert field in standard_logging_metadata


### PR DESCRIPTION
## Summary

Fixes #22341

Provider response headers (e.g. `x-request-id`, `openai-organization`) were being dropped from `StandardLoggingAdditionalHeaders`, causing `additional_headers` to always be `null` or only contain rate-limit fields in logging callbacks.

## Root Cause

`get_additional_headers()` iterated only over the 4 rate-limit fields defined in `StandardLoggingAdditionalHeaders`, silently dropping all provider-specific headers that were already correctly stored as `llm_provider-{header}` in `additional_headers` by the upstream `get_response_headers()` function.

Additionally, the key lookup logic did not account for the `llm_provider-` prefix format (underscore before `provider`, hyphens in the rest), so even when headers were present, the lookup failed due to key format mismatch.

## Changes

1. **`litellm/types/utils.py`**: Added provider-specific fields to `StandardLoggingAdditionalHeaders`:
   - `llm_provider_x_request_id` (OpenAI)
   - `llm_provider_request_id` (Anthropic)
   - `llm_provider_openai_organization`
   - `llm_provider_openai_processing_ms`

2. **`litellm/litellm_core_utils/litellm_logging.py`**: Fixed `get_additional_headers()`:
   - Resolves `llm_provider`-prefixed annotation keys against the canonical `llm_provider-{rest}` header format
   - Falls back to `llm_provider-` prefixed rate-limit keys when raw keys are absent
   - Stores non-integer header values as strings instead of silently dropping them

3. **`tests/logging_callback_tests/test_standard_logging_payload.py`**: Added 2 new tests + updated existing test:
   - `test_get_additional_headers_openai_x_request_id`: verifies OpenAI headers extraction
   - `test_get_additional_headers_only_prefixed_ratelimit`: verifies extraction when only `llm_provider-` prefixed rate-limit headers exist

## Testing

- 45 tests in `test_standard_logging_payload.py` pass (2 consecutive runs, 0 errors, 0 warnings)
- `test_standard_logging_payload_excluded_fields.py`: 17 tests pass
- Backward compatible: existing rate-limit header extraction is unchanged