### PR TITLE
fix(cost): extract provider from base_model for cross-provider cost calculation

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1203,7 +1203,7 @@ def completion_cost(  # noqa: PLR0915
                         prompt_tokens = token_counter(model=model, text=prompt)
                     completion_tokens = token_counter(model=model, text=completion)
 
-                # When base_model contains a provider prefix (e.g. "gemini/gemini-3-flash"),
+                # When base_model contains a provider prefix (e.g. "gemini/gemini-2.0-flash"),
                 # use that provider for cost lookup instead of the deployment provider.
                 # Applied after hidden_params extraction to avoid being overridden.
                 if base_model is not None and _model_contains_known_llm_provider(base_model):

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1093,13 +1093,6 @@ def completion_cost(  # noqa: PLR0915
             router_model_id=router_model_id,
         )
 
-        # When base_model is used and contains a provider prefix (e.g. "gemini/gemini-3-flash"),
-        # extract the provider from base_model so cost lookup uses the correct provider
-        # instead of the deployment provider (e.g. "anthropic").
-        if base_model is not None and _model_contains_known_llm_provider(base_model):
-            base_model_provider = base_model.split("/")[0]
-            custom_llm_provider = base_model_provider
-
         potential_model_names = [
             selected_model,
             _get_response_model(completion_response),
@@ -1209,6 +1202,12 @@ def completion_cost(  # noqa: PLR0915
                     elif len(prompt) > 0:
                         prompt_tokens = token_counter(model=model, text=prompt)
                     completion_tokens = token_counter(model=model, text=completion)
+
+                # When base_model contains a provider prefix (e.g. "gemini/gemini-3-flash"),
+                # use that provider for cost lookup instead of the deployment provider.
+                # Applied after hidden_params extraction to avoid being overridden.
+                if base_model is not None and _model_contains_known_llm_provider(base_model):
+                    custom_llm_provider = base_model.split("/")[0]
 
                 # Handle A2A calls before model check - A2A doesn't require a model
                 if call_type in _A2A_CALL_TYPES:

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1093,6 +1093,13 @@ def completion_cost(  # noqa: PLR0915
             router_model_id=router_model_id,
         )
 
+        # When base_model is used and contains a provider prefix (e.g. "gemini/gemini-3-flash"),
+        # extract the provider from base_model so cost lookup uses the correct provider
+        # instead of the deployment provider (e.g. "anthropic").
+        if base_model is not None and _model_contains_known_llm_provider(base_model):
+            base_model_provider = base_model.split("/")[0]
+            custom_llm_provider = base_model_provider
+
         potential_model_names = [
             selected_model,
             _get_response_model(completion_response),

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -2847,6 +2847,7 @@ def test_cost_calculator_base_model_cross_provider():
     assert selected == "gemini/gemini-2.0-flash"
 
     # Verify cost calculation uses base_model pricing (gemini provider, not anthropic)
+    # Uses a random model name since mock_response bypasses actual API calls
     resp = litellm.completion(
         model="anthropic/random-model",
         messages=[{"role": "user", "content": "Hello"}],

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -2853,7 +2853,12 @@ def test_cost_calculator_base_model_cross_provider():
         base_model="gemini/gemini-2.0-flash",
         mock_response="Hello",
     )
-    assert resp._hidden_params["response_cost"] > 0
+    response_cost = resp._hidden_params["response_cost"]
+    assert response_cost > 0
+    # Verify Gemini pricing was used, not Anthropic pricing.
+    # gemini-2.0-flash: input=$0.10/M, output=$0.40/M
+    # A short mock response should cost less than $0.001
+    assert response_cost < 0.001, f"Cost {response_cost} too high — likely wrong provider pricing"
 
 
 def test_cost_calculator_with_custom_pricing():

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -2833,7 +2833,7 @@ def test_cost_calculator_base_model_cross_provider():
         _select_model_name_for_cost_calc,
     )
 
-    # Simulate: deployed as anthropic/gemini-3-flash but base_model is gemini/gemini-2.0-flash
+    # Simulate: deployed as anthropic/random-model but base_model is gemini/gemini-2.0-flash
     base_model = "gemini/gemini-2.0-flash"
     assert _model_contains_known_llm_provider(base_model) is True
 

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -2825,6 +2825,37 @@ def test_cost_calculator_with_base_model_with_router_embedding(base_model_arg):
     assert resp._hidden_params["response_cost"] > 0
 
 
+def test_cost_calculator_base_model_cross_provider():
+    """When base_model has a different provider than the deployment model,
+    cost should be calculated using the base_model's provider."""
+    from litellm.cost_calculator import (
+        _model_contains_known_llm_provider,
+        _select_model_name_for_cost_calc,
+    )
+
+    # Simulate: deployed as anthropic/gemini-3-flash but base_model is gemini/gemini-2.0-flash
+    base_model = "gemini/gemini-2.0-flash"
+    assert _model_contains_known_llm_provider(base_model) is True
+
+    selected = _select_model_name_for_cost_calc(
+        model="anthropic/gemini-3-flash",
+        completion_response=None,
+        base_model=base_model,
+        custom_llm_provider="anthropic",
+    )
+    # base_model already has provider prefix, so it should be returned as-is
+    assert selected == "gemini/gemini-2.0-flash"
+
+    # Verify cost calculation uses base_model pricing (gemini provider, not anthropic)
+    resp = litellm.completion(
+        model="anthropic/random-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        base_model="gemini/gemini-2.0-flash",
+        mock_response="Hello",
+    )
+    assert resp._hidden_params["response_cost"] > 0
+
+
 def test_cost_calculator_with_custom_pricing():
     resp = litellm.completion(
         model="bedrock/random-model",


### PR DESCRIPTION
## Summary

When `base_model` has a different provider prefix than the deployment model (e.g., deployed as `anthropic/gemini-3-flash` with `base_model="gemini/gemini-2.0-flash"`), cost calculation was using the wrong provider.

This fix extracts the provider from `base_model` so cost lookup uses the correct provider.

## Changes
- `litellm/cost_calculator.py`: Extract provider from `base_model` when it contains a known LLM provider prefix
- `tests/local_testing/test_completion_cost.py`: Added `test_cost_calculator_base_model_cross_provider` test

Supersedes #22408 (rebased on main, fixed orphaned test function)