### PR TITLE
fix(video): use DEFAULT_VIDEO_ENDPOINT_MODEL in avideo_list provider resolution

### DIFF
--- a/litellm/videos/main.py
+++ b/litellm/videos/main.py
@@ -71,7 +71,7 @@ async def avideo_generation(
         # get custom llm provider so we can use this for mapping exceptions
         if custom_llm_provider is None:
             _, custom_llm_provider, _, _ = litellm.get_llm_provider(
-                model=model or DEFAULT_VIDEO_ENDPOINT_MODEL, api_base=local_vars.get("api_base", None)
+                model=model or DEFAULT_VIDEO_ENDPOINT_MODEL, api_base=kwargs.get("api_base", None)
             )
 
         func = partial(
@@ -699,7 +699,7 @@ async def avideo_list(
         # get custom llm provider so we can use this for mapping exceptions
         if custom_llm_provider is None:
             _, custom_llm_provider, _, _ = litellm.get_llm_provider(
-                model="", api_base=local_vars.get("api_base", None)
+                model=DEFAULT_VIDEO_ENDPOINT_MODEL, api_base=kwargs.get("api_base", None)
             )
 
         func = partial(

--- a/litellm/videos/main.py
+++ b/litellm/videos/main.py
@@ -70,6 +70,8 @@ async def avideo_generation(
 
         # get custom llm provider so we can use this for mapping exceptions
         if custom_llm_provider is None:
+            # api_base is not a named parameter of avideo_generation, so it
+            # lives inside **kwargs; using local_vars would always yield None.
             _, custom_llm_provider, _, _ = litellm.get_llm_provider(
                 model=model or DEFAULT_VIDEO_ENDPOINT_MODEL, api_base=kwargs.get("api_base", None)
             )

--- a/tests/test_litellm/test_video_generation.py
+++ b/tests/test_litellm/test_video_generation.py
@@ -1260,7 +1260,7 @@ class TestAvideoListProviderFallback:
     """Regression test for https://github.com/BerriAI/litellm/issues/22130.
 
     avideo_list must not raise BadRequestError when custom_llm_provider is
-    omitted.  It should fall back to DEFAULT_VIDEO_ENDPOINT_MODEL instead of
+    omitted. It should fall back to DEFAULT_VIDEO_ENDPOINT_MODEL instead of
     passing model="" to get_llm_provider.
     """
 
@@ -1288,6 +1288,25 @@ class TestAvideoListProviderFallback:
             mock_get_provider.assert_called_once_with(
                 model=DEFAULT_VIDEO_ENDPOINT_MODEL,
                 api_base=None,
+            )
+
+
+class TestAvideoGenerationApiBase:
+    """Regression test: avideo_generation must forward api_base from **kwargs
+    to get_llm_provider, not silently drop it via local_vars."""
+
+    @pytest.mark.asyncio
+    async def test_api_base_forwarded_to_get_llm_provider(self):
+        """api_base passed via kwargs must reach get_llm_provider."""
+        from litellm.videos.main import avideo_generation
+
+        with patch("litellm.videos.main.video_generation") as mock_vg, \
+             patch("litellm.videos.main.litellm.get_llm_provider", return_value=("openai/sora-2", "openai", None, None)) as mock_get_provider:
+            mock_vg.return_value = MagicMock()
+            await avideo_generation(prompt="test", api_base="https://custom.endpoint/v1")
+            mock_get_provider.assert_called_once_with(
+                model="sora-2",
+                api_base="https://custom.endpoint/v1",
             )
 
 


### PR DESCRIPTION
## Summary

Fixes `avideo_list()` raising `BadRequestError: LLM Provider NOT provided` when `custom_llm_provider` is not explicitly passed (issue #22130). The root cause was `model=""` being passed to `get_llm_provider`.

## Changes
- Use `DEFAULT_VIDEO_ENDPOINT_MODEL` as fallback when model is empty
- Added regression test `TestAvideoListProviderFallback`

Supersedes #22353 (rebased on main, fixed typo in test class name)