### PR TITLE
perf(mcp): replace list.pop(0) with deque.popleft() in MCPEnhancedStreamingIterator

### DIFF
--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -274,10 +274,10 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         self.finished = False
 
         # Event queues and generation flags
-        self.mcp_discovery_events: deque[
-            ResponsesAPIStreamingResponse
-        ] = deque(mcp_events)  # Pre-generated MCP discovery events
-        self.tool_execution_events: deque[ResponsesAPIStreamingResponse] = deque()
+        self.mcp_discovery_events: "deque[ResponsesAPIStreamingResponse]" = deque(
+            mcp_events
+        )  # Pre-generated MCP discovery events
+        self.tool_execution_events: "deque[ResponsesAPIStreamingResponse]" = deque()
         self.mcp_discovery_generated = True  # Events are already generated
         self.mcp_events = self.mcp_discovery_events  # Shared reference for backward compat
         self.tool_server_map = tool_server_map

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -1,3 +1,4 @@
+from collections import deque
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 from litellm._logging import verbose_logger
@@ -273,14 +274,12 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         self.finished = False
 
         # Event queues and generation flags
-        self.mcp_discovery_events: List[
+        self.mcp_discovery_events: deque[
             ResponsesAPIStreamingResponse
-        ] = mcp_events  # Pre-generated MCP discovery events
-        self.tool_execution_events: List[ResponsesAPIStreamingResponse] = []
+        ] = deque(mcp_events)  # Pre-generated MCP discovery events
+        self.tool_execution_events: deque[ResponsesAPIStreamingResponse] = deque()
         self.mcp_discovery_generated = True  # Events are already generated
-        self.mcp_events = (
-            mcp_events  # Store the initial MCP events for backward compatibility
-        )
+        self.mcp_events = self.mcp_discovery_events  # Shared reference for backward compat
         self.tool_server_map = tool_server_map
 
         # Iterator references
@@ -412,7 +411,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         if self.phase == "mcp_discovery":
             # Emit MCP discovery events
             if self.mcp_discovery_events:
-                return self.mcp_discovery_events.pop(0)
+                return self.mcp_discovery_events.popleft()
             self.phase = "continue_initial_response"
             # Fall through to continue processing the initial response
 
@@ -433,7 +432,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         if self.phase == "tool_execution":
             # Emit any queued tool execution events
             if self.tool_execution_events:
-                return self.tool_execution_events.pop(0)
+                return self.tool_execution_events.popleft()
 
             # Move to follow-up response phase
             self.phase = "follow_up_response"
@@ -778,7 +777,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
     def __next__(self) -> ResponsesAPIStreamingResponse:
         # First, emit any queued MCP events
         if self.mcp_events:  # type: ignore[attr-defined]
-            return self.mcp_events.pop(0)  # type: ignore[attr-defined]
+            return self.mcp_events.popleft()  # type: ignore[attr-defined]
 
         # Then delegate to the base iterator
         if not self.is_async:


### PR DESCRIPTION
## Summary

Switches three internal event queues (`mcp_discovery_events`, `tool_execution_events`, `mcp_events`) in `MCPEnhancedStreamingIterator` from `list` to `collections.deque`, replacing O(n) `pop(0)` with O(1) `popleft()`.

Supersedes #22351 (rebased on main)