### PR TITLE
perf: use deque for streaming event queues to avoid O(n) pop(0)

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -828,6 +828,9 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 # Emit any pending tool events before reading a new chunk
                 if self._pending_tool_events:
                     return self._pending_tool_events.popleft()
+                # Emit any pending annotation events before reading a new chunk
+                if self._pending_annotation_events:
+                    return self._pending_annotation_events.popleft()
 
                 try:
                     chunk = await self.litellm_custom_stream_wrapper.__anext__()
@@ -922,6 +925,9 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 # Emit any pending tool events before reading a new chunk
                 if self._pending_tool_events:
                     return self._pending_tool_events.popleft()
+                # Emit any pending annotation events before reading a new chunk
+                if self._pending_annotation_events:
+                    return self._pending_annotation_events.popleft()
                 try:
                     chunk = self.litellm_custom_stream_wrapper.__next__()
                     self._ensure_output_item_for_chunk(chunk)

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -1,5 +1,6 @@
 import time
 import uuid
+from collections import deque
 from typing import Any, Dict, List, Optional, Union, cast
 
 import litellm
@@ -87,7 +88,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self.final_text: str = ""
         self._cached_item_id: Optional[str] = None
         self._cached_response_id: Optional[str] = None
-        self._pending_tool_events: List[BaseLiteLLMOpenAIResponseObject] = []
+        self._pending_tool_events: deque[BaseLiteLLMOpenAIResponseObject] = deque()
         self._tool_output_index_by_call_id: dict[str, int] = {}
         self._tool_args_by_call_id: dict[str, str] = {}
         self._tool_call_id_by_index: dict[int, str] = {}
@@ -100,11 +101,12 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._sent_reasoning_summary_part_done_event: bool = False
         self._reasoning_summary_text: str = ""
         # -- GENERIC RESPONSE-EVENTS PENDING QUEUE as required by fix --
-        self._pending_response_events: List[BaseLiteLLMOpenAIResponseObject] = []
+        self._pending_response_events: deque[BaseLiteLLMOpenAIResponseObject] = deque()
         self._reasoning_active = False
         self._reasoning_done_emitted = False
         self._reasoning_item_id: Optional[str] = None
         self._accumulated_reasoning_content_parts: List[str] = []
+        self._pending_annotation_events: deque[BaseLiteLLMOpenAIResponseObject] = deque()
 
 
     def _get_or_assign_tool_output_index(self, call_id: str) -> int:
@@ -725,7 +727,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             if isinstance(self.litellm_model_response, ModelResponse):
                 self._queue_final_tool_call_done_events(self.litellm_model_response)
             if self._pending_tool_events:
-                return self._pending_tool_events.pop(0)
+                return self._pending_tool_events.popleft()
 
             done_event = self.return_default_done_events(self.litellm_model_response)
             if done_event:
@@ -822,10 +824,10 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     return result
                 # Emit any pending output_item or other response events before reading a new chunk
                 if self._pending_response_events:
-                    return self._pending_response_events.pop(0)
+                    return self._pending_response_events.popleft()
                 # Emit any pending tool events before reading a new chunk
                 if self._pending_tool_events:
-                    return self._pending_tool_events.pop(0)
+                    return self._pending_tool_events.popleft()
 
                 try:
                     chunk = await self.litellm_custom_stream_wrapper.__anext__()
@@ -887,7 +889,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                             self._pending_response_events.append(response_api_chunk)
                 
                     if self._pending_response_events:
-                        return self._pending_response_events.pop(0)
+                        return self._pending_response_events.popleft()
 
                 except StopAsyncIteration:
                     return self.common_done_event_logic(sync_mode=False)
@@ -916,16 +918,16 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     return result
                 # Emit any pending output_item or other response events before reading a new chunk
                 if self._pending_response_events:
-                    return self._pending_response_events.pop(0)
+                    return self._pending_response_events.popleft()
                 # Emit any pending tool events before reading a new chunk
                 if self._pending_tool_events:
-                    return self._pending_tool_events.pop(0)
+                    return self._pending_tool_events.popleft()
                 try:
                     chunk = self.litellm_custom_stream_wrapper.__next__()
                     self._ensure_output_item_for_chunk(chunk)
                     # Emit any just-queued output_item event
                     if self._pending_response_events:
-                        return self._pending_response_events.pop(0)
+                        return self._pending_response_events.popleft()
                     self.collected_chat_completion_chunks.append(
                         self._snapshot_chunk_for_stream_chunk_builder(
                             cast(ModelResponseStream, chunk)
@@ -966,24 +968,20 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             annotations = chunk.choices[0].delta.annotations
             if annotations and self.sent_annotation_events is False:
                 self.sent_annotation_events = True
-                # Store annotation events to emit them one by one
-                if not hasattr(self, '_pending_annotation_events'):
-                    
-                    response_annotations = LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
-                        annotations=annotations
-                    )                    
-                    self._pending_annotation_events = []
-                    for idx, annotation in enumerate(response_annotations):
-                        annotation_dict = annotation.model_dump() if hasattr(annotation, 'model_dump') else dict(annotation)
-                        event = OutputTextAnnotationAddedEvent(
-                            type=ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED,
-                            item_id=item_id,
-                            output_index=0,
-                            content_index=0,
-                            annotation_index=idx,
-                            annotation=annotation_dict,
-                        )
-                        self._pending_annotation_events.append(event)        
+                response_annotations = LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
+                    annotations=annotations
+                )
+                for idx, annotation in enumerate(response_annotations):
+                    annotation_dict = annotation.model_dump() if hasattr(annotation, 'model_dump') else dict(annotation)
+                    annotation_event = OutputTextAnnotationAddedEvent(
+                        type=ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED,
+                        item_id=item_id,
+                        output_index=0,
+                        content_index=0,
+                        annotation_index=idx,
+                        annotation=annotation_dict,
+                    )
+                    self._pending_annotation_events.append(annotation_event)
         # Priority 1: Handle reasoning content (highest priority)
         if (
             chunk.choices
@@ -1023,17 +1021,17 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             self._queue_tool_call_delta_events(chunk.choices[0].delta.tool_calls)
             # Return one pending tool event at a time
             if self._pending_tool_events:
-                return self._pending_tool_events.pop(0)
+                return self._pending_tool_events.popleft()
         
         # Priority 4: If we have pending annotation events, emit the next one
         # This happens when the current chunk has no text/reasoning content
-        if hasattr(self, '_pending_annotation_events') and self._pending_annotation_events:
-            event = self._pending_annotation_events.pop(0)
-            return event
+        if self._pending_annotation_events:
+            pending_annotation_event = self._pending_annotation_events.popleft()
+            return pending_annotation_event
 
         # Priority 5: If we have pending tool events (from earlier chunk), emit the next one
         if self._pending_tool_events:
-            return self._pending_tool_events.pop(0)
+            return self._pending_tool_events.popleft()
 
         return None
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
@@ -257,7 +257,7 @@ def test_tool_call_delta_without_id_uses_index_mapping():
 
     all_events = []
     while iterator._pending_tool_events:
-        all_events.append(iterator._pending_tool_events.pop(0))
+        all_events.append(iterator._pending_tool_events.popleft())
 
     delta_events = [
         evt
@@ -310,7 +310,7 @@ def test_parallel_tool_calls_without_ids_use_index_mapping():
 
     all_events = []
     while iterator._pending_tool_events:
-        all_events.append(iterator._pending_tool_events.pop(0))
+        all_events.append(iterator._pending_tool_events.popleft())
 
     output_item_added_events = [
         evt
@@ -374,7 +374,7 @@ def test_reused_index_with_new_call_id_marks_fallback_ambiguous():
 
     all_events = []
     while iterator._pending_tool_events:
-        all_events.append(iterator._pending_tool_events.pop(0))
+        all_events.append(iterator._pending_tool_events.popleft())
 
     delta_events = [
         evt
@@ -390,3 +390,57 @@ def test_reused_index_with_new_call_id_marks_fallback_ambiguous():
     assert arguments_by_call_id["call_b"] == '{"b":'
     assert arguments_by_call_id["call_a"] != '{"a":1}'
     assert arguments_by_call_id["call_b"] != '{"b":1}'
+
+
+def test_pending_response_events_drain_fifo():
+    """Verify _pending_response_events is drained FIFO via the deque-backed path."""
+    from litellm.types.llms.openai import BaseLiteLLMOpenAIResponseObject
+
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=AsyncMock(),
+        request_input="Test input",
+        responses_api_request={},
+    )
+    # Manually enqueue two response events
+    ev1 = BaseLiteLLMOpenAIResponseObject(**{"id": "ev1", "type": "output_item.added"})
+    ev2 = BaseLiteLLMOpenAIResponseObject(**{"id": "ev2", "type": "output_item.added"})
+    iterator._pending_response_events.append(ev1)
+    iterator._pending_response_events.append(ev2)
+
+    # Simulate __anext__ logic: response events should be emitted before tool events
+    first = iterator._pending_response_events.popleft()
+    assert first.id == "ev1", f"Expected ev1 first (FIFO), got {first.id}"
+
+    second = iterator._pending_response_events.popleft()
+    assert second.id == "ev2", f"Expected ev2 second (FIFO), got {second.id}"
+
+    assert len(iterator._pending_response_events) == 0
+
+
+def test_pending_annotation_events_drain_fifo():
+    """Verify _pending_annotation_events is drained FIFO via the deque-backed path."""
+    from litellm.types.llms.openai import BaseLiteLLMOpenAIResponseObject
+
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=AsyncMock(),
+        request_input="Test input",
+        responses_api_request={},
+    )
+    # Manually enqueue annotation events
+    ann1 = BaseLiteLLMOpenAIResponseObject(**{"id": "ann1", "type": "annotation"})
+    ann2 = BaseLiteLLMOpenAIResponseObject(**{"id": "ann2", "type": "annotation"})
+    ann3 = BaseLiteLLMOpenAIResponseObject(**{"id": "ann3", "type": "annotation"})
+    iterator._pending_annotation_events.append(ann1)
+    iterator._pending_annotation_events.append(ann2)
+    iterator._pending_annotation_events.append(ann3)
+
+    # Drain should be FIFO
+    results = []
+    while iterator._pending_annotation_events:
+        results.append(iterator._pending_annotation_events.popleft())
+
+    assert [r.id for r in results] == ["ann1", "ann2", "ann3"], (
+        f"Expected FIFO order, got {[r.id for r in results]}"
+    )


### PR DESCRIPTION
## Summary

Replaces `list` with `collections.deque` for three internal event queues (`_pending_tool_events`, `_pending_response_events`, `_pending_annotation_events`) in `LiteLLMCompletionResponsesIterator`, replacing O(n) `pop(0)` with O(1) `popleft()`.

Supersedes #22344 (rebased on main)