### PR TITLE
Fix typo: funtion to function

### DIFF
--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -295,7 +295,7 @@ class BaseConfig(ABC):
         fake_stream: Optional[bool] = None,
     ) -> Tuple[dict, Optional[bytes]]:
         """
-        Some providers like Bedrock require signing the request. The sign request funtion needs access to `request_data` and `complete_url`
+        Some providers like Bedrock require signing the request. The sign request function needs access to `request_data` and `complete_url`
         Args:
             headers: dict
             optional_params: dict

--- a/litellm/llms/base_llm/passthrough/transformation.py
+++ b/litellm/llms/base_llm/passthrough/transformation.py
@@ -79,7 +79,7 @@ class BasePassthroughConfig(BaseLLMModelInfo):
         model: Optional[str] = None,
     ) -> Tuple[dict, Optional[bytes]]:
         """
-        Some providers like Bedrock require signing the request. The sign request funtion needs access to `request_data` and `complete_url`
+        Some providers like Bedrock require signing the request. The sign request function needs access to `request_data` and `complete_url`
         Args:
             headers: dict
             optional_params: dict


### PR DESCRIPTION
Fixes typo in code comments where 'funtion' should be 'function'. This affects two files in the transformation modules where the sign request function is described.