### PR TITLE
refactor(featherless_ai): rename FEATHERLESS_API_KEY to FEATHERLESS_AI_API_KEY for consistency

### DIFF
--- a/litellm/llms/featherless_ai/chat/transformation.py
+++ b/litellm/llms/featherless_ai/chat/transformation.py
@@ -106,7 +106,7 @@ class FeatherlessAIConfig(OpenAIGPTConfig):
             or get_secret_str("FEATHERLESS_API_BASE")
             or "https://api.featherless.ai/v1"
         )
-        dynamic_api_key = api_key or get_secret_str("FEATHERLESS_API_KEY")
+        dynamic_api_key = api_key or get_secret_str("FEATHERLESS_AI_API_KEY")
         return api_base, dynamic_api_key
 
     def validate_environment(

--- a/litellm/llms/featherless_ai/chat/transformation.py
+++ b/litellm/llms/featherless_ai/chat/transformation.py
@@ -120,7 +120,7 @@ class FeatherlessAIConfig(OpenAIGPTConfig):
         api_base: Optional[str] = None,
     ) -> dict:
         if not api_key:
-            raise ValueError("Missing Featherless AI API Key")
+            raise ValueError("Missing Featherless AI API Key - set the FEATHERLESS_AI_API_KEY environment variable")
 
         headers["Authorization"] = f"Bearer {api_key}"
         headers["Content-Type"] = "application/json"

--- a/tests/test_litellm/llms/featherless_ai/chat/test_featherless_chat_transformation.py
+++ b/tests/test_litellm/llms/featherless_ai/chat/test_featherless_chat_transformation.py
@@ -149,6 +149,45 @@ class TestFeatherlessAIConfig:
             )
         assert "Featherless AI doesn't support tools=" in str(excinfo.value)
 
+    def test_get_openai_compatible_provider_info_with_new_key(self):
+        """
+        Tests that _get_openai_compatible_provider_info correctly 
+        looks up the NEW environment variable 'FEATHERLESS_AI_API_KEY'.
+        """
+        config = FeatherlessAIConfig()
+        fake_key = "sk-featherless-12345"
+        
+        # We mock 'get_secret_str' and check if it's called with the new key name
+        with patch("litellm.llms.featherless_ai.chat.transformation.get_secret_str") as mock_get_secret:
+            mock_get_secret.return_value = fake_key
+            
+            api_base, api_key = config._get_openai_compatible_provider_info(
+                api_base=None, 
+                api_key=None
+            )
+            
+            # Verify the function tried to fetch the NEW key name
+            mock_get_secret.assert_any_call("FEATHERLESS_AI_API_KEY")
+            assert api_key == fake_key
+
+    def test_validate_environment_error_message(self):
+        """
+        Optional: Verify the error message prompts for the correct key 
+        if you updated the ValueError in transformation.py
+        """
+        config = FeatherlessAIConfig()
+        with pytest.raises(ValueError) as excinfo:
+            config.validate_environment(
+                headers={},
+                model="featherless-ai/Qwerky-72B",
+                messages=[],
+                optional_params={},
+                litellm_params={},
+                api_key=None
+            )
+        # This ensures the user is guided to the right environment variable
+        assert "FEATHERLESS_AI_API_KEY" in str(excinfo.value)
+
     def test_default_api_base(self):
         """Test that default API base is used when none is provided"""
         config = FeatherlessAIConfig()


### PR DESCRIPTION
Changed the environment variable key from "FEATHERLESS_API_KEY" to "FEATHERLESS_AI_API_KEY" for consistency and clarity in the FeatherlessAIConfig class.

## Relevant issues

<!-- e.g. "Fixes #22490 -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🧹 Refactoring

## Changes


Configuration: Changed default API key environment variable from FEATHERLESS_API_KEY to FEATHERLESS_AI_API_KEY.
Tests:
Added test_get_openai_compatible_provider_info_with_new_key to verify the logic correctly retrieves the new key.
Updated test_validate_environment_error_message to ensure the error output is user-friendly.
Tests:
Added test_get_openai_compatible_provider_info_with_new_key to verify the logic correctly retrieves the new key.
Updated test_validate_environment_error_message to ensure the error output is user-friendly.

## Closes #22490 