### PR TITLE
fix(responses-bridge): inject reasoning summary when auto_summary enabled without explicit effort

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -250,6 +250,17 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             elif key == "web_search_options":
                 self._add_web_search_tool(responses_api_request, value)
 
+        # When reasoning_auto_summary is enabled but no reasoning_effort was
+        # provided, inject reasoning={summary: "detailed"} so that OpenAI
+        # returns reasoning summaries even without explicit effort config.
+        if "reasoning" not in responses_api_request:
+            auto_summary_enabled = (
+                litellm.reasoning_auto_summary
+                or os.getenv("LITELLM_REASONING_AUTO_SUMMARY", "false").lower() == "true"
+            )
+            if auto_summary_enabled:
+                responses_api_request["reasoning"] = Reasoning(summary="detailed")  # type: ignore
+
     def _build_sanitized_litellm_params(
         self, litellm_params: dict
     ) -> Dict[str, Any]:

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1778,3 +1778,82 @@ def test_parallel_tool_calls_comprehensive_streaming_integration():
     )
 
     print("✓ Parallel tool calls with split argument deltas stream correctly end-to-end")
+
+def test_reasoning_auto_summary_injected_without_reasoning_effort():
+    """
+    When reasoning_auto_summary is enabled but no reasoning_effort is passed,
+    reasoning={summary: "detailed"} should be injected into the Responses API
+    request so OpenAI returns reasoning summaries by default.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/13419
+    """
+    import litellm
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+    from litellm.types.llms.openai import ResponsesAPIOptionalRequestParams
+
+    handler = LiteLLMResponsesTransformationHandler()
+    original_flag = litellm.reasoning_auto_summary
+    original_env = os.environ.get("LITELLM_REASONING_AUTO_SUMMARY")
+
+    try:
+        # Clear env var to prevent it overriding the flag
+        if "LITELLM_REASONING_AUTO_SUMMARY" in os.environ:
+            del os.environ["LITELLM_REASONING_AUTO_SUMMARY"]
+
+        # --- Case 1: auto_summary OFF, no reasoning_effort → no reasoning injected ---
+        litellm.reasoning_auto_summary = False
+        req1 = ResponsesAPIOptionalRequestParams()
+        handler._map_optional_params_to_responses_api_request(
+            optional_params={"max_completion_tokens": 4096},
+            responses_api_request=req1,
+        )
+        assert "reasoning" not in req1, (
+            "reasoning should NOT be injected when auto_summary is off"
+        )
+        print("✓ No reasoning injected when auto_summary is off and no reasoning_effort passed")
+
+        # --- Case 2: auto_summary ON, no reasoning_effort → reasoning injected ---
+        litellm.reasoning_auto_summary = True
+        req2 = ResponsesAPIOptionalRequestParams()
+        handler._map_optional_params_to_responses_api_request(
+            optional_params={"max_completion_tokens": 4096},
+            responses_api_request=req2,
+        )
+        assert "reasoning" in req2, (
+            "reasoning should be injected when auto_summary is on"
+        )
+        reasoning = req2["reasoning"]
+        assert reasoning.get("summary") == "detailed", (
+            f"Expected summary='detailed', got {reasoning.get('summary')}"
+        )
+        # effort should NOT be set — let the model use its default
+        assert reasoning.get("effort") is None, (
+            f"effort should not be set when no reasoning_effort passed, got {reasoning.get('effort')}"
+        )
+        print("✓ reasoning={summary: 'detailed'} injected when auto_summary is on")
+
+        # --- Case 3: auto_summary ON + explicit reasoning_effort → no double injection ---
+        litellm.reasoning_auto_summary = True
+        req3 = ResponsesAPIOptionalRequestParams()
+        handler._map_optional_params_to_responses_api_request(
+            optional_params={"reasoning_effort": "high"},
+            responses_api_request=req3,
+        )
+        reasoning3 = req3["reasoning"]
+        assert reasoning3.get("effort") == "high", (
+            f"Expected effort='high', got {reasoning3.get('effort')}"
+        )
+        assert reasoning3.get("summary") == "detailed", (
+            f"Expected summary='detailed', got {reasoning3.get('summary')}"
+        )
+        print("✓ Explicit reasoning_effort preserved with auto_summary, no double injection")
+
+        print("✓ All reasoning_auto_summary injection tests passed")
+    finally:
+        litellm.reasoning_auto_summary = original_flag
+        if original_env is not None:
+            os.environ["LITELLM_REASONING_AUTO_SUMMARY"] = original_env
+        elif "LITELLM_REASONING_AUTO_SUMMARY" in os.environ:
+            del os.environ["LITELLM_REASONING_AUTO_SUMMARY"]


### PR DESCRIPTION
## Summary

Fixes #13419

When `reasoning_auto_summary: true` is configured (or `LITELLM_REASONING_AUTO_SUMMARY=true` env var) but no `reasoning_effort` is passed in the Chat Completions request, the Responses API request was sent **without** a `reasoning` parameter. OpenAI defaults to no reasoning summaries, so users on OpenWebUI and other Chat Completions clients never received thinking/reasoning output from GPT-5 and o-series models.

### Root Cause

The `reasoning` parameter was only injected when `reasoning_effort` was explicitly in `optional_params` (line 248-249). If a user sends a plain message to GPT-5 without specifying effort, `_map_reasoning_effort` was never called and no summary was requested.

### Fix

After the parameter mapping loop in `_map_optional_params_to_responses_api_request`, check:
1. If `reasoning` is NOT already in the request
2. If `reasoning_auto_summary` is enabled (flag or env var)

If both conditions are true, inject `reasoning={summary: "detailed"}` — without setting `effort`, so the model uses its default.

### Test

Added `test_reasoning_auto_summary_injected_without_reasoning_effort` covering:
- Auto-summary OFF + no effort → no reasoning injected ✅
- Auto-summary ON + no effort → `reasoning={summary: "detailed"}` injected ✅
- Auto-summary ON + explicit effort → no double injection, effort preserved ✅

All 22 existing tests continue to pass.