### PR TITLE
fix(cost): fix Vercel AI Gateway cost tracking returning $0

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2109,6 +2109,11 @@ _STREAMING_CALL_TYPES = frozenset(
     }
 )
 
+# Providers that use a gateway/<sub-provider>/<model> naming scheme.
+# Used by get_model_info() to try stripping the sub-provider prefix when
+# the full key is not found in model_cost.
+_GATEWAY_PROVIDERS = frozenset({"vercel_ai_gateway"})
+
 
 def _is_streaming_request(
     kwargs: Dict[str, Any],
@@ -5331,6 +5336,10 @@ def _check_provider_match(model_info: dict, custom_llm_provider: Optional[str]) 
         elif custom_llm_provider == "github":
             # Allow github/<model> aliases to reuse existing provider metadata.
             return True
+        elif custom_llm_provider == "vercel_ai_gateway":
+            # Allow vercel_ai_gateway to fall back to sub-provider pricing
+            # e.g. vercel_ai_gateway/openai/gpt-4.1 can use gpt-4.1's pricing
+            return True
         else:
             return False
 
@@ -5583,6 +5592,21 @@ def _get_model_info_helper(  # noqa: PLR0915
                     _model_info = _get_model_info_from_model_cost(key=cast(str, key))
                     if not _check_provider_match(
                         model_info=_model_info, custom_llm_provider=custom_llm_provider
+                    ):
+                        _model_info = None
+            # For gateway providers (e.g. vercel_ai_gateway/openai/gpt-4.1),
+            # split_model is "openai/gpt-4.1" — try the base model name "gpt-4.1"
+            if _model_info is None and custom_llm_provider in _GATEWAY_PROVIDERS and "/" in split_model:
+                _base_model = split_model.rsplit("/", 1)[-1]
+                _matched_key = _get_model_cost_key(_base_model)
+                if _matched_key is not None:
+                    key = _matched_key
+                    _model_info = _get_model_info_from_model_cost(
+                        key=cast(str, key)
+                    )
+                    if not _check_provider_match(
+                        model_info=_model_info,
+                        custom_llm_provider=custom_llm_provider,
                     ):
                         _model_info = None
 

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -31328,7 +31328,9 @@
         "supports_vision": true,
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "output_cost_per_reasoning_token": 2.5e-06
     },
     "vercel_ai_gateway/google/gemini-2.5-pro": {
         "input_cost_per_token": 2.5e-06,
@@ -31341,7 +31343,8 @@
         "supports_vision": true,
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_reasoning": true
     },
     "vercel_ai_gateway/google/gemini-embedding-001": {
         "input_cost_per_token": 1.5e-07,

--- a/tests/test_litellm/llms/vercel_ai_gateway/test_vercel_ai_gateway.py
+++ b/tests/test_litellm/llms/vercel_ai_gateway/test_vercel_ai_gateway.py
@@ -2,6 +2,7 @@
 Mock tests for vercel_ai_gateway provider
 """
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -231,17 +232,118 @@ def test_vercel_ai_gateway_models_endpoint_failure():
 def test_vercel_ai_gateway_glm46_cost_math():
     """Test the cost math for glm-4.6"""
 
-    with open("model_prices_and_context_window.json", "r") as f:
+    _repo_root = Path(__file__).resolve().parents[4]
+    _json_path = _repo_root / "model_prices_and_context_window.json"
+    original_cost = litellm.model_cost.copy()
+    with open(_json_path, "r") as f:
         litellm.model_cost = json.load(f)
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+    _invalidate_model_cost_lowercase_map()
 
-    key = "vercel_ai_gateway/zai/glm-4.6"
-    info = litellm.model_cost[key]
+    try:
+        key = "vercel_ai_gateway/zai/glm-4.6"
+        info = litellm.model_cost[key]
 
-    prompt_cost, completion_cost = cost_per_token(
-        model="vercel_ai_gateway/zai/glm-4.6",
-        prompt_tokens=1000,
-        completion_tokens=500,
-    )
+        prompt_cost, completion_cost = cost_per_token(
+            model="vercel_ai_gateway/zai/glm-4.6",
+            prompt_tokens=1000,
+            completion_tokens=500,
+        )
 
-    assert math.isclose(prompt_cost, 1000 * info["input_cost_per_token"], rel_tol=1e-12)
-    assert math.isclose(completion_cost, 500 * info["output_cost_per_token"], rel_tol=1e-12)
+        assert math.isclose(prompt_cost, 1000 * info["input_cost_per_token"], rel_tol=1e-12)
+        assert math.isclose(completion_cost, 500 * info["output_cost_per_token"], rel_tol=1e-12)
+    finally:
+        litellm.model_cost = original_cost
+        _invalidate_model_cost_lowercase_map()
+
+
+@pytest.fixture(autouse=False)
+def reload_model_cost():
+    """Reload model cost from JSON to pick up any updates, then restore the original."""
+    _repo_root = Path(__file__).resolve().parents[4]
+    _json_path = _repo_root / "model_prices_and_context_window.json"
+
+    original_model_cost = litellm.model_cost.copy()
+    with open(_json_path, "r") as f:
+        litellm.model_cost = json.load(f)
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+    _invalidate_model_cost_lowercase_map()
+    yield
+    litellm.model_cost = original_model_cost
+    _invalidate_model_cost_lowercase_map()
+
+
+class TestVercelCostTracking:
+    """Tests for Vercel AI Gateway cost tracking — addresses GitHub issue #20412."""
+
+    def test_cost_for_model_in_json(self, reload_model_cost):
+        """Cost calculation works for Vercel models that exist in the pricing JSON."""
+        prompt_cost, completion_cost = cost_per_token(
+            model="vercel_ai_gateway/anthropic/claude-opus-4.5",
+            prompt_tokens=1000,
+            completion_tokens=500,
+        )
+        assert prompt_cost > 0, "Prompt cost must be non-zero"
+        assert completion_cost > 0, "Completion cost must be non-zero"
+
+    def test_cost_fallback_for_unlisted_model(self, reload_model_cost):
+        """When a Vercel model is NOT in the JSON, fall back to the sub-provider pricing."""
+        # Remove a vercel entry temporarily to simulate a missing model
+        saved = litellm.model_cost.pop("vercel_ai_gateway/openai/gpt-4o", None)
+        from litellm.utils import _invalidate_model_cost_lowercase_map
+        _invalidate_model_cost_lowercase_map()
+        try:
+            prompt_cost, completion_cost = cost_per_token(
+                model="vercel_ai_gateway/openai/gpt-4o",
+                prompt_tokens=1000,
+                completion_tokens=500,
+            )
+            assert prompt_cost > 0, "Fallback pricing must produce non-zero prompt cost"
+            assert completion_cost > 0, "Fallback pricing must produce non-zero completion cost"
+        finally:
+            if saved is not None:
+                litellm.model_cost["vercel_ai_gateway/openai/gpt-4o"] = saved
+                _invalidate_model_cost_lowercase_map()
+
+    def test_gemini_supports_reasoning(self, reload_model_cost):
+        """Vercel Gemini 2.5 models must have supports_reasoning=True."""
+        for model_key in [
+            "vercel_ai_gateway/google/gemini-2.5-pro",
+            "vercel_ai_gateway/google/gemini-2.5-flash",
+        ]:
+            assert model_key in litellm.model_cost
+            assert litellm.model_cost[model_key].get("supports_reasoning") is True, (
+                f"{model_key} must have supports_reasoning=True"
+            )
+
+    def test_gemini_flash_reasoning_token_cost(self, reload_model_cost):
+        """Vercel Gemini 2.5 Flash must have output_cost_per_reasoning_token set."""
+        flash = litellm.model_cost["vercel_ai_gateway/google/gemini-2.5-flash"]
+        assert flash.get("output_cost_per_reasoning_token") is not None
+        assert flash["output_cost_per_reasoning_token"] > 0
+
+    def test_provider_match_allows_vercel_fallback(self):
+        """_check_provider_match must accept vercel_ai_gateway matching any sub-provider."""
+        from litellm.utils import _check_provider_match
+
+        # Simulate a model_info from OpenAI
+        model_info = {"litellm_provider": "openai"}
+        assert _check_provider_match(model_info=model_info, custom_llm_provider="vercel_ai_gateway")
+
+        # Simulate a model_info from Anthropic
+        model_info = {"litellm_provider": "anthropic"}
+        assert _check_provider_match(model_info=model_info, custom_llm_provider="vercel_ai_gateway")
+
+    def test_cost_per_token_multiple_providers(self, reload_model_cost):
+        """Cost calculation produces non-zero values for multiple Vercel sub-providers."""
+        models = [
+            "vercel_ai_gateway/anthropic/claude-opus-4.5",
+            "vercel_ai_gateway/openai/gpt-4o",
+            "vercel_ai_gateway/google/gemini-2.5-pro",
+        ]
+        for model in models:
+            prompt_cost, completion_cost = cost_per_token(
+                model=model, prompt_tokens=1000, completion_tokens=500,
+            )
+            assert prompt_cost > 0, f"{model}: prompt cost must be non-zero"
+            assert completion_cost > 0, f"{model}: completion cost must be non-zero"


### PR DESCRIPTION
## Summary

Fixes #20412 — Vercel AI Gateway models return $0 for cost tracking.

### Root Cause

When a Vercel AI Gateway model is **not** in `model_prices_and_context_window.json`, the fallback to the sub-provider's pricing fails because:

1. **Provider match rejection**: `_check_provider_match()` rejects the fallback because the matched model's `litellm_provider` (e.g. `openai`) ≠ `vercel_ai_gateway`
2. **Incomplete model name stripping**: For gateway models like `vercel_ai_gateway/openai/gpt-4.1`, the lookup tries `openai/gpt-4.1` but never tries just `gpt-4.1` (which exists in the pricing JSON)

Additionally, Vercel Gemini 2.5 models were missing `supports_reasoning: true`, causing reasoning tokens to not be properly tracked.

### Changes

**`litellm/utils.py`** (code fix):
- Add `vercel_ai_gateway` to `_check_provider_match()` exception list (same pattern as `github` provider) — allows fallback to sub-provider pricing
- Add a deeper model name lookup in `_get_model_info_helper()` that strips the sub-provider prefix (e.g. `openai/gpt-4.1` → `gpt-4.1`) for models with nested paths

**`model_prices_and_context_window.json`** (data fix):
- Add `supports_reasoning: true` to `vercel_ai_gateway/google/gemini-2.5-pro` and `gemini-2.5-flash`
- Add `output_cost_per_reasoning_token` to `vercel_ai_gateway/google/gemini-2.5-flash`

**`tests/test_litellm/llms/vercel_ai_gateway/test_vercel_ai_gateway.py`** (tests):
- 6 new tests covering cost calculation, fallback pricing, reasoning flags, and provider match behavior

### Testing

All 17 Vercel tests pass (11 existing + 6 new), plus 24 model cost map resilience tests pass with zero regressions.