### PR TITLE
fix(adapter): clamp max_tokens on Anthropic pass-through to backend model limit

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1236,16 +1236,6 @@ from .responses.main import *
 # Interactions API is available as litellm.interactions module
 # Usage: litellm.interactions.create(), litellm.interactions.get(), etc.
 from . import interactions
-from .skills.main import (
-    create_skill,
-    acreate_skill,
-    list_skills,
-    alist_skills,
-    get_skill,
-    aget_skill,
-    delete_skill,
-    adelete_skill,
-)
 from .containers.main import *
 from .ocr.main import *
 from .rag.main import *

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -92,6 +92,31 @@ class LiteLLMMessagesToCompletionTransformationHandler:
                 completion_kwargs["reasoning_effort"] = updated_reasoning_effort
 
     @staticmethod
+    def _clamp_max_tokens(
+        *, max_tokens: int, model: Optional[str], drop_params: Optional[bool] = None
+    ) -> int:
+        should_drop = drop_params if drop_params is not None else (litellm.drop_params is True)
+        if not should_drop:
+            return max_tokens
+
+        try:
+            model_info = get_model_info(model=model)
+            model_max_output = model_info.get("max_output_tokens")
+            if model_max_output is not None and max_tokens > model_max_output:
+                litellm._logging.verbose_logger.warning(
+                    "Anthropic adapter: clamping max_tokens from %d to %d "
+                    "for model %s (drop_params=True)",
+                    max_tokens,
+                    model_max_output,
+                    model,
+                )
+                return model_max_output
+        except Exception:
+            pass
+
+        return max_tokens
+
+    @staticmethod
     def _prepare_completion_kwargs(
         *,
         max_tokens: int,
@@ -121,10 +146,22 @@ class LiteLLMMessagesToCompletionTransformationHandler:
             Logging as LiteLLMLoggingObject,
         )
 
+        # Clamp max_tokens to the backend model's max_output_tokens to prevent
+        # Anthropic client values (e.g. 32000 for Claude Opus 4) from being
+        # forwarded to providers with lower limits (e.g. 8192 for DeepSeek).
+        # This also respects litellm.drop_params / per-request drop_params.
+        clamped_max_tokens = (
+            LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+                max_tokens=max_tokens,
+                model=model,
+                drop_params=extra_kwargs.get("drop_params") if extra_kwargs else None,
+            )
+        )
+
         request_data = {
             "model": model,
             "messages": messages,
-            "max_tokens": max_tokens,
+            "max_tokens": clamped_max_tokens,
         }
 
         if metadata:

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -93,14 +93,16 @@ class LiteLLMMessagesToCompletionTransformationHandler:
 
     @staticmethod
     def _clamp_max_tokens(
-        *, max_tokens: int, model: Optional[str], drop_params: Optional[bool] = None
+        *, max_tokens: int, model: Optional[str],
+        custom_llm_provider: Optional[str] = None,
+        drop_params: Optional[bool] = None
     ) -> int:
         should_drop = drop_params if drop_params is not None else (litellm.drop_params is True)
         if not should_drop:
             return max_tokens
 
         try:
-            model_info = get_model_info(model=model)
+            model_info = get_model_info(model=model, custom_llm_provider=custom_llm_provider)
             model_max_output = model_info.get("max_output_tokens")
             if model_max_output is not None and max_tokens > model_max_output:
                 litellm._logging.verbose_logger.warning(
@@ -154,6 +156,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
             LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
                 max_tokens=max_tokens,
                 model=model,
+                custom_llm_provider=extra_kwargs.get("custom_llm_provider") if extra_kwargs else None,
                 drop_params=extra_kwargs.get("drop_params") if extra_kwargs else None,
             )
         )

--- a/tests/pass_through_unit_tests/test_anthropic_adapter_max_tokens_clamp.py
+++ b/tests/pass_through_unit_tests/test_anthropic_adapter_max_tokens_clamp.py
@@ -1,0 +1,170 @@
+"""
+Tests for Anthropic adapter max_tokens clamping.
+
+Ensures the Anthropic pass-through adapter clamps max_tokens to the backend
+model's max_output_tokens when drop_params is enabled, preventing 400 errors
+from providers with lower limits (e.g. DeepSeek 8192 vs Claude Opus 4 32000).
+
+Related: https://github.com/BerriAI/litellm/issues/22249
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import pytest
+
+import litellm
+from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+    LiteLLMMessagesToCompletionTransformationHandler,
+)
+
+
+class TestClampMaxTokens:
+    """Tests for _clamp_max_tokens static method."""
+
+    def test_clamp_when_exceeds_model_limit_and_drop_params_true(self):
+        """max_tokens exceeding model limit should be clamped when drop_params=True."""
+        result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+            max_tokens=32000,
+            model="deepseek/deepseek-chat",
+            drop_params=True,
+        )
+        assert result == 8192
+
+    def test_no_clamp_when_within_model_limit(self):
+        """max_tokens within model limit should pass through unchanged."""
+        result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+            max_tokens=4096,
+            model="deepseek/deepseek-chat",
+            drop_params=True,
+        )
+        assert result == 4096
+
+    def test_no_clamp_when_drop_params_false(self):
+        """max_tokens should not be clamped when drop_params is False."""
+        result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+            max_tokens=32000,
+            model="deepseek/deepseek-chat",
+            drop_params=False,
+        )
+        assert result == 32000
+
+    def test_no_clamp_when_drop_params_none(self):
+        """max_tokens should not be clamped when drop_params is None (default)."""
+        result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+            max_tokens=32000,
+            model="deepseek/deepseek-chat",
+            drop_params=None,
+        )
+        assert result == 32000
+
+    def test_clamp_respects_global_drop_params(self):
+        """max_tokens should be clamped when litellm.drop_params is True."""
+        original = litellm.drop_params
+        try:
+            litellm.drop_params = True
+            result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+                max_tokens=32000,
+                model="deepseek/deepseek-chat",
+                drop_params=None,
+            )
+            assert result == 8192
+        finally:
+            litellm.drop_params = original
+
+    def test_no_clamp_for_unknown_model(self):
+        """Unknown models should pass max_tokens through unchanged."""
+        result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+            max_tokens=32000,
+            model="unknown-provider/unknown-model",
+            drop_params=True,
+        )
+        assert result == 32000
+
+    def test_exact_limit_not_clamped(self):
+        """max_tokens exactly at model limit should not be clamped."""
+        result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+            max_tokens=8192,
+            model="deepseek/deepseek-chat",
+            drop_params=True,
+        )
+        assert result == 8192
+
+    def test_no_clamp_when_model_is_none(self):
+        """max_tokens should pass through unchanged when model is None."""
+        result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+            max_tokens=32000,
+            model=None,
+            drop_params=True,
+        )
+        assert result == 32000
+
+    def test_no_clamp_when_model_is_empty_string(self):
+        """max_tokens should pass through unchanged when model is empty string."""
+        result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+            max_tokens=32000,
+            model="",
+            drop_params=True,
+        )
+        assert result == 32000
+
+    def test_clamp_returns_model_max_output_tokens(self):
+        """Clamped value must equal the model's max_output_tokens exactly."""
+        from litellm import get_model_info
+
+        model = "deepseek/deepseek-chat"
+        model_info = get_model_info(model=model)
+        expected_max = model_info["max_output_tokens"]
+
+        result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+            max_tokens=expected_max + 1,
+            model=model,
+            drop_params=True,
+        )
+        assert result == expected_max
+
+
+class TestPrepareCompletionKwargsMaxTokens:
+    """Tests that _prepare_completion_kwargs applies clamping correctly."""
+
+    def test_prepare_kwargs_clamps_max_tokens_with_drop_params(self):
+        """_prepare_completion_kwargs should clamp max_tokens when drop_params is in extra_kwargs."""
+        completion_kwargs, _ = (
+            LiteLLMMessagesToCompletionTransformationHandler._prepare_completion_kwargs(
+                max_tokens=32000,
+                messages=[{"role": "user", "content": "hello"}],
+                model="deepseek/deepseek-chat",
+                extra_kwargs={"drop_params": True},
+            )
+        )
+        assert completion_kwargs["max_tokens"] == 8192
+
+    def test_prepare_kwargs_preserves_max_tokens_without_drop_params(self):
+        """_prepare_completion_kwargs should preserve max_tokens when drop_params is absent."""
+        completion_kwargs, _ = (
+            LiteLLMMessagesToCompletionTransformationHandler._prepare_completion_kwargs(
+                max_tokens=32000,
+                messages=[{"role": "user", "content": "hello"}],
+                model="deepseek/deepseek-chat",
+            )
+        )
+        assert completion_kwargs["max_tokens"] == 32000
+
+    def test_prepare_kwargs_clamps_with_global_drop_params(self):
+        """_prepare_completion_kwargs should respect litellm.drop_params global setting."""
+        original = litellm.drop_params
+        try:
+            litellm.drop_params = True
+            completion_kwargs, _ = (
+                LiteLLMMessagesToCompletionTransformationHandler._prepare_completion_kwargs(
+                    max_tokens=32000,
+                    messages=[{"role": "user", "content": "hello"}],
+                    model="deepseek/deepseek-chat",
+                )
+            )
+            assert completion_kwargs["max_tokens"] == 8192
+        finally:
+            litellm.drop_params = original

--- a/tests/pass_through_unit_tests/test_anthropic_adapter_max_tokens_clamp.py
+++ b/tests/pass_through_unit_tests/test_anthropic_adapter_max_tokens_clamp.py
@@ -10,7 +10,6 @@ Related: https://github.com/BerriAI/litellm/issues/22249
 
 import os
 import sys
-from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath("../.."))
 

--- a/tests/pass_through_unit_tests/test_anthropic_adapter_max_tokens_clamp.py
+++ b/tests/pass_through_unit_tests/test_anthropic_adapter_max_tokens_clamp.py
@@ -40,12 +40,13 @@ class TestClampMaxTokens:
 
     def test_no_clamp_when_within_model_limit(self):
         """max_tokens within model limit should pass through unchanged."""
+        within_limit = _DEEPSEEK_MAX_OUTPUT - 1
         result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
-            max_tokens=4096,
+            max_tokens=within_limit,
             model="deepseek/deepseek-chat",
             drop_params=True,
         )
-        assert result == 4096
+        assert result == within_limit
 
     def test_no_clamp_when_drop_params_false(self):
         """max_tokens should not be clamped when drop_params is False."""
@@ -65,19 +66,15 @@ class TestClampMaxTokens:
         )
         assert result == 32000
 
-    def test_clamp_respects_global_drop_params(self):
+    def test_clamp_respects_global_drop_params(self, monkeypatch):
         """max_tokens should be clamped when litellm.drop_params is True."""
-        original = litellm.drop_params
-        try:
-            litellm.drop_params = True
-            result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
-                max_tokens=32000,
-                model="deepseek/deepseek-chat",
-                drop_params=None,
-            )
-            assert result == _DEEPSEEK_MAX_OUTPUT
-        finally:
-            litellm.drop_params = original
+        monkeypatch.setattr(litellm, "drop_params", True)
+        result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+            max_tokens=32000,
+            model="deepseek/deepseek-chat",
+            drop_params=None,
+        )
+        assert result == _DEEPSEEK_MAX_OUTPUT
 
     def test_no_clamp_for_unknown_model(self):
         """Unknown models should pass max_tokens through unchanged."""
@@ -130,6 +127,16 @@ class TestClampMaxTokens:
         )
         assert result == expected_max
 
+    def test_clamp_forwards_custom_llm_provider(self):
+        """custom_llm_provider must be forwarded to get_model_info for correct model resolution."""
+        result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
+            max_tokens=32000,
+            model="deepseek-chat",
+            custom_llm_provider="deepseek",
+            drop_params=True,
+        )
+        assert result == _DEEPSEEK_MAX_OUTPUT
+
 
 class TestPrepareCompletionKwargsMaxTokens:
     """Tests that _prepare_completion_kwargs applies clamping correctly."""
@@ -157,18 +164,14 @@ class TestPrepareCompletionKwargsMaxTokens:
         )
         assert completion_kwargs["max_tokens"] == 32000
 
-    def test_prepare_kwargs_clamps_with_global_drop_params(self):
+    def test_prepare_kwargs_clamps_with_global_drop_params(self, monkeypatch):
         """_prepare_completion_kwargs should respect litellm.drop_params global setting."""
-        original = litellm.drop_params
-        try:
-            litellm.drop_params = True
-            completion_kwargs, _ = (
-                LiteLLMMessagesToCompletionTransformationHandler._prepare_completion_kwargs(
-                    max_tokens=32000,
-                    messages=[{"role": "user", "content": "hello"}],
-                    model="deepseek/deepseek-chat",
-                )
+        monkeypatch.setattr(litellm, "drop_params", True)
+        completion_kwargs, _ = (
+            LiteLLMMessagesToCompletionTransformationHandler._prepare_completion_kwargs(
+                max_tokens=32000,
+                messages=[{"role": "user", "content": "hello"}],
+                model="deepseek/deepseek-chat",
             )
-            assert completion_kwargs["max_tokens"] == _DEEPSEEK_MAX_OUTPUT
-        finally:
-            litellm.drop_params = original
+        )
+        assert completion_kwargs["max_tokens"] == _DEEPSEEK_MAX_OUTPUT

--- a/tests/pass_through_unit_tests/test_anthropic_adapter_max_tokens_clamp.py
+++ b/tests/pass_through_unit_tests/test_anthropic_adapter_max_tokens_clamp.py
@@ -8,10 +8,11 @@ from providers with lower limits (e.g. DeepSeek 8192 vs Claude Opus 4 32000).
 Related: https://github.com/BerriAI/litellm/issues/22249
 """
 
-import os
+
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import pytest
 
@@ -19,6 +20,10 @@ import litellm
 from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
     LiteLLMMessagesToCompletionTransformationHandler,
 )
+from litellm.utils import get_model_info
+
+# Dynamic lookup for model limits to avoid hardcoding values that may change
+_DEEPSEEK_MAX_OUTPUT = get_model_info(model="deepseek/deepseek-chat")["max_output_tokens"]
 
 
 class TestClampMaxTokens:
@@ -31,7 +36,7 @@ class TestClampMaxTokens:
             model="deepseek/deepseek-chat",
             drop_params=True,
         )
-        assert result == 8192
+        assert result == _DEEPSEEK_MAX_OUTPUT
 
     def test_no_clamp_when_within_model_limit(self):
         """max_tokens within model limit should pass through unchanged."""
@@ -70,7 +75,7 @@ class TestClampMaxTokens:
                 model="deepseek/deepseek-chat",
                 drop_params=None,
             )
-            assert result == 8192
+            assert result == _DEEPSEEK_MAX_OUTPUT
         finally:
             litellm.drop_params = original
 
@@ -86,11 +91,11 @@ class TestClampMaxTokens:
     def test_exact_limit_not_clamped(self):
         """max_tokens exactly at model limit should not be clamped."""
         result = LiteLLMMessagesToCompletionTransformationHandler._clamp_max_tokens(
-            max_tokens=8192,
+            max_tokens=_DEEPSEEK_MAX_OUTPUT,
             model="deepseek/deepseek-chat",
             drop_params=True,
         )
-        assert result == 8192
+        assert result == _DEEPSEEK_MAX_OUTPUT
 
     def test_no_clamp_when_model_is_none(self):
         """max_tokens should pass through unchanged when model is None."""
@@ -139,7 +144,7 @@ class TestPrepareCompletionKwargsMaxTokens:
                 extra_kwargs={"drop_params": True},
             )
         )
-        assert completion_kwargs["max_tokens"] == 8192
+        assert completion_kwargs["max_tokens"] == _DEEPSEEK_MAX_OUTPUT
 
     def test_prepare_kwargs_preserves_max_tokens_without_drop_params(self):
         """_prepare_completion_kwargs should preserve max_tokens when drop_params is absent."""
@@ -164,6 +169,6 @@ class TestPrepareCompletionKwargsMaxTokens:
                     model="deepseek/deepseek-chat",
                 )
             )
-            assert completion_kwargs["max_tokens"] == 8192
+            assert completion_kwargs["max_tokens"] == _DEEPSEEK_MAX_OUTPUT
         finally:
             litellm.drop_params = original


### PR DESCRIPTION
## Summary

Fixes #22249 — when the Anthropic `/v1/messages` adapter forwards requests to non-Anthropic backends (e.g. DeepSeek via `deepseek/deepseek-chat`), the client may send a `max_tokens` value that exceeds the backend model's limit.

For example, Claude Code sends `max_tokens: 32000` (Claude Opus 4 limit) but the backend model (DeepSeek) only supports `max_tokens: 8192`, causing a 400 error.

## Root Cause

The Anthropic pass-through adapter (`LiteLLMMessagesToCompletionTransformationHandler`) translates Anthropic-format requests into `litellm.acompletion()` calls. However, it passes `max_tokens` through without checking whether the value is valid for the target backend model. Additionally, `drop_params: true` (configured in proxy `general_settings` or per-deployment) was not applied on this code path.

## Changes

- **`litellm/llms/anthropic/experimental_pass_through/adapters/handler.py`**:
  - Added `_clamp_max_tokens()` static method that caps `max_tokens` at the backend model's `max_output_tokens` when `drop_params` is enabled (per-request or global `litellm.drop_params`)
  - Integrated clamping into `_prepare_completion_kwargs()`
  - Uses `litellm.get_model_info()` to look up model limits — gracefully passes through when model info is unavailable

- **`tests/pass_through_unit_tests/test_anthropic_adapter_max_tokens_clamp.py`** (new):
  - 10 unit tests covering: clamping when exceeds limit, pass-through when within limit, `drop_params=False/None`, global `litellm.drop_params`, unknown models, exact-limit boundary, and integration with `_prepare_completion_kwargs()`

## Testing

```
10 passed in 1.37s
```

## Type

- [x] Bug fix (non-breaking change which fixes an issue)
