### PR TITLE
fix(cost): audio transcription cost always 0 for custom-priced models

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1419,6 +1419,15 @@ class Logging(LiteLLMLoggingBaseClass):
             ):  # use model_id if not already set
                 router_model_id = hidden_params["model_id"]
 
+        # Fallback: extract router_model_id from logging metadata when not
+        # available in _hidden_params (e.g. transcription responses).
+        if router_model_id is None:
+            _metadata = self.model_call_details.get("litellm_params", {}).get("metadata", {}) or {}
+            _mi = _metadata.get("model_info") or {}
+            _mid = _mi.get("id")
+            if _mid is not None and _mid in litellm.model_cost:
+                router_model_id = _mid
+
         ## RESPONSE COST ##
         custom_pricing = use_custom_pricing_for_model(
             litellm_params=(

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -444,6 +444,12 @@ SPECIAL_MODEL_INFO_PARAMS = [
     "output_cost_per_token",
     "input_cost_per_character",
     "output_cost_per_character",
+    "input_cost_per_second",
+    "output_cost_per_second",
+    "input_cost_per_audio_token",
+    "output_cost_per_audio_token",
+    "input_cost_per_audio_per_second",
+    "output_cost_per_audio_per_second",
 ]
 
 

--- a/tests/test_litellm/test_transcription_cost_calculation.py
+++ b/tests/test_litellm/test_transcription_cost_calculation.py
@@ -1,0 +1,334 @@
+"""
+Tests for audio transcription cost calculation with custom pricing.
+
+Verifies that `input_cost_per_second` configured on a deployment is correctly
+propagated and used when calculating the cost of audio transcription calls.
+
+Regression tests for https://github.com/BerriAI/litellm/issues/20228
+"""
+
+import datetime
+import uuid
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.types.router import (
+    Deployment,
+    LiteLLM_Params,
+    SPECIAL_MODEL_INFO_PARAMS,
+)
+from litellm.types.utils import TranscriptionResponse
+
+
+# ---------------------------------------------------------------------------
+# SPECIAL_MODEL_INFO_PARAMS includes per-second pricing
+# ---------------------------------------------------------------------------
+
+
+class TestSpecialModelInfoParams:
+    """SPECIAL_MODEL_INFO_PARAMS must include per-second pricing fields."""
+
+    def test_input_cost_per_second_in_special_params(self):
+        assert "input_cost_per_second" in SPECIAL_MODEL_INFO_PARAMS
+
+    def test_output_cost_per_second_in_special_params(self):
+        assert "output_cost_per_second" in SPECIAL_MODEL_INFO_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# Deployment.__init__ copies per-second pricing to model_info
+# ---------------------------------------------------------------------------
+
+
+class TestDeploymentCopiesPerSecondPricing:
+    """Deployment.__init__ must copy input_cost_per_second to model_info."""
+
+    def test_input_cost_per_second_copied_to_model_info(self):
+        deployment = Deployment(
+            model_name="whisper",
+            litellm_params=LiteLLM_Params(
+                model="hosted_vllm/whisper-large-v3-turbo",
+                input_cost_per_second=0.006,
+            ),
+        )
+        assert deployment.model_info.input_cost_per_second == 0.006
+
+    def test_output_cost_per_second_copied_to_model_info(self):
+        deployment = Deployment(
+            model_name="whisper",
+            litellm_params=LiteLLM_Params(
+                model="hosted_vllm/whisper-large-v3-turbo",
+                output_cost_per_second=0.012,
+            ),
+        )
+        assert deployment.model_info.output_cost_per_second == 0.012
+
+    def test_per_second_not_set_when_absent(self):
+        deployment = Deployment(
+            model_name="whisper",
+            litellm_params=LiteLLM_Params(
+                model="hosted_vllm/whisper-large-v3-turbo",
+            ),
+        )
+        assert deployment.model_info.get("input_cost_per_second") is None
+
+    def test_per_token_still_copied(self):
+        deployment = Deployment(
+            model_name="gpt-4",
+            litellm_params=LiteLLM_Params(
+                model="gpt-4",
+                input_cost_per_token=0.03,
+                output_cost_per_token=0.06,
+            ),
+        )
+        assert deployment.model_info.input_cost_per_token == 0.03
+        assert deployment.model_info.output_cost_per_token == 0.06
+
+
+# ---------------------------------------------------------------------------
+# _response_cost_calculator extracts router_model_id from metadata
+# ---------------------------------------------------------------------------
+
+
+class TestResponseCostCalculatorMetadataFallback:
+    """
+    _response_cost_calculator must fall back to metadata model_info.id
+    when _hidden_params does not contain model_id.
+
+    Tests construct a real Logging instance and call _response_cost_calculator()
+    so the actual production code path is exercised.
+    """
+
+    @staticmethod
+    def _make_logging_obj(model: str, model_id: str, cost_per_second: float = 0.006) -> Logging:
+        """Build a minimal Logging instance with metadata at the correct path."""
+        now = datetime.datetime.now()
+        logging_obj = Logging(
+            model=model,
+            messages="test audio",
+            stream=False,
+            call_type="atranscription",
+            start_time=now,
+            litellm_call_id=str(uuid.uuid4()),
+            function_id="1",
+        )
+        # update_environment_variables populates model_call_details with
+        # litellm_params & optional_params, mirroring real call setup.
+        logging_obj.update_environment_variables(
+            model=model,
+            optional_params={},
+            litellm_params={
+                "metadata": {
+                    "model_info": {
+                        "id": model_id,
+                        "input_cost_per_second": cost_per_second,
+                    },
+                },
+            },
+        )
+        return logging_obj
+
+    def test_router_model_id_extracted_from_metadata(self):
+        model_id = str(uuid.uuid4())
+        litellm.model_cost[model_id] = {
+            "input_cost_per_second": 0.006,
+            "output_cost_per_token": 0,
+            "input_cost_per_token": 0,
+            "litellm_provider": "hosted_vllm",
+            "mode": "audio_transcription",
+        }
+        try:
+            logging_obj = self._make_logging_obj(
+                model="hosted_vllm/whisper-large-v3-turbo",
+                model_id=model_id,
+            )
+            response = TranscriptionResponse(text="hello world")
+            response._hidden_params = {}
+            response.duration = 30.0  # 30 seconds of audio
+
+            cost = logging_obj._response_cost_calculator(result=response)
+            # Fallback must find model_id and compute cost = 0.006 * 30
+            assert cost is not None
+            assert abs(cost - 0.006 * 30.0) < 1e-9, f"expected 0.18, got {cost}"
+        finally:
+            litellm.model_cost.pop(model_id, None)
+
+    def test_router_model_id_not_extracted_if_not_in_model_cost(self):
+        model_id = str(uuid.uuid4())
+        logging_obj = self._make_logging_obj(
+            model="hosted_vllm/whisper-large-v3-turbo",
+            model_id=model_id,
+        )
+        response = TranscriptionResponse(text="hello world")
+        response._hidden_params = {}
+        response.duration = 30.0
+
+        # model_id is NOT in litellm.model_cost, so fallback should not match;
+        # cost calculation falls through to regular path (returns None).
+        cost = logging_obj._response_cost_calculator(result=response)
+        assert cost is None
+
+    def test_router_model_id_from_hidden_params_takes_precedence(self):
+        model_id_hidden = str(uuid.uuid4())
+        model_id_metadata = str(uuid.uuid4())
+        litellm.model_cost[model_id_hidden] = {
+            "input_cost_per_second": 0.01,
+            "output_cost_per_token": 0,
+            "input_cost_per_token": 0,
+            "litellm_provider": "hosted_vllm",
+            "mode": "audio_transcription",
+        }
+        litellm.model_cost[model_id_metadata] = {
+            "input_cost_per_second": 0.02,
+            "output_cost_per_token": 0,
+            "input_cost_per_token": 0,
+            "litellm_provider": "hosted_vllm",
+            "mode": "audio_transcription",
+        }
+        try:
+            logging_obj = self._make_logging_obj(
+                model="hosted_vllm/whisper-large-v3-turbo",
+                model_id=model_id_metadata,
+            )
+            response = TranscriptionResponse(text="test")
+            response._hidden_params = {"model_id": model_id_hidden}
+            response.duration = 10.0  # 10 seconds of audio
+
+            cost = logging_obj._response_cost_calculator(result=response)
+            # hidden_params model_id (0.01/s) takes precedence over metadata (0.02/s)
+            assert cost is not None
+            assert abs(cost - 0.01 * 10.0) < 1e-9, f"expected 0.10, got {cost}"
+        finally:
+            litellm.model_cost.pop(model_id_hidden, None)
+            litellm.model_cost.pop(model_id_metadata, None)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: cost_per_token returns non-zero for transcription
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptionCostPerSecond:
+    """
+    Verify that cost_per_token correctly calculates transcription cost
+    when using a model registered with input_cost_per_second.
+    """
+
+    def _register_model(self, model_id: str, cost_per_second: float = 0.006):
+        litellm.model_cost[model_id] = {
+            "input_cost_per_second": cost_per_second,
+            "output_cost_per_token": 0,
+            "input_cost_per_token": 0,
+            "mode": "audio_transcription",
+            "max_tokens": None,
+            "max_input_tokens": None,
+            "max_output_tokens": None,
+        }
+
+    def test_cost_per_second_via_model_id(self):
+        from litellm.llms.openai.cost_calculation import (
+            cost_per_second as openai_cost_per_second,
+        )
+
+        model_id = str(uuid.uuid4())
+        self._register_model(model_id)
+        try:
+            prompt_cost, completion_cost_val = openai_cost_per_second(
+                model=model_id, custom_llm_provider=None, duration=30.0
+            )
+            total = prompt_cost + completion_cost_val
+            assert abs(total - 0.006 * 30.0) < 1e-9
+        finally:
+            litellm.model_cost.pop(model_id, None)
+
+    def test_cost_per_token_transcription_path(self):
+        from litellm.cost_calculator import cost_per_token
+
+        model_id = str(uuid.uuid4())
+        self._register_model(model_id)
+        try:
+            prompt_cost, completion_cost_val = cost_per_token(
+                model=model_id,
+                prompt_tokens=0,
+                completion_tokens=0,
+                custom_llm_provider="hosted_vllm",
+                call_type="atranscription",
+                audio_transcription_file_duration=45.0,
+            )
+            assert abs(prompt_cost + completion_cost_val - 0.006 * 45.0) < 1e-9
+        finally:
+            litellm.model_cost.pop(model_id, None)
+
+    def test_zero_duration_gives_zero_cost(self):
+        from litellm.cost_calculator import cost_per_token
+
+        model_id = str(uuid.uuid4())
+        self._register_model(model_id)
+        try:
+            prompt_cost, completion_cost_val = cost_per_token(
+                model=model_id,
+                prompt_tokens=0,
+                completion_tokens=0,
+                custom_llm_provider="hosted_vllm",
+                call_type="transcription",
+                audio_transcription_file_duration=0.0,
+            )
+            assert prompt_cost + completion_cost_val == 0.0
+        finally:
+            litellm.model_cost.pop(model_id, None)
+
+    def test_high_duration_scales_linearly(self):
+        from litellm.cost_calculator import cost_per_token
+
+        model_id = str(uuid.uuid4())
+        self._register_model(model_id, cost_per_second=1.0)
+        try:
+            p, c = cost_per_token(
+                model=model_id,
+                prompt_tokens=0,
+                completion_tokens=0,
+                custom_llm_provider="hosted_vllm",
+                call_type="atranscription",
+                audio_transcription_file_duration=3600.0,
+            )
+            assert abs(p + c - 3600.0) < 1e-9
+        finally:
+            litellm.model_cost.pop(model_id, None)
+
+
+# ---------------------------------------------------------------------------
+# _select_model_name_for_cost_calc prefers router_model_id
+# ---------------------------------------------------------------------------
+
+
+class TestSelectModelNameForCostCalc:
+    def test_returns_router_model_id_when_custom_pricing(self):
+        from litellm.cost_calculator import _select_model_name_for_cost_calc
+
+        model_id = str(uuid.uuid4())
+        litellm.model_cost[model_id] = {"input_cost_per_second": 0.006}
+        try:
+            result = _select_model_name_for_cost_calc(
+                model="hosted_vllm/whisper-large-v3-turbo",
+                completion_response=None,
+                custom_pricing=True,
+                router_model_id=model_id,
+            )
+            # The function prepends the provider derived from model name
+            assert result is not None
+            assert model_id in result
+        finally:
+            litellm.model_cost.pop(model_id, None)
+
+    def test_falls_back_to_model_when_no_router_model_id(self):
+        from litellm.cost_calculator import _select_model_name_for_cost_calc
+
+        result = _select_model_name_for_cost_calc(
+            model="hosted_vllm/whisper-large-v3-turbo",
+            completion_response=None,
+            custom_pricing=True,
+            router_model_id=None,
+        )
+        assert result == "hosted_vllm/whisper-large-v3-turbo"


### PR DESCRIPTION
## Summary

Fixes #20228 — Audio transcription cost is always reported as `0` when using custom-priced models (e.g. `hosted_vllm/whisper-large-v3-turbo` with `input_cost_per_second`).

## Root Cause

Two independent issues conspire to produce zero cost:

### 1. `SPECIAL_MODEL_INFO_PARAMS` missing per-second pricing fields

`Deployment.__init__()` copies pricing fields from `litellm_params` to `model_info`, but only for the fields listed in `SPECIAL_MODEL_INFO_PARAMS`:

```python
# Before (types/router.py)
SPECIAL_MODEL_INFO_PARAMS = [
    "input_cost_per_token",
    "output_cost_per_token",
    "input_cost_per_character",
    "output_cost_per_character",
]
```

`input_cost_per_second` and `output_cost_per_second` were missing, so they were never propagated to `model_info`.

### 2. `_response_cost_calculator` could not resolve deployment-specific model ID

The cost calculator needs the deployment's unique `model_id` to look up the per-deployment entry in `litellm.model_cost` (which retains all custom pricing fields, including `input_cost_per_second`). The shared model-name entry intentionally strips custom pricing to prevent pollution between deployments.

For transcription responses, `_hidden_params["model_id"]` is never set, so the cost calculator fell back to the shared model-name entry (which lacks `input_cost_per_second`), yielding `cost = 0`.

## Fix

1. **`litellm/types/router.py`**: Added `input_cost_per_second` and `output_cost_per_second` to `SPECIAL_MODEL_INFO_PARAMS`.

2. **`litellm/litellm_core_utils/litellm_logging.py`**: Added a fallback in `_response_cost_calculator()` that extracts `router_model_id` from `self.model_call_details["metadata"]["model_info"]["id"]` when it's not available from `_hidden_params`. This ensures the per-deployment model_cost entry is used for cost calculation.

## Tests

15 new unit tests covering:
- `SPECIAL_MODEL_INFO_PARAMS` includes per-second fields
- `Deployment.__init__` copies per-second pricing to `model_info`
- Metadata fallback for `router_model_id` extraction
- End-to-end `cost_per_token` returns correct non-zero cost for transcription
- `_select_model_name_for_cost_calc` prefers `router_model_id` with custom pricing

All tests pass.