### PR TITLE
fix(anthropic-passthrough): defer first content_block_start to respect thinking block ordering

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -155,9 +155,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 )
 
                 if should_start_new_block and not self.sent_content_block_finish:
-                    # Queue the sequence: content_block_stop -> content_block_start
-                    # The trigger chunk itself is not emitted as a delta since the
-                    # content_block_start already carries the relevant information.
+                    # Queue the sequence: content_block_stop -> content_block_start -> delta
                     self.chunk_queue.append(
                         {
                             "type": "content_block_stop",
@@ -171,6 +169,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                             "content_block": self.current_content_block_start,
                         }
                     )
+                    self.chunk_queue.append(processed_chunk)
                     self.sent_content_block_finish = False
                     return self.chunk_queue.popleft()
 
@@ -320,19 +319,13 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
                 if not self.queued_usage_chunk:
                     if should_start_new_block and not self.sent_content_block_finish:
-                        # Queue the sequence: content_block_stop -> content_block_start
-                        # The trigger chunk itself is not emitted as a delta since the
-                        # content_block_start already carries the relevant information.
-
-                        # 1. Stop current content block
+                        # Queue the sequence: content_block_stop -> content_block_start -> delta
                         self.chunk_queue.append(
                             {
                                 "type": "content_block_stop",
                                 "index": max(self.current_content_block_index - 1, 0),
                             }
                         )
-
-                        # 2. Start new content block
                         self.chunk_queue.append(
                             {
                                 "type": "content_block_start",
@@ -340,18 +333,14 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                                 "content_block": self.current_content_block_start,
                             }
                         )
-
-                        # Reset state for new block
+                        self.chunk_queue.append(processed_chunk)
                         self.sent_content_block_finish = False
-
-                        # Return the first queued item
                         return self.chunk_queue.popleft()
 
                     if (
                         processed_chunk["type"] == "message_delta"
                         and self.sent_content_block_finish is False
                     ):
-                        # Queue both the content_block_stop and the holding chunk
                         self.chunk_queue.append(
                             {
                                 "type": "content_block_stop",
@@ -367,14 +356,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                         else:
                             self.chunk_queue.append(processed_chunk)
                         return self.chunk_queue.popleft()
-                    elif self.holding_chunk is not None:
-                        # Queue both chunks
-                        self.chunk_queue.append(self.holding_chunk)
-                        self.chunk_queue.append(processed_chunk)
-                        self.holding_chunk = None
-                        return self.chunk_queue.popleft()
                     else:
-                        # Queue the current chunk
                         self.chunk_queue.append(processed_chunk)
                         return self.chunk_queue.popleft()
 
@@ -383,10 +365,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 if self.holding_stop_reason_chunk is not None:
                     self.chunk_queue.append(self.holding_stop_reason_chunk)
                     self.holding_stop_reason_chunk = None
-
-                if self.holding_chunk is not None:
-                    self.chunk_queue.append(self.holding_chunk)
-                    self.holding_chunk = None
 
             if not self.sent_last_message:
                 self.sent_last_message = True

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -41,8 +41,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         type="text",
         text="",
     )
-    chunk_queue: deque = deque()  # Queue for buffering multiple chunks
-
     def __init__(
         self,
         completion_stream: Any,
@@ -51,8 +49,17 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
     ):
         super().__init__(completion_stream)
         self.model = model
+        self.chunk_queue: deque = deque()
+        self._adapter_instance: Optional[Any] = None
         # Mapping of truncated tool names to original names (for OpenAI's 64-char limit)
         self.tool_name_mapping = tool_name_mapping or {}
+
+    @property
+    def _adapter(self):
+        if self._adapter_instance is None:
+            from .transformation import LiteLLMAnthropicMessagesAdapter
+            self._adapter_instance = LiteLLMAnthropicMessagesAdapter()
+        return self._adapter_instance
 
     def _create_initial_usage_delta(self) -> UsageDelta:
         """
@@ -76,7 +83,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         )
 
     def __next__(self):
-        from .transformation import LiteLLMAnthropicMessagesAdapter
 
         try:
             # Always return queued chunks first
@@ -103,26 +109,41 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 )
                 return self.chunk_queue.popleft()
 
-            if self.sent_content_block_start is False:
-                self.sent_content_block_start = True
-                self.chunk_queue.append(
-                    {
-                        "type": "content_block_start",
-                        "index": self.current_content_block_index,
-                        "content_block": {"type": "text", "text": ""},
-                    }
-                )
-                return self.chunk_queue.popleft()
-
             for chunk in self.completion_stream:
                 if chunk == "None" or chunk is None:
                     raise Exception
+
+                # Deferred first content_block_start: determine actual type from
+                # the first stream chunk instead of hardcoding "text".  This is
+                # required because extended-thinking responses start with a
+                # "thinking" block, not a "text" block.
+                if self.sent_content_block_start is False:
+                    self.sent_content_block_start = True
+                    (
+                        block_type,
+                        content_block_start,
+                    ) = self._adapter._translate_streaming_openai_chunk_to_anthropic_content_block(
+                        choices=chunk.choices,
+                    )
+                    self.current_content_block_type = block_type
+                    self.current_content_block_start = content_block_start
+
+                    processed_chunk = self._adapter.translate_streaming_openai_response_to_anthropic(
+                        response=chunk,
+                        current_content_block_index=self.current_content_block_index,
+                    )
+                    self.chunk_queue.append(processed_chunk)
+                    return {
+                        "type": "content_block_start",
+                        "index": self.current_content_block_index,
+                        "content_block": content_block_start,
+                    }
 
                 should_start_new_block = self._should_start_new_content_block(chunk)
                 if should_start_new_block:
                     self._increment_content_block_index()
 
-                processed_chunk = LiteLLMAnthropicMessagesAdapter().translate_streaming_openai_response_to_anthropic(
+                processed_chunk = self._adapter.translate_streaming_openai_response_to_anthropic(
                     response=chunk,
                     current_content_block_index=self.current_content_block_index,
                 )
@@ -197,7 +218,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
             raise StopAsyncIteration
 
     async def __anext__(self):  # noqa: PLR0915
-        from .transformation import LiteLLMAnthropicMessagesAdapter
 
         try:
             # Always return queued chunks first
@@ -224,27 +244,39 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 )
                 return self.chunk_queue.popleft()
 
-            if self.sent_content_block_start is False:
-                self.sent_content_block_start = True
-                self.chunk_queue.append(
-                    {
-                        "type": "content_block_start",
-                        "index": self.current_content_block_index,
-                        "content_block": {"type": "text", "text": ""},
-                    }
-                )
-                return self.chunk_queue.popleft()
-
             async for chunk in self.completion_stream:
                 if chunk == "None" or chunk is None:
                     raise Exception
+
+                # Deferred first content_block_start (async path)
+                if self.sent_content_block_start is False:
+                    self.sent_content_block_start = True
+                    (
+                        block_type,
+                        content_block_start,
+                    ) = self._adapter._translate_streaming_openai_chunk_to_anthropic_content_block(
+                        choices=chunk.choices,
+                    )
+                    self.current_content_block_type = block_type
+                    self.current_content_block_start = content_block_start
+
+                    processed_chunk = self._adapter.translate_streaming_openai_response_to_anthropic(
+                        response=chunk,
+                        current_content_block_index=self.current_content_block_index,
+                    )
+                    self.chunk_queue.append(processed_chunk)
+                    return {
+                        "type": "content_block_start",
+                        "index": self.current_content_block_index,
+                        "content_block": content_block_start,
+                    }
 
                 # Check if we need to start a new content block
                 should_start_new_block = self._should_start_new_content_block(chunk)
                 if should_start_new_block:
                     self._increment_content_block_index()
 
-                processed_chunk = LiteLLMAnthropicMessagesAdapter().translate_streaming_openai_response_to_anthropic(
+                processed_chunk = self._adapter.translate_streaming_openai_response_to_anthropic(
                     response=chunk,
                     current_content_block_index=self.current_content_block_index,
                 )
@@ -419,7 +451,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         - Different content types in the response
         - Specific markers in the content
         """
-        from .transformation import LiteLLMAnthropicMessagesAdapter
 
         # Example logic - customize based on your needs:
         # If chunk indicates a tool call
@@ -429,7 +460,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         (
             block_type,
             content_block_start,
-        ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(
+        ) = self._adapter._translate_streaming_openai_chunk_to_anthropic_content_block(
             choices=chunk.choices  # type: ignore
         )
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -33,7 +33,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
     sent_content_block_finish: bool = False
     current_content_block_type: Literal["text", "tool_use", "thinking"] = "text"
     sent_last_message: bool = False
-    holding_chunk: Optional[Any] = None
     holding_stop_reason_chunk: Optional[Any] = None
     queued_usage_chunk: bool = False
     current_content_block_index: int = 0

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -137,6 +137,13 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                         response=chunk,
                         current_content_block_index=self.current_content_block_index,
                     )
+                    # Guard: if first chunk carries finish_reason, processed_chunk
+                    # is a message_delta — emit content_block_stop before it.
+                    if processed_chunk.get("type") == "message_delta" and not self.sent_content_block_finish:
+                        self.chunk_queue.append(
+                            {"type": "content_block_stop", "index": self.current_content_block_index}
+                        )
+                        self.sent_content_block_finish = True
                     self.chunk_queue.append(processed_chunk)
                     return {
                         "type": "content_block_start",
@@ -264,6 +271,13 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                         response=chunk,
                         current_content_block_index=self.current_content_block_index,
                     )
+                    # Guard: if first chunk carries finish_reason, processed_chunk
+                    # is a message_delta — emit content_block_stop before it.
+                    if processed_chunk.get("type") == "message_delta" and not self.sent_content_block_finish:
+                        self.chunk_queue.append(
+                            {"type": "content_block_stop", "index": self.current_content_block_index}
+                        )
+                        self.sent_content_block_finish = True
                     self.chunk_queue.append(processed_chunk)
                     return {
                         "type": "content_block_start",

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -128,6 +128,12 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     self.current_content_block_type = block_type
                     self.current_content_block_start = content_block_start
 
+                    # Restore original tool name for first block (same logic
+                    # as _should_start_new_content_block, which is bypassed here)
+                    if block_type == "tool_use" and content_block_start.get("name"):
+                        truncated = content_block_start["name"]
+                        content_block_start["name"] = self.tool_name_mapping.get(truncated, truncated)
+
                     processed_chunk = self._adapter.translate_streaming_openai_response_to_anthropic(
                         response=chunk,
                         current_content_block_index=self.current_content_block_index,
@@ -182,19 +188,9 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     self.sent_content_block_finish = True
                     self.chunk_queue.append(processed_chunk)
                     return self.chunk_queue.popleft()
-                elif self.holding_chunk is not None:
-                    self.chunk_queue.append(self.holding_chunk)
-                    self.chunk_queue.append(processed_chunk)
-                    self.holding_chunk = None
-                    return self.chunk_queue.popleft()
                 else:
                     self.chunk_queue.append(processed_chunk)
                     return self.chunk_queue.popleft()
-
-            # Handle any remaining held chunks after stream ends
-            if self.holding_chunk is not None:
-                self.chunk_queue.append(self.holding_chunk)
-                self.holding_chunk = None
 
             if not self.sent_last_message:
                 self.sent_last_message = True
@@ -259,6 +255,12 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     )
                     self.current_content_block_type = block_type
                     self.current_content_block_start = content_block_start
+
+                    # Restore original tool name for first block (same logic
+                    # as _should_start_new_content_block, which is bypassed here)
+                    if block_type == "tool_use" and content_block_start.get("name"):
+                        truncated = content_block_start["name"]
+                        content_block_start["name"] = self.tool_name_mapping.get(truncated, truncated)
 
                     processed_chunk = self._adapter.translate_streaming_openai_response_to_anthropic(
                         response=chunk,

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -23,8 +23,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
     from litellm.types.llms.anthropic import (
         ContentBlockContentBlockDict,
-        ContentBlockStart,
-        ContentBlockStartText,
         TextBlock,
     )
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1175,7 +1175,7 @@ class LiteLLMAnthropicMessagesAdapter:
                             )
 
                         return "thinking", ChatCompletionThinkingBlock(
-                            type="thinking", thinking=thinking, signature=signature
+                            type="thinking", thinking="", signature=""
                         )
 
         return "text", TextBlock(type="text", text="")

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
@@ -134,14 +134,10 @@ def test_anthropic_stream_wrapper_single_tool_call():
     # Verify the expected sequence of chunk types
     expected_types = [
         "message_start",  # Initial message start
-        # TODO: for future contributors: if the initial content_block_start
-        # respects the upstream's starting chunk, the initial empty text block
-        # should be removed (and this test should be updated accordingly)
-        # ---------------------------------------------------------------------
-        "content_block_start",  # Initial empty text block start
-        "content_block_stop",  # End of empty text block
-        # ---------------------------------------------------------------------
+        # The initial content_block_start now respects the actual first chunk
+        # type from the upstream stream (no more phantom empty text block).
         "content_block_start",  # Start of first tool_use content block
+        "content_block_delta",  # (empty args from tool header)
         "content_block_delta",  # {"city":
         "content_block_delta",  # "NY"}
         "content_block_stop",  # End of first tool_use content block
@@ -196,18 +192,15 @@ def test_anthropic_stream_wrapper_back_to_back_tool_calls():
     # Verify the expected sequence of chunk types
     expected_types = [
         "message_start",  # Initial message start
-        # TODO: for future contributors: if the initial content_block_start
-        # respects the upstream's starting chunk, the initial empty text block
-        # should be removed (and this test should be updated accordingly)
-        # ---------------------------------------------------------------------
-        "content_block_start",  # Initial empty text block start
-        "content_block_stop",  # End of empty text block
-        # ---------------------------------------------------------------------
+        # The initial content_block_start now respects the actual first chunk
+        # type from the upstream stream (no more phantom empty text block).
         "content_block_start",  # Start of first tool_use content block
+        "content_block_delta",  # (empty args from tool header)
         "content_block_delta",  # {"city":
         "content_block_delta",  # "NY"}
         "content_block_stop",  # End of first tool_use content block
         "content_block_start",  # Start of second tool_use content block
+        "content_block_delta",  # (empty args from tool header)
         "content_block_delta",  # {"city":
         "content_block_delta",  # " SF"}
         "content_block_stop",  # End of second tool_use content block
@@ -267,28 +260,28 @@ def test_anthropic_stream_wrapper_interleaved_tool_calls_and_text():
     # Verify the expected sequence of chunk types
     expected_types = [
         "message_start",  # Initial message start
-        # TODO: for future contributors: if the initial content_block_start
-        # respects the upstream's starting chunk, the initial empty text block
-        # should be removed (and this test should be updated accordingly)
-        # ---------------------------------------------------------------------
-        "content_block_start",  # Initial empty text block start
-        "content_block_stop",  # End of empty text block
-        # ---------------------------------------------------------------------
+        # The initial content_block_start now respects the actual first chunk
+        # type from the upstream stream (no more phantom empty text block).
         "content_block_start",  # Start of first tool_use content block
+        "content_block_delta",  # (empty args from tool header)
         "content_block_delta",  # {"city":
         "content_block_delta",  # "NY"}
         "content_block_stop",  # End of first tool_use content block
         "content_block_start",  # "The weather is nice today"
+        "content_block_delta",
         "content_block_stop",
         "content_block_start",  # Start of second tool_use content block
+        "content_block_delta",  # (empty args from tool header)
         "content_block_delta",  # {"city":
         "content_block_delta",  # " SF"}
         "content_block_stop",  # End of second tool_use content block
         "content_block_start",  # Start of third tool_use content block
+        "content_block_delta",  # (empty args from tool header)
         "content_block_delta",  # {"city":
         "content_block_delta",  # " CHI"}
         "content_block_stop",  # End of third tool_use content block
         "content_block_start",  # "The weather is not so nice today"
+        "content_block_delta",
         "content_block_stop",
         "message_delta",  # Stop reason with merged usage
         "message_stop",  # Final message stop

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_thinking_block_order.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_thinking_block_order.py
@@ -1,0 +1,416 @@
+"""
+Tests for AnthropicStreamWrapper thinking block ordering.
+
+Verifies that when extended thinking is enabled, the first content_block_start
+event uses the correct block type ("thinking") rather than hardcoding "text".
+This is required by the Anthropic protocol: thinking blocks must appear before
+text blocks.
+
+Fixes: https://github.com/BerriAI/litellm/issues/21128
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "..", "..", ".."))
+
+from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
+    AnthropicStreamWrapper,
+)
+from litellm.types.utils import Delta, ModelResponse, StreamingChoices
+
+
+class MockThinkingStream:
+    """Simulates a Bedrock Converse stream with extended thinking enabled.
+
+    The stream emits thinking blocks first (reasoning), followed by text blocks
+    (the final answer), which mirrors the real Anthropic/Bedrock behavior.
+    """
+
+    def __init__(self):
+        self.responses = [
+            # First chunk: thinking block
+            ModelResponse(
+                stream=True,
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(
+                            content=None,
+                            thinking_blocks=[
+                                {"type": "thinking", "thinking": "Let me think...", "signature": ""}
+                            ],
+                        ),
+                        index=0,
+                        finish_reason=None,
+                    )
+                ],
+            ),
+            # Second chunk: more thinking
+            ModelResponse(
+                stream=True,
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(
+                            content=None,
+                            thinking_blocks=[
+                                {"type": "thinking", "thinking": " about this problem.", "signature": ""}
+                            ],
+                        ),
+                        index=0,
+                        finish_reason=None,
+                    )
+                ],
+            ),
+            # Third chunk: thinking signature (end of thinking)
+            ModelResponse(
+                stream=True,
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(
+                            content=None,
+                            thinking_blocks=[
+                                {"type": "thinking", "thinking": "", "signature": "abc123sig"}
+                            ],
+                        ),
+                        index=0,
+                        finish_reason=None,
+                    )
+                ],
+            ),
+            # Fourth chunk: text content (the answer)
+            ModelResponse(
+                stream=True,
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="The answer is 4."),
+                        index=0,
+                        finish_reason=None,
+                    )
+                ],
+            ),
+            # Fifth chunk: finish
+            ModelResponse(
+                stream=True,
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content=""),
+                        index=0,
+                        finish_reason="end_turn",
+                    )
+                ],
+            ),
+        ]
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index >= len(self.responses):
+            raise StopIteration
+        response = self.responses[self.index]
+        self.index += 1
+        return response
+
+
+class AsyncMockThinkingStream:
+    """Async version of MockThinkingStream."""
+
+    def __init__(self):
+        self._sync = MockThinkingStream()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._sync)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class MockTextOnlyStream:
+    """Simulates a normal text-only stream (no thinking blocks)."""
+
+    def __init__(self):
+        self.responses = [
+            ModelResponse(
+                stream=True,
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="Hello"),
+                        index=0,
+                        finish_reason=None,
+                    )
+                ],
+            ),
+            ModelResponse(
+                stream=True,
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content=" World"),
+                        index=0,
+                        finish_reason=None,
+                    )
+                ],
+            ),
+            ModelResponse(
+                stream=True,
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content=""),
+                        index=0,
+                        finish_reason="end_turn",
+                    )
+                ],
+            ),
+        ]
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index >= len(self.responses):
+            raise StopIteration
+        response = self.responses[self.index]
+        self.index += 1
+        return response
+
+
+class AsyncMockTextOnlyStream:
+    """Async version of MockTextOnlyStream."""
+
+    def __init__(self):
+        self._sync = MockTextOnlyStream()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._sync)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+def test_thinking_block_is_first_content_block_sync():
+    """When thinking is enabled, the first content_block_start must be type='thinking'."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=MockThinkingStream(), model="claude-sonnet-4-5-20250514"
+    )
+
+    events = list(wrapper)
+
+    # Extract content_block_start events
+    block_starts = [e for e in events if e.get("type") == "content_block_start"]
+
+    assert len(block_starts) >= 2, f"Expected at least 2 content_block_start events, got {len(block_starts)}"
+
+    # First content block must be "thinking" (index 0)
+    first_block = block_starts[0]
+    assert first_block["index"] == 0
+    assert first_block["content_block"]["type"] == "thinking", (
+        f"First content block should be 'thinking', got '{first_block['content_block']['type']}'"
+    )
+
+    # Second content block must be "text" (index 1)
+    second_block = block_starts[1]
+    assert second_block["index"] == 1
+    assert second_block["content_block"]["type"] == "text", (
+        f"Second content block should be 'text', got '{second_block['content_block']['type']}'"
+    )
+
+
+def test_text_only_first_block_remains_text_sync():
+    """For non-thinking responses, the first content_block_start remains type='text'."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=MockTextOnlyStream(), model="claude-sonnet-4-5-20250514"
+    )
+
+    events = list(wrapper)
+
+    block_starts = [e for e in events if e.get("type") == "content_block_start"]
+    assert len(block_starts) >= 1
+
+    first_block = block_starts[0]
+    assert first_block["index"] == 0
+    assert first_block["content_block"]["type"] == "text"
+
+
+def test_thinking_stream_event_sequence_sync():
+    """Verify the full event sequence for a thinking stream follows Anthropic protocol."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=MockThinkingStream(), model="claude-sonnet-4-5-20250514"
+    )
+
+    events = list(wrapper)
+    event_types = [e.get("type") for e in events]
+
+    # Must start with message_start
+    assert event_types[0] == "message_start"
+
+    # Must have content_block_start as second event
+    assert event_types[1] == "content_block_start"
+
+    # The first content_block_start must be followed by thinking deltas
+    first_block_start = events[1]
+    assert first_block_start["content_block"]["type"] == "thinking"
+
+    # Must end with message_stop
+    assert event_types[-1] == "message_stop"
+
+
+def test_thinking_sse_format_sync():
+    """Verify SSE output has correct event types for thinking blocks."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=MockThinkingStream(), model="claude-sonnet-4-5-20250514"
+    )
+
+    sse_chunks = []
+    for raw in wrapper.anthropic_sse_wrapper():
+        sse_chunks.append(raw.decode("utf-8"))
+
+    # Parse SSE events
+    events = []
+    for sse in sse_chunks:
+        lines = sse.strip().split("\n")
+        event_type = None
+        data = None
+        for line in lines:
+            if line.startswith("event: "):
+                event_type = line[7:]
+            elif line.startswith("data: "):
+                data = json.loads(line[6:])
+        if event_type and data:
+            events.append({"event": event_type, "data": data})
+
+    # First event: message_start
+    assert events[0]["event"] == "message_start"
+
+    # Second event: content_block_start with thinking type
+    assert events[1]["event"] == "content_block_start"
+    assert events[1]["data"]["content_block"]["type"] == "thinking"
+
+
+@pytest.mark.asyncio
+async def test_thinking_block_is_first_content_block_async():
+    """Async: first content_block_start must be type='thinking' when thinking is enabled."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=AsyncMockThinkingStream(), model="claude-sonnet-4-5-20250514"
+    )
+
+    events = []
+    async for event in wrapper:
+        events.append(event)
+
+    block_starts = [e for e in events if e.get("type") == "content_block_start"]
+
+    assert len(block_starts) >= 2
+
+    first_block = block_starts[0]
+    assert first_block["index"] == 0
+    assert first_block["content_block"]["type"] == "thinking"
+
+    second_block = block_starts[1]
+    assert second_block["index"] == 1
+    assert second_block["content_block"]["type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_text_only_first_block_remains_text_async():
+    """Async: for non-thinking responses, first content_block_start remains type='text'."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=AsyncMockTextOnlyStream(), model="claude-sonnet-4-5-20250514"
+    )
+
+    events = []
+    async for event in wrapper:
+        events.append(event)
+
+    block_starts = [e for e in events if e.get("type") == "content_block_start"]
+    assert len(block_starts) >= 1
+
+    first_block = block_starts[0]
+    assert first_block["index"] == 0
+    assert first_block["content_block"]["type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_thinking_stream_no_content_loss_async():
+    """Async: all thinking deltas and text deltas must be present (no dropped chunks)."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=AsyncMockThinkingStream(), model="claude-sonnet-4-5-20250514"
+    )
+
+    events = []
+    async for event in wrapper:
+        events.append(event)
+
+    # Collect all delta events
+    deltas = [e for e in events if e.get("type") == "content_block_delta"]
+
+    # We should have thinking deltas and text deltas
+    thinking_deltas = [
+        d for d in deltas
+        if d.get("delta", {}).get("type") in ("thinking_delta", "signature_delta")
+    ]
+    text_deltas = [
+        d for d in deltas if d.get("delta", {}).get("type") == "text_delta"
+    ]
+
+    assert len(thinking_deltas) >= 1, "Should have at least one thinking/signature delta"
+    assert len(text_deltas) >= 1, "Should have at least one text delta"
+
+
+def test_thinking_stream_no_content_loss_sync():
+    """Sync: all thinking deltas and text deltas must be present (no dropped chunks)."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=MockThinkingStream(), model="claude-sonnet-4-5-20250514"
+    )
+
+    events = list(wrapper)
+
+    deltas = [e for e in events if e.get("type") == "content_block_delta"]
+
+    thinking_deltas = [
+        d for d in deltas
+        if d.get("delta", {}).get("type") in ("thinking_delta", "signature_delta")
+    ]
+    text_deltas = [
+        d for d in deltas if d.get("delta", {}).get("type") == "text_delta"
+    ]
+
+    assert len(thinking_deltas) >= 1, "Should have at least one thinking/signature delta"
+    assert len(text_deltas) >= 1, "Should have at least one text delta"
+
+
+@pytest.mark.asyncio
+async def test_thinking_sse_format_async():
+    """Async: verify SSE output has correct event types for thinking blocks."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=AsyncMockThinkingStream(), model="claude-sonnet-4-5-20250514"
+    )
+
+    sse_chunks = []
+    async for raw in wrapper.async_anthropic_sse_wrapper():
+        sse_chunks.append(raw.decode("utf-8"))
+
+    events = []
+    for sse in sse_chunks:
+        lines = sse.strip().split("\n")
+        event_type = None
+        data = None
+        for line in lines:
+            if line.startswith("event: "):
+                event_type = line[7:]
+            elif line.startswith("data: "):
+                data = json.loads(line[6:])
+        if event_type and data:
+            events.append({"event": event_type, "data": data})
+
+    assert events[0]["event"] == "message_start"
+    assert events[1]["event"] == "content_block_start"
+    assert events[1]["data"]["content_block"]["type"] == "thinking"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_thinking_block_order.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_thinking_block_order.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."
 from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
     AnthropicStreamWrapper,
 )
-from litellm.types.utils import Delta, ModelResponse, StreamingChoices
+from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
 
 
 class MockThinkingStream:
@@ -32,8 +32,7 @@ class MockThinkingStream:
     def __init__(self):
         self.responses = [
             # First chunk: thinking block
-            ModelResponse(
-                stream=True,
+            ModelResponseStream(
                 choices=[
                     StreamingChoices(
                         delta=Delta(
@@ -48,8 +47,7 @@ class MockThinkingStream:
                 ],
             ),
             # Second chunk: more thinking
-            ModelResponse(
-                stream=True,
+            ModelResponseStream(
                 choices=[
                     StreamingChoices(
                         delta=Delta(
@@ -64,8 +62,7 @@ class MockThinkingStream:
                 ],
             ),
             # Third chunk: thinking signature (end of thinking)
-            ModelResponse(
-                stream=True,
+            ModelResponseStream(
                 choices=[
                     StreamingChoices(
                         delta=Delta(
@@ -79,20 +76,28 @@ class MockThinkingStream:
                     )
                 ],
             ),
-            # Fourth chunk: text content (the answer)
-            ModelResponse(
-                stream=True,
+            # Fourth chunk: text content (triggers thinking->text block transition)
+            ModelResponseStream(
                 choices=[
                     StreamingChoices(
-                        delta=Delta(content="The answer is 4."),
+                        delta=Delta(content="The answer"),
                         index=0,
                         finish_reason=None,
                     )
                 ],
             ),
-            # Fifth chunk: finish
-            ModelResponse(
-                stream=True,
+            # Fifth chunk: more text content (emitted as text_delta)
+            ModelResponseStream(
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content=" is 4."),
+                        index=0,
+                        finish_reason=None,
+                    )
+                ],
+            ),
+            # Sixth chunk: finish
+            ModelResponseStream(
                 choices=[
                     StreamingChoices(
                         delta=Delta(content=""),
@@ -136,8 +141,7 @@ class MockTextOnlyStream:
 
     def __init__(self):
         self.responses = [
-            ModelResponse(
-                stream=True,
+            ModelResponseStream(
                 choices=[
                     StreamingChoices(
                         delta=Delta(content="Hello"),
@@ -146,8 +150,7 @@ class MockTextOnlyStream:
                     )
                 ],
             ),
-            ModelResponse(
-                stream=True,
+            ModelResponseStream(
                 choices=[
                     StreamingChoices(
                         delta=Delta(content=" World"),
@@ -156,8 +159,7 @@ class MockTextOnlyStream:
                     )
                 ],
             ),
-            ModelResponse(
-                stream=True,
+            ModelResponseStream(
                 choices=[
                     StreamingChoices(
                         delta=Delta(content=""),
@@ -215,6 +217,11 @@ def test_thinking_block_is_first_content_block_sync():
     assert first_block["content_block"]["type"] == "thinking", (
         f"First content block should be 'thinking', got '{first_block['content_block']['type']}'"
     )
+    # Anthropic protocol: content_block_start.content_block.thinking must be ""
+    # (all content arrives via deltas, not in the start event)
+    assert first_block["content_block"]["thinking"] == "", (
+        f"content_block_start thinking field must be empty string, got {first_block['content_block']['thinking']!r}"
+    )
 
     # Second content block must be "text" (index 1)
     second_block = block_starts[1]
@@ -258,6 +265,7 @@ def test_thinking_stream_event_sequence_sync():
     # The first content_block_start must be followed by thinking deltas
     first_block_start = events[1]
     assert first_block_start["content_block"]["type"] == "thinking"
+    assert first_block_start["content_block"]["thinking"] == ""
 
     # Must end with message_stop
     assert event_types[-1] == "message_stop"
@@ -293,6 +301,7 @@ def test_thinking_sse_format_sync():
     # Second event: content_block_start with thinking type
     assert events[1]["event"] == "content_block_start"
     assert events[1]["data"]["content_block"]["type"] == "thinking"
+    assert events[1]["data"]["content_block"]["thinking"] == ""
 
 
 @pytest.mark.asyncio
@@ -313,6 +322,10 @@ async def test_thinking_block_is_first_content_block_async():
     first_block = block_starts[0]
     assert first_block["index"] == 0
     assert first_block["content_block"]["type"] == "thinking"
+    # Anthropic protocol: content_block_start.content_block.thinking must be ""
+    assert first_block["content_block"]["thinking"] == "", (
+        f"content_block_start thinking field must be empty string, got {first_block['content_block']['thinking']!r}"
+    )
 
     second_block = block_starts[1]
     assert second_block["index"] == 1
@@ -414,3 +427,4 @@ async def test_thinking_sse_format_async():
     assert events[0]["event"] == "message_start"
     assert events[1]["event"] == "content_block_start"
     assert events[1]["data"]["content_block"]["type"] == "thinking"
+    assert events[1]["data"]["content_block"]["thinking"] == ""

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_thinking_block_order.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_thinking_block_order.py
@@ -377,7 +377,17 @@ async def test_thinking_stream_no_content_loss_async():
     assert len(thinking_deltas) >= 1, "Should have at least one thinking/signature delta"
     assert len(text_deltas) >= 1, "Should have at least one text delta"
 
-    # Verify full accumulated text content matches expected output (no dropped deltas)
+    # Verify full accumulated thinking content (no dropped deltas)
+    full_thinking = "".join(
+        d.get("delta", {}).get("thinking", "")
+        for d in thinking_deltas
+        if d.get("delta", {}).get("type") == "thinking_delta"
+    )
+    assert full_thinking == "Let me think... about this problem.", (
+        f"Expected accumulated thinking 'Let me think... about this problem.', got {full_thinking!r}"
+    )
+
+    # Verify full accumulated text content (no dropped deltas)
     accumulated_text = "".join(
         d.get("delta", {}).get("text", "") for d in text_deltas
     )
@@ -407,7 +417,17 @@ def test_thinking_stream_no_content_loss_sync():
     assert len(thinking_deltas) >= 1, "Should have at least one thinking/signature delta"
     assert len(text_deltas) >= 1, "Should have at least one text delta"
 
-    # Verify full accumulated text content matches expected output (no dropped deltas)
+    # Verify full accumulated thinking content (no dropped deltas)
+    full_thinking = "".join(
+        d.get("delta", {}).get("thinking", "")
+        for d in thinking_deltas
+        if d.get("delta", {}).get("type") == "thinking_delta"
+    )
+    assert full_thinking == "Let me think... about this problem.", (
+        f"Expected accumulated thinking 'Let me think... about this problem.', got {full_thinking!r}"
+    )
+
+    # Verify full accumulated text content (no dropped deltas)
     accumulated_text = "".join(
         d.get("delta", {}).get("text", "") for d in text_deltas
     )

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_thinking_block_order.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_thinking_block_order.py
@@ -377,6 +377,14 @@ async def test_thinking_stream_no_content_loss_async():
     assert len(thinking_deltas) >= 1, "Should have at least one thinking/signature delta"
     assert len(text_deltas) >= 1, "Should have at least one text delta"
 
+    # Verify full accumulated text content matches expected output (no dropped deltas)
+    accumulated_text = "".join(
+        d.get("delta", {}).get("text", "") for d in text_deltas
+    )
+    assert accumulated_text == "The answer is 4.", (
+        f"Expected accumulated text 'The answer is 4.', got {accumulated_text!r}"
+    )
+
 
 def test_thinking_stream_no_content_loss_sync():
     """Sync: all thinking deltas and text deltas must be present (no dropped chunks)."""
@@ -398,6 +406,14 @@ def test_thinking_stream_no_content_loss_sync():
 
     assert len(thinking_deltas) >= 1, "Should have at least one thinking/signature delta"
     assert len(text_deltas) >= 1, "Should have at least one text delta"
+
+    # Verify full accumulated text content matches expected output (no dropped deltas)
+    accumulated_text = "".join(
+        d.get("delta", {}).get("text", "") for d in text_deltas
+    )
+    assert accumulated_text == "The answer is 4.", (
+        f"Expected accumulated text 'The answer is 4.', got {accumulated_text!r}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_thinking_block_order.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_thinking_block_order.py
@@ -464,3 +464,91 @@ async def test_thinking_sse_format_async():
     assert events[1]["event"] == "content_block_start"
     assert events[1]["data"]["content_block"]["type"] == "thinking"
     assert events[1]["data"]["content_block"]["thinking"] == ""
+
+
+class MockImmediateFinishStream:
+    """Simulates a degenerate stream whose very first content chunk carries finish_reason."""
+
+    def __init__(self):
+        self.responses = [
+            ModelResponseStream(
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="done"),
+                        index=0,
+                        finish_reason="end_turn",
+                    )
+                ],
+            ),
+        ]
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index >= len(self.responses):
+            raise StopIteration
+        response = self.responses[self.index]
+        self.index += 1
+        return response
+
+
+class AsyncMockImmediateFinishStream:
+    """Async version of MockImmediateFinishStream."""
+
+    def __init__(self):
+        self._sync = MockImmediateFinishStream()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._sync)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+def test_first_chunk_finish_reason_emits_content_block_stop_sync():
+    """Sync: when the very first content chunk has finish_reason, content_block_stop must precede message_delta."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=MockImmediateFinishStream(), model="claude-sonnet-4-5-20250514"
+    )
+    events = list(wrapper)
+    event_types = [e.get("type") for e in events]
+
+    assert "content_block_start" in event_types
+    assert "message_stop" in event_types
+
+    # If there's a message_delta, content_block_stop must come before it
+    if "message_delta" in event_types:
+        stop_idx = event_types.index("content_block_stop")
+        delta_idx = event_types.index("message_delta")
+        assert stop_idx < delta_idx, (
+            f"content_block_stop (idx {stop_idx}) must precede message_delta (idx {delta_idx}). "
+            f"Event sequence: {event_types}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_first_chunk_finish_reason_emits_content_block_stop_async():
+    """Async: when the very first content chunk has finish_reason, content_block_stop must precede message_delta."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=AsyncMockImmediateFinishStream(), model="claude-sonnet-4-5-20250514"
+    )
+    events = []
+    async for event in wrapper:
+        events.append(event)
+    event_types = [e.get("type") for e in events]
+
+    assert "content_block_start" in event_types
+    assert "message_stop" in event_types
+
+    if "message_delta" in event_types:
+        stop_idx = event_types.index("content_block_stop")
+        delta_idx = event_types.index("message_delta")
+        assert stop_idx < delta_idx, (
+            f"content_block_stop (idx {stop_idx}) must precede message_delta (idx {delta_idx}). "
+            f"Event sequence: {event_types}"
+        )


### PR DESCRIPTION
## Summary

Fixes #21128 — Bedrock Converse stream wrapper emits thinking blocks in wrong order when extended thinking is enabled.

## Root Cause

`AnthropicStreamWrapper` hardcoded the first `content_block_start` event as `type="text"` **before reading any stream data**. When extended thinking is enabled, the Anthropic streaming protocol requires thinking blocks at index 0 and text blocks at index 1. This caused `Content block is not a text block` errors in the Anthropic SDK.

## Fix

1. **Defer first `content_block_start`** — instead of eagerly emitting a text block, the wrapper now reads the first actual chunk from the upstream stream and uses `_translate_streaming_openai_chunk_to_anthropic_content_block()` to determine the correct block type (text, tool_use, or thinking).

2. **Fix sync path chunk loss** — the sync `__next__` used a single-slot `holding_chunk` that could lose events when `message_delta` arrived while a chunk was already held. Replaced with a `chunk_queue` (`collections.deque`) matching the async path's pattern.

3. **Update existing tests** — the parallel tool calls tests had TODO comments anticipating this exact change. The phantom empty text block (immediately started and stopped) is now eliminated, and the first `content_block_start` correctly reflects the actual stream content type.

## Tests

- 9 new tests for thinking block ordering (sync + async + SSE format + no content loss)
- 3 existing tests updated to reflect the improved behavior (no phantom empty text block)
- All 29 tests in the `messages/` directory pass

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)