### PR TITLE
Add observatory test workflow for RC/stable releases

### DIFF
--- a/.github/observatory/litellm_config.yaml
+++ b/.github/observatory/litellm_config.yaml
@@ -1,0 +1,19 @@
+# LiteLLM Observatory Test Configuration
+# This config is used by CI to spin up a temporary LiteLLM instance
+# for running observatory tests against RC/stable releases.
+#
+# Add model definitions for the providers you want to test.
+# Provider API keys are injected via environment variables in CI.
+
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: azure/gpt-4o
+      api_key: os.environ/AZURE_API_KEY
+      api_base: os.environ/AZURE_API_BASE
+
+  - model_name: gpt-4o-mini
+    litellm_params:
+      model: azure/gpt-4o-mini
+      api_key: os.environ/AZURE_API_KEY
+      api_base: os.environ/AZURE_API_BASE

--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -299,6 +299,15 @@ jobs:
             ${{ github.event.inputs.release_type == 'stable' && format('{0}/berriai/litellm-spend_logs:main-stable', env.REGISTRY) || '' }}
           platforms: local,linux/amd64,linux/arm64,linux/arm64/v8
 
+  run-observatory-tests:
+    if: github.event.inputs.release_type == 'rc' || github.event.inputs.release_type == 'stable'
+    needs: [docker-hub-deploy]
+    uses: ./.github/workflows/run_observatory_tests.yml
+    with:
+      tag: ${{ github.event.inputs.tag }}
+      commit_hash: ${{ github.event.inputs.commit_hash }}
+    secrets: inherit
+
   build-and-push-helm-chart:
     if: github.event.inputs.release_type  != 'dev'
     needs: [docker-hub-deploy, build-and-push-image, build-and-push-image-database]

--- a/.github/workflows/run_observatory_tests.yml
+++ b/.github/workflows/run_observatory_tests.yml
@@ -137,7 +137,7 @@ jobs:
 
             if [ "$RUN_STATUS" = "completed" ] || [ "$RUN_STATUS" = "failed" ]; then
               echo "Test finished with status: $RUN_STATUS"
-              echo "run_result=$STATUS" >> $GITHUB_OUTPUT
+              echo "$STATUS" > /tmp/observatory_result.json
               exit 0
             fi
 
@@ -149,7 +149,7 @@ jobs:
 
       - name: Verify test results
         run: |
-          RESULT='${{ steps.poll.outputs.run_result }}'
+          RESULT=$(cat /tmp/observatory_result.json)
           echo "Full result: $RESULT"
 
           STATUS=$(echo "$RESULT" | jq -r '.status')

--- a/.github/workflows/run_observatory_tests.yml
+++ b/.github/workflows/run_observatory_tests.yml
@@ -37,7 +37,18 @@ jobs:
         with:
           ref: ${{ inputs.commit_hash || github.sha }}
 
+      - name: Validate tag input
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Invalid tag format: $TAG (expected vX.Y.Z...)"
+            exit 1
+          fi
+
       - name: Start LiteLLM container
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
           docker run -d \
             --name litellm-rc \
@@ -46,7 +57,7 @@ jobs:
             -e LITELLM_MASTER_KEY="${{ env.LITELLM_MASTER_KEY }}" \
             -e AZURE_API_KEY="${{ secrets.AZURE_API_KEY }}" \
             -e AZURE_API_BASE="${{ secrets.AZURE_API_BASE }}" \
-            litellm/litellm:${{ inputs.tag }} \
+            "litellm/litellm:${TAG}" \
             --config /app/config.yaml --port 4000
 
       - name: Wait for LiteLLM health check
@@ -189,5 +200,11 @@ jobs:
       - name: Print LiteLLM logs on failure
         if: failure()
         run: |
-          docker logs litellm-rc
+          docker logs litellm-rc 2>/dev/null || true
           cat /tmp/cloudflared.log 2>/dev/null || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          kill "${{ env.CLOUDFLARED_PID }}" 2>/dev/null || true
+          docker rm -f litellm-rc 2>/dev/null || true

--- a/.github/workflows/run_observatory_tests.yml
+++ b/.github/workflows/run_observatory_tests.yml
@@ -49,14 +49,16 @@ jobs:
       - name: Start LiteLLM container
         env:
           TAG: ${{ inputs.tag }}
+          AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
+          AZURE_API_BASE: ${{ secrets.AZURE_API_BASE }}
         run: |
           docker run -d \
             --name litellm-rc \
             -p 4000:4000 \
-            -v ${{ github.workspace }}/.github/observatory/litellm_config.yaml:/app/config.yaml \
-            -e LITELLM_MASTER_KEY="${{ env.LITELLM_MASTER_KEY }}" \
-            -e AZURE_API_KEY="${{ secrets.AZURE_API_KEY }}" \
-            -e AZURE_API_BASE="${{ secrets.AZURE_API_BASE }}" \
+            -v "${{ github.workspace }}/.github/observatory/litellm_config.yaml:/app/config.yaml" \
+            -e LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY}" \
+            -e AZURE_API_KEY="${AZURE_API_KEY}" \
+            -e AZURE_API_BASE="${AZURE_API_BASE}" \
             "litellm/litellm:${TAG}" \
             --config /app/config.yaml --port 4000
 
@@ -109,11 +111,13 @@ jobs:
 
       - name: Trigger observatory test run
         id: trigger
+        env:
+          OBSERVATORY_URL: ${{ secrets.OBSERVATORY_URL }}
+          OBSERVATORY_API_KEY: ${{ secrets.OBSERVATORY_API_KEY }}
         run: |
-          OBSERVATORY_URL="${{ secrets.OBSERVATORY_URL }}"
           PAYLOAD=$(jq -n \
-            --arg url "${{ env.TUNNEL_URL }}" \
-            --arg key "${{ env.LITELLM_MASTER_KEY }}" \
+            --arg url "${TUNNEL_URL}" \
+            --arg key "${LITELLM_MASTER_KEY}" \
             '{
               deployment_url: $url,
               api_key: $key,
@@ -122,7 +126,7 @@ jobs:
             }')
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${OBSERVATORY_URL}/run-test" \
             -H "Content-Type: application/json" \
-            -H "X-LiteLLM-Observatory-API-Key: ${{ secrets.OBSERVATORY_API_KEY }}" \
+            -H "X-LiteLLM-Observatory-API-Key: ${OBSERVATORY_API_KEY}" \
             -d "$PAYLOAD")
           HTTP_CODE=$(echo "$RESPONSE" | tail -1)
           BODY=$(echo "$RESPONSE" | head -n -1)
@@ -143,15 +147,17 @@ jobs:
 
       - name: Poll for test completion
         id: poll
+        env:
+          OBSERVATORY_URL: ${{ secrets.OBSERVATORY_URL }}
+          OBSERVATORY_API_KEY: ${{ secrets.OBSERVATORY_API_KEY }}
+          REQUEST_ID: ${{ steps.trigger.outputs.request_id }}
         run: |
-          OBSERVATORY_URL="${{ secrets.OBSERVATORY_URL }}"
-          REQUEST_ID="${{ steps.trigger.outputs.request_id }}"
           TIMEOUT=900  # 15 minutes
           INTERVAL=30
           ELAPSED=0
           while [ $ELAPSED -lt $TIMEOUT ]; do
             STATUS=$(curl -s "${OBSERVATORY_URL}/run-status/${REQUEST_ID}" \
-              -H "X-LiteLLM-Observatory-API-Key: ${{ secrets.OBSERVATORY_API_KEY }}")
+              -H "X-LiteLLM-Observatory-API-Key: ${OBSERVATORY_API_KEY}")
             RUN_STATUS=$(echo "$STATUS" | jq -r '.status')
             echo "Run status (${ELAPSED}s elapsed): $RUN_STATUS"
 

--- a/.github/workflows/run_observatory_tests.yml
+++ b/.github/workflows/run_observatory_tests.yml
@@ -118,6 +118,10 @@ jobs:
 
           # Extract request_id for polling this specific run
           REQUEST_ID=$(echo "$BODY" | jq -r '.results.request_id')
+          if [ -z "$REQUEST_ID" ] || [ "$REQUEST_ID" = "null" ]; then
+            echo "Failed to extract request_id from response"
+            exit 1
+          fi
           echo "Request ID: $REQUEST_ID"
           echo "request_id=$REQUEST_ID" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/run_observatory_tests.yml
+++ b/.github/workflows/run_observatory_tests.yml
@@ -30,6 +30,7 @@ env:
 jobs:
   observatory-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -99,15 +100,19 @@ jobs:
         id: trigger
         run: |
           OBSERVATORY_URL="${{ secrets.OBSERVATORY_URL }}"
+          PAYLOAD=$(jq -n \
+            --arg url "${{ env.TUNNEL_URL }}" \
+            --arg key "${{ env.LITELLM_MASTER_KEY }}" \
+            '{
+              deployment_url: $url,
+              api_key: $key,
+              test_suite: "TestOAIAzureRelease",
+              models: ["gpt-4o-mini", "gpt-4o"]
+            }')
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${OBSERVATORY_URL}/run-test" \
             -H "Content-Type: application/json" \
             -H "X-LiteLLM-Observatory-API-Key: ${{ secrets.OBSERVATORY_API_KEY }}" \
-            -d '{
-              "deployment_url": "${{ env.TUNNEL_URL }}",
-              "api_key": "${{ env.LITELLM_MASTER_KEY }}",
-              "test_suite": "TestOAIAzureRelease",
-              "models": ["gpt-4o-mini", "gpt-4o"]
-            }')
+            -d "$PAYLOAD")
           HTTP_CODE=$(echo "$RESPONSE" | tail -1)
           BODY=$(echo "$RESPONSE" | head -n -1)
           echo "Response ($HTTP_CODE): $BODY"

--- a/.github/workflows/run_observatory_tests.yml
+++ b/.github/workflows/run_observatory_tests.yml
@@ -1,0 +1,144 @@
+name: Run Observatory Tests
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Docker image tag to test (e.g. v1.61.0.rc1)"
+        required: true
+        type: string
+      commit_hash:
+        description: "Commit hash (defaults to HEAD of current branch)"
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: "Docker image tag to test"
+        required: true
+        type: string
+      commit_hash:
+        description: "Commit hash of the release"
+        required: true
+        type: string
+
+env:
+  LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY_STAGING }}
+
+jobs:
+  observatory-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_hash || github.sha }}
+
+      - name: Start LiteLLM container
+        run: |
+          docker run -d \
+            --name litellm-rc \
+            -p 4000:4000 \
+            -v ${{ github.workspace }}/.github/observatory/litellm_config.yaml:/app/config.yaml \
+            -e LITELLM_MASTER_KEY="${{ env.LITELLM_MASTER_KEY }}" \
+            -e AZURE_API_KEY="${{ secrets.AZURE_API_KEY }}" \
+            -e AZURE_API_BASE="${{ secrets.AZURE_API_BASE }}" \
+            litellm/litellm:${{ inputs.tag }} \
+            --config /app/config.yaml --port 4000
+
+      - name: Wait for LiteLLM health check
+        run: |
+          echo "Waiting for LiteLLM to be ready..."
+          for i in $(seq 1 30); do
+            if curl -s -f http://localhost:4000/health/liveliness > /dev/null 2>&1; then
+              echo "LiteLLM is healthy"
+              exit 0
+            fi
+            echo "Attempt $i/30 - not ready yet, waiting 10s..."
+            sleep 10
+          done
+          echo "LiteLLM failed to start within 5 minutes"
+          docker logs litellm-rc
+          exit 1
+
+      - name: Start cloudflared tunnel
+        run: |
+          # Install cloudflared
+          curl -sL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+          # Start a quick tunnel (no account needed) and capture the URL
+          cloudflared tunnel --url http://localhost:4000 --no-autoupdate > /tmp/cloudflared.log 2>&1 &
+          CLOUDFLARED_PID=$!
+          echo "CLOUDFLARED_PID=$CLOUDFLARED_PID" >> $GITHUB_ENV
+
+          # Wait for tunnel URL to appear in logs
+          echo "Waiting for tunnel URL..."
+          for i in $(seq 1 30); do
+            TUNNEL_URL=$(grep -oP 'https://[a-z0-9-]+\.trycloudflare\.com' /tmp/cloudflared.log | head -1 || true)
+            if [ -n "$TUNNEL_URL" ]; then
+              echo "Tunnel URL: $TUNNEL_URL"
+              echo "TUNNEL_URL=$TUNNEL_URL" >> $GITHUB_ENV
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Failed to get tunnel URL"
+          cat /tmp/cloudflared.log
+          exit 1
+
+      - name: Verify tunnel connectivity
+        run: |
+          echo "Testing tunnel at ${{ env.TUNNEL_URL }}..."
+          curl -sf "${{ env.TUNNEL_URL }}/health/liveliness"
+          echo "Tunnel is working"
+
+      - name: Trigger observatory test run
+        run: |
+          OBSERVATORY_URL="${{ secrets.OBSERVATORY_URL }}"
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${OBSERVATORY_URL}/run-test" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.OBSERVATORY_API_KEY }}" \
+            -d '{
+              "deployment_url": "${{ env.TUNNEL_URL }}",
+              "api_key": "${{ env.LITELLM_MASTER_KEY }}",
+              "test_suite": "TestOAIAzureRelease",
+              "models": ["gpt-4o-mini", "gpt-4o"]
+            }')
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | head -n -1)
+          echo "Response ($HTTP_CODE): $BODY"
+          if [ "$HTTP_CODE" -ge 400 ]; then
+            echo "Failed to trigger test run"
+            exit 1
+          fi
+
+      - name: Poll for test completion
+        run: |
+          OBSERVATORY_URL="${{ secrets.OBSERVATORY_URL }}"
+          TIMEOUT=900  # 15 minutes
+          INTERVAL=30
+          ELAPSED=0
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            STATUS=$(curl -s "${OBSERVATORY_URL}/queue-status" \
+              -H "Authorization: Bearer ${{ secrets.OBSERVATORY_API_KEY }}")
+            echo "Queue status (${ELAPSED}s elapsed): $STATUS"
+
+            PENDING=$(echo "$STATUS" | jq -r '.pending // 0')
+            ACTIVE=$(echo "$STATUS" | jq -r '.active // 0')
+
+            if [ "$PENDING" = "0" ] && [ "$ACTIVE" = "0" ]; then
+              echo "All tests completed"
+              exit 0
+            fi
+
+            sleep $INTERVAL
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+          echo "Timed out waiting for tests to complete after ${TIMEOUT}s"
+          exit 1
+
+      - name: Print LiteLLM logs on failure
+        if: failure()
+        run: |
+          docker logs litellm-rc
+          cat /tmp/cloudflared.log 2>/dev/null || true

--- a/.github/workflows/run_observatory_tests.yml
+++ b/.github/workflows/run_observatory_tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Start cloudflared tunnel
         run: |
           # Install cloudflared
-          curl -sL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -sL https://github.com/cloudflare/cloudflared/releases/download/2025.2.1/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
           # Start a quick tunnel (no account needed) and capture the URL

--- a/.github/workflows/run_observatory_tests.yml
+++ b/.github/workflows/run_observatory_tests.yml
@@ -21,6 +21,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY_STAGING }}
 
@@ -93,11 +96,12 @@ jobs:
           echo "Tunnel is working"
 
       - name: Trigger observatory test run
+        id: trigger
         run: |
           OBSERVATORY_URL="${{ secrets.OBSERVATORY_URL }}"
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${OBSERVATORY_URL}/run-test" \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${{ secrets.OBSERVATORY_API_KEY }}" \
+            -H "X-LiteLLM-Observatory-API-Key: ${{ secrets.OBSERVATORY_API_KEY }}" \
             -d '{
               "deployment_url": "${{ env.TUNNEL_URL }}",
               "api_key": "${{ env.LITELLM_MASTER_KEY }}",
@@ -112,30 +116,66 @@ jobs:
             exit 1
           fi
 
+          # Extract request_id for polling this specific run
+          REQUEST_ID=$(echo "$BODY" | jq -r '.results.request_id')
+          echo "Request ID: $REQUEST_ID"
+          echo "request_id=$REQUEST_ID" >> $GITHUB_OUTPUT
+
       - name: Poll for test completion
+        id: poll
         run: |
           OBSERVATORY_URL="${{ secrets.OBSERVATORY_URL }}"
+          REQUEST_ID="${{ steps.trigger.outputs.request_id }}"
           TIMEOUT=900  # 15 minutes
           INTERVAL=30
           ELAPSED=0
           while [ $ELAPSED -lt $TIMEOUT ]; do
-            STATUS=$(curl -s "${OBSERVATORY_URL}/queue-status" \
-              -H "Authorization: Bearer ${{ secrets.OBSERVATORY_API_KEY }}")
-            echo "Queue status (${ELAPSED}s elapsed): $STATUS"
+            STATUS=$(curl -s "${OBSERVATORY_URL}/run-status/${REQUEST_ID}" \
+              -H "X-LiteLLM-Observatory-API-Key: ${{ secrets.OBSERVATORY_API_KEY }}")
+            RUN_STATUS=$(echo "$STATUS" | jq -r '.status')
+            echo "Run status (${ELAPSED}s elapsed): $RUN_STATUS"
 
-            PENDING=$(echo "$STATUS" | jq -r '.pending // 0')
-            ACTIVE=$(echo "$STATUS" | jq -r '.active // 0')
-
-            if [ "$PENDING" = "0" ] && [ "$ACTIVE" = "0" ]; then
-              echo "All tests completed"
+            if [ "$RUN_STATUS" = "completed" ] || [ "$RUN_STATUS" = "failed" ]; then
+              echo "Test finished with status: $RUN_STATUS"
+              echo "run_result=$STATUS" >> $GITHUB_OUTPUT
               exit 0
             fi
 
             sleep $INTERVAL
             ELAPSED=$((ELAPSED + INTERVAL))
           done
-          echo "Timed out waiting for tests to complete after ${TIMEOUT}s"
+          echo "Timed out waiting for test to complete after ${TIMEOUT}s"
           exit 1
+
+      - name: Verify test results
+        run: |
+          RESULT='${{ steps.poll.outputs.run_result }}'
+          echo "Full result: $RESULT"
+
+          STATUS=$(echo "$RESULT" | jq -r '.status')
+          TEST_PASSED=$(echo "$RESULT" | jq -r '.result.test_passed // false')
+          FAILURE_RATE=$(echo "$RESULT" | jq -r '.result.failure_rate // "N/A"')
+          ERROR=$(echo "$RESULT" | jq -r '.error // empty')
+
+          echo "Status: $STATUS"
+          echo "Test passed: $TEST_PASSED"
+          echo "Failure rate: $FAILURE_RATE"
+
+          if [ -n "$ERROR" ]; then
+            echo "Error: $ERROR"
+          fi
+
+          if [ "$STATUS" = "failed" ]; then
+            echo "Test run failed"
+            exit 1
+          fi
+
+          if [ "$TEST_PASSED" != "true" ]; then
+            echo "Tests did not pass (failure rate: $FAILURE_RATE)"
+            exit 1
+          fi
+
+          echo "All tests passed!"
 
       - name: Print LiteLLM logs on failure
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ tests/test_custom_dir/*
 test.py
 
 litellm_config.yaml
+!.github/observatory/litellm_config.yaml
 .cursor
 .vscode/launch.json
 litellm/proxy/to_delete_loadtest_work/*


### PR DESCRIPTION
## Summary
- Adds a new reusable workflow (`run_observatory_tests.yml`) that spins up a LiteLLM container from the release Docker image, exposes it via a cloudflared tunnel, and triggers test runs on the Railway-hosted [litellm-observatory](https://github.com/BerriAI/litellm-observatory)
- Integrates into `ghcr_deploy.yml` so observatory tests run automatically after Docker Hub deploy for `rc` and `stable` releases
- Can also be triggered manually via `workflow_dispatch` for ad-hoc testing of any published tag
- Adds a placeholder `litellm_config.yaml` with Azure OpenAI model definitions for the test suite

### Required GitHub Secrets
| Secret | Purpose |
|--------|---------|
| `OBSERVATORY_URL` | Railway observatory URL |
| `OBSERVATORY_API_KEY` | Auth key for observatory API |
| `LITELLM_MASTER_KEY_STAGING` | Master key for temp LiteLLM instance |
| `AZURE_API_KEY` / `AZURE_API_BASE` | Provider credentials for test models |

## Test plan
- [ ] Configure required GitHub secrets
- [ ] Trigger `ghcr_deploy.yml` with `release_type: rc` and verify the observatory job runs after Docker Hub deploy
- [ ] Trigger `run_observatory_tests.yml` manually with a valid tag and confirm end-to-end flow
- [ ] Verify Slack receives test results from the observatory
- [ ] Confirm observatory job is skipped for `latest` and `dev` release types

🤖 Generated with [Claude Code](https://claude.com/claude-code)