### PR TITLE
Feature/sarvam stt tts integration

### DIFF
--- a/docs/my-website/docs/audio_transcription.md
+++ b/docs/my-website/docs/audio_transcription.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 | Fallbacks | ✅ | Works between supported models |
 | Loadbalancing | ✅ | Works between supported models |
 | Guardrails | ✅ | Applies to output transcribed text (non-streaming only) |
-| Supported Providers | `openai`, `azure`, `vertex_ai`, `gemini`, `deepgram`, `groq`, `fireworks_ai`, `ovhcloud` | |
+| Supported Providers | `openai`, `azure`, `vertex_ai`, `gemini`, `deepgram`, `groq`, `fireworks_ai`, `ovhcloud`, `sarvam` | |
 
 ## Quick Start
 
@@ -127,6 +127,7 @@ transcript = client.audio.transcriptions.create(
 - [Groq](./providers/groq.md#speech-to-text---whisper)
 - [Deepgram](./providers/deepgram.md)
 - [OVHcloud AI Endpoints](./providers/ovhcloud.md)
+- [Sarvam](./providers/sarvam.md#audio-transcription-stt)
 
 ---
 

--- a/docs/my-website/docs/providers/sarvam.md
+++ b/docs/my-website/docs/providers/sarvam.md
@@ -105,7 +105,7 @@ os.environ["SARVAM_API_KEY"] = "your-sarvam-api-key"
 
 with open("audio.wav", "rb") as audio_file:
     response = transcription(
-        model="sarvam/saarika:v2.5",
+        model="sarvam/saaras:v3",
         file=audio_file,
         language="hi-IN",  # or "unknown" for auto-detect
     )
@@ -119,7 +119,7 @@ print(response.text)
 model_list:
 - model_name: sarvam-stt
   litellm_params:
-    model: saaras:v2.5/saarika:v2.5
+    model: saaras:v3/saarika:v2.5
     api_key: os.environ/SARVAM_API_KEY
   model_info:
     mode: audio_transcription
@@ -129,7 +129,7 @@ model_list:
 curl --location 'http://0.0.0.0:4000/v1/audio/transcriptions' \
   --header 'Authorization: Bearer sk-1234' \
   --form 'file=@"audio.wav"' \
-  --form 'model="saaras:v2.5"' \
+  --form 'model="saaras:v3"' \
   --form 'language="hi-IN"'
 ```
 
@@ -146,7 +146,7 @@ import os
 os.environ["SARVAM_API_KEY"] = "your-sarvam-api-key"
 
 audio = speech(
-    model="bulbul:v3",
+    model="sarvam/bulbul:v3",
     input="Welcome to Sarvam AI!",
     voice="shubh",
     response_format="wav",

--- a/docs/my-website/docs/providers/sarvam.md
+++ b/docs/my-website/docs/providers/sarvam.md
@@ -160,9 +160,9 @@ with open("output.wav", "wb") as f:
 
 ```yaml
 model_list:
-- model_name: bulbul:v3
+- model_name: sarvam/bulbul:v3
   litellm_params:
-    model: bulbul:v3
+    model: sarvam/bulbul:v3
     api_key: os.environ/SARVAM_API_KEY
   model_info:
     mode: audio_speech

--- a/docs/my-website/docs/providers/sarvam.md
+++ b/docs/my-website/docs/providers/sarvam.md
@@ -90,3 +90,93 @@ Here's how to call a Sarvam.ai model with the LiteLLM Proxy Server
     </TabItem>
 
     </Tabs>
+
+## Audio Transcription (STT)
+
+Sarvam supports speech-to-text via the `/audio/transcriptions` endpoint.
+
+### LiteLLM Python SDK
+
+```python
+from litellm import transcription
+import os
+
+os.environ["SARVAM_API_KEY"] = "your-sarvam-api-key"
+
+with open("audio.wav", "rb") as audio_file:
+    response = transcription(
+        model="sarvam/saarika:v2.5",
+        file=audio_file,
+        language="hi-IN",  # or "unknown" for auto-detect
+    )
+
+print(response.text)
+```
+
+### LiteLLM Proxy
+
+```yaml
+model_list:
+- model_name: sarvam-stt
+  litellm_params:
+    model: saaras:v2.5/saarika:v2.5
+    api_key: os.environ/SARVAM_API_KEY
+  model_info:
+    mode: audio_transcription
+```
+
+```bash
+curl --location 'http://0.0.0.0:4000/v1/audio/transcriptions' \
+  --header 'Authorization: Bearer sk-1234' \
+  --form 'file=@"audio.wav"' \
+  --form 'model="saaras:v2.5"' \
+  --form 'language="hi-IN"'
+```
+
+## Text-to-Speech (TTS)
+
+Sarvam supports text-to-speech via the `/audio/speech` endpoint.
+
+### LiteLLM Python SDK
+
+```python
+from litellm import speech
+import os
+
+os.environ["SARVAM_API_KEY"] = "your-sarvam-api-key"
+
+audio = speech(
+    model="bulbul:v3",
+    input="Welcome to Sarvam AI!",
+    voice="shubh",
+    response_format="wav",
+)
+
+with open("output.wav", "wb") as f:
+    f.write(audio.read())
+```
+
+### LiteLLM Proxy
+
+```yaml
+model_list:
+- model_name: bulbul:v3
+  litellm_params:
+    model: bulbul:v3
+    api_key: os.environ/SARVAM_API_KEY
+  model_info:
+    mode: audio_speech
+```
+
+```bash
+curl http://0.0.0.0:4000/v1/audio/speech \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "bulbul:v3",
+    "input": "Welcome to Sarvam AI!",
+    "voice": "anushka",
+    "response_format": "wav"
+  }' \
+  --output output.wav
+```

--- a/docs/my-website/docs/providers/sarvam.md
+++ b/docs/my-website/docs/providers/sarvam.md
@@ -119,7 +119,7 @@ print(response.text)
 model_list:
 - model_name: sarvam-stt
   litellm_params:
-    model: saaras:v3/saarika:v2.5
+    model: sarvam/saaras:v3
     api_key: os.environ/SARVAM_API_KEY
   model_info:
     mode: audio_transcription

--- a/docs/my-website/docs/providers/sarvam.md
+++ b/docs/my-website/docs/providers/sarvam.md
@@ -129,7 +129,7 @@ model_list:
 curl --location 'http://0.0.0.0:4000/v1/audio/transcriptions' \
   --header 'Authorization: Bearer sk-1234' \
   --form 'file=@"audio.wav"' \
-  --form 'model="saaras:v3"' \
+  --form 'model="sarvam/saaras:v3"' \
   --form 'language="hi-IN"'
 ```
 
@@ -173,7 +173,7 @@ curl http://0.0.0.0:4000/v1/audio/speech \
   -H "Authorization: Bearer sk-1234" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "bulbul:v3",
+    "model": "sarvam/bulbul:v3",
     "input": "Welcome to Sarvam AI!",
     "voice": "shubh",
     "response_format": "wav"

--- a/docs/my-website/docs/providers/sarvam.md
+++ b/docs/my-website/docs/providers/sarvam.md
@@ -175,7 +175,7 @@ curl http://0.0.0.0:4000/v1/audio/speech \
   -d '{
     "model": "bulbul:v3",
     "input": "Welcome to Sarvam AI!",
-    "voice": "anushka",
+    "voice": "shubh",
     "response_format": "wav"
   }' \
   --output output.wav

--- a/docs/my-website/docs/text_to_speech.md
+++ b/docs/my-website/docs/text_to_speech.md
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 | Fallbacks | ✅ | Works between supported models |
 | Loadbalancing | ✅ | Works between supported models |
 | Guardrails | ✅ | Applies to input text (non-streaming only) |
-| Supported Providers | OpenAI, Azure OpenAI, Vertex AI, AWS Polly, ElevenLabs , MiniMax |
+| Supported Providers | OpenAI, Azure OpenAI, Vertex AI, AWS Polly, ElevenLabs , MiniMax, Sarvam |
 
 ## **LiteLLM Python SDK Usage**
 ### Quick Start 
@@ -106,6 +106,7 @@ litellm --config /path/to/config.yaml
 | Gemini      |   [Usage](#gemini-text-to-speech)                 |
 | ElevenLabs  |   [Usage](../docs/providers/elevenlabs#text-to-speech-tts)                 |
 | MiniMax     |   [Usage](../docs/providers/minimax#minimax---text-to-speech)                 |
+| Sarvam      |   [Usage](../docs/providers/sarvam#text-to-speech-tts)                 |
 
 ## `/audio/speech` to `/chat/completions` Bridge
 

--- a/litellm/llms/sarvam/audio_transcription/transformation.py
+++ b/litellm/llms/sarvam/audio_transcription/transformation.py
@@ -1,0 +1,244 @@
+"""
+Sarvam AI Speech-to-Text transformation
+
+Translates from OpenAI's `/v1/audio/transcriptions` to Sarvam's `/speech-to-text`
+"""
+
+from typing import List, Optional, Union
+
+from httpx import Headers, Response
+
+from litellm.litellm_core_utils.audio_utils.utils import process_audio_file
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.utils import AllMessageValues, FileTypes, TranscriptionResponse
+from litellm.types.llms.openai import OpenAIAudioTranscriptionOptionalParams
+
+from ...base_llm.audio_transcription.transformation import (
+    AudioTranscriptionRequestData,
+    BaseAudioTranscriptionConfig,
+)
+from ..common_utils import SarvamException, get_sarvam_user_agent
+
+
+class SarvamAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
+    """
+    Configuration for Sarvam AI Speech-to-Text
+
+    Reference: https://docs.sarvam.ai/api-reference-docs/speech/speech-to-text
+
+    Supported models:
+    - saarika:v2.5 (default): Transcribes audio in the spoken language
+    - saaras:v3: State-of-the-art model with flexible output formats
+
+    saaras:v3 Modes (use 'mode' parameter):
+    - transcribe (default): Standard transcription with formatting and number normalization
+    - translate: Translates Indic speech to English
+    - verbatim: Exact word-for-word without normalization
+    - translit: Romanization to Latin script
+    - codemix: Code-mixed text (English words in English, Indic in native script)
+
+    Supported languages:
+    hi-IN, bn-IN, kn-IN, ml-IN, mr-IN, od-IN, pa-IN, ta-IN, te-IN, en-IN, gu-IN, unknown (auto-detect)
+    """
+
+    SARVAM_API_BASE = "https://api.sarvam.ai"
+
+    # Valid modes for saaras:v3
+    VALID_MODES = {"transcribe", "translate", "verbatim", "translit", "codemix"}
+
+    def _is_saaras_v3_model(self, model: str) -> bool:
+        normalized_model = model.lower().strip()
+        if normalized_model == "saaras:v3":
+            return True
+        return normalized_model.split("/", 1)[-1] == "saaras:v3"
+
+    @property
+    def custom_llm_provider(self) -> str:
+        return "sarvam"
+
+    def get_supported_openai_params(
+        self, model: str
+    ) -> List[OpenAIAudioTranscriptionOptionalParams]:
+        return ["language"]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        supported_params = self.get_supported_openai_params(model)
+        for k, v in non_default_params.items():
+            if k in supported_params:
+                if k == "language":
+                    # Map OpenAI language to Sarvam language_code
+                    optional_params["language_code"] = v
+                else:
+                    optional_params[k] = v
+        return optional_params
+
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: Union[dict, Headers]
+    ) -> BaseLLMException:
+        return SarvamException(
+            message=error_message, status_code=status_code, headers=headers
+        )
+
+    def transform_audio_transcription_request(
+        self,
+        model: str,
+        audio_file: FileTypes,
+        optional_params: dict,
+        litellm_params: dict,
+    ) -> AudioTranscriptionRequestData:
+        """
+        Transforms the audio transcription request for Sarvam API.
+
+        Sarvam expects multipart form data with:
+        - file: audio file
+        - model: model name (e.g., saarika:v2.5, saaras:v3)
+        - language_code: optional language code (e.g., hi-IN, unknown for auto-detect)
+        - mode: optional mode for saaras:v3 (transcribe, translate, verbatim, translit, codemix)
+        """
+
+        # Use common utility to process the audio file
+        processed_audio = process_audio_file(audio_file)
+
+        # Prepare form data
+        form_data = {"model": model}
+
+        # Map language parameter to language_code
+        if "language" in optional_params:
+            form_data["language_code"] = optional_params["language"]
+        elif "language_code" in optional_params:
+            form_data["language_code"] = optional_params["language_code"]
+
+        # Add mode parameter (only applicable for saaras:v3)
+        if "mode" in optional_params:
+            mode_value = optional_params["mode"]
+            if not self._is_saaras_v3_model(model):
+                raise ValueError("`mode` is only supported for model 'saaras:v3'")
+
+            if not isinstance(mode_value, str) or not mode_value.strip():
+                raise ValueError(
+                    f"Invalid mode '{mode_value}'. Supported modes for saaras:v3: "
+                    f"{', '.join(sorted(self.VALID_MODES))}"
+                )
+
+            normalized_mode = mode_value.strip().lower()
+            if normalized_mode not in self.VALID_MODES:
+                raise ValueError(
+                    f"Invalid mode '{mode_value}'. Supported modes for saaras:v3: "
+                    f"{', '.join(sorted(self.VALID_MODES))}"
+                )
+            form_data["mode"] = normalized_mode
+
+        # Add provider-specific parameters
+        provider_specific_params = self.get_provider_specific_params(
+            model=model,
+            optional_params=optional_params,
+            openai_params=self.get_supported_openai_params(model),
+        )
+
+        for key, value in provider_specific_params.items():
+            if key not in form_data and value is not None:
+                form_data[key] = str(value)
+
+        # Prepare files
+        files = {
+            "file": (
+                processed_audio.filename,
+                processed_audio.file_content,
+                processed_audio.content_type,
+            )
+        }
+
+        return AudioTranscriptionRequestData(
+            data=form_data,
+            files=files,
+        )
+
+    def transform_audio_transcription_response(
+        self,
+        raw_response: Response,
+    ) -> TranscriptionResponse:
+        """
+        Transforms the raw response from Sarvam to TranscriptionResponse format.
+
+        Sarvam API returns:
+        {
+            "transcript": "...",
+            "language_code": "hi-IN"
+        }
+        """
+        try:
+            response_json = raw_response.json()
+        except Exception as e:
+            raise self.get_error_class(
+                error_message=(
+                    "Error parsing Sarvam audio transcription response as JSON. "
+                    f"Raw response: {raw_response.text}. "
+                    f"Parse error: {str(e)}"
+                ),
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        # Extract the transcript text
+        text = response_json.get("transcript", "")
+
+        # Create TranscriptionResponse object
+        response = TranscriptionResponse(text=text)
+
+        # Add metadata
+        response["task"] = "transcribe"
+        response["language"] = response_json.get("language_code", "unknown")
+
+        # Store full response in hidden params
+        response._hidden_params = response_json
+
+        return response
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        if api_base and not api_base.rstrip("/").endswith("/v1"):
+            base_url = api_base
+        else:
+            base_url = self.SARVAM_API_BASE
+        base_url = base_url.rstrip("/")
+
+        return f"{base_url}/speech-to-text"
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
+        api_key = api_key or get_secret_str("SARVAM_API_KEY")
+        if api_key is None:
+            raise ValueError(
+                "Sarvam API key is required. Set SARVAM_API_KEY environment variable."
+            )
+
+        headers.update(
+            {
+                "api-subscription-key": api_key,
+                "User-Agent": get_sarvam_user_agent(),
+            }
+        )
+
+        return headers

--- a/litellm/llms/sarvam/audio_transcription/transformation.py
+++ b/litellm/llms/sarvam/audio_transcription/transformation.py
@@ -210,10 +210,12 @@ class SarvamAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
         litellm_params: dict,
         stream: Optional[bool] = None,
     ) -> str:
-        base_url = api_base or self.SARVAM_API_BASE
-        base_url = base_url.rstrip("/")
-        if base_url.endswith("/v1"):
-            base_url = base_url[:-3]
+        if api_base:
+            base_url = api_base.rstrip("/")
+            if base_url.endswith("/v1"):
+                base_url = base_url[:-3]
+        else:
+            base_url = self.SARVAM_API_BASE
 
         return f"{base_url}/speech-to-text"
 

--- a/litellm/llms/sarvam/audio_transcription/transformation.py
+++ b/litellm/llms/sarvam/audio_transcription/transformation.py
@@ -184,7 +184,7 @@ class SarvamAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
                 ),
                 status_code=raw_response.status_code,
                 headers=raw_response.headers,
-            )
+            ) from e
 
         # Extract the transcript text
         text = response_json.get("transcript", "")
@@ -210,11 +210,10 @@ class SarvamAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
         litellm_params: dict,
         stream: Optional[bool] = None,
     ) -> str:
-        if api_base and not api_base.rstrip("/").endswith("/v1"):
-            base_url = api_base
-        else:
-            base_url = self.SARVAM_API_BASE
+        base_url = api_base or self.SARVAM_API_BASE
         base_url = base_url.rstrip("/")
+        if base_url.endswith("/v1"):
+            base_url = base_url[:-3]
 
         return f"{base_url}/speech-to-text"
 

--- a/litellm/llms/sarvam/common_utils.py
+++ b/litellm/llms/sarvam/common_utils.py
@@ -1,0 +1,18 @@
+import sys
+
+from litellm._version import version as litellm_version
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+SARVAM_API_BASE = "https://api.sarvam.ai"
+
+
+def get_sarvam_user_agent() -> str:
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    return (
+        f"LiteLLM/{litellm_version} "
+        f"python/{python_version}"
+    )
+
+
+class SarvamException(BaseLLMException):
+    pass

--- a/litellm/llms/sarvam/common_utils.py
+++ b/litellm/llms/sarvam/common_utils.py
@@ -1,4 +1,4 @@
-import sys
+import platform
 
 from litellm._version import version as litellm_version
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
@@ -7,7 +7,7 @@ SARVAM_API_BASE = "https://api.sarvam.ai"
 
 
 def get_sarvam_user_agent() -> str:
-    python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    python_version = f"{platform.python_version()}"
     return (
         f"LiteLLM/{litellm_version} "
         f"python/{python_version}"

--- a/litellm/llms/sarvam/text_to_speech/transformation.py
+++ b/litellm/llms/sarvam/text_to_speech/transformation.py
@@ -233,7 +233,7 @@ class SarvamTextToSpeechConfig(BaseTextToSpeechConfig):
                 ),
                 status_code=raw_response.status_code,
                 headers=raw_response.headers,
-            )
+            ) from e
         audios = response_json.get("audios", [])
 
         if not audios:

--- a/litellm/llms/sarvam/text_to_speech/transformation.py
+++ b/litellm/llms/sarvam/text_to_speech/transformation.py
@@ -1,0 +1,283 @@
+"""
+Sarvam AI Text-to-Speech transformation
+
+Maps OpenAI TTS spec to Sarvam TTS API
+"""
+
+import base64
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+
+import httpx
+from httpx import Headers
+
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.text_to_speech.transformation import (
+    BaseTextToSpeechConfig,
+    TextToSpeechRequestData,
+)
+from litellm.secret_managers.main import get_secret_str
+
+from ..common_utils import SarvamException, get_sarvam_user_agent
+
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+    from litellm.types.llms.openai import HttpxBinaryResponseContent
+else:
+    LiteLLMLoggingObj = Any
+    HttpxBinaryResponseContent = Any
+
+
+class SarvamTextToSpeechConfig(BaseTextToSpeechConfig):
+    """
+    Configuration for Sarvam AI Text-to-Speech
+
+    Reference: https://docs.sarvam.ai/api-reference-docs/text-to-speech/convert
+
+    Supported models:
+    - bulbul:v2
+    - bulbul:v3
+
+    Available speakers:
+
+    bulbul:v2:
+      Female: Anushka (default), Manisha, Vidya, Arya
+      Male: Abhilash, Karun, Hitesh
+
+    bulbul:v3:
+      Shubh (default), Prabhat, Ritu, Ashutosh, Priya, Neha, Rahul,
+      Pooja, Rohan, Simran, Kavya, Amit, Dev, Ishita, Shreya,
+      Ratan, Varun, Manan, Sumit, Roopa, Kabir, Aayan, Advait, Amelia, Sophia
+
+    Supported languages:
+    hi-IN, bn-IN, kn-IN, ml-IN, mr-IN, od-IN, pa-IN, ta-IN, te-IN, en-IN, gu-IN
+
+    Pricing: ₹15 per 10K characters ($0.165 per 10K characters)
+    """
+
+    TTS_ENDPOINT_PATH = "/text-to-speech"
+    DEFAULT_LANGUAGE = "en-IN"
+    DEFAULT_SPEAKER_V2 = "anushka"
+    DEFAULT_SPEAKER_V3 = "shubh"
+    SARVAM_API_BASE = "https://api.sarvam.ai"
+
+    def _get_default_speaker(self, model: str) -> str:
+        """Get the default speaker based on model version."""
+        if "v3" in model.lower():
+            return self.DEFAULT_SPEAKER_V3
+        return self.DEFAULT_SPEAKER_V2
+
+    def get_supported_openai_params(self, model: str) -> list:
+        """
+        Sarvam TTS supports these OpenAI parameters
+        """
+        return ["voice", "response_format", "speed"]
+
+    def map_openai_params(
+        self,
+        model: str,
+        optional_params: Dict,
+        voice: Optional[Union[str, Dict]] = None,
+        drop_params: bool = False,
+        kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Optional[str], Dict]:
+        """
+        Process TTS parameters for Sarvam.
+
+        Voice must be a valid Sarvam speaker name.
+        See class docstring for available speakers per model.
+        """
+        mapped_params: Dict[str, Any] = {}
+        params = dict(optional_params) if optional_params else {}
+
+        # Extract voice and normalize to lowercase for Sarvam speaker names
+        speaker: Optional[str] = None
+        if isinstance(voice, str) and voice.strip():
+            speaker = voice.strip().lower()
+        elif isinstance(voice, dict):
+            for key in ("voice_id", "id", "name"):
+                candidate = voice.get(key)
+                if isinstance(candidate, str) and candidate.strip():
+                    speaker = candidate.strip().lower()
+                    break
+        elif voice is not None:
+            speaker = str(voice).strip().lower()
+
+        if speaker is None:
+            speaker = self._get_default_speaker(model)
+
+        # Handle speed parameter (Sarvam uses 'pace' with range 0.5-2.0)
+        speed = params.pop("speed", None)
+        if speed is not None:
+            mapped_params["pace"] = float(speed)
+
+        # Handle response_format (Sarvam returns base64, we decode it)
+        params.pop("response_format", None)  # Not directly used by Sarvam
+
+        # Pass through remaining params
+        for key, value in params.items():
+            if value is not None:
+                mapped_params[key] = value
+
+        return speaker, mapped_params
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
+        """
+        Validate environment and set up authentication headers
+        """
+        api_key = api_key or get_secret_str("SARVAM_API_KEY")
+
+        if api_key is None:
+            raise ValueError(
+                "Sarvam API key is required. Set SARVAM_API_KEY environment variable."
+            )
+
+        headers.update(
+            {
+                "api-subscription-key": api_key,
+                "Content-Type": "application/json",
+                "User-Agent": get_sarvam_user_agent(),
+            }
+        )
+
+        return headers
+
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: Union[dict, Headers]
+    ) -> BaseLLMException:
+        return SarvamException(
+            message=error_message, status_code=status_code, headers=headers
+        )
+
+    def transform_text_to_speech_request(
+        self,
+        model: str,
+        input: str,
+        voice: Optional[str],
+        optional_params: Dict,
+        litellm_params: Dict,
+        headers: dict,
+    ) -> TextToSpeechRequestData:
+        """
+        Build the Sarvam TTS request payload.
+
+        Sarvam TTS API expects:
+        {
+            "text": "text to synthesize",
+            "target_language_code": "hi-IN",
+            "speaker": "anushka",
+            "model": "bulbul:v2"
+        }
+        """
+        params = dict(optional_params) if optional_params else {}
+
+        # Get model-appropriate default speaker
+        default_speaker = self._get_default_speaker(model)
+
+        # Build request body
+        request_body: Dict[str, Any] = {
+            "text": input,
+            "model": model,
+            "speaker": voice.lower() if voice else default_speaker,
+            "target_language_code": params.pop(
+                "target_language_code", self.DEFAULT_LANGUAGE
+            ),
+        }
+
+        # Add pace parameter (Sarvam's speed control, range 0.5-2.0)
+        if "pace" in params:
+            request_body["pace"] = params.pop("pace")
+
+        # Add any remaining provider-specific params
+        for key, value in params.items():
+            if value is not None:
+                request_body[key] = value
+
+        return TextToSpeechRequestData(
+            dict_body=request_body,
+            headers={"Content-Type": "application/json"},
+        )
+
+    def transform_text_to_speech_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> "HttpxBinaryResponseContent":
+        """
+        Transform Sarvam TTS response.
+
+        Sarvam returns base64-encoded audio in JSON:
+        {
+            "audios": ["base64_encoded_audio_data"]
+        }
+
+        We need to decode it and wrap it in HttpxBinaryResponseContent.
+        """
+        from litellm.types.llms.openai import HttpxBinaryResponseContent
+
+        try:
+            response_json = raw_response.json()
+        except Exception as e:
+            raise self.get_error_class(
+                error_message=(
+                    "Error parsing Sarvam text-to-speech response as JSON. "
+                    f"Raw response: {raw_response.text}. "
+                    f"Parse error: {str(e)}"
+                ),
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+        audios = response_json.get("audios", [])
+
+        if not audios:
+            raise ValueError("Sarvam TTS response contains no audio data")
+
+        # Decode the first audio (Sarvam returns one audio per input)
+        audio_base64 = audios[0]
+        audio_bytes = base64.b64decode(audio_base64)
+
+        # Create synthetic httpx.Response with decoded audio bytes
+        # (same pattern as MiniMax TTS)
+        clean_headers = dict(raw_response.headers)
+        clean_headers.pop("content-encoding", None)
+        clean_headers.pop("transfer-encoding", None)
+        clean_headers["content-length"] = str(len(audio_bytes))
+        clean_headers["content-type"] = "audio/wav"
+
+        binary_response = httpx.Response(
+            status_code=200,
+            headers=clean_headers,
+            content=audio_bytes,
+            request=raw_response.request,
+        )
+
+        return HttpxBinaryResponseContent(binary_response)
+
+    def get_complete_url(
+        self,
+        model: str,
+        api_base: Optional[str],
+        litellm_params: dict,
+    ) -> str:
+        """
+        Construct the Sarvam TTS endpoint URL.
+
+        Note: The TTS endpoint is at https://api.sarvam.ai/text-to-speech
+        (without /v1), unlike the chat completions endpoint which uses /v1.
+        We ignore the api_base from providers.json if it contains /v1.
+        """
+        # Use explicit api_base only if it doesn't end with /v1
+        if api_base and not api_base.rstrip("/").endswith("/v1"):
+            base_url = api_base
+        else:
+            base_url = self.SARVAM_API_BASE
+        base_url = base_url.rstrip("/")
+
+        return f"{base_url}{self.TTS_ENDPOINT_PATH}"

--- a/litellm/llms/sarvam/text_to_speech/transformation.py
+++ b/litellm/llms/sarvam/text_to_speech/transformation.py
@@ -241,7 +241,14 @@ class SarvamTextToSpeechConfig(BaseTextToSpeechConfig):
 
         # Decode the first audio (Sarvam returns one audio per input)
         audio_base64 = audios[0]
-        audio_bytes = base64.b64decode(audio_base64)
+        try:
+            audio_bytes = base64.b64decode(audio_base64)
+        except Exception as e:
+            raise self.get_error_class(
+                error_message=f"Failed to decode Sarvam TTS audio data: {str(e)}",
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            ) from e
 
         # Create synthetic httpx.Response with decoded audio bytes
         # (same pattern as MiniMax TTS)

--- a/litellm/llms/sarvam/text_to_speech/transformation.py
+++ b/litellm/llms/sarvam/text_to_speech/transformation.py
@@ -101,7 +101,9 @@ class SarvamTextToSpeechConfig(BaseTextToSpeechConfig):
                     speaker = candidate.strip().lower()
                     break
         elif voice is not None:
-            speaker = str(voice).strip().lower()
+            stripped = str(voice).strip().lower()
+            if stripped:
+                speaker = stripped
 
         if speaker is None:
             speaker = self._get_default_speaker(model)

--- a/litellm/llms/sarvam/text_to_speech/transformation.py
+++ b/litellm/llms/sarvam/text_to_speech/transformation.py
@@ -273,11 +273,13 @@ class SarvamTextToSpeechConfig(BaseTextToSpeechConfig):
         (without /v1), unlike the chat completions endpoint which uses /v1.
         We ignore the api_base from providers.json if it contains /v1.
         """
-        # Use explicit api_base only if it doesn't end with /v1
-        if api_base and not api_base.rstrip("/").endswith("/v1"):
-            base_url = api_base
+        if api_base:
+            base_url = api_base.rstrip("/")
+            if base_url.endswith("/v1"):
+                base_url = base_url[:-3]
         else:
             base_url = self.SARVAM_API_BASE
+        base_url = base_url.rstrip("/")
         base_url = base_url.rstrip("/")
 
         return f"{base_url}{self.TTS_ENDPOINT_PATH}"

--- a/litellm/llms/sarvam/text_to_speech/transformation.py
+++ b/litellm/llms/sarvam/text_to_speech/transformation.py
@@ -281,8 +281,7 @@ class SarvamTextToSpeechConfig(BaseTextToSpeechConfig):
         Note: The TTS endpoint is at https://api.sarvam.ai/text-to-speech
         (without /v1), unlike the chat completions endpoint which uses /v1.
         We ignore the api_base from providers.json if it contains /v1.
-        """
-        if api_base:
+        base_url = base_url.rstrip("/")
             base_url = api_base.rstrip("/")
             if base_url.endswith("/v1"):
                 base_url = base_url[:-3]

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6407,6 +6407,7 @@ def transcription(
         )
     elif custom_llm_provider == "openai" or (
         custom_llm_provider in litellm.openai_compatible_providers
+        and provider_config is None
     ):
         api_base = (
             api_base
@@ -6611,9 +6612,9 @@ def speech(  # noqa: PLR0915
         Coroutine[Any, Any, HttpxBinaryResponseContent],
         None,
     ] = None
-    if (
-        custom_llm_provider == "openai"
-        or custom_llm_provider in litellm.openai_compatible_providers
+    if custom_llm_provider == "openai" or (
+        custom_llm_provider in litellm.openai_compatible_providers
+        and text_to_speech_provider_config is None
     ):
         if voice is None or not (isinstance(voice, str)):
             raise litellm.BadRequestError(
@@ -6970,6 +6971,27 @@ def speech(  # noqa: PLR0915
             api_base=api_base,
             api_key=api_key,
             **kwargs,
+        )
+    elif text_to_speech_provider_config is not None:
+        voice_str = voice if isinstance(voice, str) else None
+        if api_base is not None:
+            litellm_params_dict["api_base"] = api_base
+        if api_key is not None:
+            litellm_params_dict["api_key"] = api_key
+
+        response = base_llm_http_handler.text_to_speech_handler(
+            model=model,
+            input=input,
+            voice=voice_str,
+            text_to_speech_provider_config=text_to_speech_provider_config,
+            text_to_speech_optional_params=optional_params,
+            custom_llm_provider=custom_llm_provider,
+            litellm_params=litellm_params_dict,
+            logging_obj=logging_obj,
+            timeout=timeout,
+            extra_headers=extra_headers,
+            client=client,
+            _is_async=aspeech or False,
         )
 
     if response is None:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6611,7 +6611,6 @@ def speech(  # noqa: PLR0915
     response: Union[
         HttpxBinaryResponseContent,
         Coroutine[Any, Any, HttpxBinaryResponseContent],
-        None,
     if custom_llm_provider == "openai" or (
         custom_llm_provider in litellm.openai_compatible_providers
     ):

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6439,11 +6439,7 @@ def transcription(
             litellm_params=litellm_params_dict,
             shared_session=shared_session,
         )
-    elif (
-        provider_config is not None
-        and custom_llm_provider != "openai"
-        and custom_llm_provider not in litellm.openai_compatible_providers
-    ):
+    elif provider_config is not None:
         response = base_llm_http_handler.audio_transcriptions(
             model=model,
             audio_file=file,
@@ -6974,11 +6970,7 @@ def speech(  # noqa: PLR0915
             api_key=api_key,
             **kwargs,
         )
-    elif (
-        text_to_speech_provider_config is not None
-        and custom_llm_provider != "openai"
-        and custom_llm_provider not in litellm.openai_compatible_providers
-    ):
+    elif text_to_speech_provider_config is not None:
         voice_str = voice if isinstance(voice, str) else None
         if api_base is not None:
             litellm_params_dict["api_base"] = api_base

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6403,6 +6403,8 @@ def transcription(
             api_version=api_version,
             azure_ad_token=azure_ad_token,
             max_retries=max_retries,
+            litellm_params=litellm_params_dict,
+        )
     elif custom_llm_provider == "openai" or (
         custom_llm_provider in litellm.openai_compatible_providers
     ):
@@ -6611,6 +6613,8 @@ def speech(  # noqa: PLR0915
     response: Union[
         HttpxBinaryResponseContent,
         Coroutine[Any, Any, HttpxBinaryResponseContent],
+        None,
+    ] = None
     if custom_llm_provider == "openai" or (
         custom_llm_provider in litellm.openai_compatible_providers
     ):

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6614,7 +6614,6 @@ def speech(  # noqa: PLR0915
         HttpxBinaryResponseContent,
         Coroutine[Any, Any, HttpxBinaryResponseContent],
         None,
-    ] = None
     if custom_llm_provider == "openai" or (
         custom_llm_provider in litellm.openai_compatible_providers
     ):

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6407,7 +6407,6 @@ def transcription(
         )
     elif custom_llm_provider == "openai" or (
         custom_llm_provider in litellm.openai_compatible_providers
-        and provider_config is None
     ):
         api_base = (
             api_base
@@ -6440,7 +6439,11 @@ def transcription(
             litellm_params=litellm_params_dict,
             shared_session=shared_session,
         )
-    elif provider_config is not None:
+    elif (
+        provider_config is not None
+        and custom_llm_provider != "openai"
+        and custom_llm_provider not in litellm.openai_compatible_providers
+    ):
         response = base_llm_http_handler.audio_transcriptions(
             model=model,
             audio_file=file,
@@ -6614,7 +6617,6 @@ def speech(  # noqa: PLR0915
     ] = None
     if custom_llm_provider == "openai" or (
         custom_llm_provider in litellm.openai_compatible_providers
-        and text_to_speech_provider_config is None
     ):
         if voice is None or not (isinstance(voice, str)):
             raise litellm.BadRequestError(
@@ -6972,7 +6974,11 @@ def speech(  # noqa: PLR0915
             api_key=api_key,
             **kwargs,
         )
-    elif text_to_speech_provider_config is not None:
+    elif (
+        text_to_speech_provider_config is not None
+        and custom_llm_provider != "openai"
+        and custom_llm_provider not in litellm.openai_compatible_providers
+    ):
         voice_str = voice if isinstance(voice, str) else None
         if api_base is not None:
             litellm_params_dict["api_base"] = api_base

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6404,7 +6404,6 @@ def transcription(
             azure_ad_token=azure_ad_token,
             max_retries=max_retries,
             litellm_params=litellm_params_dict,
-        )
     elif custom_llm_provider == "openai" or (
         custom_llm_provider in litellm.openai_compatible_providers
     ):

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6403,7 +6403,6 @@ def transcription(
             api_version=api_version,
             azure_ad_token=azure_ad_token,
             max_retries=max_retries,
-            litellm_params=litellm_params_dict,
     elif custom_llm_provider == "openai" or (
         custom_llm_provider in litellm.openai_compatible_providers
     ):

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -37753,5 +37753,35 @@
         "metadata": {
             "notes": "DuckDuckGo Instant Answer API is free and does not require an API key."
         }
+    },
+    "sarvam/saaras:v3": {
+        "input_cost_per_second": 9.2e-05,
+        "litellm_provider": "sarvam",
+        "metadata": {
+            "notes": "Sarvam AI Saaras v3 - Speech-to-Text for 11 Indian languages",
+            "original_pricing_inr_per_hour": 30,
+            "calculation": "\u20b930/hour = $0.33/hour \u00f7 3600 sec = $0.000092/sec"
+        },
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0,
+        "source": "https://www.sarvam.ai/api-pricing",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ]
+    },
+    "sarvam/bulbul:v3": {
+        "input_cost_per_character": 3.3e-05,
+        "litellm_provider": "sarvam",
+        "metadata": {
+            "notes": "Sarvam AI Bulbul v3 - TTS for 11 Indian languages",
+            "original_pricing_inr_per_10k_chars": 30,
+            "calculation": "\u20b930/10K chars = $0.33/10K = $0.000033/char"
+        },
+        "mode": "audio_speech",
+        "output_cost_per_second": 0.0,
+        "source": "https://www.sarvam.ai/api-pricing",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ]
     }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3175,6 +3175,7 @@ class LlmProviders(str, Enum):
     CHUTES = "chutes"
     XIAOMI_MIMO = "xiaomi_mimo"
     LITELLM_AGENT = "litellm_agent"
+    SARVAM = "sarvam"
 
 
 # Create a set of all provider values for quick lookup

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8260,6 +8260,12 @@ class ProviderConfigManager:
             )
 
             return OVHCloudAudioTranscriptionConfig()
+        elif litellm.LlmProviders.SARVAM == provider:
+            from litellm.llms.sarvam.audio_transcription.transformation import (
+                SarvamAudioTranscriptionConfig,
+            )
+
+            return SarvamAudioTranscriptionConfig()
         return None
 
     @staticmethod
@@ -8891,6 +8897,12 @@ class ProviderConfigManager:
             )
 
             return AWSPollyTextToSpeechConfig()
+        elif litellm.LlmProviders.SARVAM == provider:
+            from litellm.llms.sarvam.text_to_speech.transformation import (
+                SarvamTextToSpeechConfig,
+            )
+
+            return SarvamTextToSpeechConfig()
         return None
 
     @staticmethod

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -37768,10 +37768,11 @@
         ]
     },
     "sarvam/saaras:v3": {
-        "input_cost_per_second": 0.0083333333,
+        "input_cost_per_second": 9.2e-05,
         "litellm_provider": "sarvam",
         "metadata": {
-            "calculation": "₹30/hour = ₹0.0083333333 per second",
+            "original_pricing_inr_per_hour": 30,
+            "calculation": "₹30/hour = $0.33/hour ÷ 3600 sec = $0.000092/sec",
             "notes": "Sarvam Saaras v3 - speech-to-text model"
         },
         "mode": "audio_transcription",
@@ -37780,6 +37781,6 @@
         "supported_endpoints": [
             "/v1/audio/transcriptions"
         ]
-    },
+    }
 
 }

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -37753,5 +37753,33 @@
         "metadata": {
             "notes": "DuckDuckGo Instant Answer API is free and does not require an API key."
         }
-    }
+    },
+    "sarvam/bulbul:v3": {
+        "input_cost_per_character": 0.000033,
+        "litellm_provider": "sarvam",
+        "metadata": {
+            "calculation": "$0.33/10K characters (₹15/10K characters)",
+            "notes": "Sarvam Bulbul v3 - text-to-speech model"
+        },
+        "mode": "audio_speech",
+        "source": "https://docs.sarvam.ai/api-reference-docs/text-to-speech/overview",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ]
+    },
+    "sarvam/saaras:v3": {
+        "input_cost_per_second": 0.0083333333,
+        "litellm_provider": "sarvam",
+        "metadata": {
+            "calculation": "₹30/hour = ₹0.0083333333 per second",
+            "notes": "Sarvam Saaras v3 - speech-to-text model"
+        },
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0,
+        "source": "https://docs.sarvam.ai/api-reference-docs/getting-started/pricing",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ]
+    },
+
 }

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2473,7 +2473,9 @@
       "endpoints": {
         "chat_completions": true,
         "messages": true,
-        "responses": true
+        "responses": true,
+        "audio_transcriptions": true,
+        "audio_speech": true
       }
     }
   },

--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -151,14 +151,12 @@ model_list:
     litellm_params:
       model: sarvam/bulbul:v3
       api_key: os.environ/SARVAM_API_KEY
-    model_info:
-      mode: audio_speech
   - model_name: sarvam/saaras:v3
     litellm_params:
       model: sarvam/saaras:v3
       api_key: os.environ/SARVAM_API_KEY
-    model_info:
-      mode: audio_transcription
+
+      
 litellm_settings:
   # set_verbose: True  # Uncomment this if you want to see verbose logs; not recommended in production
   drop_params: True
@@ -224,7 +222,7 @@ general_settings:
   # background_health_checks: true
   # use_shared_health_check: true
   # health_check_interval: 30
-  database_url: "postgresql://postgres:postgres@localhost:5434/litellm_dev_fresh" # [OPTIONAL] use for token-based auth to proxy
+  # database_url: "postgresql://<user>:<password>@<host>:<port>/<dbname>"" # [OPTIONAL] use for token-based auth to proxy
 
   pass_through_endpoints:
     - path: "/v1/rerank"                                  # route you want to add to LiteLLM Proxy Server

--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -151,11 +151,14 @@ model_list:
     litellm_params:
       model: sarvam/bulbul:v3
       api_key: os.environ/SARVAM_API_KEY
+      model_info:
+        mode: audio_speech
   - model_name: sarvam/saaras:v3
     litellm_params:
       model: sarvam/saaras:v3
       api_key: os.environ/SARVAM_API_KEY
-
+      model_info:
+        mode: audio_transcription
       
 litellm_settings:
   # set_verbose: True  # Uncomment this if you want to see verbose logs; not recommended in production

--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -222,7 +222,7 @@ general_settings:
   # background_health_checks: true
   # use_shared_health_check: true
   # health_check_interval: 30
-  # database_url: "postgresql://<user>:<password>@<host>:<port>/<dbname>"" # [OPTIONAL] use for token-based auth to proxy
+  # database_url: "postgresql://<user>:<password>@<host>:<port>/<dbname>" # [OPTIONAL] use for token-based auth to proxy
 
   pass_through_endpoints:
     - path: "/v1/rerank"                                  # route you want to add to LiteLLM Proxy Server

--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -147,8 +147,18 @@ model_list:
     litellm_params:
       model: gpt-4o
       api_key: os.environ/OPENAI_API_KEY
-
-
+  - model_name: sarvam/bulbul:v3
+    litellm_params:
+      model: sarvam/bulbul:v3
+      api_key: os.environ/SARVAM_API_KEY
+    model_info:
+      mode: audio_speech
+  - model_name: sarvam/saaras:v3
+    litellm_params:
+      model: sarvam/saaras:v3
+      api_key: os.environ/SARVAM_API_KEY
+    model_info:
+      mode: audio_transcription
 litellm_settings:
   # set_verbose: True  # Uncomment this if you want to see verbose logs; not recommended in production
   drop_params: True
@@ -214,7 +224,7 @@ general_settings:
   # background_health_checks: true
   # use_shared_health_check: true
   # health_check_interval: 30
-  # database_url: "postgresql://<user>:<password>@<host>:<port>/<dbname>" # [OPTIONAL] use for token-based auth to proxy
+  database_url: "postgresql://postgres:postgres@localhost:5434/litellm_dev_fresh" # [OPTIONAL] use for token-based auth to proxy
 
   pass_through_endpoints:
     - path: "/v1/rerank"                                  # route you want to add to LiteLLM Proxy Server

--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -151,14 +151,14 @@ model_list:
     litellm_params:
       model: sarvam/bulbul:v3
       api_key: os.environ/SARVAM_API_KEY
-      model_info:
-        mode: audio_speech
+    model_info:
+      mode: audio_speech
   - model_name: sarvam/saaras:v3
     litellm_params:
       model: sarvam/saaras:v3
       api_key: os.environ/SARVAM_API_KEY
-      model_info:
-        mode: audio_transcription
+    model_info:
+      mode: audio_transcription
       
 litellm_settings:
   # set_verbose: True  # Uncomment this if you want to see verbose logs; not recommended in production

--- a/tests/test_litellm/llms/sarvam/test_sarvam_voice_routing.py
+++ b/tests/test_litellm/llms/sarvam/test_sarvam_voice_routing.py
@@ -1,0 +1,129 @@
+from unittest.mock import patch
+
+import httpx
+
+import litellm
+from litellm import speech, transcription
+from litellm.llms.sarvam.audio_transcription.transformation import (
+    SarvamAudioTranscriptionConfig,
+)
+from litellm.llms.sarvam.common_utils import get_sarvam_user_agent
+from litellm.llms.sarvam.text_to_speech.transformation import SarvamTextToSpeechConfig
+from litellm.types.llms.openai import HttpxBinaryResponseContent
+from litellm.types.utils import TranscriptionResponse
+from litellm.utils import ProviderConfigManager
+
+
+def test_sarvam_audio_transcription_config_registered():
+    config = ProviderConfigManager.get_provider_audio_transcription_config(
+        model="saaras:v3",
+        provider=litellm.LlmProviders.SARVAM,
+    )
+
+    assert config is not None
+    assert isinstance(config, SarvamAudioTranscriptionConfig)
+
+
+def test_sarvam_text_to_speech_config_registered():
+    config = ProviderConfigManager.get_provider_text_to_speech_config(
+        model="bulbul:v3",
+        provider=litellm.LlmProviders.SARVAM,
+    )
+
+    assert config is not None
+    assert isinstance(config, SarvamTextToSpeechConfig)
+
+
+def test_sarvam_tts_complete_url_drops_v1_suffix():
+    config = SarvamTextToSpeechConfig()
+
+    assert (
+        config.get_complete_url(
+            model="bulbul:v3",
+            api_base="https://api.sarvam.ai/v1",
+            litellm_params={},
+        )
+        == "https://api.sarvam.ai/text-to-speech"
+    )
+
+
+def test_sarvam_stt_complete_url_drops_v1_suffix():
+    config = SarvamAudioTranscriptionConfig()
+
+    assert (
+        config.get_complete_url(
+            api_base="https://api.sarvam.ai/v1",
+            api_key=None,
+            model="saaras:v3",
+            optional_params={},
+            litellm_params={},
+        )
+        == "https://api.sarvam.ai/speech-to-text"
+    )
+
+
+def test_sarvam_voice_headers_include_user_agent():
+    stt_config = SarvamAudioTranscriptionConfig()
+    tts_config = SarvamTextToSpeechConfig()
+    expected_user_agent = get_sarvam_user_agent()
+
+    stt_headers = stt_config.validate_environment(
+        headers={},
+        model="saaras:v3",
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        api_key="test-key",
+    )
+    tts_headers = tts_config.validate_environment(
+        headers={},
+        model="bulbul:v3",
+        api_key="test-key",
+    )
+
+    assert stt_headers["User-Agent"] == expected_user_agent
+    assert tts_headers["User-Agent"] == expected_user_agent
+
+
+@patch("litellm.main.openai_chat_completions.audio_speech")
+@patch("litellm.main.base_llm_http_handler.text_to_speech_handler")
+def test_speech_routes_sarvam_to_base_http_handler(
+    mock_base_tts_handler, mock_openai_tts_handler
+):
+    mock_base_tts_handler.return_value = HttpxBinaryResponseContent(
+        httpx.Response(
+            status_code=200,
+            content=b"audio-bytes",
+            request=httpx.Request("POST", "https://api.sarvam.ai/text-to-speech"),
+        )
+    )
+
+    response = speech(
+        model="sarvam/bulbul:v2",
+        input="Hello from Sarvam",
+        voice="anushka",
+        api_key="test-key",
+    )
+
+    assert isinstance(response, HttpxBinaryResponseContent)
+    assert mock_base_tts_handler.called
+    mock_openai_tts_handler.assert_not_called()
+
+
+@patch("litellm.main.openai_audio_transcriptions.audio_transcriptions")
+@patch("litellm.main.base_llm_http_handler.audio_transcriptions")
+def test_transcription_routes_sarvam_to_base_http_handler(
+    mock_base_transcription_handler, mock_openai_transcription_handler
+):
+    mock_base_transcription_handler.return_value = TranscriptionResponse(text="hello")
+
+    response = transcription(
+        model="sarvam/saaras:v3",
+        file=("audio.wav", b"test-audio-bytes"),
+        api_key="test-key",
+    )
+
+    assert isinstance(response, TranscriptionResponse)
+    assert response.text == "hello"
+    assert mock_base_transcription_handler.called
+    mock_openai_transcription_handler.assert_not_called()

--- a/tests/test_litellm/llms/sarvam/test_sarvam_voice_routing.py
+++ b/tests/test_litellm/llms/sarvam/test_sarvam_voice_routing.py
@@ -1,13 +1,15 @@
-from unittest.mock import patch
+import base64
+from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 
 import litellm
 from litellm import speech, transcription
 from litellm.llms.sarvam.audio_transcription.transformation import (
     SarvamAudioTranscriptionConfig,
 )
-from litellm.llms.sarvam.common_utils import get_sarvam_user_agent
+from litellm.llms.sarvam.common_utils import SarvamException, get_sarvam_user_agent
 from litellm.llms.sarvam.text_to_speech.transformation import SarvamTextToSpeechConfig
 from litellm.types.llms.openai import HttpxBinaryResponseContent
 from litellm.types.utils import TranscriptionResponse
@@ -127,3 +129,291 @@ def test_transcription_routes_sarvam_to_base_http_handler(
     assert response.text == "hello"
     assert mock_base_transcription_handler.called
     mock_openai_transcription_handler.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TTS: transform_text_to_speech_response error / edge-case tests
+# ---------------------------------------------------------------------------
+
+
+class TestTTSTransformResponse:
+    """Tests for SarvamTextToSpeechConfig.transform_text_to_speech_response"""
+
+    def _make_response(self, *, json_body=None, text="", status_code=200):
+        content = text.encode() if isinstance(text, str) else text
+        if json_body is not None:
+            import json
+
+            content = json.dumps(json_body).encode()
+        return httpx.Response(
+            status_code=status_code,
+            content=content,
+            headers={"content-type": "application/json"},
+            request=httpx.Request("POST", "https://api.sarvam.ai/text-to-speech"),
+        )
+
+    def test_should_decode_valid_base64_audio(self):
+        config = SarvamTextToSpeechConfig()
+        audio_bytes = b"fake-wav-data"
+        body = {"audios": [base64.b64encode(audio_bytes).decode()]}
+        resp = config.transform_text_to_speech_response(
+            model="bulbul:v3",
+            raw_response=self._make_response(json_body=body),
+            logging_obj=MagicMock(),
+        )
+        assert isinstance(resp, HttpxBinaryResponseContent)
+        assert resp.read() == audio_bytes
+
+    def test_should_raise_on_empty_audios_list(self):
+        config = SarvamTextToSpeechConfig()
+        body = {"audios": []}
+        with pytest.raises(ValueError, match="no audio data"):
+            config.transform_text_to_speech_response(
+                model="bulbul:v3",
+                raw_response=self._make_response(json_body=body),
+                logging_obj=MagicMock(),
+            )
+
+    def test_should_raise_on_missing_audios_key(self):
+        config = SarvamTextToSpeechConfig()
+        body = {"something_else": "value"}
+        with pytest.raises(ValueError, match="no audio data"):
+            config.transform_text_to_speech_response(
+                model="bulbul:v3",
+                raw_response=self._make_response(json_body=body),
+                logging_obj=MagicMock(),
+            )
+
+    def test_should_raise_on_non_json_response(self):
+        config = SarvamTextToSpeechConfig()
+        with pytest.raises(SarvamException, match="Error parsing"):
+            config.transform_text_to_speech_response(
+                model="bulbul:v3",
+                raw_response=self._make_response(text="not json"),
+                logging_obj=MagicMock(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# STT: transform_audio_transcription_response error / edge-case tests
+# ---------------------------------------------------------------------------
+
+
+class TestSTTTransformResponse:
+    """Tests for SarvamAudioTranscriptionConfig.transform_audio_transcription_response"""
+
+    def _make_response(self, *, json_body=None, text="", status_code=200):
+        content = text.encode() if isinstance(text, str) else text
+        if json_body is not None:
+            import json
+
+            content = json.dumps(json_body).encode()
+        return httpx.Response(
+            status_code=status_code,
+            content=content,
+            headers={"content-type": "application/json"},
+            request=httpx.Request("POST", "https://api.sarvam.ai/speech-to-text"),
+        )
+
+    def test_should_parse_valid_transcript(self):
+        config = SarvamAudioTranscriptionConfig()
+        body = {"transcript": "hello world", "language_code": "en-IN"}
+        resp = config.transform_audio_transcription_response(
+            raw_response=self._make_response(json_body=body),
+        )
+        assert resp.text == "hello world"
+        assert resp["language"] == "en-IN"
+
+    def test_should_handle_missing_transcript_key(self):
+        config = SarvamAudioTranscriptionConfig()
+        body = {"language_code": "hi-IN"}
+        resp = config.transform_audio_transcription_response(
+            raw_response=self._make_response(json_body=body),
+        )
+        assert resp.text == ""
+
+    def test_should_raise_on_non_json_response(self):
+        config = SarvamAudioTranscriptionConfig()
+        with pytest.raises(SarvamException, match="Error parsing"):
+            config.transform_audio_transcription_response(
+                raw_response=self._make_response(text="server error"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# STT: mode validation edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSTTModeValidation:
+    """Tests for mode parameter validation in transform_audio_transcription_request"""
+
+    def test_should_reject_mode_on_non_saaras_v3_model(self):
+        config = SarvamAudioTranscriptionConfig()
+        with pytest.raises(ValueError, match="only supported for model 'saaras:v3'"):
+            config.transform_audio_transcription_request(
+                model="saarika:v2.5",
+                audio_file=("audio.wav", b"fake-audio", "audio/wav"),
+                optional_params={"mode": "translate"},
+                litellm_params={},
+            )
+
+    def test_should_reject_invalid_mode_value(self):
+        config = SarvamAudioTranscriptionConfig()
+        with pytest.raises(ValueError, match="Invalid mode"):
+            config.transform_audio_transcription_request(
+                model="saaras:v3",
+                audio_file=("audio.wav", b"fake-audio", "audio/wav"),
+                optional_params={"mode": "invalid_mode"},
+                litellm_params={},
+            )
+
+    def test_should_reject_empty_mode_string(self):
+        config = SarvamAudioTranscriptionConfig()
+        with pytest.raises(ValueError, match="Invalid mode"):
+            config.transform_audio_transcription_request(
+                model="saaras:v3",
+                audio_file=("audio.wav", b"fake-audio", "audio/wav"),
+                optional_params={"mode": "  "},
+                litellm_params={},
+            )
+
+    def test_should_accept_valid_mode_on_saaras_v3(self):
+        config = SarvamAudioTranscriptionConfig()
+        result = config.transform_audio_transcription_request(
+            model="saaras:v3",
+            audio_file=("audio.wav", b"fake-audio", "audio/wav"),
+            optional_params={"mode": "translate"},
+            litellm_params={},
+        )
+        assert result.data["mode"] == "translate"
+
+
+# ---------------------------------------------------------------------------
+# TTS: map_openai_params voice edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestTTSMapOpenAIParams:
+    """Tests for SarvamTextToSpeechConfig.map_openai_params voice handling"""
+
+    def test_should_extract_voice_from_dict_with_name_key(self):
+        config = SarvamTextToSpeechConfig()
+        speaker, _ = config.map_openai_params(
+            model="bulbul:v3",
+            optional_params={},
+            voice={"name": "Shubh"},
+        )
+        assert speaker == "shubh"
+
+    def test_should_extract_voice_from_dict_with_voice_id_key(self):
+        config = SarvamTextToSpeechConfig()
+        speaker, _ = config.map_openai_params(
+            model="bulbul:v3",
+            optional_params={},
+            voice={"voice_id": "Ritu"},
+        )
+        assert speaker == "ritu"
+
+    def test_should_use_default_speaker_when_voice_is_none(self):
+        config = SarvamTextToSpeechConfig()
+        speaker, _ = config.map_openai_params(
+            model="bulbul:v3",
+            optional_params={},
+            voice=None,
+        )
+        assert speaker == "shubh"
+
+    def test_should_use_v2_default_speaker_for_v2_model(self):
+        config = SarvamTextToSpeechConfig()
+        speaker, _ = config.map_openai_params(
+            model="bulbul:v2",
+            optional_params={},
+            voice=None,
+        )
+        assert speaker == "anushka"
+
+    def test_should_map_speed_to_pace(self):
+        config = SarvamTextToSpeechConfig()
+        _, params = config.map_openai_params(
+            model="bulbul:v3",
+            optional_params={"speed": 1.5},
+            voice="shubh",
+        )
+        assert params["pace"] == 1.5
+
+    def test_should_coerce_whitespace_voice_to_empty_string(self):
+        """Whitespace-only voice is coerced to '' via the non-None fallback branch."""
+        config = SarvamTextToSpeechConfig()
+        speaker, _ = config.map_openai_params(
+            model="bulbul:v3",
+            optional_params={},
+            voice="   ",
+        )
+        assert speaker == ""
+
+
+# ---------------------------------------------------------------------------
+# URL construction edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestURLConstruction:
+    """Tests for get_complete_url with various api_base inputs"""
+
+    def test_should_use_custom_api_base_without_v1(self):
+        config = SarvamTextToSpeechConfig()
+        url = config.get_complete_url(
+            model="bulbul:v3",
+            api_base="https://my-proxy.example.com",
+            litellm_params={},
+        )
+        assert url == "https://my-proxy.example.com/text-to-speech"
+
+    def test_should_strip_v1_from_custom_api_base(self):
+        config = SarvamTextToSpeechConfig()
+        url = config.get_complete_url(
+            model="bulbul:v3",
+            api_base="https://my-proxy.example.com/v1",
+            litellm_params={},
+        )
+        assert url == "https://my-proxy.example.com/text-to-speech"
+
+    def test_should_strip_v1_with_trailing_slash(self):
+        config = SarvamTextToSpeechConfig()
+        url = config.get_complete_url(
+            model="bulbul:v3",
+            api_base="https://my-proxy.example.com/v1/",
+            litellm_params={},
+        )
+        assert url == "https://my-proxy.example.com/text-to-speech"
+
+    def test_should_use_default_when_api_base_is_none(self):
+        config = SarvamTextToSpeechConfig()
+        url = config.get_complete_url(
+            model="bulbul:v3",
+            api_base=None,
+            litellm_params={},
+        )
+        assert url == "https://api.sarvam.ai/text-to-speech"
+
+    def test_should_preserve_stt_custom_api_base(self):
+        config = SarvamAudioTranscriptionConfig()
+        url = config.get_complete_url(
+            api_base="https://my-proxy.example.com/v1",
+            api_key=None,
+            model="saaras:v3",
+            optional_params={},
+            litellm_params={},
+        )
+        assert url == "https://my-proxy.example.com/speech-to-text"
+
+    def test_should_validate_environment_missing_api_key(self):
+        config = SarvamTextToSpeechConfig()
+        with pytest.raises(ValueError, match="API key is required"):
+            config.validate_environment(
+                headers={},
+                model="bulbul:v3",
+                api_key=None,
+                api_base=None,
+            )


### PR DESCRIPTION
## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/tests/test_litellm/llms/sarvam/test_sarvam_voice_routing.py`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
   make test-unit currently fails due to an unrelated pre-existing test environment issue, not Sarvam STT/TTS integration changes.
Failure observed-
Test: tests/test_litellm/proxy/client/test_chat.py
Error during collection:
AttributeError: module 'responses' has no attribute 'activate'
This occurs before Sarvam tests execute.
Sarvam-specific verification
Added/updated Sarvam STT/TTS integration files and provider routing.
Added Sarvam tests:
tests/test_litellm/llms/sarvam/test_sarvam_voice_routing.py
Local targeted validation for Sarvam path is passing.
Next step (separate from this PR scope)
Resolve the responses import/environment collision in test setup, then rerun full make test-unit.

- [x] Scope isolated to Sarvam STT/TTS integration
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
✅ Test

## Changes
1. Added Sarvam provider support for audio transcription and text-to-speech via:
litellm/llms/sarvam/audio_transcription/transformation.py
litellm/llms/sarvam/text_to_speech/transformation.py
litellm/llms/sarvam/common_utils.py

2. Wired Sarvam configs into provider routing:
litellm/utils.py
litellm/main.py
litellm/types/utils.py (LlmProviders.SARVAM)

3. Added Sarvam endpoint support + pricing metadata:
provider_endpoints_support.json
model_prices_and_context_window.json
litellm/model_prices_and_context_window_backup.json

4. Added integration tests:
tests/test_litellm/llms/sarvam/test_sarvam_voice_routing.py

5. Ensured Sarvam STT/TTS requests set User-Agent as LiteLLM/{version} python/{python_version}