### PR TITLE
feat(openai): support reasoning_effort='xhigh' for gpt-5.3 models

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -36,16 +36,17 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
     
     @classmethod
     def is_model_gpt_5_1_model(cls, model: str) -> bool:
-        """Check if the model is a gpt-5.1 or gpt-5.2 chat variant.
+        """Check if the model is a gpt-5.1, gpt-5.2, or gpt-5.3 chat variant.
         
-        gpt-5.1/5.2 support temperature when reasoning_effort="none",
+        gpt-5.1/5.2/5.3 support temperature when reasoning_effort="none",
         unlike base gpt-5 which only supports temperature=1. Excludes
         pro variants which keep stricter knobs.
         """
         model_name = model.split("/")[-1]
         is_gpt_5_1 = model_name.startswith("gpt-5.1")
         is_gpt_5_2 = model_name.startswith("gpt-5.2") and "pro" not in model_name
-        return is_gpt_5_1 or is_gpt_5_2
+        is_gpt_5_3 = model_name.startswith("gpt-5.3")
+        return is_gpt_5_1 or is_gpt_5_2 or is_gpt_5_3
 
     @classmethod
     def is_model_gpt_5_2_pro_model(cls, model: str) -> bool:
@@ -58,6 +59,12 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         """Check if the model is a gpt-5.2 variant (including pro)."""
         model_name = model.split("/")[-1]
         return model_name.startswith("gpt-5.2")
+
+    @classmethod
+    def is_model_gpt_5_3_model(cls, model: str) -> bool:
+        """Check if the model is a gpt-5.3 variant (e.g. gpt-5.3-codex)."""
+        model_name = model.split("/")[-1]
+        return model_name.startswith("gpt-5.3")
 
     def get_supported_openai_params(self, model: str) -> list:
         from litellm.utils import supports_tool_choice
@@ -98,13 +105,14 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             if not (
                 self.is_model_gpt_5_1_codex_max_model(model)
                 or self.is_model_gpt_5_2_model(model)
+                or self.is_model_gpt_5_3_model(model)
             ):
                 if litellm.drop_params or drop_params:
                     non_default_params.pop("reasoning_effort", None)
                 else:
                     raise litellm.utils.UnsupportedParamsError(
                         message=(
-                            "reasoning_effort='xhigh' is only supported for gpt-5.1-codex-max and gpt-5.2 models."
+                            "reasoning_effort='xhigh' is only supported for gpt-5.1-codex-max, gpt-5.2, and gpt-5.3 models."
                         ),
                         status_code=400,
                     )

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -414,3 +414,66 @@ def test_gpt5_2_allows_reasoning_effort_xhigh(config: OpenAIConfig):
         drop_params=False,
     )
     assert params["reasoning_effort"] == "xhigh"
+
+
+# GPT-5.3 tests
+
+
+def test_gpt5_3_model_detection(gpt5_config: OpenAIGPT5Config):
+    """Test that GPT-5.3 models are correctly detected."""
+    assert gpt5_config.is_model_gpt_5_3_model("gpt-5.3-codex")
+    assert gpt5_config.is_model_gpt_5_3_model("gpt-5.3")
+    assert gpt5_config.is_model_gpt_5_3_model("openai/gpt-5.3-codex")
+    assert not gpt5_config.is_model_gpt_5_3_model("gpt-5.2")
+    assert not gpt5_config.is_model_gpt_5_3_model("gpt-5")
+
+
+def test_gpt5_3_included_in_gpt_5_1_model(gpt5_config: OpenAIGPT5Config):
+    """Test that GPT-5.3 is included in the is_model_gpt_5_1_model check for temperature support."""
+    assert gpt5_config.is_model_gpt_5_1_model("gpt-5.3-codex")
+    assert gpt5_config.is_model_gpt_5_1_model("gpt-5.3")
+
+
+def test_gpt5_3_codex_allows_reasoning_effort_xhigh(config: OpenAIConfig):
+    """Test that gpt-5.3-codex supports reasoning_effort='xhigh'."""
+    params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "xhigh"},
+        optional_params={},
+        model="gpt-5.3-codex",
+        drop_params=False,
+    )
+    assert params["reasoning_effort"] == "xhigh"
+
+
+def test_gpt5_3_allows_reasoning_effort_xhigh(config: OpenAIConfig):
+    """Test that gpt-5.3 (base) supports reasoning_effort='xhigh'."""
+    params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "xhigh"},
+        optional_params={},
+        model="gpt-5.3",
+        drop_params=False,
+    )
+    assert params["reasoning_effort"] == "xhigh"
+
+
+def test_gpt5_3_codex_with_provider_prefix(config: OpenAIConfig):
+    """Test that gpt-5.3-codex works with openai/ provider prefix."""
+    params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "xhigh"},
+        optional_params={},
+        model="openai/gpt-5.3-codex",
+        drop_params=False,
+    )
+    assert params["reasoning_effort"] == "xhigh"
+
+
+def test_gpt5_3_temperature_with_reasoning_effort_none(config: OpenAIConfig):
+    """Test that gpt-5.3 supports arbitrary temperature when reasoning_effort='none'."""
+    for temp in [0.0, 0.5, 1.0, 1.5]:
+        params = config.map_openai_params(
+            non_default_params={"temperature": temp, "reasoning_effort": "none"},
+            optional_params={},
+            model="gpt-5.3-codex",
+            drop_params=False,
+        )
+        assert params["temperature"] == temp


### PR DESCRIPTION
gpt-5.3-codex and other gpt-5.3 variants support reasoning_effort='xhigh', but the allowlist in OpenAIGPT5Config only includes gpt-5.1-codex-max and gpt-5.2 models. This causes an UnsupportedParamsError when using xhigh with gpt-5.3-codex.

Longer term I think some thought needs to be put in on how to handle new models with special args, otherwise I'd suspect that these type of issues will continue to surface. 


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
