### PR TITLE
Fix invalid secrets context in test-linting workflow

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -97,9 +97,12 @@ jobs:
         pytest tests/litellm/test_no_hardcoded_secrets.py -v
 
     - name: Run ggshield secret scan
-      if: ${{ secrets.GITGUARDIAN_API_KEY != '' }}
       env:
         GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
       run: |
-        pip install ggshield
-        ggshield secret scan repo .
+        if [ -n "$GITGUARDIAN_API_KEY" ]; then
+          pip install ggshield
+          ggshield secret scan repo .
+        else
+          echo "GITGUARDIAN_API_KEY not set, skipping ggshield scan"
+        fi


### PR DESCRIPTION
## Summary
- The `secrets` context is not available in step-level `if:` conditions, causing the workflow file to fail validation with: `Unrecognized named-value: 'secrets'`
- Moves the conditional check into the shell script instead — the secret is still passed via `env:`, and the shell checks if it's non-empty before running ggshield

## Test plan
- [ ] Verify the test-linting workflow passes on this PR
- [ ] Confirm ggshield step is skipped when `GITGUARDIAN_API_KEY` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)