### PR TITLE
Fix observatory workflow checkout failing on commit hash

### DIFF
--- a/.github/workflows/run_observatory_tests.yml
+++ b/.github/workflows/run_observatory_tests.yml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.commit_hash || github.sha }}
 
       - name: Validate tag input
         env:


### PR DESCRIPTION
## Summary
- The `actions/checkout` step was using `ref: ${{ inputs.commit_hash || github.sha }}`, which fails when a short commit hash is provided — git tries to find it as a branch name
- The checkout only needs the config file from the repo, so using the default branch is sufficient
- Fixes: https://github.com/BerriAI/litellm/actions/runs/22551172080/job/65321236969

## Test plan
- [ ] Trigger the observatory workflow manually with a tag and no commit hash
- [ ] Confirm checkout succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)