### PR TITLE
fix(streaming): propagate provider cost through streaming chunk builder

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -431,7 +431,7 @@ class ChunkProcessor:
             id=id,
         )
 
-    def _usage_chunk_calculation_helper(self, usage_chunk: Usage) -> dict:
+    def _usage_chunk_calculation_helper(self, usage_chunk: Union[Usage, dict]) -> dict:
         prompt_tokens = 0
         completion_tokens = 0
         ## anthropic prompt caching information ##
@@ -439,6 +439,7 @@ class ChunkProcessor:
         cache_read_input_tokens: Optional[int] = None
         completion_tokens_details: Optional[CompletionTokensDetails] = None
         prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
+        cost: Optional[float] = None
 
         if "prompt_tokens" in usage_chunk:
             prompt_tokens = usage_chunk.get("prompt_tokens", 0) or 0
@@ -466,6 +467,10 @@ class ChunkProcessor:
                 usage_chunk.prompt_tokens_details, PromptTokensDetailsWrapper
             ):
                 prompt_tokens_details = usage_chunk.prompt_tokens_details
+        if "cost" in usage_chunk:
+            cost = usage_chunk.get("cost")
+        elif hasattr(usage_chunk, "cost") and usage_chunk.cost is not None:
+            cost = usage_chunk.cost
 
         return {
             "prompt_tokens": prompt_tokens,
@@ -474,6 +479,7 @@ class ChunkProcessor:
             "cache_read_input_tokens": cache_read_input_tokens,
             "completion_tokens_details": completion_tokens_details,
             "prompt_tokens_details": prompt_tokens_details,
+            "cost": cost,
         }
 
     def count_reasoning_tokens(self, response: ModelResponse) -> int:
@@ -509,6 +515,7 @@ class ChunkProcessor:
         web_search_requests: Optional[int] = None
         completion_tokens_details: Optional[CompletionTokensDetails] = None
         prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
+        cost: Optional[float] = None
         for chunk in chunks:
             usage_chunk: Optional[Usage] = None
             if "usage" in chunk:
@@ -567,6 +574,9 @@ class ChunkProcessor:
 
                 prompt_tokens_details = usage_chunk_dict["prompt_tokens_details"]
 
+                if usage_chunk_dict["cost"] is not None:
+                    cost = usage_chunk_dict["cost"]
+
         return UsagePerChunk(
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
@@ -576,6 +586,7 @@ class ChunkProcessor:
             web_search_requests=web_search_requests,
             completion_tokens_details=completion_tokens_details,
             prompt_tokens_details=prompt_tokens_details,
+            cost=cost,
         )
 
     def calculate_usage(
@@ -680,6 +691,10 @@ class ChunkProcessor:
                 returned_usage.prompt_tokens_details.web_search_requests = (
                     web_search_requests
                 )
+
+        provider_cost: Optional[float] = calculated_usage_per_chunk["cost"]
+        if provider_cost is not None:
+            returned_usage.cost = provider_cost
 
         # Return a new usage object with the new values
 

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -467,9 +467,10 @@ class ChunkProcessor:
                 usage_chunk.prompt_tokens_details, PromptTokensDetailsWrapper
             ):
                 prompt_tokens_details = usage_chunk.prompt_tokens_details
-        if "cost" in usage_chunk:
-            cost = usage_chunk.get("cost")
-        elif hasattr(usage_chunk, "cost") and usage_chunk.cost is not None:
+        if isinstance(usage_chunk, dict):
+            if "cost" in usage_chunk:
+                cost = usage_chunk.get("cost")
+        elif hasattr(usage_chunk, "cost"):
             cost = usage_chunk.cost
 
         return {

--- a/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from typing_extensions import TypedDict
 
@@ -14,3 +14,4 @@ class UsagePerChunk(TypedDict):
     web_search_requests: Optional[int]
     completion_tokens_details: Optional[CompletionTokensDetails]
     prompt_tokens_details: Optional[PromptTokensDetailsWrapper]
+    cost: Optional[float]

--- a/tests/test_litellm/test_openrouter_streaming_cost.py
+++ b/tests/test_litellm/test_openrouter_streaming_cost.py
@@ -1,0 +1,201 @@
+"""
+Tests for OpenRouter cost propagation through streaming chunk builder.
+
+OpenRouter returns a ``cost`` field on ``usage`` in streaming chunks.
+The streaming chunk builder must extract and propagate this value to the
+final ``Usage`` object so that callers receive accurate cost information.
+
+Fixes: https://github.com/BerriAI/litellm/issues/16021
+"""
+
+from litellm.litellm_core_utils.streaming_chunk_builder_utils import (
+    ChunkProcessor,
+)
+from litellm.types.utils import Usage
+
+
+def _make_processor(chunks=None):
+    """Create a ChunkProcessor with minimal valid chunks."""
+    if chunks is None:
+        chunks = [{"choices": [{"delta": {"content": ""}}]}]
+    return ChunkProcessor(chunks=chunks)
+
+
+class TestUsageChunkCostExtraction:
+    """_usage_chunk_calculation_helper must extract the cost field."""
+
+    def setup_method(self):
+        self.processor = _make_processor()
+
+    def test_extracts_cost_from_usage_chunk(self):
+        usage = Usage(prompt_tokens=10, completion_tokens=20, cost=0.00123)
+        result = self.processor._usage_chunk_calculation_helper(usage)
+        assert result["cost"] == 0.00123
+
+    def test_cost_none_when_absent(self):
+        usage = Usage(prompt_tokens=10, completion_tokens=20)
+        result = self.processor._usage_chunk_calculation_helper(usage)
+        assert result["cost"] is None
+
+    def test_cost_zero_preserved(self):
+        usage = Usage(prompt_tokens=0, completion_tokens=0, cost=0.0)
+        result = self.processor._usage_chunk_calculation_helper(usage)
+        assert result["cost"] == 0.0
+
+
+class TestCalculateUsagePerChunkCost:
+    """_calculate_usage_per_chunk must propagate cost."""
+
+    def setup_method(self):
+        self.processor = _make_processor()
+
+    def test_cost_propagated_from_chunk(self):
+        chunks = [
+            {"usage": Usage(prompt_tokens=10, completion_tokens=5)},
+            {"usage": Usage(prompt_tokens=10, completion_tokens=20, cost=0.05)},
+        ]
+        result = self.processor._calculate_usage_per_chunk(chunks)
+        assert result["cost"] == 0.05
+
+    def test_last_cost_wins(self):
+        """When multiple chunks report cost, the last non-None value wins."""
+        chunks = [
+            {"usage": Usage(prompt_tokens=10, completion_tokens=5, cost=0.01)},
+            {"usage": Usage(prompt_tokens=10, completion_tokens=20, cost=0.05)},
+        ]
+        result = self.processor._calculate_usage_per_chunk(chunks)
+        assert result["cost"] == 0.05
+
+    def test_cost_none_when_no_chunks_have_cost(self):
+        chunks = [
+            {"usage": Usage(prompt_tokens=10, completion_tokens=20)},
+        ]
+        result = self.processor._calculate_usage_per_chunk(chunks)
+        assert result["cost"] is None
+
+
+class TestCalculateUsageCost:
+    """calculate_usage must set cost on the returned Usage object."""
+
+    def setup_method(self):
+        self.processor = _make_processor()
+
+    def test_cost_set_on_final_usage(self):
+        chunks = [
+            {"usage": Usage(prompt_tokens=63, completion_tokens=255, cost=0.00123)},
+        ]
+        usage = self.processor.calculate_usage(
+            chunks=chunks,
+            model="openrouter/x-ai/grok-4-fast",
+            completion_output="test output",
+        )
+        assert usage.cost == 0.00123
+        assert usage.prompt_tokens == 63
+        assert usage.completion_tokens == 255
+
+    def test_cost_none_when_not_provided(self):
+        chunks = [
+            {"usage": Usage(prompt_tokens=10, completion_tokens=20)},
+        ]
+        usage = self.processor.calculate_usage(
+            chunks=chunks,
+            model="openrouter/x-ai/grok-4-fast",
+            completion_output="test",
+        )
+        assert getattr(usage, "cost", None) is None
+
+    def test_cost_zero_preserved_on_final_usage(self):
+        chunks = [
+            {"usage": Usage(prompt_tokens=10, completion_tokens=0, cost=0.0)},
+        ]
+        usage = self.processor.calculate_usage(
+            chunks=chunks,
+            model="openrouter/x-ai/grok-4-fast",
+            completion_output="",
+        )
+        assert usage.cost == 0.0
+
+    def test_cost_from_middle_chunk_propagated(self):
+        """Cost may appear on any chunk (typically the last), not just first."""
+        chunks = [
+            {"usage": Usage(prompt_tokens=10, completion_tokens=5)},
+            {"usage": Usage(prompt_tokens=10, completion_tokens=10, cost=0.042)},
+            {"usage": Usage(prompt_tokens=10, completion_tokens=15)},
+        ]
+        usage = self.processor.calculate_usage(
+            chunks=chunks,
+            model="openrouter/anthropic/claude-sonnet-4-20250514",
+            completion_output="multi chunk output",
+        )
+        assert usage.cost == 0.042
+
+    def test_openrouter_realistic_streaming_scenario(self):
+        """Simulate realistic OpenRouter streaming: only the final chunk has usage+cost."""
+        intermediate_chunks = [
+            {},  # content chunks without usage
+            {},
+            {},
+        ]
+        final_chunk = {
+            "usage": Usage(
+                prompt_tokens=63,
+                completion_tokens=255,
+                cost=0.00492,
+            ),
+        }
+        all_chunks = intermediate_chunks + [final_chunk]
+        usage = self.processor.calculate_usage(
+            chunks=all_chunks,
+            model="openrouter/x-ai/grok-4-fast",
+            completion_output="Hello! How can I help you today?",
+        )
+        assert usage.cost == 0.00492
+        assert usage.prompt_tokens == 63
+        assert usage.completion_tokens == 255
+        assert usage.total_tokens == 318
+
+
+class TestDictFormatUsageChunks:
+    """Verify cost extraction when usage chunks are plain dicts instead of Usage objects."""
+
+    def setup_method(self):
+        self.processor = _make_processor()
+
+    def test_helper_extracts_cost_from_dict(self):
+        usage_dict = {"prompt_tokens": 10, "completion_tokens": 20, "cost": 0.003}
+        result = self.processor._usage_chunk_calculation_helper(usage_dict)
+        assert result["cost"] == 0.003
+
+    def test_helper_cost_none_when_absent_in_dict(self):
+        usage_dict = {"prompt_tokens": 10, "completion_tokens": 20}
+        result = self.processor._usage_chunk_calculation_helper(usage_dict)
+        assert result["cost"] is None
+
+    def test_helper_cost_zero_preserved_in_dict(self):
+        usage_dict = {"prompt_tokens": 0, "completion_tokens": 0, "cost": 0.0}
+        result = self.processor._usage_chunk_calculation_helper(usage_dict)
+        assert result["cost"] == 0.0
+
+    def test_calculate_usage_with_dict_format_chunks(self):
+        chunks = [
+            {"usage": {"prompt_tokens": 63, "completion_tokens": 255, "cost": 0.00492}},
+        ]
+        usage = self.processor.calculate_usage(
+            chunks=chunks,
+            model="openrouter/x-ai/grok-4-fast",
+            completion_output="Hello!",
+        )
+        assert usage.cost == 0.00492
+        assert usage.prompt_tokens == 63
+        assert usage.completion_tokens == 255
+
+    def test_calculate_usage_dict_without_cost(self):
+        chunks = [
+            {"usage": {"prompt_tokens": 10, "completion_tokens": 20}},
+        ]
+        usage = self.processor.calculate_usage(
+            chunks=chunks,
+            model="openrouter/x-ai/grok-4-fast",
+            completion_output="test",
+        )
+        assert getattr(usage, "cost", None) is None


### PR DESCRIPTION
## Summary

Fixes #16021 — OpenRouter (and other providers) return a `cost` field on `usage` in streaming chunks, but the streaming chunk builder silently dropped it. This caused cost information to be lost in streaming responses while working correctly in non-streaming mode.

## Root Cause

`_usage_chunk_calculation_helper()` extracted token counts, cache tokens, and token details from usage chunks, but never extracted the `cost` field. The `Usage` class already supports `cost: Optional[float]` (line 1449 of `types/utils.py`), and OpenRouter's `chunk_parser()` correctly preserves it — the value was simply never propagated through the aggregation pipeline.

## Changes

1. **`_usage_chunk_calculation_helper()`** — Extract `cost` from usage chunk
2. **`UsagePerChunk` TypedDict** — Add `cost: Optional[float]` field
3. **`_calculate_usage_per_chunk()`** — Propagate cost from chunks (last non-None value wins)
4. **`calculate_usage()`** — Set cost on the returned `Usage` object
5. Remove unused `TYPE_CHECKING` import (pre-existing lint issue)

## Tests

11 unit tests covering:
- Cost extraction from individual usage chunks
- Cost propagation through chunk aggregation
- Cost=None when no chunks have cost
- Cost=0.0 preserved (not falsely treated as None)
- Cost from middle chunk preserved when later chunks lack cost
- Realistic OpenRouter streaming scenario (final chunk with usage+cost)

All tests passing.