### PR TITLE
fix(proxy): remove wildcard patterns from /models endpoint response

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -319,7 +319,7 @@ def _get_wildcard_models(
                 )
                 expanded_for_model.extend(wildcard_models)
 
-            if not expanded_for_model:
+            if not expanded_for_model and not return_wildcard_routes:
                 verbose_proxy_logger.warning(
                     "Wildcard pattern '%s' removed from /models response "
                     "but could not be expanded to any concrete models. "

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -219,8 +219,10 @@ def get_known_models_from_wildcard(
     wildcard_model: str, litellm_params: Optional[LiteLLM_Params] = None
 ) -> List[str]:
     if wildcard_model == "*":
-        # Global wildcard — return all known models across all providers
-        return get_provider_models("*", litellm_params=litellm_params) or []
+        # Global wildcard — return all known models across all providers.
+        # Don't forward deployment-specific litellm_params; those credentials
+        # belong to one provider and shouldn't be used to query all providers.
+        return get_provider_models("*") or []
 
     try:
         wildcard_provider_prefix, wildcard_suffix = wildcard_model.split("/", 1)
@@ -289,6 +291,8 @@ def _get_wildcard_models(
             ):  # will add the wildcard route to the list eg: anthropic/*.
                 all_wildcard_models.append(model)
 
+            expanded_for_model: List[str] = []
+
             ## get litellm params from model
             if llm_router is not None:
                 model_list = llm_router.get_model_list(model_name=model)
@@ -300,20 +304,30 @@ def _get_wildcard_models(
                                 **router_model["litellm_params"]  # type: ignore
                             ),
                         )
-                        all_wildcard_models.extend(wildcard_models)
+                        expanded_for_model.extend(wildcard_models)
                 else:
                     # Router has no deployment for this wildcard (e.g., BYOK team models)
                     # Fall back to expanding from known provider models
                     wildcard_models = get_known_models_from_wildcard(
                         wildcard_model=model, litellm_params=None
                     )
-                    all_wildcard_models.extend(wildcard_models)
+                    expanded_for_model.extend(wildcard_models)
             else:
                 # get all known provider models
                 wildcard_models = get_known_models_from_wildcard(
                     wildcard_model=model, litellm_params=None
                 )
-                all_wildcard_models.extend(wildcard_models)
+                expanded_for_model.extend(wildcard_models)
+
+            if not expanded_for_model:
+                verbose_proxy_logger.warning(
+                    "Wildcard pattern '%s' removed from /models response "
+                    "but could not be expanded to any concrete models. "
+                    "Check that the provider is supported or that the "
+                    "router has a matching deployment.",
+                    model,
+                )
+            all_wildcard_models.extend(expanded_for_model)
 
     for model in models_to_remove:
         unique_models.remove(model)

--- a/tests/test_litellm/test_wildcard_models_endpoint.py
+++ b/tests/test_litellm/test_wildcard_models_endpoint.py
@@ -1,0 +1,400 @@
+"""
+Tests for issue #13752: Wildcard entries (e.g. openai/*) should NOT appear
+in /models endpoint unless return_wildcard_routes=True.
+
+Root cause: _get_wildcard_models() only removed wildcard entries from
+unique_models when llm_router was None or the router had no deployment.
+When the router DID have a wildcard deployment (the common case), the
+wildcard pattern stayed in the list alongside the expanded models.
+"""
+
+from litellm.proxy.auth.model_checks import (
+    _check_wildcard_routing,
+    _get_wildcard_models,
+    get_complete_model_list,
+)
+from litellm.router import Router
+
+
+class TestCheckWildcardRouting:
+    def test_wildcard_star_only(self):
+        assert _check_wildcard_routing("*") is True
+
+    def test_provider_wildcard(self):
+        assert _check_wildcard_routing("openai/*") is True
+        assert _check_wildcard_routing("anthropic/*") is True
+        assert _check_wildcard_routing("gemini/*") is True
+
+    def test_non_wildcard(self):
+        assert _check_wildcard_routing("openai/gpt-4") is False
+        assert _check_wildcard_routing("anthropic/claude-3-sonnet") is False
+
+
+class TestGetWildcardModelsRemovesPatterns:
+    """The core bug: wildcard patterns must be removed from unique_models
+    when expanded, regardless of whether the router has a deployment."""
+
+    def test_wildcard_removed_when_router_has_deployment(self):
+        """Bug repro: openai/* stays in unique_models when router has deployment."""
+        model_list = [
+            {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}}
+        ]
+        router = Router(model_list=model_list)
+
+        unique_models = ["openai/*", "some-custom-model"]
+        expanded = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+        # openai/* must be removed from unique_models
+        assert "openai/*" not in unique_models
+        # custom model must remain
+        assert "some-custom-model" in unique_models
+        # expanded list should contain real model names
+        assert len(expanded) > 0
+        assert all("*" not in m for m in expanded)
+
+    def test_wildcard_removed_when_router_has_no_deployment(self):
+        """Already worked before fix — BYOK case."""
+        router = Router(model_list=[])
+
+        unique_models = ["openai/*"]
+        expanded = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+        assert "openai/*" not in unique_models
+        assert len(expanded) > 0
+
+    def test_wildcard_removed_when_no_router(self):
+        """Already worked before fix — no router at all."""
+        unique_models = ["anthropic/*"]
+        expanded = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=None,
+        )
+        assert "anthropic/*" not in unique_models
+        assert len(expanded) > 0
+
+    def test_return_wildcard_routes_true_keeps_pattern(self):
+        """When return_wildcard_routes=True, the pattern should be in expanded."""
+        model_list = [
+            {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}}
+        ]
+        router = Router(model_list=model_list)
+
+        unique_models = ["openai/*"]
+        expanded = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=True,
+            llm_router=router,
+        )
+        # Pattern should appear in expanded list (not unique_models)
+        assert "openai/*" in expanded
+        # But it must still be removed from unique_models to avoid duplicates
+        assert "openai/*" not in unique_models
+
+    def test_multiple_wildcards_all_removed(self):
+        """Multiple wildcard providers should all be removed."""
+        model_list = [
+            {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
+            {
+                "model_name": "anthropic/*",
+                "litellm_params": {"model": "anthropic/*"},
+            },
+        ]
+        router = Router(model_list=model_list)
+
+        unique_models = ["openai/*", "anthropic/*", "my-custom-model"]
+        _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+        assert "openai/*" not in unique_models
+        assert "anthropic/*" not in unique_models
+        assert "my-custom-model" in unique_models
+
+    def test_wildcard_removed_even_when_no_expansion_possible(self):
+        """A wildcard for an unknown provider with no deployments must still
+        be removed from unique_models. Users should never see glob patterns
+        in the /models response, even if we cannot expand them."""
+        router = Router(model_list=[])
+
+        unique_models = ["unknownprovider/*", "my-custom-model"]
+        expanded = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+        # Wildcard must be removed even though nothing was expanded
+        assert "unknownprovider/*" not in unique_models
+        assert "my-custom-model" in unique_models
+        # No models expanded for unknown provider
+        assert len(expanded) == 0
+
+    def test_unknown_wildcard_removed_when_no_router(self):
+        """Even without a router, unknown-provider wildcards are removed."""
+        unique_models = ["unknownprovider/*"]
+        expanded = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=None,
+        )
+        assert "unknownprovider/*" not in unique_models
+        assert len(expanded) == 0
+
+    def test_global_star_wildcard_removed_with_router(self):
+        """The bare '*' wildcard must be removed from unique_models even
+        when no concrete models can be expanded (e.g. no API keys set)."""
+        router = Router(model_list=[])
+
+        unique_models = ["*", "my-custom-model"]
+        _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+        assert "*" not in unique_models
+        assert "my-custom-model" in unique_models
+
+    def test_global_star_wildcard_removed_without_router(self):
+        """The bare '*' wildcard must be removed even without a router."""
+        unique_models = ["*"]
+        _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=None,
+        )
+        assert "*" not in unique_models
+
+    def test_global_star_wildcard_with_router_deployment(self):
+        """Regression: bare '*' with a router deployment that has model_name='*'.
+
+        Even when the router has a deployment matching '*', the pattern must
+        be removed from unique_models and expanded to concrete model names (or
+        kept empty when no providers are resolvable in the test environment).
+        """
+        model_list = [
+            {"model_name": "*", "litellm_params": {"model": "openai/gpt-4o"}}
+        ]
+        router = Router(model_list=model_list)
+
+        unique_models = ["*", "my-custom-model"]
+        expanded = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+        # '*' must always be removed from unique_models
+        assert "*" not in unique_models
+        # Non-wildcard model must survive
+        assert "my-custom-model" in unique_models
+        # Expanded list must not contain the bare wildcard
+        assert "*" not in expanded
+
+
+class TestGetCompleteModelListEndToEnd:
+    """End-to-end test matching issue #13752 scenario."""
+
+    def test_models_endpoint_no_wildcards_in_response(self):
+        """Issue #13752: /models returns openai/*, anthropic/* etc."""
+        model_list = [
+            {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
+            {
+                "model_name": "anthropic/*",
+                "litellm_params": {"model": "anthropic/*"},
+            },
+            {
+                "model_name": "gemini/*",
+                "litellm_params": {"model": "gemini/*"},
+            },
+        ]
+        router = Router(model_list=model_list)
+
+        result = get_complete_model_list(
+            key_models=[],
+            team_models=[],
+            proxy_model_list=["openai/*", "anthropic/*", "gemini/*"],
+            user_model=None,
+            infer_model_from_keys=False,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+        # No wildcard patterns in output
+        for model in result:
+            assert "*" not in model, f"Wildcard pattern found in /models response: {model}"
+        # Should contain real expanded model names
+        assert len(result) > 0
+
+    def test_models_endpoint_with_mixed_wildcard_and_explicit(self):
+        """Explicit models should survive alongside wildcard expansion."""
+        model_list = [
+            {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
+            {
+                "model_name": "my-fine-tuned-model",
+                "litellm_params": {"model": "openai/ft:gpt-4o:my-org:custom:id"},
+            },
+        ]
+        router = Router(model_list=model_list)
+
+        result = get_complete_model_list(
+            key_models=[],
+            team_models=[],
+            proxy_model_list=["openai/*", "my-fine-tuned-model"],
+            user_model=None,
+            infer_model_from_keys=False,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+        # Wildcard gone
+        assert "openai/*" not in result
+        # Explicit model preserved
+        assert "my-fine-tuned-model" in result
+        # Real OpenAI models present
+        openai_models = [m for m in result if m.startswith("openai/")]
+        assert len(openai_models) > 0
+
+    def test_return_wildcard_routes_true_includes_patterns(self):
+        """When explicitly requested, wildcards should appear."""
+        model_list = [
+            {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
+        ]
+        router = Router(model_list=model_list)
+
+        result = get_complete_model_list(
+            key_models=[],
+            team_models=[],
+            proxy_model_list=["openai/*"],
+            user_model=None,
+            infer_model_from_keys=False,
+            return_wildcard_routes=True,
+            llm_router=router,
+        )
+        # Pattern should be present when explicitly requested
+        assert "openai/*" in result
+        # Real models should also be present
+        real_models = [m for m in result if "*" not in m]
+        assert len(real_models) > 0
+
+
+class TestRegressionIssue13752:
+    """Regression tests for issue #13752: the exact scenario from the bug
+    report where the router has wildcard deployments and /models returns
+    raw wildcard patterns instead of expanded concrete model names."""
+
+    def test_bug_report_scenario_router_with_wildcard_deployments(self):
+        """Reproduce the exact config from issue #13752.
+
+        Config had:
+            model_list:
+              - model_name: openai/*
+                litellm_params:
+                  model: openai/*
+              - model_name: anthropic/*
+                litellm_params:
+                  model: anthropic/*
+
+        Expected: /models returns concrete model names (openai/gpt-4o, etc.)
+        Bug: /models returned "openai/*", "anthropic/*" as literal strings.
+        """
+        model_list = [
+            {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
+            {
+                "model_name": "anthropic/*",
+                "litellm_params": {"model": "anthropic/*"},
+            },
+        ]
+        router = Router(model_list=model_list)
+
+        result = get_complete_model_list(
+            key_models=[],
+            team_models=[],
+            proxy_model_list=["openai/*", "anthropic/*"],
+            user_model=None,
+            infer_model_from_keys=False,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+
+        # Core assertion: no wildcard patterns in the response
+        wildcards_found = [m for m in result if "*" in m]
+        assert wildcards_found == [], (
+            f"Wildcard patterns leaked into /models response: {wildcards_found}"
+        )
+
+        # Should have expanded to real model names from both providers
+        openai_models = [m for m in result if m.startswith("openai/")]
+        anthropic_models = [m for m in result if m.startswith("anthropic/")]
+        assert len(openai_models) > 0, "Expected expanded OpenAI models"
+        assert len(anthropic_models) > 0, "Expected expanded Anthropic models"
+
+
+class TestRouterDeploymentRegression:
+    """Regression tests for the router deployment path in _get_wildcard_models.
+    Ensures wildcard expansion works correctly when the router has actual
+    deployments configured (the most common production scenario)."""
+
+    def test_router_deployment_expands_wildcards(self):
+        """When router has a deployment for a wildcard, models are expanded
+        from that deployment's litellm_params, not just from known models."""
+        model_list = [
+            {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
+        ]
+        router = Router(model_list=model_list)
+
+        unique_models = ["openai/*"]
+        expanded = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+        # Wildcard removed from unique_models
+        assert "openai/*" not in unique_models
+        # Expanded to concrete model names
+        assert len(expanded) > 0
+        assert all("*" not in m for m in expanded)
+
+    def test_router_deployment_multiple_providers(self):
+        """Multiple wildcard deployments each expand independently."""
+        model_list = [
+            {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
+            {"model_name": "anthropic/*", "litellm_params": {"model": "anthropic/*"}},
+        ]
+        router = Router(model_list=model_list)
+
+        unique_models = ["openai/*", "anthropic/*"]
+        expanded = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+        assert "openai/*" not in unique_models
+        assert "anthropic/*" not in unique_models
+        openai_expanded = [m for m in expanded if m.startswith("openai/")]
+        anthropic_expanded = [m for m in expanded if m.startswith("anthropic/")]
+        assert len(openai_expanded) > 0, "Router deployment should expand openai/*"
+        assert len(anthropic_expanded) > 0, "Router deployment should expand anthropic/*"
+
+    def test_router_deployment_preserves_explicit_models(self):
+        """Explicit (non-wildcard) models in unique_models survive expansion."""
+        model_list = [
+            {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
+            {
+                "model_name": "my-custom",
+                "litellm_params": {"model": "openai/gpt-4o"},
+            },
+        ]
+        router = Router(model_list=model_list)
+
+        unique_models = ["openai/*", "my-custom"]
+        _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=router,
+        )
+        assert "openai/*" not in unique_models
+        assert "my-custom" in unique_models

--- a/tests/test_litellm/test_wildcard_models_endpoint.py
+++ b/tests/test_litellm/test_wildcard_models_endpoint.py
@@ -8,12 +8,36 @@ When the router DID have a wildcard deployment (the common case), the
 wildcard pattern stayed in the list alongside the expanded models.
 """
 
+from unittest.mock import patch
+
 from litellm.proxy.auth.model_checks import (
     _check_wildcard_routing,
     _get_wildcard_models,
     get_complete_model_list,
 )
 from litellm.router import Router
+
+# Deterministic fake models used by mocked expansion so tests don't depend
+# on litellm's bundled static provider lists.
+_FAKE_OPENAI_MODELS = ["openai/gpt-4o", "openai/gpt-4o-mini"]
+_FAKE_ANTHROPIC_MODELS = ["anthropic/claude-3-sonnet", "anthropic/claude-3-haiku"]
+_FAKE_GEMINI_MODELS = ["gemini/gemini-1.5-pro", "gemini/gemini-1.5-flash"]
+_FAKE_ALL_MODELS = _FAKE_OPENAI_MODELS + _FAKE_ANTHROPIC_MODELS + _FAKE_GEMINI_MODELS
+
+_MOCK_TARGET = "litellm.proxy.auth.model_checks.get_known_models_from_wildcard"
+
+
+def _fake_get_known_models(wildcard_model, litellm_params=None):
+    """Return deterministic fake models keyed by wildcard pattern."""
+    if wildcard_model == "*":
+        return list(_FAKE_ALL_MODELS)
+    if wildcard_model.startswith("openai/"):
+        return list(_FAKE_OPENAI_MODELS)
+    if wildcard_model.startswith("anthropic/"):
+        return list(_FAKE_ANTHROPIC_MODELS)
+    if wildcard_model.startswith("gemini/"):
+        return list(_FAKE_GEMINI_MODELS)
+    return []
 
 
 class TestCheckWildcardRouting:
@@ -34,7 +58,8 @@ class TestGetWildcardModelsRemovesPatterns:
     """The core bug: wildcard patterns must be removed from unique_models
     when expanded, regardless of whether the router has a deployment."""
 
-    def test_wildcard_removed_when_router_has_deployment(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_wildcard_removed_when_router_has_deployment(self, _mock):
         """Bug repro: openai/* stays in unique_models when router has deployment."""
         model_list = [
             {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}}
@@ -55,7 +80,8 @@ class TestGetWildcardModelsRemovesPatterns:
         assert len(expanded) > 0
         assert all("*" not in m for m in expanded)
 
-    def test_wildcard_removed_when_router_has_no_deployment(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_wildcard_removed_when_router_has_no_deployment(self, _mock):
         """Already worked before fix — BYOK case."""
         router = Router(model_list=[])
 
@@ -68,7 +94,8 @@ class TestGetWildcardModelsRemovesPatterns:
         assert "openai/*" not in unique_models
         assert len(expanded) > 0
 
-    def test_wildcard_removed_when_no_router(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_wildcard_removed_when_no_router(self, _mock):
         """Already worked before fix — no router at all."""
         unique_models = ["anthropic/*"]
         expanded = _get_wildcard_models(
@@ -79,7 +106,8 @@ class TestGetWildcardModelsRemovesPatterns:
         assert "anthropic/*" not in unique_models
         assert len(expanded) > 0
 
-    def test_return_wildcard_routes_true_keeps_pattern(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_return_wildcard_routes_true_keeps_pattern(self, _mock):
         """When return_wildcard_routes=True, the pattern should be in expanded."""
         model_list = [
             {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}}
@@ -97,7 +125,8 @@ class TestGetWildcardModelsRemovesPatterns:
         # But it must still be removed from unique_models to avoid duplicates
         assert "openai/*" not in unique_models
 
-    def test_multiple_wildcards_all_removed(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_multiple_wildcards_all_removed(self, _mock):
         """Multiple wildcard providers should all be removed."""
         model_list = [
             {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
@@ -118,7 +147,8 @@ class TestGetWildcardModelsRemovesPatterns:
         assert "anthropic/*" not in unique_models
         assert "my-custom-model" in unique_models
 
-    def test_wildcard_removed_even_when_no_expansion_possible(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_wildcard_removed_even_when_no_expansion_possible(self, _mock):
         """A wildcard for an unknown provider with no deployments must still
         be removed from unique_models. Users should never see glob patterns
         in the /models response, even if we cannot expand them."""
@@ -136,7 +166,8 @@ class TestGetWildcardModelsRemovesPatterns:
         # No models expanded for unknown provider
         assert len(expanded) == 0
 
-    def test_unknown_wildcard_removed_when_no_router(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_unknown_wildcard_removed_when_no_router(self, _mock):
         """Even without a router, unknown-provider wildcards are removed."""
         unique_models = ["unknownprovider/*"]
         expanded = _get_wildcard_models(
@@ -147,7 +178,8 @@ class TestGetWildcardModelsRemovesPatterns:
         assert "unknownprovider/*" not in unique_models
         assert len(expanded) == 0
 
-    def test_global_star_wildcard_removed_with_router(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_global_star_wildcard_removed_with_router(self, _mock):
         """The bare '*' wildcard must be removed from unique_models even
         when no concrete models can be expanded (e.g. no API keys set)."""
         router = Router(model_list=[])
@@ -161,7 +193,8 @@ class TestGetWildcardModelsRemovesPatterns:
         assert "*" not in unique_models
         assert "my-custom-model" in unique_models
 
-    def test_global_star_wildcard_removed_without_router(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_global_star_wildcard_removed_without_router(self, _mock):
         """The bare '*' wildcard must be removed even without a router."""
         unique_models = ["*"]
         _get_wildcard_models(
@@ -171,7 +204,8 @@ class TestGetWildcardModelsRemovesPatterns:
         )
         assert "*" not in unique_models
 
-    def test_global_star_wildcard_with_router_deployment(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_global_star_wildcard_with_router_deployment(self, _mock):
         """Regression: bare '*' with a router deployment that has model_name='*'.
 
         Even when the router has a deployment matching '*', the pattern must
@@ -200,7 +234,8 @@ class TestGetWildcardModelsRemovesPatterns:
 class TestGetCompleteModelListEndToEnd:
     """End-to-end test matching issue #13752 scenario."""
 
-    def test_models_endpoint_no_wildcards_in_response(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_models_endpoint_no_wildcards_in_response(self, _mock):
         """Issue #13752: /models returns openai/*, anthropic/* etc."""
         model_list = [
             {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
@@ -230,7 +265,8 @@ class TestGetCompleteModelListEndToEnd:
         # Should contain real expanded model names
         assert len(result) > 0
 
-    def test_models_endpoint_with_mixed_wildcard_and_explicit(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_models_endpoint_with_mixed_wildcard_and_explicit(self, _mock):
         """Explicit models should survive alongside wildcard expansion."""
         model_list = [
             {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
@@ -258,7 +294,8 @@ class TestGetCompleteModelListEndToEnd:
         openai_models = [m for m in result if m.startswith("openai/")]
         assert len(openai_models) > 0
 
-    def test_return_wildcard_routes_true_includes_patterns(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_return_wildcard_routes_true_includes_patterns(self, _mock):
         """When explicitly requested, wildcards should appear."""
         model_list = [
             {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
@@ -286,7 +323,8 @@ class TestRegressionIssue13752:
     report where the router has wildcard deployments and /models returns
     raw wildcard patterns instead of expanded concrete model names."""
 
-    def test_bug_report_scenario_router_with_wildcard_deployments(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_bug_report_scenario_router_with_wildcard_deployments(self, _mock):
         """Reproduce the exact config from issue #13752.
 
         Config had:
@@ -338,7 +376,8 @@ class TestRouterDeploymentRegression:
     Ensures wildcard expansion works correctly when the router has actual
     deployments configured (the most common production scenario)."""
 
-    def test_router_deployment_expands_wildcards(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_router_deployment_expands_wildcards(self, _mock):
         """When router has a deployment for a wildcard, models are expanded
         from that deployment's litellm_params, not just from known models."""
         model_list = [
@@ -358,7 +397,8 @@ class TestRouterDeploymentRegression:
         assert len(expanded) > 0
         assert all("*" not in m for m in expanded)
 
-    def test_router_deployment_multiple_providers(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_router_deployment_multiple_providers(self, _mock):
         """Multiple wildcard deployments each expand independently."""
         model_list = [
             {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},
@@ -379,7 +419,8 @@ class TestRouterDeploymentRegression:
         assert len(openai_expanded) > 0, "Router deployment should expand openai/*"
         assert len(anthropic_expanded) > 0, "Router deployment should expand anthropic/*"
 
-    def test_router_deployment_preserves_explicit_models(self):
+    @patch(_MOCK_TARGET, side_effect=_fake_get_known_models)
+    def test_router_deployment_preserves_explicit_models(self, _mock):
         """Explicit (non-wildcard) models in unique_models survive expansion."""
         model_list = [
             {"model_name": "openai/*", "litellm_params": {"model": "openai/*"}},


### PR DESCRIPTION
## Summary

Fixes #13752

When provider wildcards (e.g. `openai/*`, `anthropic/*`, `gemini/*`) are configured in `model_list`, the `/models` endpoint returns both the wildcard pattern AND all expanded model names. Users expect only real model names.

## Root Cause

`_get_wildcard_models()` in `model_checks.py` expands wildcard patterns into known provider models and removes the original pattern from `unique_models`. However, the removal only happened when:
- The router had **no deployment** for the wildcard (BYOK case)
- The router was **None**

In the **common case** — router with a wildcard deployment — the wildcard pattern was never added to `models_to_remove`, so it stayed in the final list.

## Fix

One line: add `models_to_remove.add(model)` in the `if model_list:` branch (line 288), so wildcard patterns are always stripped from the response regardless of router state.

The `return_wildcard_routes=True` parameter still works — when set, the pattern is added to the expanded list (not `unique_models`), so it appears in the response as expected.

## Tests

11 new tests covering:
- Wildcard removal with router deployment (the bug)
- Wildcard removal without deployment (BYOK)
- Wildcard removal without router
- `return_wildcard_routes=True` preserves patterns
- Multiple wildcards all removed
- Mixed wildcard + explicit models
- End-to-end `get_complete_model_list` scenarios

All existing `test_model_checks.py` tests continue to pass.