### PR TITLE
Fix undefined kwargs in InFlightRequestsMiddleware

### DIFF
--- a/litellm/proxy/middleware/in_flight_requests_middleware.py
+++ b/litellm/proxy/middleware/in_flight_requests_middleware.py
@@ -62,13 +62,14 @@ class InFlightRequestsMiddleware:
         try:
             from prometheus_client import Gauge
 
+            kwargs: dict[str, Any] = {}
             if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
                 # livesum aggregates across all worker processes in the scrape response
                 kwargs["multiprocess_mode"] = "livesum"
             InFlightRequestsMiddleware._gauge = Gauge(
                 "litellm_in_flight_requests",
                 "Number of HTTP requests currently in-flight on this uvicorn worker",
-                **kwargs,  # type: ignore[arg-type]
+                **kwargs,
             )
         except Exception:
             InFlightRequestsMiddleware._gauge = None


### PR DESCRIPTION
## Summary
- `kwargs` was referenced on lines 67 and 71 of `in_flight_requests_middleware.py` but never initialized, causing `F821 Undefined name` lint errors
- Initialize `kwargs` as an empty dict before the conditional block

Note: The `router.py:1721 PLR0915 Too many statements` error is a pre-existing style warning and is not addressed here to keep this PR scoped.

## Test plan
- [ ] Verify `make lint-ruff` passes for this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)