### PR TITLE
Fix observatory tunnel DNS flakiness and PLR0915 lint

### DIFF
--- a/.github/workflows/run_observatory_tests.yml
+++ b/.github/workflows/run_observatory_tests.yml
@@ -104,8 +104,19 @@ jobs:
       - name: Verify tunnel connectivity
         run: |
           echo "Testing tunnel at ${{ env.TUNNEL_URL }}..."
-          curl -sf "${{ env.TUNNEL_URL }}/health/liveliness"
-          echo "Tunnel is working"
+          # Quick tunnels need time for DNS propagation; retry to avoid
+          # transient NXDOMAIN (curl exit code 6) on first attempt.
+          for i in $(seq 1 10); do
+            if curl -sf "${{ env.TUNNEL_URL }}/health/liveliness" > /dev/null 2>&1; then
+              echo "Tunnel is working (attempt $i)"
+              exit 0
+            fi
+            echo "Attempt $i/10 - tunnel not routable yet, waiting 5s..."
+            sleep 5
+          done
+          echo "Tunnel failed to become reachable after 50s"
+          cat /tmp/cloudflared.log
+          exit 1
 
       - name: Trigger observatory test run
         id: trigger

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1718,7 +1718,7 @@ class Router:
 
         return FallbackStreamWrapper(stream_with_fallbacks())
 
-    def _completion_streaming_iterator(
+    def _completion_streaming_iterator(  # noqa: PLR0915
         self,
         model_response: CustomStreamWrapper,
         messages: List[Dict[str, str]],


### PR DESCRIPTION
## Summary
- **Observatory workflow**: Replace single `curl` in "Verify tunnel connectivity" with a retry loop (10 attempts × 5s). Cloudflare quick tunnels need DNS propagation time; the first lookup can return NXDOMAIN (curl exit code 6), which is exactly what caused the [failed run](https://github.com/BerriAI/litellm/actions/runs/22551596889/job/65322302248).
- **router.py**: Add `# noqa: PLR0915` to `_completion_streaming_iterator`, matching the suppression already on its async twin `_acompletion_streaming_iterator`.

## Test plan
- [x] Reproduced tunnel DNS failure locally (curl exit 6 on first attempt, resolved on public DNS)
- [x] Verified retry loop pattern works
- [x] Confirmed `ruff check litellm/router.py --select PLR0915` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)