### PR TITLE
fix(proxy): forward retry-after header from upstream providers on 429 responses

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/get_headers.py
+++ b/litellm/litellm_core_utils/llm_response_utils/get_headers.py
@@ -35,6 +35,8 @@ def get_response_headers(_response_headers: Optional[dict] = None) -> dict:
         openai_headers["x-ratelimit-remaining-tokens"] = _response_headers[
             "x-ratelimit-remaining-tokens"
         ]
+    if "retry-after" in _response_headers:
+        openai_headers["retry-after"] = _response_headers["retry-after"]
     llm_provider_headers = _get_llm_provider_headers(_response_headers)
     return {**llm_provider_headers, **openai_headers}
 


### PR DESCRIPTION
## Summary

Fixes #21553 — When upstream providers (OpenAI, Azure, etc.) return 429 Too Many Requests with a `retry-after` header, litellm's proxy response did not forward this header to the client. This prevented clients from implementing proper backoff strategies.

## Changes

- Added `retry-after` to the list of directly forwarded headers in `get_response_headers()` (`litellm/litellm_core_utils/llm_response_utils/get_headers.py`)
- The header was already forwarded with the `llm_provider-` prefix, but not as the standard `retry-after` header that clients expect

## Tests

- Added `test_get_response_headers_with_retry_after` — verifies the header is forwarded both directly and with the `llm_provider-` prefix
- Added `test_get_response_headers_without_retry_after` — verifies no `retry-after` key appears when upstream doesn't send one
- All existing tests continue to pass