### PR TITLE
fix(cost): fix rerank cost calculation always returning 0

### DIFF
--- a/litellm/llms/base_llm/rerank/transformation.py
+++ b/litellm/llms/base_llm/rerank/transformation.py
@@ -104,31 +104,46 @@ class BaseRerankConfig(ABC):
         model_info: Optional[ModelInfo] = None,
     ) -> Tuple[float, float]:
         """
-        Calculates the cost per query for a given rerank model.
+        Calculates the cost for a given rerank model.
+
+        Supports two pricing strategies:
+        1. Per-query pricing (input_cost_per_query × search_units)
+        2. Per-token pricing (input_cost_per_token × total_tokens) as fallback
+
+        When per-query pricing is available but search_units is missing from
+        the response, defaults to 1 search unit (one query = one request).
 
         Input:
             - model: str, the model name without provider prefix
-            - custom_llm_provider: str, the provider used for the model. If provided, used to check if the litellm model info is for that provider.
-            - num_queries: int, the number of queries to calculate the cost for
+            - custom_llm_provider: str, the provider used for the model.
+            - billed_units: RerankBilledUnits, usage info from the provider response
             - model_info: ModelInfo, the model info for the given model
 
         Returns:
             Tuple[float, float] - prompt_cost_in_usd, completion_cost_in_usd
         """
+        if model_info is None:
+            return 0.0, 0.0
 
+        # Strategy 1: per-query pricing
+        input_cost_per_query = model_info.get("input_cost_per_query")
+        if input_cost_per_query is not None and input_cost_per_query > 0:
+            search_units = (
+                billed_units.get("search_units") if billed_units else None
+            )
+            if search_units is None:
+                search_units = 1  # default: one query per request
+            return input_cost_per_query * search_units, 0.0
+
+        # Strategy 2: per-token pricing (fallback)
+        input_cost_per_token = model_info.get("input_cost_per_token")
         if (
-            model_info is None
-            or "input_cost_per_query" not in model_info
-            or model_info["input_cost_per_query"] is None
-            or billed_units is None
+            input_cost_per_token is not None
+            and input_cost_per_token > 0
+            and billed_units is not None
         ):
-            return 0.0, 0.0
+            total_tokens = billed_units.get("total_tokens")
+            if total_tokens is not None and total_tokens > 0:
+                return input_cost_per_token * total_tokens, 0.0
 
-        search_units = billed_units.get("search_units")
-
-        if search_units is None:
-            return 0.0, 0.0
-
-        prompt_cost = model_info["input_cost_per_query"] * search_units
-
-        return prompt_cost, 0.0
+        return 0.0, 0.0

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -1484,6 +1484,74 @@ def test_completion_cost_azure_ai_rerank(model):
     assert cost > 0
 
 
+def test_rerank_cost_no_search_units_defaults_to_one(monkeypatch):
+    """
+    Verifies that rerank cost is non-zero even when the response has no
+    billed_units / search_units (defaults to 1 search unit per request).
+
+    Regression test for https://github.com/BerriAI/litellm/issues/13797
+    """
+    from litellm import RerankResponse
+
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    response = RerankResponse(
+        id="no-billed-units",
+        results=[{"index": 0, "relevance_score": 0.9}],
+        meta=None,
+    )
+    response._hidden_params = {"custom_llm_provider": "cohere"}
+
+    cost = completion_cost(
+        model="cohere/rerank-v3.5", completion_response=response, call_type="rerank"
+    )
+    assert cost > 0, f"Expected non-zero cost for rerank with default search_units, got {cost}"
+    assert cost == pytest.approx(0.002)
+
+
+def test_rerank_cost_token_based_pricing(monkeypatch):
+    """
+    Verifies that rerank cost calculation falls back to per-token pricing
+    when input_cost_per_query is not available (e.g. vLLM self-hosted models).
+
+    Regression test for https://github.com/BerriAI/litellm/issues/13797
+    """
+    from litellm import RerankResponse
+    from litellm.types.rerank import RerankBilledUnits, RerankResponseMeta
+
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    litellm.register_model(
+        {
+            "hosted_vllm/my-rerank-model": {
+                "input_cost_per_token": 0.000004,
+                "output_cost_per_token": 0.0,
+                "litellm_provider": "hosted_vllm",
+                "mode": "rerank",
+            }
+        }
+    )
+
+    response = RerankResponse(
+        id="token-pricing",
+        results=[{"index": 0, "relevance_score": 0.9}],
+        meta=RerankResponseMeta(
+            billed_units=RerankBilledUnits(total_tokens=500)
+        ),
+    )
+    response._hidden_params = {"custom_llm_provider": "hosted_vllm"}
+
+    cost = completion_cost(
+        model="hosted_vllm/my-rerank-model",
+        completion_response=response,
+        call_type="rerank",
+    )
+    assert cost > 0, f"Expected non-zero cost for token-based rerank pricing, got {cost}"
+    assert cost == pytest.approx(0.002)  # 0.000004 * 500
+
+
 def test_together_ai_embedding_completion_cost():
     from litellm.utils import Choices, EmbeddingResponse, Message, ModelResponse, Usage
 


### PR DESCRIPTION
## Summary

Fixes #13797 — Rerank API calls always report 0 cost because the base `calculate_rerank_cost()` returned 0 whenever `billed_units` or `search_units` were missing from the provider response, even when the model had valid pricing data.

## Root Cause

The base implementation in `BaseRerankConfig.calculate_rerank_cost()` had two problems:

1. **Missing search_units → cost 0**: When a provider response didn't include `search_units` in `billed_units` (e.g. Bedrock without usage data, vLLM), the function returned 0 even though the model had `input_cost_per_query` defined
2. **No token-based fallback**: Self-hosted providers like vLLM use `input_cost_per_token` pricing, but the base implementation only supported `input_cost_per_query` pricing

## Changes

- **Default to 1 search unit** when `input_cost_per_query` is set but `search_units` is absent (one query = one request)
- **Add per-token pricing fallback** (`input_cost_per_token × total_tokens`) for self-hosted providers like vLLM that use token-based pricing
- Provider-specific overrides (Jina AI, Voyage) are unaffected as they have their own `calculate_rerank_cost()`

## Tests

- `test_rerank_cost_no_search_units_defaults_to_one`: Verifies cost is non-zero when response lacks `billed_units`/`search_units`
- `test_rerank_cost_token_based_pricing`: Verifies per-token fallback for vLLM-style models
- Existing `test_completion_cost_azure_ai_rerank` still passes