### PR TITLE
fix(logging): enqueue async callbacks synchronously to prevent task cancellation (#8842)

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1159,39 +1159,6 @@ def function_setup(  # noqa: PLR0915
         raise e
 
 
-async def _client_async_logging_helper(
-    logging_obj: LiteLLMLoggingObject,
-    result,
-    start_time,
-    end_time,
-    is_completion_with_fallbacks: bool,
-):
-    if (
-        is_completion_with_fallbacks is False
-    ):  # don't log the parent event litellm.completion_with_fallbacks as a 'log_success_event', this will lead to double logging the same call - https://github.com/BerriAI/litellm/issues/7477
-        print_verbose(
-            f"Async Wrapper: Completed Call, calling async_success_handler: {logging_obj.async_success_handler}"
-        )
-        ################################################
-        # Async Logging Worker
-        ################################################
-        from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
-
-        GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
-            async_coroutine=logging_obj.async_success_handler(
-                result=result, start_time=start_time, end_time=end_time
-            )
-        )
-
-        ################################################
-        # Sync Logging Worker
-        ################################################
-        logging_obj.handle_sync_success_callbacks_for_async_calls(
-            result=result,
-            start_time=start_time,
-            end_time=end_time,
-        )
-
 
 def _get_wrapper_num_retries(
     kwargs: Dict[str, Any], exception: Exception
@@ -1931,15 +1898,25 @@ def client(original_function):  # noqa: PLR0915
             )
 
             # LOG SUCCESS - handle streaming success logging in the _next_ object
-            asyncio.create_task(
-                _client_async_logging_helper(
-                    logging_obj=logging_obj,
-                    result=result,
-                    start_time=start_time,
-                    end_time=end_time,
-                    is_completion_with_fallbacks=is_completion_with_fallbacks,
+            # Enqueue async callbacks synchronously (not via fire-and-forget task)
+            # to ensure they are processed even if the event loop shuts down
+            # shortly after the completion returns. Fixes #8842.
+            if not is_completion_with_fallbacks:
+                print_verbose(
+                    f"Async Wrapper: Completed Call, calling async_success_handler: {logging_obj.async_success_handler}"
                 )
-            )
+                from litellm.litellm_core_utils.logging_worker import (
+                    GLOBAL_LOGGING_WORKER,
+                )
+
+                GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
+                    async_coroutine=logging_obj.async_success_handler(
+                        result=result, start_time=start_time, end_time=end_time
+                    )
+                )
+            # Sync callbacks (e.g. langfuse, s3) must fire unconditionally —
+            # the fallbacks guard above only prevents double-firing of async
+            # callbacks (issue #7477), not sync ones.
             logging_obj.handle_sync_success_callbacks_for_async_calls(
                 result=result,
                 start_time=start_time,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1914,14 +1914,14 @@ def client(original_function):  # noqa: PLR0915
                         result=result, start_time=start_time, end_time=end_time
                     )
                 )
-            # Sync callbacks (e.g. langfuse, s3) must fire unconditionally —
-            # the fallbacks guard above only prevents double-firing of async
-            # callbacks (issue #7477), not sync ones.
-            logging_obj.handle_sync_success_callbacks_for_async_calls(
-                result=result,
-                start_time=start_time,
-                end_time=end_time,
-            )
+            # Sync callbacks must also be guarded to prevent double-firing
+            # when using completion_with_fallbacks (issue #7477).
+            if not is_completion_with_fallbacks:
+                logging_obj.handle_sync_success_callbacks_for_async_calls(
+                    result=result,
+                    start_time=start_time,
+                    end_time=end_time,
+                )
             # REBUILD EMBEDDING CACHING
             if (
                 isinstance(result, EmbeddingResponse)

--- a/tests/test_litellm/test_async_custom_logger_callback.py
+++ b/tests/test_litellm/test_async_custom_logger_callback.py
@@ -1,0 +1,112 @@
+"""
+Tests for #8842 — async CustomLogger callbacks must fire without
+requiring the caller to yield to the event loop (e.g., asyncio.sleep).
+
+The root cause was that `wrapper_async` dispatched async callbacks via a
+fire-and-forget `asyncio.create_task`, which could be cancelled before
+running. The fix enqueues the coroutine synchronously to
+GLOBAL_LOGGING_WORKER.
+"""
+
+import asyncio
+from typing import List
+
+import pytest
+
+import litellm
+from litellm.integrations.custom_logger import CustomLogger
+
+
+class _EventTracker(CustomLogger):
+    """Records which callback events fire."""
+
+    def __init__(self):
+        super().__init__()
+        self.events: List[str] = []
+
+    def log_pre_api_call(self, model, messages, kwargs):
+        self.events.append("pre_api_call")
+
+    def log_post_api_call(self, kwargs, response_obj, start_time, end_time):
+        self.events.append("post_api_call")
+
+    def log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.events.append("sync_success")
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.events.append("async_success")
+
+
+@pytest.mark.asyncio
+async def test_acompletion_fires_async_callback():
+    """Direct litellm.acompletion must trigger async_log_success_event."""
+    tracker = _EventTracker()
+    old_callbacks = list(litellm.callbacks)
+    litellm.callbacks = [tracker]
+    try:
+        await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "Hello"}],
+            mock_response="Hi!",
+        )
+
+        from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+        await asyncio.wait_for(GLOBAL_LOGGING_WORKER.flush(), timeout=5.0)
+
+        assert "async_success" in tracker.events, (
+            f"async_log_success_event was NOT called. Events: {tracker.events}"
+        )
+    finally:
+        litellm.callbacks = old_callbacks
+
+
+@pytest.mark.asyncio
+async def test_router_acompletion_fires_async_callback():
+    """Router.acompletion must trigger async_log_success_event."""
+    tracker = _EventTracker()
+    old_callbacks = list(litellm.callbacks)
+    litellm.callbacks = [tracker]
+    try:
+        router = litellm.Router(
+            model_list=[
+                {"model_name": "default", "litellm_params": {"model": "gpt-3.5-turbo"}},
+            ],
+        )
+        await router.acompletion(
+            model="default",
+            messages=[{"role": "user", "content": "Hello"}],
+            mock_response="Hi!",
+        )
+
+        from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+        await asyncio.wait_for(GLOBAL_LOGGING_WORKER.flush(), timeout=5.0)
+
+        assert "async_success" in tracker.events, (
+            f"async_log_success_event was NOT called via router. Events: {tracker.events}"
+        )
+    finally:
+        litellm.callbacks = old_callbacks
+
+
+@pytest.mark.asyncio
+async def test_no_double_async_callback():
+    """async_log_success_event must fire exactly once per completion."""
+    tracker = _EventTracker()
+    old_callbacks = list(litellm.callbacks)
+    litellm.callbacks = [tracker]
+    try:
+        await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "Hello"}],
+            mock_response="Hi!",
+        )
+
+        from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+        await asyncio.wait_for(GLOBAL_LOGGING_WORKER.flush(), timeout=5.0)
+
+        count = tracker.events.count("async_success")
+        assert count == 1, (
+            f"async_log_success_event called {count} times (expected 1). Events: {tracker.events}"
+        )
+    finally:
+        litellm.callbacks = old_callbacks


### PR DESCRIPTION
## Summary

Fixes #8842 — `CustomLogger.async_log_success_event` never fires for `litellm.acompletion()` and `router.acompletion()`.

## Root Cause

In `wrapper_async` (utils.py), the async success handler was dispatched via `asyncio.create_task(_client_async_logging_helper(...))` — a fire-and-forget task. When the caller does not yield to the event loop before `asyncio.run()` shuts down, the task is cancelled before it ever runs, and the callback is silently lost.

## Fix

Replace the fire-and-forget `asyncio.create_task` with a direct synchronous call to `GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue()`. This ensures the `async_success_handler` coroutine is immediately placed in the worker queue, where it will be:
- Processed by the worker loop at the next event loop yield, or
- Flushed by the `_flush_on_exit` atexit handler on shutdown

The `is_completion_with_fallbacks` guard (#7477) is preserved to prevent double-logging.

## Changes

- **`litellm/utils.py`**: Inline the async callback enqueue in `wrapper_async` instead of delegating to `asyncio.create_task`. Remove now-unused `_client_async_logging_helper` function.
- **`tests/test_litellm/test_async_custom_logger_callback.py`**: 3 new tests verifying async callbacks fire for direct `acompletion`, `router.acompletion`, and that no double-logging occurs.
- **`tests/test_litellm/responses/test_no_duplicate_spend_logs.py`**: Updated comment to reflect the new dispatch mechanism.

## Test Results

All 5 tests pass (2 existing + 3 new):

```
tests/test_litellm/test_async_custom_logger_callback.py::test_acompletion_fires_async_callback PASSED
tests/test_litellm/test_async_custom_logger_callback.py::test_no_double_async_callback PASSED  
tests/test_litellm/test_async_custom_logger_callback.py::test_router_acompletion_fires_async_callback PASSED
tests/test_litellm/responses/test_no_duplicate_spend_logs.py::test_async_no_duplicate_spend_logs PASSED
tests/test_litellm/responses/test_no_duplicate_spend_logs.py::test_logging_object_not_popped PASSED
```