### PR TITLE
fix(http): add connection pool limits to prevent file descriptor exhaustion (fixes #13220)

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -197,14 +197,34 @@ RUNWAYML_POLLING_TIMEOUT = int(
 ########## Networking constants ##############################################################
 _DEFAULT_TTL_FOR_HTTPX_CLIENTS = 3600  # 1 hour, re-use the same httpx client for 1 hour
 
+# HTTPX connection pooling - prevents file descriptor exhaustion from unbounded connection growth
+# See: https://github.com/BerriAI/litellm/issues/13220
+
+
+def _safe_int_env(name: str, default: int) -> int:
+    """Parse an integer environment variable with a safe fallback."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return default
+
+
+# NOTE: These values are read once at import time. Changing the env vars after
+# process start (e.g. via os.environ at runtime) will NOT affect existing or new
+# httpx.Client instances. This is intentional — connection pool limits must remain
+# stable for the lifetime of the process to avoid resource leaks.
+HTTPX_MAX_CONNECTIONS = _safe_int_env("LITELLM_HTTP_MAX_CONNECTIONS", 100)
+HTTPX_MAX_KEEPALIVE_CONNECTIONS = _safe_int_env("LITELLM_HTTP_MAX_KEEPALIVE", 20)
+
 # Aiohttp connection pooling - prevents memory leaks from unbounded connection growth
 # Set to 0 for unlimited (not recommended for production)
-AIOHTTP_CONNECTOR_LIMIT = int(os.getenv("AIOHTTP_CONNECTOR_LIMIT", 1000))
-AIOHTTP_CONNECTOR_LIMIT_PER_HOST = int(
-    os.getenv("AIOHTTP_CONNECTOR_LIMIT_PER_HOST", 500)
-)
-AIOHTTP_KEEPALIVE_TIMEOUT = int(os.getenv("AIOHTTP_KEEPALIVE_TIMEOUT", 120))
-AIOHTTP_TTL_DNS_CACHE = int(os.getenv("AIOHTTP_TTL_DNS_CACHE", 300))
+AIOHTTP_CONNECTOR_LIMIT = get_env_int("AIOHTTP_CONNECTOR_LIMIT", 1000)
+AIOHTTP_CONNECTOR_LIMIT_PER_HOST = get_env_int("AIOHTTP_CONNECTOR_LIMIT_PER_HOST", 500)
+AIOHTTP_KEEPALIVE_TIMEOUT = get_env_int("AIOHTTP_KEEPALIVE_TIMEOUT", 120)
+AIOHTTP_TTL_DNS_CACHE = get_env_int("AIOHTTP_TTL_DNS_CACHE", 300)
 # enable_cleanup_closed is only needed for Python versions with the SSL leak bug
 # Fixed in Python 3.12.7+ and 3.13.1+ (see https://github.com/python/cpython/pull/118960)
 # Reference: https://github.com/aio-libs/aiohttp/blob/master/aiohttp/connector.py#L74-L78

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -200,24 +200,12 @@ _DEFAULT_TTL_FOR_HTTPX_CLIENTS = 3600  # 1 hour, re-use the same httpx client fo
 # HTTPX connection pooling - prevents file descriptor exhaustion from unbounded connection growth
 # See: https://github.com/BerriAI/litellm/issues/13220
 
-
-def _safe_int_env(name: str, default: int) -> int:
-    """Parse an integer environment variable with a safe fallback."""
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    try:
-        return int(raw)
-    except (ValueError, TypeError):
-        return default
-
-
 # NOTE: These values are read once at import time. Changing the env vars after
 # process start (e.g. via os.environ at runtime) will NOT affect existing or new
 # httpx.Client instances. This is intentional — connection pool limits must remain
 # stable for the lifetime of the process to avoid resource leaks.
-HTTPX_MAX_CONNECTIONS = _safe_int_env("LITELLM_HTTP_MAX_CONNECTIONS", 100)
-HTTPX_MAX_KEEPALIVE_CONNECTIONS = _safe_int_env("LITELLM_HTTP_MAX_KEEPALIVE", 20)
+HTTPX_MAX_CONNECTIONS = get_env_int("LITELLM_HTTP_MAX_CONNECTIONS", 100)
+HTTPX_MAX_KEEPALIVE_CONNECTIONS = get_env_int("LITELLM_HTTP_MAX_KEEPALIVE", 20)
 
 # Aiohttp connection pooling - prevents memory leaks from unbounded connection growth
 # Set to 0 for unlimited (not recommended for production)

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -31,6 +31,8 @@ from litellm.constants import (
     AIOHTTP_NEEDS_CLEANUP_CLOSED,
     AIOHTTP_TTL_DNS_CACHE,
     DEFAULT_SSL_CIPHERS,
+    HTTPX_MAX_CONNECTIONS,
+    HTTPX_MAX_KEEPALIVE_CONNECTIONS,
 )
 from litellm.litellm_core_utils.logging_utils import track_llm_api_timing
 from litellm.types.llms.custom_http import *
@@ -391,6 +393,10 @@ class AsyncHTTPHandler:
             transport=transport,
             event_hooks=event_hooks,
             timeout=timeout,
+            limits=httpx.Limits(
+                max_connections=HTTPX_MAX_CONNECTIONS,
+                max_keepalive_connections=HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+            ),
             verify=ssl_config,
             cert=cert,
             headers=default_headers,
@@ -941,6 +947,10 @@ class HTTPHandler:
             self.client = httpx.Client(
                 transport=transport,
                 timeout=timeout,
+                limits=httpx.Limits(
+                    max_connections=HTTPX_MAX_CONNECTIONS,
+                    max_keepalive_connections=HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+                ),
                 verify=ssl_config,
                 cert=cert,
                 headers=default_headers,

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -389,14 +389,26 @@ class AsyncHTTPHandler:
         # Get default headers (User-Agent, overridable via LITELLM_USER_AGENT)
         default_headers = get_default_headers()
 
+        # httpx ignores the `limits` param when a custom transport is active;
+        # the transport manages its own connection pool (e.g. aiohttp TCPConnector).
+        limits = httpx.Limits(
+            max_connections=HTTPX_MAX_CONNECTIONS,
+            max_keepalive_connections=HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+        )
+        if transport is not None:
+            verbose_logger.debug(
+                "Custom transport active — httpx client-level `limits` "
+                "(max_connections=%d, max_keepalive=%d) will be ignored; "
+                "the transport manages its own connection pool.",
+                HTTPX_MAX_CONNECTIONS,
+                HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+            )
+
         return httpx.AsyncClient(
             transport=transport,
             event_hooks=event_hooks,
             timeout=timeout,
-            limits=httpx.Limits(
-                max_connections=HTTPX_MAX_CONNECTIONS,
-                max_keepalive_connections=HTTPX_MAX_KEEPALIVE_CONNECTIONS,
-            ),
+            limits=limits,
             verify=ssl_config,
             cert=cert,
             headers=default_headers,
@@ -949,14 +961,25 @@ class HTTPHandler:
         if client is None:
             transport = self._create_sync_transport()
 
+            # httpx ignores the `limits` param when a custom transport is active.
+            limits = httpx.Limits(
+                max_connections=HTTPX_MAX_CONNECTIONS,
+                max_keepalive_connections=HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+            )
+            if transport is not None:
+                verbose_logger.debug(
+                    "Custom transport active — httpx client-level `limits` "
+                    "(max_connections=%d, max_keepalive=%d) will be ignored; "
+                    "the transport manages its own connection pool.",
+                    HTTPX_MAX_CONNECTIONS,
+                    HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+                )
+
             # Create a client with a connection pool
             self.client = httpx.Client(
                 transport=transport,
                 timeout=timeout,
-                limits=httpx.Limits(
-                    max_connections=HTTPX_MAX_CONNECTIONS,
-                    max_keepalive_connections=HTTPX_MAX_KEEPALIVE_CONNECTIONS,
-                ),
+                limits=limits,
                 verify=ssl_config,
                 cert=cert,
                 headers=default_headers,

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -911,7 +911,13 @@ class AsyncHTTPHandler:
         - [Default] If force_ipv4 is False, it will return None
         """
         if litellm.force_ipv4:
-            return AsyncHTTPTransport(local_address="0.0.0.0")
+            return AsyncHTTPTransport(
+                local_address="0.0.0.0",
+                limits=httpx.Limits(
+                    max_connections=HTTPX_MAX_CONNECTIONS,
+                    max_keepalive_connections=HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+                ),
+            )
         else:
             return None
 
@@ -1204,7 +1210,13 @@ class HTTPHandler:
         Some users have seen httpx ConnectionError when using ipv6 - forcing ipv4 resolves the issue for them
         """
         if litellm.force_ipv4:
-            return HTTPTransport(local_address="0.0.0.0")
+            return HTTPTransport(
+                local_address="0.0.0.0",
+                limits=httpx.Limits(
+                    max_connections=HTTPX_MAX_CONNECTIONS,
+                    max_keepalive_connections=HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+                ),
+            )
         else:
             return getattr(litellm, "sync_transport", None)
 

--- a/tests/test_http_handler_limits.py
+++ b/tests/test_http_handler_limits.py
@@ -1,0 +1,180 @@
+"""
+Tests for httpx connection pool limits (fixes #13220).
+
+Verifies that httpx clients are created with bounded connection pools
+to prevent file descriptor exhaustion under parallel load.
+"""
+
+import os
+from unittest.mock import patch
+
+import httpx
+
+
+def _get_pool_limits(client):
+    """Extract pool limits from an httpx client via private internals.
+
+    httpx does not expose pool configuration through a public API, so we
+    access ``_transport._pool._max_connections`` directly.  If httpx
+    changes its internals this will raise ``AttributeError`` — that is
+    intentional so CI catches the breakage rather than silently passing.
+    """
+    pool = client._transport._pool
+    return pool._max_connections, pool._max_keepalive_connections
+
+
+def test_sync_client_has_connection_limits():
+    """HTTPHandler creates httpx.Client with pool limits."""
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    handler = HTTPHandler(timeout=httpx.Timeout(timeout=10.0))
+    max_conn, max_keepalive = _get_pool_limits(handler.client)
+    assert max_conn == 100
+    assert max_keepalive == 20
+    handler.close()
+
+
+def test_async_client_has_connection_limits_with_httpx_transport():
+    """AsyncHTTPHandler uses pool limits when httpx transport is active."""
+    import litellm
+
+    original = getattr(litellm, "disable_aiohttp_transport", False)
+    try:
+        litellm.disable_aiohttp_transport = True
+        from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+        handler = AsyncHTTPHandler(timeout=httpx.Timeout(timeout=10.0))
+        max_conn, max_keepalive = _get_pool_limits(handler.client)
+        assert max_conn == 100
+        assert max_keepalive == 20
+    finally:
+        litellm.disable_aiohttp_transport = original
+
+
+def test_limits_configurable_via_env_max_connections():
+    """LITELLM_HTTP_MAX_CONNECTIONS env var controls max_connections."""
+    import importlib
+
+    import litellm.constants
+
+    with patch.dict(os.environ, {"LITELLM_HTTP_MAX_CONNECTIONS": "50"}):
+        importlib.reload(litellm.constants)
+        from litellm.constants import HTTPX_MAX_CONNECTIONS
+
+        assert HTTPX_MAX_CONNECTIONS == 50
+
+    os.environ.pop("LITELLM_HTTP_MAX_CONNECTIONS", None)
+    importlib.reload(litellm.constants)
+
+
+def test_limits_configurable_via_env_max_keepalive():
+    """LITELLM_HTTP_MAX_KEEPALIVE env var controls max_keepalive_connections."""
+    import importlib
+
+    import litellm.constants
+
+    with patch.dict(os.environ, {"LITELLM_HTTP_MAX_KEEPALIVE": "10"}):
+        importlib.reload(litellm.constants)
+        from litellm.constants import HTTPX_MAX_KEEPALIVE_CONNECTIONS
+
+        assert HTTPX_MAX_KEEPALIVE_CONNECTIONS == 10
+
+    os.environ.pop("LITELLM_HTTP_MAX_KEEPALIVE", None)
+    importlib.reload(litellm.constants)
+
+
+def test_default_constants_values():
+    """Default constants match expected values."""
+    from litellm.constants import HTTPX_MAX_CONNECTIONS, HTTPX_MAX_KEEPALIVE_CONNECTIONS
+
+    assert HTTPX_MAX_CONNECTIONS == 100
+    assert HTTPX_MAX_KEEPALIVE_CONNECTIONS == 20
+
+
+def test_invalid_env_values_fallback_to_defaults():
+    """Non-integer env values fall back to defaults instead of crashing."""
+    import importlib
+
+    import litellm.constants
+
+    with patch.dict(
+        os.environ,
+        {"LITELLM_HTTP_MAX_CONNECTIONS": "not_a_number", "LITELLM_HTTP_MAX_KEEPALIVE": ""},
+    ):
+        importlib.reload(litellm.constants)
+        assert litellm.constants.HTTPX_MAX_CONNECTIONS == 100
+        assert litellm.constants.HTTPX_MAX_KEEPALIVE_CONNECTIONS == 20
+
+    os.environ.pop("LITELLM_HTTP_MAX_CONNECTIONS", None)
+    os.environ.pop("LITELLM_HTTP_MAX_KEEPALIVE", None)
+    importlib.reload(litellm.constants)
+
+
+def test_multiple_sync_handlers_all_enforce_limits():
+    """Multiple HTTPHandler instances all enforce pool limits."""
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    handlers = [HTTPHandler(timeout=httpx.Timeout(timeout=10.0)) for _ in range(3)]
+    for handler in handlers:
+        max_conn, max_keepalive = _get_pool_limits(handler.client)
+        assert max_conn == 100
+        assert max_keepalive == 20
+        handler.close()
+
+
+def test_get_httpx_client_returns_handler_with_limits():
+    """_get_httpx_client returns an HTTPHandler with pool limits."""
+    from litellm.llms.custom_httpx.http_handler import _get_httpx_client
+
+    client = _get_httpx_client()
+    max_conn, max_keepalive = _get_pool_limits(client.client)
+    assert max_conn == 100
+    assert max_keepalive == 20
+
+
+def test_sync_client_custom_env_limits():
+    """HTTPHandler respects custom env var limits at creation time."""
+    import importlib
+
+    import litellm.constants
+    import litellm.llms.custom_httpx.http_handler as handler_mod
+
+    with patch.dict(
+        os.environ,
+        {"LITELLM_HTTP_MAX_CONNECTIONS": "200", "LITELLM_HTTP_MAX_KEEPALIVE": "40"},
+    ):
+        importlib.reload(litellm.constants)
+        importlib.reload(handler_mod)
+        from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+        h = HTTPHandler(timeout=httpx.Timeout(timeout=10.0))
+        max_conn, max_keepalive = _get_pool_limits(h.client)
+        assert max_conn == 200
+        assert max_keepalive == 40
+        h.close()
+
+    os.environ.pop("LITELLM_HTTP_MAX_CONNECTIONS", None)
+    os.environ.pop("LITELLM_HTTP_MAX_KEEPALIVE", None)
+    importlib.reload(litellm.constants)
+    importlib.reload(handler_mod)
+
+
+def test_invalid_env_values_fallback_to_defaults_non_numeric():
+    """Non-integer env values fall back to defaults instead of crashing."""
+    import importlib
+
+    import litellm.constants
+
+    with patch.dict(
+        os.environ,
+        {"LITELLM_HTTP_MAX_CONNECTIONS": "not_a_number", "LITELLM_HTTP_MAX_KEEPALIVE": ""},
+    ):
+        importlib.reload(litellm.constants)
+        from litellm.constants import HTTPX_MAX_CONNECTIONS, HTTPX_MAX_KEEPALIVE_CONNECTIONS
+
+        assert HTTPX_MAX_CONNECTIONS == 100
+        assert HTTPX_MAX_KEEPALIVE_CONNECTIONS == 20
+
+    os.environ.pop("LITELLM_HTTP_MAX_CONNECTIONS", None)
+    os.environ.pop("LITELLM_HTTP_MAX_KEEPALIVE", None)
+    importlib.reload(litellm.constants)

--- a/tests/test_http_handler_limits.py
+++ b/tests/test_http_handler_limits.py
@@ -178,3 +178,20 @@ def test_invalid_env_values_fallback_to_defaults_non_numeric():
     os.environ.pop("LITELLM_HTTP_MAX_CONNECTIONS", None)
     os.environ.pop("LITELLM_HTTP_MAX_KEEPALIVE", None)
     importlib.reload(litellm.constants)
+
+
+def test_force_ipv4_transport_has_pool_limits():
+    """When force_ipv4=True, custom transport must carry the same pool limits."""
+    import litellm
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    original = getattr(litellm, "force_ipv4", False)
+    try:
+        litellm.force_ipv4 = True
+        handler = HTTPHandler(timeout=httpx.Timeout(timeout=10.0))
+        max_conn, max_keepalive = _get_pool_limits(handler.client)
+        assert max_conn == 100
+        assert max_keepalive == 20
+        handler.close()
+    finally:
+        litellm.force_ipv4 = original


### PR DESCRIPTION
## Summary
Fixes #13220 — parallel calls through the router cause file descriptor exhaustion (`OSError: [Errno 24] Too many open files`).

## Root Cause
httpx clients (`AsyncClient` and `Client`) were created without connection pool limits, allowing unbounded connection accumulation during parallel calls.

## Changes
- **`litellm/constants.py`**: Added `HTTPX_MAX_CONNECTIONS` (default: 100) and `HTTPX_MAX_KEEPALIVE_CONNECTIONS` (default: 20) constants, configurable via `LITELLM_HTTP_MAX_CONNECTIONS` and `LITELLM_HTTP_MAX_KEEPALIVE` env vars
- **`litellm/llms/custom_httpx/http_handler.py`**: Added `httpx.Limits(max_connections=..., max_keepalive_connections=...)` to both `httpx.AsyncClient` and `httpx.Client` creation

## Notes
- The aiohttp transport (default for async) already had connection limits via `AIOHTTP_CONNECTOR_LIMIT`. This fix adds equivalent limits to the httpx transport path, used when aiohttp is disabled or for sync clients.
- Defaults (100 max connections, 20 keepalive) match common production settings and are tunable via environment variables.

## Tests
- 8 tests in `tests/test_http_handler_limits.py` covering default limits, env var configurability, sync/async handlers, and client reuse.

Fixes #13220