### PR TITLE
fix(otel): decouple OTel tracing from proxy dependencies (fixes #13081)

### DIFF
--- a/litellm/integrations/langtrace.py
+++ b/litellm/integrations/langtrace.py
@@ -1,7 +1,7 @@
 import json
 from typing import TYPE_CHECKING, Any, Union
 
-from litellm.proxy._types import SpanAttributes
+from litellm.types.integrations.otel import SpanAttributes
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -203,8 +203,10 @@ class OpenTelemetry(CustomLogger):
         try:
             from litellm.proxy import proxy_server
         except ImportError:
-            verbose_logger.warning(
-                "Proxy Server is not installed. Skipping OpenTelemetry initialization."
+            verbose_logger.debug(
+                "Proxy server dependencies not available. "
+                "Skipping proxy-specific OpenTelemetry initialization. "
+                "This is expected when using litellm SDK without litellm[proxy]."
             )
             return
 
@@ -1374,7 +1376,7 @@ class OpenTelemetry(CustomLogger):
     def set_tools_attributes(self, span: Span, tools):
         import json
 
-        from litellm.proxy._types import SpanAttributes
+        from litellm.types.integrations.otel import SpanAttributes
 
         if not tools:
             return
@@ -1428,7 +1430,7 @@ class OpenTelemetry(CustomLogger):
     def _tool_calls_kv_pair(
         tool_calls: List[ChatCompletionMessageToolCall],
     ) -> Dict[str, Any]:
-        from litellm.proxy._types import SpanAttributes
+        from litellm.types.integrations.otel import SpanAttributes
 
         kv_pairs: Dict[str, Any] = {}
         for idx, tool_call in enumerate(tool_calls):
@@ -1473,7 +1475,7 @@ class OpenTelemetry(CustomLogger):
 
                 set_weave_otel_attributes(span, kwargs, response_obj)
                 return
-            from litellm.proxy._types import SpanAttributes
+            from litellm.types.integrations.otel import SpanAttributes
 
             optional_params = kwargs.get("optional_params", {})
             litellm_params = kwargs.get("litellm_params", {}) or {}

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3169,64 +3169,9 @@ class SpendLogsPayload(TypedDict):
     status: Literal["success", "failure"]
 
 
-class SpanAttributes(str, enum.Enum):
-    # Note: We've taken this from opentelemetry-semantic-conventions-ai
-    # I chose to not add a new dependency to litellm for this
-
-    # Semantic Conventions for LLM requests, this needs to be removed after
-    # OpenTelemetry Semantic Conventions support Gen AI.
-    # Issue at https://github.com/open-telemetry/opentelemetry-python/issues/3868
-    # Refer to https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/llm-spans.md
-
-    LLM_SYSTEM = "gen_ai.system"
-    LLM_REQUEST_MODEL = "gen_ai.request.model"
-    LLM_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens"
-    LLM_REQUEST_TEMPERATURE = "gen_ai.request.temperature"
-    LLM_REQUEST_TOP_P = "gen_ai.request.top_p"
-    LLM_PROMPTS = "gen_ai.prompt"
-    LLM_COMPLETIONS = "gen_ai.completion"
-    LLM_RESPONSE_MODEL = "gen_ai.response.model"
-    LLM_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens"
-    LLM_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens"
-
-    # OTEL 1.38 attributes
-    GEN_AI_INPUT_MESSAGES = "gen_ai.input.messages"
-    GEN_AI_OUTPUT_MESSAGES = "gen_ai.output.messages"
-    GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
-    GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
-    GEN_AI_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
-    GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
-    GEN_AI_REQUEST_ID = "gen_ai.request.id"
-    GEN_AI_SYSTEM_INSTRUCTIONS = "gen_ai.system_instructions"
-    GEN_AI_RESPONSE_FINISH_REASONS = "gen_ai.response.finish_reasons"
-
-    LLM_TOKEN_TYPE = "gen_ai.token.type"
-    # To be added
-    # LLM_RESPONSE_FINISH_REASON = "gen_ai.response.finish_reasons"
-    # LLM_RESPONSE_ID = "gen_ai.response.id"
-
-    # LLM
-    LLM_REQUEST_TYPE = "llm.request.type"
-    LLM_USAGE_TOTAL_TOKENS = "llm.usage.total_tokens"
-    LLM_USAGE_TOKEN_TYPE = "llm.usage.token_type"
-    LLM_USER = "llm.user"
-    LLM_HEADERS = "llm.headers"
-    LLM_TOP_K = "llm.top_k"
-    LLM_IS_STREAMING = "llm.is_streaming"
-    LLM_FREQUENCY_PENALTY = "llm.frequency_penalty"
-    LLM_PRESENCE_PENALTY = "llm.presence_penalty"
-    LLM_CHAT_STOP_SEQUENCES = "llm.chat.stop_sequences"
-    LLM_REQUEST_FUNCTIONS = "llm.request.functions"
-    LLM_REQUEST_REPETITION_PENALTY = "llm.request.repetition_penalty"
-    LLM_RESPONSE_FINISH_REASON = "llm.response.finish_reason"
-    LLM_RESPONSE_STOP_REASON = "llm.response.stop_reason"
-    LLM_CONTENT_COMPLETION_CHUNK = "llm.content.completion.chunk"
-
-    # OpenAI
-    LLM_OPENAI_RESPONSE_SYSTEM_FINGERPRINT = "gen_ai.openai.system_fingerprint"
-    LLM_OPENAI_API_BASE = "gen_ai.openai.api_base"
-    LLM_OPENAI_API_VERSION = "gen_ai.openai.api_version"
-    LLM_OPENAI_API_TYPE = "gen_ai.openai.api_type"
+# Re-exported from litellm.types.integrations.otel for backward compatibility.
+# New code should import directly from litellm.types.integrations.otel.
+from litellm.types.integrations.otel import SpanAttributes as SpanAttributes  # noqa: F401
 
 
 class ManagementEndpointLoggingPayload(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -277,6 +277,14 @@ async def create_interaction(
 
     data = await _read_request_body(request=request)
 
+    # `agent` and `model` are mutually exclusive in the Interactions API.
+    # Sending both is ambiguous — reject early with a clear error.
+    if data.get("agent") and data.get("model"):
+        raise HTTPException(
+            status_code=400,
+            detail="'agent' and 'model' are mutually exclusive. Provide one or the other, not both.",
+        )
+
     # Default to gemini provider for interactions
     if "custom_llm_provider" not in data:
         data["custom_llm_provider"] = "gemini"

--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -277,14 +277,6 @@ async def create_interaction(
 
     data = await _read_request_body(request=request)
 
-    # `agent` and `model` are mutually exclusive in the Interactions API.
-    # Sending both is ambiguous — reject early with a clear error.
-    if data.get("agent") and data.get("model"):
-        raise HTTPException(
-            status_code=400,
-            detail="'agent' and 'model' are mutually exclusive. Provide one or the other, not both.",
-        )
-
     # Default to gemini provider for interactions
     if "custom_llm_provider" not in data:
         data["custom_llm_provider"] = "gemini"

--- a/litellm/types/integrations/otel.py
+++ b/litellm/types/integrations/otel.py
@@ -1,0 +1,70 @@
+"""
+OpenTelemetry Span Attributes for LLM observability.
+
+Moved from litellm.proxy._types so that OTel tracing can be used
+without installing the heavy litellm[proxy] dependency group.
+
+See https://github.com/BerriAI/litellm/issues/13081
+"""
+
+import enum
+
+
+class SpanAttributes(str, enum.Enum):
+    # Note: We've taken this from opentelemetry-semantic-conventions-ai
+    # I chose to not add a new dependency to litellm for this
+
+    # Semantic Conventions for LLM requests, this needs to be removed after
+    # OpenTelemetry Semantic Conventions support Gen AI.
+    # Issue at https://github.com/open-telemetry/opentelemetry-python/issues/3868
+    # Refer to https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/llm-spans.md
+
+    LLM_SYSTEM = "gen_ai.system"
+    LLM_REQUEST_MODEL = "gen_ai.request.model"
+    LLM_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens"
+    LLM_REQUEST_TEMPERATURE = "gen_ai.request.temperature"
+    LLM_REQUEST_TOP_P = "gen_ai.request.top_p"
+    LLM_PROMPTS = "gen_ai.prompt"
+    LLM_COMPLETIONS = "gen_ai.completion"
+    LLM_RESPONSE_MODEL = "gen_ai.response.model"
+    LLM_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens"
+    LLM_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens"
+
+    # OTEL 1.38 attributes
+    GEN_AI_INPUT_MESSAGES = "gen_ai.input.messages"
+    GEN_AI_OUTPUT_MESSAGES = "gen_ai.output.messages"
+    GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+    GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+    GEN_AI_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
+    GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
+    GEN_AI_REQUEST_ID = "gen_ai.request.id"
+    GEN_AI_SYSTEM_INSTRUCTIONS = "gen_ai.system_instructions"
+    GEN_AI_RESPONSE_FINISH_REASONS = "gen_ai.response.finish_reasons"
+
+    LLM_TOKEN_TYPE = "gen_ai.token.type"
+    # To be added
+    # LLM_RESPONSE_FINISH_REASON = "gen_ai.response.finish_reasons"
+    # LLM_RESPONSE_ID = "gen_ai.response.id"
+
+    # LLM
+    LLM_REQUEST_TYPE = "llm.request.type"
+    LLM_USAGE_TOTAL_TOKENS = "llm.usage.total_tokens"
+    LLM_USAGE_TOKEN_TYPE = "llm.usage.token_type"
+    LLM_USER = "llm.user"
+    LLM_HEADERS = "llm.headers"
+    LLM_TOP_K = "llm.top_k"
+    LLM_IS_STREAMING = "llm.is_streaming"
+    LLM_FREQUENCY_PENALTY = "llm.frequency_penalty"
+    LLM_PRESENCE_PENALTY = "llm.presence_penalty"
+    LLM_CHAT_STOP_SEQUENCES = "llm.chat.stop_sequences"
+    LLM_REQUEST_FUNCTIONS = "llm.request.functions"
+    LLM_REQUEST_REPETITION_PENALTY = "llm.request.repetition_penalty"
+    LLM_RESPONSE_FINISH_REASON = "llm.response.finish_reason"
+    LLM_RESPONSE_STOP_REASON = "llm.response.stop_reason"
+    LLM_CONTENT_COMPLETION_CHUNK = "llm.content.completion.chunk"
+
+    # OpenAI
+    LLM_OPENAI_RESPONSE_SYSTEM_FINGERPRINT = "gen_ai.openai.system_fingerprint"
+    LLM_OPENAI_API_BASE = "gen_ai.openai.api_base"
+    LLM_OPENAI_API_VERSION = "gen_ai.openai.api_version"
+    LLM_OPENAI_API_TYPE = "gen_ai.openai.api_type"

--- a/tests/test_otel_no_proxy.py
+++ b/tests/test_otel_no_proxy.py
@@ -1,0 +1,210 @@
+"""
+Tests for OTel tracing without proxy dependencies.
+
+Verifies that the OpenTelemetry integration can be imported, initialized,
+and used without requiring litellm[proxy] dependencies.
+
+Fixes https://github.com/BerriAI/litellm/issues/13081
+"""
+
+import ast
+import enum
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestSpanAttributesLocation(unittest.TestCase):
+    """Test that SpanAttributes is importable from the new shared location."""
+
+    def test_import_from_types_integrations_otel(self):
+        """SpanAttributes should be importable from litellm.types.integrations.otel."""
+        from litellm.types.integrations.otel import SpanAttributes
+
+        assert issubclass(SpanAttributes, enum.Enum)
+        assert SpanAttributes.LLM_SYSTEM.value == "gen_ai.system"
+
+    def test_backward_compat_import_from_proxy_types(self):
+        """SpanAttributes should still be importable from litellm.proxy._types."""
+        from litellm.proxy._types import SpanAttributes
+
+        assert SpanAttributes.LLM_SYSTEM.value == "gen_ai.system"
+
+    def test_same_class_both_locations(self):
+        """Both import paths should resolve to the exact same class."""
+        from litellm.proxy._types import SpanAttributes as ProxySpanAttributes
+        from litellm.types.integrations.otel import SpanAttributes as OtelSpanAttributes
+
+        assert ProxySpanAttributes is OtelSpanAttributes
+
+    def test_all_expected_attributes_present(self):
+        """SpanAttributes should contain all expected OTel semantic convention attributes."""
+        from litellm.types.integrations.otel import SpanAttributes
+
+        expected = [
+            "LLM_SYSTEM",
+            "LLM_REQUEST_MODEL",
+            "LLM_REQUEST_MAX_TOKENS",
+            "LLM_REQUEST_TEMPERATURE",
+            "LLM_COMPLETIONS",
+            "LLM_PROMPTS",
+            "LLM_RESPONSE_MODEL",
+            "LLM_USAGE_COMPLETION_TOKENS",
+            "LLM_USAGE_PROMPT_TOKENS",
+            "LLM_REQUEST_FUNCTIONS",
+            "GEN_AI_INPUT_MESSAGES",
+            "GEN_AI_OUTPUT_MESSAGES",
+            "GEN_AI_USAGE_INPUT_TOKENS",
+            "GEN_AI_USAGE_OUTPUT_TOKENS",
+        ]
+        for attr in expected:
+            assert hasattr(SpanAttributes, attr), f"Missing attribute: {attr}"
+
+    def test_span_attributes_is_str_enum(self):
+        """SpanAttributes members should be usable as strings."""
+        from litellm.types.integrations.otel import SpanAttributes
+
+        val = SpanAttributes.LLM_REQUEST_MODEL
+        assert isinstance(val, str)
+        assert val == "gen_ai.request.model"
+
+
+class TestOtelImportWithoutProxy(unittest.TestCase):
+    """Test that the OTel integration module can be imported without proxy deps."""
+
+    def test_opentelemetry_module_importable(self):
+        """litellm.integrations.opentelemetry should import without error."""
+        mod = importlib.import_module("litellm.integrations.opentelemetry")
+        assert hasattr(mod, "OpenTelemetry")
+        assert hasattr(mod, "OpenTelemetryConfig")
+
+    def test_otel_no_runtime_proxy_types_import_for_span_attributes(self):
+        """
+        The OTel integration should import SpanAttributes from
+        litellm.types.integrations.otel, NOT from litellm.proxy._types.
+
+        Uses ast module for robust source analysis instead of string heuristics.
+        """
+        source_path = importlib.util.find_spec(
+            "litellm.integrations.opentelemetry"
+        ).origin
+        with open(source_path, "r") as f:
+            tree = ast.parse(f.read())
+
+        # Walk the AST to find imports of SpanAttributes from proxy._types
+        # that are NOT inside an `if TYPE_CHECKING:` guard.
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if node.module != "litellm.proxy._types":
+                continue
+            if not any(alias.name == "SpanAttributes" for alias in node.names):
+                continue
+            # Found a proxy._types SpanAttributes import — check if it's
+            # guarded by TYPE_CHECKING by inspecting parent If nodes.
+            if not self._is_inside_type_checking(tree, node):
+                self.fail(
+                    f"Line {node.lineno}: runtime import of SpanAttributes "
+                    f"from litellm.proxy._types (should use "
+                    f"litellm.types.integrations.otel)"
+                )
+
+    @staticmethod
+    def _is_inside_type_checking(tree: ast.Module, target: ast.AST) -> bool:
+        """Check if an AST node is inside an `if TYPE_CHECKING:` block."""
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            # Match `if TYPE_CHECKING:` pattern
+            test = node.test
+            if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+                # Check if target is anywhere inside this If body
+                for child in ast.walk(node):
+                    if child is target:
+                        return True
+        return False
+
+    def test_langtrace_imports_from_shared_location(self):
+        """langtrace.py should import SpanAttributes from the shared location."""
+        import litellm.integrations.langtrace as langtrace_mod
+
+        from litellm.types.integrations.otel import SpanAttributes as SharedSpanAttributes
+
+        # Runtime check: langtrace's module-level SpanAttributes should be
+        # the shared enum, not a proxy-specific copy.
+        self.assertIs(
+            langtrace_mod.SpanAttributes,
+            SharedSpanAttributes,
+            "langtrace should import SpanAttributes from "
+            "litellm.types.integrations.otel",
+        )
+
+
+class TestOtelInitializationWithoutProxy(unittest.TestCase):
+    """Test that OpenTelemetry class can be initialized without proxy server."""
+
+    @patch("litellm.integrations.opentelemetry.OpenTelemetry._init_tracing")
+    @patch("litellm.integrations.opentelemetry.OpenTelemetry._init_metrics")
+    @patch("litellm.integrations.opentelemetry.OpenTelemetry._init_logs")
+    def test_otel_init_without_proxy_server(
+        self, mock_logs, mock_metrics, mock_tracing
+    ):
+        """OpenTelemetry should initialize even when proxy_server can't be imported."""
+        from litellm.integrations.opentelemetry import OpenTelemetry
+
+        # Temporarily make proxy_server un-importable
+        original_import = __builtins__.__import__ if hasattr(__builtins__, '__import__') else __import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "litellm.proxy.proxy_server" or (
+                name == "litellm.proxy" and args and "proxy_server" in str(args)
+            ):
+                raise ImportError("Simulated: proxy_server not available")
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            otel = OpenTelemetry()
+            assert otel is not None
+            assert otel.config is not None
+
+    def test_proxy_init_uses_debug_not_warning(self):
+        """_init_otel_logger_on_litellm_proxy should use debug log, not warning."""
+        source = importlib.util.find_spec(
+            "litellm.integrations.opentelemetry"
+        ).origin
+        with open(source, "r") as f:
+            content = f.read()
+
+        # Find the _init_otel_logger_on_litellm_proxy method
+        method_start = content.find("def _init_otel_logger_on_litellm_proxy")
+        assert method_start != -1
+        # Get the next method (or end of file)
+        next_def = content.find("\n    def ", method_start + 1)
+        method_body = content[method_start:next_def] if next_def != -1 else content[method_start:]
+
+        # Should NOT use verbose_logger.warning for the ImportError case
+        assert "verbose_logger.warning" not in method_body, (
+            "_init_otel_logger_on_litellm_proxy should use debug, not warning"
+        )
+        assert "verbose_logger.debug" in method_body
+
+    def test_set_tools_attributes_uses_shared_span_attributes(self):
+        """set_tools_attributes should work with SpanAttributes from shared location."""
+        from litellm.types.integrations.otel import SpanAttributes
+
+        # Verify the attributes used in set_tools_attributes exist
+        assert hasattr(SpanAttributes, "LLM_REQUEST_FUNCTIONS")
+        assert SpanAttributes.LLM_REQUEST_FUNCTIONS.value == "llm.request.functions"
+
+    def test_tool_calls_kv_pair_uses_shared_span_attributes(self):
+        """_tool_calls_kv_pair should work with SpanAttributes from shared location."""
+        from litellm.types.integrations.otel import SpanAttributes
+
+        assert hasattr(SpanAttributes, "LLM_COMPLETIONS")
+        assert SpanAttributes.LLM_COMPLETIONS.value == "gen_ai.completion"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_otel_no_proxy.py
+++ b/tests/test_otel_no_proxy.py
@@ -10,10 +10,8 @@ Fixes https://github.com/BerriAI/litellm/issues/13081
 import ast
 import enum
 import importlib
-import sys
-import types
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 class TestSpanAttributesLocation(unittest.TestCase):

--- a/tests/test_otel_no_proxy.py
+++ b/tests/test_otel_no_proxy.py
@@ -10,6 +10,7 @@ Fixes https://github.com/BerriAI/litellm/issues/13081
 import ast
 import enum
 import importlib
+import importlib.util
 import sys
 import unittest
 from unittest.mock import patch

--- a/tests/test_otel_no_proxy.py
+++ b/tests/test_otel_no_proxy.py
@@ -10,6 +10,7 @@ Fixes https://github.com/BerriAI/litellm/issues/13081
 import ast
 import enum
 import importlib
+import sys
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_otel_no_proxy.py
+++ b/tests/test_otel_no_proxy.py
@@ -162,6 +162,10 @@ class TestOtelInitializationWithoutProxy(unittest.TestCase):
                 raise ImportError("Simulated: proxy_server not available")
             return original_import(name, *args, **kwargs)
 
+        # Remove cached modules so __import__ mock is actually hit
+        sys.modules.pop("litellm.proxy.proxy_server", None)
+        sys.modules.pop("litellm.proxy", None)
+
         with patch("builtins.__import__", side_effect=mock_import):
             otel = OpenTelemetry()
             assert otel is not None


### PR DESCRIPTION
## Summary
Fixes #13081 — OTel tracing no longer requires `litellm[proxy]`.

## Root Cause
The OTel callback imports `SpanAttributes` from `litellm.proxy._types`, which lives inside the proxy module. When `litellm.proxy.proxy_server` is loaded (e.g. via `_get_custom_logger_settings_from_proxy_server`), it triggers a cascade of imports requiring `backoff`, `fastapi`, `prisma`, etc. — all proxy-only dependencies.

Additionally, `_init_otel_logger_on_litellm_proxy` emits a misleading WARNING when the proxy server isn't installed, causing noise for SDK-only users.

## Changes
- **Moved `SpanAttributes` enum** from `litellm/proxy/_types.py` to `litellm/types/integrations/otel.py` — a lightweight module with zero proxy dependencies
- **Re-export in `litellm/proxy/_types.py`** for full backward compatibility
- **Updated imports** in `opentelemetry.py` and `langtrace.py` to use the new location
- **Downgraded log level** in `_init_otel_logger_on_litellm_proxy` from WARNING to DEBUG with a clearer message

## No Breaking Changes
- `from litellm.proxy._types import SpanAttributes` still works (re-exported)
- All existing proxy functionality is unaffected
- OTel callback now works with just base `litellm` + `opentelemetry-api` + `opentelemetry-sdk`

## Tests
12 tests in `tests/test_otel_no_proxy.py`:
- SpanAttributes importable from new location
- Backward compatibility with proxy._types import
- Both paths resolve to same class
- All expected attributes present
- OTel module importable without proxy
- No runtime proxy imports for SpanAttributes
- langtrace uses shared location
- OTel initializes without proxy_server
- Debug log (not warning) for missing proxy
- SpanAttributes used by set_tools_attributes/tool_calls_kv_pair

Fixes #13081