### PR TITLE
Fix(anthropic): anthropic messages response cost

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
+++ b/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
@@ -25,7 +25,7 @@ class ResponseMetadata:
                 result.get("_hidden_params", {}) or {}
             )
         else:
-            self._hidden_params: Union[HiddenParams, dict] = (
+            self._hidden_params = (
                 getattr(result, "_hidden_params", {}) or {}
             )
 

--- a/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
+++ b/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
@@ -20,9 +20,14 @@ class ResponseMetadata:
 
     def __init__(self, result: Any):
         self.result = result
-        self._hidden_params: Union[HiddenParams, dict] = (
-            getattr(result, "_hidden_params", {}) or {}
-        )
+        if isinstance(result, dict):
+            self._hidden_params: Union[HiddenParams, dict] = (
+                result.get("_hidden_params", {}) or {}
+            )
+        else:
+            self._hidden_params: Union[HiddenParams, dict] = (
+                getattr(result, "_hidden_params", {}) or {}
+            )
 
     @property
     def supports_response_time(self) -> bool:
@@ -169,6 +174,8 @@ class ResponseMetadata:
         """Apply metadata to the response object"""
         if hasattr(self.result, "_hidden_params"):
             self.result._hidden_params = self._hidden_params
+        elif isinstance(self.result, dict):
+            self.result["_hidden_params"] = self._hidden_params
 
 
 def update_response_metadata(

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -887,7 +887,11 @@ class ProxyBaseLLMRequestProcessing:
 
         response = responses[1]
 
-        hidden_params = getattr(response, "_hidden_params", {}) or {}
+        hidden_params = (
+            response.get("_hidden_params", {})
+            if isinstance(response, dict)
+            else getattr(response, "_hidden_params", {})
+        ) or {}
         model_id = self._get_model_id_from_response(hidden_params, self.data)
 
         cache_key, api_base, response_cost = (

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1018,9 +1018,13 @@ class ProxyBaseLLMRequestProcessing:
                 log_context=f"litellm_call_id={logging_obj.litellm_call_id}",
             )
 
+
         hidden_params = (
-            getattr(response, "_hidden_params", {}) or {}
-        )  # get any updated response headers
+            response.get("_hidden_params", {})
+            if isinstance(response, dict)
+            else getattr(response, "_hidden_params", {})
+        ) or {}
+ 
         additional_headers = hidden_params.get("additional_headers", {}) or {}
 
         fastapi_response.headers.update(

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
@@ -317,7 +317,7 @@ class TestDictResponseHiddenParams:
         assert metadata._hidden_params == {"existing_key": "value"}
 
     def test_proxy_reads_hidden_params_from_dict_response(self):
-        """Proxy's getattr/get logic should retrieve _hidden_params from dict responses."""
+        """ResponseMetadata.__init__ should extract _hidden_params from dict responses (same path proxy relies on)."""
         response = {
             "id": "msg_abc",
             "_hidden_params": {
@@ -326,12 +326,7 @@ class TestDictResponseHiddenParams:
             },
         }
 
-        # Simulate what the proxy does after the fix
-        hidden_params = (
-            response.get("_hidden_params", {})
-            if isinstance(response, dict)
-            else getattr(response, "_hidden_params", {})
-        ) or {}
+        metadata = ResponseMetadata(response)
 
-        assert hidden_params["response_cost"] == 0.01
-        assert hidden_params["api_base"] == "https://api.anthropic.com"
+        assert metadata._hidden_params["response_cost"] == 0.01
+        assert metadata._hidden_params["api_base"] == "https://api.anthropic.com"

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
@@ -262,3 +262,76 @@ class TestLoggingInitCallbackDuration:
         # Should still be set (deep copy of None is essentially a no-op)
         assert hasattr(obj, "callback_duration_ms")
         assert obj.callback_duration_ms >= 0
+
+
+class TestDictResponseHiddenParams:
+    """Tests that dict-based responses (e.g. AnthropicMessagesResponse TypedDict) get _hidden_params populated."""
+
+    def _make_logging_obj(self):
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {"llm_api_duration_ms": 500.0}
+        logging_obj.caching_details = None
+        logging_obj._response_cost_calculator = MagicMock(return_value=0.0025)
+        logging_obj.litellm_call_id = "test-dict-call"
+        logging_obj.callback_duration_ms = 1.0
+        return logging_obj
+
+    def test_apply_sets_hidden_params_on_dict_response(self):
+        """ResponseMetadata.apply() should store _hidden_params as a dict key on dict responses."""
+        result = {"id": "msg_123", "type": "message", "content": []}
+
+        metadata = ResponseMetadata(result)
+        metadata._hidden_params = {"response_cost": 0.005}
+        metadata.apply()
+
+        assert "_hidden_params" in result
+        assert result["_hidden_params"]["response_cost"] == 0.005
+
+    def test_update_response_metadata_works_for_dict_response(self):
+        """End-to-end: update_response_metadata should populate _hidden_params on a dict response."""
+        result = {"id": "msg_456", "type": "message", "usage": {"input_tokens": 10, "output_tokens": 20}}
+        logging_obj = self._make_logging_obj()
+
+        start = datetime.datetime(2025, 1, 1, 0, 0, 0)
+        end = datetime.datetime(2025, 1, 1, 0, 0, 1)
+
+        update_response_metadata(
+            result=result,
+            logging_obj=logging_obj,
+            model="anthropic/claude-sonnet-4-20250514",
+            kwargs={},
+            start_time=start,
+            end_time=end,
+        )
+
+        assert "_hidden_params" in result
+        hidden = result["_hidden_params"]
+        assert hidden["response_cost"] == 0.0025
+        assert hidden["litellm_call_id"] == "test-dict-call"
+
+    def test_init_reads_existing_hidden_params_from_dict(self):
+        """ResponseMetadata.__init__ should read pre-existing _hidden_params from dict responses."""
+        result = {"id": "msg_789", "_hidden_params": {"existing_key": "value"}}
+
+        metadata = ResponseMetadata(result)
+        assert metadata._hidden_params == {"existing_key": "value"}
+
+    def test_proxy_reads_hidden_params_from_dict_response(self):
+        """Proxy's getattr/get logic should retrieve _hidden_params from dict responses."""
+        response = {
+            "id": "msg_abc",
+            "_hidden_params": {
+                "response_cost": 0.01,
+                "api_base": "https://api.anthropic.com",
+            },
+        }
+
+        # Simulate what the proxy does after the fix
+        hidden_params = (
+            response.get("_hidden_params", {})
+            if isinstance(response, dict)
+            else getattr(response, "_hidden_params", {})
+        ) or {}
+
+        assert hidden_params["response_cost"] == 0.01
+        assert hidden_params["api_base"] == "https://api.anthropic.com"

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
@@ -316,6 +316,17 @@ class TestDictResponseHiddenParams:
         metadata = ResponseMetadata(result)
         assert metadata._hidden_params == {"existing_key": "value"}
 
+    def test_init_handles_none_hidden_params_in_dict_response(self):
+        """When _hidden_params key exists but is None, should fall back to empty dict."""
+        response = {
+            "id": "msg_none",
+            "_hidden_params": None,
+        }
+
+        metadata = ResponseMetadata(response)
+
+        assert metadata._hidden_params == {}
+
     def test_proxy_reads_hidden_params_from_dict_response(self):
         """ResponseMetadata.__init__ should extract _hidden_params from dict responses (same path proxy relies on)."""
         response = {


### PR DESCRIPTION
## Relevant issues

fixes #22557

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix


## Changes
The system calculates the response cost, but it is never persisted to the response object because the `apply()` method fails to handle dictionary-typed responses.
Three modifications to make apply() handle dict-typed responses:                                                      
1. `ResponseMetadata.__init__ `— Read existing _hidden_params from dict responses using `.get()` instead of `getattr()`. 
2. `ResponseMetadata.apply()` — Added an elif isinstance(self.result, dict) branch that stores _hidden_params as a
dict key (self.result["_hidden_params"]), so the computed response_cost is no longer discarded.
3. `Proxy common_request_processing.py` — Updated the hidden params retrieval to use `response.get("_hidden_params",  
{})` for dict responses instead of `getattr()`, the same with non-streaming

I think there is another better but difficult way.Refactor `AnthropicMessagesResponse` from a `TypedDict` to a `Pydantic BaseModel` (similar to `ModelResponse`) to support `_hidden_params`. But I cannot guarantee that this won't cause breaking changes for downstream consumers.

## Tests
1. add `test_proxy_reads_hidden_params_from_dict_response`
2. add `test_init_handles_none_hidden_params_in_dict_response` for edge case