### PR TITLE
feat(proxy): suppress health check access logs via LITELLM_SUPPRESS_HEALTH_LOGS

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -1,6 +1,7 @@
 import ast
 import logging
 import os
+import re
 import sys
 from datetime import datetime
 from logging import Formatter
@@ -246,6 +247,72 @@ def _initialize_loggers_with_handler(handler: logging.Handler):
         lg.propagate = False  # prevent bubbling to parent/root
 
 
+class HealthCheckAccessFilter(logging.Filter):
+    """Filter that suppresses Uvicorn access log entries for health check endpoints."""
+
+    _HTTP_PATH_PATTERN = re.compile(r'"[A-Z]+ ([^ ]+) HTTP/')
+    _HEALTH_PATHS = {
+        "/health",
+        "/health/readiness",
+        "/health/liveliness",
+        "/health/liveness",
+    }
+
+    @staticmethod
+    def _extract_path_from_record(record: logging.LogRecord) -> Optional[str]:
+        args = getattr(record, "args", None)
+        raw_path: Optional[Any] = None
+
+        if isinstance(args, dict):
+            raw_path = args.get("path")
+        elif isinstance(args, tuple) and len(args) >= 3:
+            raw_path = args[2]
+
+        if raw_path is None:
+            return None
+
+        return str(raw_path).split("?", 1)[0]
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        path = self._extract_path_from_record(record)
+        if path is not None:
+            return path not in self._HEALTH_PATHS
+
+        msg = record.getMessage()
+        match = self._HTTP_PATH_PATTERN.search(msg)
+        if match:
+            request_path = match.group(1).split("?", 1)[0]
+            return request_path not in self._HEALTH_PATHS
+        # Could not extract path from structured args or regex — allow the log through
+        # rather than relying on brittle substring matching.
+        return True
+
+
+def apply_health_check_log_filter() -> None:
+    """Attach HealthCheckAccessFilter to the uvicorn.access logger at runtime.
+
+    Works regardless of whether JSON logging is enabled. Safe to call
+    multiple times — the filter is only added once.
+    """
+    access_logger = logging.getLogger("uvicorn.access")
+    if not any(isinstance(f, HealthCheckAccessFilter) for f in access_logger.filters):
+        access_logger.addFilter(HealthCheckAccessFilter())
+
+
+def remove_health_check_log_filter() -> None:
+    """Remove HealthCheckAccessFilter from uvicorn.access logger and handlers."""
+    access_logger = logging.getLogger("uvicorn.access")
+
+    for _filter in list(access_logger.filters):
+        if isinstance(_filter, HealthCheckAccessFilter):
+            access_logger.removeFilter(_filter)
+
+    for handler in list(access_logger.handlers):
+        for _filter in list(handler.filters):
+            if isinstance(_filter, HealthCheckAccessFilter):
+                handler.removeFilter(_filter)
+
+
 def _get_uvicorn_json_log_config():
     """
     Generate a uvicorn log_config dictionary that applies JSON formatting to all loggers.
@@ -302,6 +369,21 @@ def _get_uvicorn_json_log_config():
             },
         },
     }
+
+    # Add health check log suppression if configured
+    if os.getenv("LITELLM_SUPPRESS_HEALTH_LOGS", "false").lower() == "true":
+        filters = log_config.setdefault("filters", {})
+        filters.setdefault(
+            "health_check",
+            {
+                "()": "litellm._logging.HealthCheckAccessFilter",
+            },
+        )
+
+        access_handler = log_config["handlers"].setdefault("access", {})
+        access_filters = access_handler.setdefault("filters", [])
+        if "health_check" not in access_filters:
+            access_filters.append("health_check")
 
     return log_config
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2123,6 +2123,14 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "health checks run without a concurrency cap"
         ),
     )
+    suppress_health_check_logs: Optional[bool] = Field(
+        None,
+        description=(
+            "suppress Uvicorn access logs for health check endpoints "
+            "(/health, /health/readiness, /health/liveliness, /health/liveness). "
+            "Also settable via LITELLM_SUPPRESS_HEALTH_LOGS env var."
+        ),
+    )
     alerting: Optional[List] = Field(
         None,
         description="List of alerting integrations. Today, just slack - `alerting: ['slack']`",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -762,6 +762,12 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
     import json
 
     init_verbose_loggers()
+
+    if os.getenv("LITELLM_SUPPRESS_HEALTH_LOGS", "false").lower() == "true":
+        from litellm._logging import apply_health_check_log_filter
+
+        apply_health_check_log_filter()
+
     ## CHECK PREMIUM USER
     verbose_proxy_logger.debug(
         "litellm.proxy.proxy_server.py::startup() - CHECKING PREMIUM USER - {}".format(
@@ -3119,6 +3125,21 @@ class ProxyConfig:
                 health_check_concurrency,
                 health_check_details,
             )
+
+            ### SUPPRESS HEALTH CHECK LOGS ###
+            suppress_health_check_logs = general_settings.get(
+                "suppress_health_check_logs", None
+            )
+            if suppress_health_check_logs is True:
+                os.environ["LITELLM_SUPPRESS_HEALTH_LOGS"] = "true"
+                from litellm._logging import apply_health_check_log_filter
+
+                apply_health_check_log_filter()
+            elif suppress_health_check_logs is False:
+                os.environ["LITELLM_SUPPRESS_HEALTH_LOGS"] = "false"
+                from litellm._logging import remove_health_check_log_filter
+
+                remove_health_check_log_filter()
 
             ### RBAC ###
             rbac_role_permissions = general_settings.get("role_permissions", None)

--- a/tests/litellm/test_health_check_log_filter.py
+++ b/tests/litellm/test_health_check_log_filter.py
@@ -1,0 +1,114 @@
+"""Tests for the health check access log filter."""
+
+import logging
+
+from litellm._logging import (
+    HealthCheckAccessFilter,
+    apply_health_check_log_filter,
+    remove_health_check_log_filter,
+)
+
+
+class TestHealthCheckAccessFilter:
+    """Test HealthCheckAccessFilter suppresses health check access log entries."""
+
+    def _make_record(self, msg: str, args=()) -> logging.LogRecord:
+        return logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=msg,
+            args=args,
+            exc_info=None,
+        )
+
+    def test_filters_readiness(self):
+        f = HealthCheckAccessFilter()
+        record = self._make_record(
+            '10.0.0.1:1234 - "GET /health/readiness HTTP/1.1" 200 OK'
+        )
+        assert f.filter(record) is False
+
+    def test_filters_liveliness(self):
+        f = HealthCheckAccessFilter()
+        record = self._make_record(
+            '10.0.0.1:1234 - "GET /health/liveliness HTTP/1.1" 200 OK'
+        )
+        assert f.filter(record) is False
+
+    def test_filters_liveness(self):
+        f = HealthCheckAccessFilter()
+        record = self._make_record(
+            '10.0.0.1:1234 - "GET /health/liveness HTTP/1.1" 200 OK'
+        )
+        assert f.filter(record) is False
+
+    def test_allows_regular_request(self):
+        f = HealthCheckAccessFilter()
+        record = self._make_record(
+            '10.0.0.1:1234 - "POST /v1/chat/completions HTTP/1.1" 200 OK'
+        )
+        assert f.filter(record) is True
+
+    def test_allows_health_services(self):
+        f = HealthCheckAccessFilter()
+        record = self._make_record(
+            '10.0.0.1:1234 - "GET /health/services HTTP/1.1" 200 OK'
+        )
+        assert f.filter(record) is True
+
+    def test_filters_bare_health_endpoint(self):
+        f = HealthCheckAccessFilter()
+        record = self._make_record(
+            '10.0.0.1:1234 - "GET /health HTTP/1.1" 200 OK'
+        )
+        assert f.filter(record) is False
+
+    def test_filters_bare_health_endpoint_with_query_param(self):
+        f = HealthCheckAccessFilter()
+        record = self._make_record(
+            '10.0.0.1:1234 - "GET /health?full=true HTTP/1.1" 200 OK'
+        )
+        assert f.filter(record) is False
+
+    def test_filters_using_uvicorn_tuple_args(self):
+        f = HealthCheckAccessFilter()
+        record = self._make_record(
+            '%s - "%s %s HTTP/%s" %s',
+            args=("10.0.0.1:1234", "GET", "/health/liveness?full=true", "1.1", 200),
+        )
+        assert f.filter(record) is False
+
+
+class TestApplyHealthCheckLogFilter:
+    """Test runtime attachment of the filter to uvicorn.access logger."""
+
+    def test_attaches_filter_to_uvicorn_access(self):
+        logger = logging.getLogger("uvicorn.access")
+        apply_health_check_log_filter()
+        count = len(
+            [f for f in logger.filters if isinstance(f, HealthCheckAccessFilter)]
+        )
+        assert count >= 1
+        remove_health_check_log_filter()
+
+    def test_idempotent(self):
+        logger = logging.getLogger("uvicorn.access")
+        remove_health_check_log_filter()
+        apply_health_check_log_filter()
+        apply_health_check_log_filter()
+        count = len(
+            [f for f in logger.filters if isinstance(f, HealthCheckAccessFilter)]
+        )
+        assert count == 1
+        remove_health_check_log_filter()
+
+    def test_remove_filter(self):
+        logger = logging.getLogger("uvicorn.access")
+        apply_health_check_log_filter()
+        remove_health_check_log_filter()
+        count = len(
+            [f for f in logger.filters if isinstance(f, HealthCheckAccessFilter)]
+        )
+        assert count == 0

--- a/tests/litellm/test_health_check_log_filter.py
+++ b/tests/litellm/test_health_check_log_filter.py
@@ -80,6 +80,27 @@ class TestHealthCheckAccessFilter:
         )
         assert f.filter(record) is False
 
+    def test_filters_using_dict_args(self):
+        """Test the dict-args code path in _extract_path_from_record."""
+        f = HealthCheckAccessFilter()
+        record = self._make_record("%(method)s %(path)s")
+        record.args = {"method": "GET", "path": "/health/readiness"}
+        assert f.filter(record) is False
+
+    def test_allows_regular_request_using_dict_args(self):
+        """Test that non-health paths via dict-args are allowed through."""
+        f = HealthCheckAccessFilter()
+        record = self._make_record("%(method)s %(path)s")
+        record.args = {"method": "POST", "path": "/v1/chat/completions"}
+        assert f.filter(record) is True
+
+    def test_filters_dict_args_with_query_param(self):
+        """Test that dict-args with query params are correctly stripped."""
+        f = HealthCheckAccessFilter()
+        record = self._make_record("%(method)s %(path)s")
+        record.args = {"method": "GET", "path": "/health?full=true"}
+        assert f.filter(record) is False
+
 
 class TestApplyHealthCheckLogFilter:
     """Test runtime attachment of the filter to uvicorn.access logger."""


### PR DESCRIPTION
## Problem

When running LiteLLM proxy in Kubernetes (or behind load balancers), health check endpoint access logs flood the output:

```
INFO:     10.72.4.1:58058 - "GET /health/readiness HTTP/1.1" 200 OK
INFO:     10.72.4.1:58068 - "GET /health/liveliness HTTP/1.1" 200 OK
```

With typical probe intervals (every 10-30s), this generates significant noise that obscures meaningful log entries.

## Solution

Adds a Uvicorn access log filter that selectively suppresses INFO-level access log entries for health check probe endpoints:

- `/health/readiness`
- `/health/liveliness`
- `/health/liveness`
- `/health` (bare endpoint)

Other health endpoints like `/health/services` and `/health/history` are **not** suppressed (they carry operational value).

### Configuration

**Option A: Environment variable**
```bash
LITELLM_SUPPRESS_HEALTH_LOGS=true
```

**Option B: YAML config**
```yaml
general_settings:
  suppress_health_check_logs: true
```

Both methods are supported and can be used together.

## Changes

- `litellm/_logging.py`: Added `HealthCheckAccessFilter` class and integration into uvicorn log config
- `litellm/proxy/_types.py`: Added `suppress_health_check_logs` field to `ConfigGeneralSettings`
- `litellm/proxy/proxy_server.py`: Wire YAML config to env var
- `tests/litellm/test_health_check_log_filter.py`: 6 unit tests

## Tests

All 6 tests pass:
- Filters readiness, liveliness, liveness, bare /health endpoints
- Allows regular requests (/v1/chat/completions)
- Allows operational health endpoints (/health/services)

Fixes #18992