### PR TITLE
fix(proxy): auto-generate Prisma client on startup for custom installs

### DIFF
--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -384,11 +384,11 @@ class PrismaManager:
             if result.returncode != 0:
                 verbose_proxy_logger.error(
                     f"'prisma generate' failed (exit {result.returncode}): "
-                    f"{result.stderr}"
+                    f"stdout: {result.stdout}, stderr: {result.stderr}"
                 )
                 raise RuntimeError(
                     f"'prisma generate' failed with exit code {result.returncode}. "
-                    f"stderr: {result.stderr}"
+                    f"stdout: {result.stdout}, stderr: {result.stderr}"
                 )
             # Clear stale import cache and verify generated client is importable.
             # Note: this purges all prisma.* entries from sys.modules even if

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -66,7 +66,6 @@ class PrismaWrapper:
                 return urllib.parse.unquote(parsed.password)
             return None
         except Exception:
-
             return None
 
     def _parse_token_expiration(self, token: Optional[str]) -> Optional[datetime]:
@@ -392,6 +391,9 @@ class PrismaManager:
                     f"stderr: {result.stderr}"
                 )
             # Clear stale import cache and verify generated client is importable.
+            # Note: this purges all prisma.* entries from sys.modules even if
+            # the re-import below fails — acceptable because the proxy cannot
+            # function with a broken Prisma client regardless.
             importlib.invalidate_caches()
             for mod_name in list(sys.modules.keys()):
                 if mod_name == "prisma" or mod_name.startswith("prisma."):
@@ -433,6 +435,8 @@ class PrismaManager:
                         )
                         return False
 
+                    # Note: ProxyExtrasDBManager.setup_database handles its own
+                    # working-directory context internally; no cwd override needed here.
                     return ProxyExtrasDBManager.setup_database(use_migrate=use_migrate)
                 else:
                     # Use prisma db push with increased timeout

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -65,7 +65,7 @@ class PrismaWrapper:
                 # Now decode just the password/token
                 return urllib.parse.unquote(parsed.password)
             return None
-        except ImportError:
+        except Exception:
 
             return None
 

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -433,8 +433,6 @@ class PrismaManager:
                         )
                         return False
 
-                    prisma_dir = PrismaManager._get_prisma_dir()
-
                     return ProxyExtrasDBManager.setup_database(use_migrate=use_migrate)
                 else:
                     # Use prisma db push with increased timeout

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -365,8 +365,8 @@ class PrismaManager:
     def ensure_client_generated() -> None:
         try:
             prisma_module = importlib.import_module("prisma")
-            getattr(prisma_module, "Client")
-            return  # Client already importable — no need to regenerate
+            getattr(prisma_module, "Prisma")
+            return  # Prisma class already importable — no need to regenerate
         except (ImportError, AttributeError):
             pass  # prisma not installed or not yet generated — continue to generate
 
@@ -397,7 +397,7 @@ class PrismaManager:
                 if mod_name == "prisma" or mod_name.startswith("prisma."):
                     sys.modules.pop(mod_name, None)
             prisma_module = importlib.import_module("prisma")
-            getattr(prisma_module, "Client")
+            getattr(prisma_module, "Prisma")
             verbose_proxy_logger.info("Prisma client generated successfully.")
         except subprocess.TimeoutExpired as e:
             timeout_val = getattr(e, "timeout", 120)

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -3,9 +3,11 @@ This file contains the PrismaWrapper class, which is used to wrap the Prisma cli
 """
 
 import asyncio
+import importlib
 import os
 import random
 import subprocess
+import sys
 import time
 import urllib
 import urllib.parse
@@ -63,7 +65,8 @@ class PrismaWrapper:
                 # Now decode just the password/token
                 return urllib.parse.unquote(parsed.password)
             return None
-        except Exception:
+        except ImportError:
+
             return None
 
     def _parse_token_expiration(self, token: Optional[str]) -> Optional[datetime]:
@@ -359,6 +362,57 @@ class PrismaManager:
         return dname
 
     @staticmethod
+    def ensure_client_generated() -> None:
+        try:
+            prisma_module = importlib.import_module("prisma")
+            getattr(prisma_module, "Client")
+            return  # Client already importable — no need to regenerate
+        except (ImportError, AttributeError):
+            pass  # prisma not installed or not yet generated — continue to generate
+
+        verbose_proxy_logger.info(
+            "Prisma client not found – auto-generating via 'prisma generate'..."
+        )
+        prisma_dir = PrismaManager._get_prisma_dir()
+        try:
+            result = subprocess.run(
+                ["prisma", "generate"],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                cwd=prisma_dir,
+            )
+            if result.returncode != 0:
+                verbose_proxy_logger.error(
+                    f"'prisma generate' failed (exit {result.returncode}): "
+                    f"{result.stderr}"
+                )
+                raise RuntimeError(
+                    f"'prisma generate' failed with exit code {result.returncode}. "
+                    f"stderr: {result.stderr}"
+                )
+            # Clear stale import cache and verify generated client is importable.
+            importlib.invalidate_caches()
+            for mod_name in list(sys.modules.keys()):
+                if mod_name == "prisma" or mod_name.startswith("prisma."):
+                    sys.modules.pop(mod_name, None)
+            prisma_module = importlib.import_module("prisma")
+            getattr(prisma_module, "Client")
+            verbose_proxy_logger.info("Prisma client generated successfully.")
+        except subprocess.TimeoutExpired as e:
+            timeout_val = getattr(e, "timeout", 120)
+            cmd = getattr(e, "cmd", ["prisma", "generate"])
+            raise RuntimeError(
+                f"'prisma generate' timed out after {timeout_val} seconds. "
+                f"Command: {cmd!r}. Prisma directory: {prisma_dir!r}."
+            ) from e
+        except (ImportError, AttributeError) as e:
+            raise RuntimeError(
+                "Prisma client import still failing after 'prisma generate'. "
+                f"cwd={prisma_dir}"
+            ) from e
+
+    @staticmethod
     def setup_database(use_migrate: bool = False) -> bool:
         """
         Set up the database using either prisma migrate or prisma db push
@@ -368,9 +422,7 @@ class PrismaManager:
         """
 
         for attempt in range(4):
-            original_dir = os.getcwd()
             prisma_dir = PrismaManager._get_prisma_dir()
-            os.chdir(prisma_dir)
             try:
                 if use_migrate:
                     try:
@@ -386,10 +438,12 @@ class PrismaManager:
                     return ProxyExtrasDBManager.setup_database(use_migrate=use_migrate)
                 else:
                     # Use prisma db push with increased timeout
+                    # Pass cwd instead of os.chdir() to avoid mutating process-wide state
                     subprocess.run(
                         ["prisma", "db", "push", "--accept-data-loss"],
                         timeout=60,
                         check=True,
+                        cwd=prisma_dir,
                     )
                     return True
             except subprocess.TimeoutExpired:
@@ -406,8 +460,6 @@ class PrismaManager:
                     f"The process failed to execute. Details: {e}.{retry_msg}"
                 )
                 time.sleep(random.randrange(5, 15))
-            finally:
-                os.chdir(original_dir)
         return False
 
 

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -18,6 +18,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
+    Dict,
     List,
     Literal,
     NamedTuple,
@@ -48,6 +49,7 @@ from litellm.types.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
     BedrockContentItem,
     BedrockGuardrailOutput,
     BedrockGuardrailResponse,
+    BedrockGuardrailUsage,
     BedrockRequest,
     BedrockTextContent,
 )
@@ -122,6 +124,16 @@ def _redact_pii_matches(response_json: dict) -> dict:
 
 
 class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
+    BEDROCK_GUARDRAIL_MAX_CHARS = 25_000
+
+    @staticmethod
+    def _extract_content_text(item: BedrockContentItem) -> str:
+        text_obj = item.get("text")
+        if not isinstance(text_obj, dict):
+            return ""
+        text = text_obj.get("text") or ""
+        return text if isinstance(text, str) else ""
+
     def __init__(
         self,
         guardrailIdentifier: Optional[str] = None,
@@ -406,34 +418,130 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         return prepped_request
 
-    async def make_bedrock_api_request(
-        self,
-        source: Literal["INPUT", "OUTPUT"],
-        messages: Optional[List[AllMessageValues]] = None,
-        response: Optional[Union[Any, litellm.ModelResponse]] = None,
-        request_data: Optional[dict] = None,
-    ) -> BedrockGuardrailResponse:
-        from datetime import datetime
+    @staticmethod
+    def _chunk_content_items(
+        content: List[BedrockContentItem],
+        max_chars: int = BEDROCK_GUARDRAIL_MAX_CHARS,
+    ) -> List[List[BedrockContentItem]]:
+        """Split content items into chunks that stay within the character limit.
 
-        start_time = datetime.now()
-        credentials, aws_region_name = self._load_credentials()
-        bedrock_request_data: dict = dict(
-            self.convert_to_bedrock_format(
-                source=source, messages=messages, response=response
-            )
-        )
-        bedrock_guardrail_response: BedrockGuardrailResponse = (
-            BedrockGuardrailResponse()
-        )
-        api_key: Optional[str] = None
-        if request_data:
-            bedrock_request_data.update(
-                self.get_guardrail_dynamic_request_body_params(
-                    request_data=request_data
+        Each chunk contains one or more content items whose combined text length
+        does not exceed *max_chars*. If a single text item exceeds the limit it
+        is split across chunks at the character boundary.
+        """
+
+        chunks: List[List[BedrockContentItem]] = []
+        current_chunk: List[BedrockContentItem] = []
+        current_chars = 0
+
+        for item in content:
+            text = BedrockGuardrail._extract_content_text(item)
+            if text == "":
+                current_chunk.append(item)
+                continue
+            text_len = len(text)
+
+            # If the single item fits in the current chunk, add it
+            if current_chars + text_len <= max_chars:
+                current_chunk.append(item)
+                current_chars += text_len
+                continue
+
+            # Item doesn't fit — slice it across chunk boundaries
+            offset = 0
+            while offset < text_len:
+                remaining_space = max_chars - current_chars
+                if remaining_space <= 0:
+                    chunks.append(current_chunk)
+                    current_chunk = []
+                    current_chars = 0
+                    remaining_space = max_chars
+
+                slice_end = min(offset + remaining_space, text_len)
+                chunk_text = text[offset:slice_end]
+                current_chunk.append(
+                    BedrockContentItem(text=BedrockTextContent(text=chunk_text))
                 )
+                current_chars += len(chunk_text)
+                offset = slice_end
+
+                if current_chars >= max_chars:
+                    chunks.append(current_chunk)
+                    current_chunk = []
+                    current_chars = 0
+
+        if current_chunk:
+            chunks.append(current_chunk)
+
+        return chunks if chunks else [content]
+
+    @staticmethod
+    def _merge_guardrail_responses(
+        responses: List[Tuple[BedrockGuardrailResponse, dict]],
+    ) -> Tuple[BedrockGuardrailResponse, dict]:
+        """Merge multiple guardrail responses — worst action wins."""
+        if len(responses) == 1:
+            return responses[0]
+
+        merged_response = BedrockGuardrailResponse()
+        all_assessments: list = []
+        all_outputs: list = []
+        merged_usage: Dict[str, int] = {}
+
+        worst_action = "NONE"
+        action_priority = {"NONE": 0, "GUARDRAIL_INTERVENED": 1}
+
+        for resp, _json_resp in responses:
+            action: str = resp.get("action") or "NONE"
+            if action_priority.get(action, 2) > action_priority.get(worst_action, 0):
+                worst_action = action
+
+            assessments = resp.get("assessments") or []
+            all_assessments.extend(assessments)
+
+            outputs = resp.get("outputs")
+            if outputs is None:
+                outputs = resp.get("output")
+            if outputs is None:
+                outputs = []
+            elif isinstance(outputs, (dict, str)):
+                outputs = [outputs]
+            elif not isinstance(outputs, list):
+                outputs = [outputs]
+            all_outputs.extend(outputs)
+
+            usage = resp.get("usage") or {}
+            for key, val in usage.items():
+                if isinstance(val, (int, float)):
+                    merged_usage[key] = merged_usage.get(key, 0) + val
+
+        merged_response["action"] = worst_action
+        if all_assessments:
+            merged_response["assessments"] = all_assessments
+        if all_outputs:
+            merged_response["outputs"] = all_outputs
+        if merged_usage:
+            # Ensure values are int for BedrockGuardrailUsage
+            merged_response["usage"] = BedrockGuardrailUsage(
+                **{k: int(v) for k, v in merged_usage.items()}
             )
-            if request_data.get("api_key") is not None:
-                api_key = request_data["api_key"]
+
+        merged_json = dict(merged_response)
+        return merged_response, merged_json
+
+    async def _make_single_bedrock_api_request(
+        self,
+        bedrock_request_data: dict,
+        credentials: Any,
+        aws_region_name: str,
+        api_key: Optional[str],
+        source: Literal["INPUT", "OUTPUT"],
+        request_data: Optional[dict],
+        start_time: Any,
+        event_type: GuardrailEventHooks = GuardrailEventHooks.pre_call,
+    ) -> Tuple[BedrockGuardrailResponse, dict]:
+        """Execute a single ApplyGuardrail API call and return parsed response + raw JSON."""
+        from datetime import datetime
 
         prepared_request = self._prepare_request(
             credentials=credentials,
@@ -441,18 +549,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             optional_params=self.optional_params,
             aws_region_name=aws_region_name,
             api_key=api_key,
-        )
-        verbose_proxy_logger.debug(
-            "Bedrock AI request body: %s, url %s, headers: %s",
-            bedrock_request_data,
-            prepared_request.url,
-            prepared_request.headers,
-        )
-
-        event_type = (
-            GuardrailEventHooks.pre_call
-            if source == "INPUT"
-            else GuardrailEventHooks.post_call
         )
 
         try:
@@ -462,11 +558,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 headers=prepared_request.headers,  # type: ignore
             )
         except HTTPException:
-            # Propagate HTTPException (e.g. from non-200 path) as-is
             raise
         except Exception as e:
-            # If this is an HTTP error with a response body (e.g. httpx.HTTPStatusError),
-            # extract the AWS error message and propagate it
             response = getattr(e, "response", None)
             if isinstance(response, httpx.Response):
                 try:
@@ -488,7 +581,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     ) from e
                 except HTTPException:
                     raise
-            # Endpoint down, timeout, or other HTTP/network errors
             verbose_proxy_logger.error(
                 "Bedrock AI: failed to make guardrail request: %s", str(e)
             )
@@ -504,46 +596,170 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             )
             raise
 
-        #########################################################
-        # Add guardrail information to request trace
-        #########################################################
-        self.add_standard_logging_guardrail_information_to_request_data(
-            guardrail_provider=self.guardrail_provider,
-            guardrail_json_response=httpx_response.json(),
-            request_data=request_data or {},
-            guardrail_status=self._get_bedrock_guardrail_response_status(
-                response=httpx_response
-            ),
-            start_time=start_time.timestamp(),
-            end_time=datetime.now().timestamp(),
-            duration=(datetime.now() - start_time).total_seconds(),
-            event_type=event_type,
-        )
-        #########################################################
         if httpx_response.status_code == 200:
-            # check if the response was flagged
-            _json_response = httpx_response.json()
-            redacted_response = _redact_pii_matches(_json_response)
-            verbose_proxy_logger.debug("Bedrock AI response : %s", redacted_response)
-            bedrock_guardrail_response = BedrockGuardrailResponse(**_json_response)
-            if self._should_raise_guardrail_blocked_exception(
-                bedrock_guardrail_response
-            ):
-                raise self._get_http_exception_for_blocked_guardrail(
-                    bedrock_guardrail_response
-                )
+            json_response = httpx_response.json()
+            guardrail_response = BedrockGuardrailResponse(**json_response)
+            return guardrail_response, json_response
         else:
-            status_code, detail_message = self._parse_bedrock_guardrail_error_response(
-                httpx_response
+            status_code, detail_message = (
+                self._parse_bedrock_guardrail_error_response(httpx_response)
             )
             verbose_proxy_logger.error(
                 "Bedrock AI: error in response. Status code: %s, response: %s",
                 httpx_response.status_code,
                 httpx_response.text,
             )
+            self.add_standard_logging_guardrail_information_to_request_data(
+                guardrail_provider=self.guardrail_provider,
+                guardrail_json_response={"error": detail_message},
+                request_data=request_data or {},
+                guardrail_status="guardrail_failed_to_respond",
+                start_time=start_time.timestamp(),
+                end_time=datetime.now().timestamp(),
+                duration=(datetime.now() - start_time).total_seconds(),
+                event_type=event_type,
+            )
             raise HTTPException(status_code=status_code, detail=detail_message)
 
-        return bedrock_guardrail_response
+    async def make_bedrock_api_request(
+        self,
+        source: Literal["INPUT", "OUTPUT"],
+        messages: Optional[List[AllMessageValues]] = None,
+        response: Optional[Union[Any, litellm.ModelResponse]] = None,
+        request_data: Optional[dict] = None,
+    ) -> BedrockGuardrailResponse:
+        from datetime import datetime
+
+        start_time = datetime.now()
+        credentials, aws_region_name = self._load_credentials()
+        bedrock_request_data: dict = dict(
+            self.convert_to_bedrock_format(
+                source=source, messages=messages, response=response
+            )
+        )
+        api_key: Optional[str] = None
+        if request_data:
+            bedrock_request_data.update(
+                self.get_guardrail_dynamic_request_body_params(
+                    request_data=request_data
+                )
+            )
+            if request_data.get("api_key") is not None:
+                api_key = request_data["api_key"]
+
+        verbose_proxy_logger.debug(
+            "Bedrock AI request body: %s",
+            bedrock_request_data,
+        )
+
+        event_type = (
+            GuardrailEventHooks.pre_call
+            if source == "INPUT"
+            else GuardrailEventHooks.post_call
+        )
+
+        # --- chunking logic ---
+        content = bedrock_request_data.get("content", [])
+        total_chars = 0
+        for item in content:
+            text_obj = item.get("text") or {}
+            if isinstance(text_obj, dict):
+                text_val = text_obj.get("text") or ""
+            else:
+                text_val = ""
+            total_chars += len(text_val)
+
+        if total_chars > self.BEDROCK_GUARDRAIL_MAX_CHARS:
+            verbose_proxy_logger.info(
+                "Bedrock guardrail: content is %d chars, chunking into batches of %d",
+                total_chars,
+                self.BEDROCK_GUARDRAIL_MAX_CHARS,
+            )
+            chunks = self._chunk_content_items(
+                content, max_chars=self.BEDROCK_GUARDRAIL_MAX_CHARS
+            )
+            responses: List[Tuple[BedrockGuardrailResponse, dict]] = []
+            for chunk in chunks:
+                chunk_request = copy.deepcopy(bedrock_request_data)
+                chunk_request["content"] = chunk
+                resp, json_resp = await self._make_single_bedrock_api_request(
+                    bedrock_request_data=chunk_request,
+                    credentials=credentials,
+                    aws_region_name=aws_region_name,
+                    api_key=api_key,
+                    source=source,
+                    request_data=request_data,
+                    start_time=start_time,
+                    event_type=event_type,
+                )
+                responses.append((resp, json_resp))
+                # Short-circuit: if any chunk is blocked, stop processing
+                if self._should_raise_guardrail_blocked_exception(resp):
+                    break
+
+            bedrock_guardrail_response, merged_json = (
+                self._merge_guardrail_responses(responses)
+            )
+
+            redacted_response = _redact_pii_matches(merged_json)
+            verbose_proxy_logger.debug("Bedrock AI response : %s", redacted_response)
+
+            self.add_standard_logging_guardrail_information_to_request_data(
+                guardrail_provider=self.guardrail_provider,
+                guardrail_json_response=merged_json,
+                request_data=request_data or {},
+                guardrail_status=self._determine_guardrail_status_from_json(
+                    json_response=merged_json,
+                    guardrail_response=bedrock_guardrail_response,
+                ),
+                start_time=start_time.timestamp(),
+                end_time=datetime.now().timestamp(),
+                duration=(datetime.now() - start_time).total_seconds(),
+                event_type=event_type,
+            )
+
+            if self._should_raise_guardrail_blocked_exception(
+                bedrock_guardrail_response
+            ):
+                raise self._get_http_exception_for_blocked_guardrail(
+                    bedrock_guardrail_response
+                )
+
+            return bedrock_guardrail_response
+
+        # --- single request path (content within limit) ---
+        resp, _json_response = await self._make_single_bedrock_api_request(
+            bedrock_request_data=bedrock_request_data,
+            credentials=credentials,
+            aws_region_name=aws_region_name,
+            api_key=api_key,
+            source=source,
+            request_data=request_data,
+            start_time=start_time,
+            event_type=event_type,
+        )
+
+        redacted_response = _redact_pii_matches(_json_response)
+        verbose_proxy_logger.debug("Bedrock AI response : %s", redacted_response)
+
+        self.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_provider=self.guardrail_provider,
+            guardrail_json_response=_json_response,
+            request_data=request_data or {},
+            guardrail_status=self._determine_guardrail_status_from_json(
+                json_response=_json_response,
+                guardrail_response=resp,
+            ),
+            start_time=start_time.timestamp(),
+            end_time=datetime.now().timestamp(),
+            duration=(datetime.now() - start_time).total_seconds(),
+            event_type=event_type,
+        )
+
+        if self._should_raise_guardrail_blocked_exception(resp):
+            raise self._get_http_exception_for_blocked_guardrail(resp)
+
+        return resp
 
     def _check_bedrock_response_for_exception(self, response) -> bool:
         """
@@ -577,6 +793,27 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             return False
 
         return "Exception" in payload.get("Output", {}).get("__type", "")
+
+    def _determine_guardrail_status_from_json(
+        self,
+        json_response: dict,
+        guardrail_response: BedrockGuardrailResponse,
+    ) -> GuardrailStatus:
+        """Determine guardrail status from already-parsed response data.
+
+        Checks for the AWS exception marker in the JSON body before falling
+        back to action-based classification.
+        """
+        output_payload = json_response.get("Output")
+        if output_payload is None:
+            output_payload = json_response.get("output")
+        if isinstance(output_payload, dict):
+            output_type = output_payload.get("__type", "")
+            if isinstance(output_type, str) and "Exception" in output_type:
+                return "guardrail_failed_to_respond"
+        if self._should_raise_guardrail_blocked_exception(guardrail_response):
+            return "guardrail_intervened"
+        return "success"
 
     def _get_bedrock_guardrail_response_status(
         self, response: httpx.Response

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -437,7 +437,13 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         for item in content:
             text = BedrockGuardrail._extract_content_text(item)
             if text == "":
-                current_chunk.append(item)
+                # Non-text items (images, etc.) go into their own chunk to
+                # prevent unbounded growth that can exceed the API size limit.
+                if current_chunk:
+                    chunks.append(current_chunk)
+                    current_chunk = []
+                    current_chars = 0
+                chunks.append([item])
                 continue
             text_len = len(text)
 
@@ -686,9 +692,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     event_type=event_type,
                 )
                 responses.append((resp, json_resp))
-                # Short-circuit: if any chunk is blocked, stop processing
-                if self._should_raise_guardrail_blocked_exception(resp):
-                    break
 
             bedrock_guardrail_response, merged_json = (
                 self._merge_guardrail_responses(responses)

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -708,7 +708,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                         "Partial guardrail coverage: %d/%d chunks processed successfully. "
                         "Accumulated assessments: %s",
                         len(responses),
-                        len(list(chunks)),
+                        len(chunks),
                         merged_json.get("assessments", []),
                     )
                 raise

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -660,14 +660,9 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         # --- chunking logic ---
         content = bedrock_request_data.get("content", [])
-        total_chars = 0
-        for item in content:
-            text_obj = item.get("text") or {}
-            if isinstance(text_obj, dict):
-                text_val = text_obj.get("text") or ""
-            else:
-                text_val = ""
-            total_chars += len(text_val)
+        total_chars = sum(
+            len(BedrockGuardrail._extract_content_text(item)) for item in content
+        )
 
         if total_chars > self.BEDROCK_GUARDRAIL_MAX_CHARS:
             verbose_proxy_logger.info(

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -501,7 +501,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         for resp, _json_resp in responses:
             action: str = resp.get("action") or "NONE"
-            if action_priority.get(action, 2) > action_priority.get(worst_action, 0):  # default priority 2 for unknown actions ensures they surface rather than get swallowed
+            if action_priority.get(action, 2) > action_priority.get(worst_action, 2):  # unknown actions default to highest priority so they surface
                 worst_action = action
 
             assessments = resp.get("assessments") or []

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -465,9 +465,11 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
                 slice_end = min(offset + remaining_space, text_len)
                 chunk_text = text[offset:slice_end]
-                current_chunk.append(
-                    BedrockContentItem(text=BedrockTextContent(text=chunk_text))
+                split_item = BedrockContentItem(
+                    **{k: v for k, v in item.items() if k != "text"}
                 )
+                split_item["text"] = BedrockTextContent(text=chunk_text)
+                current_chunk.append(split_item)
                 current_chars += len(chunk_text)
                 offset = slice_end
 

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -465,6 +465,11 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
                 slice_end = min(offset + remaining_space, text_len)
                 chunk_text = text[offset:slice_end]
+                # Preserve non-text fields from the original item on each
+                # split fragment.  This is intentional: metadata like "qualifiers"
+                # is duplicated across fragments so the guardrail evaluates every
+                # text window with the correct context.  The "text" key is replaced
+                # with the sliced portion.
                 split_item = BedrockContentItem(
                     **{k: v for k, v in item.items() if k != "text"}
                 )
@@ -535,6 +540,13 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             )
 
         merged_json = dict(merged_response)
+        # Propagate per-chunk AWS exception markers (e.g. "Output": {"__type": "ThrottlingException"})
+        # so that _determine_guardrail_status_from_json correctly detects failures.
+        for _resp, _json_resp in responses:
+            for exc_key in ("Output", "output"):
+                if exc_key in _json_resp and exc_key not in merged_json:
+                    merged_json[exc_key] = _json_resp[exc_key]
+                    break
         return merged_response, merged_json
 
     async def _make_single_bedrock_api_request(

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -699,11 +699,30 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     if self._should_raise_guardrail_blocked_exception(resp):
                         break
             except HTTPException:
-                # Merge and log accumulated responses from successful chunks before re-raising
+                # Check if any prior chunk was blocked by guardrail
                 if responses:
                     bedrock_guardrail_response, merged_json = (
                         self._merge_guardrail_responses(responses)
                     )
+                    # If any prior chunk had a guardrail block, honor it instead of HTTP error
+                    if self._should_raise_guardrail_blocked_exception(bedrock_guardrail_response):
+                        redacted_response = _redact_pii_matches(merged_json)
+                        self.add_standard_logging_guardrail_information_to_request_data(
+                            guardrail_provider=self.guardrail_provider,
+                            guardrail_json_response=merged_json,
+                            request_data=request_data or {},
+                            guardrail_status=self._determine_guardrail_status_from_json(
+                                json_response=merged_json,
+                                guardrail_response=bedrock_guardrail_response,
+                            ),
+                            start_time=start_time.timestamp(),
+                            end_time=datetime.now().timestamp(),
+                            duration=(datetime.now() - start_time).total_seconds(),
+                            event_type=event_type,
+                        )
+                        raise self._get_http_exception_for_blocked_guardrail(
+                            bedrock_guardrail_response
+                        )
                     verbose_proxy_logger.warning(
                         "Partial guardrail coverage: %d/%d chunks processed successfully. "
                         "Accumulated assessments: %s",

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -692,6 +692,9 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     event_type=event_type,
                 )
                 responses.append((resp, json_resp))
+                # Stop processing remaining chunks if this one was blocked
+                if self._should_raise_guardrail_blocked_exception(resp):
+                    break
 
             bedrock_guardrail_response, merged_json = (
                 self._merge_guardrail_responses(responses)

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -679,22 +679,37 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 content, max_chars=self.BEDROCK_GUARDRAIL_MAX_CHARS
             )
             responses: List[Tuple[BedrockGuardrailResponse, dict]] = []
-            for chunk in chunks:
-                chunk_request = copy.deepcopy(bedrock_request_data)
-                chunk_request["content"] = chunk
-                resp, json_resp = await self._make_single_bedrock_api_request(
-                    bedrock_request_data=chunk_request,
-                    credentials=credentials,
-                    aws_region_name=aws_region_name,
-                    api_key=api_key,
-                    request_data=request_data,
-                    start_time=start_time,
-                    event_type=event_type,
-                )
-                responses.append((resp, json_resp))
-                # Stop processing remaining chunks if this one was blocked
-                if self._should_raise_guardrail_blocked_exception(resp):
-                    break
+            try:
+                for chunk in chunks:
+                    chunk_request = copy.deepcopy(bedrock_request_data)
+                    chunk_request["content"] = chunk
+                    resp, json_resp = await self._make_single_bedrock_api_request(
+                        bedrock_request_data=chunk_request,
+                        credentials=credentials,
+                        aws_region_name=aws_region_name,
+                        api_key=api_key,
+                        request_data=request_data,
+                        start_time=start_time,
+                        event_type=event_type,
+                    )
+                    responses.append((resp, json_resp))
+                    # Stop processing remaining chunks if this one was blocked
+                    if self._should_raise_guardrail_blocked_exception(resp):
+                        break
+            except HTTPException:
+                # Merge and log accumulated responses from successful chunks before re-raising
+                if responses:
+                    bedrock_guardrail_response, merged_json = (
+                        self._merge_guardrail_responses(responses)
+                    )
+                    verbose_proxy_logger.warning(
+                        "Partial guardrail coverage: %d/%d chunks processed successfully. "
+                        "Accumulated assessments: %s",
+                        len(responses),
+                        len(list(chunks)),
+                        merged_json.get("assessments", []),
+                    )
+                raise
 
             bedrock_guardrail_response, merged_json = (
                 self._merge_guardrail_responses(responses)

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -493,7 +493,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         for resp, _json_resp in responses:
             action: str = resp.get("action") or "NONE"
-            if action_priority.get(action, 2) > action_priority.get(worst_action, 0):
+            if action_priority.get(action, 2) > action_priority.get(worst_action, 0):  # default priority 2 for unknown actions ensures they surface rather than get swallowed
                 worst_action = action
 
             assessments = resp.get("assessments") or []
@@ -535,7 +535,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         credentials: Any,
         aws_region_name: str,
         api_key: Optional[str],
-        source: Literal["INPUT", "OUTPUT"],
         request_data: Optional[dict],
         start_time: Any,
         event_type: GuardrailEventHooks = GuardrailEventHooks.pre_call,
@@ -682,7 +681,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     credentials=credentials,
                     aws_region_name=aws_region_name,
                     api_key=api_key,
-                    source=source,
                     request_data=request_data,
                     start_time=start_time,
                     event_type=event_type,
@@ -728,7 +726,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             credentials=credentials,
             aws_region_name=aws_region_name,
             api_key=api_key,
-            source=source,
             request_data=request_data,
             start_time=start_time,
             event_type=event_type,

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -845,6 +845,11 @@ def run_server(  # noqa: PLR0915
                     should_update_prisma_schema,
                 )
 
+                # Ensure the Prisma Python client is generated. Docker
+                # images run 'prisma generate' at build time, but custom
+                # (non-Docker) installs may not have done so yet.
+                PrismaManager.ensure_client_generated()
+
                 if (
                     should_update_prisma_schema(
                         general_settings.get("disable_prisma_schema_update")

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -850,10 +850,11 @@ def run_server(  # noqa: PLR0915
                 # (non-Docker) installs may not have done so yet.
                 try:
                     PrismaManager.ensure_client_generated()
-                except RuntimeError:
+                except RuntimeError as e:
                     verbose_proxy_logger.warning(
-                        "Prisma client auto-generation failed — "
-                        "setup_database will retry schema push"
+                        "Prisma client auto-generation failed: %s — "
+                        "setup_database will retry schema push",
+                        e,
                     )
 
                 if (

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -853,7 +853,8 @@ def run_server(  # noqa: PLR0915
                 except RuntimeError as e:
                     verbose_proxy_logger.warning(
                         "Prisma client auto-generation failed: %s — "
-                        "setup_database will retry schema push",
+                        "database operations will be unavailable until resolved. "
+                        "Run 'prisma generate' manually or check schema path.",
                         e,
                     )
 

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -848,7 +848,13 @@ def run_server(  # noqa: PLR0915
                 # Ensure the Prisma Python client is generated. Docker
                 # images run 'prisma generate' at build time, but custom
                 # (non-Docker) installs may not have done so yet.
-                PrismaManager.ensure_client_generated()
+                try:
+                    PrismaManager.ensure_client_generated()
+                except RuntimeError:
+                    verbose_proxy_logger.warning(
+                        "Prisma client auto-generation failed — "
+                        "setup_database will retry schema push"
+                    )
 
                 if (
                     should_update_prisma_schema(

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -853,8 +853,8 @@ def run_server(  # noqa: PLR0915
                 except RuntimeError as e:
                     verbose_proxy_logger.warning(
                         "Prisma client auto-generation failed: %s — "
-                        "database operations will be unavailable until resolved. "
-                        "Run 'prisma generate' manually or check schema path.",
+                        "the proxy may fail at runtime when importing the Prisma client. "
+                        "Run 'prisma generate' manually in the schema directory to fix this.",
                         e,
                     )
 

--- a/tests/test_litellm/proxy/db/test_ensure_prisma_client_generated.py
+++ b/tests/test_litellm/proxy/db/test_ensure_prisma_client_generated.py
@@ -20,7 +20,7 @@ class TestEnsureClientGenerated:
     def test_skips_generate_when_client_exists(self, mock_run):
         """When the Prisma client is already importable, prisma generate is NOT called."""
         prisma_module = MagicMock()
-        prisma_module.Client = object()
+        prisma_module.Prisma = object()
         with patch(
             "litellm.proxy.db.prisma_client.importlib.import_module",
             return_value=prisma_module,
@@ -36,7 +36,7 @@ class TestEnsureClientGenerated:
             args=["prisma", "generate"], returncode=0, stdout="", stderr=""
         )
         prisma_module = MagicMock()
-        prisma_module.Client = object()
+        prisma_module.Prisma = object()
         with patch(
             "litellm.proxy.db.prisma_client.importlib.import_module",
             side_effect=[ImportError("missing prisma"), prisma_module],

--- a/tests/test_litellm/proxy/db/test_ensure_prisma_client_generated.py
+++ b/tests/test_litellm/proxy/db/test_ensure_prisma_client_generated.py
@@ -91,7 +91,8 @@ class TestEnsureClientGenerated:
         mock_run.return_value = subprocess.CompletedProcess(
             args=["prisma", "generate"], returncode=0, stdout="", stderr=""
         )
-        mock_sys.modules = {}
+        # Populate mock_sys.modules with fake prisma keys to ensure cleanup loop body executes
+        mock_sys.modules = {"prisma": MagicMock(), "prisma.engine": MagicMock()}
         with patch(
             "litellm.proxy.db.prisma_client.importlib.import_module",
             side_effect=[ImportError("missing prisma"), ImportError("still missing")],

--- a/tests/test_litellm/proxy/db/test_ensure_prisma_client_generated.py
+++ b/tests/test_litellm/proxy/db/test_ensure_prisma_client_generated.py
@@ -28,13 +28,16 @@ class TestEnsureClientGenerated:
             PrismaManager.ensure_client_generated()
         mock_run.assert_not_called()
 
+    @patch("litellm.proxy.db.prisma_client.sys")
     @patch("litellm.proxy.db.prisma_client.subprocess.run")
     @patch("litellm.proxy.db.prisma_client.importlib.invalidate_caches")
-    def test_runs_generate_when_client_missing(self, mock_invalidate_caches, mock_run):
+    def test_runs_generate_when_client_missing(self, mock_invalidate_caches, mock_run, mock_sys):
         """When the Prisma client cannot be imported, prisma generate is called."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=["prisma", "generate"], returncode=0, stdout="", stderr=""
         )
+        # Prevent real sys.modules mutation during test
+        mock_sys.modules = {}
         prisma_module = MagicMock()
         prisma_module.Prisma = object()
         with patch(
@@ -78,15 +81,17 @@ class TestEnsureClientGenerated:
             with pytest.raises(RuntimeError, match="timed out after"):
                 PrismaManager.ensure_client_generated()
 
+    @patch("litellm.proxy.db.prisma_client.sys")
     @patch("litellm.proxy.db.prisma_client.subprocess.run")
     @patch("litellm.proxy.db.prisma_client.importlib.invalidate_caches")
     def test_raises_when_still_not_importable_after_generate(
-        self, mock_invalidate_caches, mock_run
+        self, mock_invalidate_caches, mock_run, mock_sys
     ):
         """If import still fails after generate, raise a clear RuntimeError."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=["prisma", "generate"], returncode=0, stdout="", stderr=""
         )
+        mock_sys.modules = {}
         with patch(
             "litellm.proxy.db.prisma_client.importlib.import_module",
             side_effect=[ImportError("missing prisma"), ImportError("still missing")],

--- a/tests/test_litellm/proxy/db/test_ensure_prisma_client_generated.py
+++ b/tests/test_litellm/proxy/db/test_ensure_prisma_client_generated.py
@@ -1,0 +1,96 @@
+"""
+Tests for PrismaManager.ensure_client_generated().
+
+Verifies that the Prisma Python client is auto-generated when missing,
+and that the method is a no-op when the client already exists.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from litellm.proxy.db.prisma_client import PrismaManager
+
+
+class TestEnsureClientGenerated:
+    """Tests for PrismaManager.ensure_client_generated"""
+
+    @patch("litellm.proxy.db.prisma_client.subprocess.run")
+    def test_skips_generate_when_client_exists(self, mock_run):
+        """When the Prisma client is already importable, prisma generate is NOT called."""
+        prisma_module = MagicMock()
+        prisma_module.Client = object()
+        with patch(
+            "litellm.proxy.db.prisma_client.importlib.import_module",
+            return_value=prisma_module,
+        ):
+            PrismaManager.ensure_client_generated()
+        mock_run.assert_not_called()
+
+    @patch("litellm.proxy.db.prisma_client.subprocess.run")
+    @patch("litellm.proxy.db.prisma_client.importlib.invalidate_caches")
+    def test_runs_generate_when_client_missing(self, mock_invalidate_caches, mock_run):
+        """When the Prisma client cannot be imported, prisma generate is called."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["prisma", "generate"], returncode=0, stdout="", stderr=""
+        )
+        prisma_module = MagicMock()
+        prisma_module.Client = object()
+        with patch(
+            "litellm.proxy.db.prisma_client.importlib.import_module",
+            side_effect=[ImportError("missing prisma"), prisma_module],
+        ):
+            PrismaManager.ensure_client_generated()
+
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args == ["prisma", "generate"]
+        assert mock_run.call_args.kwargs.get("cwd") == PrismaManager._get_prisma_dir()
+        mock_invalidate_caches.assert_called_once()
+
+    @patch("litellm.proxy.db.prisma_client.subprocess.run")
+    def test_raises_on_generate_failure(self, mock_run):
+        """When prisma generate fails, a RuntimeError is raised."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["prisma", "generate"],
+            returncode=1,
+            stdout="",
+            stderr="error: schema not found",
+        )
+        with patch(
+            "litellm.proxy.db.prisma_client.importlib.import_module",
+            side_effect=ImportError("missing prisma"),
+        ):
+            with pytest.raises(RuntimeError, match="prisma generate"):
+                PrismaManager.ensure_client_generated()
+
+    @patch("litellm.proxy.db.prisma_client.subprocess.run")
+    def test_raises_on_timeout(self, mock_run):
+        """When prisma generate times out, a RuntimeError is raised."""
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd=["prisma", "generate"], timeout=120
+        )
+        with patch(
+            "litellm.proxy.db.prisma_client.importlib.import_module",
+            side_effect=ImportError("missing prisma"),
+        ):
+            with pytest.raises(RuntimeError, match="timed out after"):
+                PrismaManager.ensure_client_generated()
+
+    @patch("litellm.proxy.db.prisma_client.subprocess.run")
+    @patch("litellm.proxy.db.prisma_client.importlib.invalidate_caches")
+    def test_raises_when_still_not_importable_after_generate(
+        self, mock_invalidate_caches, mock_run
+    ):
+        """If import still fails after generate, raise a clear RuntimeError."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["prisma", "generate"], returncode=0, stdout="", stderr=""
+        )
+        with patch(
+            "litellm.proxy.db.prisma_client.importlib.import_module",
+            side_effect=[ImportError("missing prisma"), ImportError("still missing")],
+        ):
+            with pytest.raises(RuntimeError, match="import still failing"):
+                PrismaManager.ensure_client_generated()
+        mock_invalidate_caches.assert_called_once()

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrail_chunking.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrail_chunking.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../../.."))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../..")))
 
 from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
     BedrockGuardrail,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrail_chunking.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrail_chunking.py
@@ -1,0 +1,426 @@
+"""
+Unit tests for Bedrock Guardrail content-chunking pipeline.
+
+Covers:
+- _extract_content_text
+- _chunk_content_items
+- _merge_guardrail_responses
+- _determine_guardrail_status_from_json
+- The overall chunked request path via make_bedrock_api_request
+"""
+
+import copy
+import json
+import os
+import sys
+from typing import List, Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../../.."))
+
+from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
+    BedrockGuardrail,
+)
+from litellm.types.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
+    BedrockContentItem,
+    BedrockGuardrailResponse,
+    BedrockGuardrailUsage,
+    BedrockTextContent,
+)
+
+MAX = BedrockGuardrail.BEDROCK_GUARDRAIL_MAX_CHARS  # 25_000
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _text_item(text: str) -> BedrockContentItem:
+    """Create a BedrockContentItem with the given text."""
+    return BedrockContentItem(text=BedrockTextContent(text=text))
+
+
+def _total_text(chunks: List[List[BedrockContentItem]]) -> str:
+    """Concatenate all text across all chunks for round-trip verification."""
+    parts = []
+    for chunk in chunks:
+        for item in chunk:
+            parts.append(BedrockGuardrail._extract_content_text(item))
+    return "".join(parts)
+
+
+def _make_guardrail() -> BedrockGuardrail:
+    """Construct a BedrockGuardrail with minimal config, mocking heavy deps."""
+    with patch(
+        "litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails.get_async_httpx_client"
+    ):
+        return BedrockGuardrail(
+            guardrailIdentifier="test-id",
+            guardrailVersion="1",
+        )
+
+
+# =========================================================================
+# _extract_content_text
+# =========================================================================
+
+class TestExtractContentText:
+    def test_normal_text(self):
+        item = _text_item("hello")
+        assert BedrockGuardrail._extract_content_text(item) == "hello"
+
+    def test_empty_text(self):
+        item = _text_item("")
+        assert BedrockGuardrail._extract_content_text(item) == ""
+
+    def test_missing_text_key(self):
+        item = BedrockContentItem()
+        assert BedrockGuardrail._extract_content_text(item) == ""
+
+    def test_non_dict_text_value(self):
+        item: BedrockContentItem = {"text": "not-a-dict"}  # type: ignore[typeddict-item]
+        assert BedrockGuardrail._extract_content_text(item) == ""
+
+    def test_text_inner_value_is_none(self):
+        item = BedrockContentItem(text=BedrockTextContent())
+        assert BedrockGuardrail._extract_content_text(item) == ""
+
+
+# =========================================================================
+# _chunk_content_items
+# =========================================================================
+
+class TestChunkContentItems:
+    def test_content_under_limit_returns_single_chunk(self):
+        items = [_text_item("a" * 100)]
+        chunks = BedrockGuardrail._chunk_content_items(items, max_chars=MAX)
+        assert len(chunks) == 1
+        assert chunks[0] == items
+
+    def test_content_exactly_at_limit_returns_single_chunk(self):
+        items = [_text_item("x" * MAX)]
+        chunks = BedrockGuardrail._chunk_content_items(items, max_chars=MAX)
+        assert len(chunks) == 1
+        assert _total_text(chunks) == "x" * MAX
+
+    def test_content_over_limit_returns_multiple_chunks(self):
+        text = "a" * (MAX + 5000)
+        items = [_text_item(text)]
+        chunks = BedrockGuardrail._chunk_content_items(items, max_chars=MAX)
+        assert len(chunks) == 2
+        # Round-trip: concatenated text matches original
+        assert _total_text(chunks) == text
+
+    def test_multiple_items_split_across_chunks(self):
+        # Two items each 60% of limit -> can't fit both in one chunk
+        size = int(MAX * 0.6)
+        items = [_text_item("A" * size), _text_item("B" * size)]
+        chunks = BedrockGuardrail._chunk_content_items(items, max_chars=MAX)
+        assert len(chunks) == 2
+        assert _total_text(chunks) == "A" * size + "B" * size
+
+    def test_single_large_item_split_across_many_chunks(self):
+        text = "z" * (MAX * 3 + 100)
+        items = [_text_item(text)]
+        chunks = BedrockGuardrail._chunk_content_items(items, max_chars=MAX)
+        assert len(chunks) == 4
+        assert _total_text(chunks) == text
+
+    def test_empty_content_returns_original(self):
+        items: List[BedrockContentItem] = []
+        chunks = BedrockGuardrail._chunk_content_items(items, max_chars=MAX)
+        # Empty list → returns [content] which is [[]]
+        assert chunks == [items]
+
+    def test_non_text_item_gets_own_chunk(self):
+        """Non-text items (e.g. images) are placed in their own chunk."""
+        non_text = BedrockContentItem()  # no 'text' key
+        text_item = _text_item("hello")
+        items = [text_item, non_text]
+        chunks = BedrockGuardrail._chunk_content_items(items, max_chars=MAX)
+        assert len(chunks) == 2
+        assert chunks[0] == [text_item]
+        assert chunks[1] == [non_text]
+
+    def test_each_chunk_respects_max_chars(self):
+        """Every chunk's combined text length stays within max_chars."""
+        # Use a smaller limit for fast testing
+        limit = 50
+        items = [_text_item("a" * 30), _text_item("b" * 30), _text_item("c" * 30)]
+        chunks = BedrockGuardrail._chunk_content_items(items, max_chars=limit)
+        for chunk in chunks:
+            total = sum(len(BedrockGuardrail._extract_content_text(i)) for i in chunk)
+            assert total <= limit, f"Chunk exceeds limit: {total} > {limit}"
+        assert _total_text(chunks) == "a" * 30 + "b" * 30 + "c" * 30
+
+
+# =========================================================================
+# _merge_guardrail_responses
+# =========================================================================
+
+class TestMergeGuardrailResponses:
+    def test_single_response_returned_as_is(self):
+        resp = BedrockGuardrailResponse(action="NONE")
+        json_resp: dict = dict(resp)
+        merged_resp, merged_json = BedrockGuardrail._merge_guardrail_responses(
+            [(resp, json_resp)]
+        )
+        assert merged_resp is resp
+        assert merged_json is json_resp
+
+    def test_all_allow_merged_is_none_action(self):
+        r1 = BedrockGuardrailResponse(action="NONE")
+        r2 = BedrockGuardrailResponse(action="NONE")
+        merged_resp, _ = BedrockGuardrail._merge_guardrail_responses(
+            [(r1, dict(r1)), (r2, dict(r2))]
+        )
+        assert merged_resp["action"] == "NONE"
+
+    def test_one_block_makes_merged_block(self):
+        """Worst-action semantics: one GUARDRAIL_INTERVENED overrides NONE."""
+        r_allow = BedrockGuardrailResponse(action="NONE")
+        r_block = BedrockGuardrailResponse(action="GUARDRAIL_INTERVENED")
+        merged_resp, _ = BedrockGuardrail._merge_guardrail_responses(
+            [(r_allow, dict(r_allow)), (r_block, dict(r_block))]
+        )
+        assert merged_resp["action"] == "GUARDRAIL_INTERVENED"
+
+    def test_block_first_then_allow_still_block(self):
+        """Order shouldn't matter — worst action wins regardless of position."""
+        r_block = BedrockGuardrailResponse(action="GUARDRAIL_INTERVENED")
+        r_allow = BedrockGuardrailResponse(action="NONE")
+        merged_resp, _ = BedrockGuardrail._merge_guardrail_responses(
+            [(r_block, dict(r_block)), (r_allow, dict(r_allow))]
+        )
+        assert merged_resp["action"] == "GUARDRAIL_INTERVENED"
+
+    def test_unknown_action_surfaces_as_worst(self):
+        """Unknown actions default to highest priority (worst) per the code."""
+        r_none = BedrockGuardrailResponse(action="NONE")
+        r_unknown = BedrockGuardrailResponse(action="SOME_NEW_ACTION")
+        merged_resp, _ = BedrockGuardrail._merge_guardrail_responses(
+            [(r_none, dict(r_none)), (r_unknown, dict(r_unknown))]
+        )
+        assert merged_resp["action"] == "SOME_NEW_ACTION"
+
+    def test_assessments_merged(self):
+        a1 = {"topicPolicy": {"topics": [{"name": "t1"}]}}
+        a2 = {"contentPolicy": {"filters": [{"type": "f1"}]}}
+        r1 = BedrockGuardrailResponse(action="NONE", assessments=[a1])
+        r2 = BedrockGuardrailResponse(action="NONE", assessments=[a2])
+        merged_resp, _ = BedrockGuardrail._merge_guardrail_responses(
+            [(r1, dict(r1)), (r2, dict(r2))]
+        )
+        assert merged_resp.get("assessments") == [a1, a2]
+
+    def test_usage_summed(self):
+        u1 = BedrockGuardrailUsage(topicPolicyUnits=10, contentPolicyUnits=5)
+        u2 = BedrockGuardrailUsage(topicPolicyUnits=20, contentPolicyUnits=15)
+        r1 = BedrockGuardrailResponse(action="NONE", usage=u1)
+        r2 = BedrockGuardrailResponse(action="NONE", usage=u2)
+        merged_resp, _ = BedrockGuardrail._merge_guardrail_responses(
+            [(r1, dict(r1)), (r2, dict(r2))]
+        )
+        merged_usage = merged_resp.get("usage", {})
+        assert merged_usage.get("topicPolicyUnits") == 30
+        assert merged_usage.get("contentPolicyUnits") == 20
+
+    def test_outputs_merged_from_both_keys(self):
+        """Handles both 'output' and 'outputs' keys in responses."""
+        r1 = BedrockGuardrailResponse(action="NONE", outputs=[{"text": "out1"}])
+        r2 = BedrockGuardrailResponse(action="NONE", output=[{"text": "out2"}])
+        merged_resp, _ = BedrockGuardrail._merge_guardrail_responses(
+            [(r1, dict(r1)), (r2, dict(r2))]
+        )
+        assert len(merged_resp.get("outputs", [])) == 2
+
+    def test_exception_marker_propagated(self):
+        """AWS exception marker in json_resp should be propagated to merged json."""
+        r1 = BedrockGuardrailResponse(action="NONE")
+        json1 = dict(r1)
+        r2 = BedrockGuardrailResponse(action="NONE")
+        json2 = {"Output": {"__type": "ThrottlingException", "message": "rate limited"}}
+        _, merged_json = BedrockGuardrail._merge_guardrail_responses(
+            [(r1, json1), (r2, json2)]
+        )
+        assert "Output" in merged_json
+        assert "ThrottlingException" in merged_json["Output"]["__type"]
+
+
+# =========================================================================
+# _determine_guardrail_status_from_json
+# =========================================================================
+
+class TestDetermineGuardrailStatusFromJson:
+    def setup_method(self):
+        self.guardrail = _make_guardrail()
+
+    def test_exception_in_output_returns_failed(self):
+        json_resp = {"Output": {"__type": "ThrottlingException"}}
+        resp = BedrockGuardrailResponse(action="NONE")
+        status = self.guardrail._determine_guardrail_status_from_json(json_resp, resp)
+        assert status == "guardrail_failed_to_respond"
+
+    def test_exception_lowercase_output_key(self):
+        json_resp = {"output": {"__type": "ServiceUnavailableException"}}
+        resp = BedrockGuardrailResponse(action="NONE")
+        status = self.guardrail._determine_guardrail_status_from_json(json_resp, resp)
+        assert status == "guardrail_failed_to_respond"
+
+    def test_guardrail_intervened_with_blocked_assessment(self):
+        """GUARDRAIL_INTERVENED with BLOCKED assessment → guardrail_intervened."""
+        resp = BedrockGuardrailResponse(
+            action="GUARDRAIL_INTERVENED",
+            assessments=[
+                {
+                    "contentPolicy": {
+                        "filters": [
+                            {"type": "HATE", "action": "BLOCKED", "confidence": "HIGH"}
+                        ]
+                    }
+                }
+            ],
+        )
+        json_resp: dict = dict(resp)
+        status = self.guardrail._determine_guardrail_status_from_json(json_resp, resp)
+        assert status == "guardrail_intervened"
+
+    def test_no_intervention_returns_success(self):
+        resp = BedrockGuardrailResponse(action="NONE")
+        json_resp: dict = dict(resp)
+        status = self.guardrail._determine_guardrail_status_from_json(json_resp, resp)
+        assert status == "success"
+
+    def test_no_output_key_and_no_intervention_returns_success(self):
+        resp = BedrockGuardrailResponse(action="NONE")
+        status = self.guardrail._determine_guardrail_status_from_json({}, resp)
+        assert status == "success"
+
+    def test_output_without_exception_type_returns_success(self):
+        """Output dict present but no __type with 'Exception' → not failed."""
+        json_resp = {"Output": {"someKey": "someValue"}}
+        resp = BedrockGuardrailResponse(action="NONE")
+        status = self.guardrail._determine_guardrail_status_from_json(json_resp, resp)
+        assert status == "success"
+
+
+# =========================================================================
+# Integration: make_bedrock_api_request with chunked content
+# =========================================================================
+
+class TestMakeBedrockApiRequestChunking:
+    """Test the overall chunked request path end-to-end using mocks."""
+
+    def setup_method(self):
+        self.guardrail = _make_guardrail()
+
+    @pytest.mark.asyncio
+    async def test_small_content_makes_single_api_call(self):
+        """Content under 25K chars → single API call, no chunking."""
+        mock_resp = BedrockGuardrailResponse(action="NONE")
+        mock_json = dict(mock_resp)
+        mock_credentials = MagicMock()
+
+        with patch.object(
+            self.guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")
+        ), patch.object(
+            self.guardrail, "convert_to_bedrock_format", return_value={
+                "source": "INPUT",
+                "content": [_text_item("short text")],
+            }
+        ), patch.object(
+            self.guardrail, "_prepare_request", return_value=MagicMock()
+        ), patch.object(
+            self.guardrail, "_make_single_bedrock_api_request",
+            new_callable=AsyncMock,
+            return_value=(mock_resp, mock_json),
+        ) as mock_api, patch.object(
+            self.guardrail, "get_guardrail_dynamic_request_body_params", return_value={}
+        ):
+            result = await self.guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=[{"role": "user", "content": "short text"}],
+                request_data={"model": "gpt-4"},
+            )
+            assert mock_api.call_count == 1
+            assert result.get("action") == "NONE"
+
+    @pytest.mark.asyncio
+    async def test_large_content_triggers_chunking(self):
+        """Content over 25K chars → multiple API calls via chunking."""
+        large_text = "x" * (MAX + 1000)
+        mock_resp = BedrockGuardrailResponse(action="NONE")
+        mock_json = dict(mock_resp)
+        mock_credentials = MagicMock()
+
+        with patch.object(
+            self.guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")
+        ), patch.object(
+            self.guardrail, "convert_to_bedrock_format", return_value={
+                "source": "INPUT",
+                "content": [_text_item(large_text)],
+            }
+        ), patch.object(
+            self.guardrail, "_prepare_request", return_value=MagicMock()
+        ), patch.object(
+            self.guardrail, "_make_single_bedrock_api_request",
+            new_callable=AsyncMock,
+            return_value=(mock_resp, mock_json),
+        ) as mock_api, patch.object(
+            self.guardrail, "get_guardrail_dynamic_request_body_params", return_value={}
+        ):
+            result = await self.guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=[{"role": "user", "content": large_text}],
+                request_data={"model": "gpt-4"},
+            )
+            assert mock_api.call_count == 2
+            assert result.get("action") == "NONE"
+
+    @pytest.mark.asyncio
+    async def test_chunked_request_stops_on_block(self):
+        """When a chunk is blocked, processing stops early and raises HTTPException."""
+        from fastapi import HTTPException
+
+        large_text = "x" * (MAX * 3)  # would produce 3 chunks
+        block_resp = BedrockGuardrailResponse(
+            action="GUARDRAIL_INTERVENED",
+            assessments=[
+                {
+                    "contentPolicy": {
+                        "filters": [
+                            {"type": "HATE", "action": "BLOCKED", "confidence": "HIGH"}
+                        ]
+                    }
+                }
+            ],
+            outputs=[{"text": "Blocked by guardrail"}],
+        )
+        mock_credentials = MagicMock()
+
+        with patch.object(
+            self.guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")
+        ), patch.object(
+            self.guardrail, "convert_to_bedrock_format", return_value={
+                "source": "INPUT",
+                "content": [_text_item(large_text)],
+            }
+        ), patch.object(
+            self.guardrail, "_prepare_request", return_value=MagicMock()
+        ), patch.object(
+            self.guardrail, "_make_single_bedrock_api_request",
+            new_callable=AsyncMock,
+            return_value=(block_resp, dict(block_resp)),
+        ) as mock_api, patch.object(
+            self.guardrail, "get_guardrail_dynamic_request_body_params", return_value={}
+        ):
+            with pytest.raises(HTTPException):
+                await self.guardrail.make_bedrock_api_request(
+                    source="INPUT",
+                    messages=[{"role": "user", "content": large_text}],
+                    request_data={"model": "gpt-4"},
+                )
+            # Should stop after first chunk since it was blocked
+            assert mock_api.call_count == 1


### PR DESCRIPTION
## Fixes #10024

### Problem

When using `--use_prisma_migrate` (or `prisma db push`) in a **custom (non-Docker) installation**, the proxy fails to start because the Prisma Python client was never generated. Docker builds run `prisma generate` during image build, but custom installs skip this step entirely, causing an `ImportError` when the proxy tries to import `prisma.Client`.

### Solution

Added `PrismaManager.ensure_client_generated()` which:

1. **Checks** if the Prisma client is already importable (`from prisma import Client`)
2. If not, **auto-runs** `prisma generate` (with the correct working directory set to the schema location)
3. **Logs** clearly what it is doing (`"Prisma client not found – auto-generating..."`)
4. Raises a helpful `RuntimeError` if generation fails

This method is called in `proxy_cli.py` **right after** confirming the `prisma` CLI is available, and **before** any database operations (`db push` / `migrate`).

### Why this PR also includes Bedrock Guardrail chunking

Both features address **proxy initialization and resilience**:

- **Prisma auto-generate** fixes a cold-start failure where the proxy cannot boot without a pre-generated client.
- **Bedrock Guardrail chunking** fixes a runtime failure where guardrail requests silently fail or error when content exceeds the 25K-character API limit.

They were developed together because both surfaced during the same cold-start / first-request investigation, and share no conflicting code paths. Keeping them in one PR simplifies review of the overall reliability improvement.

### Changes

**Prisma auto-generate:**
- `litellm/proxy/db/prisma_client.py` — Added `PrismaManager.ensure_client_generated()`
- `litellm/proxy/proxy_cli.py` — Call `ensure_client_generated()` in startup flow
- `tests/test_litellm/proxy/db/test_ensure_prisma_client_generated.py` — 5 unit tests

**Bedrock Guardrail chunking:**
- `litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py` — Added content-chunking pipeline (`_chunk_content_items`, `_merge_guardrail_responses`, etc.)
- `litellm/types/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py` — Added type definitions for chunking
- `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrail_chunking.py` — Comprehensive unit tests

### Testing

All new tests pass. Existing prisma and guardrail tests unaffected.