### PR TITLE
fix(anthropic): merge OAuth beta header with existing anthropic-beta instead of overwriting

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -31,6 +31,7 @@ def is_anthropic_oauth_key(value: Optional[str]) -> bool:
         value = value[7:]
     return value.startswith(ANTHROPIC_OAUTH_TOKEN_PREFIX)
 
+
 def optionally_handle_anthropic_oauth(
     headers: dict, api_key: Optional[str]
 ) -> tuple[dict, Optional[str]]:
@@ -52,16 +53,29 @@ def optionally_handle_anthropic_oauth(
     if auth_header and auth_header.startswith(f"Bearer {ANTHROPIC_OAUTH_TOKEN_PREFIX}"):
         api_key = auth_header.replace("Bearer ", "")
         headers.pop("x-api-key", None)
-        headers["anthropic-beta"] = ANTHROPIC_OAUTH_BETA_HEADER
+        headers["anthropic-beta"] = _merge_anthropic_beta(
+            headers.get("anthropic-beta", ""), ANTHROPIC_OAUTH_BETA_HEADER
+        )
         headers["anthropic-dangerous-direct-browser-access"] = "true"
         return headers, api_key
     # Check api_key directly (standard chat/completion flow)
     if api_key and api_key.startswith(ANTHROPIC_OAUTH_TOKEN_PREFIX):
         headers.pop("x-api-key", None)
         headers["authorization"] = f"Bearer {api_key}"
-        headers["anthropic-beta"] = ANTHROPIC_OAUTH_BETA_HEADER
+        headers["anthropic-beta"] = _merge_anthropic_beta(
+            headers.get("anthropic-beta", ""), ANTHROPIC_OAUTH_BETA_HEADER
+        )
         headers["anthropic-dangerous-direct-browser-access"] = "true"
     return headers, api_key
+
+
+def _merge_anthropic_beta(existing: str, new_value: str) -> str:
+    """Merge a new beta header value with existing ones, deduplicating."""
+    if not existing:
+        return new_value
+    betas = {b.strip() for b in existing.split(",") if b.strip()}
+    betas.add(new_value)
+    return ",".join(sorted(betas))
 
 
 class AnthropicError(BaseLLMException):
@@ -425,9 +439,9 @@ class AnthropicModelInfo(BaseLLMModelInfo):
             if web_search_tool_used:
                 from litellm.types.llms.anthropic import ANTHROPIC_BETA_HEADER_VALUES
 
-                headers[
-                    "anthropic-beta"
-                ] = ANTHROPIC_BETA_HEADER_VALUES.WEB_SEARCH_2025_03_05.value
+                headers["anthropic-beta"] = (
+                    ANTHROPIC_BETA_HEADER_VALUES.WEB_SEARCH_2025_03_05.value
+                )
         elif len(betas) > 0:
             headers["anthropic-beta"] = ",".join(betas)
 

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -433,14 +433,18 @@ class TestProxyOAuthHeaderForwarding:
                 (b"content-type", b"application/json"),
             ]
         )
-        
+
         # Should preserve OAuth even with flag=False
-        cleaned_without_flag = clean_headers(raw_headers, forward_llm_provider_auth_headers=False)
+        cleaned_without_flag = clean_headers(
+            raw_headers, forward_llm_provider_auth_headers=False
+        )
         assert "authorization" in cleaned_without_flag
         assert cleaned_without_flag["authorization"] == f"Bearer {FAKE_OAUTH_TOKEN}"
-        
+
         # Should also preserve OAuth with flag=True
-        cleaned_with_flag = clean_headers(raw_headers, forward_llm_provider_auth_headers=True)
+        cleaned_with_flag = clean_headers(
+            raw_headers, forward_llm_provider_auth_headers=True
+        )
         assert "authorization" in cleaned_with_flag
         assert cleaned_with_flag["authorization"] == f"Bearer {FAKE_OAUTH_TOKEN}"
 
@@ -503,3 +507,57 @@ class TestProxyOAuthHeaderForwarding:
         psh = data["provider_specific_header"]
         assert psh["extra_headers"]["authorization"] == f"Bearer {FAKE_OAUTH_TOKEN}"
         assert psh["extra_headers"]["anthropic-beta"] == "oauth-2025-04-20"
+
+
+class TestOAuthBetaHeaderMerging:
+    """Test that OAuth handler merges beta headers instead of overwriting."""
+
+    def test_oauth_preserves_existing_beta_via_auth_header(self):
+        """OAuth via Authorization header should merge with existing beta headers."""
+        from litellm.llms.anthropic.common_utils import (
+            optionally_handle_anthropic_oauth,
+        )
+
+        headers = {
+            "authorization": f"Bearer {FAKE_OAUTH_TOKEN}",
+            "anthropic-beta": "prompt-caching-scope-2026-01-05,interleaved-thinking-2025-05-14",
+        }
+        updated_headers, _ = optionally_handle_anthropic_oauth(headers, None)
+
+        beta = updated_headers["anthropic-beta"]
+        assert "oauth-2025-04-20" in beta
+        assert "prompt-caching-scope-2026-01-05" in beta
+        assert "interleaved-thinking-2025-05-14" in beta
+
+    def test_oauth_preserves_existing_beta_via_api_key(self):
+        """OAuth via api_key should merge with existing beta headers."""
+        from litellm.llms.anthropic.common_utils import (
+            optionally_handle_anthropic_oauth,
+        )
+
+        headers = {
+            "anthropic-beta": "prompt-caching-scope-2026-01-05",
+        }
+        updated_headers, _ = optionally_handle_anthropic_oauth(
+            headers, FAKE_OAUTH_TOKEN
+        )
+
+        beta = updated_headers["anthropic-beta"]
+        assert "oauth-2025-04-20" in beta
+        assert "prompt-caching-scope-2026-01-05" in beta
+
+    def test_oauth_no_duplicate_beta_headers(self):
+        """If oauth beta is already present, it should not be duplicated."""
+        from litellm.llms.anthropic.common_utils import (
+            optionally_handle_anthropic_oauth,
+        )
+
+        headers = {
+            "authorization": f"Bearer {FAKE_OAUTH_TOKEN}",
+            "anthropic-beta": "oauth-2025-04-20,some-other-beta",
+        }
+        updated_headers, _ = optionally_handle_anthropic_oauth(headers, None)
+
+        beta = updated_headers["anthropic-beta"]
+        assert beta.count("oauth-2025-04-20") == 1
+        assert "some-other-beta" in beta


### PR DESCRIPTION
## Relevant issues

Fixes #22398

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

`optionally_handle_anthropic_oauth()` overwrites the entire `anthropic-beta` header with `oauth-2025-04-20`, dropping all client beta headers (e.g. `prompt-caching-scope-2026-01-05`). This causes requests using OAuth + newer beta features to fail.

**`litellm/llms/anthropic/common_utils.py`**:
- Added `_merge_anthropic_beta()` helper that merges a new beta value with existing ones (deduplicating)
- Updated both branches (Authorization header and api_key) in `optionally_handle_anthropic_oauth()` to merge instead of overwrite

**`tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py`**:
- Added `TestOAuthBetaHeaderMerging` class with 3 tests:
  - Preserves existing beta headers via Authorization header path
  - Preserves existing beta headers via api_key path
  - Deduplicates when OAuth beta already present