### PR TITLE
fix(a2a): add safe card resolver fallback when a2a-sdk is missing

### DIFF
--- a/litellm/a2a_protocol/card_resolver.py
+++ b/litellm/a2a_protocol/card_resolver.py
@@ -12,19 +12,28 @@ from litellm.constants import LOCALHOST_URL_PATTERNS
 if TYPE_CHECKING:
     from a2a.types import AgentCard
 
-# Runtime imports with availability check
-_A2ACardResolver: Any = None
 AGENT_CARD_WELL_KNOWN_PATH: str = "/.well-known/agent-card.json"
 PREV_AGENT_CARD_WELL_KNOWN_PATH: str = "/.well-known/agent.json"
 
 try:
-    from a2a.client import A2ACardResolver as _A2ACardResolver  # type: ignore[no-redef]
+    from a2a.client import A2ACardResolver as _A2ACardResolver
     from a2a.utils.constants import (  # type: ignore[no-redef]
         AGENT_CARD_WELL_KNOWN_PATH,
         PREV_AGENT_CARD_WELL_KNOWN_PATH,
     )
 except ImportError:
-    pass
+
+    class _A2ACardResolver:  # type: ignore[no-redef]
+        def __init__(
+            self, httpx_client: Optional[Any] = None, base_url: Optional[str] = None
+        ):
+            self.httpx_client = httpx_client
+            self.base_url = base_url or ""
+
+        async def get_agent_card(self, *args, **kwargs):
+            raise RuntimeError(
+                "a2a-sdk is not installed. Install it with: pip install a2a-sdk"
+            )
 
 
 def is_localhost_or_internal_url(url: Optional[str]) -> bool:

--- a/litellm/a2a_protocol/card_resolver.py
+++ b/litellm/a2a_protocol/card_resolver.py
@@ -24,6 +24,13 @@ try:
 except ImportError:
 
     class _A2ACardResolver:  # type: ignore[no-redef]
+        """Stub fallback when a2a-sdk is not installed.
+
+        Provides the same constructor signature so LiteLLMA2ACardResolver can
+        be instantiated without the SDK.  Any actual card resolution raises a
+        clear RuntimeError directing the user to install the package.
+        """
+
         def __init__(
             self, httpx_client: Optional[Any] = None, base_url: Optional[str] = None
         ):

--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -1,10 +1,14 @@
 import json
+import time
 from typing import Any, List, Literal, Optional, Tuple
+
+import httpx
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm._uuid import uuid
 from litellm.types.llms.openai import Batch
-from litellm.types.utils import CallTypes, ModelInfo, Usage
+from litellm.types.utils import CallTypes, ModelInfo, ModelResponse, Usage
 from litellm.utils import token_counter
 
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1530,7 +1530,9 @@ class Usage(SafeAttributeModel, CompletionUsage):
                     **prompt_tokens_details.model_dump()
                 )
             elif isinstance(prompt_tokens_details, PromptTokensDetailsWrapper):
-                _prompt_tokens_details = prompt_tokens_details
+                _prompt_tokens_details = PromptTokensDetailsWrapper(
+                    **prompt_tokens_details.model_dump()
+                )
 
         ## DEEPSEEK MAPPING ##
         if "prompt_cache_hit_tokens" in params and isinstance(
@@ -1590,16 +1592,32 @@ class Usage(SafeAttributeModel, CompletionUsage):
         ):
             self._cache_creation_input_tokens = params["cache_creation_input_tokens"]
 
-        if "cache_read_input_tokens" in params and isinstance(
+        has_cache_read_input_tokens = "cache_read_input_tokens" in params and isinstance(
             params["cache_read_input_tokens"], int
-        ):
+        )
+        has_prompt_cache_hit_tokens = "prompt_cache_hit_tokens" in params and isinstance(
+            params["prompt_cache_hit_tokens"], int
+        )
+
+        if has_cache_read_input_tokens:
             self._cache_read_input_tokens = params["cache_read_input_tokens"]
 
         ## DEEPSEEK MAPPING ##
-        if "prompt_cache_hit_tokens" in params and isinstance(
-            params["prompt_cache_hit_tokens"], int
-        ):
+        if has_prompt_cache_hit_tokens:
             self._cache_read_input_tokens = params["prompt_cache_hit_tokens"]
+
+        # Provider-specific cache-read fields above intentionally override
+        # prompt_tokens_details.cached_tokens when both are provided.
+        # _prompt_tokens_details is copied during initialization, so caller input
+        # objects are not mutated; this fallback only applies when provider fields
+        # are absent.
+        if (
+            not has_cache_read_input_tokens
+            and not has_prompt_cache_hit_tokens
+            and self.prompt_tokens_details is not None
+            and self.prompt_tokens_details.cached_tokens is not None
+        ):
+            self._cache_read_input_tokens = self.prompt_tokens_details.cached_tokens
 
         for k, v in params.items():
             setattr(self, k, v)

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -151,6 +151,37 @@ def test_chat_completion_token_logprob_null_top_logprobs():
     assert isinstance(logprob.top_logprobs, list)
 
 
+def test_usage_maps_cache_read_from_prompt_details():
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    usage = Usage(
+        prompt_tokens=10,
+        completion_tokens=2,
+        total_tokens=12,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=300),
+    )
+
+    assert usage._cache_read_input_tokens == 300
+
+
+def test_usage_cache_read_param_not_overwritten_by_prompt_details():
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    input_prompt_tokens_details = PromptTokensDetailsWrapper(cached_tokens=300)
+    usage = Usage(
+        prompt_tokens=10,
+        completion_tokens=2,
+        total_tokens=12,
+        prompt_tokens_details=input_prompt_tokens_details,
+        cache_read_input_tokens=500,
+    )
+
+    assert usage._cache_read_input_tokens == 500
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cached_tokens == 500
+    assert input_prompt_tokens_details.cached_tokens == 300
+
+
 def test_chat_completion_token_logprob_valid_top_logprobs():
     """
     Test that ChatCompletionTokenLogprob still accepts valid top_logprobs arrays.


### PR DESCRIPTION
## Summary
- add a runtime-safe fallback base resolver when `a2a-sdk` is unavailable
- preserve well-known path constants in fallback mode
- ensure fallback stores `base_url` / `httpx_client` so existing resolver behavior and tests remain stable
- map `_cache_read_input_tokens` from `prompt_tokens_details.cached_tokens` only when provider-specific cache fields are absent
- add regression tests for cache-read mapping precedence

## Validation
- `python3 -m pytest tests/test_litellm/a2a_protocol/test_card_resolver.py -q`
- `python3 -m pytest tests/test_litellm/types/test_types_utils.py -k "usage_maps_cache_read_from_prompt_details or usage_cache_read_param_not_overwritten_by_prompt_details" -q`

## Context
- Applies valid review feedback from PR #20865 (ImportError handling and fallback robustness)
- Applies valid review feedback from PR #20878 (cache-read mapping precedence and test coverage)
