### PR TITLE
fix(streaming): map vLLM 'reasoning' field to 'reasoning_content' in Delta

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1224,6 +1224,11 @@ class Delta(SafeAttributeModel, OpenAIObject):
         annotations: Optional[List[ChatCompletionAnnotation]] = None,
         **params,
     ):
+        # Map 'reasoning' -> 'reasoning_content' for providers like vLLM
+        # that use 'reasoning' instead of 'reasoning_content' in streaming deltas
+        if reasoning_content is None and "reasoning" in params:
+            reasoning_content = params.pop("reasoning")
+
         super(Delta, self).__init__(**params)
         add_provider_specific_fields(self, params.get("provider_specific_fields", {}))
         self.content = content
@@ -2730,9 +2735,7 @@ class CostBreakdown(TypedDict, total=False):
     """
 
     input_cost: float  # Cost of input/prompt tokens
-    output_cost: (
-        float  # Cost of output/completion tokens (includes reasoning if applicable)
-    )
+    output_cost: float  # Cost of output/completion tokens (includes reasoning if applicable)
     total_cost: float  # Total cost (input + output + tool usage)
     tool_usage_cost: float  # Cost of usage of built-in tools
     additional_costs: Dict[

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -158,6 +158,41 @@ def test_is_chunk_non_empty(initialized_custom_stream_wrapper: CustomStreamWrapp
     )
 
 
+def test_is_chunk_non_empty_with_vllm_reasoning_field(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """
+    vLLM returns 'reasoning' instead of 'reasoning_content' in streaming deltas.
+    Chunks with 'reasoning' should be treated as non-empty after Delta normalizes
+    the field name to 'reasoning_content'.
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/20246
+    """
+    chunk = {
+        "id": "chatcmpl-abc123",
+        "object": "chat.completion.chunk",
+        "created": 1741037890,
+        "model": "Qwen3-35B",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": None, "reasoning": "Let me think..."},
+                "logprobs": None,
+                "finish_reason": None,
+            }
+        ],
+    }
+    model_response = ModelResponseStream(**chunk)
+    # Verify Delta mapped reasoning -> reasoning_content
+    assert model_response.choices[0].delta.reasoning_content == "Let me think..."
+    # Verify is_chunk_non_empty sees the reasoning_content
+    assert initialized_custom_stream_wrapper.is_chunk_non_empty(
+        completion_obj={"content": ""},
+        model_response=model_response,
+        response_obj={},
+    )
+
+
 def test_is_chunk_non_empty_with_annotations(
     initialized_custom_stream_wrapper: CustomStreamWrapper,
 ):
@@ -390,12 +425,12 @@ def test_multi_chunk_reasoning_and_content(
         # Check content
         assert (
             response.choices[0].delta.content == expected_content
-        ), f"Chunk {i+1}: content mismatch"
+        ), f"Chunk {i + 1}: content mismatch"
 
         # Check reasoning_content was removed
         assert not hasattr(
             response.choices[0].delta, "reasoning_content"
-        ), f"Chunk {i+1}: reasoning_content should be removed"
+        ), f"Chunk {i + 1}: reasoning_content should be removed"
 
     # Verify final state
     assert initialized_custom_stream_wrapper.sent_first_thinking_block is True
@@ -539,15 +574,16 @@ async def test_streaming_with_usage_and_logging(sync_mode: bool):
         cache_read_input_tokens=1796,
     )
 
-    with patch.object(
-        mock_callback, "log_success_event"
-    ) as mock_log_success_event, patch.object(
-        mock_callback, "log_stream_event"
-    ) as mock_log_stream_event, patch.object(
-        mock_callback, "async_log_success_event"
-    ) as mock_async_log_success_event, patch.object(
-        mock_callback, "async_log_stream_event"
-    ) as mock_async_log_stream_event:
+    with (
+        patch.object(mock_callback, "log_success_event") as mock_log_success_event,
+        patch.object(mock_callback, "log_stream_event") as mock_log_stream_event,
+        patch.object(
+            mock_callback, "async_log_success_event"
+        ) as mock_async_log_success_event,
+        patch.object(
+            mock_callback, "async_log_stream_event"
+        ) as mock_async_log_stream_event,
+    ):
         await test_streaming_handler_with_usage(
             sync_mode=sync_mode, final_usage_block=final_usage_block
         )
@@ -697,7 +733,9 @@ async def test_vertex_streaming_bad_request_not_midstream(logging_obj: Logging):
     from litellm.llms.vertex_ai.common_utils import VertexAIError
 
     async def _raise_bad_request(**kwargs):
-        raise VertexAIError(status_code=400, message="invalid maxOutputTokens", headers=None)
+        raise VertexAIError(
+            status_code=400, message="invalid maxOutputTokens", headers=None
+        )
 
     response = CustomStreamWrapper(
         completion_stream=None,
@@ -715,7 +753,9 @@ async def test_vertex_streaming_bad_request_not_midstream(logging_obj: Logging):
 
 
 @pytest.mark.asyncio
-async def test_vertex_streaming_rate_limit_triggers_midstream_fallback(logging_obj: Logging):
+async def test_vertex_streaming_rate_limit_triggers_midstream_fallback(
+    logging_obj: Logging,
+):
     """Ensure Vertex 429 rate-limit errors raise MidStreamFallbackError, not RateLimitError.
 
     Regression test for https://github.com/BerriAI/litellm/issues/20870
@@ -724,7 +764,9 @@ async def test_vertex_streaming_rate_limit_triggers_midstream_fallback(logging_o
     from litellm.llms.vertex_ai.common_utils import VertexAIError
 
     async def _raise_rate_limit(**kwargs):
-        raise VertexAIError(status_code=429, message="Resource exhausted.", headers=None)
+        raise VertexAIError(
+            status_code=429, message="Resource exhausted.", headers=None
+        )
 
     response = CustomStreamWrapper(
         completion_stream=None,
@@ -752,7 +794,9 @@ def test_sync_streaming_rate_limit_triggers_midstream_fallback(logging_obj: Logg
     from litellm.llms.vertex_ai.common_utils import VertexAIError
 
     def _raise_rate_limit(**kwargs):
-        raise VertexAIError(status_code=429, message="Resource exhausted.", headers=None)
+        raise VertexAIError(
+            status_code=429, message="Resource exhausted.", headers=None
+        )
 
     response = CustomStreamWrapper(
         completion_stream=None,
@@ -777,7 +821,9 @@ def test_sync_streaming_bad_request_not_midstream(logging_obj: Logging):
     from litellm.llms.vertex_ai.common_utils import VertexAIError
 
     def _raise_bad_request(**kwargs):
-        raise VertexAIError(status_code=400, message="invalid maxOutputTokens", headers=None)
+        raise VertexAIError(
+            status_code=400, message="invalid maxOutputTokens", headers=None
+        )
 
     response = CustomStreamWrapper(
         completion_stream=None,

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -80,50 +80,50 @@ def test_usage_completion_tokens_details_text_tokens():
 
     # Test data from the reported issue
     usage_data = {
-        'completion_tokens': 77,
-        'prompt_tokens': 11937,
-        'total_tokens': 12014,
-        'completion_tokens_details': {
-            'accepted_prediction_tokens': None,
-            'audio_tokens': None,
-            'reasoning_tokens': 65,
-            'rejected_prediction_tokens': None,
-            'text_tokens': 12
+        "completion_tokens": 77,
+        "prompt_tokens": 11937,
+        "total_tokens": 12014,
+        "completion_tokens_details": {
+            "accepted_prediction_tokens": None,
+            "audio_tokens": None,
+            "reasoning_tokens": 65,
+            "rejected_prediction_tokens": None,
+            "text_tokens": 12,
         },
-        'prompt_tokens_details': {
-            'audio_tokens': None,
-            'cached_tokens': None,
-            'text_tokens': 11937,
-            'image_tokens': None
-        }
+        "prompt_tokens_details": {
+            "audio_tokens": None,
+            "cached_tokens": None,
+            "text_tokens": 11937,
+            "image_tokens": None,
+        },
     }
 
     # Create Usage object
     u = Usage(**usage_data)
-    
+
     # Verify the object has the text_tokens field
-    assert hasattr(u.completion_tokens_details, 'text_tokens')
+    assert hasattr(u.completion_tokens_details, "text_tokens")
     assert u.completion_tokens_details.text_tokens == 12
-    
+
     # Get model_dump output
     dump_result = u.model_dump()
-    
+
     # Verify text_tokens is present in the model_dump output
-    assert 'completion_tokens_details' in dump_result
-    assert 'text_tokens' in dump_result['completion_tokens_details']
-    assert dump_result['completion_tokens_details']['text_tokens'] == 12
-    
+    assert "completion_tokens_details" in dump_result
+    assert "text_tokens" in dump_result["completion_tokens_details"]
+    assert dump_result["completion_tokens_details"]["text_tokens"] == 12
+
     # Verify the full completion_tokens_details structure
     expected_completion_details = {
-        'accepted_prediction_tokens': None,
-        'audio_tokens': None,
-        'reasoning_tokens': 65,
-        'rejected_prediction_tokens': None,
-        'text_tokens': 12,
-        'image_tokens': None
+        "accepted_prediction_tokens": None,
+        "audio_tokens": None,
+        "reasoning_tokens": 65,
+        "rejected_prediction_tokens": None,
+        "text_tokens": 12,
+        "image_tokens": None,
     }
-    assert dump_result['completion_tokens_details'] == expected_completion_details
-    
+    assert dump_result["completion_tokens_details"] == expected_completion_details
+
     # Verify round-trip serialization works
     new_usage = Usage(**dump_result)
     assert new_usage.completion_tokens_details.text_tokens == 12
@@ -222,3 +222,64 @@ def test_chat_completion_token_logprob_invalid_top_logprobs_rejected():
             logprob=-0.31725305,
             top_logprobs="invalid_string",
         )
+
+
+class TestDeltaReasoningMapping:
+    """
+    Tests for Delta class handling of 'reasoning' -> 'reasoning_content' mapping.
+
+    vLLM and some other OpenAI-compatible providers return 'reasoning' in streaming
+    deltas instead of 'reasoning_content'. Delta.__init__ must normalize this.
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/20246
+    """
+
+    def test_delta_maps_reasoning_to_reasoning_content(self):
+        """Delta created with reasoning= kwarg should expose it as reasoning_content."""
+        from litellm.types.utils import Delta
+
+        delta = Delta(content=None, reasoning="Let me think about this...")
+        assert delta.reasoning_content == "Let me think about this..."
+
+    def test_delta_reasoning_content_takes_precedence(self):
+        """When both reasoning_content and reasoning are given, reasoning_content wins."""
+        from litellm.types.utils import Delta
+
+        delta = Delta(
+            content=None,
+            reasoning_content="from reasoning_content",
+            reasoning="from reasoning",
+        )
+        assert delta.reasoning_content == "from reasoning_content"
+
+    def test_delta_without_reasoning_has_no_reasoning_content(self):
+        """Delta without reasoning or reasoning_content should not have the attribute."""
+        from litellm.types.utils import Delta
+
+        delta = Delta(content="Hello")
+        assert not hasattr(delta, "reasoning_content")
+
+    def test_delta_reasoning_content_kwarg_works(self):
+        """Standard reasoning_content kwarg should still work as before."""
+        from litellm.types.utils import Delta
+
+        delta = Delta(content=None, reasoning_content="thinking...")
+        assert delta.reasoning_content == "thinking..."
+
+    def test_streaming_choices_with_reasoning_delta_dict(self):
+        """
+        StreamingChoices with a delta dict containing 'reasoning' (as from
+        OpenAI SDK's dict(ChoiceDelta)) should produce Delta with reasoning_content.
+        """
+        from litellm.types.utils import StreamingChoices
+
+        # This simulates dict(openai_sdk_choice_delta) from vLLM
+        delta_dict = {
+            "content": None,
+            "role": None,
+            "function_call": None,
+            "tool_calls": None,
+            "reasoning": "step by step...",
+        }
+        choice = StreamingChoices(index=0, delta=delta_dict)
+        assert choice.delta.reasoning_content == "step by step..."


### PR DESCRIPTION
## Summary
- Fix streaming reasoning content being silently dropped for vLLM and other OpenAI-compatible providers that return `reasoning` instead of `reasoning_content` in streaming deltas
- The prior fix (PR #21468) only handled the `BaseModelResponseIterator` path via `chunk_parser`, but chunks from the OpenAI SDK path (used by `openai/` provider prefix) bypass `chunk_parser` entirely
- Add 2-line normalization in `Delta.__init__` to map `reasoning` → `reasoning_content`, covering all code paths universally

## Test plan
- [x] 5 new unit tests in `TestDeltaReasoningMapping` covering: direct mapping, precedence, absence, standard kwarg, and StreamingChoices integration
- [x] 1 new streaming handler test `test_is_chunk_non_empty_with_vllm_reasoning_field` verifying chunks with vLLM's `reasoning` field pass the non-empty check
- [x] All 60 related tests pass (types, streaming handler, openai transformation)
- [x] Verified against live vLLM server (Qwen3.5-35B-A3B) with both `hosted_vllm/` and `openai/` prefixes

Fixes https://github.com/BerriAI/litellm/issues/20246

🤖 Generated with [Claude Code](https://claude.com/claude-code)