### PR TITLE
fix(proxy): resolve team edit failure caused by organization_id field

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -756,19 +756,25 @@ async def new_team(  # noqa: PLR0915
         if data.max_budget is not None and data.max_budget < 0:
             raise HTTPException(
                 status_code=400,
-                detail={"error": f"max_budget cannot be negative. Received: {data.max_budget}"}
+                detail={
+                    "error": f"max_budget cannot be negative. Received: {data.max_budget}"
+                },
             )
         if data.team_member_budget is not None and data.team_member_budget < 0:
             raise HTTPException(
                 status_code=400,
-                detail={"error": f"team_member_budget cannot be negative. Received: {data.team_member_budget}"}
+                detail={
+                    "error": f"team_member_budget cannot be negative. Received: {data.team_member_budget}"
+                },
             )
         if data.soft_budget is not None and data.soft_budget < 0:
             raise HTTPException(
                 status_code=400,
-                detail={"error": f"soft_budget cannot be negative. Received: {data.soft_budget}"}
+                detail={
+                    "error": f"soft_budget cannot be negative. Received: {data.soft_budget}"
+                },
             )
-        
+
         if data.soft_budget is not None:
             if data.max_budget is not None:
                 # If max_budget is set, soft_budget must be strictly lower than max_budget
@@ -777,7 +783,7 @@ async def new_team(  # noqa: PLR0915
                         status_code=400,
                         detail={
                             "error": f"soft_budget ({data.soft_budget}) must be strictly lower than max_budget ({data.max_budget})"
-                        }
+                        },
                     )
 
         # Check if license is over limit
@@ -937,12 +943,16 @@ async def new_team(  # noqa: PLR0915
             complete_team_data.members_with_roles = []
 
         complete_team_data_dict = complete_team_data.model_dump(exclude_none=True)
-        
+
         # Serialize router_settings to JSON (matching key creation pattern)
         router_settings_value = getattr(data, "router_settings", None)
-        router_settings_json = safe_dumps(router_settings_value) if router_settings_value is not None else safe_dumps({})
+        router_settings_json = (
+            safe_dumps(router_settings_value)
+            if router_settings_value is not None
+            else safe_dumps({})
+        )
         complete_team_data_dict["router_settings"] = router_settings_json
-        
+
         complete_team_data_dict = prisma_client.jsonify_team_object(
             db_data=complete_team_data_dict
         )
@@ -1118,7 +1128,9 @@ async def fetch_and_validate_organization(
 
     validate_team_org_change(
         team=LiteLLM_TeamTable(**existing_team_row.model_dump()),
-        organization=LiteLLM_OrganizationTableWithMembers(**organization_row.model_dump()),
+        organization=LiteLLM_OrganizationTableWithMembers(
+            **organization_row.model_dump()
+        ),
         llm_router=llm_router,
     )
 
@@ -1126,7 +1138,9 @@ async def fetch_and_validate_organization(
 
 
 def validate_team_org_change(
-    team: LiteLLM_TeamTable, organization: LiteLLM_OrganizationTableWithMembers, llm_router: Router
+    team: LiteLLM_TeamTable,
+    organization: LiteLLM_OrganizationTableWithMembers,
+    llm_router: Router,
 ) -> bool:
     """
     Validate that a team can be moved to an organization.
@@ -1177,7 +1191,9 @@ def validate_team_org_change(
 
     # Check if the team's user_id is a member of the org
     team_members = [m.user_id for m in team.members_with_roles]
-    org_members = [m.user_id for m in organization.members] if organization.members else []
+    org_members = (
+        [m.user_id for m in organization.members] if organization.members else []
+    )
     not_in_org = [
         m
         for m in team_members
@@ -1223,7 +1239,7 @@ def validate_team_org_change(
     "/team/update", tags=["team management"], dependencies=[Depends(user_api_key_auth)]
 )
 @management_endpoint_wrapper
-async def update_team(   # noqa: PLR0915
+async def update_team(  # noqa: PLR0915
     data: UpdateTeamRequest,
     http_request: Request,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
@@ -1309,24 +1325,32 @@ async def update_team(   # noqa: PLR0915
             )
 
         if data.team_id is None:
-            raise HTTPException(status_code=400, detail={"error": "No team id passed in"})
+            raise HTTPException(
+                status_code=400, detail={"error": "No team id passed in"}
+            )
         verbose_proxy_logger.debug("/team/update - %s", data)
 
         # Validate budget values are not negative
         if data.max_budget is not None and data.max_budget < 0:
             raise HTTPException(
                 status_code=400,
-                detail={"error": f"max_budget cannot be negative. Received: {data.max_budget}"}
+                detail={
+                    "error": f"max_budget cannot be negative. Received: {data.max_budget}"
+                },
             )
         if data.team_member_budget is not None and data.team_member_budget < 0:
             raise HTTPException(
                 status_code=400,
-                detail={"error": f"team_member_budget cannot be negative. Received: {data.team_member_budget}"}
+                detail={
+                    "error": f"team_member_budget cannot be negative. Received: {data.team_member_budget}"
+                },
             )
         if data.soft_budget is not None and data.soft_budget < 0:
             raise HTTPException(
                 status_code=400,
-                detail={"error": f"soft_budget cannot be negative. Received: {data.soft_budget}"}
+                detail={
+                    "error": f"soft_budget cannot be negative. Received: {data.soft_budget}"
+                },
             )
 
         existing_team_row = await prisma_client.db.litellm_teamtable.find_unique(
@@ -1338,28 +1362,38 @@ async def update_team(   # noqa: PLR0915
                 status_code=404,
                 detail={"error": f"Team not found, passed team_id={data.team_id}"},
             )
-        
+
         if data.soft_budget is not None:
-            max_budget_to_check = data.max_budget if data.max_budget is not None else existing_team_row.max_budget
+            max_budget_to_check = (
+                data.max_budget
+                if data.max_budget is not None
+                else existing_team_row.max_budget
+            )
             if max_budget_to_check is not None:
                 if data.soft_budget >= max_budget_to_check:
                     raise HTTPException(
                         status_code=400,
                         detail={
                             "error": f"soft_budget ({data.soft_budget}) must be strictly lower than max_budget ({max_budget_to_check})"
-                        }
+                        },
                     )
-        
+
         if data.max_budget is not None:
-            existing_soft_budget = getattr(existing_team_row, 'soft_budget', None)
-            soft_budget_to_check = data.soft_budget if data.soft_budget is not None else existing_soft_budget
-            if soft_budget_to_check is not None and isinstance(soft_budget_to_check, (int, float)):
+            existing_soft_budget = getattr(existing_team_row, "soft_budget", None)
+            soft_budget_to_check = (
+                data.soft_budget
+                if data.soft_budget is not None
+                else existing_soft_budget
+            )
+            if soft_budget_to_check is not None and isinstance(
+                soft_budget_to_check, (int, float)
+            ):
                 if data.max_budget <= soft_budget_to_check:
                     raise HTTPException(
                         status_code=400,
                         detail={
                             "error": f"max_budget ({data.max_budget}) must be strictly greater than soft_budget ({soft_budget_to_check})"
-                        }
+                        },
                     )
 
         if (
@@ -1460,8 +1494,23 @@ async def update_team(   # noqa: PLR0915
                 updated_kv["model_id"] = _model_id
 
         # Serialize router_settings to JSON if present (matching key update pattern)
-        if "router_settings" in updated_kv and updated_kv["router_settings"] is not None:
+        if (
+            "router_settings" in updated_kv
+            and updated_kv["router_settings"] is not None
+        ):
             updated_kv["router_settings"] = safe_dumps(updated_kv["router_settings"])
+
+        # Convert organization_id to Prisma relation syntax — Prisma
+        # Client Python requires connect/disconnect on relation foreign
+        # keys in update operations.
+        if "organization_id" in updated_kv:
+            org_id = updated_kv.pop("organization_id")
+            if org_id is not None and org_id != "":
+                updated_kv["litellm_organization_table"] = {
+                    "connect": {"organization_id": org_id}
+                }
+            else:
+                updated_kv["litellm_organization_table"] = {"disconnect": True}
 
         updated_kv = prisma_client.jsonify_team_object(db_data=updated_kv)
         team_row: Optional[LiteLLM_TeamTable] = (
@@ -1478,7 +1527,9 @@ async def update_team(   # noqa: PLR0915
                 detail={"error": "Team doesn't exist. Got={}".format(team_row)},
             )
 
-        verbose_proxy_logger.info("Successfully updated team - %s, info", team_row.team_id)
+        verbose_proxy_logger.info(
+            "Successfully updated team - %s, info", team_row.team_id
+        )
         await _cache_team_object(
             team_id=team_row.team_id,
             team_table=LiteLLM_TeamTableCachedObj(**team_row.model_dump()),
@@ -1826,14 +1877,14 @@ async def _validate_and_populate_member_user_info(
 ) -> Member:
     """
     Validate and populate user_email/user_id for a member.
-    
+
     Logic:
     1. If both user_email and user_id are provided, verify they belong to the same user (use user_email as source of truth)
     2. If only user_email is provided, populate user_id from DB
     3. If only user_id is provided, populate user_email from DB (if user exists)
     4. If only user_id is provided and doesn't exist, allow it to pass with user_email as None (will be upserted later)
     5. If user_email and user_id mismatch, throw error
-    
+
     Returns a Member with user_email and user_id populated (user_email may be None if only user_id provided and user doesn't exist).
     """
     if member.user_email is None and member.user_id is None:
@@ -1841,7 +1892,7 @@ async def _validate_and_populate_member_user_info(
             status_code=400,
             detail={"error": "Either user_id or user_email must be provided"},
         )
-    
+
     # Case 1: Both user_email and user_id provided - verify they match
     if member.user_email is not None and member.user_id is not None:
         # Use user_email as source of truth
@@ -1851,13 +1902,13 @@ async def _validate_and_populate_member_user_info(
             table_name="user",
             query_type="find_all",
         )
-        
+
         if users_by_email is None or (
             isinstance(users_by_email, list) and len(users_by_email) == 0
         ):
             # User doesn't exist yet - this is fine, will be created later
             return member
-        
+
         if isinstance(users_by_email, list) and len(users_by_email) > 1:
             raise HTTPException(
                 status_code=400,
@@ -1865,10 +1916,10 @@ async def _validate_and_populate_member_user_info(
                     "error": f"Multiple users found with email '{member.user_email}'. Please use 'user_id' instead."
                 },
             )
-        
+
         # Get the single user
         user_by_email = users_by_email[0]
-        
+
         # Verify the user_id matches
         if user_by_email.user_id != member.user_id:
             raise HTTPException(
@@ -1877,55 +1928,60 @@ async def _validate_and_populate_member_user_info(
                     "error": f"user_email '{member.user_email}' and user_id '{member.user_id}' do not belong to the same user."
                 },
             )
-        
+
         # Both match, return as is
         return member
-    
+
     # Case 2: Only user_email provided - populate user_id from DB
     if member.user_email is not None and member.user_id is None:
         user_by_email = await prisma_client.db.litellm_usertable.find_first(
             where={"user_email": {"equals": member.user_email, "mode": "insensitive"}}
         )
-        
+
         if user_by_email is None:
             # User doesn't exist yet - this is fine, will be created later
             return member
-        
+
         # Check for multiple users with same email
         users_by_email = await prisma_client.get_data(
             key_val={"user_email": member.user_email},
             table_name="user",
             query_type="find_all",
         )
-        
-        if users_by_email and isinstance(users_by_email, list) and len(users_by_email) > 1:
+
+        if (
+            users_by_email
+            and isinstance(users_by_email, list)
+            and len(users_by_email) > 1
+        ):
             raise HTTPException(
                 status_code=400,
                 detail={
                     "error": f"Multiple users found with email '{member.user_email}'. Please use 'user_id' instead."
                 },
             )
-        
+
         # Populate user_id
         member.user_id = user_by_email.user_id
         return member
-    
+
     # Case 3: Only user_id provided - populate user_email from DB if user exists
     if member.user_id is not None and member.user_email is None:
         user_by_id = await prisma_client.db.litellm_usertable.find_unique(
             where={"user_id": member.user_id}
         )
-        
+
         if user_by_id is None:
             # User doesn't exist yet - allow it to pass with user_email as None
             # Will be upserted later with just user_id and null email
             return member
-        
+
         # Populate user_email
         member.user_email = user_by_id.user_email
         return member
-    
+
     return member
+
 
 @router.post(
     "/team/member_add",
@@ -2209,7 +2265,7 @@ async def team_member_delete(
                 }
             )
         )
-        
+
         if keys_to_delete:
             await _persist_deleted_verification_tokens(
                 keys=keys_to_delete,
@@ -2692,7 +2748,6 @@ async def delete_team(
     return deleted_teams
 
 
-
 def _transform_teams_to_deleted_records(
     teams: List[LiteLLM_TeamTable],
     user_api_key_dict: UserAPIKeyAuth,
@@ -2715,7 +2770,13 @@ def _transform_teams_to_deleted_records(
         )
         record = deleted_record.model_dump()
 
-        for json_field in ["members_with_roles", "metadata", "model_spend", "model_max_budget", "router_settings"]:
+        for json_field in [
+            "members_with_roles",
+            "metadata",
+            "model_spend",
+            "model_max_budget",
+            "router_settings",
+        ]:
             if json_field in record and record[json_field] is not None:
                 record[json_field] = json.dumps(record[json_field])
 
@@ -2734,9 +2795,7 @@ async def _save_deleted_team_records(
     """Save deleted team records to the database."""
     if not records:
         return
-    await prisma_client.db.litellm_deletedteamtable.create_many(
-        data=records
-    )
+    await prisma_client.db.litellm_deletedteamtable.create_many(data=records)
 
 
 async def _persist_deleted_team_records(
@@ -2755,6 +2814,7 @@ async def _persist_deleted_team_records(
         records=records,
         prisma_client=prisma_client,
     )
+
 
 def validate_membership(
     user_api_key_dict: UserAPIKeyAuth, team_table: LiteLLM_TeamTable
@@ -3341,7 +3401,9 @@ async def list_team_v2(
             order=order_by if order_by else {"created_at": "desc"},  # Default sort
         )
         # Get total count for pagination
-        total_count = await prisma_client.db.litellm_teamtable.count(where=where_conditions)
+        total_count = await prisma_client.db.litellm_teamtable.count(
+            where=where_conditions
+        )
 
     # Calculate total pages
     total_pages = -(-total_count // page_size)  # Ceiling division
@@ -3449,9 +3511,7 @@ async def list_team(
         except Exception as e:
             team_exception = """Invalid team object for team_id: {}. team_object={}.
             Error: {}
-            """.format(
-                team.team_id, team.model_dump(), str(e)
-            )
+            """.format(team.team_id, team.model_dump(), str(e))
             verbose_proxy_logger.exception(team_exception)
             continue
     # Sort the responses by team_alias

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -447,10 +447,10 @@ async def test_new_team_with_object_permission(mock_db_client, mock_admin_auth):
     assert mock_team_create.call_count == 1
     created_team_kwargs = mock_team_create.call_args.kwargs
     team_data = created_team_kwargs["data"]
-    
+
     # Verify object_permission_id is in the team data
     assert team_data.get("object_permission_id") == "objperm123"
-    
+
     # Verify object_permission dict is NOT in the team data
     assert "object_permission" not in team_data
 
@@ -459,7 +459,7 @@ async def test_new_team_with_object_permission(mock_db_client, mock_admin_auth):
 async def test_new_team_with_mcp_tool_permissions(mock_db_client, mock_admin_auth):
     """
     Test that /team/new correctly handles mcp_tool_permissions in object_permission.
-    
+
     This test verifies that:
     1. mcp_tool_permissions is accepted in the object_permission field
     2. The field is properly stored in the LiteLLM_ObjectPermissionTable
@@ -497,9 +497,13 @@ async def test_new_team_with_mcp_tool_permissions(mock_db_client, mock_admin_aut
         "object_permission_id": "objperm_team_mcp_456",
     }
     mock_db_client.db.litellm_teamtable = MagicMock()
-    mock_db_client.db.litellm_teamtable.create = AsyncMock(return_value=team_create_result)
+    mock_db_client.db.litellm_teamtable.create = AsyncMock(
+        return_value=team_create_result
+    )
     mock_db_client.db.litellm_teamtable.count = AsyncMock(return_value=0)
-    mock_db_client.db.litellm_teamtable.update = AsyncMock(return_value=team_create_result)
+    mock_db_client.db.litellm_teamtable.update = AsyncMock(
+        return_value=team_create_result
+    )
 
     # Mock user table
     mock_db_client.db.litellm_usertable = MagicMock()
@@ -532,6 +536,7 @@ async def test_new_team_with_mcp_tool_permissions(mock_db_client, mock_admin_aut
 
     # Verify mcp_tool_permissions was stored
     import json
+
     assert "mcp_tool_permissions" in created_permission_data
     # mcp_tool_permissions is stored as a JSON string
     assert json.loads(created_permission_data["mcp_tool_permissions"]) == {
@@ -1287,7 +1292,13 @@ async def test_update_team_team_member_budget_not_passed_to_db():
 
         # Mock budget upsert to return updated_kv without team_member_budget
         def mock_upsert_side_effect(
-            team_table, user_api_key_dict, updated_kv, team_member_budget=None, team_member_rpm_limit=None, team_member_tpm_limit=None, team_member_budget_duration=None
+            team_table,
+            user_api_key_dict,
+            updated_kv,
+            team_member_budget=None,
+            team_member_rpm_limit=None,
+            team_member_tpm_limit=None,
+            team_member_budget_duration=None,
         ):
             # Remove team_member_budget from updated_kv as the real function does
             result_kv = updated_kv.copy()
@@ -1467,7 +1478,7 @@ async def test_create_team_member_budget_table():
 
     with patch(
         "litellm.proxy.management_endpoints.budget_management_endpoints.new_budget",
-        new_callable=AsyncMock
+        new_callable=AsyncMock,
     ) as mock_new_budget:
         mock_new_budget.return_value = mock_budget_response
 
@@ -1528,7 +1539,7 @@ async def test_create_team_member_budget_table_without_team_alias():
 
     with patch(
         "litellm.proxy.management_endpoints.budget_management_endpoints.new_budget",
-        new_callable=AsyncMock
+        new_callable=AsyncMock,
     ) as mock_new_budget:
         mock_new_budget.return_value = mock_budget_response
 
@@ -1578,7 +1589,7 @@ async def test_upsert_team_member_budget_table_existing_budget():
 
     with patch(
         "litellm.proxy.management_endpoints.budget_management_endpoints.update_budget",
-        new_callable=AsyncMock
+        new_callable=AsyncMock,
     ) as mock_update_budget:
         mock_update_budget.return_value = mock_budget_response
 
@@ -1640,7 +1651,7 @@ async def test_upsert_team_member_budget_table_no_existing_budget():
 
     with patch(
         "litellm.proxy.management_endpoints.budget_management_endpoints.new_budget",
-        new_callable=AsyncMock
+        new_callable=AsyncMock,
     ) as mock_new_budget:
         mock_new_budget.return_value = mock_budget_response
 
@@ -1713,7 +1724,13 @@ async def test_update_team_with_team_member_budget_duration():
         )
 
         def mock_upsert_side_effect(
-            team_table, user_api_key_dict, updated_kv, team_member_budget=None, team_member_rpm_limit=None, team_member_tpm_limit=None, team_member_budget_duration=None
+            team_table,
+            user_api_key_dict,
+            updated_kv,
+            team_member_budget=None,
+            team_member_rpm_limit=None,
+            team_member_tpm_limit=None,
+            team_member_budget_duration=None,
         ):
             result_kv = updated_kv.copy()
             result_kv.pop("team_member_budget", None)
@@ -2145,7 +2162,7 @@ async def test_list_team_v2_security_check_non_admin_user_own_teams():
         # Mock prisma client and database operations
         mock_db = Mock()
         mock_prisma_client.db = mock_db
-        
+
         # Mock user lookup
         mock_user_object = Mock()
         mock_user_object.model_dump.return_value = {
@@ -2153,7 +2170,7 @@ async def test_list_team_v2_security_check_non_admin_user_own_teams():
             "teams": ["team_1", "team_2"],
         }
         mock_db.litellm_usertable.find_unique = AsyncMock(return_value=mock_user_object)
-        
+
         # Mock team lookup
         mock_teams = [
             Mock(model_dump=lambda: {"team_id": "team_1", "team_alias": "Team 1"}),
@@ -2204,7 +2221,7 @@ async def test_list_team_v2_security_check_admin_user():
         # Mock prisma client and database operations
         mock_db = Mock()
         mock_prisma_client.db = mock_db
-        
+
         # Mock team lookup
         mock_teams = [
             Mock(model_dump=lambda: {"team_id": "team_1", "team_alias": "Team 1"}),
@@ -2235,38 +2252,44 @@ async def test_list_team_v2_with_status_deleted():
     Test that status="deleted" parameter correctly queries the deleted teams table.
     """
     from unittest.mock import AsyncMock, Mock, patch
-    
+
     from fastapi import Request
-    
+
     from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
     from litellm.proxy.management_endpoints.team_endpoints import list_team_v2
-    
+
     # Mock request
     mock_request = Mock(spec=Request)
-    
+
     # Mock admin user
     mock_user_api_key_dict_admin = UserAPIKeyAuth(
         user_role=LitellmUserRoles.PROXY_ADMIN,
         user_id="admin_user_123",
     )
-    
+
     with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client:
         # Mock prisma client and database operations
         mock_db = Mock()
         mock_prisma_client.db = mock_db
-        
+
         # Mock deleted teams
-        mock_deleted_team1 = Mock(model_dump=lambda: {"team_id": "team_1", "team_alias": "Deleted Team 1"})
-        mock_deleted_team2 = Mock(model_dump=lambda: {"team_id": "team_2", "team_alias": "Deleted Team 2"})
-        
+        mock_deleted_team1 = Mock(
+            model_dump=lambda: {"team_id": "team_1", "team_alias": "Deleted Team 1"}
+        )
+        mock_deleted_team2 = Mock(
+            model_dump=lambda: {"team_id": "team_2", "team_alias": "Deleted Team 2"}
+        )
+
         # Mock deleted teams table (should be called)
-        mock_db.litellm_deletedteamtable.find_many = AsyncMock(return_value=[mock_deleted_team1, mock_deleted_team2])
+        mock_db.litellm_deletedteamtable.find_many = AsyncMock(
+            return_value=[mock_deleted_team1, mock_deleted_team2]
+        )
         mock_db.litellm_deletedteamtable.count = AsyncMock(return_value=2)
-        
+
         # Mock regular teams table (should NOT be called)
         mock_db.litellm_teamtable.find_many = AsyncMock(return_value=[])
         mock_db.litellm_teamtable.count = AsyncMock(return_value=0)
-        
+
         # Should NOT raise an exception
         result = await list_team_v2(
             http_request=mock_request,
@@ -2276,15 +2299,15 @@ async def test_list_team_v2_with_status_deleted():
             page_size=10,
             status="deleted",  # Test the status parameter
         )
-        
+
         # Verify that deleted table was queried
         mock_db.litellm_deletedteamtable.find_many.assert_called_once()
         mock_db.litellm_deletedteamtable.count.assert_called_once()
-        
+
         # Verify that regular table was NOT queried
         mock_db.litellm_teamtable.find_many.assert_not_called()
         mock_db.litellm_teamtable.count.assert_not_called()
-        
+
         # Should return results without error
         assert "teams" in result
         assert "total" in result
@@ -2298,23 +2321,23 @@ async def test_list_team_v2_with_invalid_status():
     Test that invalid status parameter raises HTTPException.
     """
     from unittest.mock import Mock, patch
-    
+
     from fastapi import HTTPException, Request
-    
+
     from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
     from litellm.proxy.management_endpoints.team_endpoints import list_team_v2
-    
+
     # Mock request
     mock_request = Mock(spec=Request)
-    
+
     # Mock admin user
     mock_user_api_key_dict_admin = UserAPIKeyAuth(
         user_role=LitellmUserRoles.PROXY_ADMIN,
         user_id="admin_user_123",
     )
-    
+
     mock_prisma_client = Mock()
-    
+
     # Mock prisma_client to be non-None
     with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
         # Should raise HTTPException for invalid status
@@ -2327,7 +2350,7 @@ async def test_list_team_v2_with_invalid_status():
                 page_size=10,
                 status="invalid_status",  # Invalid status value
             )
-        
+
         assert exc_info.value.status_code == 400
         assert "Invalid status value" in str(exc_info.value.detail)
         assert "deleted" in str(exc_info.value.detail)
@@ -2359,24 +2382,32 @@ async def test_team_member_delete_cleans_membership(mock_db_client, mock_admin_a
     }
 
     # Configure DB mocks used by team_member_delete
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_team_row)
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=mock_team_row
+    )
     mock_db_client.db.litellm_teamtable.update = AsyncMock(return_value=mock_team_row)
 
     # User row to allow removal from user's teams list
     mock_user_row = MagicMock()
     mock_user_row.user_id = test_user_id
     mock_user_row.teams = [test_team_id]
-    mock_db_client.db.litellm_usertable.find_many = AsyncMock(return_value=[mock_user_row])
+    mock_db_client.db.litellm_usertable.find_many = AsyncMock(
+        return_value=[mock_user_row]
+    )
     mock_db_client.db.litellm_usertable.update = AsyncMock(return_value=MagicMock())
 
     # Membership deletion should be called
     mock_db_client.db.litellm_teammembership = MagicMock()
-    mock_db_client.db.litellm_teammembership.delete_many = AsyncMock(return_value=MagicMock())
+    mock_db_client.db.litellm_teammembership.delete_many = AsyncMock(
+        return_value=MagicMock()
+    )
 
     # Verification token deletion should be called
     mock_db_client.db.litellm_verificationtoken = MagicMock()
     mock_db_client.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
-    mock_db_client.db.litellm_verificationtoken.delete_many = AsyncMock(return_value=MagicMock())
+    mock_db_client.db.litellm_verificationtoken.delete_many = AsyncMock(
+        return_value=MagicMock()
+    )
 
     # Execute
     await team_member_delete(
@@ -2388,10 +2419,12 @@ async def test_team_member_delete_cleans_membership(mock_db_client, mock_admin_a
     mock_db_client.db.litellm_teammembership.delete_many.assert_awaited_with(
         where={"team_id": test_team_id, "user_id": test_user_id}
     )
-    
+
 
 @pytest.mark.asyncio
-async def test_team_member_delete_cleans_verification_tokens(mock_db_client, mock_admin_auth):
+async def test_team_member_delete_cleans_verification_tokens(
+    mock_db_client, mock_admin_auth
+):
     from litellm.proxy._types import TeamMemberDeleteRequest
     from litellm.proxy.management_endpoints.team_endpoints import team_member_delete
 
@@ -2410,21 +2443,29 @@ async def test_team_member_delete_cleans_verification_tokens(mock_db_client, moc
         "spend": 0.0,
     }
 
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_team_row)
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=mock_team_row
+    )
     mock_db_client.db.litellm_teamtable.update = AsyncMock(return_value=mock_team_row)
 
     mock_user_row = MagicMock()
     mock_user_row.user_id = test_user_id
     mock_user_row.teams = [test_team_id]
-    mock_db_client.db.litellm_usertable.find_many = AsyncMock(return_value=[mock_user_row])
+    mock_db_client.db.litellm_usertable.find_many = AsyncMock(
+        return_value=[mock_user_row]
+    )
     mock_db_client.db.litellm_usertable.update = AsyncMock(return_value=MagicMock())
 
     mock_db_client.db.litellm_teammembership = MagicMock()
-    mock_db_client.db.litellm_teammembership.delete_many = AsyncMock(return_value=MagicMock())
+    mock_db_client.db.litellm_teammembership.delete_many = AsyncMock(
+        return_value=MagicMock()
+    )
 
     mock_db_client.db.litellm_verificationtoken = MagicMock()
     mock_db_client.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
-    mock_db_client.db.litellm_verificationtoken.delete_many = AsyncMock(return_value=MagicMock())
+    mock_db_client.db.litellm_verificationtoken.delete_many = AsyncMock(
+        return_value=MagicMock()
+    )
 
     await team_member_delete(
         data=TeamMemberDeleteRequest(team_id=test_team_id, user_id=test_user_id),
@@ -2443,7 +2484,7 @@ async def test_team_member_delete_cleans_verification_tokens(mock_db_client, moc
 async def test_new_team_max_budget_exceeds_user_max_budget():
     """
     Test that /team/new raises ProxyException when max_budget exceeds user's end_user_max_budget.
-    
+
     This validates the budget enforcement logic where non-admin users cannot create teams
     with budgets higher than their personal maximum budget limit.
     """
@@ -2480,15 +2521,16 @@ async def test_new_team_max_budget_exceeds_user_max_budget():
         mock_prisma.db.litellm_teamtable.count = AsyncMock(return_value=0)
         mock_license.is_team_count_over_limit.return_value = False
         mock_prisma.get_data = AsyncMock(return_value=None)
-        
+
         # Mock user cache to return a user object with max_budget=100.0
         from litellm.proxy._types import LiteLLM_UserTable
+
         mock_user_obj = LiteLLM_UserTable(
             user_id="non-admin-user-123",
             max_budget=100.0,
         )
         mock_cache.async_get_cache = AsyncMock(return_value=mock_user_obj)
-        
+
         # Should raise ProxyException (HTTPException gets converted by handle_exception_on_proxy)
         with pytest.raises(ProxyException) as exc_info:
             await new_team(
@@ -2499,9 +2541,11 @@ async def test_new_team_max_budget_exceeds_user_max_budget():
 
         # Verify exception details
         # ProxyException stores status_code in 'code' attribute
-        assert exc_info.value.code == '400'
+        assert exc_info.value.code == "400"
         assert "max budget higher than user max" in str(exc_info.value.message)
-        assert "100.0" in str(exc_info.value.message)  # User's user_max_budget should be mentioned
+        assert "100.0" in str(
+            exc_info.value.message
+        )  # User's user_max_budget should be mentioned
         assert LitellmUserRoles.INTERNAL_USER.value in str(exc_info.value.message)
 
 
@@ -2509,7 +2553,7 @@ async def test_new_team_max_budget_exceeds_user_max_budget():
 async def test_new_team_max_budget_within_user_limit():
     """
     Test that /team/new succeeds when max_budget is within user's user_max_budget.
-    
+
     This ensures that users can create teams with budgets at or below their personal limit.
     """
     from fastapi import Request
@@ -2549,15 +2593,16 @@ async def test_new_team_max_budget_within_user_limit():
         mock_prisma.jsonify_team_object = lambda db_data: db_data
         mock_prisma.get_data = AsyncMock(return_value=None)
         mock_prisma.update_data = AsyncMock()
-        
+
         # Mock user cache to return a user object with max_budget=100.0
         from litellm.proxy._types import LiteLLM_UserTable
+
         mock_user_obj = LiteLLM_UserTable(
             user_id="non-admin-user-456",
             max_budget=100.0,
         )
         mock_cache.async_get_cache = AsyncMock(return_value=mock_user_obj)
-        
+
         # Mock team creation
         mock_created_team = MagicMock()
         mock_created_team.team_id = "team-within-budget-789"
@@ -2571,21 +2616,30 @@ async def test_new_team_max_budget_within_user_limit():
             "max_budget": 50.0,
             "members_with_roles": [],
         }
-        mock_prisma.db.litellm_teamtable.create = AsyncMock(return_value=mock_created_team)
-        mock_prisma.db.litellm_teamtable.update = AsyncMock(return_value=mock_created_team)
-        
+        mock_prisma.db.litellm_teamtable.create = AsyncMock(
+            return_value=mock_created_team
+        )
+        mock_prisma.db.litellm_teamtable.update = AsyncMock(
+            return_value=mock_created_team
+        )
+
         # Mock model table
         mock_prisma.db.litellm_modeltable = MagicMock()
-        mock_prisma.db.litellm_modeltable.create = AsyncMock(return_value=MagicMock(id="model123"))
-        
+        mock_prisma.db.litellm_modeltable.create = AsyncMock(
+            return_value=MagicMock(id="model123")
+        )
+
         # Mock user table operations for adding the creator as a member
         mock_user = MagicMock()
         mock_user.user_id = "non-admin-user-456"
-        mock_user.model_dump.return_value = {"user_id": "non-admin-user-456", "teams": ["team-within-budget-789"]}
+        mock_user.model_dump.return_value = {
+            "user_id": "non-admin-user-456",
+            "teams": ["team-within-budget-789"],
+        }
         mock_prisma.db.litellm_usertable = MagicMock()
         mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
-        
+
         # Mock team membership table
         mock_membership = MagicMock()
         mock_membership.model_dump.return_value = {
@@ -2594,7 +2648,9 @@ async def test_new_team_max_budget_within_user_limit():
             "budget_id": None,
         }
         mock_prisma.db.litellm_teammembership = MagicMock()
-        mock_prisma.db.litellm_teammembership.create = AsyncMock(return_value=mock_membership)
+        mock_prisma.db.litellm_teammembership.create = AsyncMock(
+            return_value=mock_membership
+        )
 
         # Should NOT raise an exception
         result = await new_team(
@@ -2700,17 +2756,26 @@ async def test_new_team_org_scoped_budget_bypasses_user_limit():
             "organization_id": "test-org-123",
             "members_with_roles": [],
         }
-        mock_prisma.db.litellm_teamtable.create = AsyncMock(return_value=mock_created_team)
-        mock_prisma.db.litellm_teamtable.update = AsyncMock(return_value=mock_created_team)
+        mock_prisma.db.litellm_teamtable.create = AsyncMock(
+            return_value=mock_created_team
+        )
+        mock_prisma.db.litellm_teamtable.update = AsyncMock(
+            return_value=mock_created_team
+        )
 
         # Mock model table
         mock_prisma.db.litellm_modeltable = MagicMock()
-        mock_prisma.db.litellm_modeltable.create = AsyncMock(return_value=MagicMock(id="model123"))
+        mock_prisma.db.litellm_modeltable.create = AsyncMock(
+            return_value=MagicMock(id="model123")
+        )
 
         # Mock user table operations
         mock_user = MagicMock()
         mock_user.user_id = "org-admin-user-123"
-        mock_user.model_dump.return_value = {"user_id": "org-admin-user-123", "teams": ["team-org-scoped-789"]}
+        mock_user.model_dump.return_value = {
+            "user_id": "org-admin-user-123",
+            "teams": ["team-org-scoped-789"],
+        }
         mock_prisma.db.litellm_usertable = MagicMock()
         mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
@@ -2723,7 +2788,9 @@ async def test_new_team_org_scoped_budget_bypasses_user_limit():
             "budget_id": None,
         }
         mock_prisma.db.litellm_teammembership = MagicMock()
-        mock_prisma.db.litellm_teammembership.create = AsyncMock(return_value=mock_membership)
+        mock_prisma.db.litellm_teammembership.create = AsyncMock(
+            return_value=mock_membership
+        )
 
         # Should NOT raise an exception - the fix should bypass user budget validation for org-scoped teams
         result = await new_team(
@@ -2775,7 +2842,9 @@ async def test_new_team_org_scoped_models_bypasses_user_limit():
     # Create team request with models that are within org's allowed models but not user's
     team_request = NewTeamRequest(
         team_alias="org-scoped-models-team",
-        models=["gpt-4"],  # Within org's allowed models, but not in user's personal models
+        models=[
+            "gpt-4"
+        ],  # Within org's allowed models, but not in user's personal models
         organization_id="test-org-456",  # This makes it an org-scoped team
     )
 
@@ -2832,17 +2901,26 @@ async def test_new_team_org_scoped_models_bypasses_user_limit():
             "models": ["gpt-4"],
             "members_with_roles": [],
         }
-        mock_prisma.db.litellm_teamtable.create = AsyncMock(return_value=mock_created_team)
-        mock_prisma.db.litellm_teamtable.update = AsyncMock(return_value=mock_created_team)
+        mock_prisma.db.litellm_teamtable.create = AsyncMock(
+            return_value=mock_created_team
+        )
+        mock_prisma.db.litellm_teamtable.update = AsyncMock(
+            return_value=mock_created_team
+        )
 
         # Mock model table
         mock_prisma.db.litellm_modeltable = MagicMock()
-        mock_prisma.db.litellm_modeltable.create = AsyncMock(return_value=MagicMock(id="model123"))
+        mock_prisma.db.litellm_modeltable.create = AsyncMock(
+            return_value=MagicMock(id="model123")
+        )
 
         # Mock user table operations
         mock_user = MagicMock()
         mock_user.user_id = "org-admin-user-456"
-        mock_user.model_dump.return_value = {"user_id": "org-admin-user-456", "teams": ["team-org-scoped-models-789"]}
+        mock_user.model_dump.return_value = {
+            "user_id": "org-admin-user-456",
+            "teams": ["team-org-scoped-models-789"],
+        }
         mock_prisma.db.litellm_usertable = MagicMock()
         mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
@@ -2855,7 +2933,9 @@ async def test_new_team_org_scoped_models_bypasses_user_limit():
             "budget_id": None,
         }
         mock_prisma.db.litellm_teammembership = MagicMock()
-        mock_prisma.db.litellm_teammembership.create = AsyncMock(return_value=mock_membership)
+        mock_prisma.db.litellm_teammembership.create = AsyncMock(
+            return_value=mock_membership
+        )
 
         # Should NOT raise an exception - the fix should bypass user model validation for org-scoped teams
         result = await new_team(
@@ -2926,7 +3006,7 @@ async def test_new_team_standalone_validates_against_user_models():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
+        assert exc_info.value.code == "400"
         assert "Model not in allowed user models" in str(exc_info.value.message)
         assert "no-default-models" in str(exc_info.value.message)
 
@@ -3002,9 +3082,11 @@ async def test_new_team_standalone_validates_against_user_budget():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
+        assert exc_info.value.code == "400"
         assert "max budget higher than user max" in str(exc_info.value.message)
-        assert "3.0" in str(exc_info.value.message)  # User's max_budget should be mentioned
+        assert "3.0" in str(
+            exc_info.value.message
+        )  # User's max_budget should be mentioned
 
 
 @pytest.mark.asyncio
@@ -3080,8 +3162,11 @@ async def test_new_team_org_scoped_budget_exceeds_org_limit():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
-        assert "exceeds organization" in str(exc_info.value.message).lower() or "organization" in str(exc_info.value.message).lower()
+        assert exc_info.value.code == "400"
+        assert (
+            "exceeds organization" in str(exc_info.value.message).lower()
+            or "organization" in str(exc_info.value.message).lower()
+        )
 
 
 @pytest.mark.asyncio
@@ -3154,8 +3239,11 @@ async def test_new_team_org_scoped_models_not_in_org_models():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
-        assert "claude-3-opus" in str(exc_info.value.message) or "organization" in str(exc_info.value.message).lower()
+        assert exc_info.value.code == "400"
+        assert (
+            "claude-3-opus" in str(exc_info.value.message)
+            or "organization" in str(exc_info.value.message).lower()
+        )
 
 
 @pytest.mark.asyncio
@@ -3212,7 +3300,9 @@ async def test_update_team_standalone_budget_exceeds_user_limit():
             "organization_id": None,
             "max_budget": 30.0,
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
 
         # Mock user cache to return user with restrictive budget
         mock_user_obj = LiteLLM_UserTable(
@@ -3230,7 +3320,7 @@ async def test_update_team_standalone_budget_exceeds_user_limit():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
+        assert exc_info.value.code == "400"
         assert "budget" in str(exc_info.value.message).lower()
 
 
@@ -3288,7 +3378,7 @@ async def test_update_team_org_scoped_budget_exceeds_org_limit():
         "litellm.proxy.proxy_server.create_audit_log_for_update", new=AsyncMock()
     ) as mock_audit, patch(
         "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
-        new=AsyncMock(return_value=mock_org)
+        new=AsyncMock(return_value=mock_org),
     ) as mock_get_org:
 
         # Mock existing org-scoped team
@@ -3301,7 +3391,9 @@ async def test_update_team_org_scoped_budget_exceeds_org_limit():
             "organization_id": "test-org-update",
             "max_budget": 80.0,
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
 
         # Should raise ProxyException because new budget exceeds org's max_budget
         with pytest.raises(ProxyException) as exc_info:
@@ -3312,8 +3404,11 @@ async def test_update_team_org_scoped_budget_exceeds_org_limit():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
-        assert "organization" in str(exc_info.value.message).lower() or "budget" in str(exc_info.value.message).lower()
+        assert exc_info.value.code == "400"
+        assert (
+            "organization" in str(exc_info.value.message).lower()
+            or "budget" in str(exc_info.value.message).lower()
+        )
 
 
 @pytest.mark.asyncio
@@ -3365,7 +3460,9 @@ async def test_update_team_standalone_models_exceeds_user_limit():
             "organization_id": None,
             "models": ["gpt-3.5-turbo"],
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
 
         # Should raise ProxyException because model not in user's allowed models
         with pytest.raises(ProxyException) as exc_info:
@@ -3376,7 +3473,7 @@ async def test_update_team_standalone_models_exceeds_user_limit():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
+        assert exc_info.value.code == "400"
         assert "model" in str(exc_info.value.message).lower()
 
 
@@ -3435,7 +3532,7 @@ async def test_update_team_org_scoped_budget_bypasses_user_limit():
         "litellm.proxy.proxy_server.create_audit_log_for_update", new=AsyncMock()
     ) as mock_audit, patch(
         "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
-        new=AsyncMock(return_value=mock_org)
+        new=AsyncMock(return_value=mock_org),
     ) as mock_get_org:
 
         # Mock existing org-scoped team
@@ -3449,7 +3546,9 @@ async def test_update_team_org_scoped_budget_bypasses_user_limit():
             "organization_id": "test-org-update-budget",
             "max_budget": 30.0,
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
         mock_prisma.jsonify_team_object = lambda db_data: db_data
 
         # Mock user cache to return user with restrictive budget
@@ -3458,7 +3557,9 @@ async def test_update_team_org_scoped_budget_bypasses_user_limit():
             max_budget=3.0,  # Restrictive personal budget
         )
         mock_cache.async_get_cache = AsyncMock(return_value=mock_user_obj)
-        mock_cache.async_set_cache = AsyncMock()  # Mock cache set for _cache_team_object
+        mock_cache.async_set_cache = (
+            AsyncMock()
+        )  # Mock cache set for _cache_team_object
 
         # Mock team update
         mock_updated_team = MagicMock()
@@ -3471,7 +3572,9 @@ async def test_update_team_org_scoped_budget_bypasses_user_limit():
             "organization_id": "test-org-update-budget",
             "max_budget": 50.0,
         }
-        mock_prisma.db.litellm_teamtable.update = AsyncMock(return_value=mock_updated_team)
+        mock_prisma.db.litellm_teamtable.update = AsyncMock(
+            return_value=mock_updated_team
+        )
 
         # Should NOT raise an exception - bypass user budget validation for org-scoped teams
         result = await update_team(
@@ -3535,7 +3638,7 @@ async def test_update_team_org_scoped_models_bypasses_user_limit():
         "litellm.proxy.proxy_server.create_audit_log_for_update", new=AsyncMock()
     ) as mock_audit, patch(
         "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
-        new=AsyncMock(return_value=mock_org)
+        new=AsyncMock(return_value=mock_org),
     ) as mock_get_org:
 
         # Mock existing org-scoped team
@@ -3549,9 +3652,13 @@ async def test_update_team_org_scoped_models_bypasses_user_limit():
             "organization_id": "test-org-update-models",
             "models": ["gpt-3.5-turbo"],
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
         mock_prisma.jsonify_team_object = lambda db_data: db_data
-        mock_cache.async_set_cache = AsyncMock()  # Mock cache set for _cache_team_object
+        mock_cache.async_set_cache = (
+            AsyncMock()
+        )  # Mock cache set for _cache_team_object
 
         # Mock team update
         mock_updated_team = MagicMock()
@@ -3564,7 +3671,9 @@ async def test_update_team_org_scoped_models_bypasses_user_limit():
             "organization_id": "test-org-update-models",
             "models": ["gpt-4"],
         }
-        mock_prisma.db.litellm_teamtable.update = AsyncMock(return_value=mock_updated_team)
+        mock_prisma.db.litellm_teamtable.update = AsyncMock(
+            return_value=mock_updated_team
+        )
 
         # Should NOT raise an exception - bypass user models validation for org-scoped teams
         result = await update_team(
@@ -3628,7 +3737,7 @@ async def test_update_team_org_scoped_models_not_in_org_models():
         "litellm.proxy.proxy_server.create_audit_log_for_update", new=AsyncMock()
     ) as mock_audit, patch(
         "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
-        new=AsyncMock(return_value=mock_org)
+        new=AsyncMock(return_value=mock_org),
     ) as mock_get_org:
 
         # Mock existing org-scoped team
@@ -3641,7 +3750,9 @@ async def test_update_team_org_scoped_models_not_in_org_models():
             "organization_id": "test-org-update-models-fail",
             "models": ["gpt-4"],
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
 
         # Should raise ProxyException because claude-3-opus is not in org's allowed models
         with pytest.raises(ProxyException) as exc_info:
@@ -3652,8 +3763,11 @@ async def test_update_team_org_scoped_models_not_in_org_models():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
-        assert "claude-3-opus" in str(exc_info.value.message) or "organization" in str(exc_info.value.message).lower()
+        assert exc_info.value.code == "400"
+        assert (
+            "claude-3-opus" in str(exc_info.value.message)
+            or "organization" in str(exc_info.value.message).lower()
+        )
 
 
 @pytest.mark.asyncio
@@ -3707,7 +3821,7 @@ async def test_update_team_org_scoped_models_with_all_proxy_models():
         "litellm.proxy.proxy_server.create_audit_log_for_update", new=AsyncMock()
     ) as mock_audit, patch(
         "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
-        new=AsyncMock(return_value=mock_org)
+        new=AsyncMock(return_value=mock_org),
     ) as mock_get_org:
 
         # Mock existing org-scoped team
@@ -3721,22 +3835,36 @@ async def test_update_team_org_scoped_models_with_all_proxy_models():
             "organization_id": "test-org-all-proxy-models",
             "models": ["gpt-4"],
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
         mock_prisma.jsonify_team_object = lambda db_data: db_data
-        mock_cache.async_set_cache = AsyncMock()  # Mock cache set for _cache_team_object
+        mock_cache.async_set_cache = (
+            AsyncMock()
+        )  # Mock cache set for _cache_team_object
 
         # Mock team update
         mock_updated_team = MagicMock()
         mock_updated_team.team_id = "org-team-all-proxy-models-123"
         mock_updated_team.organization_id = "test-org-all-proxy-models"
-        mock_updated_team.models = ["rerank-english-v3.0", "text-embedding-3-small", "gpt-4o-mini-test"]
+        mock_updated_team.models = [
+            "rerank-english-v3.0",
+            "text-embedding-3-small",
+            "gpt-4o-mini-test",
+        ]
         mock_updated_team.litellm_model_table = None
         mock_updated_team.model_dump.return_value = {
             "team_id": "org-team-all-proxy-models-123",
             "organization_id": "test-org-all-proxy-models",
-            "models": ["rerank-english-v3.0", "text-embedding-3-small", "gpt-4o-mini-test"],
+            "models": [
+                "rerank-english-v3.0",
+                "text-embedding-3-small",
+                "gpt-4o-mini-test",
+            ],
         }
-        mock_prisma.db.litellm_teamtable.update = AsyncMock(return_value=mock_updated_team)
+        mock_prisma.db.litellm_teamtable.update = AsyncMock(
+            return_value=mock_updated_team
+        )
 
         # Should NOT raise an exception - 'all-proxy-models' allows all models
         result = await update_team(
@@ -3747,7 +3875,11 @@ async def test_update_team_org_scoped_models_with_all_proxy_models():
 
         # Verify the team was updated successfully with the new models
         assert result is not None
-        assert result["data"].models == ["rerank-english-v3.0", "text-embedding-3-small", "gpt-4o-mini-test"]
+        assert result["data"].models == [
+            "rerank-english-v3.0",
+            "text-embedding-3-small",
+            "gpt-4o-mini-test",
+        ]
 
 
 @pytest.mark.asyncio
@@ -3797,7 +3929,9 @@ async def test_update_team_tpm_limit_exceeds_user_limit():
             "organization_id": None,
             "tpm_limit": 500,
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
 
         # Should raise ProxyException because new TPM exceeds user's limit
         with pytest.raises(ProxyException) as exc_info:
@@ -3808,7 +3942,7 @@ async def test_update_team_tpm_limit_exceeds_user_limit():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
+        assert exc_info.value.code == "400"
         assert "tpm" in str(exc_info.value.message).lower()
 
 
@@ -3859,7 +3993,9 @@ async def test_update_team_rpm_limit_exceeds_user_limit():
             "organization_id": None,
             "rpm_limit": 50,
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
 
         # Should raise ProxyException because new RPM exceeds user's limit
         with pytest.raises(ProxyException) as exc_info:
@@ -3870,7 +4006,7 @@ async def test_update_team_rpm_limit_exceeds_user_limit():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
+        assert exc_info.value.code == "400"
         assert "rpm" in str(exc_info.value.message).lower()
 
 
@@ -3931,7 +4067,7 @@ async def test_new_team_org_scoped_tpm_exceeds_org_limit():
         "litellm.proxy.proxy_server._license_check"
     ) as mock_license, patch(
         "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
-        new=AsyncMock(return_value=mock_org)
+        new=AsyncMock(return_value=mock_org),
     ):
         mock_license.is_team_count_over_limit.return_value = False
         mock_prisma.db.litellm_teamtable.count = AsyncMock(return_value=0)
@@ -3946,7 +4082,7 @@ async def test_new_team_org_scoped_tpm_exceeds_org_limit():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
+        assert exc_info.value.code == "400"
         assert "tpm" in str(exc_info.value.message).lower()
 
 
@@ -4007,7 +4143,7 @@ async def test_new_team_org_scoped_rpm_exceeds_org_limit():
         "litellm.proxy.proxy_server._license_check"
     ) as mock_license, patch(
         "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
-        new=AsyncMock(return_value=mock_org)
+        new=AsyncMock(return_value=mock_org),
     ):
         mock_license.is_team_count_over_limit.return_value = False
         mock_prisma.db.litellm_teamtable.count = AsyncMock(return_value=0)
@@ -4022,7 +4158,7 @@ async def test_new_team_org_scoped_rpm_exceeds_org_limit():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
+        assert exc_info.value.code == "400"
         assert "rpm" in str(exc_info.value.message).lower()
 
 
@@ -4054,7 +4190,7 @@ async def test_new_team_org_scoped_tpm_rpm_bypasses_user_limit():
         user_id="org-admin-bypass-test",
         models=[],
         tpm_limit=1000,  # Restrictive user TPM limit
-        rpm_limit=100,   # Restrictive user RPM limit
+        rpm_limit=100,  # Restrictive user RPM limit
     )
 
     # Create team request exceeding user limits but within org limits
@@ -4062,7 +4198,7 @@ async def test_new_team_org_scoped_tpm_rpm_bypasses_user_limit():
         team_alias="org-bypass-test-team",
         organization_id="test-org-bypass",
         tpm_limit=10000,  # Exceeds user's 1000 but within org's 50000
-        rpm_limit=1000,   # Exceeds user's 100 but within org's 5000
+        rpm_limit=1000,  # Exceeds user's 100 but within org's 5000
     )
 
     dummy_request = MagicMock(spec=Request)
@@ -4070,7 +4206,7 @@ async def test_new_team_org_scoped_tpm_rpm_bypasses_user_limit():
     # Mock organization with generous limits
     mock_budget_table = MagicMock(spec=LiteLLM_BudgetTable)
     mock_budget_table.tpm_limit = 50000  # Generous org TPM limit
-    mock_budget_table.rpm_limit = 5000   # Generous org RPM limit
+    mock_budget_table.rpm_limit = 5000  # Generous org RPM limit
     mock_budget_table.max_budget = None
 
     mock_org = MagicMock(spec=LiteLLM_OrganizationTable)
@@ -4088,10 +4224,10 @@ async def test_new_team_org_scoped_tpm_rpm_bypasses_user_limit():
         "litellm.proxy.proxy_server.create_audit_log_for_update", new=AsyncMock()
     ), patch(
         "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
-        new=AsyncMock(return_value=mock_org)
+        new=AsyncMock(return_value=mock_org),
     ), patch(
         "litellm.proxy.management_endpoints.team_endpoints._add_team_members_to_team",
-        new=AsyncMock()
+        new=AsyncMock(),
     ):
         mock_license.is_team_count_over_limit.return_value = False
         mock_prisma.db.litellm_teamtable.count = AsyncMock(return_value=0)
@@ -4113,8 +4249,12 @@ async def test_new_team_org_scoped_tpm_rpm_bypasses_user_limit():
             "metadata": None,
             "members_with_roles": [],
         }
-        mock_prisma.db.litellm_teamtable.create = AsyncMock(return_value=mock_created_team)
-        mock_prisma.db.litellm_teamtable.update = AsyncMock(return_value=mock_created_team)
+        mock_prisma.db.litellm_teamtable.create = AsyncMock(
+            return_value=mock_created_team
+        )
+        mock_prisma.db.litellm_teamtable.update = AsyncMock(
+            return_value=mock_created_team
+        )
         mock_prisma.jsonify_team_object = MagicMock(side_effect=lambda db_data: db_data)
 
         # Should succeed - bypasses user limits since org-scoped
@@ -4182,7 +4322,7 @@ async def test_update_team_org_scoped_tpm_exceeds_org_limit():
         "litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"
     ), patch(
         "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
-        new=AsyncMock(return_value=mock_org)
+        new=AsyncMock(return_value=mock_org),
     ):
 
         # Mock existing org-scoped team
@@ -4195,7 +4335,9 @@ async def test_update_team_org_scoped_tpm_exceeds_org_limit():
             "organization_id": "test-org-update-tpm",
             "tpm_limit": 5000,
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
 
         # Should raise ProxyException because TPM exceeds org limit
         with pytest.raises(ProxyException) as exc_info:
@@ -4206,7 +4348,7 @@ async def test_update_team_org_scoped_tpm_exceeds_org_limit():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
+        assert exc_info.value.code == "400"
         assert "tpm" in str(exc_info.value.message).lower()
 
 
@@ -4264,7 +4406,7 @@ async def test_update_team_org_scoped_rpm_exceeds_org_limit():
         "litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"
     ), patch(
         "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
-        new=AsyncMock(return_value=mock_org)
+        new=AsyncMock(return_value=mock_org),
     ):
 
         # Mock existing org-scoped team
@@ -4277,7 +4419,9 @@ async def test_update_team_org_scoped_rpm_exceeds_org_limit():
             "organization_id": "test-org-update-rpm",
             "rpm_limit": 500,
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
 
         # Should raise ProxyException because RPM exceeds org limit
         with pytest.raises(ProxyException) as exc_info:
@@ -4288,7 +4432,7 @@ async def test_update_team_org_scoped_rpm_exceeds_org_limit():
             )
 
         # Verify exception details
-        assert exc_info.value.code == '400'
+        assert exc_info.value.code == "400"
         assert "rpm" in str(exc_info.value.message).lower()
 
 
@@ -4320,14 +4464,14 @@ async def test_update_team_org_scoped_tpm_rpm_bypasses_user_limit():
         user_id="org-admin-update-bypass-test",
         models=[],
         tpm_limit=1000,  # Restrictive user TPM limit
-        rpm_limit=100,   # Restrictive user RPM limit
+        rpm_limit=100,  # Restrictive user RPM limit
     )
 
     # Create update request exceeding user limits but within org limits
     update_request = UpdateTeamRequest(
         team_id="org-team-update-bypass-123",
         tpm_limit=10000,  # Exceeds user's 1000 but within org's 50000
-        rpm_limit=1000,   # Exceeds user's 100 but within org's 5000
+        rpm_limit=1000,  # Exceeds user's 100 but within org's 5000
     )
 
     dummy_request = MagicMock(spec=Request)
@@ -4335,7 +4479,7 @@ async def test_update_team_org_scoped_tpm_rpm_bypasses_user_limit():
     # Mock organization with generous limits
     mock_budget_table = MagicMock(spec=LiteLLM_BudgetTable)
     mock_budget_table.tpm_limit = 50000  # Generous org TPM limit
-    mock_budget_table.rpm_limit = 5000   # Generous org RPM limit
+    mock_budget_table.rpm_limit = 5000  # Generous org RPM limit
     mock_budget_table.max_budget = None
 
     mock_org = MagicMock(spec=LiteLLM_OrganizationTable)
@@ -4351,7 +4495,7 @@ async def test_update_team_org_scoped_tpm_rpm_bypasses_user_limit():
         "litellm.proxy.proxy_server.proxy_logging_obj"
     ) as mock_logging, patch(
         "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
-        new=AsyncMock(return_value=mock_org)
+        new=AsyncMock(return_value=mock_org),
     ):
 
         # Mock existing org-scoped team
@@ -4367,7 +4511,9 @@ async def test_update_team_org_scoped_tpm_rpm_bypasses_user_limit():
             "tpm_limit": 5000,
             "rpm_limit": 500,
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
         mock_cache.async_set_cache = AsyncMock()
 
         # Mock team update
@@ -4380,7 +4526,9 @@ async def test_update_team_org_scoped_tpm_rpm_bypasses_user_limit():
             "tpm_limit": 10000,
             "rpm_limit": 1000,
         }
-        mock_prisma.db.litellm_teamtable.update = AsyncMock(return_value=mock_updated_team)
+        mock_prisma.db.litellm_teamtable.update = AsyncMock(
+            return_value=mock_updated_team
+        )
         mock_prisma.jsonify_team_object = MagicMock(side_effect=lambda db_data: db_data)
 
         # Should succeed - bypasses user limits since org-scoped
@@ -4428,6 +4576,7 @@ async def test_update_team_guardrails_with_org_id():
 
     # Mock organization with all required fields including teams (the fix)
     from datetime import datetime
+
     mock_org = MagicMock(spec=LiteLLM_OrganizationTable)
     mock_org.organization_id = "test-org-guardrails"
     mock_org.models = ["gpt-4", "gpt-3.5-turbo"]
@@ -4459,7 +4608,8 @@ async def test_update_team_guardrails_with_org_id():
     ), patch(
         "litellm.proxy.proxy_server.create_audit_log_for_update", new=AsyncMock()
     ), patch(
-        "litellm.proxy.proxy_server.premium_user", True  # Required for guardrails feature
+        "litellm.proxy.proxy_server.premium_user",
+        True,  # Required for guardrails feature
     ):
         # Mock existing team - must have compatible models with organization
         mock_existing_team = MagicMock()
@@ -4495,7 +4645,9 @@ async def test_update_team_guardrails_with_org_id():
         mock_updated_team = MagicMock(spec=LiteLLM_TeamTable)
         mock_updated_team.team_id = "team-guardrails-123"
         mock_updated_team.organization_id = "test-org-guardrails"
-        mock_updated_team.metadata = {"guardrails": ["aporia-pre-call", "aporia-post-call"]}
+        mock_updated_team.metadata = {
+            "guardrails": ["aporia-pre-call", "aporia-post-call"]
+        }
         mock_updated_team.litellm_model_table = None
         mock_updated_team.model_dump.return_value = {
             "team_id": "team-guardrails-123",
@@ -4520,16 +4672,23 @@ async def test_update_team_guardrails_with_org_id():
             # Verify the team was updated successfully with guardrails
             assert result is not None
             assert result["data"].organization_id == "test-org-guardrails"
-            assert result["data"].metadata["guardrails"] == ["aporia-pre-call", "aporia-post-call"]
+            assert result["data"].metadata["guardrails"] == [
+                "aporia-pre-call",
+                "aporia-post-call",
+            ]
 
             # Verify that organization fetch was called with proper include clause
             # The function is called twice: once by fetch_and_validate_organization (with include)
             # and once by get_org_object (without include). We verify the first call has 'teams'.
             assert mock_prisma.db.litellm_organizationtable.find_unique.call_count >= 1
-            
+
             # Get the first call (from fetch_and_validate_organization)
-            first_call_kwargs = mock_prisma.db.litellm_organizationtable.find_unique.call_args_list[0].kwargs
-            
+            first_call_kwargs = (
+                mock_prisma.db.litellm_organizationtable.find_unique.call_args_list[
+                    0
+                ].kwargs
+            )
+
             # Verify that 'teams' is included in the fetch
             assert "include" in first_call_kwargs
             assert "teams" in first_call_kwargs["include"]
@@ -4579,7 +4738,9 @@ def test_transform_teams_to_deleted_records():
     assert all("litellm_changed_by" in record for record in records)
     assert all(record["deleted_by"] == "user-123" for record in records)
     # UserAPIKeyAuth hashes the api_key, so we check against the hashed value
-    assert all(record["deleted_by_api_key"] == user_api_key_dict.api_key for record in records)
+    assert all(
+        record["deleted_by_api_key"] == user_api_key_dict.api_key for record in records
+    )
     assert all(record["litellm_changed_by"] == "admin-user" for record in records)
 
     record1 = records[0]
@@ -4878,16 +5039,18 @@ async def test_team_member_delete_persists_deleted_keys(monkeypatch):
     assert all(record["team_id"] == "team-1" for record in records)
     assert all(record["user_id"] == "user-123" for record in records)
     mock_delete_keys.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_new_team_negative_max_budget():
     """
     Test that NewTeamRequest model allows negative max_budget values.
     Validation is done at API level, not model level.
-    
+
     This prevents GET requests from breaking when they receive data with negative budgets.
     """
     from litellm.proxy._types import NewTeamRequest
-    
+
     # Should not raise any errors at model level
     request = NewTeamRequest(team_alias="test-team", max_budget=-7.0)
     assert request.max_budget == -7.0
@@ -4900,7 +5063,7 @@ async def test_new_team_negative_team_member_budget():
     Validation is done at API level, not model level.
     """
     from litellm.proxy._types import NewTeamRequest
-    
+
     # Should not raise any errors at model level
     request = NewTeamRequest(team_alias="test-team", team_member_budget=-10.0)
     assert request.team_member_budget == -10.0
@@ -4913,7 +5076,7 @@ async def test_update_team_negative_max_budget():
     Validation is done at API level, not model level.
     """
     from litellm.proxy._types import UpdateTeamRequest
-    
+
     # Should not raise any errors at model level
     request = UpdateTeamRequest(team_id="test-team-id", max_budget=-5.0)
     assert request.max_budget == -5.0
@@ -4926,7 +5089,7 @@ async def test_update_team_negative_team_member_budget():
     Validation is done at API level, not model level.
     """
     from litellm.proxy._types import UpdateTeamRequest
-    
+
     # Should not raise any errors at model level
     request = UpdateTeamRequest(team_id="test-team-id", team_member_budget=-15.0)
     assert request.team_member_budget == -15.0
@@ -4941,18 +5104,37 @@ async def test_update_team_negative_team_member_budget():
         # Test 2: Soft budget with higher max budget, success with both set
         (50.0, 100.0, True, 50.0, 100.0, None),
         # Test 3: Soft budget with lower max budget, fail
-        (100.0, 50.0, False, None, None, "soft_budget (100.0) must be strictly lower than max_budget (50.0)"),
+        (
+            100.0,
+            50.0,
+            False,
+            None,
+            None,
+            "soft_budget (100.0) must be strictly lower than max_budget (50.0)",
+        ),
         # Test 4: Soft budget equal to max budget, fail
-        (100.0, 100.0, False, None, None, "soft_budget (100.0) must be strictly lower than max_budget (100.0)"),
+        (
+            100.0,
+            100.0,
+            False,
+            None,
+            None,
+            "soft_budget (100.0) must be strictly lower than max_budget (100.0)",
+        ),
     ],
 )
 @pytest.mark.asyncio
 async def test_new_team_soft_budget_validation(
-    soft_budget, max_budget, should_succeed, expected_soft_budget, expected_max_budget, error_message
+    soft_budget,
+    max_budget,
+    should_succeed,
+    expected_soft_budget,
+    expected_max_budget,
+    error_message,
 ):
     """
     Test soft_budget validation in /team/new endpoint.
-    
+
     Covers:
     - Soft budget only - success + soft budget set
     - Soft budget with higher max budget, success with both set
@@ -4995,15 +5177,16 @@ async def test_new_team_soft_budget_validation(
         mock_prisma.jsonify_team_object = lambda db_data: db_data
         mock_prisma.get_data = AsyncMock(return_value=None)
         mock_prisma.update_data = AsyncMock()
-        
+
         # Mock user cache
         from litellm.proxy._types import LiteLLM_UserTable
+
         mock_user_obj = LiteLLM_UserTable(
             user_id="admin-user",
             max_budget=None,  # Admin has no budget limit
         )
         mock_cache.async_get_cache = AsyncMock(return_value=mock_user_obj)
-        
+
         # Mock team creation
         mock_created_team = MagicMock()
         mock_created_team.team_id = "test-team-123"
@@ -5019,21 +5202,30 @@ async def test_new_team_soft_budget_validation(
             "max_budget": expected_max_budget,
             "members_with_roles": [],
         }
-        mock_prisma.db.litellm_teamtable.create = AsyncMock(return_value=mock_created_team)
-        mock_prisma.db.litellm_teamtable.update = AsyncMock(return_value=mock_created_team)
-        
+        mock_prisma.db.litellm_teamtable.create = AsyncMock(
+            return_value=mock_created_team
+        )
+        mock_prisma.db.litellm_teamtable.update = AsyncMock(
+            return_value=mock_created_team
+        )
+
         # Mock model table
         mock_prisma.db.litellm_modeltable = MagicMock()
-        mock_prisma.db.litellm_modeltable.create = AsyncMock(return_value=MagicMock(id="model123"))
-        
+        mock_prisma.db.litellm_modeltable.create = AsyncMock(
+            return_value=MagicMock(id="model123")
+        )
+
         # Mock user table operations
         mock_user = MagicMock()
         mock_user.user_id = "admin-user"
-        mock_user.model_dump.return_value = {"user_id": "admin-user", "teams": ["test-team-123"]}
+        mock_user.model_dump.return_value = {
+            "user_id": "admin-user",
+            "teams": ["test-team-123"],
+        }
         mock_prisma.db.litellm_usertable = MagicMock()
         mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
-        
+
         # Mock team membership table
         mock_membership = MagicMock()
         mock_membership.model_dump.return_value = {
@@ -5042,7 +5234,9 @@ async def test_new_team_soft_budget_validation(
             "budget_id": None,
         }
         mock_prisma.db.litellm_teammembership = MagicMock()
-        mock_prisma.db.litellm_teammembership.create = AsyncMock(return_value=mock_membership)
+        mock_prisma.db.litellm_teammembership.create = AsyncMock(
+            return_value=mock_membership
+        )
 
         if should_succeed:
             # Should NOT raise an exception
@@ -5069,7 +5263,7 @@ async def test_new_team_soft_budget_validation(
                 )
 
             # Verify exception details
-            assert exc_info.value.code == '400'
+            assert exc_info.value.code == "400"
             if error_message:
                 assert error_message in str(exc_info.value.message)
 
@@ -5083,25 +5277,58 @@ async def test_new_team_soft_budget_validation(
         # Test 2: Soft budget with max budget - success if soft budget is strictly lower than max budget
         (None, None, 50.0, 100.0, True, 50.0, 100.0, None),
         # Test 3: Soft budget with max budget - fail if soft budget >= max budget
-        (None, None, 100.0, 50.0, False, None, None, "soft_budget (100.0) must be strictly lower than max_budget (50.0)"),
+        (
+            None,
+            None,
+            100.0,
+            50.0,
+            False,
+            None,
+            None,
+            "soft_budget (100.0) must be strictly lower than max_budget (50.0)",
+        ),
         # Test 4: Only max budget with existing soft_budget, success with max_budget strictly greater
         (50.0, None, None, 100.0, True, 50.0, 100.0, None),
         # Test 5: Only max budget with existing soft_budget, fail if max_budget <= soft_budget
-        (50.0, None, None, 50.0, False, None, None, "max_budget (50.0) must be strictly greater than soft_budget (50.0)"),
+        (
+            50.0,
+            None,
+            None,
+            50.0,
+            False,
+            None,
+            None,
+            "max_budget (50.0) must be strictly greater than soft_budget (50.0)",
+        ),
         # Test 6: Update both soft_budget and max_budget - success if soft < max
         (30.0, 100.0, 40.0, 80.0, True, 40.0, 80.0, None),
         # Test 7: Update both soft_budget and max_budget - fail if soft >= max
-        (30.0, 100.0, 80.0, 40.0, False, None, None, "soft_budget (80.0) must be strictly lower than max_budget (40.0)"),
+        (
+            30.0,
+            100.0,
+            80.0,
+            40.0,
+            False,
+            None,
+            None,
+            "soft_budget (80.0) must be strictly lower than max_budget (40.0)",
+        ),
     ],
 )
 @pytest.mark.asyncio
 async def test_update_team_soft_budget_validation(
-    existing_soft_budget, existing_max_budget, update_soft_budget, update_max_budget,
-    should_succeed, expected_soft_budget, expected_max_budget, error_message
+    existing_soft_budget,
+    existing_max_budget,
+    update_soft_budget,
+    update_max_budget,
+    should_succeed,
+    expected_soft_budget,
+    expected_max_budget,
+    error_message,
 ):
     """
     Test soft_budget validation in /team/update endpoint.
-    
+
     Covers:
     - Soft budget only (no previous max_budget) - success with soft budget set
     - Soft budget with max budget - success if soft budget is strictly lower than max budget, fail otherwise
@@ -5153,7 +5380,9 @@ async def test_update_team_soft_budget_validation(
             "soft_budget": existing_soft_budget,
             "max_budget": existing_max_budget,
         }
-        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+        mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
 
         # Mock user cache
         mock_user_obj = LiteLLM_UserTable(
@@ -5163,9 +5392,15 @@ async def test_update_team_soft_budget_validation(
         mock_cache.async_get_cache = AsyncMock(return_value=mock_user_obj)
 
         # Mock updated team - preserve existing values if not being updated
-        final_soft_budget = update_soft_budget if update_soft_budget is not None else existing_soft_budget
-        final_max_budget = update_max_budget if update_max_budget is not None else existing_max_budget
-        
+        final_soft_budget = (
+            update_soft_budget
+            if update_soft_budget is not None
+            else existing_soft_budget
+        )
+        final_max_budget = (
+            update_max_budget if update_max_budget is not None else existing_max_budget
+        )
+
         mock_updated_team = MagicMock()
         mock_updated_team.team_id = "test-team-123"
         mock_updated_team.organization_id = None
@@ -5177,9 +5412,13 @@ async def test_update_team_soft_budget_validation(
             "soft_budget": final_soft_budget,
             "max_budget": final_max_budget,
         }
-        mock_prisma.db.litellm_teamtable.update = AsyncMock(return_value=mock_updated_team)
+        mock_prisma.db.litellm_teamtable.update = AsyncMock(
+            return_value=mock_updated_team
+        )
         mock_prisma.jsonify_team_object = lambda db_data: db_data
-        mock_cache.async_set_cache = AsyncMock()  # Mock cache set for _cache_team_object
+        mock_cache.async_set_cache = (
+            AsyncMock()
+        )  # Mock cache set for _cache_team_object
 
         if should_succeed:
             # Should NOT raise an exception
@@ -5212,7 +5451,7 @@ async def test_update_team_soft_budget_validation(
                 )
 
             # Verify exception details
-            assert exc_info.value.code == '400'
+            assert exc_info.value.code == "400"
             if error_message:
                 assert error_message in str(exc_info.value.message)
 
@@ -5223,12 +5462,10 @@ async def test_new_team_positive_budgets_accepted():
     Test that NewTeamRequest accepts positive budget values.
     """
     from litellm.proxy._types import NewTeamRequest
-    
+
     # Should not raise any errors
     request = NewTeamRequest(
-        team_alias="test-team", 
-        max_budget=100.0, 
-        team_member_budget=50.0
+        team_alias="test-team", max_budget=100.0, team_member_budget=50.0
     )
     assert request.max_budget == 100.0
     assert request.team_member_budget == 50.0
@@ -5363,9 +5600,7 @@ async def test_get_team_daily_activity_non_admin_filters_by_user_api_keys(
     user_api_key_2.token = "user_key_2"
 
     # Setup mocks
-    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(
-        return_value=[mock_team]
-    )
+    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(return_value=[mock_team])
     mock_db_client.db.litellm_verificationtoken.find_many = AsyncMock(
         return_value=[user_api_key_1, user_api_key_2]
     )
@@ -5451,9 +5686,7 @@ async def test_get_team_daily_activity_team_admin_sees_all_spend(mock_db_client)
     }
 
     # Setup mocks
-    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(
-        return_value=[mock_team]
-    )
+    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(return_value=[mock_team])
 
     # Mock get_user_object
     with patch(
@@ -5489,9 +5722,10 @@ async def test_get_team_daily_activity_team_admin_sees_all_spend(mock_db_client)
             assert call_kwargs["entity_id"] == [team_id]
 
             # Verify user's API keys were NOT fetched (since they're admin)
-            if hasattr(
-                mock_db_client.db.litellm_verificationtoken, "find_many"
-            ) and mock_db_client.db.litellm_verificationtoken.find_many.called:
+            if (
+                hasattr(mock_db_client.db.litellm_verificationtoken, "find_many")
+                and mock_db_client.db.litellm_verificationtoken.find_many.called
+            ):
                 # If it was called, that's unexpected for admin users
                 assert False, "API keys should not be fetched for team admin users"
 
@@ -5540,9 +5774,7 @@ async def test_get_team_daily_activity_member_with_permission_sees_all_spend(
     }
 
     # Setup mocks
-    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(
-        return_value=[mock_team]
-    )
+    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(return_value=[mock_team])
 
     # Mock get_user_object
     with patch(
@@ -5578,9 +5810,10 @@ async def test_get_team_daily_activity_member_with_permission_sees_all_spend(
             assert call_kwargs["entity_id"] == [team_id]
 
             # Verify user's API keys were NOT fetched
-            if hasattr(
-                mock_db_client.db.litellm_verificationtoken, "find_many"
-            ) and mock_db_client.db.litellm_verificationtoken.find_many.called:
+            if (
+                hasattr(mock_db_client.db.litellm_verificationtoken, "find_many")
+                and mock_db_client.db.litellm_verificationtoken.find_many.called
+            ):
                 assert (
                     False
                 ), "API keys should not be fetched for members with /team/daily/activity permission"
@@ -5636,9 +5869,7 @@ async def test_get_team_daily_activity_member_without_permission_filters_by_keys
     user_api_key_2.token = "user_key_def"
 
     # Setup mocks
-    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(
-        return_value=[mock_team]
-    )
+    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(return_value=[mock_team])
     mock_db_client.db.litellm_verificationtoken.find_many = AsyncMock(
         return_value=[user_api_key_1, user_api_key_2]
     )
@@ -5806,9 +6037,7 @@ async def test_get_team_daily_activity_non_admin_filters_by_user_api_keys(
     user_api_key_2.token = "user_key_2"
 
     # Setup mocks
-    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(
-        return_value=[mock_team]
-    )
+    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(return_value=[mock_team])
     mock_db_client.db.litellm_verificationtoken.find_many = AsyncMock(
         return_value=[user_api_key_1, user_api_key_2]
     )
@@ -5894,9 +6123,7 @@ async def test_get_team_daily_activity_team_admin_sees_all_spend(mock_db_client)
     }
 
     # Setup mocks
-    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(
-        return_value=[mock_team]
-    )
+    mock_db_client.db.litellm_teamtable.find_many = AsyncMock(return_value=[mock_team])
 
     # Mock get_user_object
     with patch(
@@ -5932,9 +6159,10 @@ async def test_get_team_daily_activity_team_admin_sees_all_spend(mock_db_client)
             assert call_kwargs["entity_id"] == [team_id]
 
             # Verify user's API keys were NOT fetched (since they're admin)
-            if hasattr(
-                mock_db_client.db.litellm_verificationtoken, "find_many"
-            ) and mock_db_client.db.litellm_verificationtoken.find_many.called:
+            if (
+                hasattr(mock_db_client.db.litellm_verificationtoken, "find_many")
+                and mock_db_client.db.litellm_verificationtoken.find_many.called
+            ):
                 # If it was called, that's unexpected for admin users
                 assert False, "API keys should not be fetched for team admin users"
 
@@ -5947,28 +6175,28 @@ async def test_validate_and_populate_member_user_info_both_provided_match():
     """
     # Create member with both user_email and user_id
     member = Member(user_email="test@example.com", user_id="user-123", role="user")
-    
+
     # Mock prisma client
     mock_prisma_client = MagicMock()
-    
+
     # Mock user object that matches both email and user_id
     mock_user = MagicMock()
     mock_user.user_id = "user-123"
     mock_user.user_email = "test@example.com"
-    
+
     # Mock get_data to return single user matching email
     mock_prisma_client.get_data = AsyncMock(return_value=[mock_user])
-    
+
     # Call the function
     result = await _validate_and_populate_member_user_info(
         member=member,
         prisma_client=mock_prisma_client,
     )
-    
+
     # Verify result matches input (both already provided and match)
     assert result.user_email == "test@example.com"
     assert result.user_id == "user-123"
-    
+
     # Verify get_data was called with correct parameters
     mock_prisma_client.get_data.assert_called_once_with(
         key_val={"user_email": "test@example.com"},
@@ -5985,38 +6213,38 @@ async def test_validate_and_populate_member_user_info_only_email_provided():
     """
     # Create member with only user_email
     member = Member(user_email="test@example.com", user_id=None, role="user")
-    
+
     # Mock prisma client
     mock_prisma_client = MagicMock()
-    
+
     # Mock user object from find_first
     mock_user_find_first = MagicMock()
     mock_user_find_first.user_id = "user-456"
     mock_user_find_first.user_email = "test@example.com"
-    
+
     # Mock find_first to return the user
     mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
         return_value=mock_user_find_first
     )
-    
+
     # Mock get_data to return single user (no duplicates)
     mock_prisma_client.get_data = AsyncMock(return_value=[mock_user_find_first])
-    
+
     # Call the function
     result = await _validate_and_populate_member_user_info(
         member=member,
         prisma_client=mock_prisma_client,
     )
-    
+
     # Verify user_id was populated
     assert result.user_email == "test@example.com"
     assert result.user_id == "user-456"
-    
+
     # Verify find_first was called with correct parameters
     mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(
         where={"user_email": {"equals": "test@example.com", "mode": "insensitive"}}
     )
-    
+
     # Verify get_data was called to check for duplicates
     mock_prisma_client.get_data.assert_called_once_with(
         key_val={"user_email": "test@example.com"},
@@ -6034,24 +6262,24 @@ async def test_validate_and_populate_member_user_info_only_user_id_not_found():
     """
     # Create member with only user_id
     member = Member(user_email=None, user_id="nonexistent-user", role="user")
-    
+
     # Mock prisma client
     mock_prisma_client = MagicMock()
-    
+
     # Mock find_unique to return None (user not found)
     mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-    
+
     # Call the function - should NOT raise an exception
     result = await _validate_and_populate_member_user_info(
         member=member,
         prisma_client=mock_prisma_client,
     )
-    
+
     # Verify the result - should return member with user_id set and user_email as None
     assert result.user_id == "nonexistent-user"
     assert result.user_email is None
     assert result.role == "user"
-    
+
     # Verify find_unique was called with correct parameters
     mock_prisma_client.db.litellm_usertable.find_unique.assert_called_once_with(
         where={"user_id": "nonexistent-user"}
@@ -6069,9 +6297,7 @@ async def test_list_available_teams_returns_empty_list_when_none_configured():
     mock_request = MagicMock()
     mock_user_key = UserAPIKeyAuth(user_id="test-user", token="fake-token")
 
-    with patch(
-        "litellm.proxy.proxy_server.prisma_client", mock_prisma_client
-    ):
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
         # Case 1: default_internal_user_params is None
         original = litellm.default_internal_user_params
         litellm.default_internal_user_params = None
@@ -6090,3 +6316,108 @@ async def test_list_available_teams_returns_empty_list_when_none_configured():
         assert result == []
 
         litellm.default_internal_user_params = original
+
+
+@pytest.mark.asyncio
+async def test_update_team_converts_organization_id_to_relation_syntax(
+    mock_db_client, mock_admin_auth
+):
+    """
+    Test that /team/update converts organization_id to Prisma relation
+    connect/disconnect syntax instead of passing it as a scalar field,
+    which causes 'Could not find field at
+    updateOneLiteLLM_TeamTable.data.organization_id'.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/22201
+    """
+    mock_db_client.jsonify_team_object = lambda db_data: db_data
+    mock_db_client.db = MagicMock()
+
+    existing_team_mock = MagicMock()
+    existing_team_mock.team_id = "team-org-update-123"
+    existing_team_mock.organization_id = None
+    existing_team_mock.max_budget = None
+    existing_team_mock.soft_budget = None
+    existing_team_mock.models = []
+    existing_team_mock.members_with_roles = []
+    existing_team_mock.model_id = None
+    existing_team_mock.model_dump.return_value = {
+        "team_id": "team-org-update-123",
+        "organization_id": None,
+        "models": [],
+        "members_with_roles": [],
+    }
+
+    updated_team_result = MagicMock(team_id="team-org-update-123")
+    updated_team_result.model_dump.return_value = {
+        "team_id": "team-org-update-123",
+    }
+    mock_db_client.db.litellm_teamtable = MagicMock()
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=existing_team_mock
+    )
+    mock_db_client.db.litellm_teamtable.update = AsyncMock(
+        return_value=updated_team_result
+    )
+
+    from fastapi import Request
+
+    from litellm.proxy._types import UpdateTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import update_team
+
+    # Test 1: setting organization_id should use connect
+    team_update_request = UpdateTeamRequest(
+        team_id="team-org-update-123",
+        organization_id="org-456",
+    )
+
+    dummy_request = MagicMock(spec=Request)
+
+    with patch(
+        "litellm.proxy.management_endpoints.team_endpoints.fetch_and_validate_organization",
+        new_callable=AsyncMock,
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints.get_org_object",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        await update_team(
+            data=team_update_request,
+            http_request=dummy_request,
+            user_api_key_dict=mock_admin_auth,
+        )
+
+    update_call_kwargs = mock_db_client.db.litellm_teamtable.update.call_args.kwargs
+    team_data = update_call_kwargs["data"]
+
+    # organization_id should NOT be a direct scalar field
+    assert "organization_id" not in team_data
+    # Should use Prisma relation connect syntax
+    assert "litellm_organization_table" in team_data
+    assert team_data["litellm_organization_table"] == {
+        "connect": {"organization_id": "org-456"}
+    }
+
+    # Test 2: unsetting organization_id (empty string) should use disconnect
+    mock_db_client.db.litellm_teamtable.update.reset_mock()
+    mock_db_client.db.litellm_teamtable.update = AsyncMock(
+        return_value=updated_team_result
+    )
+
+    team_update_request_unset = UpdateTeamRequest(
+        team_id="team-org-update-123",
+        organization_id="",
+    )
+
+    await update_team(
+        data=team_update_request_unset,
+        http_request=dummy_request,
+        user_api_key_dict=mock_admin_auth,
+    )
+
+    update_call_kwargs = mock_db_client.db.litellm_teamtable.update.call_args.kwargs
+    team_data = update_call_kwargs["data"]
+
+    assert "organization_id" not in team_data
+    assert "litellm_organization_table" in team_data
+    assert team_data["litellm_organization_table"] == {"disconnect": True}


### PR DESCRIPTION
## Relevant issues

Fixes #22201

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai`

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
      Link:

- [ ] **CI run for the last commit**
      Link:

- [ ] **Merge / cherry-pick CI run**
      Links:

## Type

🐛 Bug Fix

## Changes

Editing a team in the proxy UI fails with `"Could not find field at updateOneLiteLLM_TeamTable.data.organization_id"` because Prisma Client Python does not accept scalar foreign key fields directly in `update()` operations when a relation is defined on that field.

**Root cause:** The `/team/update` endpoint serializes the `UpdateTeamRequest` to a dict (including `organization_id`) and passes it directly to `prisma_client.db.litellm_teamtable.update(data=...)`. Prisma requires the relation `connect`/`disconnect` syntax instead.

**Fix:** Before the Prisma `update()` call, pop `organization_id` from the update dict and convert it to proper Prisma relation syntax:
- Non-empty `organization_id` → `{"litellm_organization_table": {"connect": {"organization_id": ...}}}`
- Empty/null `organization_id` → `{"litellm_organization_table": {"disconnect": True}}`