### PR TITLE
fix(proxy): use exact match for key_alias filter in spend logs UI

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1672,7 +1672,8 @@ async def ui_view_spend_logs(  # noqa: PLR0915
         default=None, description="Filter logs by model"
     ),
     model_id: Optional[str] = fastapi.Query(
-        default=None, description="Filter logs by model ID (litellm model deployment id)"
+        default=None,
+        description="Filter logs by model ID (litellm model deployment id)",
     ),
     key_alias: Optional[str] = fastapi.Query(
         default=None, description="Filter logs by key alias"
@@ -1726,7 +1727,13 @@ async def ui_view_spend_logs(  # noqa: PLR0915
         )
 
     # Validate sort_by and sort_order
-    valid_sort_fields = {"spend", "total_tokens", "startTime", "endTime", "request_duration_ms"}
+    valid_sort_fields = {
+        "spend",
+        "total_tokens",
+        "startTime",
+        "endTime",
+        "request_duration_ms",
+    }
     if sort_by not in valid_sort_fields:
         raise ProxyException(
             message=f"Invalid sort_by: {sort_by}. Must be one of: {', '.join(sorted(valid_sort_fields))}",
@@ -1753,7 +1760,11 @@ async def ui_view_spend_logs(  # noqa: PLR0915
                     return datetime.strptime(date_str, fmt).replace(tzinfo=timezone.utc)
                 except ValueError:
                     continue
-            expected = "'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS'" if is_v2 else "'YYYY-MM-DD HH:MM:SS'"
+            expected = (
+                "'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS'"
+                if is_v2
+                else "'YYYY-MM-DD HH:MM:SS'"
+            )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Invalid date format: {date_str}. Expected: {expected}",
@@ -1796,22 +1807,28 @@ async def ui_view_spend_logs(  # noqa: PLR0915
         # Build metadata filters
         metadata_filters = []
         if key_alias is not None:
-            metadata_filters.append({
-                "path": ["user_api_key_alias"],
-                "string_contains": key_alias,
-            })
+            metadata_filters.append(
+                {
+                    "path": ["user_api_key_alias"],
+                    "equals": f'"{key_alias}"',
+                }
+            )
 
         if error_code is not None:
-            metadata_filters.append({
-                "path": ["error_information", "error_code"],
-                "equals": f'"{error_code}"',
-            })
+            metadata_filters.append(
+                {
+                    "path": ["error_information", "error_code"],
+                    "equals": f'"{error_code}"',
+                }
+            )
 
         if error_message is not None:
-            metadata_filters.append({
-                "path": ["error_information", "error_message"],
-                "string_contains": error_message,
-            })
+            metadata_filters.append(
+                {
+                    "path": ["error_information", "error_message"],
+                    "string_contains": error_message,
+                }
+            )
 
         if metadata_filters:
             if len(metadata_filters) == 1:
@@ -1919,16 +1936,24 @@ async def ui_view_spend_logs(  # noqa: PLR0915
             sql_params.append(f"%{key_alias}%")
             p += 1
         if error_code is not None:
-            sql_conditions.append(f"metadata->'error_information'->>'error_code' = ${p}")
+            sql_conditions.append(
+                f"metadata->'error_information'->>'error_code' = ${p}"
+            )
             sql_params.append(error_code)
             p += 1
         if error_message is not None:
-            sql_conditions.append(f"metadata->'error_information'->>'error_message' LIKE ${p}")
+            sql_conditions.append(
+                f"metadata->'error_information'->>'error_message' LIKE ${p}"
+            )
             sql_params.append(f"%{error_message}%")
             p += 1
 
         # Quote column names that need quoting in SQL
-        _sql_col = f'"{order_column}"' if order_column in ("startTime", "endTime") else order_column
+        _sql_col = (
+            f'"{order_column}"'
+            if order_column in ("startTime", "endTime")
+            else order_column
+        )
         _sql_dir = "ASC" if order_direction == "asc" else "DESC"
 
         sql_query = f"""
@@ -3041,16 +3066,14 @@ async def provider_budgets() -> ProviderBudgetResponse:
 async def get_spend_by_tags(
     prisma_client: PrismaClient, start_date=None, end_date=None
 ):
-    response = await prisma_client.db.query_raw(
-        """
+    response = await prisma_client.db.query_raw("""
         SELECT
         jsonb_array_elements_text(request_tags) AS individual_request_tag,
         COUNT(*) AS log_count,
         SUM(spend) AS total_spend
         FROM "LiteLLM_SpendLogs"
         GROUP BY individual_request_tag;
-        """
-    )
+        """)
 
     return response
 
@@ -3218,7 +3241,9 @@ async def ui_view_session_spend_logs(
             ORDER BY "startTime" ASC
             LIMIT $2 OFFSET $3
         """
-        result = await prisma_client.db.query_raw(sql_query, session_id, page_size, skip)
+        result = await prisma_client.db.query_raw(
+            sql_query, session_id, page_size, skip
+        )
 
         total_pages = (total_records + page_size - 1) // page_size
 
@@ -3280,9 +3305,17 @@ async def _build_ui_spend_logs_response(
     if enrich_session_counts:
         session_ids = list(
             {
-                (row.get("session_id") if isinstance(row, dict) else getattr(row, "session_id", None))
+                (
+                    row.get("session_id")
+                    if isinstance(row, dict)
+                    else getattr(row, "session_id", None)
+                )
                 for row in data
-                if (row.get("session_id") if isinstance(row, dict) else getattr(row, "session_id", None))
+                if (
+                    row.get("session_id")
+                    if isinstance(row, dict)
+                    else getattr(row, "session_id", None)
+                )
             }
         )
         if session_ids:
@@ -3304,11 +3337,7 @@ async def _build_ui_spend_logs_response(
     if enrich_session_counts:
         enriched: List[dict] = []
         for row in data:
-            row_dict = (
-                dict(row)
-                if isinstance(row, dict)
-                else row.model_dump()
-            )
+            row_dict = dict(row) if isinstance(row, dict) else row.model_dump()
             sid = row_dict.get("session_id")
             row_dict["session_total_count"] = count_map.get(sid, 1) if sid else 1
             enriched.append(row_dict)
@@ -3383,7 +3412,11 @@ def _can_user_view_spend_log(user_api_key_dict: UserAPIKeyAuth) -> bool:
     """
     user_role = user_api_key_dict.user_role
     user_id = user_api_key_dict.user_id
-    return user_role in (
-        LitellmUserRoles.INTERNAL_USER,
-        LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
-    ) and user_id is not None
+    return (
+        user_role
+        in (
+            LitellmUserRoles.INTERNAL_USER,
+            LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
+        )
+        and user_id is not None
+    )

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -94,6 +94,8 @@ def make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_fn, team_lookup_fn=No
                 self.find_unique = team_lookup_fn
 
     return MockPrismaClient()
+
+
 from litellm.proxy._types import (
     LitellmUserRoles,
     Member,
@@ -111,7 +113,9 @@ from litellm.types.utils import BudgetConfig
 async def test_is_admin_view_safe_true(monkeypatch):
     # Force underlying check to return True
     monkeypatch.setattr(
-        spend_management_endpoints, "_user_has_admin_view", lambda user_api_key_dict: True
+        spend_management_endpoints,
+        "_user_has_admin_view",
+        lambda user_api_key_dict: True,
     )
     auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user")
     assert spend_management_endpoints._is_admin_view_safe(auth) is True
@@ -121,7 +125,9 @@ async def test_is_admin_view_safe_true(monkeypatch):
 async def test_is_admin_view_safe_false(monkeypatch):
     # Force underlying check to return False
     monkeypatch.setattr(
-        spend_management_endpoints, "_user_has_admin_view", lambda user_api_key_dict: False
+        spend_management_endpoints,
+        "_user_has_admin_view",
+        lambda user_api_key_dict: False,
     )
     auth = UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER, user_id="user_1")
     assert spend_management_endpoints._is_admin_view_safe(auth) is False
@@ -179,7 +185,9 @@ async def test_can_team_member_view_log_team_not_found(monkeypatch):
     prisma = MockPrisma()
     # Even if admin check would return True, no team means False
     monkeypatch.setattr(
-        spend_management_endpoints, "_is_user_team_admin", lambda user_api_key_dict, team_obj: True
+        spend_management_endpoints,
+        "_is_user_team_admin",
+        lambda user_api_key_dict, team_obj: True,
     )
     auth = UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER, user_id="user_1")
     allowed = await spend_management_endpoints._can_team_member_view_log(
@@ -208,7 +216,9 @@ async def test_can_team_member_view_log_not_admin(monkeypatch):
 
     prisma = MockPrisma()
     monkeypatch.setattr(
-        spend_management_endpoints, "_is_user_team_admin", lambda user_api_key_dict, team_obj: False
+        spend_management_endpoints,
+        "_is_user_team_admin",
+        lambda user_api_key_dict, team_obj: False,
     )
     auth = UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER, user_id="user_1")
     allowed = await spend_management_endpoints._can_team_member_view_log(
@@ -237,7 +247,9 @@ async def test_can_team_member_view_log_admin(monkeypatch):
 
     prisma = MockPrisma()
     monkeypatch.setattr(
-        spend_management_endpoints, "_is_user_team_admin", lambda user_api_key_dict, team_obj: True
+        spend_management_endpoints,
+        "_is_user_team_admin",
+        lambda user_api_key_dict, team_obj: True,
     )
     auth = UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER, user_id="user_1")
     allowed = await spend_management_endpoints._can_team_member_view_log(
@@ -266,6 +278,7 @@ def test_can_user_view_spend_log_false_without_user_id():
 def test_can_user_view_spend_log_false_for_other_roles():
     auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin")
     assert spend_management_endpoints._can_user_view_spend_log(auth) is False
+
 
 ignored_keys = [
     "request_id",
@@ -502,7 +515,11 @@ async def test_ui_view_spend_logs_sort_by_and_sort_order(
 
     async def mock_query_raw(sql_query, *params):
         # Endpoint uses raw SQL with ORDER BY startTime DESC; mock returns sorted data
-        order = {"startTime": "desc"} if sort_by is None else {sort_by: sort_order or "desc"}
+        order = (
+            {"startTime": "desc"}
+            if sort_by is None
+            else {sort_by: sort_order or "desc"}
+        )
         sorted_logs = _sort_logs(base_logs, order)
         page_size = params[-2] if len(params) >= 2 else 50
         skip = params[-1] if len(params) >= 1 else 0
@@ -568,6 +585,7 @@ async def test_ui_view_spend_logs_sort_validation_errors(
     client, monkeypatch, sort_by, sort_order
 ):
     """Test that invalid sort_by and sort_order return 400."""
+
     async def mock_count(*args, **kwargs):
         return 0
 
@@ -752,13 +770,33 @@ async def test_ui_view_spend_logs_with_team_id(client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_ui_view_spend_logs_internal_user_scoped_without_user_id(client, monkeypatch):
+async def test_ui_view_spend_logs_internal_user_scoped_without_user_id(
+    client, monkeypatch
+):
     """
     Internal users should only be able to view their own spend even if user_id is not provided.
     """
     mock_spend_logs = [
-        {"id": "log1", "request_id": "req1", "api_key": "sk-test-key", "user": "internal_user_1", "team_id": "team1", "spend": 0.05, "startTime": datetime.datetime.now(timezone.utc).isoformat(), "model": "gpt-3.5-turbo"},
-        {"id": "log2", "request_id": "req2", "api_key": "sk-test-key", "user": "internal_user_2", "team_id": "team1", "spend": 0.10, "startTime": datetime.datetime.now(timezone.utc).isoformat(), "model": "gpt-4"},
+        {
+            "id": "log1",
+            "request_id": "req1",
+            "api_key": "sk-test-key",
+            "user": "internal_user_1",
+            "team_id": "team1",
+            "spend": 0.05,
+            "startTime": datetime.datetime.now(timezone.utc).isoformat(),
+            "model": "gpt-3.5-turbo",
+        },
+        {
+            "id": "log2",
+            "request_id": "req2",
+            "api_key": "sk-test-key",
+            "user": "internal_user_2",
+            "team_id": "team1",
+            "spend": 0.10,
+            "startTime": datetime.datetime.now(timezone.utc).isoformat(),
+            "model": "gpt-4",
+        },
     ]
 
     def filter_by_user(where):
@@ -799,8 +837,26 @@ async def test_ui_view_spend_logs_team_admin_can_view_team_spend(client, monkeyp
     Team admins should be able to view team-wide spend when team_id is provided.
     """
     mock_spend_logs = [
-        {"id": "log1", "request_id": "req1", "api_key": "sk-test-key", "user": "member1", "team_id": "team_admin_team", "spend": 0.05, "startTime": datetime.datetime.now(timezone.utc).isoformat(), "model": "gpt-3.5-turbo"},
-        {"id": "log2", "request_id": "req2", "api_key": "sk-test-key", "user": "member2", "team_id": "team_other", "spend": 0.10, "startTime": datetime.datetime.now(timezone.utc).isoformat(), "model": "gpt-4"},
+        {
+            "id": "log1",
+            "request_id": "req1",
+            "api_key": "sk-test-key",
+            "user": "member1",
+            "team_id": "team_admin_team",
+            "spend": 0.05,
+            "startTime": datetime.datetime.now(timezone.utc).isoformat(),
+            "model": "gpt-3.5-turbo",
+        },
+        {
+            "id": "log2",
+            "request_id": "req2",
+            "api_key": "sk-test-key",
+            "user": "member2",
+            "team_id": "team_other",
+            "spend": 0.10,
+            "startTime": datetime.datetime.now(timezone.utc).isoformat(),
+            "model": "gpt-4",
+        },
     ]
 
     def filter_by_team(where):
@@ -827,7 +883,11 @@ async def test_ui_view_spend_logs_team_admin_can_view_team_spend(client, monkeyp
 
         response = client.get(
             "/spend/logs/ui",
-            params={"team_id": "team_admin_team", "start_date": start_date, "end_date": end_date},
+            params={
+                "team_id": "team_admin_team",
+                "start_date": start_date,
+                "end_date": end_date,
+            },
             headers={"Authorization": "Bearer sk-test"},
         )
 
@@ -838,6 +898,7 @@ async def test_ui_view_spend_logs_team_admin_can_view_team_spend(client, monkeyp
         assert data["data"][0]["team_id"] == "team_admin_team"
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
 
 @pytest.mark.asyncio
 async def test_ui_view_spend_logs_pagination(client, monkeypatch):
@@ -2163,7 +2224,9 @@ async def test_ui_view_spend_logs_with_error_code(client):
 
     try:
         with patch.object(
-            ps, "prisma_client", make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_by_error_code)
+            ps,
+            "prisma_client",
+            make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_by_error_code),
         ):
             start_date, end_date = _default_date_range()
 
@@ -2234,7 +2297,9 @@ async def test_ui_view_spend_logs_with_error_message(client):
 
     try:
         with patch.object(
-            ps, "prisma_client", make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_by_error_message)
+            ps,
+            "prisma_client",
+            make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_by_error_message),
         ):
             start_date, end_date = _default_date_range()
 
@@ -2255,7 +2320,9 @@ async def test_ui_view_spend_logs_with_error_message(client):
             assert data["data"][0]["id"] == "log1"
             metadata = json.loads(data["data"][0]["metadata"])
             assert "error_information" in metadata
-            assert "Rate limit exceeded" in metadata["error_information"]["error_message"]
+            assert (
+                "Rate limit exceeded" in metadata["error_information"]["error_message"]
+            )
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
 
@@ -2306,7 +2373,7 @@ async def test_ui_view_spend_logs_with_error_code_and_key_alias(client):
                 if "metadata" in cond:
                     mf = cond["metadata"]
                     if mf.get("path") == ["user_api_key_alias"]:
-                        key_alias = mf.get("string_contains")
+                        key_alias = str(mf.get("equals", "")).strip('"')
                     elif mf.get("path") == ["error_information", "error_code"]:
                         error_code = str(mf.get("equals", "")).strip('"')
             if key_alias == "test-key-1" and error_code == "500":
@@ -2321,7 +2388,9 @@ async def test_ui_view_spend_logs_with_error_code_and_key_alias(client):
         with patch.object(
             ps,
             "prisma_client",
-            make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_by_error_code_and_key_alias),
+            make_ui_spend_logs_mock_prisma(
+                mock_spend_logs, filter_by_error_code_and_key_alias
+            ),
         ):
             start_date, end_date = _default_date_range()
 
@@ -2346,6 +2415,91 @@ async def test_ui_view_spend_logs_with_error_code_and_key_alias(client):
             assert metadata["user_api_key_alias"] == "test-key-1"
             assert "error_information" in metadata
             assert metadata["error_information"]["error_code"] == "500"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_ui_view_spend_logs_key_alias_uses_exact_match(client):
+    """
+    Test that key_alias filter uses exact match (equals) instead of fuzzy
+    match (string_contains).  Fuzzy matching caused the UI to show logs
+    for "user01-cli" when searching for "user01", but paging used the
+    exact key hash, resulting in empty pages.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/22556
+    """
+    mock_spend_logs = [
+        {
+            "id": "log-exact",
+            "request_id": "req-exact",
+            "api_key": "sk-key-exact",
+            "user": "u1",
+            "team_id": "team1",
+            "spend": 0.01,
+            "startTime": datetime.datetime.now(timezone.utc).isoformat(),
+            "model": "gpt-4",
+            "metadata": '{"user_api_key_alias": "user01"}',
+        },
+        {
+            "id": "log-partial",
+            "request_id": "req-partial",
+            "api_key": "sk-key-partial",
+            "user": "u2",
+            "team_id": "team1",
+            "spend": 0.02,
+            "startTime": datetime.datetime.now(timezone.utc).isoformat(),
+            "model": "gpt-4",
+            "metadata": '{"user_api_key_alias": "user01-cli"}',
+        },
+    ]
+
+    def verify_exact_match(where):
+        """Only return the exact-match log to prove equals is used."""
+        metadata_cond = where.get("metadata", {})
+        if metadata_cond.get("path") == ["user_api_key_alias"]:
+            # Should be equals, NOT string_contains
+            assert "equals" in metadata_cond, (
+                "key_alias filter should use 'equals' for exact match, "
+                "not 'string_contains'"
+            )
+            assert "string_contains" not in metadata_cond
+            val = str(metadata_cond["equals"]).strip('"')
+            return [
+                r
+                for r in mock_spend_logs
+                if json.loads(r["metadata"])["user_api_key_alias"] == val
+            ]
+        return mock_spend_logs
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        with patch.object(
+            ps,
+            "prisma_client",
+            make_ui_spend_logs_mock_prisma(mock_spend_logs, verify_exact_match),
+        ):
+            start_date, end_date = _default_date_range()
+
+            response = client.get(
+                "/spend/logs/ui",
+                params={
+                    "key_alias": "user01",
+                    "start_date": start_date,
+                    "end_date": end_date,
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            # Should only return the exact match, not the partial match
+            assert data["total"] == 1
+            assert len(data["data"]) == 1
+            assert data["data"][0]["id"] == "log-exact"
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
 


### PR DESCRIPTION
## Relevant issues

Fixes #22556

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai`

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
      Link:

- [ ] **CI run for the last commit**
      Link:

- [ ] **Merge / cherry-pick CI run**
      Links:

## Type

🐛 Bug Fix

## Changes

The `/spend/logs/ui` endpoint used `string_contains` (fuzzy/partial match) for the `key_alias` filter, but the UI's pagination logic resolves the key alias to an exact key hash for subsequent queries. This mismatch caused:

1. First page shows logs for both "user01" and "user01-cli" (partial match)
2. Next page uses the exact hash for "user01", returning empty results

**Fix:** Changed the `key_alias` metadata filter from `string_contains` to `equals` (exact match), making the filtering consistent with the pagination behavior.