### PR TITLE
fix(gemini): accumulate tool_calls from consecutive assistant messages

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -474,7 +474,16 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                             excluded_keys=["thoughtSignature"],
                         ):
                             assistant_content.append(gemini_tool_call_part)
-                    last_message_with_tool_calls = assistant_msg
+                    _tool_calls = assistant_msg.get("tool_calls") or []
+                    if _tool_calls:
+                        if last_message_with_tool_calls is None:
+                            last_message_with_tool_calls = {
+                                "tool_calls": list(_tool_calls)
+                            }
+                        else:
+                            last_message_with_tool_calls["tool_calls"].extend(
+                                _tool_calls
+                            )
 
                 msg_i += 1
 


### PR DESCRIPTION
## Summary
- Fixed parallel tool call matching in Gemini transformation layer by accumulating `tool_calls` from all consecutive assistant messages instead of overwriting with only the last one

## Problem
When using the Responses API (`/v1/responses`) with Gemini 3 models in streaming mode, parallel tool calls fail with:

```
Missing corresponding tool call for tool response message.
```

The Responses API creates one separate assistant message per `function_call` input item. The Gemini format converter merges these into a single `model` turn, but [this line](https://github.com/BerriAI/litellm/blob/main/litellm/llms/vertex_ai/gemini/transformation.py#L477):

```python
last_message_with_tool_calls = assistant_msg
```

...overwrites on each iteration, so only the last assistant message's `tool_calls` survive. When `convert_to_gemini_tool_call_result` then tries to match tool results by call ID, the first tool result can't find its ID.

## Fix
Accumulate `tool_calls` from all consecutive assistant messages:

```python
_tool_calls = assistant_msg.get("tool_calls") or []
if _tool_calls:
    if last_message_with_tool_calls is None:
        last_message_with_tool_calls = {"tool_calls": list(_tool_calls)}
    else:
        last_message_with_tool_calls["tool_calls"].extend(_tool_calls)
```

## Test plan
- [ ] Send parallel tool calls via `/v1/responses` with a Gemini 3 model
- [ ] Verify all tool results are matched to their corresponding tool calls
- [ ] Verify single tool calls still work correctly

**Note:** This PR was generated with AI assistance (Claude Code).

Fixes #22578

🤖 Generated with [Claude Code](https://claude.com/claude-code)