### PR TITLE
fix: update Gemini model deprecation dates

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10996,7 +10996,7 @@
         "supports_tool_choice": true
     },
     "deepinfra/google/gemini-2.0-flash-001": {
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "max_tokens": 1000000,
         "max_input_tokens": 1000000,
         "max_output_tokens": 1000000,
@@ -13497,7 +13497,7 @@
     },
     "gemini-2.0-flash": {
         "cache_read_input_token_cost": 2.5e-08,
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-language-models",
@@ -13537,7 +13537,7 @@
     },
     "gemini-2.0-flash-001": {
         "cache_read_input_token_cost": 3.75e-08,
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai-language-models",
@@ -13623,7 +13623,7 @@
     },
     "gemini-2.0-flash-lite": {
         "cache_read_input_token_cost": 1.875e-08,
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "input_cost_per_audio_token": 7.5e-08,
         "input_cost_per_token": 7.5e-08,
         "litellm_provider": "vertex_ai-language-models",
@@ -13659,7 +13659,7 @@
     },
     "gemini-2.0-flash-lite-001": {
         "cache_read_input_token_cost": 1.875e-08,
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "input_cost_per_audio_token": 7.5e-08,
         "input_cost_per_token": 7.5e-08,
         "litellm_provider": "vertex_ai-language-models",
@@ -14544,6 +14544,7 @@
         "supports_web_search": true
     },
     "gemini-3-pro-preview": {
+        "deprecation_date": "2026-03-26",
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,
         "cache_creation_input_token_cost_above_200k_tokens": 2.5e-07,
@@ -15680,7 +15681,7 @@
     },
     "gemini/gemini-2.0-flash": {
         "cache_read_input_token_cost": 2.5e-08,
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "gemini",
@@ -15721,7 +15722,7 @@
     },
     "gemini/gemini-2.0-flash-001": {
         "cache_read_input_token_cost": 2.5e-08,
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "gemini",
@@ -15809,7 +15810,7 @@
     },
     "gemini/gemini-2.0-flash-lite": {
         "cache_read_input_token_cost": 1.875e-08,
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "input_cost_per_audio_token": 7.5e-08,
         "input_cost_per_token": 7.5e-08,
         "litellm_provider": "gemini",
@@ -15883,7 +15884,7 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.0-flash-live-001": {
-        "deprecation_date": "2025-12-09",
+        "deprecation_date": "2026-06-01",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 2.1e-06,
         "input_cost_per_image": 2.1e-06,
@@ -25119,7 +25120,7 @@
         "supports_tool_choice": true
     },
     "openrouter/google/gemini-2.0-flash-001": {
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
@@ -29933,7 +29934,7 @@
         "supports_tool_choice": true
     },
     "vercel_ai_gateway/google/gemini-2.0-flash": {
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 1048576,
@@ -29947,7 +29948,7 @@
         "supports_response_schema": true
     },
     "vercel_ai_gateway/google/gemini-2.0-flash-lite": {
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "input_cost_per_token": 7.5e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 1048576,
@@ -37288,7 +37289,7 @@
     },
     "gemini/gemini-2.0-flash-lite-001": {
         "cache_read_input_token_cost": 1.875e-08,
-        "deprecation_date": "2026-03-31",
+        "deprecation_date": "2026-06-01",
         "input_cost_per_audio_token": 7.5e-08,
         "input_cost_per_token": 7.5e-08,
         "litellm_provider": "gemini",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -15884,7 +15884,7 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.0-flash-live-001": {
-        "deprecation_date": "2026-06-01",
+        "deprecation_date": "2025-12-09",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 2.1e-06,
         "input_cost_per_image": 2.1e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -15846,7 +15846,7 @@
         "tpm": 4000000
     },
     "gemini/gemini-2.0-flash-lite-preview-02-05": {
-        "deprecation_date": "2025-12-02",
+        "deprecation_date": "2025-12-09",
         "cache_read_input_token_cost": 1.875e-08,
         "input_cost_per_audio_token": 7.5e-08,
         "input_cost_per_token": 7.5e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16801,6 +16801,7 @@
         "tpm": 800000
     },
     "gemini/gemini-3-pro-preview": {
+        "deprecation_date": "2026-03-09",
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,
         "input_cost_per_token": 2e-06,


### PR DESCRIPTION
## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) *(N/A — data-only JSON change, no code logic affected)*
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Update `deprecation_date` values in `model_prices_and_context_window.json` to match the latest Google deprecation notices.

### Gemini 2.0 Flash / Flash Lite retirement extended to 2026-06-01

Updated from `2026-03-31` → `2026-06-01` across all providers:

- **Vertex AI**: `gemini-2.0-flash`, `gemini-2.0-flash-001`, `gemini-2.0-flash-lite`, `gemini-2.0-flash-lite-001`
- **Gemini API**: `gemini/gemini-2.0-flash`, `gemini/gemini-2.0-flash-001`, `gemini/gemini-2.0-flash-lite`, `gemini/gemini-2.0-flash-lite-001`
- **DeepInfra**: `deepinfra/google/gemini-2.0-flash-001`
- **OpenRouter**: `openrouter/google/gemini-2.0-flash-001`
- **Vercel AI Gateway**: `vercel_ai_gateway/google/gemini-2.0-flash`, `vercel_ai_gateway/google/gemini-2.0-flash-lite`

### Gemini 3 Pro Preview — add deprecation_date

Google gives different discontinuation dates per platform:

- **Vertex AI** (`gemini-3-pro-preview`): `2026-03-26`
- **Gemini API** (`gemini/gemini-3-pro-preview`): `2026-03-09`

### Gemini 2.0 Flash Lite Preview — correct deprecation_date

- `gemini/gemini-2.0-flash-lite-preview-02-05`: corrected from `2025-12-02` → `2025-12-09`

### Sources

- Google Cloud Vertex AI email notification (Gemini 3 Pro Preview discontinuation March 26, 2026)
- Google Cloud Vertex AI email notification (Gemini 2.0 Flash/Lite retirement June 1, 2026)
- Google AI Studio email notification (Gemini 2.0 Flash/Lite retirement June 1, 2026)
- https://ai.google.dev/gemini-api/docs/deprecations
- https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions