### PR TITLE
fix: add missing pricing for dashscope/qwen3.5-plus and dashscope/qwen3-vl-plus

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9660,6 +9660,74 @@
             }
         ]
     },
+    "dashscope/qwen3-vl-plus": {
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 260096,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 2e-07,
+                "output_cost_per_token": 1.6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-07,
+                "output_cost_per_token": 2.4e-06,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 6e-07,
+                "output_cost_per_token": 4.8e-06,
+                "range": [
+                    128000.0,
+                    256000.0
+                ]
+            }
+        ]
+    },
+    "dashscope/qwen3.5-plus": {
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_token": 2.4e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 3e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
     "dashscope/qwq-plus": {
         "input_cost_per_token": 8e-07,
         "litellm_provider": "dashscope",


### PR DESCRIPTION
## Relevant issues

Fixes #22591

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory - N/A (pure JSON data update, no code logic changed)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Added missing pricing entries in `model_prices_and_context_window.json` for two DashScope Qwen models that were causing `$0` cost tracking:

- **`dashscope/qwen3.5-plus`** — 1M context, 65K output, tiered pricing (2 tiers: 0-256K, 256K-1M)
- **`dashscope/qwen3-vl-plus`** — 262K context, 32K output, vision support, tiered pricing (3 tiers: 0-32K, 32K-128K, 128K-256K)

Pricing sourced from [official Alibaba Cloud Model Studio docs](https://www.alibabacloud.com/help/en/model-studio/models) (international tier, USD).

Note: `dashscope/qwen3-coder-plus` (also mentioned in the issue) already has correct tiered pricing — no changes needed.