### PR TITLE
fix(gemini): standardize thought_signature vs thought_signatures handling

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1288,8 +1288,10 @@ def _get_thought_signature_from_tool(
     # First check tool's provider_specific_fields
     provider_fields = tool.get("provider_specific_fields") or {}
     if isinstance(provider_fields, dict):
-        signature = provider_fields.get("thought_signature")
+        signature = provider_fields.get("thought_signature") or provider_fields.get("thought_signatures")
         if signature:
+            if isinstance(signature, list) and len(signature) > 0:
+                return signature[0]
             return signature
 
     # Then check function's provider_specific_fields
@@ -1298,16 +1300,20 @@ def _get_thought_signature_from_tool(
         if isinstance(function, dict):
             func_provider_fields = function.get("provider_specific_fields") or {}
             if isinstance(func_provider_fields, dict):
-                signature = func_provider_fields.get("thought_signature")
+                signature = func_provider_fields.get("thought_signature") or func_provider_fields.get("thought_signatures")
                 if signature:
+                    if isinstance(signature, list) and len(signature) > 0:
+                        return signature[0]
                     return signature
         elif (
             hasattr(function, "provider_specific_fields")
             and function.provider_specific_fields
         ):
             if isinstance(function.provider_specific_fields, dict):
-                signature = function.provider_specific_fields.get("thought_signature")
+                signature = function.provider_specific_fields.get("thought_signature") or function.provider_specific_fields.get("thought_signatures")
                 if signature:
+                    if isinstance(signature, list) and len(signature) > 0:
+                        return signature[0]
                     return signature
     # Check if thought signature is embedded in tool call ID
     tool_call_id = tool.get("id")

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -428,8 +428,11 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                     provider_specific_fields = assistant_msg.get("provider_specific_fields")
                     thought_signatures = None
                     if provider_specific_fields and isinstance(provider_specific_fields, dict):
-                        thought_signatures = provider_specific_fields.get("thought_signatures")
+                        thought_signatures = provider_specific_fields.get("thought_signatures") or provider_specific_fields.get("thought_signature")
                     
+                    if isinstance(thought_signatures, str):
+                        thought_signatures = [thought_signatures]
+
                     # If we have thought signatures, add them to the part
                     if thought_signatures and isinstance(thought_signatures, list) and len(thought_signatures) > 0:
                         # Use the first signature for the text part (Gemini expects one signature per part)

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_thought_signatures_normalization.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_thought_signatures_normalization.py
@@ -1,7 +1,7 @@
 
 import pytest
 from litellm.litellm_core_utils.prompt_templates.factory import _get_thought_signature_from_tool
-from litellm.llms.vertex_ai.gemini.transformation import _transform_request_body
+
 
 def test_get_thought_signature_from_tool_normalization():
     """

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_thought_signatures_normalization.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_thought_signatures_normalization.py
@@ -56,19 +56,52 @@ def test_get_thought_signature_from_tool_normalization():
 
 def test_gemini_transformation_thought_signatures_normalization():
     """
-    Test that _transform_request_body correctly handles 'thought_signatures' in assistant messages.
+    Test that _gemini_convert_messages_with_history correctly handles 'thought_signatures' 
+    in assistant messages (converting list to single thoughtSignature).
     """
-    # This requires mocking or carefully constructing the input to _transform_request_body
-    # simpler to test the internal logic if accessible, but _transform_request_body is acceptable.
+    from litellm.llms.vertex_ai.gemini.transformation import _gemini_convert_messages_with_history
     
-    # Actually, looking at the patch, the fix was also in `transformation.py` around line 428.
-    # It converts `thought_signatures` list to `thoughtSignature` part.
+    signature = "test_signature_abc"
     
-    # We can try to test `_gemini_convert_messages_with_history` or similar if possible, 
-    # but let's stick to unit testing the behavior if we can isolate it.
+    # Input messages simulating an assistant message with thought_signatures (plural)
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {
+            "role": "assistant", 
+            "content": "Hi there",
+            "provider_specific_fields": {
+                "thought_signatures": [signature]
+            }
+        }
+    ]
     
-    # The patch in transformation.py:
-    # thought_signatures = provider_specific_fields.get("thought_signatures") or provider_specific_fields.get("thought_signature")
-    # if isinstance(thought_signatures, list): ... use first.
+    # Run transformation
+    contents = _gemini_convert_messages_with_history(messages)
     
-    pass
+    # Verify output
+    # content[0] is user, content[1] is model (assistant)
+    assert len(contents) == 2
+    assert contents[1]["role"] == "model"
+    assert len(contents[1]["parts"]) == 1
+    part = contents[1]["parts"][0]
+    
+    # Verify thoughtSignature is present and normalized
+    assert part["text"] == "Hi there"
+    assert "thoughtSignature" in part
+    assert part["thoughtSignature"] == signature
+
+    # Test case 2: Singular 'thought_signature' (backward compatibility)
+    messages_singular = [
+        {"role": "user", "content": "Hello"},
+        {
+            "role": "assistant", 
+            "content": "Hi there",
+            "provider_specific_fields": {
+                "thought_signature": signature
+            }
+        }
+    ]
+    
+    contents_singular = _gemini_convert_messages_with_history(messages_singular)
+    part_singular = contents_singular[1]["parts"][0]
+    assert part_singular["thoughtSignature"] == signature

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_thought_signatures_normalization.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_thought_signatures_normalization.py
@@ -1,0 +1,74 @@
+
+import pytest
+from litellm.litellm_core_utils.prompt_templates.factory import _get_thought_signature_from_tool
+from litellm.llms.vertex_ai.gemini.transformation import _transform_request_body
+
+def test_get_thought_signature_from_tool_normalization():
+    """
+    Test that _get_thought_signature_from_tool correctly handles 'thought_signatures' (list)
+    and returns the first element as a string.
+    """
+    signature = "test_signature_123"
+    
+    # Case 1: thought_signatures (plural list) - The issue we fixed
+    tool_with_plural = {
+        "type": "function",
+        "function": {
+            "name": "test_func",
+            "provider_specific_fields": {
+                "thought_signatures": [signature]
+            }
+        }
+    }
+    
+    assert _get_thought_signature_from_tool(tool_with_plural) == signature
+
+    # Case 2: thought_signature (singular string) - The existing behavior
+    tool_with_singular = {
+        "type": "function",
+        "function": {
+            "name": "test_func",
+            "provider_specific_fields": {
+                "thought_signature": signature
+            }
+        }
+    }
+    
+    assert _get_thought_signature_from_tool(tool_with_singular) == signature
+
+    # Case 3: Both present (singular should take precedence if we kept that logic, 
+    # but in our fix we did `get(singular) or get(plural)`. 
+    # Let's verify behavior. fix was: `provider_fields.get("thought_signature") or provider_fields.get("thought_signatures")`
+    # So singular takes precedence if truthy.
+    
+    tool_with_both = {
+        "type": "function",
+        "function": {
+            "name": "test_func",
+            "provider_specific_fields": {
+                "thought_signature": "singular_pref",
+                "thought_signatures": ["plural_ignored"]
+            }
+        }
+    }
+    assert _get_thought_signature_from_tool(tool_with_both) == "singular_pref"
+
+
+def test_gemini_transformation_thought_signatures_normalization():
+    """
+    Test that _transform_request_body correctly handles 'thought_signatures' in assistant messages.
+    """
+    # This requires mocking or carefully constructing the input to _transform_request_body
+    # simpler to test the internal logic if accessible, but _transform_request_body is acceptable.
+    
+    # Actually, looking at the patch, the fix was also in `transformation.py` around line 428.
+    # It converts `thought_signatures` list to `thoughtSignature` part.
+    
+    # We can try to test `_gemini_convert_messages_with_history` or similar if possible, 
+    # but let's stick to unit testing the behavior if we can isolate it.
+    
+    # The patch in transformation.py:
+    # thought_signatures = provider_specific_fields.get("thought_signatures") or provider_specific_fields.get("thought_signature")
+    # if isinstance(thought_signatures, list): ... use first.
+    
+    pass


### PR DESCRIPTION
## Description
This PR addresses an issue where `thought_signatures` (plural) from Gemini's tool usage was not being correctly extracted, leading to missing signatures in some cases.

## Changes
- Updated `litellm/litellm_core_utils/prompt_templates/factory.py` to check for both `thought_signature` and `thought_signatures` in:
    - Top-level `provider_specific_fields`
    - `function.provider_specific_fields` (both dict and object access)
- Added a regression test `tests/test_litellm/llms/vertex_ai/gemini/test_gemini_thought_signatures_normalization.py` to verify the fix.

## Testing
- Ran regression test locally: `passed`