### PR TITLE
fix(proxy): grant virtual key access to team-scoped vector stores via object_permission

### DIFF
--- a/litellm/proxy/vector_store_endpoints/endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/endpoints.py
@@ -23,31 +23,43 @@ def _check_vector_store_access(
     user_api_key_dict: UserAPIKeyAuth,
 ) -> bool:
     """
-    Check if the user has access to the vector store based on team membership.
-    
+    Check if the user has access to the vector store.
+
     Args:
         vector_store: The vector store to check access for
         user_api_key_dict: User API key authentication info
-        
+
     Returns:
         True if user has access, False otherwise
-        
+
     Access rules:
     - If vector store has no team_id, it's accessible to all (legacy behavior)
+    - If the key has explicit vector store access via object_permission, access is granted
     - If user's team_id matches the vector store's team_id, access is granted
     - Otherwise, access is denied
     """
     vector_store_team_id = vector_store.get("team_id")
-    
+
     # If vector store has no team_id, it's accessible to all (legacy behavior)
     if vector_store_team_id is None:
         return True
-    
+
+    # Check if the key has explicit access to this vector store via object_permission.
+    # This allows virtual keys granted vector_stores: [id] to access team-scoped stores
+    # without needing to be on the same team.
+    vector_store_id = vector_store.get("vector_store_id")
+    if (
+        user_api_key_dict.object_permission is not None
+        and user_api_key_dict.object_permission.vector_stores
+        and vector_store_id in user_api_key_dict.object_permission.vector_stores
+    ):
+        return True
+
     # Check if user's team matches the vector store's team
     user_team_id = user_api_key_dict.team_id
     if user_team_id == vector_store_team_id:
         return True
-    
+
     return False
 
 

--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -280,31 +280,43 @@ def _check_vector_store_access(
     user_api_key_dict: UserAPIKeyAuth,
 ) -> bool:
     """
-    Check if the user has access to the vector store based on team membership.
-    
+    Check if the user has access to the vector store.
+
     Args:
         vector_store: The vector store to check access for
         user_api_key_dict: User API key authentication info
-        
+
     Returns:
         True if user has access, False otherwise
-        
+
     Access rules:
     - If vector store has no team_id, it's accessible to all (legacy behavior)
+    - If the key has explicit vector store access via object_permission, access is granted
     - If user's team_id matches the vector store's team_id, access is granted
     - Otherwise, access is denied
     """
     vector_store_team_id = vector_store.get("team_id")
-    
+
     # If vector store has no team_id, it's accessible to all (legacy behavior)
     if vector_store_team_id is None:
         return True
-    
+
+    # Check if the key has explicit access to this vector store via object_permission.
+    # This allows virtual keys granted vector_stores: [id] to access team-scoped stores
+    # without needing to be on the same team.
+    vector_store_id = vector_store.get("vector_store_id")
+    if (
+        user_api_key_dict.object_permission is not None
+        and user_api_key_dict.object_permission.vector_stores
+        and vector_store_id in user_api_key_dict.object_permission.vector_stores
+    ):
+        return True
+
     # Check if user's team matches the vector store's team
     user_team_id = user_api_key_dict.team_id
     if user_team_id == vector_store_team_id:
         return True
-    
+
     return False
 
 

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_access_control.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_access_control.py
@@ -1,9 +1,10 @@
 """
-Test vector store access control based on team membership.
+Test vector store access control based on team membership and object_permission.
 
 Core tests:
 1. Access control logic works correctly for different team scenarios
 2. Delete endpoint enforces team access control
+3. Virtual keys with object_permission.vector_stores can access team-scoped stores
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,9 +12,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import LiteLLM_ObjectPermissionTable, UserAPIKeyAuth
 from litellm.proxy.vector_store_endpoints.management_endpoints import (
     _check_vector_store_access,
+)
+from litellm.proxy.vector_store_endpoints.endpoints import (
+    _check_vector_store_access as _check_vector_store_access_endpoints,
 )
 from litellm.types.vector_stores import LiteLLM_ManagedVectorStore
 
@@ -85,3 +89,65 @@ async def test_delete_vector_store_checks_access():
 
             assert exc_info.value.status_code == 403
             assert "Access denied" in exc_info.value.detail
+
+
+# --- object_permission tests ---
+# Applied to both management_endpoints and endpoints versions since the logic
+# is identical in both.
+
+
+def _make_object_permission_user(team_id: str, permitted_store_ids: list) -> UserAPIKeyAuth:
+    perm = LiteLLM_ObjectPermissionTable(
+        object_permission_id="perm_test",
+        vector_stores=permitted_store_ids,
+    )
+    return UserAPIKeyAuth(team_id=team_id, object_permission=perm)
+
+
+def test_object_permission_grants_access_to_team_scoped_store():
+    """Virtual key with explicit vector_store_id in object_permission can access
+    a store owned by a different team."""
+    vector_store: LiteLLM_ManagedVectorStore = {
+        "vector_store_id": "vs_123",
+        "custom_llm_provider": "openai",
+        "team_id": "team_other",
+    }
+    user = _make_object_permission_user(team_id="team_mine", permitted_store_ids=["vs_123"])
+
+    # management_endpoints version
+    assert _check_vector_store_access(vector_store, user) is True
+    # endpoints version
+    assert _check_vector_store_access_endpoints(vector_store, user) is True
+
+
+def test_object_permission_denies_access_when_store_id_not_in_list():
+    """Virtual key's object_permission does not include the requested store — deny."""
+    vector_store: LiteLLM_ManagedVectorStore = {
+        "vector_store_id": "vs_456",
+        "custom_llm_provider": "openai",
+        "team_id": "team_other",
+    }
+    user = _make_object_permission_user(team_id="team_mine", permitted_store_ids=["vs_123"])
+
+    # management_endpoints version
+    assert _check_vector_store_access(vector_store, user) is False
+    # endpoints version
+    assert _check_vector_store_access_endpoints(vector_store, user) is False
+
+
+def test_object_permission_none_falls_back_to_team_check():
+    """When object_permission is None, team_id matching is still the gate."""
+    vector_store: LiteLLM_ManagedVectorStore = {
+        "vector_store_id": "vs_789",
+        "custom_llm_provider": "openai",
+        "team_id": "team_abc",
+    }
+    user_same_team = UserAPIKeyAuth(team_id="team_abc", object_permission=None)
+    user_diff_team = UserAPIKeyAuth(team_id="team_xyz", object_permission=None)
+
+    # management_endpoints version
+    assert _check_vector_store_access(vector_store, user_same_team) is True
+    assert _check_vector_store_access(vector_store, user_diff_team) is False
+    # endpoints version
+    assert _check_vector_store_access_endpoints(vector_store, user_same_team) is True
+    assert _check_vector_store_access_endpoints(vector_store, user_diff_team) is False


### PR DESCRIPTION
## Summary

Fixes #22577 — virtual keys with explicit vector store permissions (`object_permission.vector_stores`) were denied access to team-scoped vector stores with the error `"Access denied: You do not have permission to access this vector store"`, even though the key explicitly listed the vector_store_id.

## Root Cause

`_check_vector_store_access()` in `vector_store_endpoints/endpoints.py` only checked team-level access:

```python
# Only checked this:
if user_team_id == vector_store_team_id:
    return True
return False  # ← rejected keys with object_permission grants
```

It never consulted the key's `object_permission.vector_stores` list, even though that data is already loaded onto `UserAPIKeyAuth` during auth (see `get_key_object` in `auth_checks.py` lines 2090-2103).

## Fix

Before returning `False`, check if the key's `object_permission.vector_stores` explicitly includes the `vector_store_id`:

```python
vector_store_id = vector_store.get("vector_store_id")
if (
    user_api_key_dict.object_permission is not None
    and user_api_key_dict.object_permission.vector_stores
    and vector_store_id in user_api_key_dict.object_permission.vector_stores
):
    return True
```

This matches the semantics of how virtual keys are documented to work: create a key with `object_permission: {"vector_stores": ["vs_id_1"]}` and it should be able to access that vector store.

## Test plan

- [ ] Create a team with a team-scoped vector store (vector store has `team_id` set)
- [ ] Create a virtual key with `object_permission: {"vector_stores": ["<vector_store_id>"]}`
- [ ] Send `POST /v1/vector_stores/{vector_store_id}/search` with the virtual key
- [ ] Confirm: `200 OK` with results (no longer `Access denied`)
- [ ] Confirm: a key WITHOUT the object_permission still gets `403 Access denied`
- [ ] Confirm: admin key still works as before