### PR TITLE
ci: add spam detection and auto-ban workflows for GitHub issues

### DIFF
--- a/.github/workflows/spam-ban.yml
+++ b/.github/workflows/spam-ban.yml
@@ -32,9 +32,10 @@ jobs:
             console.log(`User @${user} has ${spamCount} spam-labeled issues`);
 
             if (spamCount >= 3) {
-              // Block user from the organization
+              // Block user from the BerriAI organization
               try {
-                await github.rest.users.block({
+                await github.rest.orgs.blockUser({
+                  org: context.repo.owner,
                   username: user,
                 });
                 console.log(`Blocked user: ${user}`);

--- a/.github/workflows/spam-ban.yml
+++ b/.github/workflows/spam-ban.yml
@@ -1,0 +1,64 @@
+name: Ban Spam Users
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  check-ban:
+    if: github.event.label.name == 'spam'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Check if user should be blocked
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ADMIN_PAT }}
+          script: |
+            const user = context.payload.issue.user.login;
+
+            // Count spam-labeled issues from this user
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              creator: user,
+              labels: 'spam',
+              state: 'all',
+              per_page: 100,
+            });
+
+            const spamCount = issues.data.length;
+            console.log(`User @${user} has ${spamCount} spam-labeled issues`);
+
+            if (spamCount >= 3) {
+              // Block user from the organization
+              try {
+                await github.rest.users.block({
+                  username: user,
+                });
+                console.log(`Blocked user: ${user}`);
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.issue.number,
+                  body: `User \`${user}\` has been automatically blocked after ${spamCount} spam issues.`,
+                });
+              } catch (e) {
+                console.log(`Could not block user ${user}: ${e.message}`);
+
+                // Leave a comment for maintainers to manually block
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.issue.number,
+                  body: [
+                    `**Action needed:** User \`${user}\` has ${spamCount} spam-labeled issues and should be blocked.`,
+                    '',
+                    'Automatic blocking failed. A maintainer should manually block this user:',
+                    `https://github.com/${user}`,
+                  ].join('\n'),
+                });
+              }
+            }

--- a/.github/workflows/spam-detection.yml
+++ b/.github/workflows/spam-detection.yml
@@ -61,31 +61,39 @@ jobs:
               }
             }
 
-            // 5. Check how many issues this user opened in last 24h
-            const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+            // 5. Check how many issues this user created in last 24h
+            // Note: the `since` API param filters by updated_at, not created_at,
+            // so we fetch recent issues and filter by created_at client-side.
             const recentIssues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               creator: user.login,
-              since: since,
               state: 'all',
-              per_page: 20,
+              per_page: 30,
+              sort: 'created',
+              direction: 'desc',
             });
-            if (recentIssues.data.length > 5) {
+            const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
+            const createdInLast24h = recentIssues.data.filter(
+              i => new Date(i.created_at).getTime() > oneDayAgo
+            ).length;
+            if (createdInLast24h > 5) {
               spamScore += 5;
-              reasons.push(`User opened ${recentIssues.data.length} issues in 24h`);
-            } else if (recentIssues.data.length > 3) {
+              reasons.push(`User created ${createdInLast24h} issues in 24h`);
+            } else if (createdInLast24h > 3) {
               spamScore += 2;
-              reasons.push(`User opened ${recentIssues.data.length} issues in 24h`);
+              reasons.push(`User created ${createdInLast24h} issues in 24h`);
             }
 
-            // 6. Didn't use a template (no required fields filled)
+            // 6. Didn't use a template (check for labels from actual template fields)
+            // bug_report.yml: "What happened?", "Steps to Reproduce", "Relevant log output"
+            // feature_request.yml: "The Feature", "Motivation, pitch"
             const templateMarkers = [
-              'What happened',
+              'What happened?',
               'Steps to Reproduce',
               'Relevant log output',
-              'Describe the feature',
-              'Motivation',
+              'The Feature',
+              'Motivation, pitch',
             ];
             const usedTemplate = templateMarkers.some(marker => body.includes(marker));
             if (!usedTemplate && body.length > 0) {
@@ -130,13 +138,7 @@ jobs:
                 state_reason: 'not_planned',
               });
 
-              await github.rest.issues.lock({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                lock_reason: 'spam',
-              });
-
+              // Post comment BEFORE locking — comments on locked issues silently fail
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -151,5 +153,12 @@ jobs:
                 ].join('\n'),
               });
 
-              console.log(`Closed and locked issue #${issue.number} as spam`);
+              await github.rest.issues.lock({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                lock_reason: 'spam',
+              });
+
+              console.log(`Closed, commented, and locked issue #${issue.number} as spam`);
             }

--- a/.github/workflows/spam-detection.yml
+++ b/.github/workflows/spam-detection.yml
@@ -1,0 +1,155 @@
+name: Spam Detection
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  detect-spam:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Check for spam
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const user = issue.user;
+            const body = issue.body || '';
+            const title = issue.title || '';
+
+            let spamScore = 0;
+            const reasons = [];
+
+            // 1. New account (created < 7 days ago)
+            const userDetails = await github.rest.users.getByUsername({
+              username: user.login,
+            });
+            const accountAge = (Date.now() - new Date(userDetails.data.created_at).getTime()) / (1000 * 60 * 60 * 24);
+            if (accountAge < 7) {
+              spamScore += 3;
+              reasons.push(`Account is ${Math.floor(accountAge)} days old`);
+            }
+
+            // 2. No repos, no followers — likely throwaway
+            if (userDetails.data.public_repos === 0 && userDetails.data.followers === 0) {
+              spamScore += 2;
+              reasons.push('No public repos or followers');
+            }
+
+            // 3. Body is very short or empty (low effort)
+            if (body.length < 30) {
+              spamScore += 3;
+              reasons.push(`Body too short (${body.length} chars)`);
+            }
+
+            // 4. Known spam patterns (URLs, crypto, promotion)
+            const spamPatterns = [
+              { regex: /https?:\/\/[^\s]*\.(xyz|tk|ml|ga|cf)\b/i, desc: 'Suspicious TLD link' },
+              { regex: /\b(crypto|nft|airdrop|whitelist|web3|token sale)\b/i, desc: 'Crypto/NFT spam' },
+              { regex: /\b(buy now|limited offer|act fast|click here|free money)\b/i, desc: 'Promotional spam' },
+              { regex: /\b(SEO|backlink|guest post|link building)\b/i, desc: 'SEO spam' },
+              { regex: /(.)\1{10,}/, desc: 'Repeated characters' },
+              { regex: /\b(casino|poker|betting|gambling)\b/i, desc: 'Gambling spam' },
+              { regex: /\b(viagra|cialis|pharmacy|pills)\b/i, desc: 'Pharma spam' },
+            ];
+            for (const { regex, desc } of spamPatterns) {
+              if (regex.test(title) || regex.test(body)) {
+                spamScore += 4;
+                reasons.push(`Matched pattern: ${desc}`);
+              }
+            }
+
+            // 5. Check how many issues this user opened in last 24h
+            const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+            const recentIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              creator: user.login,
+              since: since,
+              state: 'all',
+              per_page: 20,
+            });
+            if (recentIssues.data.length > 5) {
+              spamScore += 5;
+              reasons.push(`User opened ${recentIssues.data.length} issues in 24h`);
+            } else if (recentIssues.data.length > 3) {
+              spamScore += 2;
+              reasons.push(`User opened ${recentIssues.data.length} issues in 24h`);
+            }
+
+            // 6. Didn't use a template (no required fields filled)
+            const templateMarkers = [
+              'What happened',
+              'Steps to Reproduce',
+              'Relevant log output',
+              'Describe the feature',
+              'Motivation',
+            ];
+            const usedTemplate = templateMarkers.some(marker => body.includes(marker));
+            if (!usedTemplate && body.length > 0) {
+              spamScore += 2;
+              reasons.push('Did not use issue template');
+            }
+
+            console.log(`Spam score for #${issue.number} by @${user.login}: ${spamScore}`);
+            console.log(`Reasons: ${reasons.join(', ')}`);
+
+            // Threshold: close and label if score >= 7
+            if (spamScore >= 7) {
+              // Ensure the spam label exists
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'spam',
+                });
+              } catch {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'spam',
+                  color: 'B60205',
+                  description: 'Spam or bot-generated issue',
+                });
+              }
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['spam'],
+              });
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+
+              await github.rest.issues.lock({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                lock_reason: 'spam',
+              });
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: [
+                  'This issue was automatically closed as potential spam.',
+                  '',
+                  '**Reasons:**',
+                  ...reasons.map(r => `- ${r}`),
+                  '',
+                  `If this is a legitimate issue, please reopen it using our [issue templates](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new/choose) and a maintainer will review.`,
+                ].join('\n'),
+              });
+
+              console.log(`Closed and locked issue #${issue.number} as spam`);
+            }


### PR DESCRIPTION
seeing a lot of spam issues 

- spam-detection.yml: scores new issues on heuristics (account age, body length, spam patterns, issue rate, template usage) and auto-closes + locks issues that exceed the spam threshold
- spam-ban.yml: auto-blocks users after 3+ spam-labeled issues

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
