### PR TITLE
Fix UI log filtering: preserve key_alias during pagination instead of falling back to unfiltered data

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
@@ -451,7 +451,7 @@ describe("useLogFilterLogic", () => {
     );
   });
 
-  it("should fall back to logs when backend filters are active but API returns empty", async () => {
+  it("should show empty results when backend filters are active and API returns empty", async () => {
     vi.mocked(uiSpendLogsCall).mockResolvedValue({
       data: [],
       total: 0,
@@ -474,8 +474,10 @@ describe("useLogFilterLogic", () => {
       { timeout: 500 },
     );
 
-    expect(result.current.filteredLogs.data).toHaveLength(1);
-    expect(result.current.filteredLogs.data[0].request_id).toBe("client-req");
+    // Should NOT fall back to unfiltered logs; should reflect the empty backend result
+    expect(result.current.filteredLogs.data).toHaveLength(0);
+    expect(result.current.filteredLogs.total).toBe(0);
+    expect(result.current.filteredLogs.total_pages).toBe(0);
   });
 
   it("should refetch when sortBy changes and backend filters are active", async () => {
@@ -565,6 +567,97 @@ describe("useLogFilterLogic", () => {
     });
     expect(uiSpendLogsCall).toHaveBeenLastCalledWith(
       expect.objectContaining({ page: 2 }),
+    );
+  });
+
+  it("should preserve key_alias param during pagination instead of converting to hash", async () => {
+    vi.mocked(uiSpendLogsCall).mockResolvedValue(
+      createPaginatedResponse([createLogEntry()]),
+    );
+    const logs = createPaginatedResponse([createLogEntry()]);
+    const { result, rerender } = renderHook(
+      (props) => useLogFilterLogic({ ...defaultProps, logs, ...props }),
+      { wrapper, initialProps: { currentPage: 1 } },
+    );
+
+    act(() => {
+      result.current.handleFilterChange({ "Key Alias": "user01" });
+    });
+
+    await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalledTimes(1), {
+      timeout: 500,
+    });
+
+    // Verify initial call uses key_alias (not api_key / hash)
+    expect(uiSpendLogsCall).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        page: 1,
+        params: expect.objectContaining({ key_alias: "user01" }),
+      }),
+    );
+    // api_key should be undefined when filtering by alias
+    expect(vi.mocked(uiSpendLogsCall).mock.calls[0][0].params.api_key).toBeUndefined();
+
+    // Navigate to page 2
+    rerender({ currentPage: 2 });
+
+    await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalledTimes(2), {
+      timeout: 500,
+    });
+
+    // Page 2 should still use key_alias (not api_key / hash)
+    expect(uiSpendLogsCall).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        page: 2,
+        params: expect.objectContaining({ key_alias: "user01" }),
+      }),
+    );
+    // api_key must remain undefined on page 2 as well
+    const lastCall = vi.mocked(uiSpendLogsCall).mock.calls[1][0];
+    expect(lastCall.params.api_key).toBeUndefined();
+  });
+
+  it("should use backend pagination metadata when filtering by key_alias across pages", async () => {
+    // Simulate a backend response where fuzzy match yields 3 total results across 1 page
+    const page1Response = {
+      data: [
+        createLogEntry({ request_id: "req-1" }),
+        createLogEntry({ request_id: "req-2" }),
+        createLogEntry({ request_id: "req-3" }),
+      ],
+      total: 3,
+      page: 1,
+      page_size: 50,
+      total_pages: 1,
+    };
+    vi.mocked(uiSpendLogsCall).mockResolvedValue(page1Response);
+
+    // The main query has more data (unfiltered)
+    const unfilteredLogs = {
+      data: Array.from({ length: 50 }, (_, i) => createLogEntry({ request_id: `unfiltered-${i}` })),
+      total: 100,
+      page: 1,
+      page_size: 50,
+      total_pages: 2,
+    };
+
+    const { result } = renderHook(
+      () => useLogFilterLogic({ ...defaultProps, logs: unfilteredLogs }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.handleFilterChange({ "Key Alias": "user01" });
+    });
+
+    await waitFor(
+      () => {
+        // filteredLogs should reflect the backend's total/total_pages, not the main query's
+        expect(result.current.filteredLogs.total).toBe(3);
+        expect(result.current.filteredLogs.total_pages).toBe(1);
+        expect(result.current.filteredLogs.data).toHaveLength(3);
+      },
+      { timeout: 500 },
     );
   });
 

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -227,22 +227,15 @@ export function useLogFilterLogic({
   // Choose which filtered logs to expose: backend result when active, otherwise client-derived
   const filteredLogs: PaginatedResponse = useMemo(() => {
     if (hasBackendFilters) {
-      // Prefer backend result if present; otherwise fall back to latest logs
-      if (backendFilteredLogs && backendFilteredLogs.data && backendFilteredLogs.data.length > 0) {
-        return backendFilteredLogs;
-      }
-      return (
-        logs || {
-          data: [],
-          total: 0,
-          page: 1,
-          page_size: 50,
-          total_pages: 0,
-        }
-      );
+      // Always use the backend result so that pagination metadata (total, total_pages)
+      // stays consistent with the filtered query – even when the current page is empty.
+      // Falling back to the unfiltered `logs` here would cause the UI to display stale
+      // data and wrong page counts (e.g. key_alias partial-match on page 1 returning
+      // results, but page 2 falling back to the unfiltered main query).
+      return backendFilteredLogs;
     }
     return clientDerivedFilteredLogs;
-  }, [hasBackendFilters, backendFilteredLogs, clientDerivedFilteredLogs, logs]);
+  }, [hasBackendFilters, backendFilteredLogs, clientDerivedFilteredLogs]);
 
   // Fetch all teams and users for potential filter dropdowns (optional, can be adapted)
   const { data: allTeams } = useQuery<Team[], Error>({


### PR DESCRIPTION
## Relevant issues

Fixes #22556

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
