### PR TITLE
fix: add missing pricing for OpenRouter and GPT-5.1 mini aliases

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3975,7 +3975,7 @@
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 400000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
@@ -20738,7 +20738,7 @@
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 400000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
@@ -25807,15 +25807,20 @@
         "tool_use_system_prompt_tokens": 159
     },
     "openrouter/anthropic/claude-sonnet-4.6": {
+        "input_cost_per_image": 0.0048,
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
         "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "input_cost_per_token": 3e-06,
+        "input_cost_per_token_above_200k_tokens": 6e-06,
         "litellm_provider": "openrouter",
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
         "source": "https://openrouter.ai/anthropic/claude-sonnet-4.6",
         "supported_modalities": [
             "text",
@@ -25824,12 +25829,15 @@
         "supported_output_modalities": [
             "text"
         ],
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159
     },
     "openrouter/anthropic/claude-haiku-4.5": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -26074,15 +26082,32 @@
     },
     "openrouter/google/gemini-3.1-pro-preview": {
         "cache_creation_input_token_cost": 3.75e-07,
+        "cache_creation_input_token_cost_above_200k_tokens": 2.5e-07,
         "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
         "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_200k_tokens": 4e-06,
+        "input_cost_per_token_batches": 1e-06,
         "litellm_provider": "openrouter",
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
+        "max_pdf_size_mb": 30,
         "max_tokens": 65536,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
         "mode": "chat",
         "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_above_200k_tokens": 1.8e-05,
+        "output_cost_per_token_batches": 6e-06,
         "source": "https://openrouter.ai/google/gemini-3.1-pro-preview",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
         "supported_modalities": [
             "text",
             "image",
@@ -26098,9 +26123,11 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_web_search": true
     },
     "openrouter/google/gemini-3-flash-preview": {
         "cache_read_input_token_cost": 5e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20797,6 +20797,46 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "gpt-5.1-mini": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost_flex": 1.25e-08,
+        "cache_read_input_token_cost_priority": 4.5e-08,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_flex": 1.25e-07,
+        "input_cost_per_token_priority": 4.5e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06,
+        "output_cost_per_token_flex": 1e-06,
+        "output_cost_per_token_priority": 3.6e-06,
+        "source": "https://developers.openai.com/api/docs/models/gpt-5-mini",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true
+    },
     "gpt-5.2-codex": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
@@ -20871,13 +20911,14 @@
         "input_cost_per_token_flex": 1.25e-07,
         "input_cost_per_token_priority": 4.5e-07,
         "litellm_provider": "openai",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 400000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 2e-06,
         "output_cost_per_token_flex": 1e-06,
         "output_cost_per_token_priority": 3.6e-06,
+        "source": "https://developers.openai.com/api/docs/models/gpt-5-mini",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -20910,13 +20951,14 @@
         "input_cost_per_token_flex": 1.25e-07,
         "input_cost_per_token_priority": 4.5e-07,
         "litellm_provider": "openai",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 400000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 2e-06,
         "output_cost_per_token_flex": 1e-06,
         "output_cost_per_token_priority": 3.6e-06,
+        "source": "https://developers.openai.com/api/docs/models/gpt-5-mini",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/batch",
@@ -25764,6 +25806,31 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 159
     },
+    "openrouter/anthropic/claude-sonnet-4.6": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://openrouter.ai/anthropic/claude-sonnet-4.6",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "openrouter/anthropic/claude-haiku-4.5": {
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_read_input_token_cost": 1e-07,
@@ -26004,6 +26071,36 @@
         "supports_video_input": true,
         "supports_vision": true,
         "supports_web_search": true
+    },
+    "openrouter/google/gemini-3.1-pro-preview": {
+        "cache_creation_input_token_cost": 3.75e-07,
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-05,
+        "source": "https://openrouter.ai/google/gemini-3.1-pro-preview",
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true
     },
     "openrouter/google/gemini-3-flash-preview": {
         "cache_read_input_token_cost": 5e-08,
@@ -26334,6 +26431,30 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/openai/gpt-5.1-codex-max": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "source": "https://openrouter.ai/openai/gpt-5.1-codex-max",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "openrouter/openai/gpt-5-codex": {
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
@@ -26583,6 +26704,21 @@
         "supports_tool_choice": true,
         "supports_function_calling": true
     },
+    "openrouter/qwen/qwen3-coder-plus": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 5e-06,
+        "source": "https://openrouter.ai/qwen/qwen3-coder-plus",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "openrouter/qwen/qwen3-235b-a22b-2507": {
         "input_cost_per_token": 7.1e-08,
         "litellm_provider": "openrouter",
@@ -26717,6 +26853,20 @@
         "supports_reasoning": true,
         "supports_vision": true,
         "supports_prompt_caching": false
+    },
+    "openrouter/z-ai/glm-5": {
+        "cache_read_input_token_cost": 1.6e-07,
+        "input_cost_per_token": 8e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 202752,
+        "mode": "chat",
+        "output_cost_per_token": 2.56e-06,
+        "source": "https://openrouter.ai/z-ai/glm-5",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "openrouter/minimax/minimax-m2.1": {
         "input_cost_per_token": 2.7e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -26859,6 +26859,8 @@
         "input_cost_per_token": 8e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 202752,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 2.56e-06,
         "source": "https://openrouter.ai/z-ai/glm-5",


### PR DESCRIPTION
## Relevant issues

Fixes #22609 


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, N/A (pure JSON data update, no code logic changed)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix


## Changes
Added missing pricing entries in [`model_prices_and_context_window.json`](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) for models that were routing correctly but still falling back to `$0` cost tracking:

- `gpt-5.1-mini` — explicitly mapped using [OpenAI GPT-5 mini](https://developers.openai.com/api/docs/models/gpt-5-mini) pricing, with `400K` context and `128K` max output
- `openrouter/anthropic/claude-sonnet-4.6` — added explicit pricing and standardized Anthropic/OpenRouter Sonnet fields to match sibling entries, including >200K token pricing, prompt caching fields, `supports_assistant_prefill`, `supports_computer_use`, and `tool_use_system_prompt_tokens`
- `openrouter/openai/gpt-5.1-codex-max` — added explicit pricing with `400K` context and `128K` max output, based on [OpenRouter model page](https://openrouter.ai/openai/gpt-5.1-codex-max)
- `openrouter/google/gemini-3.1-pro-preview` — added explicit pricing and standardized Gemini/OpenRouter fields to match sibling entries, including >200K pricing, batch pricing, multimodal limits, and endpoint metadata
- `openrouter/qwen/qwen3-coder-plus` — added explicit pricing with `1M` context and `65,536` max output, based on [OpenRouter model page](https://openrouter.ai/qwen/qwen3-coder-plus)
- `openrouter/z-ai/glm-5` — added explicit pricing plus `max_output_tokens` / `max_tokens` so token limit helpers do not return `None`

Also updated stale existing entries so token limits are consistent with current provider docs (openai updated their docs i believe):

- `gpt-5-mini`
- `gpt-5-mini-2025-08-07`
- `gpt-5.1-codex-max`
- `azure/gpt-5.1-codex-max`

These previously had stale `max_input_tokens` values (`272K`) and now match the current provider docs at `400K` context where applicable.

Pricing and context values were verified against:

- [OpenAI GPT-5 mini docs](https://developers.openai.com/api/docs/models/gpt-5-mini)
- [OpenAI GPT-5.1 Codex Max docs](https://developers.openai.com/api/docs/models/gpt-5.1-codex-max)
- [OpenRouter models API](https://openrouter.ai/api/v1/models)
- OpenRouter model pages:
  - [claude-sonnet-4.6](https://openrouter.ai/anthropic/claude-sonnet-4.6)
  - [gpt-5.1-codex-max](https://openrouter.ai/openai/gpt-5.1-codex-max)
  - [gemini-3.1-pro-preview](https://openrouter.ai/google/gemini-3.1-pro-preview)
  - [qwen3-coder-plus](https://openrouter.ai/qwen/qwen3-coder-plus)
  - [glm-5](https://openrouter.ai/z-ai/glm-5)
- [Alibaba Cloud Model Studio docs](https://www.alibabacloud.com/help/en/model-studio/models)
- [Z.AI parameter docs](https://docs.z.ai/guides/overview/concept-param)
- [Z.AI chat completions docs](https://docs.z.ai/api-reference/llm/chat-completion)

Note: `dashscope/qwen3-coder-plus` (also mentioned in [#22609](https://github.com/BerriAI/litellm/issues/22609)) already had correct tiered pricing, so no pricing changes were needed there.

