### PR TITLE
Bugfix/support capturing context window errors in sglang stream

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1720,9 +1720,7 @@ class Router:
                                 and isinstance(fallback_item, ModelResponseStream)
                                 and hasattr(fallback_item, "usage")
                             ):
-                                self._combine_fallback_usage(
-                                    fallback_item, complete_response_object_usage
-                                )
+                                self._combine_fallback_usage(fallback_item, complete_response_object_usage)
                             yield fallback_item
                     else:
                         # If fallback returns a non-streaming response, yield None
@@ -1801,7 +1799,7 @@ class Router:
             try:
                 for item in model_response:
                     yield item
-            except litellm.ContextWindowExceededError:
+            except litellm.ContextWindowExceededError as e:
                 # Handle ContextWindowExceededError raised mid-stream
                 # (e.g. by sglang frameworks that return context window
                 # errors during streaming instead of at request time).
@@ -1824,11 +1822,13 @@ class Router:
                     router_self._update_kwargs_before_fallbacks(
                         model=model_group, kwargs=initial_kwargs
                     )
-                    fallback_response = router_self.function_with_fallbacks(
-                        **initial_kwargs,
-                        fallbacks=fallbacks,
-                        context_window_fallbacks=context_window_fallbacks,
-                        content_policy_fallbacks=content_policy_fallbacks,
+                    fallback_response = (
+                        router_self.function_with_fallbacks(
+                            **initial_kwargs,
+                            fallbacks=fallbacks,
+                            context_window_fallbacks=context_window_fallbacks,
+                            content_policy_fallbacks=content_policy_fallbacks,
+                        )
                     )
 
                     if hasattr(fallback_response, "__iter__"):
@@ -1883,11 +1883,13 @@ class Router:
                     router_self._update_kwargs_before_fallbacks(
                         model=model_group, kwargs=initial_kwargs
                     )
-                    fallback_response = router_self.function_with_fallbacks(
-                        **initial_kwargs,
-                        fallbacks=fallbacks,
-                        context_window_fallbacks=context_window_fallbacks,
-                        content_policy_fallbacks=content_policy_fallbacks,
+                    fallback_response = (
+                        router_self.function_with_fallbacks(
+                            **initial_kwargs,
+                            fallbacks=fallbacks,
+                            context_window_fallbacks=context_window_fallbacks,
+                            content_policy_fallbacks=content_policy_fallbacks,
+                        )
                     )
 
                     if hasattr(fallback_response, "__iter__"):
@@ -1897,9 +1899,7 @@ class Router:
                                 and isinstance(fallback_item, ModelResponseStream)
                                 and hasattr(fallback_item, "usage")
                             ):
-                                router_self._combine_fallback_usage(
-                                    fallback_item, complete_response_object_usage
-                                )
+                                router_self._combine_fallback_usage(fallback_item, complete_response_object_usage)
                             yield fallback_item
                     else:
                         yield None
@@ -2811,9 +2811,10 @@ class Router:
         litellm_model = data.get("model", None)
 
         # litellm_agent/ prefix only strips the model name, no prompt_id needed
-        is_litellm_agent_model = isinstance(
-            litellm_model, str
-        ) and litellm_model.startswith("litellm_agent/")
+        is_litellm_agent_model = (
+            isinstance(litellm_model, str)
+            and litellm_model.startswith("litellm_agent/")
+        )
 
         prompt_id = kwargs.get("prompt_id") or prompt_management_deployment[
             "litellm_params"
@@ -6593,7 +6594,7 @@ class Router:
             tiers = complexity_router_config.get("tiers", {})
             # Use MEDIUM tier as fallback default
             default_model = tiers.get("MEDIUM") or tiers.get("SIMPLE")
-
+        
         if default_model is None:
             raise ValueError(
                 "complexity_router_default_model is required for complexity-router deployments, "
@@ -6826,9 +6827,7 @@ class Router:
         #########################################################
         # Check if this is a complexity-router deployment
         #########################################################
-        if self._is_complexity_router_deployment(
-            litellm_params=deployment.litellm_params
-        ):
+        if self._is_complexity_router_deployment(litellm_params=deployment.litellm_params):
             self.init_complexity_router_deployment(deployment=deployment)
 
         return deployment
@@ -6920,7 +6919,9 @@ class Router:
         # zero-cost models, causing budget checks to block free models.
         _model_id = deployment.model_info.id
         if _model_id is not None:
-            _model_info_dict: dict = deployment.model_info.model_dump(exclude_none=True)
+            _model_info_dict: dict = deployment.model_info.model_dump(
+                exclude_none=True
+            )
             for field in CustomPricingLiteLLMParams.model_fields.keys():
                 field_value = deployment.litellm_params.get(field)
                 if field_value is not None:
@@ -7201,10 +7202,7 @@ class Router:
 
     @overload
     def get_router_model_info(
-        self,
-        deployment: Union[dict, "Deployment"],
-        received_model_name: str,
-        id: None = None,
+        self, deployment: Union[dict, "Deployment"], received_model_name: str, id: None = None
     ) -> ModelMapInfo:
         pass
 
@@ -7244,9 +7242,7 @@ class Router:
         ## GET BASE MODEL
         base_model = (deployment.get("model_info") or {}).get("base_model", None)
         if base_model is None:
-            base_model = (deployment.get("litellm_params") or {}).get(
-                "base_model", None
-            )
+            base_model = (deployment.get("litellm_params") or {}).get("base_model", None)
 
         model = base_model
 
@@ -7281,12 +7277,12 @@ class Router:
                 if potential_models is not None:
                     for potential_model in potential_models:
                         try:
-                            if (potential_model.get("model_info") or {}).get("id") == (
-                                deployment.get("model_info") or {}
-                            ).get("id"):
-                                model = (
-                                    potential_model.get("litellm_params") or {}
-                                ).get("model")
+                            if (potential_model.get("model_info") or {}).get(
+                                "id"
+                            ) == (deployment.get("model_info") or {}).get("id"):
+                                model = (potential_model.get("litellm_params") or {}).get(
+                                    "model"
+                                )
                                 break
                         except Exception:
                             pass
@@ -8209,9 +8205,7 @@ class Router:
         - team_id: Optional[str] - the team id, to resolve team-specific models
         """
         # Check if this is the no-args hot path (cacheable)
-        _use_cache = (
-            model_name is None and model_access_group is None and team_id is None
-        )
+        _use_cache = model_name is None and model_access_group is None and team_id is None
 
         # Return cached result for the no-args hot path
         if _use_cache and self._access_groups_cache is not None:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1610,6 +1610,51 @@ class Router:
             try:
                 async for item in model_response:
                     yield item
+            except litellm.ContextWindowExceededError as e:
+                # Handle ContextWindowExceededError raised mid-stream
+                # (e.g. by sglang frameworks that return context window
+                # errors during streaming instead of at request time).
+                # Trigger context_window_fallbacks directly.
+                try:
+                    model_group = cast(str, initial_kwargs.get("model"))
+                    fallbacks: Optional[List] = initial_kwargs.get(
+                        "fallbacks", self.fallbacks
+                    )
+                    context_window_fallbacks: Optional[List] = initial_kwargs.get(
+                        "context_window_fallbacks", self.context_window_fallbacks
+                    )
+                    content_policy_fallbacks: Optional[List] = initial_kwargs.get(
+                        "content_policy_fallbacks", self.content_policy_fallbacks
+                    )
+                    initial_kwargs["original_function"] = self._acompletion
+                    initial_kwargs["messages"] = messages
+                    self._update_kwargs_before_fallbacks(
+                        model=model_group, kwargs=initial_kwargs
+                    )
+                    fallback_response = (
+                        await self.async_function_with_fallbacks_common_utils(
+                            e=e,
+                            disable_fallbacks=False,
+                            fallbacks=fallbacks,
+                            context_window_fallbacks=context_window_fallbacks,
+                            content_policy_fallbacks=content_policy_fallbacks,
+                            model_group=model_group,
+                            args=(),
+                            kwargs=initial_kwargs,
+                        )
+                    )
+
+                    if hasattr(fallback_response, "__aiter__"):
+                        async for fallback_item in fallback_response:  # type: ignore
+                            yield fallback_item
+                    else:
+                        yield None
+
+                except Exception as fallback_error:
+                    verbose_router_logger.error(
+                        f"Context window fallback also failed: {fallback_error}"
+                    )
+                    raise fallback_error
             except MidStreamFallbackError as e:
                 from litellm.main import stream_chunk_builder
 
@@ -1754,6 +1799,49 @@ class Router:
             try:
                 for item in model_response:
                     yield item
+            except litellm.ContextWindowExceededError as e:
+                # Handle ContextWindowExceededError raised mid-stream
+                # (e.g. by sglang frameworks that return context window
+                # errors during streaming instead of at request time).
+                # Trigger context_window_fallbacks directly.
+                try:
+                    model_group = cast(str, initial_kwargs.get("model"))
+                    fallbacks: Optional[List] = initial_kwargs.get(
+                        "fallbacks", router_self.fallbacks
+                    )
+                    context_window_fallbacks: Optional[List] = initial_kwargs.get(
+                        "context_window_fallbacks",
+                        router_self.context_window_fallbacks,
+                    )
+                    content_policy_fallbacks: Optional[List] = initial_kwargs.get(
+                        "content_policy_fallbacks",
+                        router_self.content_policy_fallbacks,
+                    )
+                    initial_kwargs["original_function"] = router_self._completion
+                    initial_kwargs["messages"] = messages
+                    router_self._update_kwargs_before_fallbacks(
+                        model=model_group, kwargs=initial_kwargs
+                    )
+                    fallback_response = (
+                        router_self.function_with_fallbacks(
+                            **initial_kwargs,
+                            fallbacks=fallbacks,
+                            context_window_fallbacks=context_window_fallbacks,
+                            content_policy_fallbacks=content_policy_fallbacks,
+                        )
+                    )
+
+                    if hasattr(fallback_response, "__iter__"):
+                        for fallback_item in fallback_response:
+                            yield fallback_item
+                    else:
+                        yield None
+
+                except Exception as fallback_error:
+                    verbose_router_logger.error(
+                        f"Context window fallback also failed: {fallback_error}"
+                    )
+                    raise fallback_error
             except MidStreamFallbackError as e:
                 from litellm.main import stream_chunk_builder
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1720,7 +1720,9 @@ class Router:
                                 and isinstance(fallback_item, ModelResponseStream)
                                 and hasattr(fallback_item, "usage")
                             ):
-                                self._combine_fallback_usage(fallback_item, complete_response_object_usage)
+                                self._combine_fallback_usage(
+                                    fallback_item, complete_response_object_usage
+                                )
                             yield fallback_item
                     else:
                         # If fallback returns a non-streaming response, yield None
@@ -1799,7 +1801,7 @@ class Router:
             try:
                 for item in model_response:
                     yield item
-            except litellm.ContextWindowExceededError as e:
+            except litellm.ContextWindowExceededError:
                 # Handle ContextWindowExceededError raised mid-stream
                 # (e.g. by sglang frameworks that return context window
                 # errors during streaming instead of at request time).
@@ -1822,13 +1824,11 @@ class Router:
                     router_self._update_kwargs_before_fallbacks(
                         model=model_group, kwargs=initial_kwargs
                     )
-                    fallback_response = (
-                        router_self.function_with_fallbacks(
-                            **initial_kwargs,
-                            fallbacks=fallbacks,
-                            context_window_fallbacks=context_window_fallbacks,
-                            content_policy_fallbacks=content_policy_fallbacks,
-                        )
+                    fallback_response = router_self.function_with_fallbacks(
+                        **initial_kwargs,
+                        fallbacks=fallbacks,
+                        context_window_fallbacks=context_window_fallbacks,
+                        content_policy_fallbacks=content_policy_fallbacks,
                     )
 
                     if hasattr(fallback_response, "__iter__"):
@@ -1883,13 +1883,11 @@ class Router:
                     router_self._update_kwargs_before_fallbacks(
                         model=model_group, kwargs=initial_kwargs
                     )
-                    fallback_response = (
-                        router_self.function_with_fallbacks(
-                            **initial_kwargs,
-                            fallbacks=fallbacks,
-                            context_window_fallbacks=context_window_fallbacks,
-                            content_policy_fallbacks=content_policy_fallbacks,
-                        )
+                    fallback_response = router_self.function_with_fallbacks(
+                        **initial_kwargs,
+                        fallbacks=fallbacks,
+                        context_window_fallbacks=context_window_fallbacks,
+                        content_policy_fallbacks=content_policy_fallbacks,
                     )
 
                     if hasattr(fallback_response, "__iter__"):
@@ -1899,7 +1897,9 @@ class Router:
                                 and isinstance(fallback_item, ModelResponseStream)
                                 and hasattr(fallback_item, "usage")
                             ):
-                                router_self._combine_fallback_usage(fallback_item, complete_response_object_usage)
+                                router_self._combine_fallback_usage(
+                                    fallback_item, complete_response_object_usage
+                                )
                             yield fallback_item
                     else:
                         yield None
@@ -2811,10 +2811,9 @@ class Router:
         litellm_model = data.get("model", None)
 
         # litellm_agent/ prefix only strips the model name, no prompt_id needed
-        is_litellm_agent_model = (
-            isinstance(litellm_model, str)
-            and litellm_model.startswith("litellm_agent/")
-        )
+        is_litellm_agent_model = isinstance(
+            litellm_model, str
+        ) and litellm_model.startswith("litellm_agent/")
 
         prompt_id = kwargs.get("prompt_id") or prompt_management_deployment[
             "litellm_params"
@@ -6594,7 +6593,7 @@ class Router:
             tiers = complexity_router_config.get("tiers", {})
             # Use MEDIUM tier as fallback default
             default_model = tiers.get("MEDIUM") or tiers.get("SIMPLE")
-        
+
         if default_model is None:
             raise ValueError(
                 "complexity_router_default_model is required for complexity-router deployments, "
@@ -6827,7 +6826,9 @@ class Router:
         #########################################################
         # Check if this is a complexity-router deployment
         #########################################################
-        if self._is_complexity_router_deployment(litellm_params=deployment.litellm_params):
+        if self._is_complexity_router_deployment(
+            litellm_params=deployment.litellm_params
+        ):
             self.init_complexity_router_deployment(deployment=deployment)
 
         return deployment
@@ -6919,9 +6920,7 @@ class Router:
         # zero-cost models, causing budget checks to block free models.
         _model_id = deployment.model_info.id
         if _model_id is not None:
-            _model_info_dict: dict = deployment.model_info.model_dump(
-                exclude_none=True
-            )
+            _model_info_dict: dict = deployment.model_info.model_dump(exclude_none=True)
             for field in CustomPricingLiteLLMParams.model_fields.keys():
                 field_value = deployment.litellm_params.get(field)
                 if field_value is not None:
@@ -7202,7 +7201,10 @@ class Router:
 
     @overload
     def get_router_model_info(
-        self, deployment: Union[dict, "Deployment"], received_model_name: str, id: None = None
+        self,
+        deployment: Union[dict, "Deployment"],
+        received_model_name: str,
+        id: None = None,
     ) -> ModelMapInfo:
         pass
 
@@ -7242,7 +7244,9 @@ class Router:
         ## GET BASE MODEL
         base_model = (deployment.get("model_info") or {}).get("base_model", None)
         if base_model is None:
-            base_model = (deployment.get("litellm_params") or {}).get("base_model", None)
+            base_model = (deployment.get("litellm_params") or {}).get(
+                "base_model", None
+            )
 
         model = base_model
 
@@ -7277,12 +7281,12 @@ class Router:
                 if potential_models is not None:
                     for potential_model in potential_models:
                         try:
-                            if (potential_model.get("model_info") or {}).get(
-                                "id"
-                            ) == (deployment.get("model_info") or {}).get("id"):
-                                model = (potential_model.get("litellm_params") or {}).get(
-                                    "model"
-                                )
+                            if (potential_model.get("model_info") or {}).get("id") == (
+                                deployment.get("model_info") or {}
+                            ).get("id"):
+                                model = (
+                                    potential_model.get("litellm_params") or {}
+                                ).get("model")
                                 break
                         except Exception:
                             pass
@@ -8205,7 +8209,9 @@ class Router:
         - team_id: Optional[str] - the team id, to resolve team-specific models
         """
         # Check if this is the no-args hot path (cacheable)
-        _use_cache = model_name is None and model_access_group is None and team_id is None
+        _use_cache = (
+            model_name is None and model_access_group is None and team_id is None
+        )
 
         # Return cached result for the no-args hot path
         if _use_cache and self._access_groups_cache is not None:

--- a/tests/test_litellm/test_router_context_window_stream_fallback.py
+++ b/tests/test_litellm/test_router_context_window_stream_fallback.py
@@ -1,0 +1,444 @@
+"""
+Tests for ContextWindowExceededError handling in streaming iterators.
+
+When certain inference frameworks (e.g. SGLang) return HTTP 200 for the
+initial request but embed a context-window-exceeded error *inside* the
+SSE stream, the Router's streaming iterators must catch the resulting
+``ContextWindowExceededError`` and route it through the fallback system
+(``context_window_fallbacks``) instead of letting it bubble up to the
+caller.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+import litellm
+
+
+# ---------------------------------------------------------------------------
+# Async streaming – ContextWindowExceededError triggers fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_acompletion_streaming_context_window_error_triggers_fallback():
+    """Async streaming: ContextWindowExceededError raised mid-stream triggers
+    context_window_fallbacks via async_function_with_fallbacks_common_utils.
+
+    This mirrors the pattern tested for MidStreamFallbackError in
+    test_acompletion_streaming_iterator (test_router.py).
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "sglang-model",
+                "litellm_params": {
+                    "model": "openai/sglang-model",
+                    "api_key": "fake-key-1",
+                },
+            },
+            {
+                "model_name": "fallback-model",
+                "litellm_params": {
+                    "model": "openai/fallback-model",
+                    "api_key": "fake-key-2",
+                },
+            },
+        ],
+        context_window_fallbacks=[{"sglang-model": ["fallback-model"]}],
+    )
+
+    messages = [{"role": "user", "content": "Hello"}]
+    initial_kwargs = {"model": "sglang-model", "stream": True}
+
+    ctx_error = litellm.ContextWindowExceededError(
+        message="The input (85066 tokens) is longer than the model's context length (81920 tokens).",
+        model="sglang-model",
+        llm_provider="openai",
+    )
+
+    # Async iterator that raises ContextWindowExceededError immediately
+    class AsyncIteratorWithContextError:
+        def __init__(self):
+            self.model = "sglang-model"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise ctx_error
+
+    mock_response = AsyncIteratorWithContextError()
+
+    # Fallback yields two chunks
+    fallback_chunks = [
+        MagicMock(choices=[MagicMock(delta=MagicMock(content="fallback"))]),
+        MagicMock(choices=[MagicMock(delta=MagicMock(content=" response"))]),
+    ]
+
+    class AsyncFallbackIterator:
+        def __init__(self, items):
+            self.items = items
+            self.index = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self.index >= len(self.items):
+                raise StopAsyncIteration
+            item = self.items[self.index]
+            self.index += 1
+            return item
+
+    mock_fallback_response = AsyncFallbackIterator(fallback_chunks)
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=mock_fallback_response,
+    ) as mock_fallback_utils:
+        result = await router._acompletion_streaming_iterator(
+            model_response=mock_response,
+            messages=messages,
+            initial_kwargs=initial_kwargs,
+        )
+
+        collected_chunks = []
+        async for chunk in result:
+            collected_chunks.append(chunk)
+
+        # Verify fallback was called
+        assert mock_fallback_utils.called
+        call_args = mock_fallback_utils.call_args
+
+        # Verify the exception was passed through
+        assert call_args.kwargs["e"] is ctx_error
+
+        # Verify disable_fallbacks is False (fallbacks should be enabled)
+        assert call_args.kwargs["disable_fallbacks"] is False
+
+        # Verify model_group
+        assert call_args.kwargs["model_group"] == "sglang-model"
+
+        # Verify original messages are used (no continuation prompt for
+        # context window errors, unlike MidStreamFallbackError)
+        fallback_kwargs = call_args.kwargs["kwargs"]
+        assert fallback_kwargs["messages"] == messages
+
+        # Verify original_function is _acompletion (async)
+        assert fallback_kwargs["original_function"] == router._acompletion
+
+        # Verify we received the fallback chunks
+        assert len(collected_chunks) == 2
+        assert collected_chunks == fallback_chunks
+
+
+@pytest.mark.asyncio
+async def test_acompletion_streaming_context_window_error_after_partial_chunks():
+    """Async streaming: ContextWindowExceededError raised after yielding some
+    chunks still triggers fallback.
+
+    SGLang may return a few empty or partial chunks before the error appears
+    in the SSE stream.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "sglang-model",
+                "litellm_params": {
+                    "model": "openai/sglang-model",
+                    "api_key": "fake-key",
+                },
+            },
+            {
+                "model_name": "fallback-model",
+                "litellm_params": {
+                    "model": "openai/fallback-model",
+                    "api_key": "fake-key-2",
+                },
+            },
+        ],
+        context_window_fallbacks=[{"sglang-model": ["fallback-model"]}],
+    )
+
+    messages = [{"role": "user", "content": "Hello"}]
+    initial_kwargs = {"model": "sglang-model", "stream": True}
+
+    ctx_error = litellm.ContextWindowExceededError(
+        message="Context length exceeded",
+        model="sglang-model",
+        llm_provider="openai",
+    )
+
+    initial_chunks = [
+        MagicMock(choices=[MagicMock(delta=MagicMock(content=""))]),
+    ]
+
+    class AsyncIteratorErrorAfterChunks:
+        def __init__(self, items, error_after_index):
+            self.items = items
+            self.index = 0
+            self.error_after_index = error_after_index
+            self.model = "sglang-model"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self.index >= self.error_after_index:
+                raise ctx_error
+            if self.index >= len(self.items):
+                raise StopAsyncIteration
+            item = self.items[self.index]
+            self.index += 1
+            return item
+
+    mock_response = AsyncIteratorErrorAfterChunks(initial_chunks, 1)
+
+    fallback_chunks = [
+        MagicMock(choices=[MagicMock(delta=MagicMock(content="ok"))]),
+    ]
+
+    class AsyncFallbackIterator:
+        def __init__(self, items):
+            self.items = items
+            self.index = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self.index >= len(self.items):
+                raise StopAsyncIteration
+            item = self.items[self.index]
+            self.index += 1
+            return item
+
+    mock_fallback_response = AsyncFallbackIterator(fallback_chunks)
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=mock_fallback_response,
+    ) as mock_fallback_utils:
+        result = await router._acompletion_streaming_iterator(
+            model_response=mock_response,
+            messages=messages,
+            initial_kwargs=initial_kwargs,
+        )
+
+        collected_chunks = []
+        async for chunk in result:
+            collected_chunks.append(chunk)
+
+        assert mock_fallback_utils.called
+        # 1 initial chunk + 1 fallback chunk
+        assert len(collected_chunks) == 2
+
+
+@pytest.mark.asyncio
+async def test_acompletion_streaming_context_window_fallback_failure_raises():
+    """When context_window_fallback itself fails, the fallback error is raised."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "sglang-model",
+                "litellm_params": {
+                    "model": "openai/sglang-model",
+                    "api_key": "fake-key",
+                },
+            },
+        ],
+    )
+
+    messages = [{"role": "user", "content": "Hello"}]
+    initial_kwargs = {"model": "sglang-model", "stream": True}
+
+    ctx_error = litellm.ContextWindowExceededError(
+        message="Context length exceeded",
+        model="sglang-model",
+        llm_provider="openai",
+    )
+
+    class AsyncIteratorImmediateError:
+        def __init__(self):
+            self.model = "sglang-model"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise ctx_error
+
+    mock_response = AsyncIteratorImmediateError()
+
+    fallback_error = Exception("No fallback models available")
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        side_effect=fallback_error,
+    ):
+        result = await router._acompletion_streaming_iterator(
+            model_response=mock_response,
+            messages=messages,
+            initial_kwargs=initial_kwargs,
+        )
+
+        with pytest.raises(Exception, match="No fallback models available"):
+            async for _ in result:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Sync streaming – ContextWindowExceededError triggers fallback
+# ---------------------------------------------------------------------------
+
+
+def test_completion_streaming_context_window_error_triggers_fallback():
+    """Sync streaming: ContextWindowExceededError raised mid-stream triggers
+    context_window_fallbacks via function_with_fallbacks.
+
+    This mirrors test_completion_streaming_iterator_fallback_on_429 in
+    test_router.py.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "sglang-model",
+                "litellm_params": {
+                    "model": "openai/sglang-model",
+                    "api_key": "fake-key-1",
+                },
+            },
+            {
+                "model_name": "fallback-model",
+                "litellm_params": {
+                    "model": "openai/fallback-model",
+                    "api_key": "fake-key-2",
+                },
+            },
+        ],
+        context_window_fallbacks=[{"sglang-model": ["fallback-model"]}],
+    )
+
+    messages = [{"role": "user", "content": "Hello"}]
+    initial_kwargs = {"model": "sglang-model", "stream": True}
+
+    ctx_error = litellm.ContextWindowExceededError(
+        message="The input (85066 tokens) is longer than the model's context length (81920 tokens).",
+        model="sglang-model",
+        llm_provider="openai",
+    )
+
+    class SyncIteratorImmediateError:
+        def __init__(self):
+            self.model = "sglang-model"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise ctx_error
+
+    mock_response = SyncIteratorImmediateError()
+
+    # Fallback returns a simple iterable
+    fallback_chunks = [
+        MagicMock(choices=[MagicMock(delta=MagicMock(content="fallback"))]),
+    ]
+    mock_fallback_response = MagicMock()
+    mock_fallback_response.__iter__ = MagicMock(return_value=iter(fallback_chunks))
+
+    with patch.object(
+        router,
+        "function_with_fallbacks",
+        return_value=mock_fallback_response,
+    ) as mock_fallback:
+        result = router._completion_streaming_iterator(
+            model_response=mock_response,
+            messages=messages,
+            initial_kwargs=initial_kwargs,
+        )
+
+        list(result)
+
+        # Verify fallback was called
+        assert mock_fallback.called
+        call_kwargs = mock_fallback.call_args
+
+        # Verify original messages are used
+        assert call_kwargs.kwargs.get("messages") == messages
+
+        # Verify original_function is _completion (sync)
+        assert call_kwargs.kwargs.get("original_function") == router._completion
+
+
+def test_completion_streaming_context_window_fallback_failure_raises():
+    """Sync streaming: when context_window_fallback itself fails, error is raised."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "sglang-model",
+                "litellm_params": {
+                    "model": "openai/sglang-model",
+                    "api_key": "fake-key",
+                },
+            },
+        ],
+    )
+
+    messages = [{"role": "user", "content": "Hello"}]
+    initial_kwargs = {"model": "sglang-model", "stream": True}
+
+    ctx_error = litellm.ContextWindowExceededError(
+        message="Context length exceeded",
+        model="sglang-model",
+        llm_provider="openai",
+    )
+
+    class SyncIteratorImmediateError:
+        def __init__(self):
+            self.model = "sglang-model"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise ctx_error
+
+    mock_response = SyncIteratorImmediateError()
+
+    fallback_error = Exception("No fallback models available")
+
+    with patch.object(
+        router,
+        "function_with_fallbacks",
+        side_effect=fallback_error,
+    ):
+        result = router._completion_streaming_iterator(
+            model_response=mock_response,
+            messages=messages,
+            initial_kwargs=initial_kwargs,
+        )
+
+        with pytest.raises(Exception, match="No fallback models available"):
+            list(result)


### PR DESCRIPTION
## Relevant issues

<!-- If there's an existing issue, link it here. Otherwise you can create one first. -->
<!-- e.g. Fixes #XXXX -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
      Link:

- [ ] **CI run for the last commit**  
      Link:

- [ ] **Merge / cherry-pick CI run**  
      Links:

## Type

🐛 Bug Fix

## Changes

### Problem

Some inference frameworks (notably **SGLang**) return **HTTP 200** for the initial streaming request but embed a `ContextWindowExceededError` **inside the SSE stream** rather than rejecting the request upfront with a 400 status code.

**Concrete scenario:**  
When using SGLang-served models behind LiteLLM Router with `context_window_fallbacks` configured, a request whose input exceeds the model's context length will:

1. Receive an HTTP 200 response (stream begins successfully)
2. The SSE stream then delivers an error chunk:
   ```json
   {
     "error": {
       "object": "error",
       "message": "The input (85066 tokens) is longer than the model's context length (81920 tokens).",
       "type": "BadRequestError",
       "param": null,
       "code": 400
     }
   }
   ```
3. LiteLLM parses this as a `ContextWindowExceededError` and raises it during stream iteration

**Before this fix:** The `stream_with_fallbacks` generator in the Router's streaming iterators only caught `MidStreamFallbackError`. A `ContextWindowExceededError` raised mid-stream would bubble up directly to the caller, completely bypassing the `context_window_fallbacks` mechanism.

### Solution

Added `ContextWindowExceededError` handling in both streaming iterator methods:

- **`_acompletion_streaming_iterator`** (async): catches `ContextWindowExceededError` and routes it through `async_function_with_fallbacks_common_utils` — the same utility used by `MidStreamFallbackError` handling.
- **`_completion_streaming_iterator`** (sync): catches `ContextWindowExceededError` and routes it through `function_with_fallbacks` — consistent with the sync `MidStreamFallbackError` handling.

The `except ContextWindowExceededError` block is placed **before** the existing `except MidStreamFallbackError` block since `ContextWindowExceededError` is not a subclass of `MidStreamFallbackError`.

Key differences from `MidStreamFallbackError` handling:
- **No continuation prompt**: Since context window errors mean the model cannot process the input at all, we use the original messages directly (no system/assistant continuation injection).
- **No `stream_chunk_builder` call**: There's typically no useful partial content to preserve.

### Testing

Added `tests/test_litellm/test_router_context_window_stream_fallback.py` with 5 mocked test cases covering:

1. **Async — immediate error triggers fallback**: `ContextWindowExceededError` on first chunk → fallback called with correct parameters
2. **Async — error after partial chunks**: Error after yielding some chunks → fallback still triggers, total chunks = partial + fallback
3. **Async — fallback failure propagates**: When fallback itself fails, exception is raised to caller
4. **Sync — immediate error triggers fallback**: Sync equivalent verifying `function_with_fallbacks` is called
5. **Sync — fallback failure propagates**: Sync equivalent of failure propagation

All tests follow the existing patterns established by `test_acompletion_streaming_iterator` and `test_completion_streaming_iterator_fallback_on_429` in `test_router.py`.