### PR TITLE
Bugfix/fix missing commas in string lists

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -835,7 +835,7 @@ clarifai_models: set = set(
         "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Instruct-2507",
         "clarifai/qwen.qwen3.qwen3-next-80B-A3B-Thinking",
         "clarifai/openai.chat-completion.gpt-oss-120b",
-        "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507"
+        "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507",
         "clarifai/openai.chat-completion.gpt-5-nano",
         "clarifai/openai.chat-completion.gpt-4o",
         "clarifai/gcp.generate.gemini-2_5-pro",

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1044,7 +1044,7 @@ OpenAIImageGenerationOptionalParams = Literal[
 OpenAIImageEditOptionalParams = Literal[
     "background",
     "n",
-    "mask"
+    "mask",
     "output_compression",
     "output_format",
     "quality",

--- a/tests/test_litellm/test_missing_comma_fixes.py
+++ b/tests/test_litellm/test_missing_comma_fixes.py
@@ -1,0 +1,56 @@
+"""
+Tests to verify that string lists/Literals do not contain
+implicit string concatenation caused by missing commas.
+"""
+
+import os
+import sys
+import typing
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from litellm.constants import clarifai_models
+from litellm.types.llms.openai import OpenAIImageEditOptionalParams
+
+
+def test_clarifai_models_no_implicit_concat():
+    """
+    Verify clarifai_models contains the two individual model strings,
+    not a single concatenated string caused by a missing comma.
+
+    Bug: missing comma between
+        "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507"
+        "clarifai/openai.chat-completion.gpt-5-nano"
+    resulted in the concatenated string:
+        "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507clarifai/openai.chat-completion.gpt-5-nano"
+    """
+    assert "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507" in clarifai_models
+    assert "clarifai/openai.chat-completion.gpt-5-nano" in clarifai_models
+
+    # The concatenated (invalid) string should NOT be present
+    bad_concat = (
+        "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507"
+        "clarifai/openai.chat-completion.gpt-5-nano"
+    )
+    assert bad_concat not in clarifai_models
+
+
+def test_openai_image_edit_params_no_implicit_concat():
+    """
+    Verify OpenAIImageEditOptionalParams Literal contains both "mask"
+    and "output_compression" as separate values, not a concatenated
+    "maskoutput_compression" caused by a missing comma.
+    """
+    valid_values = typing.get_args(OpenAIImageEditOptionalParams)
+
+    assert "mask" in valid_values, (
+        f'"mask" not found in OpenAIImageEditOptionalParams. Got: {valid_values}'
+    )
+    assert "output_compression" in valid_values, (
+        f'"output_compression" not found in OpenAIImageEditOptionalParams. Got: {valid_values}'
+    )
+
+    # The concatenated (invalid) string should NOT be present
+    assert "maskoutput_compression" not in valid_values, (
+        '"maskoutput_compression" found — likely a missing comma between "mask" and "output_compression"'
+    )


### PR DESCRIPTION
## Relevant issues

<!-- No existing issue found -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
      Link:

- [ ] **CI run for the last commit**  
      Link:

- [ ] **Merge / cherry-pick CI run**  
      Links:

## Type

🐛 Bug Fix

## Changes

### Problem

Two missing commas in string collection definitions cause Python's implicit 
string concatenation to silently merge adjacent string literals into invalid 
combined values.

**Bug 1 — `litellm/constants.py:838` (`clarifai_models` set)**

```python
# Before (missing comma):
"clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507"
"clarifai/openai.chat-completion.gpt-5-nano",
# Python sees this as one string:
# "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507clarifai/openai.chat-completion.gpt-5-nano"
```

**Impact:** Two valid Clarifai models (`Qwen3-30B-A3B-Thinking-2507` and 
`gpt-5-nano`) are missing from the `clarifai_models` set, replaced by one 
garbage concatenated string. Users routing requests through these models 
will fail to match.

**Bug 2 — `litellm/types/llms/openai.py:1047` (`OpenAIImageEditOptionalParams` Literal)**

```python
# Before (missing comma):
"mask"
"output_compression",
# Python sees this as: "maskoutput_compression"
```

**Impact:** The `OpenAIImageEditOptionalParams` Literal type is missing both 
`"mask"` and `"output_compression"` as valid values. Instead it contains the 
nonsensical `"maskoutput_compression"`. This means:
- The `mask` parameter cannot pass type validation for image edit requests
- The `output_compression` parameter is also silently dropped

### Solution

Added the missing trailing commas to both locations.

### Testing

Added `tests/test_litellm/test_missing_comma_fixes.py` with tests that verify:
1. `clarifai_models` contains both individual model strings (not the concatenated one)
2. `OpenAIImageEditOptionalParams` includes both `"mask"` and `"output_compression"` 
   as separate valid values