### PR TITLE
fix(deepinfra): set supports_function_calling=true for Llama-3.3-70B-Instruct-Turbo

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -11177,6 +11177,7 @@
         "output_cost_per_token": 4e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
+        "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo": {
@@ -11187,6 +11188,7 @@
         "output_cost_per_token": 3.9e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
+        "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
@@ -11378,6 +11380,7 @@
         "output_cost_per_token": 4e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
+        "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11271,6 +11271,7 @@
         "output_cost_per_token": 4e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
+        "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo": {
@@ -11281,6 +11282,7 @@
         "output_cost_per_token": 3.9e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
+        "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
@@ -11472,6 +11474,7 @@
         "output_cost_per_token": 4e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
+        "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2": {


### PR DESCRIPTION
Fixes #22619\n\nThe model entry had `supports_function_calling: null` despite the model supporting tools. This PR sets it to `true` for `deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo` and related variants.