### PR TITLE
fix: reject invalid audio durations from buggy libsndfile

### DIFF
--- a/litellm/litellm_core_utils/audio_utils/utils.py
+++ b/litellm/litellm_core_utils/audio_utils/utils.py
@@ -263,7 +263,15 @@ def calculate_request_duration(file: FileTypes) -> Optional[float]:
         # Extract duration using soundfile
         file_object = io.BytesIO(file_content)
         with sf.SoundFile(file_object) as audio:
-            duration = len(audio) / audio.samplerate
+            frames = len(audio)
+            # Reject sentinel values returned by buggy libsndfile versions
+            # (e.g. libsndfile 1.2.0 returns 2^63-1 for some OPUS files)
+            if frames <= 0 or frames >= 2**63 - 1:
+                return None
+            duration = frames / audio.samplerate
+            # Sanity-check: reject durations longer than 24 hours
+            if duration > 86400:
+                return None
             return duration
 
     except Exception:

--- a/tests/test_litellm/litellm_core_utils/test_audio_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_audio_utils.py
@@ -266,6 +266,62 @@ class TestCalculateRequestDuration:
         ), "File position should be restored to original position"
 
 
+    def test_rejects_sentinel_frame_count(self):
+        """
+        Test that calculate_request_duration rejects sentinel frame counts
+        returned by buggy libsndfile versions (e.g. 2^63-1 for OPUS files).
+
+        Regression test for https://github.com/BerriAI/litellm/issues/22622
+        """
+        mock_audio = type("MockAudio", (), {
+            "__len__": lambda self: 2**63 - 1,
+            "samplerate": 48000,
+            "__enter__": lambda self: self,
+            "__exit__": lambda self, *a: None,
+        })()
+
+        with patch("soundfile.SoundFile", return_value=mock_audio):
+            duration = calculate_request_duration(b"fake audio bytes")
+
+        assert duration is None, (
+            "Should return None for sentinel frame count (2^63-1)"
+        )
+
+    def test_rejects_zero_frame_count(self):
+        """Test that calculate_request_duration rejects zero-length audio."""
+        mock_audio = type("MockAudio", (), {
+            "__len__": lambda self: 0,
+            "samplerate": 48000,
+            "__enter__": lambda self: self,
+            "__exit__": lambda self, *a: None,
+        })()
+
+        with patch("soundfile.SoundFile", return_value=mock_audio):
+            duration = calculate_request_duration(b"fake audio bytes")
+
+        assert duration is None, "Should return None for zero frames"
+
+    def test_rejects_extreme_duration(self):
+        """
+        Test that calculate_request_duration rejects durations exceeding
+        24 hours (86400 seconds) as implausible.
+        """
+        # 100000 seconds at 1 Hz samplerate = 100000 frames
+        mock_audio = type("MockAudio", (), {
+            "__len__": lambda self: 100000,
+            "samplerate": 1,
+            "__enter__": lambda self: self,
+            "__exit__": lambda self, *a: None,
+        })()
+
+        with patch("soundfile.SoundFile", return_value=mock_audio):
+            duration = calculate_request_duration(b"fake audio bytes")
+
+        assert duration is None, (
+            "Should return None for durations exceeding 24 hours"
+        )
+
+
 class TestGetAudioFileContentHash:
     """Test the get_audio_file_content_hash function for cache key generation"""
 


### PR DESCRIPTION
## Summary
Fixes #22622

- `calculate_request_duration()` can return astronomically large durations (~192 trillion seconds) when `libsndfile` 1.2.0 reports a sentinel frame count (`2^63-1`) for certain OPUS files
- This causes audio transcription requests to be massively overbilled

## Changes
- Reject sentinel frame counts (`0` or `>= 2^63-1`) from `soundfile.SoundFile`
- Reject calculated durations exceeding 24 hours (86400 seconds) as implausible
- Return `None` for invalid durations, letting the caller fall back to provider-reported usage

## Test plan
- [x] Added `test_rejects_sentinel_frame_count` — mocks `len(audio)` returning `2^63-1`
- [x] Added `test_rejects_zero_frame_count` — mocks `len(audio)` returning `0`
- [x] Added `test_rejects_extreme_duration` — mocks 100,000-second audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)