### PR TITLE
fix(bedrock): add missing type field in parallel_tool_calls tool_choi…

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -918,7 +918,8 @@ class AmazonConverseConfig(BaseConfig):
                 disable_parallel = not value
                 optional_params["_parallel_tool_use_config"] = {
                     "tool_choice": {
-                        "disable_parallel_tool_use": disable_parallel
+                        "type": "auto",
+                        "disable_parallel_tool_use": disable_parallel,
                     }
                 }
             if param == "thinking":

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -3421,6 +3421,7 @@ def test_parallel_tool_calls_newer_model_adds_disable_flag():
 
     assert "additionalModelRequestFields" in request_data
     assert "tool_choice" in request_data["additionalModelRequestFields"]
+    assert request_data["additionalModelRequestFields"]["tool_choice"]["type"] == "auto"
     assert request_data["additionalModelRequestFields"]["tool_choice"]["disable_parallel_tool_use"] is True
     assert "parallel_tool_calls" not in request_data["additionalModelRequestFields"]
 
@@ -3449,6 +3450,38 @@ def test_parallel_tool_calls_older_model_drops_disable_flag():
     additional = request_data.get("additionalModelRequestFields", {})
     assert "tool_choice" not in additional
     assert "parallel_tool_calls" not in additional
+
+
+def test_parallel_tool_calls_true_includes_type_field():
+    """parallel_tool_calls=True must include 'type' in tool_choice to avoid Bedrock rejection.
+
+    Regression test: without 'type': 'auto', the Anthropic model on Bedrock rejects the
+    request with: tool_choice.type: Field required
+    """
+    config = AmazonConverseConfig()
+    model = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    messages = [{"role": "user", "content": "hi"}]
+
+    optional_params = config.map_openai_params(
+        non_default_params={"parallel_tool_calls": True, "tools": _TOOL_PARAM},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    request_data = config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert "additionalModelRequestFields" in request_data
+    tc = request_data["additionalModelRequestFields"]["tool_choice"]
+    assert tc["type"] == "auto"
+    assert tc["disable_parallel_tool_use"] is False
+    assert "parallel_tool_calls" not in request_data["additionalModelRequestFields"]
 
 
 class TestBedrockMinThinkingBudgetTokens:


### PR DESCRIPTION
## Relevant issues

Fixes #22637

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Problem

`parallel_tool_calls: true` with `tools` on Bedrock Claude 4.5+ models fails with:
`BedrockException - tool_choice.type: Field required`

In `map_openai_params()`, the `_parallel_tool_use_config` creates a `tool_choice` object without the required `"type"` field. For Claude 4.5+ this gets merged into `additionalModelRequestFields` and passed directly to the Anthropic model, which rejects it.

### Fix

Add `"type": "auto"` to the `tool_choice` object in `_parallel_tool_use_config`.

### Testing

- Updated `test_parallel_tool_calls_newer_model_adds_disable_flag` to assert `type` field
- Added `test_parallel_tool_calls_true_includes_type_field` — regression test for `parallel_tool_calls: True`
