### PR TITLE
[Chore]Remove defualt hardcoded thinking levels for gemini 3 family

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1136,23 +1136,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         if VertexGeminiConfig._is_gemini_3_or_newer(model):
             if "temperature" not in optional_params:
                 optional_params["temperature"] = 1.0
-            # Only add thinkingLevel if model supports it (exclude image models)
-            if "image" not in model.lower():
-                thinking_config = optional_params.get("thinkingConfig", {})
-                if (
-                    "thinkingLevel" not in thinking_config
-                    and "thinkingBudget" not in thinking_config
-                ):
-                    # For gemini-3-flash-preview, default to "minimal" to match Gemini 2.5 Flash behavior
-                    # For other Gemini 3 models, default to "low"
-                    is_gemini3flash = (
-                        "gemini-3-flash-preview" in model.lower()
-                        or "gemini-3-flash" in model.lower()
-                    )
-                    thinking_config["thinkingLevel"] = (
-                        "minimal" if is_gemini3flash else "low"
-                    )
-                    optional_params["thinkingConfig"] = thinking_config
 
         return optional_params
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2130,7 +2130,7 @@ def test_reasoning_effort_dict_format_gemini_3():
     assert result["thinkingConfig"]["thinkingLevel"] == "high"
     assert result["thinkingConfig"]["includeThoughts"] is True
 
-    # Test dict format without effort key - should fall back to Gemini 3 default (low)
+    # Test dict format without effort key - no thinkingConfig should be set
     optional_params = {}
     non_default_params = {"reasoning_effort": {"summary": "auto"}}
     result = v.map_openai_params(
@@ -2139,8 +2139,8 @@ def test_reasoning_effort_dict_format_gemini_3():
         model=model,
         drop_params=False,
     )
-    # Gemini 3 defaults to thinkingLevel="low" when no explicit effort is set
-    assert result["thinkingConfig"]["thinkingLevel"] == "low"
+    # No effort key in dict → no thinkingConfig set
+    assert "thinkingConfig" not in result
 
 
 def test_temperature_default_for_gemini_3():
@@ -2453,8 +2453,8 @@ def test_gemini_3_image_models_no_thinking_config():
 
 def test_gemini_3_text_models_get_thinking_config():
     """
-    Test that Gemini 3 text models DO receive automatic thinkingConfig.
-    This ensures we didn't break the existing behavior for non-image models.
+    Test that Gemini 3 text models do NOT receive automatic thinkingConfig
+    when no reasoning_effort or thinking param is provided.
     """
     from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
         VertexGeminiConfig,
@@ -2462,7 +2462,7 @@ def test_gemini_3_text_models_get_thinking_config():
 
     v = VertexGeminiConfig()
 
-    # Test gemini-3-pro-preview (text model, should get thinking)
+    # Test gemini-3-pro-preview (text model, no explicit thinking params)
     model = "gemini-3-pro-preview"
     optional_params = {}
     non_default_params = {}
@@ -2474,9 +2474,8 @@ def test_gemini_3_text_models_get_thinking_config():
         drop_params=False,
     )
 
-    # Should have thinkingConfig automatically added
-    assert "thinkingConfig" in result
-    assert result["thinkingConfig"]["thinkingLevel"] == "low"
+    # Should NOT have thinkingConfig automatically added when user provides no reasoning_effort
+    assert "thinkingConfig" not in result
     assert result["temperature"] == 1.0
 
 


### PR DESCRIPTION
## Relevant issues

This is done as gemini 3 family has high as default when not specified in request. Litellm should not create its own defaults, and also no need for tests

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
