### PR TITLE
fix(pricing): add 7 missing DashScope model pricing entries

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9779,6 +9779,122 @@
             }
         ]
     },
+    "dashscope/qwen3-max-2026-01-23": {
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 258048,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.4e-06,
+                "output_cost_per_token": 1.2e-05,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    252000.0
+                ]
+            }
+        ]
+    },
+    "dashscope/qwen3-next-80b-a3b-instruct": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/qwen3-next-80b-a3b-thinking": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/qwen3-vl-235b-a22b-instruct": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.6e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "dashscope/qwen3-vl-235b-a22b-thinking": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "dashscope/qwen3-vl-32b-instruct": {
+        "input_cost_per_token": 1.6e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 6.4e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "dashscope/qwen3-vl-32b-thinking": {
+        "input_cost_per_token": 1.6e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 2.87e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "dashscope/qwen3-vl-plus": {
         "litellm_provider": "dashscope",
         "max_input_tokens": 260096,


### PR DESCRIPTION
## Relevant issues

Fixes #22646 (partially — addresses the 7 valid DashScope models)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory - N/A (pure JSON data update, no code logic changed)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Adds pricing entries for 7 DashScope models that were missing from `model_prices_and_context_window.json`, causing `$0.00` spend tracking in the proxy dashboard.

| Model | Input $/1M | Output $/1M | Source |
|-------|-----------|------------|--------|
| `dashscope/qwen3-max-2026-01-23` | Tiered (same as qwen3-max) | Tiered | [Alibaba Models](https://www.alibabacloud.com/help/en/model-studio/models) |
| `dashscope/qwen3-next-80b-a3b-instruct` | $0.15 | $1.20 | [Alibaba Pricing](https://www.alibabacloud.com/help/en/model-studio/model-pricing) |
| `dashscope/qwen3-next-80b-a3b-thinking` | $0.15 | $1.20 | [Alibaba Pricing](https://www.alibabacloud.com/help/en/model-studio/model-pricing) |
| `dashscope/qwen3-vl-235b-a22b-instruct` | $0.40 | $1.60 | [Alibaba Pricing](https://www.alibabacloud.com/help/en/model-studio/model-pricing) |
| `dashscope/qwen3-vl-235b-a22b-thinking` | $0.40 | $4.00 | [Alibaba Pricing](https://www.alibabacloud.com/help/en/model-studio/model-pricing) |
| `dashscope/qwen3-vl-32b-instruct` | $0.16 | $0.64 | [Alibaba Pricing](https://www.alibabacloud.com/help/en/model-studio/model-pricing) |
| `dashscope/qwen3-vl-32b-thinking` | $0.16 | $2.87 | [Alibaba Pricing](https://www.alibabacloud.com/help/en/model-studio/model-pricing) |

### Triage notes on the remaining 8 models in #22646

The issue reported 15 models, but only 7 are actually missing:

- **6 already have pricing** but use non-per-token metrics that the reporter didn't recognize:
  - `dashscope/qwen3-max` — has `tiered_pricing`
  - `minimax/MiniMax-M2.5` — has `input_cost_per_token` + `output_cost_per_token`
  - `minimax/speech-2.6-hd` — has `input_cost_per_character` (audio speech model)
  - `vertex_ai/veo-3.1-generate-preview` — has `output_cost_per_second` (video generation)
  - `vertex_ai/veo-3.1-fast-generate-preview` — has `output_cost_per_second` (video generation)
  - `azure_ai/cohere-rerank-v4.0-pro` — has `input_cost_per_query` (reranking model)
- **`glm-5`** — no standalone provider exists in LiteLLM; already covered by `vertex_ai/zai-org/glm-5-maas` and `openrouter/z-ai/glm-5`
- **`openai_like/text-embedding-v4`** — `openai_like` is a generic provider for custom endpoints; pricing depends on the host, not a fixed entry