### PR TITLE
Add support for encrypted content affinity

### DIFF
--- a/docs/my-website/blog/responses_api_encrypted_content_incident/index.md
+++ b/docs/my-website/blog/responses_api_encrypted_content_incident/index.md
@@ -1,0 +1,231 @@
+---
+slug: responses-api-encrypted-content-incident
+title: "Incident Report: Encrypted Content Failures in Multi-Region Responses API Load Balancing"
+date: 2026-02-24T10:00:00
+authors:
+  - name: Sameer Kankute
+    title: SWE @ LiteLLM (LLM Translation)
+    url: https://www.linkedin.com/in/sameer-kankute/
+    image_url: https://pbs.twimg.com/profile_images/2001352686994907136/ONgNuSk5_400x400.jpg
+  - name: Krrish Dholakia
+    title: "CEO, LiteLLM"
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: "CTO, LiteLLM"
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+tags: [incident-report, proxy, responses-api, load-balancing]
+hide_table_of_contents: false
+---
+
+**Date:** Feb 24, 2026  
+**Duration:** Ongoing (until fix deployed)  
+**Severity:** High (for users load balancing Responses API across different API keys)  
+**Status:** Resolved
+
+## Summary
+
+When load balancing OpenAI's Responses API across deployments with **different API keys** (e.g., different Azure regions or OpenAI organizations), follow-up requests containing encrypted content items (like `rs_...` reasoning items) would fail with:
+
+```json
+{
+  "error": {
+    "message": "The encrypted content for item rs_0d09d6e56879e76500699d6feee41c8197bd268aae76141f87 could not be verified. Reason: Encrypted content organization_id did not match the target organization.",
+    "type": "invalid_request_error",
+    "code": "invalid_encrypted_content"
+  }
+}
+```
+
+Encrypted content items are cryptographically tied to the API key's organization that created them. When the router load balanced a follow-up request to a deployment with a different API key, decryption failed.
+
+- **Responses API calls with encrypted content:** Complete failure when routed to wrong deployment
+- **Initial requests:** Unaffected — only follow-up requests containing encrypted items failed
+- **Other API endpoints:** No impact — chat completions, embeddings, etc. functioned normally
+
+{/* truncate */}
+
+---
+
+## Background
+
+OpenAI's Responses API can return encrypted "reasoning items" (with IDs like `rs_...`) that contain intermediate reasoning steps. These items are encrypted with the organization's key and can only be decrypted by the same organization's API key.
+
+When load balancing across deployments with different API keys, the existing affinity mechanisms were insufficient:
+
+- **`responses_api_deployment_check`**: Requires `previous_response_id` which some clients (like Codex) don't provide
+- **`deployment_affinity`**: Too broad — pins *all* requests from a user to one deployment, reducing effective quota by the number of users
+- **`session_affinity`**: Requires explicit session IDs and still reduces quota
+
+```mermaid
+flowchart TD
+    A["1. Initial request to Responses API
+    router.aresponses()"] --> B["2. Router load balances to Deployment A
+    (API Key 1, Azure East US)"]
+    B --> C["3. Response contains encrypted item
+    rs_abc123 (encrypted with Org 1 key)"]
+    C --> D["4. Follow-up request includes rs_abc123 in input"]
+    D --> E["5. Router load balances to Deployment B
+    (API Key 2, Azure West Europe)"]
+    E -->|"Different API key"| F["6. ❌ Deployment B cannot decrypt rs_abc123
+    Error: invalid_encrypted_content"]
+    
+    D -.->|"With encrypted_content_affinity"| G["5b. Router detects rs_abc123 was created by Deployment A"]
+    G --> H["6b. ✅ Routes to Deployment A (bypasses rate limits)
+    Request succeeds"]
+
+    style F fill:#f8d7da,stroke:#dc3545
+    style H fill:#d4edda,stroke:#28a745
+    style E fill:#fff3cd,stroke:#ffc107
+    style G fill:#d4edda,stroke:#28a745
+```
+
+---
+
+## Root Cause
+
+LiteLLM's router had no mechanism to track which deployment created specific encrypted content items and route follow-up requests accordingly. The router treated all deployments as interchangeable, leading to decryption failures when encrypted content crossed organizational boundaries.
+
+**The Problem Flow:**
+
+1. User calls `router.aresponses()` with model `gpt-5.1-codex`
+2. Router load balances to Deployment A (Azure East US, API Key 1)
+3. Response contains encrypted reasoning item `rs_abc123` (encrypted with Org 1's key)
+4. User makes follow-up request with `rs_abc123` in the input
+5. Router load balances to Deployment B (Azure West Europe, API Key 2)
+6. Deployment B tries to decrypt `rs_abc123` with Org 2's key → **fails**
+
+**Why Existing Solutions Didn't Work:**
+
+- **`previous_response_id`**: Not provided by all clients (e.g., Codex)
+- **`deployment_affinity`**: Pins *all* user requests to one deployment → reduces quota to 1/N where N = number of deployments
+- **`session_affinity`**: Requires explicit session management and still reduces quota
+
+**Timeline:**
+
+1. Users configured multi-region Responses API load balancing with different API keys
+2. Initial requests succeeded, but follow-up requests with encrypted content failed intermittently
+3. Error rate correlated with number of deployments (more deployments = higher chance of routing to wrong one)
+4. Investigation revealed encrypted content was organization-bound
+5. Existing affinity mechanisms deemed unsuitable (quota reduction, missing `previous_response_id`)
+6. New solution designed and implemented: `encrypted_content_affinity`
+
+---
+
+## The Fix
+
+Implemented a new `encrypted_content_affinity` pre-call check that intelligently tracks encrypted content and routes follow-up requests **only when necessary**.
+
+### Implementation
+
+**1. New `EncryptedContentAffinityCheck` Class** ([`encrypted_content_affinity_check.py`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py))
+
+```python
+class EncryptedContentAffinityCheck(CustomLogger):
+    """
+    Routes follow-up Responses API requests to the deployment that produced
+    the encrypted output items they reference.
+    """
+    
+    async def async_log_success_event(self, kwargs, response_obj, ...):
+        """Track: Extract item IDs from response output, cache item_id → deployment_id"""
+        output = self._get_output_from_response(response_obj)
+        item_ids = self._extract_item_ids_from_output(output)
+        model_id = self._get_model_id_from_kwargs(kwargs)
+        
+        for item_id in item_ids:
+            await self.cache.async_set_cache(
+                f"encrypted_content_affinity:v1:{item_id}",
+                model_id,
+                ttl=86400,  # 24 hours
+            )
+    
+    async def async_filter_deployments(self, model, healthy_deployments, ...):
+        """Route: Check if input contains tracked items, pin to originating deployment"""
+        input_item_ids = self._extract_item_ids_from_input(request_kwargs.get("input"))
+        
+        for item_id in input_item_ids:
+            cached_model_id = await self.cache.async_get_cache(f"...:{item_id}")
+            if cached_model_id:
+                deployment = self._find_deployment_by_model_id(
+                    healthy_deployments, cached_model_id
+                )
+                if deployment:
+                    # Signal to bypass rate limits (encrypted content must go here)
+                    request_kwargs["_encrypted_content_affinity_pinned"] = True
+                    return [deployment]
+        
+        return healthy_deployments  # Normal load balancing
+```
+
+**2. Rate Limit Bypass** ([`router.py#L8656-L8660`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/router.py#L8656-L8660))
+
+When encrypted content requires a specific deployment, RPM/TPM limits are bypassed (the request would fail on any other deployment anyway):
+
+```python
+# In async_get_available_deployment, after filtering healthy deployments:
+if (
+    request_kwargs.get("_encrypted_content_affinity_pinned")
+    and len(healthy_deployments) == 1
+):
+    return healthy_deployments[0]  # Bypass routing strategy (RPM/TPM checks)
+```
+
+**3. Configuration**
+
+```yaml
+router_settings:
+  routing_strategy: usage-based-routing-v2
+  enable_pre_call_checks: true
+  optional_pre_call_checks:
+    - encrypted_content_affinity
+  deployment_affinity_ttl_seconds: 86400  # 24 hours
+```
+
+### Key Benefits
+
+✅ **No quota reduction**: Only pins requests containing tracked encrypted items  
+✅ **Bypasses rate limits**: When encrypted content requires a specific deployment, RPM/TPM limits don't block it  
+✅ **No `previous_response_id` required**: Works by tracking item IDs in response output  
+✅ **Globally safe**: Can be enabled for all models; non-Responses-API calls are unaffected  
+✅ **Surgical precision**: Normal requests continue to load balance freely
+
+---
+
+## Remediation
+
+| # | Action | Status | Code |
+|---|---|---|---|
+| 1 | Create `EncryptedContentAffinityCheck` class with tracking and routing logic | ✅ Done | [`encrypted_content_affinity_check.py`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py) |
+| 2 | Add `encrypted_content_affinity` to `OptionalPreCallChecks` type | ✅ Done | [`router.py`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/types/router.py) |
+| 3 | Wire up check in `Router.add_optional_pre_call_checks` | ✅ Done | [`router.py#L8656-L8660`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/router.py#L8656-L8660) |
+| 4 | Implement rate limit bypass for affinity-pinned requests | ✅ Done | [`router.py#L8656-L8660`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/router.py#L8656-L8660) |
+| 5 | Unit tests: tracking, routing, no-op for non-Responses-API, RPM bypass | ✅ Done | [`test_encrypted_content_affinity_check.py`](https://github.com/BerriAI/litellm/blob/main/litellm/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py) |
+| 6 | Documentation: Responses API guide, load balancing guide, config reference | ✅ Done | [Docs](https://docs.litellm.ai/docs/response_api#encrypted-content-affinity-multi-region-load-balancing) |
+
+---
+
+## Migration Guide
+
+### Before (Using `deployment_affinity`)
+
+```yaml
+router_settings:
+  optional_pre_call_checks:
+    - deployment_affinity  # ❌ Reduces quota by number of users
+```
+
+**Problem:** All requests from a user pin to one deployment, reducing effective quota to 1/N.
+
+### After (Using `encrypted_content_affinity`)
+
+```yaml
+router_settings:
+  optional_pre_call_checks:
+    - encrypted_content_affinity  # ✅ Only pins requests with encrypted content
+```
+
+**Benefit:** Normal requests load balance freely, only encrypted content requests pin when necessary.
+
+---

--- a/docs/my-website/blog/responses_api_encrypted_content_incident/index.md
+++ b/docs/my-website/blog/responses_api_encrypted_content_incident/index.md
@@ -119,32 +119,36 @@ Implemented a new `encrypted_content_affinity` pre-call check that intelligently
 
 ### Implementation
 
-**1. Encoding `model_id` into output item IDs** ([`responses/utils.py`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/responses/utils.py))
+**1. Encoding `model_id` into output items** ([`responses/utils.py`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/responses/utils.py))
 
-The same approach used for `previous_response_id` affinity — no cache needed. When a response contains output items with `encrypted_content`, LiteLLM rewrites their IDs to embed the originating deployment's `model_id`:
+The same approach used for `previous_response_id` affinity — no cache needed. When a response contains output items with `encrypted_content`, LiteLLM encodes the originating deployment's `model_id` in **two places** for redundancy:
+
+1. **Into the item ID** (if present): `rs_abc123` → `encitem_{base64("litellm:model_id:{model_id};item_id:rs_abc123")}`
+2. **Into the encrypted_content itself**: Wraps the content with `litellm_enc:{base64("model_id:{model_id}")};{original_encrypted_content}`
 
 ```python
-# On response: rs_abc123 → encitem_{base64("litellm:model_id:{model_id};item_id:rs_abc123")}
+# Encoding item IDs (when present)
 def _build_encrypted_item_id(model_id: str, item_id: str) -> str:
     assembled = f"litellm:model_id:{model_id};item_id:{item_id}"
     encoded = base64.b64encode(assembled.encode("utf-8")).decode("utf-8")
     return f"encitem_{encoded}"
 
-# On request: decode encitem_... → extract model_id for routing
-def _decode_encrypted_item_id(encoded_id: str) -> Optional[Dict[str, str]]:
-    if not encoded_id.startswith("encitem_"):
-        return None
-    cleaned = encoded_id[len("encitem_"):]
-    missing = len(cleaned) % 4
-    if missing:
-        cleaned += "=" * (4 - missing)  # restore padding stripped in transit
-    decoded = base64.b64decode(cleaned).decode("utf-8")
-    model_id, item_id = decoded.split(";", 1)
-    return {"model_id": model_id.replace("litellm:model_id:", ""),
-            "item_id": item_id.replace("item_id:", "")}
+# Wrapping encrypted_content (always, for redundancy)
+def _wrap_encrypted_content_with_model_id(encrypted_content: str, model_id: str) -> str:
+    metadata = f"model_id:{model_id}"
+    encoded_metadata = base64.b64encode(metadata.encode("utf-8")).decode("utf-8")
+    return f"litellm_enc:{encoded_metadata};{encrypted_content}"
 ```
 
-Before forwarding to the upstream provider, LiteLLM restores the original item IDs so the provider never sees the encoded form:
+**Why wrap encrypted_content directly?** Some clients (like Codex) don't consistently send item IDs in follow-up requests, but they always send the `encrypted_content` itself. By embedding `model_id` into the content, affinity works even when IDs are missing.
+
+**Streaming responses:** The wrapping logic is applied to both:
+- Final response objects (non-streaming)
+- Individual streaming events (`response.output_item.added`, `response.output_item.done`)
+
+This ensures clients receiving streaming responses get wrapped content they can send back.
+
+Before forwarding to the upstream provider, LiteLLM restores the original item IDs and unwraps encrypted_content so the provider never sees the encoded form:
 
 ```python
 # In responses/main.py — before calling the handler
@@ -153,22 +157,43 @@ input = ResponsesAPIRequestUtils._restore_encrypted_content_item_ids_in_input(in
 
 **2. `EncryptedContentAffinityCheck` — routing only** ([`encrypted_content_affinity_check.py`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py))
 
-No `async_log_success_event` or cache lookups — the `model_id` is decoded directly from the item ID:
+No `async_log_success_event` or cache lookups — the `model_id` is decoded directly from the item ID or encrypted_content:
 
 ```python
 class EncryptedContentAffinityCheck(CustomLogger):
     async def async_filter_deployments(self, model, healthy_deployments, ...):
-        """Decode encitem_ IDs in input to extract model_id and pin to that deployment."""
+        """Extract model_id from input items (ID or encrypted_content) and pin to that deployment."""
         for item in request_kwargs.get("input", []):
-            decoded = ResponsesAPIRequestUtils._decode_encrypted_item_id(item.get("id", ""))
-            if decoded:
+            # Try to extract model_id from two sources:
+            model_id = self._extract_model_id_from_input(item)
+            
+            if model_id:
                 deployment = self._find_deployment_by_model_id(
-                    healthy_deployments, decoded["model_id"]
+                    healthy_deployments, model_id
                 )
                 if deployment:
                     request_kwargs["_encrypted_content_affinity_pinned"] = True
                     return [deployment]
         return healthy_deployments
+    
+    def _extract_model_id_from_input(self, item: dict) -> Optional[str]:
+        """Extract model_id from either encoded ID or wrapped encrypted_content."""
+        # 1. Try decoding from item ID (if present)
+        item_id = item.get("id", "")
+        if item_id:
+            decoded = ResponsesAPIRequestUtils._decode_encrypted_item_id(item_id)
+            if decoded:
+                return decoded["model_id"]
+        
+        # 2. Try unwrapping from encrypted_content (fallback for clients that omit IDs)
+        encrypted_content = item.get("encrypted_content", "")
+        if encrypted_content and encrypted_content.startswith("litellm_enc:"):
+            model_id, _ = ResponsesAPIRequestUtils._unwrap_encrypted_content_with_model_id(
+                encrypted_content
+            )
+            return model_id
+        
+        return None
 ```
 
 **3. Rate Limit Bypass** ([`router.py`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/router.py))
@@ -217,6 +242,57 @@ router_settings:
 | 5 | Implement rate limit bypass for affinity-pinned requests | ✅ Done | [`router.py`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/router.py) |
 | 6 | Unit tests: encoding/decoding utilities, routing, RPM bypass | ✅ Done | [`test_encrypted_content_affinity_check.py`](https://github.com/BerriAI/litellm/blob/main/litellm/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py) |
 | 7 | Documentation: Responses API guide, load balancing guide, config reference | ✅ Done | [Docs](https://docs.litellm.ai/docs/response_api#encrypted-content-affinity-multi-region-load-balancing) |
+| 8 | **[Mar 3]** Fix streaming events to wrap encrypted_content | ✅ Done | [`responses/streaming_iterator.py`](https://github.com/BerriAI/litellm/blob/main/litellm/litellm/responses/streaming_iterator.py) |
+
+---
+
+## Follow-up Fix: Streaming Responses (Mar 3, 2026)
+
+### The Issue
+
+After the initial fix was deployed, users reported that the `invalid_encrypted_content` error **still occurred** when using streaming responses with clients like Codex. Investigation revealed:
+
+- ✅ Non-streaming responses: `encrypted_content` was correctly wrapped with `litellm_enc:` prefix
+- ❌ Streaming responses: Individual `response.output_item.added` and `response.output_item.done` events contained **raw, unwrapped** `encrypted_content`
+
+Since Codex and other clients consume responses as streams, they received unwrapped content in these events and sent it back in follow-up requests, causing the affinity check to fail.
+
+### The Root Cause
+
+The `_update_encrypted_content_item_ids_in_response` function only modified the **final** response object, which is used for non-streaming responses. For streaming responses, individual chunks are processed by `ResponsesAPIStreamingIterator._process_chunk`, which was **not** applying the wrapping logic to streaming events.
+
+### The Fix
+
+Modified `litellm/litellm/responses/streaming_iterator.py` to wrap `encrypted_content` in streaming events:
+
+```python
+# In ResponsesAPIStreamingIterator._process_chunk
+if (
+    self.litellm_metadata
+    and self.litellm_metadata.get("encrypted_content_affinity_enabled")
+):
+    event_type = getattr(openai_responses_api_chunk, "type", None)
+    if event_type in (
+        ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
+        ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
+    ):
+        item = getattr(openai_responses_api_chunk, "item", None)
+        if item:
+            encrypted_content = getattr(item, "encrypted_content", None)
+            if encrypted_content and isinstance(encrypted_content, str):
+                model_id = (
+                    self.litellm_metadata.get("model_info", {}).get("id")
+                    if self.litellm_metadata
+                    else None
+                )
+                if model_id:
+                    wrapped_content = ResponsesAPIRequestUtils._wrap_encrypted_content_with_model_id(
+                        encrypted_content, model_id
+                    )
+                    setattr(item, "encrypted_content", wrapped_content)
+```
+
+This ensures that **all** `encrypted_content` sent to clients (streaming or non-streaming) is wrapped with `model_id` metadata, enabling consistent affinity routing.
 
 ---
 

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -360,7 +360,7 @@ router_settings:
 | redis_url | str | URL for Redis server. **Known performance issue with Redis URL.** |
 | cache_responses | boolean | Flag to enable caching LLM Responses, if cache set under `router_settings`. If true, caches responses. Defaults to False. |
 | router_general_settings | RouterGeneralSettings | [SDK-Only] Router general settings - contains optimizations like 'async_only_mode'. [Docs](../routing.md#router-general-settings) |
-| optional_pre_call_checks | List[str] | List of pre-call checks to add to the router. Supported: `router_budget_limiting`, `prompt_caching`, `responses_api_deployment_check`, `deployment_affinity`, `forward_client_headers_by_model_group` |
+| optional_pre_call_checks | List[str] | List of pre-call checks to add to the router. Supported: `router_budget_limiting`, `prompt_caching`, `responses_api_deployment_check`, `encrypted_content_affinity`, `deployment_affinity`, `session_affinity`, `forward_client_headers_by_model_group` |
 | deployment_affinity_ttl_seconds | int | TTL (seconds) for user-key → deployment affinity mapping when `deployment_affinity` is enabled (configured at Router init / proxy startup). Defaults to `3600` (1 hour). |
 | ignore_invalid_deployments | boolean | If true, ignores invalid deployments. Default for proxy is True - to prevent invalid models from blocking other models from being loaded. |
 | search_tools | List[SearchToolTypedDict] | List of search tool configurations for Search API integration. Each tool specifies a search_tool_name and litellm_params with search_provider, api_key, api_base, etc. [Further Docs](../search.md) |

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -1,9 +1,9 @@
 import json
+import re
 import traceback
 from typing import Any, Optional
 
 import httpx
-import re
 
 import litellm
 from litellm._logging import verbose_logger
@@ -442,6 +442,27 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                         model=model,
                         response=getattr(original_exception, "response", None),
                         litellm_debug_info=extra_information,
+                    )
+                elif "invalid_encrypted_content" in error_str or "could not be verified" in error_str:
+                    exception_mapping_worked = True
+                    helpful_message = (
+                        f"{exception_provider} - {message}\n\n"
+                        " This error occurs when load balancing Responses API across deployments with different API keys.\n"
+                        "   Encrypted content is tied to the organization that created it and cannot be decrypted by other organizations.\n\n"
+                        "   Solution: Enable 'encrypted_content_affinity' to route follow-up requests to the correct deployment:\n\n"
+                        "   router_settings:\n"
+                        "     enable_pre_call_checks: true\n"
+                        "     optional_pre_call_checks:\n"
+                        "       - encrypted_content_affinity\n\n"
+                        "   Learn more: https://docs.litellm.ai/docs/response_api#encrypted-content-affinity-multi-region-load-balancing"
+                    )
+                    raise BadRequestError(
+                        message=helpful_message,
+                        llm_provider=custom_llm_provider,
+                        model=model,
+                        response=getattr(original_exception, "response", None),
+                        litellm_debug_info=extra_information,
+                        body=getattr(original_exception, "body", None),
                     )
                 elif (
                     "invalid_request_error" in error_str
@@ -2126,7 +2147,27 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                         extra_information=extra_information,
                         original_exception=original_exception,
                     )
-                    
+                elif azure_error_code == "invalid_encrypted_content" or "could not be verified" in error_str:
+                    exception_mapping_worked = True
+                    helpful_message = (
+                        f"AzureException - {message}\n\n"
+                        "This error occurs when load balancing Responses API across deployments with different API keys.\n"
+                        "   Encrypted content is tied to the organization that created it and cannot be decrypted by other organizations.\n\n"
+                        "   Solution: Enable 'encrypted_content_affinity' to route follow-up requests to the correct deployment:\n\n"
+                        "   router_settings:\n"
+                        "     enable_pre_call_checks: true\n"
+                        "     optional_pre_call_checks:\n"
+                        "       - encrypted_content_affinity\n\n"
+                        "   Learn more: https://docs.litellm.ai/docs/response_api#encrypted-content-affinity-multi-region-load-balancing"
+                    )
+                    raise BadRequestError(
+                        message=helpful_message,
+                        llm_provider="azure",
+                        model=model,
+                        litellm_debug_info=extra_information,
+                        response=getattr(original_exception, "response", None),
+                        body=getattr(original_exception, "body", None),
+                    )
                 elif "invalid_request_error" in error_str:
                     exception_mapping_worked = True
                     raise BadRequestError(

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -745,6 +745,11 @@ def responses(
             custom_llm_provider=custom_llm_provider,
         )
 
+        # Decode any litellm-encoded encrypted-content item IDs back to their original IDs
+        input = ResponsesAPIRequestUtils._restore_encrypted_content_item_ids_in_input(
+            input
+        )
+
         # Call the handler with _is_async flag instead of directly calling the async handler
         response = base_llm_http_handler.response_api_handler(
             model=model,
@@ -1615,6 +1620,12 @@ def compact_responses(
                 "litellm_call_id": litellm_call_id,
             },
             custom_llm_provider=custom_llm_provider,
+        )
+
+        # Decode any litellm-encoded encrypted-content item IDs back to their original IDs
+        # before forwarding to the upstream provider.
+        input = ResponsesAPIRequestUtils._restore_encrypted_content_item_ids_in_input(
+            input
         )
 
         # Call the handler with _is_async flag instead of directly calling the async handler

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -8,7 +8,10 @@ from typing import Any, Dict, Optional
 import httpx
 
 import litellm
-from litellm.constants import LITELLM_MAX_STREAMING_DURATION_SECONDS, STREAM_SSE_DONE_STRING
+from litellm.constants import (
+    LITELLM_MAX_STREAMING_DURATION_SECONDS,
+    STREAM_SSE_DONE_STRING,
+)
 from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.litellm_core_utils.core_helpers import process_response_headers
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -136,6 +139,31 @@ class BaseResponsesAPIStreamingIterator:
                         )
                     )
                     setattr(openai_responses_api_chunk, "response", response)
+
+                # Wrap encrypted_content in streaming events (output_item.added, output_item.done)
+                if (
+                    self.litellm_metadata
+                    and self.litellm_metadata.get("encrypted_content_affinity_enabled")
+                ):
+                    event_type = getattr(openai_responses_api_chunk, "type", None)
+                    if event_type in (
+                        ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
+                        ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
+                    ):
+                        item = getattr(openai_responses_api_chunk, "item", None)
+                        if item:
+                            encrypted_content = getattr(item, "encrypted_content", None)
+                            if encrypted_content and isinstance(encrypted_content, str):
+                                model_id = (
+                                    self.litellm_metadata.get("model_info", {}).get("id")
+                                    if self.litellm_metadata
+                                    else None
+                                )
+                                if model_id:
+                                    wrapped_content = ResponsesAPIRequestUtils._wrap_encrypted_content_with_model_id(
+                                        encrypted_content, model_id
+                                    )
+                                    setattr(item, "encrypted_content", wrapped_content)
 
                 # Store the completed response
                 if (

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -265,6 +265,56 @@ class ResponsesAPIRequestUtils:
             return None
 
     @staticmethod
+    def _wrap_encrypted_content_with_model_id(
+        encrypted_content: str, model_id: str
+    ) -> str:
+        """Wrap encrypted_content with model_id metadata for affinity routing.
+
+        When Codex or other clients send items with encrypted_content but no ID,
+        we encode the model_id directly into the encrypted_content itself.
+
+        Format: ``litellm_enc:{base64("model_id:{model_id}")};{original_encrypted_content}``
+        """
+        metadata = f"model_id:{model_id}"
+        encoded_metadata = base64.b64encode(metadata.encode("utf-8")).decode("utf-8")
+        return f"litellm_enc:{encoded_metadata};{encrypted_content}"
+
+    @staticmethod
+    def _unwrap_encrypted_content_with_model_id(
+        wrapped_content: str,
+    ) -> tuple[Optional[str], str]:
+        """Unwrap encrypted_content to extract model_id and original content.
+
+        Returns:
+            Tuple of (model_id, original_encrypted_content).
+            If not wrapped, returns (None, original_content).
+        """
+        if not wrapped_content.startswith("litellm_enc:"):
+            return None, wrapped_content
+
+        try:
+            # Split on first ";" to separate metadata from content
+            parts = wrapped_content.split(";", 1)
+            if len(parts) < 2:
+                return None, wrapped_content
+
+            metadata_b64 = parts[0].replace("litellm_enc:", "")
+            original_content = parts[1]
+
+            # Restore padding if needed
+            missing = len(metadata_b64) % 4
+            if missing:
+                metadata_b64 += "=" * (4 - missing)
+
+            decoded_metadata = base64.b64decode(metadata_b64.encode("utf-8")).decode(
+                "utf-8"
+            )
+            model_id = decoded_metadata.replace("model_id:", "")
+            return model_id, original_content
+        except Exception:
+            return None, wrapped_content
+
+    @staticmethod
     def _update_encrypted_content_item_ids_in_response(
         response: Union["ResponsesAPIResponse", Dict[str, Any]],
         model_id: Optional[str],
@@ -273,6 +323,9 @@ class ResponsesAPIRequestUtils:
 
         Encodes ``model_id`` into the item ID so that follow-up requests can be
         routed back to the originating deployment without any cache lookup.
+
+        For items without an ID (e.g., from Codex), encodes model_id directly
+        into the encrypted_content itself.
         """
         if not model_id:
             return response
@@ -289,23 +342,42 @@ class ResponsesAPIRequestUtils:
         for item in output:
             if isinstance(item, dict):
                 item_id = item.get("id")
-                if item_id and isinstance(item_id, str) and "encrypted_content" in item:
-                    item["id"] = ResponsesAPIRequestUtils._build_encrypted_item_id(
-                        model_id, item_id
+                encrypted_content = item.get("encrypted_content")
+
+                if encrypted_content and isinstance(encrypted_content, str):
+                    # Always wrap encrypted_content with model_id for redundancy
+                    item["encrypted_content"] = (
+                        ResponsesAPIRequestUtils._wrap_encrypted_content_with_model_id(
+                            encrypted_content, model_id
+                        )
                     )
+                    # Also encode the ID if present
+                    if item_id and isinstance(item_id, str):
+                        item["id"] = ResponsesAPIRequestUtils._build_encrypted_item_id(
+                            model_id, item_id
+                        )
             else:
                 item_id = getattr(item, "id", None)
-                if (
-                    item_id
-                    and isinstance(item_id, str)
-                    and hasattr(item, "encrypted_content")
-                ):
+                encrypted_content = getattr(item, "encrypted_content", None)
+
+                if encrypted_content and isinstance(encrypted_content, str):
+                    # Always wrap encrypted_content with model_id for redundancy
                     try:
-                        item.id = ResponsesAPIRequestUtils._build_encrypted_item_id(
-                            model_id, item_id
+                        item.encrypted_content = (
+                            ResponsesAPIRequestUtils._wrap_encrypted_content_with_model_id(
+                                encrypted_content, model_id
+                            )
                         )
                     except AttributeError:
                         pass
+                    # Also encode the ID if present
+                    if item_id and isinstance(item_id, str):
+                        try:
+                            item.id = ResponsesAPIRequestUtils._build_encrypted_item_id(
+                                model_id, item_id
+                            )
+                        except AttributeError:
+                            pass
 
         return response
 
@@ -314,7 +386,11 @@ class ResponsesAPIRequestUtils:
         """Decode litellm-encoded item IDs in request input back to original IDs.
 
         Called before forwarding the request to the upstream provider so the
-        provider receives the original item IDs it issued.
+        provider receives the original item IDs and unwrapped encrypted_content.
+
+        Handles both:
+        1. Items with encoded IDs (encitem_...)
+        2. Items with wrapped encrypted_content (litellm_enc:...)
         """
         if not isinstance(request_input, list):
             return request_input
@@ -326,6 +402,16 @@ class ResponsesAPIRequestUtils:
                     decoded = ResponsesAPIRequestUtils._decode_encrypted_item_id(item_id)
                     if decoded:
                         item["id"] = decoded["item_id"]
+
+                encrypted_content = item.get("encrypted_content")
+                if encrypted_content and isinstance(encrypted_content, str):
+                    _, unwrapped = (
+                        ResponsesAPIRequestUtils._unwrap_encrypted_content_with_model_id(
+                            encrypted_content
+                        )
+                    )
+                    if unwrapped != encrypted_content:
+                        item["encrypted_content"] = unwrapped
 
         return request_input
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -115,6 +115,9 @@ from litellm.router_utils.handle_error import (
 from litellm.router_utils.pre_call_checks.deployment_affinity_check import (
     DeploymentAffinityCheck,
 )
+from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+    EncryptedContentAffinityCheck,
+)
 from litellm.router_utils.pre_call_checks.model_rate_limit_check import (
     ModelRateLimitingCheck,
 )
@@ -1249,6 +1252,25 @@ class Router:
                 litellm.logging_callback_manager.add_litellm_callback(affinity_callback)
 
         # ---------------------------------------------------------------------
+        # Encrypted content affinity
+        # ---------------------------------------------------------------------
+        if "encrypted_content_affinity" in optional_pre_call_checks:
+            if self.optional_callbacks is None:
+                self.optional_callbacks = []
+
+            already_registered = any(
+                isinstance(cb, EncryptedContentAffinityCheck)
+                for cb in self.optional_callbacks
+            )
+            if not already_registered:
+                ec_callback = EncryptedContentAffinityCheck(
+                    cache=self.cache,
+                    ttl_seconds=self.deployment_affinity_ttl_seconds,
+                )
+                self.optional_callbacks.append(ec_callback)
+                litellm.logging_callback_manager.add_litellm_callback(ec_callback)
+
+        # ---------------------------------------------------------------------
         # Remaining optional pre-call checks
         # ---------------------------------------------------------------------
         for pre_call_check in optional_pre_call_checks:
@@ -1257,6 +1279,7 @@ class Router:
                 "deployment_affinity",
                 "responses_api_deployment_check",
                 "session_affinity",
+                "encrypted_content_affinity",
             ):
                 continue
             if pre_call_check == "prompt_caching":
@@ -8807,6 +8830,13 @@ class Router:
             )
             if isinstance(healthy_deployments, dict):
                 return healthy_deployments
+
+            # When encrypted content affinity pins to a specific deployment,
+            if (
+                request_kwargs.get("_encrypted_content_affinity_pinned")
+                and len(healthy_deployments) == 1
+            ):
+                return healthy_deployments[0]
 
             start_time = time.time()
             if (

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1289,6 +1289,11 @@ class Router:
                 )
             elif pre_call_check == "enforce_model_rate_limits":
                 _callback = ModelRateLimitingCheck(dual_cache=self.cache)
+            elif pre_call_check == "encrypted_content_affinity":
+                from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+                    EncryptedContentAffinityCheck,
+                )
+                _callback = EncryptedContentAffinityCheck()
 
             if _callback is None:
                 continue

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1263,10 +1263,7 @@ class Router:
                 for cb in self.optional_callbacks
             )
             if not already_registered:
-                ec_callback = EncryptedContentAffinityCheck(
-                    cache=self.cache,
-                    ttl_seconds=self.deployment_affinity_ttl_seconds,
-                )
+                ec_callback = EncryptedContentAffinityCheck()
                 self.optional_callbacks.append(ec_callback)
                 litellm.logging_callback_manager.add_litellm_callback(ec_callback)
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1255,6 +1255,10 @@ class Router:
         # Encrypted content affinity
         # ---------------------------------------------------------------------
         if "encrypted_content_affinity" in optional_pre_call_checks:
+            from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+                EncryptedContentAffinityCheck,
+            )
+
             if self.optional_callbacks is None:
                 self.optional_callbacks = []
 
@@ -1289,11 +1293,6 @@ class Router:
                 )
             elif pre_call_check == "enforce_model_rate_limits":
                 _callback = ModelRateLimitingCheck(dual_cache=self.cache)
-            elif pre_call_check == "encrypted_content_affinity":
-                from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
-                    EncryptedContentAffinityCheck,
-                )
-                _callback = EncryptedContentAffinityCheck()
 
             if _callback is None:
                 continue

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -1,0 +1,267 @@
+"""
+Encrypted-content-aware deployment affinity for the Router.
+
+When Codex or other models use `store: false` with `include: ["reasoning.encrypted_content"]`,
+the response output items contain encrypted reasoning tokens tied to the originating
+organization's API key. If a follow-up request containing those items is routed to a
+different deployment (different org), OpenAI rejects it with an `invalid_encrypted_content`
+error because the organization_id doesn't match.
+
+This callback solves the problem by:
+1. Tracking output item IDs from Responses API responses and mapping them to the
+   deployment (model_id) that produced them.
+2. On subsequent requests, scanning the `input` field for known item IDs and pinning
+   the request to the originating deployment.
+
+Safe to enable globally:
+- Only activates when known item IDs appear in the request `input`.
+- No effect on embedding models, chat completions, or first-time requests.
+- No quota reduction -- first requests are fully load balanced.
+"""
+
+from typing import Any, List, Optional, cast
+
+from litellm._logging import verbose_router_logger
+from litellm.caching.dual_cache import DualCache
+from litellm.integrations.custom_logger import CustomLogger, Span
+from litellm.types.llms.openai import AllMessageValues, ResponsesAPIResponse
+
+_DEFAULT_TTL_SECONDS = 86400  # 24 hours
+
+
+class EncryptedContentAffinityCheck(CustomLogger):
+    """
+    Routes follow-up Responses API requests to the deployment that produced
+    the encrypted output items they reference.
+
+    Wired via ``Router(optional_pre_call_checks=["encrypted_content_affinity"])``.
+    """
+
+    CACHE_KEY_PREFIX = "encrypted_content_affinity:v1"
+
+    def __init__(
+        self,
+        cache: DualCache,
+        ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    ):
+        super().__init__()
+        self.cache = cache
+        self.ttl_seconds = ttl_seconds
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_output_from_response(
+        response_obj: Any,
+    ) -> Optional[list]:
+        """
+        Extract the ``output`` list from a Responses API response, handling
+        both ``ResponsesAPIResponse`` objects and plain dicts.
+        """
+        if isinstance(response_obj, ResponsesAPIResponse):
+            return response_obj.output
+        if isinstance(response_obj, dict) and "output" in response_obj:
+            output = response_obj["output"]
+            if isinstance(output, list):
+                return output
+        if hasattr(response_obj, "output"):
+            output = response_obj.output
+            if isinstance(output, list):
+                return output
+        return None
+
+    @staticmethod
+    def _extract_item_ids_from_output(
+        output: list,
+    ) -> List[str]:
+        """Extract all item IDs from a Responses API output list."""
+        item_ids: List[str] = []
+        for item in output:
+            item_id: Optional[str] = None
+            if isinstance(item, dict):
+                item_id = item.get("id")
+            else:
+                item_id = getattr(item, "id", None)
+            if item_id and isinstance(item_id, str):
+                item_ids.append(item_id)
+        return item_ids
+
+    @staticmethod
+    def _extract_item_ids_from_input(request_input: Any) -> List[str]:
+        """
+        Extract item IDs from the ``input`` field of a Responses API request.
+
+        ``input`` can be:
+        - a plain string  -> no item IDs
+        - a list of items -> each item may have an ``id`` field
+        """
+        if not isinstance(request_input, list):
+            return []
+
+        item_ids: List[str] = []
+        for item in request_input:
+            if isinstance(item, dict):
+                item_id = item.get("id")
+                if item_id and isinstance(item_id, str):
+                    item_ids.append(item_id)
+        return item_ids
+
+    @classmethod
+    def _cache_key(cls, item_id: str) -> str:
+        return f"{cls.CACHE_KEY_PREFIX}:{item_id}"
+
+    @staticmethod
+    def _find_deployment_by_model_id(
+        healthy_deployments: List[dict], model_id: str
+    ) -> Optional[dict]:
+        for deployment in healthy_deployments:
+            model_info = deployment.get("model_info")
+            if not isinstance(model_info, dict):
+                continue
+            deployment_model_id = model_info.get("id")
+            if deployment_model_id is not None and str(deployment_model_id) == str(
+                model_id
+            ):
+                return deployment
+        return None
+
+    @staticmethod
+    def _get_model_id_from_kwargs(kwargs: dict) -> Optional[str]:
+        """
+        Extract the deployment model_id from success-callback kwargs.
+
+        The Router populates ``litellm_params.metadata.model_info.id`` after
+        selecting a deployment. Also check top-level ``model_info`` as a
+        fallback (some call paths set it there).
+        """
+        # Primary path: litellm_params -> metadata -> model_info -> id
+        litellm_params = kwargs.get("litellm_params")
+        if isinstance(litellm_params, dict):
+            metadata = litellm_params.get("metadata")
+            if isinstance(metadata, dict):
+                model_info = metadata.get("model_info")
+                if isinstance(model_info, dict):
+                    model_id = model_info.get("id")
+                    if model_id is not None:
+                        return str(model_id)
+
+        # Fallback: top-level model_info (set by some router call paths)
+        model_info = kwargs.get("model_info")
+        if isinstance(model_info, dict):
+            model_id = model_info.get("id")
+            if model_id is not None:
+                return str(model_id)
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Response tracking  (success callback)
+    # ------------------------------------------------------------------
+
+    async def async_log_success_event(
+        self, kwargs: dict, response_obj: Any, start_time: Any, end_time: Any
+    ) -> None:
+        """
+        After a successful Responses API call, cache each output item ID
+        mapped to the deployment that produced it.
+        """
+        output = self._get_output_from_response(response_obj)
+        if output is None:
+            return
+
+        model_id = self._get_model_id_from_kwargs(kwargs)
+        if not model_id:
+            verbose_router_logger.debug(
+                "EncryptedContentAffinityCheck: model_id not found in kwargs, skipping tracking",
+            )
+            return
+
+        item_ids = self._extract_item_ids_from_output(output)
+        if not item_ids:
+            return
+
+        for item_id in item_ids:
+            try:
+                cache_key = self._cache_key(item_id)
+                await self.cache.async_set_cache(
+                    cache_key,
+                    model_id,
+                    ttl=self.ttl_seconds,
+                )
+            except Exception as e:
+                verbose_router_logger.debug(
+                    "EncryptedContentAffinityCheck: failed to cache item_id=%s error=%s",
+                    item_id,
+                    e,
+                )
+
+        verbose_router_logger.info(
+            "EncryptedContentAffinityCheck: cached %d item IDs -> deployment=%s",
+            len(item_ids),
+            model_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Request routing  (pre-call filter)
+    # ------------------------------------------------------------------
+
+    async def async_filter_deployments(
+        self,
+        model: str,
+        healthy_deployments: List,
+        messages: Optional[List[AllMessageValues]],
+        request_kwargs: Optional[dict] = None,
+        parent_otel_span: Optional[Span] = None,
+    ) -> List[dict]:
+        """
+        If the request ``input`` contains items whose IDs were previously
+        tracked, pin the request to the deployment that produced them.
+        """
+        request_kwargs = request_kwargs or {}
+        typed_healthy_deployments = cast(List[dict], healthy_deployments)
+
+        request_input = request_kwargs.get("input")
+        input_item_ids = self._extract_item_ids_from_input(request_input)
+        if not input_item_ids:
+            return typed_healthy_deployments
+
+        verbose_router_logger.debug(
+            "EncryptedContentAffinityCheck: found %d item IDs in input, checking cache",
+            len(input_item_ids),
+        )
+
+        for item_id in input_item_ids:
+            cache_key = self._cache_key(item_id)
+            try:
+                cached_model_id = await self.cache.async_get_cache(key=cache_key)
+            except Exception:
+                continue
+
+            if not cached_model_id or not isinstance(cached_model_id, str):
+                continue
+
+            deployment = self._find_deployment_by_model_id(
+                healthy_deployments=typed_healthy_deployments,
+                model_id=cached_model_id,
+            )
+            if deployment is not None:
+                verbose_router_logger.info(
+                    "EncryptedContentAffinityCheck: item_id=%s pinning -> deployment=%s",
+                    item_id,
+                    cached_model_id,
+                )
+                request_kwargs[
+                    "_encrypted_content_affinity_pinned"
+                ] = True
+                return [deployment]
+
+            verbose_router_logger.info(
+                "EncryptedContentAffinityCheck: cached deployment=%s for item_id=%s "
+                "not found in healthy_deployments",
+                cached_model_id,
+                item_id,
+            )
+
+        return typed_healthy_deployments

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -263,7 +263,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
                 ] = True
                 return [deployment]
 
-            verbose_router_logger.debug(
+            verbose_router_logger.error(
                 "EncryptedContentAffinityCheck: cached deployment=%s for item_id=%s "
                 "not found in healthy_deployments",
                 cached_model_id,

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -8,24 +8,29 @@ different deployment (different org), OpenAI rejects it with an `invalid_encrypt
 error because the organization_id doesn't match.
 
 This callback solves the problem by encoding the originating deployment's ``model_id``
-directly into the item IDs of output items that carry ``encrypted_content`` (the same
-approach used by the responses-API affinity for ``previous_response_id``).  The encoded
-ID is decoded on the next request so the router can pin to the correct deployment without
-any cache lookup.
+into the response output items that carry ``encrypted_content``. Two encoding strategies:
+
+1. **Items with IDs**: Encode model_id into the item ID itself (e.g., ``encitem_...``)
+2. **Items without IDs** (Codex): Wrap the encrypted_content with model_id metadata
+   (e.g., ``litellm_enc:{base64_metadata};{original_encrypted_content}``)
+
+The encoded model_id is decoded on the next request so the router can pin to the correct
+deployment without any cache lookup.
 
 Response post-processing (encoding) is handled by
 ``ResponsesAPIRequestUtils._update_encrypted_content_item_ids_in_response`` which is
 called inside ``_update_responses_api_response_id_with_model_id`` in ``responses/utils.py``.
 
-Request pre-processing (ID restoration before forwarding to upstream) is handled by
+Request pre-processing (ID/content restoration before forwarding to upstream) is handled by
 ``ResponsesAPIRequestUtils._restore_encrypted_content_item_ids_in_input`` which is called
 in ``get_optional_params_responses_api``.
 
 This pre-call check is responsible only for the routing decision: it reads the encoded
-``model_id`` out of the item IDs and pins the request to the matching deployment.
+``model_id`` from either item IDs or wrapped encrypted_content and pins the request to
+the matching deployment.
 
 Safe to enable globally:
-- Only activates when encoded item IDs appear in the request ``input``.
+- Only activates when encoded markers appear in the request ``input``.
 - No effect on embedding models, chat completions, or first-time requests.
 - No quota reduction -- first requests are fully load balanced.
 - No cache required.
@@ -60,12 +65,16 @@ class EncryptedContentAffinityCheck(CustomLogger):
     @staticmethod
     def _extract_model_id_from_input(request_input: Any) -> Optional[str]:
         """
-        Scan ``input`` items for litellm-encoded encrypted-content item IDs and
+        Scan ``input`` items for litellm-encoded encrypted-content markers and
         return the ``model_id`` embedded in the first one found.
 
+        Checks both:
+        1. Encoded item IDs (encitem_...) - for clients that send IDs
+        2. Wrapped encrypted_content (litellm_enc:...) - for clients like Codex that don't send IDs
+
         ``input`` can be:
-        - a plain string  -> no encoded IDs
-        - a list of items -> check each item's ``id`` field
+        - a plain string  -> no encoded markers
+        - a list of items -> check each item's ``id`` and ``encrypted_content`` fields
         """
         if not isinstance(request_input, list):
             return None
@@ -73,12 +82,25 @@ class EncryptedContentAffinityCheck(CustomLogger):
         for item in request_input:
             if not isinstance(item, dict):
                 continue
+
+            # First, try to decode from item ID (if present)
             item_id = item.get("id")
-            if not item_id or not isinstance(item_id, str):
-                continue
-            decoded = ResponsesAPIRequestUtils._decode_encrypted_item_id(item_id)
-            if decoded:
-                return decoded.get("model_id")
+            if item_id and isinstance(item_id, str):
+                decoded = ResponsesAPIRequestUtils._decode_encrypted_item_id(item_id)
+                if decoded:
+                    return decoded.get("model_id")
+
+            # If no encoded ID, check if encrypted_content itself is wrapped
+            encrypted_content = item.get("encrypted_content")
+            if encrypted_content and isinstance(encrypted_content, str):
+                (
+                    model_id,
+                    _,
+                ) = ResponsesAPIRequestUtils._unwrap_encrypted_content_with_model_id(
+                    encrypted_content
+                )
+                if model_id:
+                    return model_id
 
         return None
 

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -813,6 +813,7 @@ OptionalPreCallChecks = List[
         "session_affinity",
         "forward_client_headers_by_model_group",
         "enforce_model_rate_limits",
+        "encrypted_content_affinity",
     ]
 ]
 

--- a/tests/test_litellm/llms/azure/test_azure_exception_mapping.py
+++ b/tests/test_litellm/llms/azure/test_azure_exception_mapping.py
@@ -385,3 +385,58 @@ class TestAzureExceptionMapping:
                 original_exception=mock_exception,
                 custom_llm_provider="azure",
             )
+
+    def test_invalid_encrypted_content_error_with_helpful_message(self):
+        """Test that invalid_encrypted_content errors include helpful guidance
+        about enabling encrypted_content_affinity."""
+        from litellm.exceptions import BadRequestError
+
+        mock_exception = Exception(
+            "The encrypted content gAAAAABpnW_yEYmSNEyOG... could not be verified. "
+            "Reason: Encrypted content organization_id did not match the target organization."
+        )
+        mock_exception.body = {
+            "error": {
+                "message": "The encrypted content could not be verified.",
+                "type": "invalid_request_error",
+                "code": "invalid_encrypted_content",
+            }
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_exception.response = mock_response
+
+        with pytest.raises(BadRequestError) as exc_info:
+            exception_type(
+                model="azure/gpt-5.1-codex",
+                original_exception=mock_exception,
+                custom_llm_provider="azure",
+            )
+
+        error = exc_info.value
+        assert "encrypted_content_affinity" in error.message
+        assert "enable_pre_call_checks" in error.message
+        assert "optional_pre_call_checks" in error.message
+        assert "docs.litellm.ai" in error.message
+
+    def test_openai_invalid_encrypted_content_error(self):
+        """Test that OpenAI invalid_encrypted_content errors also get helpful guidance."""
+        from litellm.exceptions import BadRequestError
+
+        mock_exception = Exception(
+            "The encrypted content could not be verified."
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_exception.response = mock_response
+
+        with pytest.raises(BadRequestError) as exc_info:
+            exception_type(
+                model="gpt-5.1-codex",
+                original_exception=mock_exception,
+                custom_llm_provider="openai",
+            )
+
+        error = exc_info.value
+        assert "encrypted_content_affinity" in error.message
+        assert "enable_pre_call_checks" in error.message

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -1,0 +1,335 @@
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import json
+
+import litellm
+from litellm.caching.dual_cache import DualCache
+from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
+    EncryptedContentAffinityCheck,
+)
+
+
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self._json_data = json_data
+        self.status_code = status_code
+        self.text = json.dumps(json_data)
+        self.headers = {}
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.mark.asyncio
+async def test_encrypted_content_affinity_tracks_and_routes():
+    """
+    When encrypted_content_affinity is enabled, output item IDs from responses
+    are tracked, and follow-up requests containing those IDs route to the same
+    deployment.
+    """
+    mock_response_data = {
+        "id": "resp_mock-123",
+        "object": "response",
+        "created_at": 1741476542,
+        "status": "completed",
+        "model": "openai/gpt-5.1-codex",
+        "output": [
+            {
+                "type": "message",
+                "id": "msg_abc123",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Hello!", "annotations": []}],
+            },
+            {
+                "type": "reasoning",
+                "id": "rs_encrypted_item_456",
+                "status": "completed",
+            },
+        ],
+        "parallel_tool_calls": True,
+        "usage": {
+            "input_tokens": 5,
+            "output_tokens": 10,
+            "total_tokens": 15,
+        },
+        "error": None,
+    }
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-1",
+                },
+                "model_info": {"id": "deployment-1"},
+            },
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-2",
+                },
+                "model_info": {"id": "deployment-2"},
+            },
+        ],
+        optional_pre_call_checks=["encrypted_content_affinity"],
+    )
+
+    model_group = "openai.gpt-5.1-codex"
+
+    # Track which deployment was selected
+    selected_deployments = []
+
+    def deterministic_choice(seq):
+        # First call: select deployment-1
+        # Second call: would select deployment-2, but affinity should override
+        if len(selected_deployments) == 0:
+            return seq[0]
+        return seq[1] if len(seq) > 1 else seq[0]
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post, patch(
+        "litellm.router_strategy.simple_shuffle.random.choice",
+        side_effect=deterministic_choice,
+    ):
+        mock_post.return_value = MockResponse(mock_response_data, 200)
+
+        # First request: no encrypted items in input
+        first_response = await router.aresponses(
+            model=model_group,
+            input="Hello, how are you?",
+        )
+        first_model_id = first_response._hidden_params["model_id"]
+        selected_deployments.append(first_model_id)
+
+        # Give async callbacks time to run
+        await asyncio.sleep(0.2)
+
+        # Second request: includes encrypted item IDs from first response
+        second_response = await router.aresponses(
+            model=model_group,
+            input=[
+                {"type": "message", "id": "msg_abc123", "role": "assistant"},
+                {"type": "reasoning", "id": "rs_encrypted_item_456"},
+            ],
+        )
+        second_model_id = second_response._hidden_params["model_id"]
+
+        # Affinity should route to the same deployment
+        assert second_model_id == first_model_id, (
+            f"Expected affinity to route to {first_model_id}, "
+            f"but got {second_model_id}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_encrypted_content_affinity_no_effect_on_chat_completions():
+    """
+    Encrypted content affinity should not affect regular chat completions
+    (they don't use the Responses API).
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": os.environ.get("OPENAI_API_KEY", "test-key"),
+                },
+                "model_info": {"id": "chat-deployment-1"},
+            },
+        ],
+        optional_pre_call_checks=["encrypted_content_affinity"],
+    )
+
+    mock_chat_response = {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "created": 1677652288,
+        "model": "gpt-3.5-turbo",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+    }
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.return_value = MockResponse(mock_chat_response, 200)
+
+        # Multiple chat completion requests should work normally
+        response1 = await router.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response2 = await router.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "Hello again"}],
+        )
+
+        # Both should succeed (no affinity interference)
+        # Check that responses have IDs (litellm may modify them)
+        assert response1.id is not None
+        assert response2.id is not None
+
+
+@pytest.mark.asyncio
+async def test_encrypted_content_affinity_bypasses_rpm_limits():
+    """
+    When encrypted content affinity pins to a deployment, it should bypass
+    RPM limits since the encrypted content will fail on any other deployment.
+    """
+    mock_response_data = {
+        "id": "resp_mock-rpm-test",
+        "object": "response",
+        "created_at": 1741476542,
+        "status": "completed",
+        "model": "openai/gpt-5.1-codex",
+        "output": [
+            {
+                "type": "reasoning",
+                "id": "rs_encrypted_must_pin",
+                "status": "completed",
+            },
+        ],
+        "usage": {"input_tokens": 5, "output_tokens": 10, "total_tokens": 15},
+        "error": None,
+    }
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-1",
+                    "rpm": 1,  # Very low limit
+                },
+                "model_info": {"id": "rpm-limited-deployment"},
+            },
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-2",
+                    "rpm": 100,
+                },
+                "model_info": {"id": "high-rpm-deployment"},
+            },
+        ],
+        optional_pre_call_checks=["encrypted_content_affinity"],
+        routing_strategy="usage-based-routing-v2",
+    )
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.return_value = MockResponse(mock_response_data, 200)
+
+        # First request goes to the low-RPM deployment
+        first_response = await router.aresponses(
+            model="openai.gpt-5.1-codex",
+            input="Initial request",
+        )
+        first_model_id = first_response._hidden_params["model_id"]
+
+        await asyncio.sleep(0.2)
+
+        # Second request with encrypted content should pin to the same deployment
+        # even though it's at RPM limit
+        second_response = await router.aresponses(
+            model="openai.gpt-5.1-codex",
+            input=[
+                {"type": "reasoning", "id": "rs_encrypted_must_pin"},
+            ],
+        )
+        second_model_id = second_response._hidden_params["model_id"]
+
+        # Should route to the same deployment despite RPM limit
+        assert second_model_id == first_model_id
+
+
+@pytest.mark.asyncio
+async def test_encrypted_content_affinity_no_match_normal_routing():
+    """
+    When input contains item IDs that aren't tracked, normal load balancing
+    should occur.
+    """
+    mock_response_data = {
+        "id": "resp_mock-no-match",
+        "object": "response",
+        "created_at": 1741476542,
+        "status": "completed",
+        "model": "openai/gpt-5.1-codex",
+        "output": [
+            {
+                "type": "message",
+                "id": "msg_new",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Response"}],
+            },
+        ],
+        "usage": {"input_tokens": 5, "output_tokens": 10, "total_tokens": 15},
+        "error": None,
+    }
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-1",
+                },
+                "model_info": {"id": "deployment-a"},
+            },
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-2",
+                },
+                "model_info": {"id": "deployment-b"},
+            },
+        ],
+        optional_pre_call_checks=["encrypted_content_affinity"],
+    )
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.return_value = MockResponse(mock_response_data, 200)
+
+        # Request with unknown item IDs should use normal routing
+        response = await router.aresponses(
+            model="openai.gpt-5.1-codex",
+            input=[
+                {"type": "message", "id": "unknown_item_id_12345"},
+            ],
+        )
+
+        # Should succeed with normal routing (litellm may modify the ID)
+        assert response.id is not None
+        # Verify it contains the original response ID in some form
+        assert "resp_mock-no-match" in str(response.id) or response.id.startswith("resp_")

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -10,10 +10,6 @@ sys.path.insert(0, os.path.abspath("../.."))
 import json
 
 import litellm
-from litellm.caching.dual_cache import DualCache
-from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
-    EncryptedContentAffinityCheck,
-)
 
 
 class MockResponse:

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -48,6 +48,7 @@ async def test_encrypted_content_affinity_tracks_and_routes():
                 "type": "reasoning",
                 "id": "rs_encrypted_item_456",
                 "status": "completed",
+                "encrypted_content": "gAAAAABpnW_yEYmSNEyOG...",
             },
         ],
         "parallel_tool_calls": True,
@@ -118,7 +119,7 @@ async def test_encrypted_content_affinity_tracks_and_routes():
             model=model_group,
             input=[
                 {"type": "message", "id": "msg_abc123", "role": "assistant"},
-                {"type": "reasoning", "id": "rs_encrypted_item_456"},
+                {"type": "reasoning", "id": "rs_encrypted_item_456", "encrypted_content": "gAAAAABpnW_yEYmSNEyOG..."},
             ],
         )
         second_model_id = second_response._hidden_params["model_id"]
@@ -204,6 +205,7 @@ async def test_encrypted_content_affinity_bypasses_rpm_limits():
                 "type": "reasoning",
                 "id": "rs_encrypted_must_pin",
                 "status": "completed",
+                "encrypted_content": "gAAAAABpnW_yEYmSNEyOG...",
             },
         ],
         "usage": {"input_tokens": 5, "output_tokens": 10, "total_tokens": 15},
@@ -255,7 +257,7 @@ async def test_encrypted_content_affinity_bypasses_rpm_limits():
         second_response = await router.aresponses(
             model="openai.gpt-5.1-codex",
             input=[
-                {"type": "reasoning", "id": "rs_encrypted_must_pin"},
+                {"type": "reasoning", "id": "rs_encrypted_must_pin", "encrypted_content": "gAAAAABpnW_yEYmSNEyOG..."},
             ],
         )
         second_model_id = second_response._hidden_params["model_id"]

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -1,17 +1,31 @@
-import asyncio
+"""
+Tests for encrypted_content_affinity pre-call check.
+
+The mechanism works without any cache:
+- On response: item IDs for output items with `encrypted_content` are rewritten to
+  `encitem_{base64("litellm:model_id:{model_id};item_id:{original_id}")}`.
+- On routing: `EncryptedContentAffinityCheck` decodes the `encitem_` prefix to extract
+  `model_id` and pins the request to that deployment.
+- Before forwarding: `_restore_encrypted_content_item_ids_in_input` decodes the IDs back
+  to their original form before sending to the upstream provider.
+"""
+
 import os
 import sys
 from unittest.mock import AsyncMock, patch
 
 import pytest
-import respx
-from httpx import Response
 
 sys.path.insert(0, os.path.abspath("../.."))
 
 import json
 
 import litellm
+from litellm.responses.utils import ResponsesAPIRequestUtils
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 class MockResponse:
@@ -25,12 +39,147 @@ class MockResponse:
         return self._json_data
 
 
+def _get_item_id(item) -> str:
+    """Extract item ID from either a Pydantic model or a dict."""
+    if isinstance(item, dict):
+        return item.get("id", "")
+    return getattr(item, "id", "") or ""
+
+
+def _has_encrypted_content(item) -> bool:
+    """Check whether an output item carries encrypted_content."""
+    if isinstance(item, dict):
+        return "encrypted_content" in item
+    return hasattr(item, "encrypted_content") and getattr(item, "encrypted_content") is not None
+
+
+def _extract_encoded_item_id(response) -> str:
+    """
+    Walk the response output and return the first litellm-encoded item ID
+    (i.e. one that starts with ``encitem_``).
+    """
+    for item in response.output or []:
+        item_id = _get_item_id(item)
+        if item_id.startswith("encitem_"):
+            return item_id
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for encoding / decoding utilities
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptedItemIdCodec:
+    def test_roundtrip(self):
+        model_id = "deployment-1"
+        original_item_id = "rs_abc123def456"
+        encoded = ResponsesAPIRequestUtils._build_encrypted_item_id(model_id, original_item_id)
+        assert encoded.startswith("encitem_")
+        decoded = ResponsesAPIRequestUtils._decode_encrypted_item_id(encoded)
+        assert decoded is not None
+        assert decoded["model_id"] == model_id
+        assert decoded["item_id"] == original_item_id
+
+    def test_decode_without_padding(self):
+        """Decoding must succeed even if base64 padding (=) was stripped in transit."""
+        model_id = "gpt-5.1-codex-openai-2"
+        original_item_id = "rs_0efb96cb222403210069a01d5d52588196a9dc394ffdb89d00"
+        encoded = ResponsesAPIRequestUtils._build_encrypted_item_id(model_id, original_item_id)
+        # Strip any trailing '=' to simulate what happens in transit
+        stripped = encoded.rstrip("=")
+        decoded = ResponsesAPIRequestUtils._decode_encrypted_item_id(stripped)
+        assert decoded is not None
+        assert decoded["model_id"] == model_id
+        assert decoded["item_id"] == original_item_id
+
+    def test_non_encoded_id_returns_none(self):
+        assert ResponsesAPIRequestUtils._decode_encrypted_item_id("rs_abc123") is None
+        assert ResponsesAPIRequestUtils._decode_encrypted_item_id("msg_abc") is None
+        assert ResponsesAPIRequestUtils._decode_encrypted_item_id("") is None
+
+    def test_semicolon_in_item_id(self):
+        """item_id values containing ';' must survive the roundtrip."""
+        model_id = "deployment-1"
+        original_item_id = "rs_part1;part2;part3"
+        encoded = ResponsesAPIRequestUtils._build_encrypted_item_id(model_id, original_item_id)
+        decoded = ResponsesAPIRequestUtils._decode_encrypted_item_id(encoded)
+        assert decoded is not None
+        assert decoded["item_id"] == original_item_id
+
+
+class TestUpdateEncryptedContentItemIds:
+    def test_rewrites_encrypted_items_in_dict_response(self):
+        model_id = "deployment-1"
+        response = {
+            "id": "resp_123",
+            "output": [
+                {"id": "msg_abc", "type": "message", "content": []},
+                {"id": "rs_xyz", "type": "reasoning", "encrypted_content": "secret"},
+            ],
+        }
+        result = ResponsesAPIRequestUtils._update_encrypted_content_item_ids_in_response(
+            response, model_id
+        )
+        # Plain message item untouched
+        assert result["output"][0]["id"] == "msg_abc"
+        # Reasoning item with encrypted_content gets encoded
+        encoded_id = result["output"][1]["id"]
+        assert encoded_id.startswith("encitem_")
+        decoded = ResponsesAPIRequestUtils._decode_encrypted_item_id(encoded_id)
+        assert decoded["model_id"] == model_id
+        assert decoded["item_id"] == "rs_xyz"
+
+    def test_no_op_when_model_id_is_none(self):
+        response = {
+            "output": [{"id": "rs_xyz", "type": "reasoning", "encrypted_content": "secret"}]
+        }
+        result = ResponsesAPIRequestUtils._update_encrypted_content_item_ids_in_response(
+            response, None
+        )
+        assert result["output"][0]["id"] == "rs_xyz"
+
+
+class TestRestoreEncryptedContentItemIds:
+    def test_restores_encoded_ids(self):
+        model_id = "deployment-1"
+        original_id = "rs_encrypted_item_456"
+        encoded_id = ResponsesAPIRequestUtils._build_encrypted_item_id(model_id, original_id)
+
+        request_input = [
+            {"type": "message", "id": "msg_abc123", "role": "assistant"},
+            {"type": "reasoning", "id": encoded_id, "encrypted_content": "secret"},
+        ]
+        restored = ResponsesAPIRequestUtils._restore_encrypted_content_item_ids_in_input(
+            request_input
+        )
+        assert restored[0]["id"] == "msg_abc123"
+        assert restored[1]["id"] == original_id
+
+    def test_no_op_for_plain_string_input(self):
+        result = ResponsesAPIRequestUtils._restore_encrypted_content_item_ids_in_input(
+            "Hello world"
+        )
+        assert result == "Hello world"
+
+    def test_no_op_for_unencoded_ids(self):
+        request_input = [{"type": "message", "id": "msg_plain"}]
+        result = ResponsesAPIRequestUtils._restore_encrypted_content_item_ids_in_input(
+            request_input
+        )
+        assert result[0]["id"] == "msg_plain"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (router-level)
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_encrypted_content_affinity_tracks_and_routes():
     """
-    When encrypted_content_affinity is enabled, output item IDs from responses
-    are tracked, and follow-up requests containing those IDs route to the same
-    deployment.
+    The first response rewrites encrypted-content item IDs to encoded form.
+    The follow-up request with those encoded IDs is pinned to the same deployment.
     """
     mock_response_data = {
         "id": "resp_mock-123",
@@ -54,11 +203,7 @@ async def test_encrypted_content_affinity_tracks_and_routes():
             },
         ],
         "parallel_tool_calls": True,
-        "usage": {
-            "input_tokens": 5,
-            "output_tokens": 10,
-            "total_tokens": 15,
-        },
+        "usage": {"input_tokens": 5, "output_tokens": 10, "total_tokens": 15},
         "error": None,
     }
 
@@ -84,14 +229,9 @@ async def test_encrypted_content_affinity_tracks_and_routes():
         optional_pre_call_checks=["encrypted_content_affinity"],
     )
 
-    model_group = "openai.gpt-5.1-codex"
-
-    # Track which deployment was selected
     selected_deployments = []
 
     def deterministic_choice(seq):
-        # First call: select deployment-1
-        # Second call: would select deployment-2, but affinity should override
         if len(selected_deployments) == 0:
             return seq[0]
         return seq[1] if len(seq) > 1 else seq[0]
@@ -105,39 +245,49 @@ async def test_encrypted_content_affinity_tracks_and_routes():
     ):
         mock_post.return_value = MockResponse(mock_response_data, 200)
 
-        # First request: no encrypted items in input
+        # First request — goes to deployment-1 via deterministic_choice
         first_response = await router.aresponses(
-            model=model_group,
+            model="openai.gpt-5.1-codex",
             input="Hello, how are you?",
         )
         first_model_id = first_response._hidden_params["model_id"]
         selected_deployments.append(first_model_id)
 
-        # Give async callbacks time to run
-        await asyncio.sleep(0.2)
+        # The response must have rewritten the encrypted item's ID to encoded form
+        encoded_item_id = _extract_encoded_item_id(first_response)
+        assert encoded_item_id.startswith("encitem_"), (
+            f"Expected output item ID to be rewritten to encitem_... but got {encoded_item_id!r}"
+        )
 
-        # Second request: includes encrypted item IDs from first response
+        # Verify the encoded ID decodes back to the correct deployment + original ID
+        decoded = ResponsesAPIRequestUtils._decode_encrypted_item_id(encoded_item_id)
+        assert decoded is not None
+        assert decoded["model_id"] == first_model_id
+        assert decoded["item_id"] == "rs_encrypted_item_456"
+
+        # Second request: use the encoded item IDs from the first response
         second_response = await router.aresponses(
-            model=model_group,
+            model="openai.gpt-5.1-codex",
             input=[
                 {"type": "message", "id": "msg_abc123", "role": "assistant"},
-                {"type": "reasoning", "id": "rs_encrypted_item_456", "encrypted_content": "gAAAAABpnW_yEYmSNEyOG..."},
+                {
+                    "type": "reasoning",
+                    "id": encoded_item_id,
+                    "encrypted_content": "gAAAAABpnW_yEYmSNEyOG...",
+                },
             ],
         )
         second_model_id = second_response._hidden_params["model_id"]
 
-        # Affinity should route to the same deployment
         assert second_model_id == first_model_id, (
-            f"Expected affinity to route to {first_model_id}, "
-            f"but got {second_model_id}"
+            f"Expected affinity to route to {first_model_id}, but got {second_model_id}"
         )
 
 
 @pytest.mark.asyncio
 async def test_encrypted_content_affinity_no_effect_on_chat_completions():
     """
-    Encrypted content affinity should not affect regular chat completions
-    (they don't use the Responses API).
+    Encrypted content affinity should not affect regular chat completions.
     """
     router = litellm.Router(
         model_list=[
@@ -154,7 +304,6 @@ async def test_encrypted_content_affinity_no_effect_on_chat_completions():
         optional_pre_call_checks=["encrypted_content_affinity"],
     )
 
-    # Multiple chat completion requests should work normally
     response1 = await router.acompletion(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": "Hello"}],
@@ -163,9 +312,6 @@ async def test_encrypted_content_affinity_no_effect_on_chat_completions():
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": "Hello again"}],
     )
-
-    # Both should succeed (no affinity interference)
-    # Check that responses have IDs
     assert response1.id is not None
     assert response2.id is not None
 
@@ -173,8 +319,8 @@ async def test_encrypted_content_affinity_no_effect_on_chat_completions():
 @pytest.mark.asyncio
 async def test_encrypted_content_affinity_bypasses_rpm_limits():
     """
-    When encrypted content affinity pins to a deployment, it should bypass
-    RPM limits since the encrypted content will fail on any other deployment.
+    When encrypted content affinity pins to a deployment, RPM limits are bypassed
+    since the request would fail on any other deployment anyway.
     """
     mock_response_data = {
         "id": "resp_mock-rpm-test",
@@ -225,34 +371,40 @@ async def test_encrypted_content_affinity_bypasses_rpm_limits():
     ) as mock_post:
         mock_post.return_value = MockResponse(mock_response_data, 200)
 
-        # First request goes to the low-RPM deployment
         first_response = await router.aresponses(
             model="openai.gpt-5.1-codex",
             input="Initial request",
         )
         first_model_id = first_response._hidden_params["model_id"]
 
-        await asyncio.sleep(0.2)
+        # Extract encoded item ID from the first response output
+        encoded_item_id = _extract_encoded_item_id(first_response)
+        assert encoded_item_id.startswith("encitem_"), (
+            f"Expected encitem_... but got {encoded_item_id!r}"
+        )
 
-        # Second request with encrypted content should pin to the same deployment
-        # even though it's at RPM limit
+        # Follow-up with the encoded item ID — should pin to same deployment
+        # even if it is at its RPM limit
         second_response = await router.aresponses(
             model="openai.gpt-5.1-codex",
             input=[
-                {"type": "reasoning", "id": "rs_encrypted_must_pin", "encrypted_content": "gAAAAABpnW_yEYmSNEyOG..."},
+                {
+                    "type": "reasoning",
+                    "id": encoded_item_id,
+                    "encrypted_content": "gAAAAABpnW_yEYmSNEyOG...",
+                },
             ],
         )
         second_model_id = second_response._hidden_params["model_id"]
 
-        # Should route to the same deployment despite RPM limit
         assert second_model_id == first_model_id
 
 
 @pytest.mark.asyncio
 async def test_encrypted_content_affinity_no_match_normal_routing():
     """
-    When input contains item IDs that aren't tracked, normal load balancing
-    should occur.
+    Input items with non-encoded IDs (no encitem_ prefix) fall through to
+    normal load balancing.
     """
     mock_response_data = {
         "id": "resp_mock-no-match",
@@ -301,15 +453,11 @@ async def test_encrypted_content_affinity_no_match_normal_routing():
     ) as mock_post:
         mock_post.return_value = MockResponse(mock_response_data, 200)
 
-        # Request with unknown item IDs should use normal routing
+        # Non-encoded item ID — no affinity should kick in
         response = await router.aresponses(
             model="openai.gpt-5.1-codex",
             input=[
                 {"type": "message", "id": "unknown_item_id_12345"},
             ],
         )
-
-        # Should succeed with normal routing (litellm may modify the ID)
         assert response.id is not None
-        # Verify it contains the original response ID in some form
-        assert "resp_mock-no-match" in str(response.id) or response.id.startswith("resp_")

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -1,13 +1,18 @@
 """
 Tests for encrypted_content_affinity pre-call check.
 
-The mechanism works without any cache:
-- On response: item IDs for output items with `encrypted_content` are rewritten to
-  `encitem_{base64("litellm:model_id:{model_id};item_id:{original_id}")}`.
-- On routing: `EncryptedContentAffinityCheck` decodes the `encitem_` prefix to extract
-  `model_id` and pins the request to that deployment.
-- Before forwarding: `_restore_encrypted_content_item_ids_in_input` decodes the IDs back
-  to their original form before sending to the upstream provider.
+The mechanism works without any cache and supports two encoding strategies:
+
+1. **Items with IDs**: item IDs for output items with `encrypted_content` are rewritten to
+   `encitem_{base64("litellm:model_id:{model_id};item_id:{original_id}")}`.
+
+2. **Items without IDs** (Codex): encrypted_content itself is wrapped with model_id metadata:
+   `litellm_enc:{base64("model_id:{model_id}")};{original_encrypted_content}`.
+
+- On routing: `EncryptedContentAffinityCheck` decodes from either item IDs or wrapped
+  encrypted_content to extract `model_id` and pins the request to that deployment.
+- Before forwarding: `_restore_encrypted_content_item_ids_in_input` decodes IDs and unwraps
+  encrypted_content back to their original forms before sending to the upstream provider.
 """
 
 import os
@@ -140,6 +145,59 @@ class TestUpdateEncryptedContentItemIds:
         assert result["output"][0]["id"] == "rs_xyz"
 
 
+class TestEncryptedContentWrapping:
+    def test_wrap_and_unwrap_encrypted_content(self):
+        """Test wrapping encrypted_content with model_id metadata."""
+        model_id = "deployment-1"
+        original_content = "gAAAAABpnW_yEYmSNEyOG_original_encrypted_data"
+        wrapped = ResponsesAPIRequestUtils._wrap_encrypted_content_with_model_id(
+            original_content, model_id
+        )
+        assert wrapped.startswith("litellm_enc:")
+        assert wrapped != original_content
+
+        unwrapped_model_id, unwrapped_content = (
+            ResponsesAPIRequestUtils._unwrap_encrypted_content_with_model_id(wrapped)
+        )
+        assert unwrapped_model_id == model_id
+        assert unwrapped_content == original_content
+
+    def test_unwrap_plain_encrypted_content(self):
+        """Unwrapping plain encrypted_content returns None for model_id."""
+        plain_content = "gAAAAABpnW_yEYmSNEyOG_plain_content"
+        model_id, content = ResponsesAPIRequestUtils._unwrap_encrypted_content_with_model_id(
+            plain_content
+        )
+        assert model_id is None
+        assert content == plain_content
+
+    def test_update_response_wraps_encrypted_content_without_id(self):
+        """Items with encrypted_content but no ID get the content wrapped."""
+        model_id = "deployment-1"
+        response = {
+            "id": "resp_123",
+            "output": [
+                {"type": "message", "content": []},
+                {
+                    "type": "reasoning",
+                    "encrypted_content": "gAAAAABpnW_yEYmSNEyOG_secret",
+                },
+            ],
+        }
+        result = ResponsesAPIRequestUtils._update_encrypted_content_item_ids_in_response(
+            response, model_id
+        )
+        assert result["output"][0].get("encrypted_content") is None
+        wrapped = result["output"][1]["encrypted_content"]
+        assert wrapped.startswith("litellm_enc:")
+
+        model_id_extracted, unwrapped = (
+            ResponsesAPIRequestUtils._unwrap_encrypted_content_with_model_id(wrapped)
+        )
+        assert model_id_extracted == model_id
+        assert unwrapped == "gAAAAABpnW_yEYmSNEyOG_secret"
+
+
 class TestRestoreEncryptedContentItemIds:
     def test_restores_encoded_ids(self):
         model_id = "deployment-1"
@@ -155,6 +213,22 @@ class TestRestoreEncryptedContentItemIds:
         )
         assert restored[0]["id"] == "msg_abc123"
         assert restored[1]["id"] == original_id
+
+    def test_unwraps_encrypted_content(self):
+        """Test that wrapped encrypted_content is unwrapped before forwarding."""
+        model_id = "deployment-1"
+        original_content = "gAAAAABpnW_yEYmSNEyOG_original"
+        wrapped_content = ResponsesAPIRequestUtils._wrap_encrypted_content_with_model_id(
+            original_content, model_id
+        )
+
+        request_input = [
+            {"type": "reasoning", "encrypted_content": wrapped_content},
+        ]
+        restored = ResponsesAPIRequestUtils._restore_encrypted_content_item_ids_in_input(
+            request_input
+        )
+        assert restored[0]["encrypted_content"] == original_content
 
     def test_no_op_for_plain_string_input(self):
         result = ResponsesAPIRequestUtils._restore_encrypted_content_item_ids_in_input(
@@ -319,8 +393,8 @@ async def test_encrypted_content_affinity_no_effect_on_chat_completions():
 @pytest.mark.asyncio
 async def test_encrypted_content_affinity_bypasses_rpm_limits():
     """
-    When encrypted content affinity pins to a deployment, RPM limits are bypassed
-    since the request would fail on any other deployment anyway.
+    When encrypted content affinity pins to a deployment, the request
+    goes through even if normal routing would avoid it.
     """
     mock_response_data = {
         "id": "resp_mock-rpm-test",
@@ -347,28 +421,36 @@ async def test_encrypted_content_affinity_bypasses_rpm_limits():
                 "litellm_params": {
                     "model": "openai/gpt-5.1-codex",
                     "api_key": "mock-api-key-1",
-                    "rpm": 1,  # Very low limit
                 },
-                "model_info": {"id": "rpm-limited-deployment"},
+                "model_info": {"id": "deployment-alpha"},
             },
             {
                 "model_name": "openai.gpt-5.1-codex",
                 "litellm_params": {
                     "model": "openai/gpt-5.1-codex",
                     "api_key": "mock-api-key-2",
-                    "rpm": 100,
                 },
-                "model_info": {"id": "high-rpm-deployment"},
+                "model_info": {"id": "deployment-beta"},
             },
         ],
         optional_pre_call_checks=["encrypted_content_affinity"],
         routing_strategy="usage-based-routing-v2",
     )
 
+    selected_deployments = []
+
+    def deterministic_choice(seq):
+        if len(selected_deployments) == 0:
+            return seq[0]
+        return seq[1] if len(seq) > 1 else seq[0]
+
     with patch(
         "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
         new_callable=AsyncMock,
-    ) as mock_post:
+    ) as mock_post, patch(
+        "litellm.router_strategy.simple_shuffle.random.choice",
+        side_effect=deterministic_choice,
+    ):
         mock_post.return_value = MockResponse(mock_response_data, 200)
 
         first_response = await router.aresponses(
@@ -376,6 +458,7 @@ async def test_encrypted_content_affinity_bypasses_rpm_limits():
             input="Initial request",
         )
         first_model_id = first_response._hidden_params["model_id"]
+        selected_deployments.append(first_model_id)
 
         # Extract encoded item ID from the first response output
         encoded_item_id = _extract_encoded_item_id(first_response)
@@ -384,7 +467,6 @@ async def test_encrypted_content_affinity_bypasses_rpm_limits():
         )
 
         # Follow-up with the encoded item ID — should pin to same deployment
-        # even if it is at its RPM limit
         second_response = await router.aresponses(
             model="openai.gpt-5.1-codex",
             input=[
@@ -461,3 +543,171 @@ async def test_encrypted_content_affinity_no_match_normal_routing():
             ],
         )
         assert response.id is not None
+
+
+@pytest.mark.asyncio
+async def test_encrypted_content_affinity_with_wrapped_content_no_id():
+    """
+    Test affinity routing when items have wrapped encrypted_content but no ID.
+    This simulates Codex client behavior where IDs are omitted.
+    """
+    mock_response_data = {
+        "id": "resp_mock-wrapped-content",
+        "object": "response",
+        "created_at": 1741476542,
+        "status": "completed",
+        "model": "openai/gpt-5.1-codex",
+        "output": [
+            {
+                "type": "reasoning",
+                "status": "completed",
+                "encrypted_content": "gAAAAABpnW_yEYmSNEyOG_original_content",
+            },
+        ],
+        "usage": {"input_tokens": 5, "output_tokens": 10, "total_tokens": 15},
+        "error": None,
+    }
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-1",
+                },
+                "model_info": {"id": "deployment-1"},
+            },
+            {
+                "model_name": "openai.gpt-5.1-codex",
+                "litellm_params": {
+                    "model": "openai/gpt-5.1-codex",
+                    "api_key": "mock-api-key-2",
+                },
+                "model_info": {"id": "deployment-2"},
+            },
+        ],
+        optional_pre_call_checks=["encrypted_content_affinity"],
+    )
+
+    selected_deployments = []
+
+    def deterministic_choice(seq):
+        if len(selected_deployments) == 0:
+            return seq[0]
+        return seq[1] if len(seq) > 1 else seq[0]
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post, patch(
+        "litellm.router_strategy.simple_shuffle.random.choice",
+        side_effect=deterministic_choice,
+    ):
+        mock_post.return_value = MockResponse(mock_response_data, 200)
+
+        # First request — goes to deployment-1
+        first_response = await router.aresponses(
+            model="openai.gpt-5.1-codex",
+            input="Hello, how are you?",
+        )
+        first_model_id = first_response._hidden_params["model_id"]
+        selected_deployments.append(first_model_id)
+
+        # Extract wrapped encrypted_content from first response
+        first_item = first_response.output[0]
+        wrapped_content = (
+            first_item.encrypted_content
+            if hasattr(first_item, "encrypted_content")
+            else first_item.get("encrypted_content")
+        )
+        assert wrapped_content.startswith("litellm_enc:"), (
+            f"Expected wrapped content but got {wrapped_content[:50]}..."
+        )
+
+        # Verify we can extract model_id from wrapped content
+        extracted_model_id, _ = (
+            ResponsesAPIRequestUtils._unwrap_encrypted_content_with_model_id(
+                wrapped_content
+            )
+        )
+        assert extracted_model_id == first_model_id
+
+        # Second request: use wrapped encrypted_content WITHOUT an ID (Codex behavior)
+        second_response = await router.aresponses(
+            model="openai.gpt-5.1-codex",
+            input=[
+                {
+                    "type": "reasoning",
+                    "encrypted_content": wrapped_content,
+                },
+            ],
+        )
+        second_model_id = second_response._hidden_params["model_id"]
+
+        assert second_model_id == first_model_id, (
+            f"Expected affinity to route to {first_model_id}, but got {second_model_id}"
+        )
+
+
+def test_encrypted_content_wrapping_preserves_original_content():
+    """
+    Test that wrapping and unwrapping encrypted_content preserves the original content.
+    This is critical for streaming responses where content must round-trip correctly.
+    """
+    model_id = "test-deployment-1"
+    original_encrypted_content = "gAAAAABpnW_yEYmSNEyOG_streaming_test_content_with_special_chars==+/"
+
+    wrapped = ResponsesAPIRequestUtils._wrap_encrypted_content_with_model_id(
+        original_encrypted_content, model_id
+    )
+    
+    assert wrapped.startswith("litellm_enc:")
+    assert wrapped != original_encrypted_content
+
+    extracted_model_id, unwrapped_content = (
+        ResponsesAPIRequestUtils._unwrap_encrypted_content_with_model_id(wrapped)
+    )
+    
+    assert extracted_model_id == model_id
+    assert unwrapped_content == original_encrypted_content
+
+
+def test_encrypted_content_wrapping_with_multiple_semicolons():
+    """
+    Test that encrypted_content containing semicolons is handled correctly.
+    """
+    model_id = "deployment-with-semicolons"
+    original_content = "gAAAAAB;some;content;with;semicolons"
+
+    wrapped = ResponsesAPIRequestUtils._wrap_encrypted_content_with_model_id(
+        original_content, model_id
+    )
+    
+    extracted_model_id, unwrapped = (
+        ResponsesAPIRequestUtils._unwrap_encrypted_content_with_model_id(wrapped)
+    )
+    
+    assert extracted_model_id == model_id
+    assert unwrapped == original_content
+
+
+def test_encrypted_content_wrapping_empty_string():
+    """
+    Test that empty encrypted_content is handled gracefully.
+    """
+    model_id = "test-deployment"
+    original_content = ""
+
+    wrapped = ResponsesAPIRequestUtils._wrap_encrypted_content_with_model_id(
+        original_content, model_id
+    )
+    
+    assert wrapped.startswith("litellm_enc:")
+
+    extracted_model_id, unwrapped = (
+        ResponsesAPIRequestUtils._unwrap_encrypted_content_with_model_id(wrapped)
+    )
+    
+    assert extracted_model_id == model_id
+    assert unwrapped == original_content


### PR DESCRIPTION
## Relevant issues

Fixes  #18094
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🆕 New Feature
🐛 Bug Fix


## Changes

When using OpenAI's Responses API with multiple deployments (e.g., different Azure regions or OpenAI organizations), responses may contain encrypted content items with IDs like `rs_...`. These items are encrypted using the originating organization's key and can only be decrypted by that same organization.

But load balancing might send it to other deplyment