### PR TITLE
fix(ollama): map session usage limit and rate limit errors to RateLimitError

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2040,6 +2040,14 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                         llm_provider="ollama",
                         model=model,
                     )
+                elif "session usage limit" in error_str or "rate limit" in error_str.lower():
+                    exception_mapping_worked = True
+                    raise RateLimitError(
+                        message=f"OllamaException: {original_exception}",
+                        llm_provider="ollama",
+                        model=model,
+                        response=getattr(original_exception, "response", None),
+                    )
             elif custom_llm_provider == "vllm":
                 if hasattr(original_exception, "status_code"):
                     if original_exception.status_code == 0:

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2040,7 +2040,7 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                         llm_provider="ollama",
                         model=model,
                     )
-                elif "session usage limit" in error_str or "rate limit" in error_str.lower():
+                elif "session usage limit" in error_str.lower() or "rate limit" in error_str.lower():
                     exception_mapping_worked = True
                     raise RateLimitError(
                         message=f"OllamaException: {original_exception}",

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -281,6 +281,43 @@ def test_vertex_ai_rate_limit_error_mapping(error_message, should_raise_rate_lim
             )
 
 
+ollama_rate_limit_test_cases = [
+    # Positive cases — session/rate-limit messages that should map to RateLimitError
+    ('{"error": "you (tom9876) have reached your session usage limit, please wait or upgrade to continue"}', True),
+    ("session usage limit reached", True),
+    ("rate limit exceeded", True),
+    ("Rate Limit: too many requests", True),
+    # Negative case — generic error, not a rate limit
+    ("no such file or directory", False),
+]
+
+
+@pytest.mark.parametrize(
+    "error_message, should_raise_rate_limit", ollama_rate_limit_test_cases
+)
+def test_ollama_rate_limit_error_mapping(error_message, should_raise_rate_limit):
+    """
+    Tests that the exception_type function correctly maps Ollama's
+    session usage limit and rate limit errors to litellm.RateLimitError.
+    """
+    for provider in ("ollama", "ollama_chat"):
+        original_exception = Exception(error_message)
+        if should_raise_rate_limit:
+            with pytest.raises(litellm.RateLimitError):
+                exception_type(
+                    model="llama3",
+                    original_exception=original_exception,
+                    custom_llm_provider=provider,
+                )
+        else:
+            with pytest.raises((litellm.BadRequestError, litellm.APIConnectionError)):
+                exception_type(
+                    model="llama3",
+                    original_exception=original_exception,
+                    custom_llm_provider=provider,
+                )
+
+
 class TestExtractAndRaiseLitellmException:
     """Tests for extract_and_raise_litellm_exception function"""
 


### PR DESCRIPTION
## Summary

- Ollama's `"session usage limit"` error was not matched by any existing pattern in the exception mapper, so it fell through to a generic `APIConnectionError` (status 500)
- `APIConnectionError` strings are explicitly excluded from cooldown logic in `cooldown_handlers.py`, so the failing deployment was never cooled down
- This meant retries kept hitting the same `order=1` deployment instead of failing over to `order=2`
- Added `"session usage limit"` and generic `"rate limit"` string matching to the Ollama exception handler, raising `RateLimitError` (429) instead
- `RateLimitError` triggers deployment cooldown, allowing the router to select the next-priority deployment on retry

## Root cause chain

1. Ollama returns `{"error": "you have reached your session usage limit..."}`
2. No pattern matched → wrapped as `APIConnectionError` (status 500)
3. `_is_cooldown_required()` checks `if "APIConnectionError" in exception_str: return False`
4. No cooldown → `order=1` deployment stays healthy → retries always pick `order=1`
5. `order=2` deployment never tried

## Test plan

- [x] Added `test_ollama_rate_limit_error_mapping` parametrized over both `ollama` and `ollama_chat` providers
- [x] Covers the exact session usage limit error string from the bug report
- [x] Covers generic `"rate limit"` strings
- [x] Covers negative case (unrelated error stays as `BadRequestError`/`APIConnectionError`)
- [x] `make test-unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)