### PR TITLE
fix(sagemaker): honor aws_role_name/aws_session_name in embedding()

### DIFF
--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -583,35 +583,14 @@ class SagemakerLLM(BaseAWSLLM):
         ### BOTO3 INIT
         import boto3
 
-        # pop aws_secret_access_key, aws_access_key_id, aws_region_name from kwargs, since completion calls fail with them
-        aws_secret_access_key = optional_params.pop("aws_secret_access_key", None)
-        aws_access_key_id = optional_params.pop("aws_access_key_id", None)
-        aws_region_name = optional_params.pop("aws_region_name", None)
-
-        if aws_access_key_id is not None:
-            # uses auth params passed to completion
-            # aws_access_key_id is not None, assume user is trying to auth using litellm.completion
-            client = boto3.client(
-                service_name="sagemaker-runtime",
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-                region_name=aws_region_name,
-            )
-        else:
-            # aws_access_key_id is None, assume user is trying to auth using env variables
-            # boto3 automaticaly reads env variables
-
-            # we need to read region name from env
-            # I assume majority of users use .env for auth
-            region_name = (
-                get_secret("AWS_REGION_NAME")
-                or aws_region_name  # get region from config file if specified
-                or "us-west-2"  # default to us-west-2 if region not specified
-            )
-            client = boto3.client(
-                service_name="sagemaker-runtime",
-                region_name=region_name,
-            )
+        credentials, aws_region_name = self._load_credentials(optional_params)
+        client = boto3.client(
+            service_name="sagemaker-runtime",
+            aws_access_key_id=credentials.access_key,
+            aws_secret_access_key=credentials.secret_key,
+            aws_session_token=credentials.token,
+            region_name=aws_region_name,
+        )
 
         # pop streaming if it's in the optional params as 'stream' raises an error with sagemaker
         inference_params = deepcopy(optional_params)

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_auth.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_auth.py
@@ -1,5 +1,6 @@
 import json
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from litellm.llms.sagemaker.completion.handler import SagemakerLLM
@@ -25,11 +26,28 @@ def test_embedding_uses_load_credentials_for_role_assumption():
         "aws_region_name": "us-east-1",
     }
 
+    mocked_boto3_client_factory = MagicMock(return_value=mocked_sagemaker_client)
+    mocked_boto3_module = ModuleType("boto3")
+    mocked_boto3_module.client = mocked_boto3_client_factory
+    mocked_botocore_module = ModuleType("botocore")
+    mocked_botocore_credentials_module = ModuleType("botocore.credentials")
+
+    class MockCredentials:
+        pass
+
+    mocked_botocore_credentials_module.Credentials = MockCredentials
+    mocked_botocore_module.credentials = mocked_botocore_credentials_module
+
     with patch.object(
         SagemakerLLM, "get_credentials", return_value=assumed_credentials
-    ) as mock_get_credentials, patch(
-        "boto3.client", return_value=mocked_sagemaker_client
-    ) as mock_boto3_client:
+    ) as mock_get_credentials, patch.dict(
+        sys.modules,
+        {
+            "boto3": mocked_boto3_module,
+            "botocore": mocked_botocore_module,
+            "botocore.credentials": mocked_botocore_credentials_module,
+        },
+    ):
         response = llm.embedding(
             model="sentence-transformers-model",
             input=["hello world"],
@@ -51,7 +69,7 @@ def test_embedding_uses_load_credentials_for_role_assumption():
     )
     assert get_credentials_kwargs["aws_session_name"] == "litellm-session"
 
-    mock_boto3_client.assert_called_once_with(
+    mocked_boto3_client_factory.assert_called_once_with(
         service_name="sagemaker-runtime",
         aws_access_key_id="assumed-access-key",
         aws_secret_access_key="assumed-secret-key",

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_auth.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_auth.py
@@ -1,0 +1,63 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from litellm.llms.sagemaker.completion.handler import SagemakerLLM
+from litellm.types.utils import EmbeddingResponse
+
+
+def test_embedding_uses_load_credentials_for_role_assumption():
+    llm = SagemakerLLM()
+    assumed_credentials = SimpleNamespace(
+        access_key="assumed-access-key",
+        secret_key="assumed-secret-key",
+        token="assumed-session-token",
+    )
+    mocked_sagemaker_client = MagicMock()
+    mocked_sagemaker_client.invoke_endpoint.return_value = {
+        "Body": MagicMock(
+            read=MagicMock(return_value=json.dumps([[0.1, 0.2, 0.3]]).encode("utf-8"))
+        )
+    }
+    optional_params = {
+        "aws_role_name": "arn:aws:iam::123456789012:role/CrossAccountRole",
+        "aws_session_name": "litellm-session",
+        "aws_region_name": "us-east-1",
+    }
+
+    with patch.object(
+        SagemakerLLM, "get_credentials", return_value=assumed_credentials
+    ) as mock_get_credentials, patch(
+        "boto3.client", return_value=mocked_sagemaker_client
+    ) as mock_boto3_client:
+        response = llm.embedding(
+            model="sentence-transformers-model",
+            input=["hello world"],
+            model_response=EmbeddingResponse(),
+            print_verbose=lambda *_: None,
+            encoding=None,
+            logging_obj=MagicMock(),
+            optional_params=optional_params,
+            litellm_params={},
+        )
+
+    assert isinstance(response, EmbeddingResponse)
+    assert len(response.data or []) == 1
+
+    get_credentials_kwargs = mock_get_credentials.call_args.kwargs
+    assert (
+        get_credentials_kwargs["aws_role_name"]
+        == "arn:aws:iam::123456789012:role/CrossAccountRole"
+    )
+    assert get_credentials_kwargs["aws_session_name"] == "litellm-session"
+
+    mock_boto3_client.assert_called_once_with(
+        service_name="sagemaker-runtime",
+        aws_access_key_id="assumed-access-key",
+        aws_secret_access_key="assumed-secret-key",
+        aws_session_token="assumed-session-token",
+        region_name="us-east-1",
+    )
+
+    assert "aws_role_name" not in optional_params
+    assert "aws_session_name" not in optional_params


### PR DESCRIPTION
## Summary
- use `_load_credentials(optional_params)` in SageMaker `embedding()` before creating the runtime client
- ensure `aws_role_name` / `aws_session_name` are passed into credential resolution (AssumeRole path)
- keep auth params out of inference payload by relying on existing `_load_credentials` pop behavior
- add a regression test validating role/session propagation and credentialed `boto3.client(...)` initialization
- make the regression test portable by stubbing `boto3` and `botocore.credentials` via `sys.modules`

## Validation
- `venv/bin/pytest tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_auth.py -q`
- result: `1 passed`

Closes BerriAI/litellm#22210