### PR TITLE
feat(models): add zai/glm-5 and zai/glm-5-code to model cost map

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -33811,6 +33811,36 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
+    "zai/glm-5": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 3.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-5-code": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 1.2e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-4.7": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 1.1e-07,


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/22646

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) — N/A: pure data update to model cost JSON, no code logic affected
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Adds native ZhipuAI model entries to `model_prices_and_context_window.json`:

- **`zai/glm-5`** — Input: $1.00/1M, Output: $3.20/1M, Cached input: $0.20/1M
- **`zai/glm-5-code`** — Input: $1.20/1M, Output: $5.00/1M, Cached input: $0.30/1M

Pricing sourced from https://docs.z.ai/guides/overview/pricing

The Vertex AI variant (`vertex_ai/zai-org/glm-5-maas`) already existed but the native ZhipuAI entries were missing.