### PR TITLE
fix(responses): preserve query params when building /responses/compact URL

### DIFF
--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -524,7 +524,10 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         OpenAI API expects the following request
         - POST /v1/responses/compact
         """
-        url = f"{api_base}/compact"
+        # Preserve query params (e.g., api-version) while appending /compact.
+        parsed_url = httpx.URL(api_base)
+        compact_path = parsed_url.path.rstrip("/") + "/compact"
+        url = str(parsed_url.copy_with(path=compact_path))
         
         input = self._validate_input_param(input)
         data = dict(

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -686,6 +686,48 @@ class TestTransformListInputItemsRequest:
         # Assert
         assert "include" not in params  # Empty list should not be included
 
+    def test_openai_transform_compact_response_api_request_query_params_preserved(self):
+        """Test compact URL construction preserves query params and appends path."""
+        # Setup
+        azure_style_api_base = (
+            "https://test.openai.azure.com/openai/responses?api-version=2024-05-01-preview"
+        )
+
+        # Execute
+        url, data = self.openai_config.transform_compact_response_api_request(
+            model="gpt-5.2-codex",
+            input="hello",
+            response_api_optional_request_params={},
+            api_base=azure_style_api_base,
+            litellm_params=self.litellm_params,
+            headers=self.headers,
+        )
+
+        # Assert
+        assert (
+            url
+            == "https://test.openai.azure.com/openai/responses/compact?api-version=2024-05-01-preview"
+        )
+        assert data["model"] == "gpt-5.2-codex"
+        assert data["input"] == "hello"
+
+    def test_openai_transform_compact_response_api_request_path_without_query(self):
+        """Test compact URL construction for base URL without query params."""
+        # Execute
+        url, data = self.openai_config.transform_compact_response_api_request(
+            model="gpt-4o",
+            input="hello",
+            response_api_optional_request_params={},
+            api_base="https://api.openai.com/v1/responses",
+            litellm_params=self.litellm_params,
+            headers=self.headers,
+        )
+
+        # Assert
+        assert url == "https://api.openai.com/v1/responses/compact"
+        assert data["model"] == "gpt-4o"
+        assert data["input"] == "hello"
+
     def test_azure_transform_list_input_items_request_minimal(self):
         """Test Azure implementation with minimal parameters"""
         # Setup


### PR DESCRIPTION
## Relevant issues

Fixes #22664

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix
✅ Test

## Changes

- Fix `/responses/compact` URL construction in `OpenAIResponsesAPIConfig.transform_compact_response_api_request`.
  - Previous behavior used string concatenation: `f"{api_base}/compact"`
  - This breaks query-bearing URLs (e.g. Azure URLs with `?api-version=...`) by producing malformed routes like `...?api-version=.../compact`
  - New behavior uses `httpx.URL` path-safe mutation, preserving query params:
    - parse URL
    - append `/compact` to path
    - keep original query string intact

- Added focused unit tests in `tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py`:
  - `test_openai_transform_compact_response_api_request_query_params_preserved`
  - `test_openai_transform_compact_response_api_request_path_without_query`

## Validation performed

- `uv run pytest -q tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py`
  - Result: `46 passed`

- Additional live verification was done separately in a running LiteLLM proxy with Azure backend:
  - before patch: `/v1/responses/compact` returned Azure `404 Resource not found`
  - after patch: no 404 from malformed URL path construction (remaining responses depend on Azure model/api-version compatibility)
