### PR TITLE
fix(prompt_templates): ensure_alternating_roles skips tool call messages

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -256,6 +256,23 @@ def detect_first_expected_role(
     return None
 
 
+def _counts_in_alternation(msg: AllMessageValues) -> bool:
+    """
+    Returns True if a message should be counted when checking role alternation.
+
+    Matches llamacpp's Jinja2 template logic: only user messages and assistant
+    messages WITHOUT tool_calls are counted. Tool messages and assistant messages
+    with tool_calls are skipped.
+    """
+    role = msg.get("role")
+    if role == "user":
+        return True
+    if role == "assistant":
+        tool_calls = msg.get("tool_calls")
+        return not tool_calls or len(tool_calls) == 0
+    return False  # Skip tool messages and others
+
+
 def _insert_user_continue_message(
     messages: List[AllMessageValues],
     user_continue_message: Optional[ChatCompletionUserMessage],
@@ -268,8 +285,8 @@ def _insert_user_continue_message(
     2. Final assistant message
     3. Consecutive assistant messages
 
-    Only inserts messages between consecutive assistant messages,
-    ignoring all other role types.
+    Skips 'tool' messages and assistant messages with tool_calls when checking
+    for alternation, matching llamacpp's Jinja2 template validation logic.
     """
     if not messages:
         return messages
@@ -277,26 +294,42 @@ def _insert_user_continue_message(
     result_messages = messages.copy()  # Don't modify the input list
     continue_message = user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE
 
-    # Handle first message if it's an assistant message
-    if result_messages[0]["role"] == "assistant":
+    # Handle first message if it's an assistant message (without tool calls)
+    if result_messages[0]["role"] == "assistant" and _counts_in_alternation(
+        result_messages[0]
+    ):
         result_messages.insert(0, continue_message)
 
-    # Handle consecutive assistant messages and final message
-    i = 1  # Start from second message since we handled first message
+    # Handle consecutive assistant messages (without tool calls)
+    i = 1
     while i < len(result_messages):
         curr_message = result_messages[i]
-        prev_message = result_messages[i - 1]
 
-        # Only check for consecutive assistant messages
-        # Ignore all other role types
-        if curr_message["role"] == "assistant" and prev_message["role"] == "assistant":
-            result_messages.insert(i, continue_message)
-            i += 2  # Skip over the message we just inserted
-        else:
+        # Check if current is assistant without tool_calls
+        if curr_message["role"] == "assistant" and _counts_in_alternation(
+            curr_message
+        ):
+            # Look backwards for previous message that counts, skipping tool messages
+            j = i - 1
+            while j >= 0:
+                prev_msg = result_messages[j]
+                if _counts_in_alternation(prev_msg):
+                    # Found a message that counts — if it's also assistant, insert user
+                    if prev_msg["role"] == "assistant":
+                        result_messages.insert(i, continue_message)
+                        i += 2  # Skip over inserted message
+                    break
+                j -= 1
+
+        if i < len(result_messages):
             i += 1
 
     # Handle final message
-    if result_messages[-1]["role"] == "assistant" and ensure_alternating_roles:
+    if (
+        result_messages[-1]["role"] == "assistant"
+        and _counts_in_alternation(result_messages[-1])
+        and ensure_alternating_roles
+    ):
         result_messages.append(continue_message)
 
     return result_messages
@@ -309,6 +342,9 @@ def _insert_assistant_continue_message(
 ) -> List[AllMessageValues]:
     """
     Add assistant continuation messages between consecutive user messages.
+
+    Follows llamacpp's Jinja2 template logic: skips 'tool' messages and
+    'assistant' messages with tool_calls when checking for alternation.
 
     Args:
         messages: List of message dictionaries
@@ -327,17 +363,24 @@ def _insert_assistant_continue_message(
     for i, message in enumerate(messages):
         modified_messages.append(message)
 
-        # Check if we need to insert an assistant message
-        if (
-            i < len(messages) - 1  # Not the last message
-            and message.get("role") == "user"  # Current is user
-            and messages[i + 1].get("role") == "user"
-        ):  # Next is user
-            # Insert assistant message
-            continue_message = (
-                assistant_continue_message or DEFAULT_ASSISTANT_CONTINUE_MESSAGE
-            )
-            modified_messages.append(continue_message)
+        # Only act on user messages that count in alternation
+        if message.get("role") == "user" and _counts_in_alternation(message):
+            # Find the next message that counts in alternation
+            next_counting_idx = i + 1
+            while next_counting_idx < len(messages) and not _counts_in_alternation(
+                messages[next_counting_idx]
+            ):
+                next_counting_idx += 1
+
+            # If the next counting message is also a user message, insert assistant
+            if (
+                next_counting_idx < len(messages)
+                and messages[next_counting_idx].get("role") == "user"
+            ):
+                continue_message = (
+                    assistant_continue_message or DEFAULT_ASSISTANT_CONTINUE_MESSAGE
+                )
+                modified_messages.append(continue_message)
 
     return modified_messages
 

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -359,30 +359,24 @@ def _insert_assistant_continue_message(
     if not ensure_alternating_roles or len(messages) <= 1:
         return messages
 
-    # Create a new list to store modified messages
     modified_messages: List[AllMessageValues] = []
+    continue_message = assistant_continue_message or DEFAULT_ASSISTANT_CONTINUE_MESSAGE
 
     for i, message in enumerate(messages):
-        modified_messages.append(message)
-
-        # Only act on user messages that count in alternation
+        # Before appending a counting user message, check if the previous counting
+        # message was also a user — if so, insert an assistant continue right here.
+        # This mirrors the backward-scan pattern in _insert_user_continue_message and
+        # ensures we never insert inside a tool-call sequence.
         if message.get("role") == "user" and _counts_in_alternation(message):
-            # Find the next message that counts in alternation
-            next_counting_idx = i + 1
-            while next_counting_idx < len(messages) and not _counts_in_alternation(
-                messages[next_counting_idx]
-            ):
-                next_counting_idx += 1
+            j = i - 1
+            while j >= 0:
+                if _counts_in_alternation(messages[j]):
+                    if messages[j].get("role") == "user":
+                        modified_messages.append(continue_message)
+                    break
+                j -= 1
 
-            # If the next counting message is also a user message, insert assistant
-            if (
-                next_counting_idx < len(messages)
-                and messages[next_counting_idx].get("role") == "user"
-            ):
-                continue_message = (
-                    assistant_continue_message or DEFAULT_ASSISTANT_CONTINUE_MESSAGE
-                )
-                modified_messages.append(continue_message)
+        modified_messages.append(message)
 
     return modified_messages
 

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -273,114 +273,6 @@ def _counts_in_alternation(msg: AllMessageValues) -> bool:
     return False  # Skip tool messages and others
 
 
-def _insert_user_continue_message(
-    messages: List[AllMessageValues],
-    user_continue_message: Optional[ChatCompletionUserMessage],
-    ensure_alternating_roles: bool,
-) -> List[AllMessageValues]:
-    """
-    Inserts a user continue message into the messages list.
-    Handles three cases:
-    1. Initial assistant message
-    2. Final assistant message
-    3. Consecutive assistant messages
-
-    Skips 'tool' messages and assistant messages with tool_calls when checking
-    for alternation, matching llamacpp's Jinja2 template validation logic.
-    """
-    if not messages:
-        return messages
-
-    result_messages = messages.copy()  # Don't modify the input list
-    continue_message = user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE
-
-    # Handle first message if it's an assistant message (without tool calls)
-    if result_messages[0]["role"] == "assistant" and _counts_in_alternation(
-        result_messages[0]
-    ):
-        result_messages.insert(0, continue_message)
-
-    # Handle consecutive assistant messages (without tool calls)
-    i = 1
-    while i < len(result_messages):
-        curr_message = result_messages[i]
-        inserted = False
-
-        # Check if current is assistant without tool_calls
-        if curr_message["role"] == "assistant" and _counts_in_alternation(
-            curr_message
-        ):
-            # Look backwards for previous message that counts, skipping tool messages
-            j = i - 1
-            while j >= 0:
-                prev_msg = result_messages[j]
-                if _counts_in_alternation(prev_msg):
-                    # Found a message that counts — if it's also assistant, insert user
-                    if prev_msg["role"] == "assistant":
-                        result_messages.insert(i, continue_message)
-                        i += 2  # Skip inserted + curr; process next message
-                        inserted = True
-                    break
-                j -= 1
-
-        if not inserted:
-            i += 1
-
-    # Handle final message
-    if (
-        result_messages[-1]["role"] == "assistant"
-        and _counts_in_alternation(result_messages[-1])
-        and ensure_alternating_roles
-    ):
-        result_messages.append(continue_message)
-
-    return result_messages
-
-
-def _insert_assistant_continue_message(
-    messages: List[AllMessageValues],
-    assistant_continue_message: Optional[ChatCompletionAssistantMessage] = None,
-    ensure_alternating_roles: bool = True,
-) -> List[AllMessageValues]:
-    """
-    Add assistant continuation messages between consecutive user messages.
-
-    Follows llamacpp's Jinja2 template logic: skips 'tool' messages and
-    'assistant' messages with tool_calls when checking for alternation.
-
-    Args:
-        messages: List of message dictionaries
-        assistant_continue_message: Optional custom assistant message
-        ensure_alternating_roles: Whether to enforce alternating roles
-
-    Returns:
-        Modified list of messages with inserted assistant messages
-    """
-    if not ensure_alternating_roles or len(messages) <= 1:
-        return messages
-
-    modified_messages: List[AllMessageValues] = []
-    continue_message = assistant_continue_message or DEFAULT_ASSISTANT_CONTINUE_MESSAGE
-
-    for i, message in enumerate(messages):
-        # Before appending a counting user message, check if the previous counting
-        # message was also a user — if so, insert an assistant continue right here.
-        # This mirrors the backward-scan pattern in _insert_user_continue_message and
-        # ensures we never insert inside a tool-call sequence.
-        if message.get("role") == "user" and _counts_in_alternation(message):
-            j = i - 1
-            while j >= 0:
-                if _counts_in_alternation(messages[j]):
-                    if messages[j].get("role") == "user":
-                        modified_messages.append(continue_message)
-                    break
-                j -= 1
-
-        modified_messages.append(message)
-
-    return modified_messages
-
-
 def get_completion_messages(
     messages: List[AllMessageValues],
     assistant_continue_message: Optional[ChatCompletionAssistantMessage],
@@ -388,25 +280,48 @@ def get_completion_messages(
     ensure_alternating_roles: bool,
 ) -> List[AllMessageValues]:
     """
-    Ensures messages alternate between user and assistant roles by adding placeholders
-    only when there are consecutive messages of the same role.
+    Ensures messages alternate between user and assistant roles by inserting
+    placeholder continuation messages wherever two consecutive counting messages
+    have the same role.
 
-    1. ensure 'user' message before 1st 'assistant' message
-    2. ensure 'user' message after last 'assistant' message
+    Tool messages and assistant messages with tool_calls are transparent —
+    they are passed through unchanged and do not affect the alternation check.
+    This matches the validation logic used by backends like llamacpp.
     """
     if not ensure_alternating_roles:
         return messages.copy()
 
-    ## INSERT USER CONTINUE MESSAGE
-    messages = _insert_user_continue_message(
-        messages, user_continue_message, ensure_alternating_roles
-    )
+    user_cont = user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE
+    asst_cont = assistant_continue_message or DEFAULT_ASSISTANT_CONTINUE_MESSAGE
 
-    ## INSERT ASSISTANT CONTINUE MESSAGE
-    messages = _insert_assistant_continue_message(
-        messages, assistant_continue_message, ensure_alternating_roles
-    )
-    return messages
+    result: List[AllMessageValues] = []
+    last_counting_role: Optional[str] = None
+
+    for msg in messages:
+        if _counts_in_alternation(msg):
+            role = msg.get("role")
+
+            # First counting message is assistant → prepend a user turn
+            if last_counting_role is None and role == "assistant":
+                result.append(user_cont)
+                last_counting_role = "user"
+
+            # Two consecutive counting messages of the same role → insert separator
+            if last_counting_role == role == "assistant":
+                result.append(user_cont)
+            elif last_counting_role == role == "user":
+                result.append(asst_cont)
+
+            result.append(msg)
+            last_counting_role = role
+        else:
+            result.append(msg)
+
+    # Trailing assistant → append a user turn
+    if last_counting_role == "assistant":
+        result.append(user_cont)
+
+    return result
 
 
 def get_format_from_file_id(file_id: Optional[str]) -> Optional[str]:

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -269,7 +269,7 @@ def _counts_in_alternation(msg: AllMessageValues) -> bool:
         return True
     if role == "assistant":
         tool_calls = msg.get("tool_calls")
-        return not tool_calls or len(tool_calls) == 0
+        return not tool_calls
     return False  # Skip tool messages and others
 
 
@@ -304,6 +304,7 @@ def _insert_user_continue_message(
     i = 1
     while i < len(result_messages):
         curr_message = result_messages[i]
+        inserted = False
 
         # Check if current is assistant without tool_calls
         if curr_message["role"] == "assistant" and _counts_in_alternation(
@@ -317,11 +318,12 @@ def _insert_user_continue_message(
                     # Found a message that counts — if it's also assistant, insert user
                     if prev_msg["role"] == "assistant":
                         result_messages.insert(i, continue_message)
-                        i += 2  # Skip over inserted message
+                        i += 2  # Skip inserted + curr; process next message
+                        inserted = True
                     break
                 j -= 1
 
-        if i < len(result_messages):
+        if not inserted:
             i += 1
 
     # Handle final message

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9779,6 +9779,122 @@
             }
         ]
     },
+    "dashscope/qwen3-max-2026-01-23": {
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 258048,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.4e-06,
+                "output_cost_per_token": 1.2e-05,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    252000.0
+                ]
+            }
+        ]
+    },
+    "dashscope/qwen3-next-80b-a3b-instruct": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/qwen3-next-80b-a3b-thinking": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/qwen3-vl-235b-a22b-instruct": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.6e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "dashscope/qwen3-vl-235b-a22b-thinking": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "dashscope/qwen3-vl-32b-instruct": {
+        "input_cost_per_token": 1.6e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 6.4e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "dashscope/qwen3-vl-32b-thinking": {
+        "input_cost_per_token": 1.6e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 2.87e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "dashscope/qwen3-vl-plus": {
         "litellm_provider": "dashscope",
         "max_input_tokens": 260096,
@@ -25702,6 +25818,30 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 159
     },
+    "openrouter/anthropic/claude-sonnet-4.6": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "input_cost_per_token": 3e-06,
+        "input_cost_per_token_above_200k_tokens": 6e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        "source": "https://openrouter.ai/anthropic/claude-sonnet-4.6",
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159
+    },
     "openrouter/anthropic/claude-opus-4.5": {
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
@@ -26051,6 +26191,39 @@
         "supports_vision": true,
         "supports_web_search": true,
         "tpm": 800000
+    },
+    "openrouter/google/gemini-3.1-pro-preview": {
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "cache_creation_input_token_cost_above_200k_tokens": 2.5e-07,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_200k_tokens": 4e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_above_200k_tokens": 1.8e-05,
+        "source": "https://openrouter.ai/google/gemini-3.1-pro-preview",
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "openrouter/gryphe/mythomax-l2-13b": {
         "input_cost_per_token": 1.875e-06,
@@ -26429,6 +26602,29 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/openai/gpt-5.1-codex-max": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "source": "https://openrouter.ai/openai/gpt-5.1-codex-max",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "openrouter/openai/gpt-5.2": {
         "input_cost_per_image": 0,
         "cache_read_input_token_cost": 1.75e-07,
@@ -26583,6 +26779,19 @@
         "supports_tool_choice": true,
         "supports_function_calling": true
     },
+    "openrouter/qwen/qwen3-coder-plus": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 5e-06,
+        "source": "https://openrouter.ai/qwen/qwen3-coder-plus",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "openrouter/qwen/qwen3-235b-a22b-2507": {
         "input_cost_per_token": 7.1e-08,
         "litellm_provider": "openrouter",
@@ -26717,6 +26926,19 @@
         "supports_reasoning": true,
         "supports_vision": true,
         "supports_prompt_caching": false
+    },
+    "openrouter/z-ai/glm-5": {
+        "input_cost_per_token": 8e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.56e-06,
+        "source": "https://openrouter.ai/z-ai/glm-5",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
     },
     "openrouter/minimax/minimax-m2.1": {
         "input_cost_per_token": 2.7e-07,
@@ -34159,6 +34381,36 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "zai/glm-5": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 3.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-5-code": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 1.2e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.7": {
         "cache_creation_input_token_cost": 0,

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -849,6 +849,48 @@ def test_azure_tool_call_invoke_helper():
             None,
             None,
         ),
+        # Consecutive users after a tool-call sequence — assistant continue must go
+        # between the two user messages, NOT inside the tool-call sequence
+        (
+            [
+                {"role": "user", "content": "Q1"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "content": "result", "tool_call_id": "c1"},
+                {"role": "user", "content": "Q2"},
+                {"role": "user", "content": "Q3"},
+            ],
+            [
+                {"role": "user", "content": "Q1"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "content": "result", "tool_call_id": "c1"},
+                {"role": "assistant", "content": "Please continue."},
+                {"role": "user", "content": "Q2"},
+                {"role": "assistant", "content": "Please continue."},
+                {"role": "user", "content": "Q3"},
+            ],
+            None,
+            None,
+        ),
     ],
 )
 def test_ensure_alternating_roles(

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -758,6 +758,77 @@ def test_azure_tool_call_invoke_helper():
                 "content": "Please continue",
             },
         ),
+        # Tool call scenario: assistant with tool_calls + tool result messages
+        # should be skipped when checking alternation (matches llamacpp Jinja2 logic)
+        (
+            [
+                {"role": "user", "content": "What's the weather?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "content": "Sunny, 72F", "tool_call_id": "call_1"},
+                {"role": "assistant", "content": "It's sunny and 72F."},
+                {"role": "user", "content": "What about tomorrow?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "content": "Rainy, 60F", "tool_call_id": "call_2"},
+                {"role": "assistant", "content": "Tomorrow will be rainy and 60F."},
+                {"role": "user", "content": "Thanks!"},
+                {"role": "user", "content": "One more question."},
+            ],
+            [
+                {"role": "user", "content": "What's the weather?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "content": "Sunny, 72F", "tool_call_id": "call_1"},
+                {"role": "assistant", "content": "It's sunny and 72F."},
+                {"role": "user", "content": "What about tomorrow?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "content": "Rainy, 60F", "tool_call_id": "call_2"},
+                {"role": "assistant", "content": "Tomorrow will be rainy and 60F."},
+                {"role": "user", "content": "Thanks!"},
+                {"role": "assistant", "content": "Please continue."},
+                {"role": "user", "content": "One more question."},
+            ],
+            None,
+            None,
+        ),
     ],
 )
 def test_ensure_alternating_roles(

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -829,6 +829,26 @@ def test_azure_tool_call_invoke_helper():
             None,
             None,
         ),
+        # Triple consecutive assistant messages — all three should get user separators
+        (
+            [
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "content": "A1"},
+                {"role": "assistant", "content": "A2"},
+                {"role": "assistant", "content": "A3"},
+            ],
+            [
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "content": "A1"},
+                {"role": "user", "content": "Please continue."},
+                {"role": "assistant", "content": "A2"},
+                {"role": "user", "content": "Please continue."},
+                {"role": "assistant", "content": "A3"},
+                {"role": "user", "content": "Please continue."},
+            ],
+            None,
+            None,
+        ),
     ],
 )
 def test_ensure_alternating_roles(


### PR DESCRIPTION
## Relevant issues

Fixes #18685

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

`ensure_alternating_roles` was broken for conversations with tool calls. When a conversation had `assistant` messages with `tool_calls` followed by `tool` result messages, the alternation check would incorrectly flag them as violations.

Root cause: llamacpp's Jinja2 template skips `tool` messages and `assistant` messages that have `tool_calls` when checking alternation. The old code didn't do this, so it counted those messages and got confused.

Fix: extracted a shared `_counts_in_alternation()` helper that mirrors llamacpp's logic. Both `_insert_user_continue_message` and `_insert_assistant_continue_message` now use it to skip tool-related messages when looking for consecutive same-role messages.

Before the fix, a sequence like:
```
user → assistant(tool_calls) → tool → assistant → user → user
```
would incorrectly see `assistant → assistant` (skipping the tool messages in between) and inject a spurious user message.

After the fix, tool messages and assistant-with-tool_calls messages are transparent to the alternation check, so only the "real" user/assistant pairs are considered.