### PR TITLE
Add Support for OpenAI's Chat-GPT 5.3 Chat model

### DIFF
--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -191,6 +191,7 @@ os.environ["OPENAI_BASE_URL"] = "https://your_host/v1"     # OPTIONAL
 | gpt-5.2 | `response = completion(model="gpt-5.2", messages=messages)` |
 | gpt-5.2-2025-12-11 | `response = completion(model="gpt-5.2-2025-12-11", messages=messages)` |
 | gpt-5.2-chat-latest | `response = completion(model="gpt-5.2-chat-latest", messages=messages)` |
+| gpt-5.3-chat-latest | `response = completion(model="gpt-5.3-chat-latest", messages=messages)` |
 | gpt-5.2-pro | `response = completion(model="gpt-5.2-pro", messages=messages)` |
 | gpt-5.2-pro-2025-12-11 | `response = completion(model="gpt-5.2-pro-2025-12-11", messages=messages)` |
 | gpt-5.1 | `response = completion(model="gpt-5.1", messages=messages)` |

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -20544,6 +20544,40 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "gpt-5.3-chat-latest": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
+        "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "gpt-5.2-pro": {
         "input_cost_per_token": 2.1e-05,
         "litellm_provider": "openai",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20660,6 +20660,40 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "gpt-5.3-chat-latest": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
+        "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "gpt-5.2-pro": {
         "input_cost_per_token": 2.1e-05,
         "litellm_provider": "openai",

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -269,6 +269,7 @@ def test_gpt5_1_model_detection(gpt5_config: OpenAIGPT5Config):
     assert gpt5_config.is_model_gpt_5_1_model("gpt-5.2-2025-12-11")
     assert not gpt5_config.is_model_gpt_5_1_model("gpt-5.2-chat")
     assert not gpt5_config.is_model_gpt_5_1_model("gpt-5.2-chat-latest")
+    assert not gpt5_config.is_model_gpt_5_1_model("gpt-5.3-chat-latest")
     assert not gpt5_config.is_model_gpt_5_1_model("gpt-5.2-pro")
     assert not gpt5_config.is_model_gpt_5_1_model("gpt-5")
     assert not gpt5_config.is_model_gpt_5_1_model("gpt-5-mini")
@@ -402,7 +403,7 @@ def test_gpt5_2_chat_temperature_restricted(config: OpenAIConfig):
     Regression test for https://github.com/BerriAI/litellm/issues/21911
     """
     # gpt-5.2-chat should reject non-1 temperature when drop_params=False
-    for model in ["gpt-5.2-chat", "gpt-5.2-chat-latest"]:
+    for model in ["gpt-5.2-chat", "gpt-5.2-chat-latest", "gpt-5.3-chat-latest"]:
         with pytest.raises(litellm.utils.UnsupportedParamsError):
             config.map_openai_params(
                 non_default_params={"temperature": 0.7},


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - Updated: `tests/test_litellm/llms/openai/test_gpt5_transformation.py`
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - Ran targeted tests for this change:
    - `poetry run pytest tests/test_litellm/llms/openai/test_gpt5_transformation.py -x -vv`
    - `poetry run pytest tests/test_litellm/test_utils.py::test_max_tokens_consistency -x -vv`
    - `poetry run pytest tests/test_litellm/test_utils.py::test_aaamodel_prices_and_context_window_json_is_valid -x -vv`
  - Results:
    - `44 passed`
    - `1 passed`
    - `1 failed` (pre-existing schema baseline issue unrelated to this PR: `vertex_ai/gemini-3.1-flash-lite-preview` has fields not listed in `INTENDED_SCHEMA`)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🚀 Feature
✅ Test
📝 Documentation

## Commits in this PR (`main..HEAD`)

- `96dd6f26ff` Add Support for OpenAI's Chat-GPT 5.3 Chat model

## Changes

1. Add `gpt-5.3-chat-latest` model metadata (OpenAI)
   - Added pricing/context/capability entry to:
     - `model_prices_and_context_window.json`
     - `litellm/model_prices_and_context_window_backup.json`
   - Configured to match current OpenAI model docs:
     - `max_input_tokens=128000`
     - `max_output_tokens=16384`
     - `input=$1.75 / 1M`, `cached_input=$0.175 / 1M`, `output=$14 / 1M`
     - `supported_endpoints=["/v1/chat/completions", "/v1/responses"]`
     - input modalities: `text,image`; output modality: `text`

2. Extend OpenAI GPT-5 parameter behavior coverage
   - Updated GPT-5 transformation tests to include `gpt-5.3-chat-latest` in:
     - GPT-5.1 model detection exclusion checks
     - chat temperature restriction checks (`temperature != 1` handling)

3. Update OpenAI provider documentation
   - Added `gpt-5.3-chat-latest` in the "OpenAI Chat Completion Models" table:
     - `docs/my-website/docs/providers/openai.md`

## Reference
- https://openai.com/index/gpt-5-3-instant/
- https://developers.openai.com/api/docs/models/gpt-5.3-chat-latest
