### PR TITLE
fix(azure_ai): remove openai_key fallback from Azure AI get_api_key

### DIFF
--- a/litellm/llms/azure_ai/common_utils.py
+++ b/litellm/llms/azure_ai/common_utils.py
@@ -46,7 +46,6 @@ class AzureFoundryModelInfo(BaseLLMModelInfo):
         return (
             api_key
             or litellm.api_key
-            or litellm.openai_key
             or get_secret_str("AZURE_AI_API_KEY")
         )
 


### PR DESCRIPTION
## Summary

- Remove `litellm.openai_key` from the fallback chain in `AzureFoundryModelInfo.get_api_key()` (`litellm/llms/azure_ai/common_utils.py`)

## Problem

When using Azure AI Foundry Agents (`azure_ai/agents/*`) in an environment where `OPENAI_API_KEY` is also set (e.g., via a LangChain wrapper like `ChatLiteLLM`), requests fail with **401 Unauthorized**.

### Root Cause

`AzureFoundryModelInfo.get_api_key()` has this fallback chain:

```python
api_key or litellm.api_key or litellm.openai_key or get_secret_str("AZURE_AI_API_KEY")
```

When `litellm.openai_key` is populated (by `ChatLiteLLM._client_params` setting it as a module-level global from `OPENAI_API_KEY`), the Azure AI Agents handler uses the OpenAI API key as a `Bearer` token against Azure. Since OpenAI keys are not valid Azure AD tokens, Azure returns 401.

This prevents `DefaultAzureCredential` from being used — the correct auth flow in `agents/transformation.py:344-351` is only reached when `api_key is None`.

### Reproduction

```python
import litellm

# Simulate what ChatLiteLLM does (or simply having OPENAI_API_KEY in env)
litellm.openai_key = "sk-proj-..."

# This fails with 401
response = await litellm.acompletion(
    model="azure_ai/agents/asst_xxx",
    messages=[{"role": "user", "content": "Hello"}],
    api_base="https://my-resource.services.ai.azure.com/api/projects/my-project",
    stream=True,
)
```

```python
# Without litellm.openai_key set, it works (uses DefaultAzureCredential)
litellm.openai_key = None
response = await litellm.acompletion(...)  # SUCCESS
```

## Fix

Remove `litellm.openai_key` from the fallback chain. OpenAI API keys are never valid credentials for Azure AI services. `litellm.api_key` is retained as an explicit user override.

## Test plan

- [ ] Verify `azure_ai/agents/*` works with `DefaultAzureCredential` when `OPENAI_API_KEY` is set
- [ ] Verify `azure_ai/agents/*` still works with explicit `api_key` parameter
- [ ] Verify `azure_ai/agents/*` still works with `AZURE_AI_API_KEY` env var
- [ ] Verify other Azure AI models (non-agents) are unaffected