### PR TITLE
fix: don't retry ContextWindowExceededError

### DIFF
--- a/litellm/router_utils/get_retry_from_policy.py
+++ b/litellm/router_utils/get_retry_from_policy.py
@@ -10,6 +10,7 @@ from litellm.exceptions import (
     AuthenticationError,
     BadRequestError,
     ContentPolicyViolationError,
+    ContextWindowExceededError,
     RateLimitError,
     Timeout,
 )
@@ -28,6 +29,7 @@ def get_num_retries_from_retry_policy(
     TimeoutErrorRetries: Optional[int] = None
     RateLimitErrorRetries: Optional[int] = None
     ContentPolicyViolationErrorRetries: Optional[int] = None
+    ContextWindowExceededErrorRetries: Optional[int] = None
     """
     # if we can find the exception then in the retry policy -> return the number of retries
 
@@ -60,6 +62,11 @@ def get_num_retries_from_retry_policy(
         and retry_policy.ContentPolicyViolationErrorRetries is not None
     ):
         return retry_policy.ContentPolicyViolationErrorRetries
+    # Check ContextWindowExceededError before BadRequestError since it's a subclass
+    if isinstance(exception, ContextWindowExceededError):
+        if retry_policy.ContextWindowExceededErrorRetries is not None:
+            return retry_policy.ContextWindowExceededErrorRetries
+        return 0
     if (
         isinstance(exception, BadRequestError)
         and retry_policy.BadRequestErrorRetries is not None

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -552,6 +552,7 @@ class RetryPolicy(BaseModel):
     RateLimitErrorRetries: Optional[int] = None
     ContentPolicyViolationErrorRetries: Optional[int] = None
     InternalServerErrorRetries: Optional[int] = None
+    ContextWindowExceededErrorRetries: Optional[int] = None
 
 
 class AlertingConfig(BaseModel):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1216,6 +1216,8 @@ def _get_wrapper_num_retries(
         kwargs["retry_policy"] = reset_retry_policy()
         if retry_policy_num_retries is not None:
             num_retries = retry_policy_num_retries
+    elif isinstance(exception, litellm.exceptions.ContextWindowExceededError):
+        num_retries = 0
 
     return num_retries, kwargs
 
@@ -1672,6 +1674,8 @@ def client(original_function):  # noqa: PLR0915
                     kwargs["retry_policy"] = (
                         reset_retry_policy()
                     )  # prevent infinite loops
+                elif isinstance(e, litellm.exceptions.ContextWindowExceededError):
+                    num_retries = 0
                 litellm.num_retries = (
                     None  # set retries to None to prevent infinite loops
                 )
@@ -1721,6 +1725,8 @@ def client(original_function):  # noqa: PLR0915
                     kwargs["retry_policy"] = (
                         reset_retry_policy()
                     )  # prevent infinite loops
+                elif isinstance(e, litellm.exceptions.ContextWindowExceededError):
+                    num_retries = 0
                 litellm.num_retries = (
                     None  # set retries to None to prevent infinite loops
                 )

--- a/tests/test_litellm/router_utils/test_get_retry_from_policy.py
+++ b/tests/test_litellm/router_utils/test_get_retry_from_policy.py
@@ -1,0 +1,67 @@
+"""
+Tests for get_num_retries_from_retry_policy in litellm/router_utils/get_retry_from_policy.py
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm
+from litellm.exceptions import BadRequestError, ContextWindowExceededError
+from litellm.router_utils.get_retry_from_policy import get_num_retries_from_retry_policy
+from litellm.types.router import RetryPolicy
+
+
+def _make_context_window_error() -> ContextWindowExceededError:
+    return ContextWindowExceededError(
+        message="context window exceeded",
+        llm_provider="azure",
+        model="gpt-4o",
+    )
+
+
+class TestContextWindowExceededRetryPolicy:
+    """ContextWindowExceededError should not be retried by default."""
+
+    def test_context_window_error_returns_zero_with_default_policy(self):
+        """Even when BadRequestErrorRetries is set, ContextWindowExceededError should return 0."""
+        policy = RetryPolicy(BadRequestErrorRetries=5)
+        retries = get_num_retries_from_retry_policy(
+            exception=_make_context_window_error(),
+            retry_policy=policy,
+        )
+        assert retries == 0
+
+    def test_context_window_error_returns_zero_with_empty_policy(self):
+        """With an empty retry policy, ContextWindowExceededError should return 0."""
+        policy = RetryPolicy()
+        retries = get_num_retries_from_retry_policy(
+            exception=_make_context_window_error(),
+            retry_policy=policy,
+        )
+        assert retries == 0
+
+    def test_context_window_error_respects_explicit_override(self):
+        """If user explicitly sets ContextWindowExceededErrorRetries, honor it."""
+        policy = RetryPolicy(ContextWindowExceededErrorRetries=3)
+        retries = get_num_retries_from_retry_policy(
+            exception=_make_context_window_error(),
+            retry_policy=policy,
+        )
+        assert retries == 3
+
+    def test_bad_request_error_still_retried(self):
+        """Regular BadRequestError should still be retried when policy is set."""
+        policy = RetryPolicy(BadRequestErrorRetries=5)
+        retries = get_num_retries_from_retry_policy(
+            exception=BadRequestError(
+                message="bad request",
+                llm_provider="azure",
+                model="gpt-4o",
+            ),
+            retry_policy=policy,
+        )
+        assert retries == 5


### PR DESCRIPTION
ContextWindowExceededError inherits from BadRequestError which
inherits from openai.APIError, so it was being retried by the
isinstance(e, openai.APIError) checks in all retry paths.

Changes:
- Add ContextWindowExceededErrorRetries field to RetryPolicy
- Check ContextWindowExceededError before BadRequestError in
  get_num_retries_from_retry_policy, defaulting to 0 retries
- Set num_retries=0 for ContextWindowExceededError in
  _get_wrapper_num_retries and sync wrapper paths when no
  explicit retry policy is configured

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
