### PR TITLE
Fix mypy override errors in count_tokens signatures

### DIFF
--- a/litellm/llms/gemini/common_utils.py
+++ b/litellm/llms/gemini/common_utils.py
@@ -166,7 +166,8 @@ class GoogleAIStudioTokenCounter(BaseTokenCounter):
         contents: Optional[List[Dict[str, Any]]],
         deployment: Optional[Dict[str, Any]] = None,
         request_model: str = "",
-        **kwargs,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[Any] = None,
     ) -> Optional[TokenCountResponse]:
         import copy
 

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -1030,7 +1030,8 @@ class VertexAITokenCounter(BaseTokenCounter):
         contents: Optional[List[Dict[str, Any]]],
         deployment: Optional[Dict[str, Any]] = None,
         request_model: str = "",
-        **kwargs,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        system: Optional[Any] = None,
     ) -> Optional[TokenCountResponse]:
         import copy
 


### PR DESCRIPTION
## Summary
- Replace `**kwargs` with explicit `tools` and `system` parameters in `VertexAITokenCounter.count_tokens` and `GoogleAIStudioTokenCounter.count_tokens` to match the `BaseTokenCounter` abstract method signature
- Neither implementation used `kwargs` in the method body, so this is a signature-only change with no behavioral impact

## Test plan
- [x] `mypy` passes on both modified files with no `[override]` errors
- [x] No functional change — `tools` and `system` params were already being silently absorbed by `**kwargs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)