### PR TITLE
fix(proxy): guard against None return in async_post_call_streaming_iterator_hook

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2122,13 +2122,15 @@ class ProxyLogging:
                             current_response = _new_response
                     elif "apply_guardrail" in type(_callback).__dict__:
                         request_data["guardrail_to_apply"] = callback
-                        current_response = (
+                        _new_response = (
                             unified_guardrail.async_post_call_streaming_iterator_hook(
                                 user_api_key_dict=user_api_key_dict,
                                 request_data=request_data,
                                 response=current_response,
                             )
                         )
+                        if _new_response is not None:
+                            current_response = _new_response
                     else:
                         _new_response = (
                             _callback.async_post_call_streaming_iterator_hook(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2109,16 +2109,18 @@ class ProxyLogging:
                 ):
                     if (
                         "async_post_call_streaming_iterator_hook"
-                        in type(callback).__dict__
+                        in type(_callback).__dict__
                     ):
-                        current_response = (
+                        _new_response = (
                             _callback.async_post_call_streaming_iterator_hook(
                                 user_api_key_dict=user_api_key_dict,
                                 response=current_response,
                                 request_data=request_data,
                             )
                         )
-                    elif "apply_guardrail" in type(callback).__dict__:
+                        if _new_response is not None:
+                            current_response = _new_response
+                    elif "apply_guardrail" in type(_callback).__dict__:
                         request_data["guardrail_to_apply"] = callback
                         current_response = (
                             unified_guardrail.async_post_call_streaming_iterator_hook(
@@ -2128,13 +2130,15 @@ class ProxyLogging:
                             )
                         )
                     else:
-                        current_response = (
+                        _new_response = (
                             _callback.async_post_call_streaming_iterator_hook(
                                 user_api_key_dict=user_api_key_dict,
                                 response=current_response,
                                 request_data=request_data,
                             )
                         )
+                        if _new_response is not None:
+                            current_response = _new_response
 
         # Actually iterate through the chained async generator and yield chunks
         async for chunk in current_response:

--- a/tests/test_litellm/proxy/hooks/test_async_post_call_streaming_iterator_hook.py
+++ b/tests/test_litellm/proxy/hooks/test_async_post_call_streaming_iterator_hook.py
@@ -192,3 +192,46 @@ async def test_streaming_hook_propagates_callback_errors():
         with pytest.raises(RuntimeError, match="Callback failed!"):
             async for _ in result:
                 pass
+
+
+@pytest.mark.asyncio
+async def test_no_double_strip_on_second_call():
+    """Regression test: callback returning None should not break the streaming chain.
+
+    This tests the fix for: 'async for' requires an object with __aiter__ method, got NoneType
+    Caused by a user-defined callback whose async_post_call_streaming_iterator_hook
+    is a regular sync method (not an async generator) that returns None.
+    """
+    proxy_logging = ProxyLogging(user_api_key_cache=MagicMock())
+
+    class NoneReturningCallback(CustomLogger):
+        """Simulates a badly-implemented callback that returns None instead of an async generator."""
+
+        def async_post_call_streaming_iterator_hook(
+            self,
+            user_api_key_dict: UserAPIKeyAuth,
+            response: Any,
+            request_data: dict,
+        ):
+            # Regular sync method, not an async generator — returns None implicitly
+            pass
+
+    bad_callback = NoneReturningCallback()
+
+    user_api_key_dict = UserAPIKeyAuth(api_key="test_key")
+    request_data = {"model": "gpt-4", "messages": []}
+
+    with patch.object(litellm, "callbacks", [bad_callback]):
+        result = proxy_logging.async_post_call_streaming_iterator_hook(
+            response=mock_streaming_response(),
+            user_api_key_dict=user_api_key_dict,
+            request_data=request_data,
+        )
+
+        # Should not raise TypeError about NoneType
+        collected_chunks = []
+        async for chunk in result:
+            collected_chunks.append(chunk)
+
+        # All 4 original chunks should pass through unmodified
+        assert len(collected_chunks) == 4


### PR DESCRIPTION
## Summary

- Fixes `TypeError: 'async for' requires an object with __aiter__ method, got NoneType` in streaming responses
- Corrects `type(callback).__dict__` → `type(_callback).__dict__` so the resolved callback instance is checked (not the raw string/object from `litellm.callbacks`)
- Adds a `None` guard after each hook call so a badly-implemented custom callback (e.g. a sync method returning `None`) can't break the entire streaming chain — the previous valid iterator is preserved instead

## Root Cause

In `ProxyLogging.async_post_call_streaming_iterator_hook` (`proxy/utils.py`), the callback dispatch loop unconditionally assigned the return value of each hook to `current_response`. If a user-defined callback's `async_post_call_streaming_iterator_hook` is a regular sync method (not an async generator), calling it returns `None`. The next hook in the chain then receives `None` as `response` and fails with the above `TypeError`.

## Test plan

- [x] Added regression test `test_no_double_strip_on_second_call` that simulates a callback with a sync (non-generator) `async_post_call_streaming_iterator_hook` returning `None` — verifies the streaming chain continues and all chunks are yielded
- [x] All existing tests in `tests/test_litellm/proxy/hooks/test_async_post_call_streaming_iterator_hook.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)