### PR TITLE
fix(proxy): ProxyException.__str__() returns empty string - all error logs are blank

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3208,6 +3208,7 @@ class ProxyException(Exception):
         provider_specific_fields: Optional[dict] = None,
     ):
         self.message = str(message)
+        super().__init__(self.message)
         self.type = type
         self.param = param
         self.openai_code = openai_code or code
@@ -3231,6 +3232,9 @@ class ProxyException(Exception):
             self.code = "429"
         elif RouterErrors.no_deployments_with_tag_routing.value in self.message:
             self.code = "401"
+
+    def __str__(self) -> str:
+        return self.message
 
     def to_dict(self) -> dict:
         """Converts the ProxyException instance to a dictionary."""

--- a/tests/test_litellm/proxy/test_proxy_exception_str.py
+++ b/tests/test_litellm/proxy/test_proxy_exception_str.py
@@ -33,7 +33,7 @@ class TestProxyExceptionStr:
 
     def test_proxy_exception_str_unicode(self):
         """str() should handle unicode messages correctly."""
-        msg = "Error: \u2018invalid key\u2019 \u2014 please retry \U0001f512"
+        msg = "Error: \u2018invalid key\u2019 please retry \U0001f512"
         exc = ProxyException(
             message=msg,
             type="bad_request_error",

--- a/tests/test_litellm/proxy/test_proxy_exception_str.py
+++ b/tests/test_litellm/proxy/test_proxy_exception_str.py
@@ -1,0 +1,114 @@
+"""
+Tests for ProxyException string representation.
+
+Verifies that str(ProxyException(...)) returns the exception message
+instead of an empty string. See https://github.com/BerriAI/litellm/issues/22644
+"""
+
+from litellm.proxy._types import ProxyException
+
+
+class TestProxyExceptionStr:
+    """Tests for ProxyException.__str__() behavior."""
+
+    def test_proxy_exception_str_returns_message(self):
+        """str(ProxyException(...)) should return the message, not empty string."""
+        exc = ProxyException(
+            message="auth failed",
+            type="bad_request_error",
+            param="key_alias",
+            code=400,
+        )
+        assert str(exc) == "auth failed"
+
+    def test_proxy_exception_str_empty_message(self):
+        """str() should work correctly with an empty message."""
+        exc = ProxyException(
+            message="",
+            type="bad_request_error",
+            param="key_alias",
+            code=400,
+        )
+        assert str(exc) == ""
+
+    def test_proxy_exception_str_unicode(self):
+        """str() should handle unicode messages correctly."""
+        msg = "Error: \u2018invalid key\u2019 \u2014 please retry \U0001f512"
+        exc = ProxyException(
+            message=msg,
+            type="bad_request_error",
+            param="key_alias",
+            code=400,
+        )
+        assert str(exc) == msg
+
+    def test_proxy_exception_repr(self):
+        """repr() should include the message text."""
+        exc = ProxyException(
+            message="something broke",
+            type="internal_error",
+            param=None,
+            code=500,
+        )
+        assert "something broke" in repr(exc)
+
+    def test_proxy_exception_to_dict_unchanged(self):
+        """to_dict() output format must remain exactly the same after the fix."""
+        exc = ProxyException(
+            message="model not found",
+            type="invalid_request_error",
+            param="model",
+            code=404,
+        )
+        result = exc.to_dict()
+        assert result == {
+            "message": "model not found",
+            "type": "invalid_request_error",
+            "param": "model",
+            "code": "404",
+        }
+
+    def test_proxy_exception_to_dict_with_provider_fields(self):
+        """to_dict() should include provider_specific_fields when present."""
+        exc = ProxyException(
+            message="rate limited",
+            type="rate_limit_error",
+            param=None,
+            code=429,
+            provider_specific_fields={"retry_after": 30},
+        )
+        result = exc.to_dict()
+        assert result["provider_specific_fields"] == {"retry_after": 30}
+        assert result["message"] == "rate limited"
+
+    def test_proxy_exception_chaining(self):
+        """raise ProxyException from ValueError should preserve __cause__."""
+        inner = ValueError("inner error")
+        try:
+            try:
+                raise inner
+            except ValueError:
+                raise ProxyException(
+                    message="outer error",
+                    type="bad_request_error",
+                    param="test",
+                    code=400,
+                ) from inner
+        except ProxyException as exc:
+            assert str(exc) == "outer error"
+            assert exc.__cause__ is inner
+
+    def test_proxy_exception_catch_and_stringify(self):
+        """Simulates the real-world pattern: try/except that formats str(e) into a log."""
+        log_output = ""
+        try:
+            raise ProxyException(
+                message="key expired",
+                type="authentication_error",
+                param="api_key",
+                code=401,
+            )
+        except ProxyException as exc:
+            log_output = "Error - {}".format(str(exc))
+
+        assert log_output == "Error - key expired"


### PR DESCRIPTION
## Relevant issues

Fixes #22644

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`ProxyException` in `litellm/proxy/_types.py` never calls `super().__init__(message)` and has no `__str__` method. Since Python's `Exception.__str__()` returns `str(self.args[0])` and `self.args` is an empty tuple, every `str(e)` call returns `""`.

**Before:**
```python
e = ProxyException(message="auth failed", type="bad_request", param="key")
str(e)  # returns ""
logger.error("Error - {}".format(str(e)))  # logs "Error - "
```

**After:**
```python
str(e)  # returns "auth failed"
logger.error("Error - {}".format(str(e)))  # logs "Error - auth failed"
```

### What changed
Two lines added to `ProxyException`:
1. `super().__init__(self.message)` in `__init__` - populates `self.args` so Python's default stringification works
2. `def __str__(self) -> str: return self.message` - explicit string representation

### What did NOT change
- HTTP response format (`to_dict()` is untouched)
- Client-facing error schema
- Any existing exception attributes or methods

### Tests added
- `tests/test_litellm/proxy/test_proxy_exception_str.py` - 8 test cases covering str(), repr(), unicode, empty messages, to_dict() backwards compatibility, exception chaining, and the real-world catch-and-stringify pattern