### PR TITLE
chore: fix pre-existing ruff lint violations blocking CI

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -17,3 +17,6 @@ exclude = ["litellm/types/*", "litellm/__init__.py", "litellm/proxy/example_conf
 "litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py" = ["PLR0915"]
 "litellm/proxy/guardrails/guardrail_hooks/guardrail_benchmarks/test_eval.py" = ["PLR0915"]
 "litellm/responses/streaming_iterator.py" = ["PLR0915"]
+"litellm/fine_tuning/main.py" = ["PLR0915"]
+"litellm/proxy/auth/auth_checks.py" = ["PLR0915"]
+"litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py" = ["PLR0915"]


### PR DESCRIPTION
## Summary

Suppress pre-existing PLR0915 (too-many-statements) ruff lint violations that were blocking CI.

### Changes

- **`ruff.toml`**: Add per-file PLR0915 suppressions for:
  - `litellm/fine_tuning/main.py`
  - `litellm/proxy/auth/auth_checks.py`
  - `litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py`

These functions exceed the default statement limit but are stable, pre-existing code. Suppressing here unblocks CI without refactoring.

> **Note:** The F401 (unused import) fixes mentioned in the original description were merged separately and are not part of this PR.