### PR TITLE
Litellm feat batch expiry setting teams

### DIFF
--- a/litellm/batches/main.py
+++ b/litellm/batches/main.py
@@ -154,7 +154,7 @@ async def acreate_batch(
 
 
 @client
-def create_batch(
+def create_batch(  # noqa: PLR0915
     completion_window: Literal["24h"],
     endpoint: Literal["/v1/chat/completions", "/v1/embeddings", "/v1/completions"],
     input_file_id: str,

--- a/litellm/batches/main.py
+++ b/litellm/batches/main.py
@@ -112,6 +112,7 @@ async def acreate_batch(
     metadata: Optional[Dict[str, str]] = None,
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
+    output_expires_after: Optional[Dict[str, Any]] = None,
     **kwargs,
 ) -> LiteLLMBatch:
     """
@@ -133,6 +134,7 @@ async def acreate_batch(
             metadata,
             extra_headers,
             extra_body,
+            output_expires_after,
             **kwargs,
         )
 
@@ -160,6 +162,7 @@ def create_batch(
     metadata: Optional[Dict[str, str]] = None,
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
+    output_expires_after: Optional[Dict[str, Any]] = None,
     **kwargs,
 ) -> Union[LiteLLMBatch, Coroutine[Any, Any, LiteLLMBatch]]:
     """
@@ -215,6 +218,8 @@ def create_batch(
             extra_headers=extra_headers,
             extra_body=extra_body,
         )
+        if output_expires_after is not None:
+            _create_batch_request["output_expires_after"] = output_expires_after
         if model is not None:
             provider_config = ProviderConfigManager.get_provider_batches_config(
                 model=model,

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1551,6 +1551,8 @@ class NewTeamRequest(TeamBase):
     ] = None  # allow user to set TPM limit for all team members
     team_member_key_duration: Optional[str] = None  # e.g. "1d", "1w", "1m"
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
+    enforced_batch_output_expires_after: Optional[dict] = None
+    enforced_file_expires_after: Optional[dict] = None
 
     model_config = ConfigDict(protected_namespaces=())
 
@@ -1606,6 +1608,8 @@ class UpdateTeamRequest(LiteLLMPydanticObjectBase):
     model_rpm_limit: Optional[Dict[str, int]] = None
     model_tpm_limit: Optional[Dict[str, int]] = None
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
+    enforced_batch_output_expires_after: Optional[dict] = None
+    enforced_file_expires_after: Optional[dict] = None
     router_settings: Optional[dict] = None
     access_group_ids: Optional[List[str]] = None
 
@@ -3783,6 +3787,8 @@ LiteLLM_ManagementEndpoint_MetadataFields = [
     "temp_budget_increase",
     "temp_budget_expiry",
     "allowed_vector_store_indexes",
+    "enforced_batch_output_expires_after",
+    "enforced_file_expires_after",
 ]
 
 LiteLLM_ManagementEndpoint_MetadataFields_Premium = [

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -125,6 +125,13 @@ async def create_batch(  # noqa: PLR0915
             "enforced_batch_output_expires_after"
         )
         if enforced_batch_expiry is not None:
+            if "anchor" not in enforced_batch_expiry or "seconds" not in enforced_batch_expiry:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": "enforced_batch_output_expires_after must contain 'anchor' and 'seconds' keys",
+                    },
+                )
             _create_batch_data["output_expires_after"] = enforced_batch_expiry
 
         input_file_id = _create_batch_data.get("input_file_id", None)

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -118,6 +118,15 @@ async def create_batch(  # noqa: PLR0915
             or "openai"
         )
         _create_batch_data = LiteLLMBatchCreateRequest(**data)
+
+        # Apply team-level batch output expiry enforcement
+        team_metadata = user_api_key_dict.team_metadata or {}
+        enforced_batch_expiry = team_metadata.get(
+            "enforced_batch_output_expires_after"
+        )
+        if enforced_batch_expiry is not None:
+            _create_batch_data["output_expires_after"] = enforced_batch_expiry
+
         input_file_id = _create_batch_data.get("input_file_id", None)
         unified_file_id: Union[str, Literal[False]] = False
         

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -454,8 +454,17 @@ async def create_file(  # noqa: PLR0915
                     model=router_model, llm_router=llm_router
                 )
 
+        # Apply team-level file expiry enforcement
+        team_metadata = user_api_key_dict.team_metadata or {}
+        enforced_file_expiry = team_metadata.get("enforced_file_expires_after")
+        if enforced_file_expiry is not None:
+            expires_after = FileExpiresAfter(
+                anchor=enforced_file_expiry["anchor"],
+                seconds=enforced_file_expiry["seconds"],
+            )
+
         _create_file_request = CreateFileRequest(
-            file=file_data, 
+            file=file_data,
             purpose=cast(CREATE_FILE_REQUESTS_PURPOSE, purpose),
             expires_after=expires_after,
             **data

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -458,10 +458,21 @@ async def create_file(  # noqa: PLR0915
         team_metadata = user_api_key_dict.team_metadata or {}
         enforced_file_expiry = team_metadata.get("enforced_file_expires_after")
         if enforced_file_expiry is not None:
+            if "anchor" not in enforced_file_expiry or "seconds" not in enforced_file_expiry:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": "enforced_file_expires_after must contain 'anchor' and 'seconds' keys",
+                    },
+                )
             expires_after = FileExpiresAfter(
                 anchor=enforced_file_expiry["anchor"],
                 seconds=enforced_file_expiry["seconds"],
             )
+
+        verbose_proxy_logger.info(
+            "create_file expires_after: %s", expires_after
+        )
 
         _create_file_request = CreateFileRequest(
             file=file_data,

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -465,8 +465,15 @@ async def create_file(  # noqa: PLR0915
                         "error": "enforced_file_expires_after must contain 'anchor' and 'seconds' keys",
                     },
                 )
+            if enforced_file_expiry["anchor"] != "created_at":
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": f"enforced_file_expires_after anchor must be 'created_at', got '{enforced_file_expiry['anchor']}'",
+                    },
+                )
             expires_after = FileExpiresAfter(
-                anchor=enforced_file_expiry["anchor"],
+                anchor="created_at",
                 seconds=enforced_file_expiry["seconds"],
             )
 

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -477,7 +477,7 @@ async def create_file(  # noqa: PLR0915
                 seconds=enforced_file_expiry["seconds"],
             )
 
-        verbose_proxy_logger.info(
+        verbose_proxy_logger.debug(
             "create_file expires_after: %s", expires_after
         )
 

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -424,6 +424,7 @@ class CreateBatchRequest(TypedDict, total=False):
     endpoint: Literal["/v1/chat/completions", "/v1/embeddings", "/v1/completions"]
     input_file_id: str
     metadata: Optional[Dict[str, str]]
+    output_expires_after: Optional[FileExpiresAfter]
     extra_headers: Optional[Dict[str, str]]
     extra_body: Optional[Dict[str, str]]
     timeout: Optional[float]

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -1168,3 +1168,138 @@ def test_create_file_with_deep_nested_litellm_metadata(
     assert captured_litellm_metadata["config"]["database"]["port"] == "5432"
     assert "cache" in captured_litellm_metadata["config"]
     assert captured_litellm_metadata["config"]["cache"]["enabled"] == "true"
+
+
+# ---------------------------------------------------------------------------
+# Team-level enforced_file_expires_after tests
+# ---------------------------------------------------------------------------
+
+
+def _make_capturing_managed_files():
+    """Create a DummyManagedFiles that captures the expires_after from the request."""
+    from litellm.llms.base_llm.files.transformation import BaseFileEndpoints
+
+    captured = {}
+
+    class CapturingManagedFiles(BaseFileEndpoints):
+        async def acreate_file(
+            self,
+            llm_router,
+            create_file_request,
+            target_model_names_list,
+            litellm_parent_otel_span,
+            user_api_key_dict,
+        ):
+            if isinstance(create_file_request, dict):
+                captured["expires_after"] = create_file_request.get("expires_after")
+            else:
+                captured["expires_after"] = getattr(
+                    create_file_request, "expires_after", None
+                )
+            return OpenAIFileObject(
+                id="file-abc123",
+                object="file",
+                bytes=100,
+                created_at=1234567890,
+                filename="mydata.jsonl",
+                purpose="batch",
+                status="uploaded",
+            )
+
+        async def afile_retrieve(self, file_id, litellm_parent_otel_span, llm_router):
+            raise NotImplementedError
+
+        async def afile_list(self, purpose, litellm_parent_otel_span):
+            raise NotImplementedError
+
+        async def afile_delete(
+            self, file_id, litellm_parent_otel_span, llm_router, **data
+        ):
+            raise NotImplementedError
+
+        async def afile_content(
+            self, file_id, litellm_parent_otel_span, llm_router, **data
+        ):
+            raise NotImplementedError
+
+    return CapturingManagedFiles(), captured
+
+
+def _post_file_with_team_metadata(
+    monkeypatch,
+    llm_router: Router,
+    team_metadata: dict,
+    form_data: dict,
+):
+    """POST /v1/files with given team_metadata, return captured expires_after."""
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    proxy_logging_obj = ProxyLogging(
+        user_api_key_cache=DualCache(default_in_memory_ttl=1)
+    )
+    dummy, captured = _make_capturing_managed_files()
+    proxy_logging_obj.proxy_hook_mapping["managed_files"] = dummy
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", llm_router)
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.proxy_logging_obj", proxy_logging_obj
+    )
+
+    user_key = UserAPIKeyAuth(api_key="test-key", team_metadata=team_metadata)
+    app.dependency_overrides[user_api_key_auth] = lambda: user_key
+
+    test_file = ("mydata.jsonl", b'{"prompt": "Hello"}', "application/json")
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": test_file},
+            data=form_data,
+            headers={"Authorization": "Bearer test-key"},
+        )
+        assert response.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+    return captured["expires_after"]
+
+
+def test_file_team_override_overrides_caller(
+    mocker: MockerFixture, monkeypatch, llm_router: Router
+):
+    """Team enforced_file_expires_after wins over caller-provided value."""
+    expires_after = _post_file_with_team_metadata(
+        monkeypatch,
+        llm_router,
+        team_metadata={
+            "enforced_file_expires_after": {
+                "anchor": "created_at",
+                "seconds": 3600,
+            }
+        },
+        form_data={
+            "purpose": "batch",
+            "target_model_names": "gpt-3.5-turbo",
+            "expires_after[anchor]": "created_at",
+            "expires_after[seconds]": "86400",
+        },
+    )
+    assert expires_after["anchor"] == "created_at"
+    assert expires_after["seconds"] == 3600
+
+
+def test_file_no_team_setting_preserves_caller(
+    mocker: MockerFixture, monkeypatch, llm_router: Router
+):
+    """No team setting = caller-provided expires_after passes through."""
+    expires_after = _post_file_with_team_metadata(
+        monkeypatch,
+        llm_router,
+        team_metadata={},
+        form_data={
+            "purpose": "batch",
+            "target_model_names": "gpt-3.5-turbo",
+            "expires_after[anchor]": "created_at",
+            "expires_after[seconds]": "86400",
+        },
+    )
+    assert expires_after["anchor"] == "created_at"
+    assert expires_after["seconds"] == 86400

--- a/tests/test_litellm/proxy/test_batch_expiry.py
+++ b/tests/test_litellm/proxy/test_batch_expiry.py
@@ -1,0 +1,74 @@
+"""
+Tests for batch output_expires_after passthrough and team-level expiry enforcement.
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+import litellm
+from litellm.types.llms.openai import CreateBatchRequest
+
+
+class TestCreateBatchOutputExpiresAfterPassthrough:
+    """Verify output_expires_after flows through create_batch to the provider."""
+
+    def test_output_expires_after_included_in_request(self):
+        """When output_expires_after is provided, it reaches the openai batches instance."""
+        captured = {}
+
+        original_create = None
+
+        def capturing_create(**kwargs):
+            captured.update(kwargs)
+            mock_response = MagicMock()
+            mock_response.id = "batch_123"
+            return mock_response
+
+        with patch(
+            "litellm.batches.main.openai_batches_instance"
+        ) as mock_instance:
+            mock_instance.create_batch.side_effect = capturing_create
+            litellm.create_batch(
+                completion_window="24h",
+                endpoint="/v1/chat/completions",
+                input_file_id="file-abc123",
+                output_expires_after={"anchor": "created_at", "seconds": 86400},
+                custom_llm_provider="openai",
+            )
+
+        create_batch_data = captured["create_batch_data"]
+        assert create_batch_data["output_expires_after"] == {
+            "anchor": "created_at",
+            "seconds": 86400,
+        }
+
+    def test_output_expires_after_absent_when_not_provided(self):
+        """Backward compat: output_expires_after not in request when omitted."""
+        captured = {}
+
+        def capturing_create(**kwargs):
+            captured.update(kwargs)
+            mock_response = MagicMock()
+            mock_response.id = "batch_123"
+            return mock_response
+
+        with patch(
+            "litellm.batches.main.openai_batches_instance"
+        ) as mock_instance:
+            mock_instance.create_batch.side_effect = capturing_create
+            litellm.create_batch(
+                completion_window="24h",
+                endpoint="/v1/chat/completions",
+                input_file_id="file-abc123",
+                custom_llm_provider="openai",
+            )
+
+        create_batch_data = captured["create_batch_data"]
+        assert "output_expires_after" not in create_batch_data

--- a/tests/test_litellm/proxy/test_batch_expiry.py
+++ b/tests/test_litellm/proxy/test_batch_expiry.py
@@ -4,7 +4,7 @@ Tests for batch output_expires_after passthrough and team-level expiry enforceme
 
 import os
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -13,62 +13,150 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 import litellm
-from litellm.types.llms.openai import CreateBatchRequest
+from litellm.caching.caching import DualCache
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.proxy_server import app
+from litellm.proxy.utils import ProxyLogging
+from litellm.router import Router
+from litellm.types.utils import LiteLLMBatch
+
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+TEAM_EXPIRY = {"anchor": "created_at", "seconds": 3600}
+CALLER_EXPIRY = {"anchor": "created_at", "seconds": 86400}
 
 
-class TestCreateBatchOutputExpiresAfterPassthrough:
-    """Verify output_expires_after flows through create_batch to the provider."""
+@pytest.fixture
+def llm_router() -> Router:
+    return Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {
+                    "model": "openai/gpt-3.5-turbo",
+                    "api_key": "test-key",
+                },
+                "model_info": {"id": "gpt-3.5-turbo-id"},
+            },
+        ]
+    )
 
-    def test_output_expires_after_included_in_request(self):
-        """When output_expires_after is provided, it reaches the openai batches instance."""
-        captured = {}
 
-        original_create = None
+def _setup_proxy(monkeypatch, llm_router: Router):
+    proxy_logging_obj = ProxyLogging(
+        user_api_key_cache=DualCache(default_in_memory_ttl=1)
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", llm_router)
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.proxy_logging_obj", proxy_logging_obj
+    )
 
-        def capturing_create(**kwargs):
-            captured.update(kwargs)
-            mock_response = MagicMock()
-            mock_response.id = "batch_123"
-            return mock_response
 
-        with patch(
-            "litellm.batches.main.openai_batches_instance"
-        ) as mock_instance:
-            mock_instance.create_batch.side_effect = capturing_create
-            litellm.create_batch(
-                completion_window="24h",
-                endpoint="/v1/chat/completions",
-                input_file_id="file-abc123",
-                output_expires_after={"anchor": "created_at", "seconds": 86400},
-                custom_llm_provider="openai",
+def _make_batch_response() -> LiteLLMBatch:
+    return LiteLLMBatch(
+        id="batch_abc123",
+        completion_window="24h",
+        created_at=1234567890,
+        endpoint="/v1/chat/completions",
+        input_file_id="file-abc123",
+        object="batch",
+        status="validating",
+    )
+
+
+def test_output_expires_after_passthrough():
+    """output_expires_after flows through create_batch to the provider."""
+    captured = {}
+
+    def capturing_create(**kwargs):
+        captured.update(kwargs)
+        mock_response = MagicMock()
+        mock_response.id = "batch_123"
+        return mock_response
+
+    with patch("litellm.batches.main.openai_batches_instance") as mock_instance:
+        mock_instance.create_batch.side_effect = capturing_create
+        litellm.create_batch(
+            completion_window="24h",
+            endpoint="/v1/chat/completions",
+            input_file_id="file-abc123",
+            output_expires_after=CALLER_EXPIRY,
+            custom_llm_provider="openai",
+        )
+
+    assert captured["create_batch_data"]["output_expires_after"] == CALLER_EXPIRY
+
+
+class TestBatchEndpointTeamOverride:
+    """Verify team-level enforced_batch_output_expires_after in the proxy endpoint."""
+
+    def _post_batch(
+        self,
+        monkeypatch,
+        llm_router: Router,
+        team_metadata: dict,
+        request_body: dict,
+    ) -> dict:
+        """POST /v1/batches with given team_metadata and body, return captured kwargs."""
+        _setup_proxy(monkeypatch, llm_router)
+
+        user_key = UserAPIKeyAuth(
+            api_key="test-key",
+            team_metadata=team_metadata,
+        )
+        app.dependency_overrides[user_api_key_auth] = lambda: user_key
+
+        captured_kwargs = {}
+
+        async def mock_acreate_batch(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _make_batch_response()
+
+        monkeypatch.setattr(litellm, "acreate_batch", mock_acreate_batch)
+
+        try:
+            response = client.post(
+                "/v1/batches",
+                json=request_body,
+                headers={"Authorization": "Bearer test-key"},
             )
+            assert response.status_code == 200
+        finally:
+            app.dependency_overrides.clear()
 
-        create_batch_data = captured["create_batch_data"]
-        assert create_batch_data["output_expires_after"] == {
-            "anchor": "created_at",
-            "seconds": 86400,
-        }
+        return captured_kwargs
 
-    def test_output_expires_after_absent_when_not_provided(self):
-        """Backward compat: output_expires_after not in request when omitted."""
-        captured = {}
+    def test_team_override_overrides_caller(self, monkeypatch, llm_router):
+        """Team enforcement wins over caller-provided value."""
+        kwargs = self._post_batch(
+            monkeypatch,
+            llm_router,
+            team_metadata={
+                "enforced_batch_output_expires_after": TEAM_EXPIRY,
+            },
+            request_body={
+                "input_file_id": "file-abc123",
+                "endpoint": "/v1/chat/completions",
+                "completion_window": "24h",
+                "output_expires_after": CALLER_EXPIRY,
+            },
+        )
+        assert kwargs["output_expires_after"] == TEAM_EXPIRY
 
-        def capturing_create(**kwargs):
-            captured.update(kwargs)
-            mock_response = MagicMock()
-            mock_response.id = "batch_123"
-            return mock_response
-
-        with patch(
-            "litellm.batches.main.openai_batches_instance"
-        ) as mock_instance:
-            mock_instance.create_batch.side_effect = capturing_create
-            litellm.create_batch(
-                completion_window="24h",
-                endpoint="/v1/chat/completions",
-                input_file_id="file-abc123",
-                custom_llm_provider="openai",
-            )
-
-        create_batch_data = captured["create_batch_data"]
-        assert "output_expires_after" not in create_batch_data
+    def test_no_team_setting_preserves_caller(self, monkeypatch, llm_router):
+        """No team setting = caller value passes through."""
+        kwargs = self._post_batch(
+            monkeypatch,
+            llm_router,
+            team_metadata={},
+            request_body={
+                "input_file_id": "file-abc123",
+                "endpoint": "/v1/chat/completions",
+                "completion_window": "24h",
+                "output_expires_after": CALLER_EXPIRY,
+            },
+        )
+        assert kwargs["output_expires_after"] == CALLER_EXPIRY


### PR DESCRIPTION
## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes

The `output_expires_after` param for the batches api was getting silently dropped by callers and wasn't officially supported by LiteLLM (outdated). 

Updated to make it so that it's officially supported and then also if any new parameters get added they don't get silently dropped and can be plugged in without having to update LiteLLM's support for it. 

Also added a feature for the files api and the batches api to be able to enforce `output_expires_after` for the batches api, and `expires_after` for the files api on a team level. 
- team-level`enforced_batch_output_expires_after` setting that overrides caller's `output_expires_after` on batch creation
- team-level `enforced_file_expires_after` setting that overrides caller's `expires_after` on file upload

<img width="757" height="363" alt="Screenshot 2026-03-03 at 1 30 44 PM" src="https://github.com/user-attachments/assets/7c6ab3a3-7798-4416-8e49-56590391b6f3" />

<img width="731" height="166" alt="Screenshot 2026-03-03 at 1 31 07 PM" src="https://github.com/user-attachments/assets/6f07de14-f139-4d88-9a0d-818c88a570aa" />

<img width="753" height="141" alt="Screenshot 2026-03-03 at 1 31 22 PM" src="https://github.com/user-attachments/assets/65c97bd7-3e71-4507-a406-2a36660a4d91" />
