### PR TITLE
feat(proxy): add key_alias, key_hash, requested_model DD APM span tags

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9779,6 +9779,122 @@
             }
         ]
     },
+    "dashscope/qwen3-max-2026-01-23": {
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 258048,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.4e-06,
+                "output_cost_per_token": 1.2e-05,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    252000.0
+                ]
+            }
+        ]
+    },
+    "dashscope/qwen3-next-80b-a3b-instruct": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/qwen3-next-80b-a3b-thinking": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/qwen3-vl-235b-a22b-instruct": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.6e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "dashscope/qwen3-vl-235b-a22b-thinking": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "dashscope/qwen3-vl-32b-instruct": {
+        "input_cost_per_token": 1.6e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 6.4e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "dashscope/qwen3-vl-32b-thinking": {
+        "input_cost_per_token": 1.6e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 2.87e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "dashscope/qwen3-vl-plus": {
         "litellm_provider": "dashscope",
         "max_input_tokens": 260096,
@@ -25806,6 +25922,30 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 159
     },
+    "openrouter/anthropic/claude-sonnet-4.6": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "input_cost_per_token": 3e-06,
+        "input_cost_per_token_above_200k_tokens": 6e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        "source": "https://openrouter.ai/anthropic/claude-sonnet-4.6",
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159
+    },
     "openrouter/anthropic/claude-opus-4.5": {
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
@@ -26155,6 +26295,39 @@
         "supports_vision": true,
         "supports_web_search": true,
         "tpm": 800000
+    },
+    "openrouter/google/gemini-3.1-pro-preview": {
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "cache_creation_input_token_cost_above_200k_tokens": 2.5e-07,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_200k_tokens": 4e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_above_200k_tokens": 1.8e-05,
+        "source": "https://openrouter.ai/google/gemini-3.1-pro-preview",
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "openrouter/gryphe/mythomax-l2-13b": {
         "input_cost_per_token": 1.875e-06,
@@ -26533,6 +26706,29 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/openai/gpt-5.1-codex-max": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "source": "https://openrouter.ai/openai/gpt-5.1-codex-max",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "openrouter/openai/gpt-5.2": {
         "input_cost_per_image": 0,
         "cache_read_input_token_cost": 1.75e-07,
@@ -26687,6 +26883,19 @@
         "supports_tool_choice": true,
         "supports_function_calling": true
     },
+    "openrouter/qwen/qwen3-coder-plus": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 5e-06,
+        "source": "https://openrouter.ai/qwen/qwen3-coder-plus",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "openrouter/qwen/qwen3-235b-a22b-2507": {
         "input_cost_per_token": 7.1e-08,
         "litellm_provider": "openrouter",
@@ -26821,6 +27030,19 @@
         "supports_reasoning": true,
         "supports_vision": true,
         "supports_prompt_caching": false
+    },
+    "openrouter/z-ai/glm-5": {
+        "input_cost_per_token": 8e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.56e-06,
+        "source": "https://openrouter.ai/z-ai/glm-5",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
     },
     "openrouter/minimax/minimax-m2.1": {
         "input_cost_per_token": 2.7e-07,
@@ -34314,6 +34536,36 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "zai/glm-5": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 3.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-5-code": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 1.2e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.7": {
         "cache_creation_input_token_cost": 0,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -29,7 +29,7 @@ from litellm.constants import (
     MAX_PAYLOAD_SIZE_FOR_DEBUG_LOG,
     STREAM_SSE_DATA_PREFIX,
 )
-from litellm.litellm_core_utils.dd_tracing import set_active_span_tag, tracer
+from litellm.litellm_core_utils.dd_tracing import tracer
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.llm_response_utils.get_headers import (
     get_response_headers,
@@ -41,6 +41,7 @@ from litellm.proxy.common_utils.callback_utils import (
     get_logging_caching_headers,
     get_remaining_tokens_and_requests_from_request_data,
 )
+from litellm.proxy.dd_span_tagger import DDSpanTagger
 from litellm.proxy.route_llm_request import route_request
 from litellm.proxy.utils import ProxyLogging
 from litellm.router import Router
@@ -243,61 +244,6 @@ async def create_response(
         headers=headers,
         status_code=final_status_code,
     )
-
-
-class DDSpanTagger:
-    """Best-effort helpers for tagging the active Datadog APM span with LiteLLM request metadata."""
-
-    @staticmethod
-    def tag_call_id(litellm_call_id: Optional[str]) -> None:
-        """
-        Attach LiteLLM call id to the active Datadog APM span.
-
-        This enables searching APM traces by LiteLLM call id returned in
-        `x-litellm-call-id`.
-        """
-        if not litellm_call_id:
-            return
-        try:
-            set_active_span_tag("litellm.call_id", str(litellm_call_id))
-        except Exception:
-            verbose_proxy_logger.debug(
-                "Failed to tag active ddtrace span with litellm.call_id",
-                exc_info=True,
-            )
-
-    @staticmethod
-    def tag_request(
-        user_api_key_dict: UserAPIKeyAuth,
-        requested_model: Optional[str],
-    ) -> None:
-        """
-        Attach key and model tags to the active Datadog APM span.
-
-        Tags set (all best-effort, skipped when value is absent):
-        - ``litellm.key_alias``      — human-readable alias for the API key
-        - ``litellm.key_hash``       — hashed API key (safe to log; never the raw secret)
-        - ``litellm.requested_model``— model name as sent by the client
-
-        Use cases:
-        - Trace all requests from a specific user/key: filter by ``litellm.key_alias`` or
-          ``litellm.key_hash``.
-        - Trace all requests for a specific model: filter by ``litellm.requested_model``.
-
-        Note: key_alias / key_hash are not available for unauthenticated (e.g. 401) requests.
-        """
-        try:
-            if user_api_key_dict.key_alias:
-                set_active_span_tag("litellm.key_alias", str(user_api_key_dict.key_alias))
-            if user_api_key_dict.token:
-                set_active_span_tag("litellm.key_hash", str(user_api_key_dict.token))
-            if requested_model:
-                set_active_span_tag("litellm.requested_model", str(requested_model))
-        except Exception:
-            verbose_proxy_logger.debug(
-                "Failed to tag active ddtrace span with key/model tags",
-                exc_info=True,
-            )
 
 
 def _override_openai_response_model(

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -265,6 +265,39 @@ def _add_dd_apm_tags_for_litellm_call_id(litellm_call_id: Optional[str]) -> None
         )
 
 
+def _add_dd_apm_tags_for_request(
+    user_api_key_dict: UserAPIKeyAuth,
+    requested_model: Optional[str],
+) -> None:
+    """
+    Attach key and model tags to the active Datadog APM span.
+
+    Tags set (all best-effort, skipped when value is absent):
+    - ``litellm.key_alias``      — human-readable alias for the API key
+    - ``litellm.key_hash``       — hashed API key (safe to log; never the raw secret)
+    - ``litellm.requested_model``— model name as sent by the client
+
+    Use cases:
+    - Trace all requests from a specific user/key: filter by ``litellm.key_alias`` or
+      ``litellm.key_hash``.
+    - Trace all requests for a specific model: filter by ``litellm.requested_model``.
+
+    Note: key_alias / key_hash are not available for unauthenticated (e.g. 401) requests.
+    """
+    try:
+        if user_api_key_dict.key_alias:
+            set_active_span_tag("litellm.key_alias", str(user_api_key_dict.key_alias))
+        if user_api_key_dict.token:
+            set_active_span_tag("litellm.key_hash", str(user_api_key_dict.token))
+        if requested_model:
+            set_active_span_tag("litellm.requested_model", str(requested_model))
+    except Exception:
+        verbose_proxy_logger.debug(
+            "Failed to tag active ddtrace span with key/model tags",
+            exc_info=True,
+        )
+
+
 def _override_openai_response_model(
     *,
     response_obj: Any,
@@ -663,6 +696,10 @@ class ProxyBaseLLMRequestProcessing:
             "x-litellm-call-id", str(uuid.uuid4())
         )
         _add_dd_apm_tags_for_litellm_call_id(self.data.get("litellm_call_id"))
+        _add_dd_apm_tags_for_request(
+            user_api_key_dict=user_api_key_dict,
+            requested_model=self.data.get("model"),
+        )
 
         ### AUTO STREAM USAGE TRACKING ###
         # If always_include_stream_usage is enabled and this is a streaming request

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -245,57 +245,59 @@ async def create_response(
     )
 
 
-def _add_dd_apm_tags_for_litellm_call_id(litellm_call_id: Optional[str]) -> None:
-    """
-    Attach LiteLLM call id to the active Datadog APM span.
+class DDSpanTagger:
+    """Best-effort helpers for tagging the active Datadog APM span with LiteLLM request metadata."""
 
-    This enables searching APM traces by LiteLLM call id returned in
-    `x-litellm-call-id`.
-    """
-    if not litellm_call_id:
-        return
+    @staticmethod
+    def tag_call_id(litellm_call_id: Optional[str]) -> None:
+        """
+        Attach LiteLLM call id to the active Datadog APM span.
 
-    try:
-        set_active_span_tag("litellm.call_id", str(litellm_call_id))
-    except Exception:
-        # Tagging is best-effort and should never impact request processing.
-        verbose_proxy_logger.debug(
-            "Failed to tag active ddtrace span with litellm.call_id",
-            exc_info=True,
-        )
+        This enables searching APM traces by LiteLLM call id returned in
+        `x-litellm-call-id`.
+        """
+        if not litellm_call_id:
+            return
+        try:
+            set_active_span_tag("litellm.call_id", str(litellm_call_id))
+        except Exception:
+            verbose_proxy_logger.debug(
+                "Failed to tag active ddtrace span with litellm.call_id",
+                exc_info=True,
+            )
 
+    @staticmethod
+    def tag_request(
+        user_api_key_dict: UserAPIKeyAuth,
+        requested_model: Optional[str],
+    ) -> None:
+        """
+        Attach key and model tags to the active Datadog APM span.
 
-def _add_dd_apm_tags_for_request(
-    user_api_key_dict: UserAPIKeyAuth,
-    requested_model: Optional[str],
-) -> None:
-    """
-    Attach key and model tags to the active Datadog APM span.
+        Tags set (all best-effort, skipped when value is absent):
+        - ``litellm.key_alias``      — human-readable alias for the API key
+        - ``litellm.key_hash``       — hashed API key (safe to log; never the raw secret)
+        - ``litellm.requested_model``— model name as sent by the client
 
-    Tags set (all best-effort, skipped when value is absent):
-    - ``litellm.key_alias``      — human-readable alias for the API key
-    - ``litellm.key_hash``       — hashed API key (safe to log; never the raw secret)
-    - ``litellm.requested_model``— model name as sent by the client
+        Use cases:
+        - Trace all requests from a specific user/key: filter by ``litellm.key_alias`` or
+          ``litellm.key_hash``.
+        - Trace all requests for a specific model: filter by ``litellm.requested_model``.
 
-    Use cases:
-    - Trace all requests from a specific user/key: filter by ``litellm.key_alias`` or
-      ``litellm.key_hash``.
-    - Trace all requests for a specific model: filter by ``litellm.requested_model``.
-
-    Note: key_alias / key_hash are not available for unauthenticated (e.g. 401) requests.
-    """
-    try:
-        if user_api_key_dict.key_alias:
-            set_active_span_tag("litellm.key_alias", str(user_api_key_dict.key_alias))
-        if user_api_key_dict.token:
-            set_active_span_tag("litellm.key_hash", str(user_api_key_dict.token))
-        if requested_model:
-            set_active_span_tag("litellm.requested_model", str(requested_model))
-    except Exception:
-        verbose_proxy_logger.debug(
-            "Failed to tag active ddtrace span with key/model tags",
-            exc_info=True,
-        )
+        Note: key_alias / key_hash are not available for unauthenticated (e.g. 401) requests.
+        """
+        try:
+            if user_api_key_dict.key_alias:
+                set_active_span_tag("litellm.key_alias", str(user_api_key_dict.key_alias))
+            if user_api_key_dict.token:
+                set_active_span_tag("litellm.key_hash", str(user_api_key_dict.token))
+            if requested_model:
+                set_active_span_tag("litellm.requested_model", str(requested_model))
+        except Exception:
+            verbose_proxy_logger.debug(
+                "Failed to tag active ddtrace span with key/model tags",
+                exc_info=True,
+            )
 
 
 def _override_openai_response_model(
@@ -695,8 +697,8 @@ class ProxyBaseLLMRequestProcessing:
         self.data["litellm_call_id"] = request.headers.get(
             "x-litellm-call-id", str(uuid.uuid4())
         )
-        _add_dd_apm_tags_for_litellm_call_id(self.data.get("litellm_call_id"))
-        _add_dd_apm_tags_for_request(
+        DDSpanTagger.tag_call_id(self.data.get("litellm_call_id"))
+        DDSpanTagger.tag_request(
             user_api_key_dict=user_api_key_dict,
             requested_model=self.data.get("model"),
         )

--- a/litellm/proxy/dd_span_tagger.py
+++ b/litellm/proxy/dd_span_tagger.py
@@ -1,0 +1,60 @@
+from typing import Optional
+
+from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.dd_tracing import set_active_span_tag
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+class DDSpanTagger:
+    """Best-effort helpers for tagging the active Datadog APM span with LiteLLM request metadata."""
+
+    @staticmethod
+    def tag_call_id(litellm_call_id: Optional[str]) -> None:
+        """
+        Attach LiteLLM call id to the active Datadog APM span.
+
+        This enables searching APM traces by LiteLLM call id returned in
+        `x-litellm-call-id`.
+        """
+        if not litellm_call_id:
+            return
+        try:
+            set_active_span_tag("litellm.call_id", str(litellm_call_id))
+        except Exception:
+            verbose_proxy_logger.debug(
+                "Failed to tag active ddtrace span with litellm.call_id",
+                exc_info=True,
+            )
+
+    @staticmethod
+    def tag_request(
+        user_api_key_dict: UserAPIKeyAuth,
+        requested_model: Optional[str],
+    ) -> None:
+        """
+        Attach key and model tags to the active Datadog APM span.
+
+        Tags set (all best-effort, skipped when value is absent):
+        - ``litellm.key_alias``      — human-readable alias for the API key
+        - ``litellm.key_hash``       — hashed API key (safe to log; never the raw secret)
+        - ``litellm.requested_model``— model name as sent by the client
+
+        Use cases:
+        - Trace all requests from a specific user/key: filter by ``litellm.key_alias`` or
+          ``litellm.key_hash``.
+        - Trace all requests for a specific model: filter by ``litellm.requested_model``.
+
+        Note: key_alias / key_hash are not available for unauthenticated (e.g. 401) requests.
+        """
+        try:
+            if user_api_key_dict.key_alias:
+                set_active_span_tag("litellm.key_alias", str(user_api_key_dict.key_alias))
+            if user_api_key_dict.token:
+                set_active_span_tag("litellm.key_hash", str(user_api_key_dict.token))
+            if requested_model:
+                set_active_span_tag("litellm.requested_model", str(requested_model))
+        except Exception:
+            verbose_proxy_logger.debug(
+                "Failed to tag active ddtrace span with key/model tags",
+                exc_info=True,
+            )

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -11,10 +11,9 @@ import litellm
 from litellm._uuid import uuid
 from litellm.integrations.opentelemetry import UserAPIKeyAuth
 from litellm.proxy.common_request_processing import (
+    DDSpanTagger,
     ProxyBaseLLMRequestProcessing,
     ProxyConfig,
-    _add_dd_apm_tags_for_litellm_call_id,
-    _add_dd_apm_tags_for_request,
     _extract_error_from_sse_chunk,
     _get_cost_breakdown_from_logging_obj,
     _override_openai_response_model,
@@ -89,7 +88,7 @@ class TestProxyBaseLLMRequestProcessing:
             mock_set_active_span_tag,
         )
 
-        _add_dd_apm_tags_for_litellm_call_id("test-call-id")
+        DDSpanTagger.tag_call_id("test-call-id")
 
         mock_set_active_span_tag.assert_called_once_with(
             "litellm.call_id", "test-call-id"
@@ -1567,8 +1566,8 @@ class TestStreamingOverheadHeader:
         assert custom_headers["x-litellm-overhead-duration-ms"] == "55.3"
 
 
-class TestAddDdApmTagsForRequest:
-    """Tests for _add_dd_apm_tags_for_request - key/model DD span tagging."""
+class TestDDSpanTaggerTagRequest:
+    """Tests for DDSpanTagger.tag_request - key/model DD span tagging."""
 
     def _make_user_api_key_dict(self, key_alias=None, token=None):
         from litellm.proxy._types import UserAPIKeyAuth
@@ -1585,7 +1584,7 @@ class TestAddDdApmTagsForRequest:
         with patch(
             "litellm.proxy.common_request_processing.set_active_span_tag"
         ) as mock_set_tag:
-            _add_dd_apm_tags_for_request(
+            DDSpanTagger.tag_request(
                 user_api_key_dict=user_key,
                 requested_model="gpt-4o",
             )
@@ -1601,7 +1600,7 @@ class TestAddDdApmTagsForRequest:
         with patch(
             "litellm.proxy.common_request_processing.set_active_span_tag"
         ) as mock_set_tag:
-            _add_dd_apm_tags_for_request(
+            DDSpanTagger.tag_request(
                 user_api_key_dict=user_key,
                 requested_model=None,
             )
@@ -1615,7 +1614,7 @@ class TestAddDdApmTagsForRequest:
         with patch(
             "litellm.proxy.common_request_processing.set_active_span_tag"
         ) as mock_set_tag:
-            _add_dd_apm_tags_for_request(
+            DDSpanTagger.tag_request(
                 user_api_key_dict=user_key,
                 requested_model="claude-3-5-sonnet",
             )

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1,7 +1,7 @@
 import copy
 import datetime
 from typing import AsyncGenerator
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import Request, status
@@ -14,6 +14,7 @@ from litellm.proxy.common_request_processing import (
     ProxyBaseLLMRequestProcessing,
     ProxyConfig,
     _add_dd_apm_tags_for_litellm_call_id,
+    _add_dd_apm_tags_for_request,
     _extract_error_from_sse_chunk,
     _get_cost_breakdown_from_logging_obj,
     _override_openai_response_model,
@@ -1564,3 +1565,59 @@ class TestStreamingOverheadHeader:
             "It was missing — this is the streaming overhead header regression."
         )
         assert custom_headers["x-litellm-overhead-duration-ms"] == "55.3"
+
+
+class TestAddDdApmTagsForRequest:
+    """Tests for _add_dd_apm_tags_for_request - key/model DD span tagging."""
+
+    def _make_user_api_key_dict(self, key_alias=None, token=None):
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        d = UserAPIKeyAuth()
+        d.key_alias = key_alias
+        d.token = token
+        return d
+
+    def test_tags_key_alias_and_model(self):
+        """key_alias and requested_model are set on the span when present."""
+        user_key = self._make_user_api_key_dict(key_alias="my-prod-key", token="hashed123")
+
+        with patch(
+            "litellm.proxy.common_request_processing.set_active_span_tag"
+        ) as mock_set_tag:
+            _add_dd_apm_tags_for_request(
+                user_api_key_dict=user_key,
+                requested_model="gpt-4o",
+            )
+
+        mock_set_tag.assert_any_call("litellm.key_alias", "my-prod-key")
+        mock_set_tag.assert_any_call("litellm.key_hash", "hashed123")
+        mock_set_tag.assert_any_call("litellm.requested_model", "gpt-4o")
+
+    def test_no_tags_when_key_absent(self):
+        """No key tags are set when key_alias and token are None (e.g. 401 path)."""
+        user_key = self._make_user_api_key_dict(key_alias=None, token=None)
+
+        with patch(
+            "litellm.proxy.common_request_processing.set_active_span_tag"
+        ) as mock_set_tag:
+            _add_dd_apm_tags_for_request(
+                user_api_key_dict=user_key,
+                requested_model=None,
+            )
+
+        mock_set_tag.assert_not_called()
+
+    def test_only_model_tagged_when_no_key_info(self):
+        """requested_model is tagged even when there's no key info."""
+        user_key = self._make_user_api_key_dict(key_alias=None, token=None)
+
+        with patch(
+            "litellm.proxy.common_request_processing.set_active_span_tag"
+        ) as mock_set_tag:
+            _add_dd_apm_tags_for_request(
+                user_api_key_dict=user_key,
+                requested_model="claude-3-5-sonnet",
+            )
+
+        mock_set_tag.assert_called_once_with("litellm.requested_model", "claude-3-5-sonnet")

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -11,7 +11,6 @@ import litellm
 from litellm._uuid import uuid
 from litellm.integrations.opentelemetry import UserAPIKeyAuth
 from litellm.proxy.common_request_processing import (
-    DDSpanTagger,
     ProxyBaseLLMRequestProcessing,
     ProxyConfig,
     _extract_error_from_sse_chunk,
@@ -20,6 +19,7 @@ from litellm.proxy.common_request_processing import (
     _parse_event_data_for_error,
     create_response,
 )
+from litellm.proxy.dd_span_tagger import DDSpanTagger
 from litellm.proxy.utils import ProxyLogging
 
 
@@ -82,8 +82,10 @@ class TestProxyBaseLLMRequestProcessing:
 
     def test_add_dd_apm_tags_for_litellm_call_id_uses_dd_tracing_helper(self, monkeypatch):
         mock_set_active_span_tag = MagicMock(return_value=True)
+        import litellm.proxy.dd_span_tagger
+
         monkeypatch.setattr(
-            litellm.proxy.common_request_processing,
+            litellm.proxy.dd_span_tagger,
             "set_active_span_tag",
             mock_set_active_span_tag,
         )
@@ -1582,7 +1584,7 @@ class TestDDSpanTaggerTagRequest:
         user_key = self._make_user_api_key_dict(key_alias="my-prod-key", token="hashed123")
 
         with patch(
-            "litellm.proxy.common_request_processing.set_active_span_tag"
+            "litellm.proxy.dd_span_tagger.set_active_span_tag"
         ) as mock_set_tag:
             DDSpanTagger.tag_request(
                 user_api_key_dict=user_key,
@@ -1598,7 +1600,7 @@ class TestDDSpanTaggerTagRequest:
         user_key = self._make_user_api_key_dict(key_alias=None, token=None)
 
         with patch(
-            "litellm.proxy.common_request_processing.set_active_span_tag"
+            "litellm.proxy.dd_span_tagger.set_active_span_tag"
         ) as mock_set_tag:
             DDSpanTagger.tag_request(
                 user_api_key_dict=user_key,
@@ -1612,7 +1614,7 @@ class TestDDSpanTaggerTagRequest:
         user_key = self._make_user_api_key_dict(key_alias=None, token=None)
 
         with patch(
-            "litellm.proxy.common_request_processing.set_active_span_tag"
+            "litellm.proxy.dd_span_tagger.set_active_span_tag"
         ) as mock_set_tag:
             DDSpanTagger.tag_request(
                 user_api_key_dict=user_key,


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

Adds `_add_dd_apm_tags_for_request` to `common_request_processing.py`, called on every authenticated request alongside the existing `call_id` tag.

Three new tags on each DD APM span:
- `litellm.key_alias` — human-readable API key alias (e.g. `"prod-app"`)
- `litellm.key_hash` — hashed API key (already hashed before storage, safe to log)
- `litellm.requested_model` — model as sent by the client

Useful for:
- tracing all calls from a specific user/key by filtering on `litellm.key_alias` or `litellm.key_hash`
- tracing all calls to a specific model by filtering on `litellm.requested_model`

Key info is skipped when not available (e.g. 401 unauthenticated requests). All tagging is best-effort and never affects request processing.