### PR TITLE
[Fix] Key Expiry Default Duration

### DIFF
--- a/enterprise/litellm_enterprise/proxy/management_endpoints/key_management_endpoints.py
+++ b/enterprise/litellm_enterprise/proxy/management_endpoints/key_management_endpoints.py
@@ -17,7 +17,12 @@ def add_team_member_key_duration(
         team_table.metadata is not None
         and team_table.metadata.get("team_member_key_duration") is not None
     ):
-        data.duration = team_table.metadata["team_member_key_duration"]
+        team_max = team_table.metadata["team_member_key_duration"]
+        # Act as a ceiling: only apply team max when the user didn't provide a
+        # duration. If the user explicitly supplied a shorter duration (already
+        # validated against team max upstream), respect their value.
+        if "duration" not in data.model_fields_set:
+            data.duration = team_max
 
     return data
 

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -534,6 +534,13 @@ async def _common_key_generation_helper(  # noqa: PLR0915
                         upperbound_duration = duration_in_seconds(
                             duration=upperbound_value
                         )
+                        if value == "-1":
+                            raise HTTPException(
+                                status_code=400,
+                                detail={
+                                    "error": "'-1' is no longer a valid duration value. Pass duration: null to set a key to never expire."
+                                },
+                            )
                         user_duration = duration_in_seconds(duration=value)
                         if user_duration > upperbound_duration:
                             raise HTTPException(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -512,6 +512,14 @@ async def _common_key_generation_helper(  # noqa: PLR0915
             )
             if upperbound_value is not None:
                 if value is None:
+                    if key == "duration" and key in data.model_fields_set:
+                        # Explicitly null = never expires → exceeds any finite upperbound
+                        raise HTTPException(
+                            status_code=400,
+                            detail={
+                                "error": f"{key} is over max limit set in config - user_value=null (never expires); max_value={upperbound_value}"
+                            },
+                        )
                     # Use the upperbound value if user didn't provide a value
                     setattr(data, key, upperbound_value)
                 else:

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -555,18 +555,20 @@ async def _common_key_generation_helper(  # noqa: PLR0915
         and data.duration is not None
     ):
         team_max_duration = team_table.metadata["team_member_key_duration"]
-        team_max_seconds = duration_in_seconds(duration=team_max_duration)
-        if data.duration == "-1":
-            user_key_duration: float = float("inf")
-        else:
-            user_key_duration = duration_in_seconds(duration=data.duration)
-        if user_key_duration > team_max_seconds:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": f"Key duration exceeds team maximum. Requested: {data.duration}; Team maximum: {team_max_duration}"
-                },
-            )
+        # "-1" on the team side means no limit is enforced
+        if team_max_duration != "-1":
+            team_max_seconds = duration_in_seconds(duration=team_max_duration)
+            if data.duration == "-1":
+                user_key_duration: float = float("inf")
+            else:
+                user_key_duration = duration_in_seconds(duration=data.duration)
+            if user_key_duration > team_max_seconds:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": f"Key duration exceeds team maximum. Requested: {data.duration}; Team maximum: {team_max_duration}"
+                    },
+                )
 
     # APPLY ENTERPRISE KEY MANAGEMENT PARAMS
     try:
@@ -1483,8 +1485,8 @@ async def prepare_key_update_data(
 
     if "duration" in non_default_values:
         duration = non_default_values.pop("duration")
-        if duration == "-1":
-            # Set expires to None to indicate the key never expires
+        if duration == "-1" or duration is None:
+            # "-1" (legacy) or null (never-expires checkbox) both mean no expiry
             non_default_values["expires"] = None
         elif duration and (isinstance(duration, str)) and len(duration) > 0:
             duration_s = duration_in_seconds(duration=duration)
@@ -3400,8 +3402,19 @@ async def _validate_regenerate_key_duration_against_team(
     user_api_key_cache: DualCache,
 ) -> None:
     """Raise HTTP 400 if the requested duration exceeds the team's max key duration."""
-    if data is None or not data.duration:
+    if data is None:
         return
+
+    # Determine the user's requested duration in seconds.
+    # Distinguish "duration not sent" (leave unchanged) from "duration: null" (never expires).
+    if data.duration is None:
+        if "duration" not in data.model_fields_set:
+            return  # Not provided — leave the existing expiry unchanged
+        user_seconds: float = float("inf")  # Explicitly null = never expires
+    elif data.duration == "-1":
+        user_seconds = float("inf")  # Legacy sentinel for never-expires
+    else:
+        user_seconds = duration_in_seconds(duration=data.duration)
 
     team_id = getattr(key_in_db, "team_id", None)
     if not team_id:
@@ -3431,12 +3444,11 @@ async def _validate_regenerate_key_duration_against_team(
         return
 
     team_max_duration = team_table.metadata["team_member_key_duration"]
-    team_max_seconds = duration_in_seconds(duration=team_max_duration)
+    # "-1" on the team side means no limit is enforced
+    if team_max_duration == "-1":
+        return
 
-    if data.duration == "-1":
-        user_seconds: float = float("inf")
-    else:
-        user_seconds = duration_in_seconds(duration=data.duration)
+    team_max_seconds = duration_in_seconds(duration=team_max_duration)
 
     if user_seconds > team_max_seconds:
         raise HTTPException(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3415,7 +3415,12 @@ async def _validate_regenerate_key_duration_against_team(
             parent_otel_span=None,
             check_db_only=True,
         )
-    except Exception:
+    except Exception as e:
+        verbose_proxy_logger.warning(
+            "Could not look up team %s for duration validation during key regeneration, skipping check: %s",
+            team_id,
+            str(e),
+        )
         return
 
     if (

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3408,6 +3408,11 @@ async def _validate_regenerate_key_duration_against_team(
     if data is None:
         return
 
+    # Service account keys are exempt from team member duration limits,
+    # mirroring the enterprise add_team_member_key_duration guard.
+    if getattr(key_in_db, "user_id", None) is None:
+        return
+
     # Determine the user's requested duration in seconds.
     # Distinguish "duration not sent" (leave unchanged) from "duration: null" (never expires).
     if data.duration is None:
@@ -3427,7 +3432,6 @@ async def _validate_regenerate_key_duration_against_team(
             prisma_client=prisma_client,
             user_api_key_cache=user_api_key_cache,
             parent_otel_span=None,
-            check_db_only=True,
         )
     except Exception as e:
         verbose_proxy_logger.warning(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -534,11 +534,7 @@ async def _common_key_generation_helper(  # noqa: PLR0915
                         upperbound_duration = duration_in_seconds(
                             duration=upperbound_value
                         )
-                        # Handle special case where duration is "-1" (never expires)
-                        if value == "-1":
-                            user_duration = float("inf")  # Infinite duration
-                        else:
-                            user_duration = duration_in_seconds(duration=value)
+                        user_duration = duration_in_seconds(duration=value)
                         if user_duration > upperbound_duration:
                             raise HTTPException(
                                 status_code=400,
@@ -547,28 +543,28 @@ async def _common_key_generation_helper(  # noqa: PLR0915
                                 },
                             )
 
-    # Validate key duration against the team's max key duration
+    # Validate key duration against the team's max key duration.
+    # Only runs when the caller explicitly included "duration" in the request
+    # (distinguishes "omitted" from "null = never expires").
     if (
         team_table is not None
         and team_table.metadata is not None
         and team_table.metadata.get("team_member_key_duration")
-        and data.duration is not None
+        and "duration" in data.model_fields_set
     ):
         team_max_duration = team_table.metadata["team_member_key_duration"]
-        # "-1" on the team side means no limit is enforced
-        if team_max_duration != "-1":
-            team_max_seconds = duration_in_seconds(duration=team_max_duration)
-            if data.duration == "-1":
-                user_key_duration: float = float("inf")
-            else:
-                user_key_duration = duration_in_seconds(duration=data.duration)
-            if user_key_duration > team_max_seconds:
-                raise HTTPException(
-                    status_code=400,
-                    detail={
-                        "error": f"Key duration exceeds team maximum. Requested: {data.duration}; Team maximum: {team_max_duration}"
-                    },
-                )
+        team_max_seconds = duration_in_seconds(duration=team_max_duration)
+        if data.duration is None:
+            user_key_duration: float = float("inf")  # null = never expires = infinite
+        else:
+            user_key_duration = duration_in_seconds(duration=data.duration)
+        if user_key_duration > team_max_seconds:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"Key duration exceeds team maximum. Requested: {data.duration}; Team maximum: {team_max_duration}"
+                },
+            )
 
     # APPLY ENTERPRISE KEY MANAGEMENT PARAMS
     try:
@@ -1485,8 +1481,8 @@ async def prepare_key_update_data(
 
     if "duration" in non_default_values:
         duration = non_default_values.pop("duration")
-        if duration == "-1" or duration is None:
-            # "-1" (legacy) or null (never-expires checkbox) both mean no expiry
+        if duration is None:
+            # null (never-expires checkbox) means no expiry
             non_default_values["expires"] = None
         elif duration and (isinstance(duration, str)) and len(duration) > 0:
             duration_s = duration_in_seconds(duration=duration)
@@ -1809,7 +1805,7 @@ async def update_key_fn(
     - tpm_limit_type: Optional[str] - TPM rate limit type - "best_effort_throughput", "guaranteed_throughput", or "dynamic"
     - rpm_limit_type: Optional[str] - RPM rate limit type - "best_effort_throughput", "guaranteed_throughput", or "dynamic"
     - allowed_cache_controls: Optional[list] - List of allowed cache control values
-    - duration: Optional[str] - Key validity duration ("30d", "1h", etc.) or "-1" to never expire
+    - duration: Optional[str] - Key validity duration ("30d", "1h", etc.) or null to never expire
     - permissions: Optional[dict] - Key-specific permissions
     - send_invite_email: Optional[bool] - Send invite email to user_id
     - guardrails: Optional[List[str]] - List of active guardrails for the key
@@ -3411,8 +3407,6 @@ async def _validate_regenerate_key_duration_against_team(
         if "duration" not in data.model_fields_set:
             return  # Not provided — leave the existing expiry unchanged
         user_seconds: float = float("inf")  # Explicitly null = never expires
-    elif data.duration == "-1":
-        user_seconds = float("inf")  # Legacy sentinel for never-expires
     else:
         user_seconds = duration_in_seconds(duration=data.duration)
 
@@ -3444,10 +3438,6 @@ async def _validate_regenerate_key_duration_against_team(
         return
 
     team_max_duration = team_table.metadata["team_member_key_duration"]
-    # "-1" on the team side means no limit is enforced
-    if team_max_duration == "-1":
-        return
-
     team_max_seconds = duration_in_seconds(duration=team_max_duration)
 
     if user_seconds > team_max_seconds:

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -547,6 +547,27 @@ async def _common_key_generation_helper(  # noqa: PLR0915
                                 },
                             )
 
+    # Validate key duration against the team's max key duration
+    if (
+        team_table is not None
+        and team_table.metadata is not None
+        and team_table.metadata.get("team_member_key_duration")
+        and data.duration is not None
+    ):
+        team_max_duration = team_table.metadata["team_member_key_duration"]
+        team_max_seconds = duration_in_seconds(duration=team_max_duration)
+        if data.duration == "-1":
+            user_key_duration: float = float("inf")
+        else:
+            user_key_duration = duration_in_seconds(duration=data.duration)
+        if user_key_duration > team_max_seconds:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"Key duration exceeds team maximum. Requested: {data.duration}; Team maximum: {team_max_duration}"
+                },
+            )
+
     # APPLY ENTERPRISE KEY MANAGEMENT PARAMS
     try:
         from litellm_enterprise.proxy.management_endpoints.key_management_endpoints import (
@@ -3372,6 +3393,55 @@ async def _insert_deprecated_key(
             "Failed to insert deprecated key for grace period: %s",
             deprecated_err,
         )
+async def _validate_regenerate_key_duration_against_team(
+    data: Optional[RegenerateKeyRequest],
+    key_in_db: LiteLLM_VerificationToken,
+    prisma_client: PrismaClient,
+    user_api_key_cache: DualCache,
+) -> None:
+    """Raise HTTP 400 if the requested duration exceeds the team's max key duration."""
+    if data is None or not data.duration:
+        return
+
+    team_id = getattr(key_in_db, "team_id", None)
+    if not team_id:
+        return
+
+    try:
+        team_table = await get_team_object(
+            team_id=team_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=None,
+            check_db_only=True,
+        )
+    except Exception:
+        return
+
+    if (
+        team_table is None
+        or team_table.metadata is None
+        or not team_table.metadata.get("team_member_key_duration")
+    ):
+        return
+
+    team_max_duration = team_table.metadata["team_member_key_duration"]
+    team_max_seconds = duration_in_seconds(duration=team_max_duration)
+
+    if data.duration == "-1":
+        user_seconds: float = float("inf")
+    else:
+        user_seconds = duration_in_seconds(duration=data.duration)
+
+    if user_seconds > team_max_seconds:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": f"Key duration exceeds team maximum. Requested: {data.duration}; Team maximum: {team_max_duration}"
+            },
+        )
+
+
 async def _execute_virtual_key_regeneration(
     *,
     prisma_client: PrismaClient,
@@ -3386,6 +3456,13 @@ async def _execute_virtual_key_regeneration(
 ) -> GenerateKeyResponse:
     """Generate new token, update DB, invalidate cache, and return response."""
     from litellm.proxy.proxy_server import hash_token
+
+    await _validate_regenerate_key_duration_against_team(
+        data=data,
+        key_in_db=key_in_db,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
+    )
 
     new_token = get_new_token(data=data)
     new_token_hash = hash_token(new_token)

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -678,8 +678,8 @@ async def test_prepare_key_update_data():
     updated_data = await prepare_key_update_data(data, existing_key_row)
     assert updated_data["metadata"] is None
 
-    # Test duration "-1" sets expires to None (never expires)
-    data = UpdateKeyRequest(key="test_key", duration="-1")
+    # Test duration=null sets expires to None (never expires)
+    data = UpdateKeyRequest(key="test_key", duration=None)
     updated_data = await prepare_key_update_data(data, existing_key_row)
     assert updated_data["expires"] is None
 

--- a/tests/test_litellm/enterprise/proxy/test_key_duration_ceiling.py
+++ b/tests/test_litellm/enterprise/proxy/test_key_duration_ceiling.py
@@ -17,21 +17,27 @@ from unittest.mock import MagicMock
 
 from litellm.proxy._types import GenerateKeyRequest, LiteLLM_TeamTable
 
+_ENTERPRISE_SOURCE = os.path.normpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..", "..", "..", "..",
+        "enterprise", "litellm_enterprise", "proxy",
+        "management_endpoints", "key_management_endpoints.py",
+    )
+)
+
+pytestmark = pytest.mark.skipif(
+    not os.path.exists(_ENTERPRISE_SOURCE),
+    reason=f"Enterprise source not available at {_ENTERPRISE_SOURCE}",
+)
+
 
 def _load_local_add_team_member_key_duration():
     """Load add_team_member_key_duration from the local enterprise source tree."""
-    local_path = os.path.normpath(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..", "..", "..", "..",
-            "enterprise", "litellm_enterprise", "proxy",
-            "management_endpoints", "key_management_endpoints.py",
-        )
-    )
     module_name = "_local_enterprise_key_management_endpoints"
     # Remove cached version so we always reload from the local file
     sys.modules.pop(module_name, None)
-    spec = importlib.util.spec_from_file_location(module_name, local_path)
+    spec = importlib.util.spec_from_file_location(module_name, _ENTERPRISE_SOURCE)
     module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
     spec.loader.exec_module(module)  # type: ignore[union-attr]
     return module.add_team_member_key_duration
@@ -109,10 +115,12 @@ class TestAddTeamMemberKeyDuration:
         assert result.duration is None
 
     def test_service_account_returns_unchanged(self):
-        """user_id=None (service account) → data is returned unchanged."""
+        """user_id=None (service account) → team duration is NOT applied."""
         fn = _load_local_add_team_member_key_duration()
 
         data = GenerateKeyRequest(user_id=None)
         result = fn(_make_team("30d"), data)
 
-        assert result.duration is None
+        # Verify the service-account guard prevented the team max from being applied
+        assert result.duration is None, "Service account should not inherit team duration"
+        assert result.duration != "30d"

--- a/tests/test_litellm/enterprise/proxy/test_key_duration_ceiling.py
+++ b/tests/test_litellm/enterprise/proxy/test_key_duration_ceiling.py
@@ -1,0 +1,118 @@
+"""
+Tests for add_team_member_key_duration ceiling behavior.
+
+team_member_key_duration acts as a ceiling:
+- Not provided by user → apply team max as default
+- Provided and shorter than team max → respect user's value
+- No team / no metadata / no team_member_key_duration → leave unchanged
+- Service account (user_id=None) → leave unchanged
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+from unittest.mock import MagicMock
+
+from litellm.proxy._types import GenerateKeyRequest, LiteLLM_TeamTable
+
+
+def _load_local_add_team_member_key_duration():
+    """Load add_team_member_key_duration from the local enterprise source tree."""
+    local_path = os.path.normpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..",
+            "enterprise", "litellm_enterprise", "proxy",
+            "management_endpoints", "key_management_endpoints.py",
+        )
+    )
+    module_name = "_local_enterprise_key_management_endpoints"
+    # Remove cached version so we always reload from the local file
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, local_path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module.add_team_member_key_duration
+
+
+def _make_team(duration: str) -> LiteLLM_TeamTable:
+    team = MagicMock(spec=LiteLLM_TeamTable)
+    team.metadata = {"team_member_key_duration": duration}
+    return team
+
+
+class TestAddTeamMemberKeyDuration:
+    def test_no_duration_provided_uses_team_max(self):
+        """User omits duration → team max is applied as the default."""
+        fn = _load_local_add_team_member_key_duration()
+
+        data = GenerateKeyRequest(user_id="user-1")
+        assert "duration" not in data.model_fields_set
+
+        result = fn(_make_team("30d"), data)
+
+        assert result.duration == "30d"
+
+    def test_shorter_duration_respected(self):
+        """User provides a duration shorter than team max → their value is kept."""
+        fn = _load_local_add_team_member_key_duration()
+
+        data = GenerateKeyRequest(user_id="user-1", duration="5d")
+        assert "duration" in data.model_fields_set
+
+        result = fn(_make_team("30d"), data)
+
+        assert result.duration == "5d"
+
+    def test_duration_equal_to_team_max_respected(self):
+        """User provides duration equal to team max → their value is kept."""
+        fn = _load_local_add_team_member_key_duration()
+
+        data = GenerateKeyRequest(user_id="user-1", duration="30d")
+        result = fn(_make_team("30d"), data)
+
+        assert result.duration == "30d"
+
+    def test_no_team_returns_unchanged(self):
+        """team_table=None → data is returned unchanged."""
+        fn = _load_local_add_team_member_key_duration()
+
+        data = GenerateKeyRequest(user_id="user-1")
+        result = fn(None, data)
+
+        assert result.duration is None
+
+    def test_no_metadata_returns_unchanged(self):
+        """Team has no metadata → data is returned unchanged."""
+        fn = _load_local_add_team_member_key_duration()
+
+        team = MagicMock(spec=LiteLLM_TeamTable)
+        team.metadata = None
+
+        data = GenerateKeyRequest(user_id="user-1")
+        result = fn(team, data)
+
+        assert result.duration is None
+
+    def test_no_team_member_key_duration_returns_unchanged(self):
+        """team_member_key_duration absent from metadata → data is returned unchanged."""
+        fn = _load_local_add_team_member_key_duration()
+
+        team = MagicMock(spec=LiteLLM_TeamTable)
+        team.metadata = {}
+
+        data = GenerateKeyRequest(user_id="user-1")
+        result = fn(team, data)
+
+        assert result.duration is None
+
+    def test_service_account_returns_unchanged(self):
+        """user_id=None (service account) → data is returned unchanged."""
+        fn = _load_local_add_team_member_key_duration()
+
+        data = GenerateKeyRequest(user_id=None)
+        result = fn(_make_team("30d"), data)
+
+        assert result.duration is None

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6457,6 +6457,75 @@ class TestValidateKeyAliasFormat:
             assert "Invalid key_alias format" in str(exc.value.message)
 
 
+class TestUpperboundNullDurationValidation:
+    """Tests for upperbound validation when duration is explicitly null (never expires)."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_null_duration_raises_when_upperbound_set(self):
+        """duration=null (never expires) should raise 400 when upperbound duration is set."""
+        import litellm
+        from litellm.types.proxy.management_endpoints.ui_sso import (
+            LiteLLM_UpperboundKeyGenerateParams,
+        )
+
+        original = litellm.upperbound_key_generate_params
+        try:
+            litellm.upperbound_key_generate_params = (
+                LiteLLM_UpperboundKeyGenerateParams(duration="30d")
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                await _common_key_generation_helper(
+                    data=GenerateKeyRequest(user_id="user-1", duration=None),
+                    user_api_key_dict=UserAPIKeyAuth(
+                        user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
+                    ),
+                    litellm_changed_by=None,
+                    team_table=None,
+                )
+            assert exc_info.value.status_code == 400
+            assert "never expires" in str(exc_info.value.detail).lower()
+        finally:
+            litellm.upperbound_key_generate_params = original
+
+    @pytest.mark.asyncio
+    async def test_omitted_duration_uses_upperbound_as_default(self):
+        """Duration not sent → upperbound is applied as default (no error)."""
+        import litellm
+        from litellm.types.proxy.management_endpoints.ui_sso import (
+            LiteLLM_UpperboundKeyGenerateParams,
+        )
+
+        original = litellm.upperbound_key_generate_params
+        try:
+            litellm.upperbound_key_generate_params = (
+                LiteLLM_UpperboundKeyGenerateParams(duration="30d")
+            )
+            with patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+                new_callable=AsyncMock,
+                return_value={
+                    "key": "sk-test",
+                    "expires": None,
+                    "user_id": "user-1",
+                },
+            ), patch("litellm.proxy.proxy_server.prisma_client"), patch(
+                "litellm.proxy.proxy_server.llm_router"
+            ), patch(
+                "litellm.proxy.proxy_server.premium_user", False
+            ):
+                # Should not raise — duration omitted, so upperbound fills in as default
+                await _common_key_generation_helper(
+                    data=GenerateKeyRequest(user_id="user-1"),
+                    user_api_key_dict=UserAPIKeyAuth(
+                        user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
+                    ),
+                    litellm_changed_by=None,
+                    team_table=None,
+                )
+        finally:
+            litellm.upperbound_key_generate_params = original
+
+
 class TestCommonKeyGenerationHelperTeamDurationValidation:
     """Tests for team duration validation inside _common_key_generation_helper."""
 

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6602,6 +6602,7 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
 
         mock_key = MagicMock(spec=LiteLLM_VerificationToken)
         mock_key.team_id = "team-123"
+        mock_key.user_id = "user-123"
         mock_prisma = AsyncMock()
         mock_cache = MagicMock()
         # Should not raise
@@ -6622,6 +6623,7 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
 
         mock_key = MagicMock(spec=LiteLLM_VerificationToken)
         mock_key.team_id = "team-123"
+        mock_key.user_id = "user-123"
         # No duration kwarg at all → not in model_fields_set
         data = RegenerateKeyRequest()
         mock_prisma = AsyncMock()
@@ -6644,6 +6646,7 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
 
         mock_key = MagicMock(spec=LiteLLM_VerificationToken)
         mock_key.team_id = "team-123"
+        mock_key.user_id = "user-123"
         # Explicitly set duration=None → "duration" IS in model_fields_set
         data = RegenerateKeyRequest(duration=None)
         assert "duration" in data.model_fields_set
@@ -6678,6 +6681,7 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
 
         mock_key = MagicMock(spec=LiteLLM_VerificationToken)
         mock_key.team_id = "team-123"
+        mock_key.user_id = "user-123"
         data = RegenerateKeyRequest(duration="999d")
 
         mock_team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
@@ -6708,10 +6712,33 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
 
         mock_key = MagicMock(spec=LiteLLM_VerificationToken)
         mock_key.team_id = None
+        mock_key.user_id = "user-123"
         data = RegenerateKeyRequest(duration="10d")
         mock_prisma = AsyncMock()
         mock_cache = MagicMock()
         # Should not raise
+        await _validate_regenerate_key_duration_against_team(
+            data=data,
+            key_in_db=mock_key,
+            prisma_client=mock_prisma,
+            user_api_key_cache=mock_cache,
+        )
+
+    @pytest.mark.asyncio
+    async def test_service_account_key_skips_validation(self):
+        """Service account keys (user_id=None) are exempt from team duration limits."""
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _validate_regenerate_key_duration_against_team,
+        )
+        from litellm.proxy._types import RegenerateKeyRequest
+
+        mock_key = MagicMock(spec=LiteLLM_VerificationToken)
+        mock_key.team_id = "team-123"
+        mock_key.user_id = None  # service account key has no user_id
+        data = RegenerateKeyRequest(duration="999d")
+        mock_prisma = AsyncMock()
+        mock_cache = MagicMock()
+        # Should not raise even though "999d" would exceed a finite team max
         await _validate_regenerate_key_duration_against_team(
             data=data,
             key_in_db=mock_key,
@@ -6728,6 +6755,7 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
 
         mock_key = MagicMock(spec=LiteLLM_VerificationToken)
         mock_key.team_id = "team-123"
+        mock_key.user_id = "user-123"
         data = RegenerateKeyRequest(duration="3d")
 
         mock_team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
@@ -6758,6 +6786,7 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
 
         mock_key = MagicMock(spec=LiteLLM_VerificationToken)
         mock_key.team_id = "team-123"
+        mock_key.user_id = "user-123"
         data = RegenerateKeyRequest(duration="10d")
 
         mock_team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
@@ -6790,6 +6819,7 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
 
         mock_key = MagicMock(spec=LiteLLM_VerificationToken)
         mock_key.team_id = "team-123"
+        mock_key.user_id = "user-123"
         data = RegenerateKeyRequest(duration=None)  # null = never expires = infinite
 
         mock_team = MagicMock(spec=LiteLLM_TeamTableCachedObj)

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6436,7 +6436,7 @@ class TestValidateKeyAliasFormat:
     def test_validate_key_alias_format_invalid(self):
         from litellm.proxy.management_endpoints.key_management_endpoints import _validate_key_alias_format
         from litellm.proxy._types import ProxyException
-        
+
         invalid_aliases = [
             "",               # empty
             " ",              # whitespace
@@ -6449,9 +6449,273 @@ class TestValidateKeyAliasFormat:
             "  leading",
             "trailing  ",
         ]
-        
+
         for alias in invalid_aliases:
             with pytest.raises(ProxyException) as exc:
                 _validate_key_alias_format(alias)
             assert str(exc.value.code) == "400"
             assert "Invalid key_alias format" in str(exc.value.message)
+
+
+class TestCommonKeyGenerationHelperTeamDurationValidation:
+    """Tests for team duration validation inside _common_key_generation_helper."""
+
+    @pytest.mark.asyncio
+    async def test_duration_exceeds_team_max_raises(self):
+        """Raises HTTP 400 when the requested duration exceeds the team's max."""
+        team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
+        team.metadata = {"team_member_key_duration": "5d"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _common_key_generation_helper(
+                data=GenerateKeyRequest(user_id="user-1", duration="10d"),
+                user_api_key_dict=UserAPIKeyAuth(
+                    user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
+                ),
+                litellm_changed_by=None,
+                team_table=team,
+            )
+        assert exc_info.value.status_code == 400
+        assert "Team maximum" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_never_expires_exceeds_team_max_raises(self):
+        """Duration '-1' (never expires) exceeds any finite team max."""
+        team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
+        team.metadata = {"team_member_key_duration": "30d"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _common_key_generation_helper(
+                data=GenerateKeyRequest(user_id="user-1", duration="-1"),
+                user_api_key_dict=UserAPIKeyAuth(
+                    user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
+                ),
+                litellm_changed_by=None,
+                team_table=team,
+            )
+        assert exc_info.value.status_code == 400
+        assert "Team maximum" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_duration_within_team_max_passes(self):
+        """Duration within the team max proceeds past the validation block."""
+        team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
+        team.metadata = {"team_member_key_duration": "5d"}
+
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+            new_callable=AsyncMock,
+            return_value={"key": "sk-test", "expires": None, "user_id": "user-1"},
+        ), patch("litellm.proxy.proxy_server.prisma_client"), patch(
+            "litellm.proxy.proxy_server.llm_router"
+        ), patch(
+            "litellm.proxy.proxy_server.premium_user", False
+        ):
+            await _common_key_generation_helper(
+                data=GenerateKeyRequest(user_id="user-1", duration="3d"),
+                user_api_key_dict=UserAPIKeyAuth(
+                    user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
+                ),
+                litellm_changed_by=None,
+                team_table=team,
+            )
+
+    @pytest.mark.asyncio
+    async def test_no_duration_skips_team_validation(self):
+        """No duration provided — team validation is skipped."""
+        team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
+        team.metadata = {"team_member_key_duration": "5d"}
+
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+            new_callable=AsyncMock,
+            return_value={"key": "sk-test", "expires": None, "user_id": "user-1"},
+        ), patch("litellm.proxy.proxy_server.prisma_client"), patch(
+            "litellm.proxy.proxy_server.llm_router"
+        ), patch(
+            "litellm.proxy.proxy_server.premium_user", False
+        ):
+            await _common_key_generation_helper(
+                data=GenerateKeyRequest(user_id="user-1", duration=None),
+                user_api_key_dict=UserAPIKeyAuth(
+                    user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
+                ),
+                litellm_changed_by=None,
+                team_table=team,
+            )
+
+    @pytest.mark.asyncio
+    async def test_no_team_skips_team_validation(self):
+        """No team_table — team duration validation is skipped."""
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+            new_callable=AsyncMock,
+            return_value={"key": "sk-test", "expires": None, "user_id": "user-1"},
+        ), patch("litellm.proxy.proxy_server.prisma_client"), patch(
+            "litellm.proxy.proxy_server.llm_router"
+        ), patch(
+            "litellm.proxy.proxy_server.premium_user", False
+        ):
+            await _common_key_generation_helper(
+                data=GenerateKeyRequest(user_id="user-1", duration="100d"),
+                user_api_key_dict=UserAPIKeyAuth(
+                    user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
+                ),
+                litellm_changed_by=None,
+                team_table=None,
+            )
+
+
+class TestValidateRegenerateKeyDurationAgainstTeam:
+    """Tests for _validate_regenerate_key_duration_against_team."""
+
+    @pytest.mark.asyncio
+    async def test_no_data_skips_validation(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _validate_regenerate_key_duration_against_team,
+        )
+
+        mock_key = MagicMock(spec=LiteLLM_VerificationToken)
+        mock_key.team_id = "team-123"
+        mock_prisma = AsyncMock()
+        mock_cache = MagicMock()
+        # Should not raise
+        await _validate_regenerate_key_duration_against_team(
+            data=None,
+            key_in_db=mock_key,
+            prisma_client=mock_prisma,
+            user_api_key_cache=mock_cache,
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_duration_skips_validation(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _validate_regenerate_key_duration_against_team,
+        )
+        from litellm.proxy._types import RegenerateKeyRequest
+
+        mock_key = MagicMock(spec=LiteLLM_VerificationToken)
+        mock_key.team_id = "team-123"
+        data = RegenerateKeyRequest(duration=None)
+        mock_prisma = AsyncMock()
+        mock_cache = MagicMock()
+        # Should not raise
+        await _validate_regenerate_key_duration_against_team(
+            data=data,
+            key_in_db=mock_key,
+            prisma_client=mock_prisma,
+            user_api_key_cache=mock_cache,
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_team_id_skips_validation(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _validate_regenerate_key_duration_against_team,
+        )
+        from litellm.proxy._types import RegenerateKeyRequest
+
+        mock_key = MagicMock(spec=LiteLLM_VerificationToken)
+        mock_key.team_id = None
+        data = RegenerateKeyRequest(duration="10d")
+        mock_prisma = AsyncMock()
+        mock_cache = MagicMock()
+        # Should not raise
+        await _validate_regenerate_key_duration_against_team(
+            data=data,
+            key_in_db=mock_key,
+            prisma_client=mock_prisma,
+            user_api_key_cache=mock_cache,
+        )
+
+    @pytest.mark.asyncio
+    async def test_duration_within_team_max_passes(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _validate_regenerate_key_duration_against_team,
+        )
+        from litellm.proxy._types import RegenerateKeyRequest, LiteLLM_TeamTableCachedObj
+
+        mock_key = MagicMock(spec=LiteLLM_VerificationToken)
+        mock_key.team_id = "team-123"
+        data = RegenerateKeyRequest(duration="3d")
+
+        mock_team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
+        mock_team.metadata = {"team_member_key_duration": "5d"}
+
+        mock_prisma = AsyncMock()
+        mock_cache = MagicMock()
+
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_team_object",
+            new_callable=AsyncMock,
+            return_value=mock_team,
+        ):
+            # Should not raise
+            await _validate_regenerate_key_duration_against_team(
+                data=data,
+                key_in_db=mock_key,
+                prisma_client=mock_prisma,
+                user_api_key_cache=mock_cache,
+            )
+
+    @pytest.mark.asyncio
+    async def test_duration_exceeds_team_max_raises(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _validate_regenerate_key_duration_against_team,
+        )
+        from litellm.proxy._types import RegenerateKeyRequest, LiteLLM_TeamTableCachedObj
+
+        mock_key = MagicMock(spec=LiteLLM_VerificationToken)
+        mock_key.team_id = "team-123"
+        data = RegenerateKeyRequest(duration="10d")
+
+        mock_team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
+        mock_team.metadata = {"team_member_key_duration": "5d"}
+
+        mock_prisma = AsyncMock()
+        mock_cache = MagicMock()
+
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_team_object",
+            new_callable=AsyncMock,
+            return_value=mock_team,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _validate_regenerate_key_duration_against_team(
+                    data=data,
+                    key_in_db=mock_key,
+                    prisma_client=mock_prisma,
+                    user_api_key_cache=mock_cache,
+                )
+        assert exc_info.value.status_code == 400
+        assert "Team maximum" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_never_expires_duration_exceeds_team_max_raises(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _validate_regenerate_key_duration_against_team,
+        )
+        from litellm.proxy._types import RegenerateKeyRequest, LiteLLM_TeamTableCachedObj
+
+        mock_key = MagicMock(spec=LiteLLM_VerificationToken)
+        mock_key.team_id = "team-123"
+        data = RegenerateKeyRequest(duration="-1")
+
+        mock_team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
+        mock_team.metadata = {"team_member_key_duration": "30d"}
+
+        mock_prisma = AsyncMock()
+        mock_cache = MagicMock()
+
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_team_object",
+            new_callable=AsyncMock,
+            return_value=mock_team,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _validate_regenerate_key_duration_against_team(
+                    data=data,
+                    key_in_db=mock_key,
+                    prisma_client=mock_prisma,
+                    user_api_key_cache=mock_cache,
+                )
+        assert exc_info.value.status_code == 400

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6565,6 +6565,31 @@ class TestCommonKeyGenerationHelperTeamDurationValidation:
                 team_table=None,
             )
 
+    @pytest.mark.asyncio
+    async def test_team_max_minus_one_skips_validation(self):
+        """team_member_key_duration='-1' means no limit — any user duration is accepted."""
+        team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
+        team.metadata = {"team_member_key_duration": "-1"}
+
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+            new_callable=AsyncMock,
+            return_value={"key": "sk-test", "expires": None, "user_id": "user-1"},
+        ), patch("litellm.proxy.proxy_server.prisma_client"), patch(
+            "litellm.proxy.proxy_server.llm_router"
+        ), patch(
+            "litellm.proxy.proxy_server.premium_user", False
+        ):
+            # Should not raise even though "999d" would otherwise exceed any finite team max
+            await _common_key_generation_helper(
+                data=GenerateKeyRequest(user_id="user-1", duration="999d"),
+                user_api_key_dict=UserAPIKeyAuth(
+                    user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
+                ),
+                litellm_changed_by=None,
+                team_table=team,
+            )
+
 
 class TestValidateRegenerateKeyDurationAgainstTeam:
     """Tests for _validate_regenerate_key_duration_against_team."""
@@ -6588,7 +6613,8 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
         )
 
     @pytest.mark.asyncio
-    async def test_no_duration_skips_validation(self):
+    async def test_duration_not_sent_skips_validation(self):
+        """Duration field absent from request (leave existing expiry unchanged)."""
         from litellm.proxy.management_endpoints.key_management_endpoints import (
             _validate_regenerate_key_duration_against_team,
         )
@@ -6596,7 +6622,8 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
 
         mock_key = MagicMock(spec=LiteLLM_VerificationToken)
         mock_key.team_id = "team-123"
-        data = RegenerateKeyRequest(duration=None)
+        # No duration kwarg at all → not in model_fields_set
+        data = RegenerateKeyRequest()
         mock_prisma = AsyncMock()
         mock_cache = MagicMock()
         # Should not raise
@@ -6606,6 +6633,71 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
             prisma_client=mock_prisma,
             user_api_key_cache=mock_cache,
         )
+
+    @pytest.mark.asyncio
+    async def test_null_duration_treated_as_never_expires_raises_when_team_has_limit(self):
+        """duration=null (Never Expires checkbox) is treated as infinite and rejected when team has a limit."""
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _validate_regenerate_key_duration_against_team,
+        )
+        from litellm.proxy._types import RegenerateKeyRequest, LiteLLM_TeamTableCachedObj
+
+        mock_key = MagicMock(spec=LiteLLM_VerificationToken)
+        mock_key.team_id = "team-123"
+        # Explicitly set duration=None → "duration" IS in model_fields_set
+        data = RegenerateKeyRequest(duration=None)
+        assert "duration" in data.model_fields_set
+
+        mock_team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
+        mock_team.metadata = {"team_member_key_duration": "5d"}
+
+        mock_prisma = AsyncMock()
+        mock_cache = MagicMock()
+
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_team_object",
+            new_callable=AsyncMock,
+            return_value=mock_team,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _validate_regenerate_key_duration_against_team(
+                    data=data,
+                    key_in_db=mock_key,
+                    prisma_client=mock_prisma,
+                    user_api_key_cache=mock_cache,
+                )
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_team_max_duration_minus_one_skips_validation(self):
+        """team_member_key_duration='-1' means no team limit — skip validation regardless of user duration."""
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _validate_regenerate_key_duration_against_team,
+        )
+        from litellm.proxy._types import RegenerateKeyRequest, LiteLLM_TeamTableCachedObj
+
+        mock_key = MagicMock(spec=LiteLLM_VerificationToken)
+        mock_key.team_id = "team-123"
+        data = RegenerateKeyRequest(duration="999d")
+
+        mock_team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
+        mock_team.metadata = {"team_member_key_duration": "-1"}
+
+        mock_prisma = AsyncMock()
+        mock_cache = MagicMock()
+
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_team_object",
+            new_callable=AsyncMock,
+            return_value=mock_team,
+        ):
+            # Should not raise — team max is "-1" (no limit)
+            await _validate_regenerate_key_duration_against_team(
+                data=data,
+                key_in_db=mock_key,
+                prisma_client=mock_prisma,
+                user_api_key_cache=mock_cache,
+            )
 
     @pytest.mark.asyncio
     async def test_no_team_id_skips_validation(self):

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -1058,7 +1058,7 @@ async def test_update_service_account_works_with_team_id():
 
 @pytest.mark.asyncio
 async def test_prepare_key_update_data_duration_never_expires():
-    """Test that duration="-1" sets expires to None (never expires)."""
+    """Test that duration=null sets expires to None (never expires)."""
     from litellm.proxy._types import UpdateKeyRequest
     from litellm.proxy.management_endpoints.key_management_endpoints import (
         prepare_key_update_data,
@@ -1076,8 +1076,8 @@ async def test_prepare_key_update_data_duration_never_expires():
         metadata={},
     )
 
-    # Test setting duration to "-1" (never expires)
-    update_request = UpdateKeyRequest(key="test-token", duration="-1")
+    # Test setting duration to null (never expires)
+    update_request = UpdateKeyRequest(key="test-token", duration=None)
 
     result = await prepare_key_update_data(
         data=update_request, existing_key_row=existing_key
@@ -6480,13 +6480,13 @@ class TestCommonKeyGenerationHelperTeamDurationValidation:
 
     @pytest.mark.asyncio
     async def test_never_expires_exceeds_team_max_raises(self):
-        """Duration '-1' (never expires) exceeds any finite team max."""
+        """duration=null (never expires) exceeds any finite team max."""
         team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
         team.metadata = {"team_member_key_duration": "30d"}
 
         with pytest.raises(HTTPException) as exc_info:
             await _common_key_generation_helper(
-                data=GenerateKeyRequest(user_id="user-1", duration="-1"),
+                data=GenerateKeyRequest(user_id="user-1", duration=None),
                 user_api_key_dict=UserAPIKeyAuth(
                     user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
                 ),
@@ -6521,8 +6521,8 @@ class TestCommonKeyGenerationHelperTeamDurationValidation:
             )
 
     @pytest.mark.asyncio
-    async def test_no_duration_skips_team_validation(self):
-        """No duration provided — team validation is skipped."""
+    async def test_duration_not_sent_skips_team_validation(self):
+        """Duration field absent from request — team validation is skipped."""
         team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
         team.metadata = {"team_member_key_duration": "5d"}
 
@@ -6536,7 +6536,7 @@ class TestCommonKeyGenerationHelperTeamDurationValidation:
             "litellm.proxy.proxy_server.premium_user", False
         ):
             await _common_key_generation_helper(
-                data=GenerateKeyRequest(user_id="user-1", duration=None),
+                data=GenerateKeyRequest(user_id="user-1"),
                 user_api_key_dict=UserAPIKeyAuth(
                     user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-1"
                 ),
@@ -6566,10 +6566,10 @@ class TestCommonKeyGenerationHelperTeamDurationValidation:
             )
 
     @pytest.mark.asyncio
-    async def test_team_max_minus_one_skips_validation(self):
-        """team_member_key_duration='-1' means no limit — any user duration is accepted."""
+    async def test_team_max_not_set_skips_validation(self):
+        """No team_member_key_duration in metadata — any user duration is accepted."""
         team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
-        team.metadata = {"team_member_key_duration": "-1"}
+        team.metadata = {}  # no team_member_key_duration
 
         with patch(
             "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
@@ -6669,8 +6669,8 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
         assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_team_max_duration_minus_one_skips_validation(self):
-        """team_member_key_duration='-1' means no team limit — skip validation regardless of user duration."""
+    async def test_team_max_not_set_skips_validation(self):
+        """No team_member_key_duration in metadata — skip validation regardless of user duration."""
         from litellm.proxy.management_endpoints.key_management_endpoints import (
             _validate_regenerate_key_duration_against_team,
         )
@@ -6681,7 +6681,7 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
         data = RegenerateKeyRequest(duration="999d")
 
         mock_team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
-        mock_team.metadata = {"team_member_key_duration": "-1"}
+        mock_team.metadata = {}  # no team_member_key_duration
 
         mock_prisma = AsyncMock()
         mock_cache = MagicMock()
@@ -6691,7 +6691,7 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
             new_callable=AsyncMock,
             return_value=mock_team,
         ):
-            # Should not raise — team max is "-1" (no limit)
+            # Should not raise — no team max set
             await _validate_regenerate_key_duration_against_team(
                 data=data,
                 key_in_db=mock_key,
@@ -6790,7 +6790,7 @@ class TestValidateRegenerateKeyDurationAgainstTeam:
 
         mock_key = MagicMock(spec=LiteLLM_VerificationToken)
         mock_key.team_id = "team-123"
-        data = RegenerateKeyRequest(duration="-1")
+        data = RegenerateKeyRequest(duration=None)  # null = never expires = infinite
 
         mock_team = MagicMock(spec=LiteLLM_TeamTableCachedObj)
         mock_team.metadata = {"team_member_key_duration": "30d"}

--- a/ui/litellm-dashboard/src/components/common_components/KeyLifecycleSettings.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/KeyLifecycleSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Select, Tooltip, Divider, Switch } from "antd";
+import { Select, Tooltip, Divider, Switch, Checkbox } from "antd";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { TextInput } from "@tremor/react";
 
@@ -11,7 +11,7 @@ interface KeyLifecycleSettingsProps {
   onAutoRotationChange: (enabled: boolean) => void;
   rotationInterval: string;
   onRotationIntervalChange: (interval: string) => void;
-  isCreateMode?: boolean; // If true, shows "leave empty to never expire" instead of "-1 to never expire"
+  isCreateMode?: boolean;
 }
 
 const KeyLifecycleSettings: React.FC<KeyLifecycleSettingsProps> = ({
@@ -31,6 +31,7 @@ const KeyLifecycleSettings: React.FC<KeyLifecycleSettingsProps> = ({
   const [showCustomInput, setShowCustomInput] = useState(isCustomInterval);
   const [customInterval, setCustomInterval] = useState(isCustomInterval ? rotationInterval : "");
   const [durationValue, setDurationValue] = useState<string>(form?.getFieldValue?.("duration") || "");
+  const [neverExpires, setNeverExpires] = useState<boolean>(false);
 
   const handleIntervalChange = (value: string) => {
     if (value === "custom") {
@@ -57,6 +58,20 @@ const KeyLifecycleSettings: React.FC<KeyLifecycleSettingsProps> = ({
       form.setFieldsValue({ duration: value });
     }
   };
+
+  const handleNeverExpiresChange = (e: any) => {
+    const checked = e.target.checked;
+    setNeverExpires(checked);
+    if (checked) {
+      setDurationValue("");
+      if (form && typeof form.setFieldValue === "function") {
+        form.setFieldValue("duration", null);
+      } else if (form && typeof form.setFieldsValue === "function") {
+        form.setFieldsValue({ duration: null });
+      }
+    }
+  };
+
   return (
     <div className="space-y-6">
       {/* Key Expiry Section */}
@@ -64,24 +79,24 @@ const KeyLifecycleSettings: React.FC<KeyLifecycleSettingsProps> = ({
         <span className="text-sm font-medium text-gray-700">Key Expiry Settings</span>
 
         <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-700 flex items-center space-x-1">
-            <span>Expire Key</span>
-            <Tooltip
-              title={
-                isCreateMode
-                  ? "Set when this key should expire. Format: 30s (seconds), 30m (minutes), 30h (hours), 30d (days). Leave empty to never expire."
-                  : "Set when this key should expire. Format: 30s (seconds), 30m (minutes), 30h (hours), 30d (days). Use -1 to never expire."
-              }
-            >
-              <InfoCircleOutlined className="text-gray-400 cursor-help text-xs" />
-            </Tooltip>
+          <label className="text-sm font-medium text-gray-700 flex items-center space-x-3">
+            <span className="flex items-center space-x-1">
+              <span>Expire Key</span>
+              <Tooltip title="Set when this key should expire. Format: 30s (seconds), 30m (minutes), 30h (hours), 30d (days).">
+                <InfoCircleOutlined className="text-gray-400 cursor-help text-xs" />
+              </Tooltip>
+            </span>
+            <Checkbox checked={neverExpires} onChange={handleNeverExpiresChange}>
+              Never Expires
+            </Checkbox>
           </label>
           <TextInput
             name="duration"
-            placeholder={isCreateMode ? "e.g., 30d or leave empty to never expire" : "e.g., 30d or -1 to never expire"}
+            placeholder="e.g., 30s, 30m, 30h, 30d"
             className="w-full"
             value={durationValue}
             onValueChange={handleDurationChange}
+            disabled={neverExpires}
           />
         </div>
       </div>

--- a/ui/litellm-dashboard/src/components/common_components/KeyLifecycleSettings.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/KeyLifecycleSettings.tsx
@@ -69,6 +69,13 @@ const KeyLifecycleSettings: React.FC<KeyLifecycleSettingsProps> = ({
       } else if (form && typeof form.setFieldsValue === "function") {
         form.setFieldsValue({ duration: null });
       }
+    } else {
+      // Clear the null so duration is omitted from the request (not sent as never-expires)
+      if (form && typeof form.setFieldValue === "function") {
+        form.setFieldValue("duration", undefined);
+      } else if (form && typeof form.setFieldsValue === "function") {
+        form.setFieldsValue({ duration: undefined });
+      }
     }
   };
 

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -350,9 +350,11 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
         formValues.rotation_interval = rotationInterval;
       }
 
-      // Handle duration field for key expiry - convert empty string to null
-      if (!formValues.duration || formValues.duration.trim() === "") {
-        formValues.duration = null;
+      // Handle duration field for key expiry:
+      // - null means Never Expires (explicitly set by checkbox) — keep as-is
+      // - empty string or undefined means not provided — omit entirely
+      if (formValues.duration !== null && (!formValues.duration || formValues.duration.trim() === "")) {
+        delete formValues.duration;
       }
 
       // Update the formValues with the final metadata
@@ -1407,7 +1409,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
                         />
                       </div>
                     </AccordionBody>
-                    <Form.Item name="duration" hidden initialValue={null}>
+                    <Form.Item name="duration" hidden>
                       <Input />
                     </Form.Item>
                   </Accordion>

--- a/ui/litellm-dashboard/src/components/organisms/regenerate_key_modal.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/regenerate_key_modal.tsx
@@ -1,6 +1,6 @@
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { Button, Col, Grid, Text, TextInput, Title } from "@tremor/react";
-import { Form, InputNumber, Modal } from "antd";
+import { Checkbox, Form, InputNumber, Modal } from "antd";
 import { add } from "date-fns";
 import { useEffect, useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
@@ -22,6 +22,7 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
   const [regenerateFormData, setRegenerateFormData] = useState<any>(null);
   const [newExpiryTime, setNewExpiryTime] = useState<string | null>(null);
   const [isRegenerating, setIsRegenerating] = useState(false);
+  const [neverExpires, setNeverExpires] = useState<boolean>(false);
 
   // Track whether this is the user's own authentication key
   const [isOwnKey, setIsOwnKey] = useState<boolean>(false);
@@ -31,12 +32,14 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
 
   useEffect(() => {
     if (visible && selectedToken && accessToken) {
+      const currentlyNeverExpires = !selectedToken.expires;
+      setNeverExpires(currentlyNeverExpires);
       form.setFieldsValue({
         key_alias: selectedToken.key_alias,
         max_budget: selectedToken.max_budget,
         tpm_limit: selectedToken.tpm_limit,
         rpm_limit: selectedToken.rpm_limit,
-        duration: selectedToken.duration || "",
+        duration: currentlyNeverExpires ? null : (selectedToken.duration || ""),
         grace_period: "",
       });
 
@@ -56,6 +59,7 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
       setIsRegenerating(false);
       setIsOwnKey(false);
       setCurrentAccessToken(null);
+      setNeverExpires(false);
       form.resetFields();
     }
   }, [visible, form]);
@@ -97,6 +101,13 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
     setIsRegenerating(true);
     try {
       const formValues = await form.validateFields();
+
+      // Translate "Never Expires" checkbox to an explicit null duration
+      if (neverExpires) {
+        formValues.duration = null;
+      } else if (!formValues.duration || formValues.duration.trim() === "") {
+        delete formValues.duration; // Not provided — leave existing expiry unchanged
+      }
 
       // Use the current access token for the API call
       const response = await regenerateKeyCall(
@@ -217,13 +228,35 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
           <Form.Item name="rpm_limit" label="RPM Limit">
             <InputNumber style={{ width: "100%" }} />
           </Form.Item>
-          <Form.Item name="duration" label="Expire Key (eg: 30s, 30h, 30d)" className="mt-8">
-            <TextInput placeholder="" />
+          <Form.Item
+            label={
+              <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+                <span>Expire Key (eg: 30s, 30h, 30d)</span>
+                <Checkbox
+                  checked={neverExpires}
+                  onChange={(e) => {
+                    const checked = e.target.checked;
+                    setNeverExpires(checked);
+                    if (checked) {
+                      form.setFieldValue("duration", null);
+                      setRegenerateFormData((prev: any) => ({ ...prev, duration: null }));
+                    }
+                  }}
+                >
+                  Never Expires
+                </Checkbox>
+              </div>
+            }
+            name="duration"
+            className="mt-8"
+          >
+            <TextInput placeholder="e.g., 30s, 30m, 30h, 30d" disabled={neverExpires} />
           </Form.Item>
           <div className="mt-2 text-sm text-gray-500">
             Current expiry: {selectedToken?.expires ? new Date(selectedToken.expires).toLocaleString() : "Never"}
           </div>
-          {newExpiryTime && <div className="mt-2 text-sm text-green-600">New expiry: {newExpiryTime}</div>}
+          {!neverExpires && newExpiryTime && <div className="mt-2 text-sm text-green-600">New expiry: {newExpiryTime}</div>}
+          {neverExpires && <div className="mt-2 text-sm text-green-600">New expiry: Never</div>}
           <Form.Item
             name="grace_period"
             label="Grace Period (eg: 24h, 2d)"

--- a/ui/litellm-dashboard/src/components/organisms/regenerate_key_modal.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/regenerate_key_modal.tsx
@@ -240,6 +240,8 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
                     if (checked) {
                       form.setFieldValue("duration", null);
                       setRegenerateFormData((prev: any) => ({ ...prev, duration: null }));
+                    } else {
+                      form.setFieldValue("duration", undefined);
                     }
                   }}
                 >

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -263,6 +263,11 @@ export function KeyEditView({
       }
       // If it's already an array (shouldn't happen, but handle it), keep as is
 
+      // Handle duration: null = Never Expires (keep); empty string or undefined = not changed (omit)
+      if (values.duration !== null && (!values.duration || values.duration.trim() === "")) {
+        delete values.duration;
+      }
+
       await onSubmit(values);
     } finally {
       setIsKeySaving(false);
@@ -659,7 +664,7 @@ export function KeyEditView({
           rotationInterval={rotationInterval}
           onRotationIntervalChange={setRotationInterval}
         />
-        <Form.Item name="duration" hidden initialValue="">
+        <Form.Item name="duration" hidden>
           <Input />
         </Form.Item>
       </div>


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Summary

### Problem

Two related issues with virtual key expiration validation against a team's `team_member_key_duration` limit:

1. **Key creation**: When a user entered a duration longer than the team maximum, the backend silently capped it to the team max and returned a success response. The UI showed success, but after refresh the key had a different expiry than what was entered — giving the user no indication their value was changed.

2. **Key regeneration**: The regeneration endpoint (`POST /key/{key}/regenerate`) never validated the requested duration against the team's limit at all. The user-provided duration was stored as-is, allowing the team maximum to be bypassed entirely.

### Fix

- In `_common_key_generation_helper`: added a duration check against `team_table.metadata["team_member_key_duration"]` before the enterprise params block. Returns HTTP 400 if the requested duration exceeds the team max.
- In `_execute_virtual_key_regeneration`: added `_validate_regenerate_key_duration_against_team` helper that looks up the key's team, checks `team_member_key_duration`, and returns HTTP 400 if exceeded.

Both checks treat `"-1"` (never-expires) as infinite, which always exceeds a finite team max.

## Testing

11 new unit tests added to `tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py`:
- `TestCommonKeyGenerationHelperTeamDurationValidation` (5 tests): key creation raises 400 when duration exceeds team max, passes when within limit, skips when no duration or no team
- `TestValidateRegenerateKeyDurationAgainstTeam` (6 tests): regeneration raises 400 when duration exceeds team max, passes when within limit, skips when no data/duration/team

## Type

🐛 Bug Fix
✅ Test