### PR TITLE
[Feat[ extends OAuth2 M2M authentication support to info routes (/key/info, /team/info, /user/info, /model/info)

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -790,7 +790,7 @@ def _check_end_user_budget(
     Raises:
         litellm.BudgetExceededError: If end user has exceeded their budget
     """
-    if route in LiteLLMRoutes.info_routes.value:
+    if RouteChecks.is_info_route(route):
         return
 
     if end_user_obj.litellm_budget_table is None:

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -1,5 +1,4 @@
 import re
-from turtle import st
 from typing import List, Optional
 
 from fastapi import HTTPException, Request, status

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -1,4 +1,5 @@
 import re
+from turtle import st
 from typing import List, Optional
 
 from fastapi import HTTPException, Request, status
@@ -164,9 +165,8 @@ class RouteChecks:
 
         if RouteChecks.is_llm_api_route(route=route):
             pass
-        elif (
-            route in LiteLLMRoutes.info_routes.value
-        ):  # check if user allowed to call an info route
+        elif RouteChecks.is_info_route(route=route):
+            # check if user allowed to call an info route
             if route == "/key/info":
                 # handled by function itself
                 pass
@@ -357,6 +357,13 @@ class RouteChecks:
         Check if route is a management route
         """
         return route in LiteLLMRoutes.management_routes.value
+
+    @staticmethod
+    def is_info_route(route: str) -> bool:
+        """
+        Check if route is an info route
+        """
+        return route in LiteLLMRoutes.info_routes.value
 
     @staticmethod
     def _is_azure_openai_route(route: str) -> bool:

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -561,9 +561,10 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         ########## End of Route Checks Before Reading DB / Cache for "token" ########
 
         if general_settings.get("enable_oauth2_auth", False) is True:
-            # Only apply OAuth2 M2M authentication to LLM API routes, not UI/management routes
+            # Only apply OAuth2 M2M authentication to LLM API routes and info routes, not UI/management routes
             # This allows UI SSO to work separately from API M2M authentication
-            if RouteChecks.is_llm_api_route(route=route):
+            # Note: Info routes are already scoped to the user
+            if RouteChecks.is_llm_api_route(route=route) or RouteChecks.is_info_route(route=route):
                 # return UserAPIKeyAuth object
                 # helper to check if the api_key is a valid oauth2 token
                 from litellm.proxy.proxy_server import premium_user

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -38,8 +38,9 @@ class _ProxyDBLogger(CustomLogger):
         request_route = user_api_key_dict.request_route
         if _ProxyDBLogger._should_track_errors_in_db() is False:
             return
-        elif request_route is not None and not RouteChecks.is_llm_api_route(
-            route=request_route
+        elif request_route is not None and not (
+            RouteChecks.is_llm_api_route(route=request_route) or
+            RouteChecks.is_info_route(route=request_route)
         ):
             return
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1773,7 +1773,7 @@ class ProxyLogging:
         """
 
         #########################################################
-        # Only log LLM API errors for proxy level hooks
+        # Only log LLM API and info route errors for proxy level hooks
         # eg. Authentication errors, rate limit errors, etc.
         # Note: This fixes a security issue where we
         #       would log temporary keys/auth info
@@ -1781,7 +1781,10 @@ class ProxyLogging:
         #########################################################
         if route is None:
             return False
-        if RouteChecks.is_llm_api_route(route) is not True:
+        if (
+            RouteChecks.is_llm_api_route(route) is not True or
+            RouteChecks.is_info_route(route) is not True
+        ):
             return False
 
         return isinstance(original_exception, HTTPException) or (

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1781,9 +1781,9 @@ class ProxyLogging:
         #########################################################
         if route is None:
             return False
-        if (
-            RouteChecks.is_llm_api_route(route) is not True or
-            RouteChecks.is_info_route(route) is not True
+        if not (
+            RouteChecks.is_llm_api_route(route) or
+            RouteChecks.is_info_route(route)
         ):
             return False
 

--- a/tests/test_litellm/proxy/auth/test_info_routes.py
+++ b/tests/test_litellm/proxy/auth/test_info_routes.py
@@ -1,0 +1,119 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from fastapi import HTTPException, Request
+
+from litellm.proxy._types import LiteLLM_UserTable, LiteLLMRoutes, LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.auth.route_checks import RouteChecks
+
+
+def test_info_route_identification():
+    """Test that info routes are correctly identified"""
+    for route in LiteLLMRoutes.info_routes.value:
+        assert RouteChecks.is_info_route(route) is True
+
+    # Non-info routes should return False
+    assert RouteChecks.is_info_route("/chat/completions") is False
+    assert RouteChecks.is_info_route("/v1/models") is False
+
+
+def test_key_info_route_access():
+    """Test access control for /key/info route"""
+    # This route handles its own access control, so it should pass for any user
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+    valid_token = UserAPIKeyAuth(user_id="test_user")
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    # Should not raise exception as /key/info handles its own logic
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=LitellmUserRoles.INTERNAL_USER,
+        route="/key/info",
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+
+
+def test_user_info_route_access():
+    """Test access control for /user/info route"""
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+    valid_token = UserAPIKeyAuth(user_id="test_user")
+    request = MagicMock(spec=Request)
+    request.query_params = {"user_id": "test_user"}
+
+    # Should not raise exception when user_id matches token's user_id
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=LitellmUserRoles.INTERNAL_USER,
+        route="/user/info",
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+
+    # Should raise exception when user_id does not match
+    request.query_params = {"user_id": "different_user"}
+    with pytest.raises(HTTPException) as exc_info:
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=user_obj,
+            _user_role=LitellmUserRoles.INTERNAL_USER,
+            route="/user/info",
+            request=request,
+            valid_token=valid_token,
+            request_data={},
+        )
+    assert exc_info.value.status_code == 403
+
+
+def test_model_info_route_access():
+    """Test access control for /model/info route"""
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+    valid_token = UserAPIKeyAuth(user_id="test_user")
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    # Should not raise exception as /model/info is accessible to show user's models
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=LitellmUserRoles.INTERNAL_USER,
+        route="/model/info",
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+
+
+def test_team_info_route_access():
+    """Test access control for /team/info route"""
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+    valid_token = UserAPIKeyAuth(user_id="test_user")
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    # Should not raise exception as /team/info handles its own logic
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=LitellmUserRoles.INTERNAL_USER,
+        route="/team/info",
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )

--- a/tests/test_litellm/proxy/auth/test_info_routes.py
+++ b/tests/test_litellm/proxy/auth/test_info_routes.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from fastapi import HTTPException, Request
 
@@ -14,7 +14,7 @@ def test_info_route_identification():
 
     # Non-info routes should return False
     assert RouteChecks.is_info_route("/chat/completions") is False
-    assert RouteChecks.is_info_route("/v1/models") is False
+    assert RouteChecks.is_info_route("/key/generate") is False
 
 
 def test_key_info_route_access():

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -47,6 +47,18 @@ def test_proxy_only_error_true_for_info_route():
     )
 
 
+def test_proxy_only_error_false_for_non_llm_non_info_route():
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
+    assert (
+        proxy_logging_obj._is_proxy_only_llm_api_error(
+            original_exception=Exception(),
+            error_type=ProxyErrorTypes.auth_error,
+            route="/key/generate",
+        )
+        is False
+    )
+
+
 def test_proxy_only_error_false_for_other_error_type():
     proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
     assert (

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -35,7 +35,7 @@ def test_proxy_only_error_true_for_llm_route():
     )
 
 
-def test_proxy_only_error_false_for_non_llm_route():
+def test_proxy_only_error_true_for_info_route():
     proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
     assert (
         proxy_logging_obj._is_proxy_only_llm_api_error(
@@ -43,7 +43,7 @@ def test_proxy_only_error_false_for_non_llm_route():
             error_type=ProxyErrorTypes.auth_error,
             route="/key/info",
         )
-        is False
+        is True
     )
 
 


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [X] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
Made it so info routes can use oauth