### PR TITLE
Litellm hashicorp vault config UI

### DIFF
--- a/litellm/proxy/management_endpoints/config_override_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_override_endpoints.py
@@ -30,6 +30,7 @@ HASHICORP_ENV_VAR_MAPPING: Dict[str, str] = {
     "approle_mount_path": "HCP_VAULT_APPROLE_MOUNT_PATH",
     "client_cert": "HCP_VAULT_CLIENT_CERT",
     "client_key": "HCP_VAULT_CLIENT_KEY",
+    "vault_cert_role": "HCP_VAULT_CERT_ROLE",
     "vault_namespace": "HCP_VAULT_NAMESPACE",
     "vault_mount_name": "HCP_VAULT_MOUNT_NAME",
     "vault_path_prefix": "HCP_VAULT_PATH_PREFIX",
@@ -200,7 +201,7 @@ async def update_hashicorp_vault_config(
     if not has_vault_addr:
         raise HTTPException(
             status_code=400,
-            detail={"error": "vault_addr is required"},
+            detail={"error": "Vault Address is required"},
         )
 
     if not has_token_auth and not has_approle_auth:
@@ -208,7 +209,7 @@ async def update_hashicorp_vault_config(
             status_code=400,
             detail={
                 "error": "At least one authentication method is required: "
-                "provide vault_token, or both approle_role_id and approle_secret_id"
+                "provide a Token, or both AppRole Role ID and Secret ID"
             },
         )
 

--- a/litellm/proxy/management_endpoints/config_override_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_override_endpoints.py
@@ -183,10 +183,27 @@ async def update_hashicorp_vault_config(
             },
         )
 
-    # Encrypt sensitive fields before storing in DB
-    encrypted_data = _encrypt_sensitive_fields(config_data, HASHICORP_SENSITIVE_FIELDS)
+    # Set env vars and verify the secret manager can initialize before persisting
+    _set_env_vars(config_data)
 
-    # Upsert to DB first — only mutate env vars after DB write succeeds
+    try:
+        proxy_config.initialize_secret_manager(
+            key_management_system="hashicorp_vault"
+        )
+    except Exception as e:
+        _set_env_vars({})
+        verbose_proxy_logger.exception(
+            "Error reinitializing Hashicorp Vault secret manager: %s", str(e)
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": f"Failed to initialize secret manager: {str(e)}"
+            },
+        )
+
+    # Only persist to DB after successful init
+    encrypted_data = _encrypt_sensitive_fields(config_data, HASHICORP_SENSITIVE_FIELDS)
     await prisma_client.db.litellm_configoverrides.upsert(
         where={"config_type": "hashicorp_vault"},
         data={
@@ -199,25 +216,6 @@ async def update_hashicorp_vault_config(
             },
         },
     )
-
-    # Set environment variables after DB write succeeds
-    _set_env_vars(config_data)
-
-    # Reinitialize the secret manager on this pod
-    try:
-        proxy_config.initialize_secret_manager(
-            key_management_system="hashicorp_vault"
-        )
-    except Exception as e:
-        verbose_proxy_logger.exception(
-            "Error reinitializing Hashicorp Vault secret manager: %s", str(e)
-        )
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": f"Config saved but failed to initialize secret manager: {str(e)}"
-            },
-        )
 
     return {
         "message": "Hashicorp Vault configuration updated successfully",

--- a/litellm/proxy/management_endpoints/config_override_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_override_endpoints.py
@@ -109,11 +109,13 @@ def _parse_config_value(raw: Any) -> Dict[str, Any]:
 
 
 def _set_env_vars(config_data: Dict[str, Any]) -> None:
-    """Set HCP_VAULT_* env vars from config data."""
-    for field_name, value in config_data.items():
-        env_var_name = HASHICORP_ENV_VAR_MAPPING.get(field_name)
-        if env_var_name and value is not None:
+    """Set HCP_VAULT_* env vars from config data. Unsets vars for missing/None fields."""
+    for field_name, env_var_name in HASHICORP_ENV_VAR_MAPPING.items():
+        value = config_data.get(field_name)
+        if value is not None:
             os.environ[env_var_name] = str(value)
+        else:
+            os.environ.pop(env_var_name, None)
 
 
 # --- Hashicorp Vault endpoints ---

--- a/litellm/proxy/management_endpoints/config_override_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_override_endpoints.py
@@ -135,6 +135,28 @@ async def update_hashicorp_vault_config(
 
     config_data = config.model_dump(exclude_none=True)
 
+    # Validate that the config has enough fields to initialize
+    has_vault_addr = bool(config_data.get("vault_addr"))
+    has_token_auth = bool(config_data.get("vault_token"))
+    has_approle_auth = bool(
+        config_data.get("approle_role_id") and config_data.get("approle_secret_id")
+    )
+
+    if not has_vault_addr:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "vault_addr is required"},
+        )
+
+    if not has_token_auth and not has_approle_auth:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "At least one authentication method is required: "
+                "provide vault_token, or both approle_role_id and approle_secret_id"
+            },
+        )
+
     # Set environment variables
     for field_name, value in config_data.items():
         env_var_name = HASHICORP_ENV_VAR_MAPPING.get(field_name)

--- a/litellm/proxy/management_endpoints/config_override_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_override_endpoints.py
@@ -1,0 +1,241 @@
+import json
+import os
+from typing import Any, Dict, Set
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import CommonProxyErrors, LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+    decrypt_value_helper,
+    encrypt_value_helper,
+)
+from litellm.types.proxy.management_endpoints.config_overrides import (
+    ConfigOverrideSettingsResponse,
+    HashicorpVaultConfig,
+)
+
+router = APIRouter()
+
+# --- Hashicorp Vault constants ---
+
+HASHICORP_ENV_VAR_MAPPING: Dict[str, str] = {
+    "vault_addr": "HCP_VAULT_ADDR",
+    "vault_token": "HCP_VAULT_TOKEN",
+    "approle_role_id": "HCP_VAULT_APPROLE_ROLE_ID",
+    "approle_secret_id": "HCP_VAULT_APPROLE_SECRET_ID",
+    "approle_mount_path": "HCP_VAULT_APPROLE_MOUNT_PATH",
+    "client_cert": "HCP_VAULT_CLIENT_CERT",
+    "client_key": "HCP_VAULT_CLIENT_KEY",
+    "vault_namespace": "HCP_VAULT_NAMESPACE",
+    "vault_mount_name": "HCP_VAULT_MOUNT_NAME",
+    "vault_path_prefix": "HCP_VAULT_PATH_PREFIX",
+}
+
+HASHICORP_SENSITIVE_FIELDS: Set[str] = {
+    "vault_token",
+    "approle_role_id",
+    "approle_secret_id",
+    "client_key",
+}
+
+
+# --- Shared helpers (reusable by future config types) ---
+
+
+def _encrypt_sensitive_fields(
+    data: Dict[str, Any], sensitive_fields: Set[str]
+) -> Dict[str, Any]:
+    """Encrypt sensitive fields in a config dict. Non-sensitive fields are left as-is."""
+    encrypted = {}
+    for key, value in data.items():
+        if value is not None and key in sensitive_fields and isinstance(value, str):
+            encrypted[key] = encrypt_value_helper(value)
+        else:
+            encrypted[key] = value
+    return encrypted
+
+
+def _decrypt_sensitive_fields(
+    data: Dict[str, Any], sensitive_fields: Set[str]
+) -> Dict[str, Any]:
+    """Decrypt sensitive fields in a config dict. Non-sensitive fields are left as-is."""
+    decrypted = {}
+    for key, value in data.items():
+        if value is not None and key in sensitive_fields and isinstance(value, str):
+            decrypted_value = decrypt_value_helper(
+                value,
+                key=key,
+                exception_type="debug",
+                return_original_value=True,
+            )
+            decrypted[key] = decrypted_value
+        else:
+            decrypted[key] = value
+    return decrypted
+
+
+def _get_current_env_values(env_var_mapping: Dict[str, str]) -> Dict[str, Any]:
+    """Read current env var values as fallback when no DB record exists."""
+    values = {}
+    for field_name, env_var_name in env_var_mapping.items():
+        env_value = os.environ.get(env_var_name)
+        values[field_name] = env_value
+    return values
+
+
+def _build_field_schema(model_class: type) -> Dict[str, Any]:
+    """Build field_schema dict from a Pydantic model for UI rendering."""
+    from pydantic import TypeAdapter
+
+    schema = TypeAdapter(model_class).json_schema(by_alias=True)
+    properties = {}
+    for field_name, field_info in schema.get("properties", {}).items():
+        properties[field_name] = {
+            "description": field_info.get("description", ""),
+            "type": field_info.get("type", "string"),
+        }
+    return {
+        "description": schema.get("description", ""),
+        "properties": properties,
+    }
+
+
+# --- Hashicorp Vault endpoints ---
+
+
+@router.post(
+    "/config_overrides/hashicorp_vault",
+    tags=["Config Overrides"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def update_hashicorp_vault_config(
+    config: HashicorpVaultConfig,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Update Hashicorp Vault secret manager configuration.
+    Sets environment variables, encrypts sensitive fields, and stores in DB.
+    Reinitializes the secret manager on this pod.
+    """
+    from litellm.proxy.proxy_server import prisma_client, proxy_config
+
+    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "Only admin users can update config overrides"},
+        )
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
+
+    config_data = config.model_dump(exclude_none=True)
+
+    # Set environment variables
+    for field_name, value in config_data.items():
+        env_var_name = HASHICORP_ENV_VAR_MAPPING.get(field_name)
+        if env_var_name and value is not None:
+            os.environ[env_var_name] = str(value)
+
+    # Encrypt sensitive fields before storing in DB
+    encrypted_data = _encrypt_sensitive_fields(config_data, HASHICORP_SENSITIVE_FIELDS)
+
+    # Upsert to DB
+    await prisma_client.db.litellm_configoverrides.upsert(
+        where={"config_type": "hashicorp_vault"},
+        data={
+            "create": {
+                "config_type": "hashicorp_vault",
+                "config_value": json.dumps(encrypted_data),
+            },
+            "update": {
+                "config_value": json.dumps(encrypted_data),
+            },
+        },
+    )
+
+    # Reinitialize the secret manager on this pod
+    try:
+        proxy_config.initialize_secret_manager(
+            key_management_system="hashicorp_vault"
+        )
+    except Exception as e:
+        verbose_proxy_logger.exception(
+            "Error reinitializing Hashicorp Vault secret manager: %s", str(e)
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": f"Config saved but failed to initialize secret manager: {str(e)}"
+            },
+        )
+
+    return {
+        "message": "Hashicorp Vault configuration updated successfully",
+        "status": "success",
+    }
+
+
+@router.get(
+    "/config_overrides/hashicorp_vault",
+    tags=["Config Overrides"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=ConfigOverrideSettingsResponse,
+)
+async def get_hashicorp_vault_config(
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Get current Hashicorp Vault configuration.
+    Returns decrypted values from DB, or falls back to current env vars.
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "Only admin users can view config overrides"},
+        )
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
+
+    field_schema = _build_field_schema(HashicorpVaultConfig)
+
+    # Try to load from DB
+    db_record = await prisma_client.db.litellm_configoverrides.find_unique(
+        where={"config_type": "hashicorp_vault"}
+    )
+
+    if db_record is not None and db_record.config_value is not None:
+        if isinstance(db_record.config_value, str):
+            config_data = json.loads(db_record.config_value)
+        else:
+            config_data = dict(db_record.config_value)
+
+        # Decrypt sensitive fields
+        decrypted_data = _decrypt_sensitive_fields(
+            config_data, HASHICORP_SENSITIVE_FIELDS
+        )
+
+        return ConfigOverrideSettingsResponse(
+            config_type="hashicorp_vault",
+            values=decrypted_data,
+            field_schema=field_schema,
+        )
+
+    # Fallback to env vars
+    env_values = _get_current_env_values(HASHICORP_ENV_VAR_MAPPING)
+
+    return ConfigOverrideSettingsResponse(
+        config_type="hashicorp_vault",
+        values=env_values,
+        field_schema=field_schema,
+    )

--- a/litellm/proxy/management_endpoints/config_override_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_override_endpoints.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, Dict, Set
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import TypeAdapter
 
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import CommonProxyErrors, LitellmUserRoles, UserAPIKeyAuth
@@ -87,8 +88,6 @@ def _get_current_env_values(env_var_mapping: Dict[str, str]) -> Dict[str, Any]:
 
 def _build_field_schema(model_class: type) -> Dict[str, Any]:
     """Build field_schema dict from a Pydantic model for UI rendering."""
-    from pydantic import TypeAdapter
-
     schema = TypeAdapter(model_class).json_schema(by_alias=True)
     properties = {}
     for field_name, field_info in schema.get("properties", {}).items():
@@ -100,6 +99,21 @@ def _build_field_schema(model_class: type) -> Dict[str, Any]:
         "description": schema.get("description", ""),
         "properties": properties,
     }
+
+
+def _parse_config_value(raw: Any) -> Dict[str, Any]:
+    """Parse a config_value from DB (may be JSON string or dict)."""
+    if isinstance(raw, str):
+        return json.loads(raw)
+    return dict(raw)
+
+
+def _set_env_vars(config_data: Dict[str, Any]) -> None:
+    """Set HCP_VAULT_* env vars from config data."""
+    for field_name, value in config_data.items():
+        env_var_name = HASHICORP_ENV_VAR_MAPPING.get(field_name)
+        if env_var_name and value is not None:
+            os.environ[env_var_name] = str(value)
 
 
 # --- Hashicorp Vault endpoints ---
@@ -157,16 +171,10 @@ async def update_hashicorp_vault_config(
             },
         )
 
-    # Set environment variables
-    for field_name, value in config_data.items():
-        env_var_name = HASHICORP_ENV_VAR_MAPPING.get(field_name)
-        if env_var_name and value is not None:
-            os.environ[env_var_name] = str(value)
-
     # Encrypt sensitive fields before storing in DB
     encrypted_data = _encrypt_sensitive_fields(config_data, HASHICORP_SENSITIVE_FIELDS)
 
-    # Upsert to DB
+    # Upsert to DB first — only mutate env vars after DB write succeeds
     await prisma_client.db.litellm_configoverrides.upsert(
         where={"config_type": "hashicorp_vault"},
         data={
@@ -179,6 +187,9 @@ async def update_hashicorp_vault_config(
             },
         },
     )
+
+    # Set environment variables after DB write succeeds
+    _set_env_vars(config_data)
 
     # Reinitialize the secret manager on this pod
     try:
@@ -237,10 +248,7 @@ async def get_hashicorp_vault_config(
     )
 
     if db_record is not None and db_record.config_value is not None:
-        if isinstance(db_record.config_value, str):
-            config_data = json.loads(db_record.config_value)
-        else:
-            config_data = dict(db_record.config_value)
+        config_data = _parse_config_value(db_record.config_value)
 
         # Decrypt sensitive fields
         decrypted_data = _decrypt_sensitive_fields(

--- a/litellm/proxy/management_endpoints/config_override_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_override_endpoints.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import TypeAdapter
 
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from litellm.proxy._types import CommonProxyErrors, LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.encrypt_decrypt_utils import (
@@ -41,6 +42,8 @@ HASHICORP_SENSITIVE_FIELDS: Set[str] = {
     "client_key",
 }
 
+_sensitive_masker = SensitiveDataMasker()
+
 
 # --- Shared helpers (reusable by future config types) ---
 
@@ -75,6 +78,19 @@ def _decrypt_sensitive_fields(
         else:
             decrypted[key] = value
     return decrypted
+
+
+def _mask_sensitive_fields(
+    data: Dict[str, Any], sensitive_fields: Set[str]
+) -> Dict[str, Any]:
+    """Mask sensitive fields for API responses. Non-sensitive fields are left as-is."""
+    masked = {}
+    for key, value in data.items():
+        if value is not None and key in sensitive_fields and isinstance(value, str):
+            masked[key] = _sensitive_masker._mask_value(value)
+        else:
+            masked[key] = value
+    return masked
 
 
 def _get_current_env_values(env_var_mapping: Dict[str, str]) -> Dict[str, Any]:
@@ -161,6 +177,19 @@ async def update_hashicorp_vault_config(
 
     config_data = config.model_dump(exclude_none=True)
 
+    # Merge with existing DB record: preserve sensitive fields the user didn't re-enter
+    existing_record = await prisma_client.db.litellm_configoverrides.find_unique(
+        where={"config_type": "hashicorp_vault"}
+    )
+    if existing_record is not None and existing_record.config_value is not None:
+        existing_data = _parse_config_value(existing_record.config_value)
+        existing_decrypted = _decrypt_sensitive_fields(
+            existing_data, HASHICORP_SENSITIVE_FIELDS
+        )
+        for field in HASHICORP_SENSITIVE_FIELDS:
+            if field not in config_data and existing_decrypted.get(field):
+                config_data[field] = existing_decrypted[field]
+
     # Validate that the config has enough fields to initialize
     has_vault_addr = bool(config_data.get("vault_addr"))
     has_token_auth = bool(config_data.get("vault_token"))
@@ -183,6 +212,9 @@ async def update_hashicorp_vault_config(
             },
         )
 
+    # Snapshot current env vars so we can restore on failure
+    previous_env = _get_current_env_values(HASHICORP_ENV_VAR_MAPPING)
+
     # Set env vars and verify the secret manager can initialize before persisting
     _set_env_vars(config_data)
 
@@ -191,7 +223,7 @@ async def update_hashicorp_vault_config(
             key_management_system="hashicorp_vault"
         )
     except Exception as e:
-        _set_env_vars({})
+        _set_env_vars(previous_env)
         verbose_proxy_logger.exception(
             "Error reinitializing Hashicorp Vault secret manager: %s", str(e)
         )
@@ -204,18 +236,22 @@ async def update_hashicorp_vault_config(
 
     # Only persist to DB after successful init
     encrypted_data = _encrypt_sensitive_fields(config_data, HASHICORP_SENSITIVE_FIELDS)
+    config_value = json.dumps(encrypted_data)
     await prisma_client.db.litellm_configoverrides.upsert(
         where={"config_type": "hashicorp_vault"},
         data={
             "create": {
                 "config_type": "hashicorp_vault",
-                "config_value": json.dumps(encrypted_data),
+                "config_value": config_value,
             },
             "update": {
-                "config_value": json.dumps(encrypted_data),
+                "config_value": config_value,
             },
         },
     )
+
+    # Update change-detection cache so the background reload doesn't redundantly re-init
+    proxy_config._last_hashicorp_vault_config = json.loads(config_value)
 
     return {
         "message": "Hashicorp Vault configuration updated successfully",
@@ -260,22 +296,28 @@ async def get_hashicorp_vault_config(
     if db_record is not None and db_record.config_value is not None:
         config_data = _parse_config_value(db_record.config_value)
 
-        # Decrypt sensitive fields
+        # Decrypt then mask sensitive fields so plaintext secrets are never sent to the UI
         decrypted_data = _decrypt_sensitive_fields(
             config_data, HASHICORP_SENSITIVE_FIELDS
+        )
+        masked_data = _mask_sensitive_fields(
+            decrypted_data, HASHICORP_SENSITIVE_FIELDS
         )
 
         return ConfigOverrideSettingsResponse(
             config_type="hashicorp_vault",
-            values=decrypted_data,
+            values=masked_data,
             field_schema=field_schema,
         )
 
-    # Fallback to env vars
+    # Fallback to env vars — also mask sensitive values
     env_values = _get_current_env_values(HASHICORP_ENV_VAR_MAPPING)
+    masked_env_values = _mask_sensitive_fields(
+        env_values, HASHICORP_SENSITIVE_FIELDS
+    )
 
     return ConfigOverrideSettingsResponse(
         config_type="hashicorp_vault",
-        values=env_values,
+        values=masked_env_values,
         field_schema=field_schema,
     )

--- a/litellm/proxy/management_endpoints/config_override_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_override_endpoints.py
@@ -178,7 +178,7 @@ async def update_hashicorp_vault_config(
 
     config_data = config.model_dump(exclude_none=True)
 
-    # Merge with existing DB record: preserve sensitive fields the user didn't re-enter
+    # Merge sensitive fields the user didn't re-enter: try DB first, fall back to env vars
     existing_record = await prisma_client.db.litellm_configoverrides.find_unique(
         where={"config_type": "hashicorp_vault"}
     )
@@ -190,6 +190,12 @@ async def update_hashicorp_vault_config(
         for field in HASHICORP_SENSITIVE_FIELDS:
             if field not in config_data and existing_decrypted.get(field):
                 config_data[field] = existing_decrypted[field]
+    else:
+        # No DB record yet — merge from current env vars
+        env_values = _get_current_env_values(HASHICORP_ENV_VAR_MAPPING)
+        for field in HASHICORP_SENSITIVE_FIELDS:
+            if field not in config_data and env_values.get(field):
+                config_data[field] = env_values[field]
 
     # Validate that the config has enough fields to initialize
     has_vault_addr = bool(config_data.get("vault_addr"))

--- a/litellm/proxy/management_endpoints/config_override_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_override_endpoints.py
@@ -86,6 +86,16 @@ def _get_current_env_values(env_var_mapping: Dict[str, str]) -> Dict[str, Any]:
     return values
 
 
+def _extract_field_type(field_info: Dict[str, Any]) -> str:
+    """Extract the non-null type from a Pydantic v2 JSON schema field."""
+    if "type" in field_info:
+        return field_info["type"]
+    for option in field_info.get("anyOf", []):
+        if option.get("type") != "null":
+            return option.get("type", "string")
+    return "string"
+
+
 def _build_field_schema(model_class: type) -> Dict[str, Any]:
     """Build field_schema dict from a Pydantic model for UI rendering."""
     schema = TypeAdapter(model_class).json_schema(by_alias=True)
@@ -93,7 +103,7 @@ def _build_field_schema(model_class: type) -> Dict[str, Any]:
     for field_name, field_info in schema.get("properties", {}).items():
         properties[field_name] = {
             "description": field_info.get("description", ""),
-            "type": field_info.get("type", "string"),
+            "type": _extract_field_type(field_info),
         }
     return {
         "description": schema.get("description", ""),

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2238,7 +2238,6 @@ class ProxyConfig:
     def __init__(self) -> None:
         self.config: Dict[str, Any] = {}
         self._last_semantic_filter_config: Optional[Dict[str, Any]] = None
-        self._hashicorp_config_override_initialized: bool = False
 
     def is_yaml(self, config_file_path: str) -> bool:
         if not os.path.isfile(config_file_path):
@@ -4436,7 +4435,7 @@ class ProxyConfig:
         if self._should_load_db_object(object_type="semantic_filter_settings"):
             await self._init_semantic_filter_settings_in_db(prisma_client=prisma_client)
 
-        if not self._hashicorp_config_override_initialized:
+        if self._should_load_db_object(object_type="config_overrides"):
             await self._init_hashicorp_vault_config_override(
                 prisma_client=prisma_client
             )
@@ -4554,9 +4553,9 @@ class ProxyConfig:
         self, prisma_client: PrismaClient
     ):
         """
-        Load Hashicorp Vault config override from DB on startup.
+        Load Hashicorp Vault config override from DB.
         Decrypts sensitive fields, sets HCP_VAULT_* env vars, and reinitializes the secret manager.
-        Only runs once at startup (guarded by _hashicorp_config_override_initialized flag).
+        Called periodically via _init_non_llm_objects_in_db to sync config across pods.
         """
         from litellm.proxy.management_endpoints.config_override_endpoints import (
             HASHICORP_SENSITIVE_FIELDS,
@@ -4571,7 +4570,6 @@ class ProxyConfig:
             )
 
             if db_record is None or db_record.config_value is None:
-                self._hashicorp_config_override_initialized = True
                 return
 
             config_data = _parse_config_value(db_record.config_value)
@@ -4587,10 +4585,9 @@ class ProxyConfig:
                 key_management_system="hashicorp_vault"
             )
 
-            verbose_proxy_logger.info(
+            verbose_proxy_logger.debug(
                 "Hashicorp Vault config override loaded from DB"
             )
-            self._hashicorp_config_override_initialized = True
         except Exception as e:
             verbose_proxy_logger.exception(
                 "Error loading Hashicorp Vault config override from DB: %s",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4560,9 +4560,10 @@ class ProxyConfig:
         Only runs once at startup (guarded by _hashicorp_config_override_initialized flag).
         """
         from litellm.proxy.management_endpoints.config_override_endpoints import (
-            HASHICORP_ENV_VAR_MAPPING,
             HASHICORP_SENSITIVE_FIELDS,
             _decrypt_sensitive_fields,
+            _parse_config_value,
+            _set_env_vars,
         )
 
         try:
@@ -4573,23 +4574,13 @@ class ProxyConfig:
             if db_record is None or db_record.config_value is None:
                 return
 
-            import json
+            config_data = _parse_config_value(db_record.config_value)
 
-            if isinstance(db_record.config_value, str):
-                config_data = json.loads(db_record.config_value)
-            else:
-                config_data = dict(db_record.config_value)
-
-            # Decrypt sensitive fields
+            # Decrypt sensitive fields and set env vars
             decrypted_data = _decrypt_sensitive_fields(
                 config_data, HASHICORP_SENSITIVE_FIELDS
             )
-
-            # Set env vars
-            for field_name, value in decrypted_data.items():
-                env_var_name = HASHICORP_ENV_VAR_MAPPING.get(field_name)
-                if env_var_name and value is not None:
-                    os.environ[env_var_name] = str(value)
+            _set_env_vars(decrypted_data)
 
             # Reinitialize the secret manager
             self.initialize_secret_manager(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2238,6 +2238,7 @@ class ProxyConfig:
     def __init__(self) -> None:
         self.config: Dict[str, Any] = {}
         self._last_semantic_filter_config: Optional[Dict[str, Any]] = None
+        self._last_hashicorp_vault_config: Optional[Dict[str, Any]] = None
 
     def is_yaml(self, config_file_path: str) -> bool:
         if not os.path.isfile(config_file_path):
@@ -4558,8 +4559,10 @@ class ProxyConfig:
         Called periodically via _init_non_llm_objects_in_db to sync config across pods.
         """
         from litellm.proxy.management_endpoints.config_override_endpoints import (
+            HASHICORP_ENV_VAR_MAPPING,
             HASHICORP_SENSITIVE_FIELDS,
             _decrypt_sensitive_fields,
+            _get_current_env_values,
             _parse_config_value,
             _set_env_vars,
         )
@@ -4574,10 +4577,17 @@ class ProxyConfig:
 
             config_data = _parse_config_value(db_record.config_value)
 
+            # Skip reinit if config hasn't changed since last poll
+            if self._last_hashicorp_vault_config == config_data:
+                return
+
             # Decrypt sensitive fields and set env vars
             decrypted_data = _decrypt_sensitive_fields(
                 config_data, HASHICORP_SENSITIVE_FIELDS
             )
+
+            # Snapshot current env vars so we can restore on failure
+            previous_env = _get_current_env_values(HASHICORP_ENV_VAR_MAPPING)
             _set_env_vars(decrypted_data)
 
             # Reinitialize the secret manager
@@ -4586,10 +4596,11 @@ class ProxyConfig:
                     key_management_system="hashicorp_vault"
                 )
             except Exception:
-                # Roll back env vars so the broken config doesn't affect secret lookups
-                _set_env_vars({})
+                # Restore previous working env vars instead of wiping all
+                _set_env_vars(previous_env)
                 raise
 
+            self._last_hashicorp_vault_config = config_data.copy()
             verbose_proxy_logger.debug(
                 "Hashicorp Vault config override loaded from DB"
             )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -346,6 +346,9 @@ from litellm.proxy.management_endpoints.cache_settings_endpoints import (
 from litellm.proxy.management_endpoints.callback_management_endpoints import (
     router as callback_management_endpoints_router,
 )
+from litellm.proxy.management_endpoints.config_override_endpoints import (
+    router as config_override_router,
+)
 from litellm.proxy.management_endpoints.common_utils import (
     _user_has_admin_privileges,
     admin_can_invite_user,
@@ -2235,6 +2238,7 @@ class ProxyConfig:
     def __init__(self) -> None:
         self.config: Dict[str, Any] = {}
         self._last_semantic_filter_config: Optional[Dict[str, Any]] = None
+        self._hashicorp_config_override_initialized: bool = False
 
     def is_yaml(self, config_file_path: str) -> bool:
         if not os.path.isfile(config_file_path):
@@ -4432,6 +4436,12 @@ class ProxyConfig:
         if self._should_load_db_object(object_type="semantic_filter_settings"):
             await self._init_semantic_filter_settings_in_db(prisma_client=prisma_client)
 
+        if not self._hashicorp_config_override_initialized:
+            await self._init_hashicorp_vault_config_override(
+                prisma_client=prisma_client
+            )
+            self._hashicorp_config_override_initialized = True
+
     async def _init_semantic_filter_settings_in_db(self, prisma_client: PrismaClient):
         """
         Initialize MCP semantic filter settings from database.
@@ -4539,6 +4549,60 @@ class ProxyConfig:
                 "litellm.proxy.proxy_server.py::ProxyConfig:_init_sso_settings_in_db - {}".format(
                     str(e)
                 )
+            )
+
+    async def _init_hashicorp_vault_config_override(
+        self, prisma_client: PrismaClient
+    ):
+        """
+        Load Hashicorp Vault config override from DB on startup.
+        Decrypts sensitive fields, sets HCP_VAULT_* env vars, and reinitializes the secret manager.
+        Only runs once at startup (guarded by _hashicorp_config_override_initialized flag).
+        """
+        from litellm.proxy.management_endpoints.config_override_endpoints import (
+            HASHICORP_ENV_VAR_MAPPING,
+            HASHICORP_SENSITIVE_FIELDS,
+            _decrypt_sensitive_fields,
+        )
+
+        try:
+            db_record = await prisma_client.db.litellm_configoverrides.find_unique(
+                where={"config_type": "hashicorp_vault"}
+            )
+
+            if db_record is None or db_record.config_value is None:
+                return
+
+            import json
+
+            if isinstance(db_record.config_value, str):
+                config_data = json.loads(db_record.config_value)
+            else:
+                config_data = dict(db_record.config_value)
+
+            # Decrypt sensitive fields
+            decrypted_data = _decrypt_sensitive_fields(
+                config_data, HASHICORP_SENSITIVE_FIELDS
+            )
+
+            # Set env vars
+            for field_name, value in decrypted_data.items():
+                env_var_name = HASHICORP_ENV_VAR_MAPPING.get(field_name)
+                if env_var_name and value is not None:
+                    os.environ[env_var_name] = str(value)
+
+            # Reinitialize the secret manager
+            self.initialize_secret_manager(
+                key_management_system="hashicorp_vault"
+            )
+
+            verbose_proxy_logger.info(
+                "Hashicorp Vault config override loaded from DB"
+            )
+        except Exception as e:
+            verbose_proxy_logger.exception(
+                "Error loading Hashicorp Vault config override from DB: %s",
+                str(e),
             )
 
     async def _check_and_reload_model_cost_map(self, prisma_client: PrismaClient):
@@ -12971,6 +13035,7 @@ app.include_router(cost_tracking_settings_router)
 app.include_router(router_settings_router)
 app.include_router(fallback_management_router)
 app.include_router(cache_settings_router)
+app.include_router(config_override_router)
 app.include_router(user_agent_analytics_router)
 app.include_router(enterprise_router)
 app.include_router(ui_discovery_endpoints_router)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4581,9 +4581,14 @@ class ProxyConfig:
             _set_env_vars(decrypted_data)
 
             # Reinitialize the secret manager
-            self.initialize_secret_manager(
-                key_management_system="hashicorp_vault"
-            )
+            try:
+                self.initialize_secret_manager(
+                    key_management_system="hashicorp_vault"
+                )
+            except Exception:
+                # Roll back env vars so the broken config doesn't affect secret lookups
+                _set_env_vars({})
+                raise
 
             verbose_proxy_logger.debug(
                 "Hashicorp Vault config override loaded from DB"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4440,7 +4440,6 @@ class ProxyConfig:
             await self._init_hashicorp_vault_config_override(
                 prisma_client=prisma_client
             )
-            self._hashicorp_config_override_initialized = True
 
     async def _init_semantic_filter_settings_in_db(self, prisma_client: PrismaClient):
         """
@@ -4572,6 +4571,7 @@ class ProxyConfig:
             )
 
             if db_record is None or db_record.config_value is None:
+                self._hashicorp_config_override_initialized = True
                 return
 
             config_data = _parse_config_value(db_record.config_value)
@@ -4590,6 +4590,7 @@ class ProxyConfig:
             verbose_proxy_logger.info(
                 "Hashicorp Vault config override loaded from DB"
             )
+            self._hashicorp_config_override_initialized = True
         except Exception as e:
             verbose_proxy_logger.exception(
                 "Error loading Hashicorp Vault config override from DB: %s",

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -1000,6 +1000,14 @@ model LiteLLM_UISettings {
   updated_at DateTime @updatedAt
 }
 
+// Generic config overrides table - one row per config_type
+model LiteLLM_ConfigOverrides {
+  config_type  String   @id
+  config_value Json
+  created_at   DateTime @default(now())
+  updated_at   DateTime @updatedAt
+}
+
 // Skills table for storing LiteLLM-managed skills
 model LiteLLM_SkillsTable {
   skill_id       String   @id @default(uuid())

--- a/litellm/types/proxy/management_endpoints/config_overrides.py
+++ b/litellm/types/proxy/management_endpoints/config_overrides.py
@@ -1,0 +1,60 @@
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class HashicorpVaultConfig(BaseModel):
+    """Configuration for Hashicorp Vault secret manager integration."""
+
+    vault_addr: Optional[str] = Field(
+        default=None,
+        description="The address of the Vault server (e.g., https://vault.example.com:8200)",
+    )
+    vault_token: Optional[str] = Field(
+        default=None,
+        description="Token for Vault token-based authentication",
+    )
+    approle_role_id: Optional[str] = Field(
+        default=None,
+        description="Role ID for Vault AppRole authentication",
+    )
+    approle_secret_id: Optional[str] = Field(
+        default=None,
+        description="Secret ID for Vault AppRole authentication",
+    )
+    approle_mount_path: Optional[str] = Field(
+        default=None,
+        description="Mount path for the AppRole auth method (default: approle)",
+    )
+    client_cert: Optional[str] = Field(
+        default=None,
+        description="Path to the client TLS certificate for Vault",
+    )
+    client_key: Optional[str] = Field(
+        default=None,
+        description="Path to the client TLS private key for Vault",
+    )
+    vault_namespace: Optional[str] = Field(
+        default=None,
+        description="Vault namespace (for multi-tenant Vault, sent as X-Vault-Namespace header)",
+    )
+    vault_mount_name: Optional[str] = Field(
+        default=None,
+        description="KV engine mount name (default: secret)",
+    )
+    vault_path_prefix: Optional[str] = Field(
+        default=None,
+        description="Optional path prefix for secrets (e.g., myapp -> secret/data/myapp/{secret_name})",
+    )
+
+
+class ConfigOverrideSettingsResponse(BaseModel):
+    """Response model for config override settings GET endpoints."""
+
+    config_type: str = Field(description="The type of config override")
+    values: Dict[str, Any] = Field(
+        description="Current configuration values (sensitive fields decrypted)"
+    )
+    field_schema: Dict[str, Any] = Field(
+        description="Schema information for UI rendering"
+    )

--- a/litellm/types/proxy/management_endpoints/config_overrides.py
+++ b/litellm/types/proxy/management_endpoints/config_overrides.py
@@ -34,6 +34,10 @@ class HashicorpVaultConfig(BaseModel):
         default=None,
         description="Path to the client TLS private key for Vault",
     )
+    vault_cert_role: Optional[str] = Field(
+        default=None,
+        description="Certificate role name for TLS cert authentication",
+    )
     vault_namespace: Optional[str] = Field(
         default=None,
         description="Vault namespace (for multi-tenant Vault, sent as X-Vault-Namespace header)",

--- a/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
@@ -119,7 +119,7 @@ async def test_get_hashicorp_config_fallback_to_env(client, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_hashicorp_config_from_db(client, monkeypatch):
-    """When a DB record exists, GET should return decrypted values."""
+    """When a DB record exists, GET should return masked sensitive values."""
     mock_record = MagicMock()
     mock_record.config_value = {
         "vault_addr": "https://vault.db.com",
@@ -139,7 +139,7 @@ async def test_get_hashicorp_config_from_db(client, monkeypatch):
     with patch(
         "litellm.proxy.management_endpoints.config_override_endpoints.decrypt_value_helper"
     ) as mock_decrypt:
-        mock_decrypt.return_value = "decrypted_token"
+        mock_decrypt.return_value = "decrypted_token_value"
 
         app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
             user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
@@ -150,9 +150,13 @@ async def test_get_hashicorp_config_from_db(client, monkeypatch):
             assert response.status_code == 200
             data = response.json()
             assert data["config_type"] == "hashicorp_vault"
+            # Non-sensitive fields returned as-is
             assert data["values"]["vault_addr"] == "https://vault.db.com"
-            assert data["values"]["vault_token"] == "decrypted_token"
             assert data["values"]["vault_namespace"] == "db-ns"
+            # Sensitive fields should be masked, not plaintext
+            vault_token_value = data["values"]["vault_token"]
+            assert "*" in vault_token_value
+            assert vault_token_value != "decrypted_token_value"
         finally:
             app.dependency_overrides.pop(ps.user_api_key_auth, None)
 
@@ -161,6 +165,7 @@ async def test_get_hashicorp_config_from_db(client, monkeypatch):
 async def test_update_hashicorp_config_success(client, monkeypatch):
     """POST should set env vars, encrypt sensitive fields, upsert DB, and reinit secret manager."""
     mock_configoverrides = MagicMock()
+    mock_configoverrides.find_unique = AsyncMock(return_value=None)
     mock_configoverrides.upsert = AsyncMock(return_value=None)
 
     mock_prisma = MagicMock()
@@ -169,6 +174,7 @@ async def test_update_hashicorp_config_success(client, monkeypatch):
 
     mock_proxy_config = MagicMock()
     mock_proxy_config.initialize_secret_manager = MagicMock()
+    mock_proxy_config._last_hashicorp_vault_config = None
 
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
     monkeypatch.setattr(ps, "proxy_config", mock_proxy_config)
@@ -215,6 +221,9 @@ async def test_update_hashicorp_config_success(client, monkeypatch):
             mock_proxy_config.initialize_secret_manager.assert_called_once_with(
                 key_management_system="hashicorp_vault"
             )
+
+            # Verify change-detection cache was updated
+            assert mock_proxy_config._last_hashicorp_vault_config is not None
         finally:
             app.dependency_overrides.pop(ps.user_api_key_auth, None)
             # Clean up env vars
@@ -227,6 +236,7 @@ async def test_update_hashicorp_config_success(client, monkeypatch):
 async def test_update_hashicorp_config_excludes_none_fields(client, monkeypatch):
     """POST with partial fields should only store provided fields (None fields excluded)."""
     mock_configoverrides = MagicMock()
+    mock_configoverrides.find_unique = AsyncMock(return_value=None)
     mock_configoverrides.upsert = AsyncMock(return_value=None)
 
     mock_prisma = MagicMock()
@@ -235,6 +245,7 @@ async def test_update_hashicorp_config_excludes_none_fields(client, monkeypatch)
 
     mock_proxy_config = MagicMock()
     mock_proxy_config.initialize_secret_manager = MagicMock()
+    mock_proxy_config._last_hashicorp_vault_config = None
 
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
     monkeypatch.setattr(ps, "proxy_config", mock_proxy_config)
@@ -274,10 +285,64 @@ async def test_update_hashicorp_config_excludes_none_fields(client, monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_update_hashicorp_config_missing_vault_addr(client, monkeypatch):
-    """POST without vault_addr should return 400."""
+async def test_update_hashicorp_config_init_failure_restores_env_vars(
+    client, monkeypatch
+):
+    """When initialize_secret_manager fails, env vars should be restored to previous values and DB should not be updated."""
+    mock_configoverrides = MagicMock()
+    mock_configoverrides.find_unique = AsyncMock(return_value=None)
+    mock_configoverrides.upsert = AsyncMock(return_value=None)
+
     mock_prisma = MagicMock()
     mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_configoverrides = mock_configoverrides
+
+    mock_proxy_config = MagicMock()
+    mock_proxy_config.initialize_secret_manager = MagicMock(
+        side_effect=Exception("Vault connection refused")
+    )
+
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "proxy_config", mock_proxy_config)
+
+    # Set pre-existing env vars that should be restored on failure
+    monkeypatch.setenv("HCP_VAULT_ADDR", "https://vault.old.com")
+    monkeypatch.setenv("HCP_VAULT_TOKEN", "old-token")
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        response = client.post(
+            "/config_overrides/hashicorp_vault",
+            json={
+                "vault_addr": "https://vault.bad.com",
+                "vault_token": "bad-token",
+            },
+        )
+        assert response.status_code == 500
+        assert "Vault connection refused" in response.json()["detail"]["error"]
+
+        # Env vars should be restored to previous values, not wiped
+        assert os.environ.get("HCP_VAULT_ADDR") == "https://vault.old.com"
+        assert os.environ.get("HCP_VAULT_TOKEN") == "old-token"
+
+        # DB should NOT have been updated
+        mock_configoverrides.upsert.assert_not_awaited()
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_update_hashicorp_config_missing_vault_addr(client, monkeypatch):
+    """POST without vault_addr should return 400."""
+    mock_configoverrides = MagicMock()
+    mock_configoverrides.find_unique = AsyncMock(return_value=None)
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_configoverrides = mock_configoverrides
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
 
     app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
@@ -298,8 +363,12 @@ async def test_update_hashicorp_config_missing_vault_addr(client, monkeypatch):
 @pytest.mark.asyncio
 async def test_update_hashicorp_config_missing_auth(client, monkeypatch):
     """POST with vault_addr but no auth method should return 400."""
+    mock_configoverrides = MagicMock()
+    mock_configoverrides.find_unique = AsyncMock(return_value=None)
+
     mock_prisma = MagicMock()
     mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_configoverrides = mock_configoverrides
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
 
     app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(

--- a/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
@@ -12,7 +12,6 @@ from litellm.proxy.management_endpoints.config_override_endpoints import (
     _build_field_schema,
     _decrypt_sensitive_fields,
     _encrypt_sensitive_fields,
-    _get_current_env_values,
 )
 from litellm.proxy.proxy_server import app
 from litellm.types.proxy.management_endpoints.config_overrides import (
@@ -34,6 +33,7 @@ def test_encrypt_decrypt_sensitive_fields_roundtrip():
         "approle_secret_id": "secret-456",
         "vault_namespace": "admin",
         "vault_mount_name": "secret",
+        "client_key": None,
     }
 
     with patch(
@@ -53,6 +53,9 @@ def test_encrypt_decrypt_sensitive_fields_roundtrip():
         assert encrypted["approle_role_id"] == "enc_role-123"
         assert encrypted["approle_secret_id"] == "enc_secret-456"
 
+        # None values should not be encrypted
+        assert encrypted["client_key"] is None
+
     with patch(
         "litellm.proxy.management_endpoints.config_override_endpoints.decrypt_value_helper"
     ) as mock_decrypt:
@@ -66,24 +69,7 @@ def test_encrypt_decrypt_sensitive_fields_roundtrip():
         assert decrypted["approle_role_id"] == "role-123"
         assert decrypted["approle_secret_id"] == "secret-456"
         assert decrypted["vault_namespace"] == "admin"
-
-
-def test_encrypt_sensitive_fields_skips_none_values():
-    """None values should not be encrypted."""
-    data = {
-        "vault_addr": "https://vault.example.com",
-        "vault_token": None,
-        "approle_role_id": None,
-    }
-
-    with patch(
-        "litellm.proxy.management_endpoints.config_override_endpoints.encrypt_value_helper"
-    ) as mock_encrypt:
-        encrypted = _encrypt_sensitive_fields(data, HASHICORP_SENSITIVE_FIELDS)
-
-        mock_encrypt.assert_not_called()
-        assert encrypted["vault_token"] is None
-        assert encrypted["approle_role_id"] is None
+        assert decrypted["client_key"] is None
 
 
 def test_build_field_schema():
@@ -98,23 +84,6 @@ def test_build_field_schema():
     # Check that descriptions are populated
     assert len(schema["properties"]["vault_addr"]["description"]) > 0
     assert len(schema["properties"]["vault_token"]["description"]) > 0
-
-
-def test_get_current_env_values(monkeypatch):
-    """Should return current env var values using the mapping."""
-    from litellm.proxy.management_endpoints.config_override_endpoints import (
-        HASHICORP_ENV_VAR_MAPPING,
-    )
-
-    monkeypatch.setenv("HCP_VAULT_ADDR", "https://vault.test.com")
-    monkeypatch.setenv("HCP_VAULT_NAMESPACE", "test-ns")
-    # Don't set HCP_VAULT_TOKEN — should be None
-
-    values = _get_current_env_values(HASHICORP_ENV_VAR_MAPPING)
-
-    assert values["vault_addr"] == "https://vault.test.com"
-    assert values["vault_namespace"] == "test-ns"
-    assert values["vault_token"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
@@ -1,0 +1,331 @@
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import litellm.proxy.proxy_server as ps
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.management_endpoints.config_override_endpoints import (
+    HASHICORP_SENSITIVE_FIELDS,
+    _build_field_schema,
+    _decrypt_sensitive_fields,
+    _encrypt_sensitive_fields,
+    _get_current_env_values,
+)
+from litellm.proxy.proxy_server import app
+from litellm.types.proxy.management_endpoints.config_overrides import (
+    HashicorpVaultConfig,
+)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_encrypt_decrypt_sensitive_fields_roundtrip():
+    """Sensitive fields should be encrypted, non-sensitive fields left as-is."""
+    data = {
+        "vault_addr": "https://vault.example.com:8200",
+        "vault_token": "my-secret-token",
+        "approle_role_id": "role-123",
+        "approle_secret_id": "secret-456",
+        "vault_namespace": "admin",
+        "vault_mount_name": "secret",
+    }
+
+    with patch(
+        "litellm.proxy.management_endpoints.config_override_endpoints.encrypt_value_helper"
+    ) as mock_encrypt:
+        mock_encrypt.side_effect = lambda v: f"enc_{v}"
+
+        encrypted = _encrypt_sensitive_fields(data, HASHICORP_SENSITIVE_FIELDS)
+
+        # Non-sensitive fields unchanged
+        assert encrypted["vault_addr"] == "https://vault.example.com:8200"
+        assert encrypted["vault_namespace"] == "admin"
+        assert encrypted["vault_mount_name"] == "secret"
+
+        # Sensitive fields encrypted
+        assert encrypted["vault_token"] == "enc_my-secret-token"
+        assert encrypted["approle_role_id"] == "enc_role-123"
+        assert encrypted["approle_secret_id"] == "enc_secret-456"
+
+    with patch(
+        "litellm.proxy.management_endpoints.config_override_endpoints.decrypt_value_helper"
+    ) as mock_decrypt:
+        mock_decrypt.side_effect = lambda v, **kwargs: v.replace("enc_", "")
+
+        decrypted = _decrypt_sensitive_fields(encrypted, HASHICORP_SENSITIVE_FIELDS)
+
+        # Round-trip: values should match original
+        assert decrypted["vault_addr"] == "https://vault.example.com:8200"
+        assert decrypted["vault_token"] == "my-secret-token"
+        assert decrypted["approle_role_id"] == "role-123"
+        assert decrypted["approle_secret_id"] == "secret-456"
+        assert decrypted["vault_namespace"] == "admin"
+
+
+def test_encrypt_sensitive_fields_skips_none_values():
+    """None values should not be encrypted."""
+    data = {
+        "vault_addr": "https://vault.example.com",
+        "vault_token": None,
+        "approle_role_id": None,
+    }
+
+    with patch(
+        "litellm.proxy.management_endpoints.config_override_endpoints.encrypt_value_helper"
+    ) as mock_encrypt:
+        encrypted = _encrypt_sensitive_fields(data, HASHICORP_SENSITIVE_FIELDS)
+
+        mock_encrypt.assert_not_called()
+        assert encrypted["vault_token"] is None
+        assert encrypted["approle_role_id"] is None
+
+
+def test_build_field_schema():
+    """Field schema should include description and type for all HashicorpVaultConfig fields."""
+    schema = _build_field_schema(HashicorpVaultConfig)
+
+    assert "properties" in schema
+    assert "vault_addr" in schema["properties"]
+    assert "vault_token" in schema["properties"]
+    assert "approle_role_id" in schema["properties"]
+
+    # Check that descriptions are populated
+    assert len(schema["properties"]["vault_addr"]["description"]) > 0
+    assert len(schema["properties"]["vault_token"]["description"]) > 0
+
+
+def test_get_current_env_values(monkeypatch):
+    """Should return current env var values using the mapping."""
+    from litellm.proxy.management_endpoints.config_override_endpoints import (
+        HASHICORP_ENV_VAR_MAPPING,
+    )
+
+    monkeypatch.setenv("HCP_VAULT_ADDR", "https://vault.test.com")
+    monkeypatch.setenv("HCP_VAULT_NAMESPACE", "test-ns")
+    # Don't set HCP_VAULT_TOKEN — should be None
+
+    values = _get_current_env_values(HASHICORP_ENV_VAR_MAPPING)
+
+    assert values["vault_addr"] == "https://vault.test.com"
+    assert values["vault_namespace"] == "test-ns"
+    assert values["vault_token"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_hashicorp_config_fallback_to_env(client, monkeypatch):
+    """When no DB record exists, GET should return env var values."""
+    mock_configoverrides = MagicMock()
+    mock_configoverrides.find_unique = AsyncMock(return_value=None)
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_configoverrides = mock_configoverrides
+
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setenv("HCP_VAULT_ADDR", "https://vault.env.com")
+    monkeypatch.setenv("HCP_VAULT_NAMESPACE", "env-ns")
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        response = client.get("/config_overrides/hashicorp_vault")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["config_type"] == "hashicorp_vault"
+        assert data["values"]["vault_addr"] == "https://vault.env.com"
+        assert data["values"]["vault_namespace"] == "env-ns"
+        assert "field_schema" in data
+        assert "properties" in data["field_schema"]
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_get_hashicorp_config_from_db(client, monkeypatch):
+    """When a DB record exists, GET should return decrypted values."""
+    mock_record = MagicMock()
+    mock_record.config_value = {
+        "vault_addr": "https://vault.db.com",
+        "vault_token": "encrypted_token",
+        "vault_namespace": "db-ns",
+    }
+
+    mock_configoverrides = MagicMock()
+    mock_configoverrides.find_unique = AsyncMock(return_value=mock_record)
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_configoverrides = mock_configoverrides
+
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+
+    with patch(
+        "litellm.proxy.management_endpoints.config_override_endpoints.decrypt_value_helper"
+    ) as mock_decrypt:
+        mock_decrypt.return_value = "decrypted_token"
+
+        app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+        )
+
+        try:
+            response = client.get("/config_overrides/hashicorp_vault")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["config_type"] == "hashicorp_vault"
+            assert data["values"]["vault_addr"] == "https://vault.db.com"
+            assert data["values"]["vault_token"] == "decrypted_token"
+            assert data["values"]["vault_namespace"] == "db-ns"
+        finally:
+            app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_update_hashicorp_config_success(client, monkeypatch):
+    """POST should set env vars, encrypt sensitive fields, upsert DB, and reinit secret manager."""
+    mock_configoverrides = MagicMock()
+    mock_configoverrides.upsert = AsyncMock(return_value=None)
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_configoverrides = mock_configoverrides
+
+    mock_proxy_config = MagicMock()
+    mock_proxy_config.initialize_secret_manager = MagicMock()
+
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "proxy_config", mock_proxy_config)
+
+    with patch(
+        "litellm.proxy.management_endpoints.config_override_endpoints.encrypt_value_helper"
+    ) as mock_encrypt:
+        mock_encrypt.side_effect = lambda v: f"enc_{v}"
+
+        app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+        )
+
+        try:
+            response = client.post(
+                "/config_overrides/hashicorp_vault",
+                json={
+                    "vault_addr": "https://vault.new.com",
+                    "vault_token": "new-token",
+                    "vault_namespace": "new-ns",
+                },
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "success"
+
+            # Verify env vars were set
+            assert os.environ.get("HCP_VAULT_ADDR") == "https://vault.new.com"
+            assert os.environ.get("HCP_VAULT_TOKEN") == "new-token"
+            assert os.environ.get("HCP_VAULT_NAMESPACE") == "new-ns"
+
+            # Verify DB upsert was called
+            mock_configoverrides.upsert.assert_awaited_once()
+            upsert_call = mock_configoverrides.upsert.call_args
+            create_data = json.loads(
+                upsert_call.kwargs["data"]["create"]["config_value"]
+            )
+            assert create_data["vault_token"] == "enc_new-token"
+            assert (
+                create_data["vault_addr"] == "https://vault.new.com"
+            )  # not encrypted
+
+            # Verify secret manager was reinitialized
+            mock_proxy_config.initialize_secret_manager.assert_called_once_with(
+                key_management_system="hashicorp_vault"
+            )
+        finally:
+            app.dependency_overrides.pop(ps.user_api_key_auth, None)
+            # Clean up env vars
+            os.environ.pop("HCP_VAULT_ADDR", None)
+            os.environ.pop("HCP_VAULT_TOKEN", None)
+            os.environ.pop("HCP_VAULT_NAMESPACE", None)
+
+
+@pytest.mark.asyncio
+async def test_update_hashicorp_config_excludes_none_fields(client, monkeypatch):
+    """POST with partial fields should only set provided fields."""
+    mock_configoverrides = MagicMock()
+    mock_configoverrides.upsert = AsyncMock(return_value=None)
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_configoverrides = mock_configoverrides
+
+    mock_proxy_config = MagicMock()
+    mock_proxy_config.initialize_secret_manager = MagicMock()
+
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "proxy_config", mock_proxy_config)
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        response = client.post(
+            "/config_overrides/hashicorp_vault",
+            json={"vault_addr": "https://vault.partial.com"},
+        )
+        assert response.status_code == 200
+
+        # Only vault_addr should be in the upserted data
+        upsert_call = mock_configoverrides.upsert.call_args
+        create_data = json.loads(
+            upsert_call.kwargs["data"]["create"]["config_value"]
+        )
+        assert create_data == {"vault_addr": "https://vault.partial.com"}
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+        os.environ.pop("HCP_VAULT_ADDR", None)
+
+
+@pytest.mark.asyncio
+async def test_admin_only_access_get(client, monkeypatch):
+    """Non-admin users should get 403 on GET."""
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id="normal_user"
+    )
+
+    try:
+        response = client.get("/config_overrides/hashicorp_vault")
+        assert response.status_code == 403
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_admin_only_access_post(client, monkeypatch):
+    """Non-admin users should get 403 on POST."""
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id="normal_user"
+    )
+
+    try:
+        response = client.post(
+            "/config_overrides/hashicorp_vault",
+            json={"vault_addr": "https://vault.example.com"},
+        )
+        assert response.status_code == 403
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)

--- a/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
@@ -285,6 +285,70 @@ async def test_update_hashicorp_config_excludes_none_fields(client, monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_update_hashicorp_config_preserves_existing_sensitive_fields(
+    client, monkeypatch
+):
+    """POST without sensitive fields should merge them from the existing DB record."""
+    existing_record = MagicMock()
+    existing_record.config_value = json.dumps(
+        {
+            "vault_addr": "https://vault.old.com",
+            "vault_token": "enc_old-token",
+            "approle_role_id": "enc_old-role",
+        }
+    )
+
+    mock_configoverrides = MagicMock()
+    mock_configoverrides.find_unique = AsyncMock(return_value=existing_record)
+    mock_configoverrides.upsert = AsyncMock(return_value=None)
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_configoverrides = mock_configoverrides
+
+    mock_proxy_config = MagicMock()
+    mock_proxy_config.initialize_secret_manager = MagicMock()
+    mock_proxy_config._last_hashicorp_vault_config = None
+
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "proxy_config", mock_proxy_config)
+
+    with patch(
+        "litellm.proxy.management_endpoints.config_override_endpoints.encrypt_value_helper"
+    ) as mock_encrypt, patch(
+        "litellm.proxy.management_endpoints.config_override_endpoints.decrypt_value_helper"
+    ) as mock_decrypt:
+        mock_encrypt.side_effect = lambda v: f"enc_{v}"
+        mock_decrypt.side_effect = lambda v, **kwargs: v.replace("enc_", "")
+
+        app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+        )
+
+        try:
+            # Only send vault_addr — no vault_token or approle_role_id
+            response = client.post(
+                "/config_overrides/hashicorp_vault",
+                json={"vault_addr": "https://vault.new.com"},
+            )
+            assert response.status_code == 200
+
+            # Verify the upserted data preserved existing sensitive fields
+            upsert_call = mock_configoverrides.upsert.call_args
+            create_data = json.loads(
+                upsert_call.kwargs["data"]["create"]["config_value"]
+            )
+            assert create_data["vault_addr"] == "https://vault.new.com"
+            assert create_data["vault_token"] == "enc_old-token"
+            assert create_data["approle_role_id"] == "enc_old-role"
+        finally:
+            app.dependency_overrides.pop(ps.user_api_key_auth, None)
+            os.environ.pop("HCP_VAULT_ADDR", None)
+            os.environ.pop("HCP_VAULT_TOKEN", None)
+            os.environ.pop("HCP_VAULT_APPROLE_ROLE_ID", None)
+
+
+@pytest.mark.asyncio
 async def test_update_hashicorp_config_init_failure_restores_env_vars(
     client, monkeypatch
 ):
@@ -355,7 +419,7 @@ async def test_update_hashicorp_config_missing_vault_addr(client, monkeypatch):
             json={"vault_token": "some-token"},
         )
         assert response.status_code == 400
-        assert "vault_addr" in response.json()["detail"]["error"]
+        assert "Vault Address" in response.json()["detail"]["error"]
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
 

--- a/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
@@ -349,6 +349,57 @@ async def test_update_hashicorp_config_preserves_existing_sensitive_fields(
 
 
 @pytest.mark.asyncio
+async def test_update_hashicorp_config_merges_env_vars_when_no_db_record(
+    client, monkeypatch
+):
+    """POST without sensitive fields and no DB record should merge from env vars."""
+    mock_configoverrides = MagicMock()
+    mock_configoverrides.find_unique = AsyncMock(return_value=None)
+    mock_configoverrides.upsert = AsyncMock(return_value=None)
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_configoverrides = mock_configoverrides
+
+    mock_proxy_config = MagicMock()
+    mock_proxy_config.initialize_secret_manager = MagicMock()
+    mock_proxy_config._last_hashicorp_vault_config = None
+
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "proxy_config", mock_proxy_config)
+
+    # Simulate existing env var token (set before UI was used)
+    monkeypatch.setenv("HCP_VAULT_TOKEN", "env-token")
+
+    with patch(
+        "litellm.proxy.management_endpoints.config_override_endpoints.encrypt_value_helper"
+    ) as mock_encrypt:
+        mock_encrypt.side_effect = lambda v: f"enc_{v}"
+
+        app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+        )
+
+        try:
+            # Only send vault_addr — token should merge from env var
+            response = client.post(
+                "/config_overrides/hashicorp_vault",
+                json={"vault_addr": "https://vault.new.com"},
+            )
+            assert response.status_code == 200
+
+            upsert_call = mock_configoverrides.upsert.call_args
+            create_data = json.loads(
+                upsert_call.kwargs["data"]["create"]["config_value"]
+            )
+            assert create_data["vault_addr"] == "https://vault.new.com"
+            assert create_data["vault_token"] == "enc_env-token"
+        finally:
+            app.dependency_overrides.pop(ps.user_api_key_auth, None)
+            os.environ.pop("HCP_VAULT_ADDR", None)
+
+
+@pytest.mark.asyncio
 async def test_update_hashicorp_config_init_failure_restores_env_vars(
     client, monkeypatch
 ):

--- a/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_config_override_endpoints.py
@@ -256,7 +256,7 @@ async def test_update_hashicorp_config_success(client, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_update_hashicorp_config_excludes_none_fields(client, monkeypatch):
-    """POST with partial fields should only set provided fields."""
+    """POST with partial fields should only store provided fields (None fields excluded)."""
     mock_configoverrides = MagicMock()
     mock_configoverrides.upsert = AsyncMock(return_value=None)
 
@@ -270,6 +270,47 @@ async def test_update_hashicorp_config_excludes_none_fields(client, monkeypatch)
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
     monkeypatch.setattr(ps, "proxy_config", mock_proxy_config)
 
+    with patch(
+        "litellm.proxy.management_endpoints.config_override_endpoints.encrypt_value_helper"
+    ) as mock_encrypt:
+        mock_encrypt.side_effect = lambda v: f"enc_{v}"
+
+        app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+        )
+
+        try:
+            response = client.post(
+                "/config_overrides/hashicorp_vault",
+                json={
+                    "vault_addr": "https://vault.partial.com",
+                    "vault_token": "tok",
+                },
+            )
+            assert response.status_code == 200
+
+            # Only vault_addr and vault_token should be in the upserted data
+            upsert_call = mock_configoverrides.upsert.call_args
+            create_data = json.loads(
+                upsert_call.kwargs["data"]["create"]["config_value"]
+            )
+            assert create_data == {
+                "vault_addr": "https://vault.partial.com",
+                "vault_token": "enc_tok",
+            }
+        finally:
+            app.dependency_overrides.pop(ps.user_api_key_auth, None)
+            os.environ.pop("HCP_VAULT_ADDR", None)
+            os.environ.pop("HCP_VAULT_TOKEN", None)
+
+
+@pytest.mark.asyncio
+async def test_update_hashicorp_config_missing_vault_addr(client, monkeypatch):
+    """POST without vault_addr should return 400."""
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+
     app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
         user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
     )
@@ -277,19 +318,34 @@ async def test_update_hashicorp_config_excludes_none_fields(client, monkeypatch)
     try:
         response = client.post(
             "/config_overrides/hashicorp_vault",
-            json={"vault_addr": "https://vault.partial.com"},
+            json={"vault_token": "some-token"},
         )
-        assert response.status_code == 200
-
-        # Only vault_addr should be in the upserted data
-        upsert_call = mock_configoverrides.upsert.call_args
-        create_data = json.loads(
-            upsert_call.kwargs["data"]["create"]["config_value"]
-        )
-        assert create_data == {"vault_addr": "https://vault.partial.com"}
+        assert response.status_code == 400
+        assert "vault_addr" in response.json()["detail"]["error"]
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
-        os.environ.pop("HCP_VAULT_ADDR", None)
+
+
+@pytest.mark.asyncio
+async def test_update_hashicorp_config_missing_auth(client, monkeypatch):
+    """POST with vault_addr but no auth method should return 400."""
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        response = client.post(
+            "/config_overrides/hashicorp_vault",
+            json={"vault_addr": "https://vault.example.com"},
+        )
+        assert response.status_code == 400
+        assert "authentication" in response.json()["detail"]["error"].lower()
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
 
 
 @pytest.mark.asyncio

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/configOverrides/useHashicorpVaultConfig.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/configOverrides/useHashicorpVaultConfig.ts
@@ -1,0 +1,23 @@
+import { getHashicorpVaultConfig } from "@/components/networking";
+import { useQuery } from "@tanstack/react-query";
+import useAuthorized from "../useAuthorized";
+import { createQueryKeys } from "../common/queryKeysFactory";
+
+const hashicorpVaultKeys = createQueryKeys("hashicorpVaultConfig");
+
+export const useHashicorpVaultConfig = () => {
+  const { accessToken } = useAuthorized();
+
+  return useQuery<Record<string, any>>({
+    queryKey: hashicorpVaultKeys.list({}),
+    queryFn: async () => {
+      if (!accessToken) {
+        throw new Error("Access token is required");
+      }
+      return getHashicorpVaultConfig(accessToken);
+    },
+    enabled: !!accessToken,
+    staleTime: 60 * 60 * 1000,
+    gcTime: 60 * 60 * 1000,
+  });
+};

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/configOverrides/useUpdateHashicorpVaultConfig.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/configOverrides/useUpdateHashicorpVaultConfig.ts
@@ -1,0 +1,21 @@
+import { updateHashicorpVaultConfig } from "@/components/networking";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createQueryKeys } from "../common/queryKeysFactory";
+
+const hashicorpVaultKeys = createQueryKeys("hashicorpVaultConfig");
+
+export const useUpdateHashicorpVaultConfig = (accessToken: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (config: Record<string, any>) => {
+      if (!accessToken) {
+        throw new Error("Access token is required");
+      }
+      return updateHashicorpVaultConfig(accessToken, config);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: hashicorpVaultKeys.all });
+    },
+  });
+};

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/configOverrides/useUpdateHashicorpVaultConfig.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/configOverrides/useUpdateHashicorpVaultConfig.ts
@@ -4,7 +4,7 @@ import { createQueryKeys } from "../common/queryKeysFactory";
 
 const hashicorpVaultKeys = createQueryKeys("hashicorpVaultConfig");
 
-export const useUpdateHashicorpVaultConfig = (accessToken: string) => {
+export const useUpdateHashicorpVaultConfig = (accessToken: string | null) => {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/ui/litellm-dashboard/src/components/AdminPanel.tsx
+++ b/ui/litellm-dashboard/src/components/AdminPanel.tsx
@@ -22,6 +22,7 @@ import NotificationsManager from "./molecules/notifications_manager";
 import { addAllowedIP, deleteAllowedIP, getAllowedIPs, getSSOSettings } from "./networking";
 import SCIMConfig from "./SCIM";
 import SSOSettings from "./Settings/AdminSettings/SSOSettings/SSOSettings";
+import HashicorpVault from "./Settings/AdminSettings/HashicorpVault/HashicorpVault";
 import UISettings from "./Settings/AdminSettings/UISettings/UISettings";
 import SSOModals from "./SSOModals";
 import UIAccessControlForm from "./UIAccessControlForm";
@@ -360,6 +361,11 @@ const AdminPanel: React.FC<AdminPanelProps> = ({ proxySettings }) => {
         </Space>
       ),
       children: <UISettings />,
+    },
+    {
+      key: "hashicorp-vault",
+      label: "Hashicorp Vault",
+      children: <HashicorpVault />,
     },
   ];
 

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
@@ -90,11 +90,17 @@ export default function HashicorpVault() {
     const fieldSchema = properties[fieldName];
     if (!fieldSchema) return null;
 
+    const rules =
+      fieldName === "vault_addr"
+        ? [{ type: "url" as const, message: "Please enter a valid URL" }]
+        : undefined;
+
     return (
       <Form.Item
         key={fieldName}
         name={fieldName}
         label={FIELD_LABELS[fieldName] ?? fieldName}
+        rules={rules}
       >
         {SENSITIVE_FIELDS.has(fieldName) ? (
           <Input.Password placeholder={fieldSchema?.description} />

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
@@ -60,7 +60,6 @@ export default function HashicorpVault() {
   const {
     mutate: updateConfig,
     isPending: isUpdating,
-    error: updateError,
   } = useUpdateHashicorpVaultConfig(accessToken);
 
   const schema = data?.field_schema;
@@ -127,14 +126,6 @@ export default function HashicorpVault() {
             <Typography.Paragraph style={{ marginBottom: 0 }}>
               {schema.description}
             </Typography.Paragraph>
-          )}
-
-          {updateError && (
-            <Alert
-              type="error"
-              message="Could not update Hashicorp Vault configuration"
-              description={updateError instanceof Error ? updateError.message : undefined}
-            />
           )}
 
           <Form layout="vertical" initialValues={values} onFinish={handleSave}>

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
@@ -64,7 +64,17 @@ export default function HashicorpVault() {
 
   const schema = data?.field_schema;
   const properties = schema?.properties ?? {};
-  const values = data?.values ?? {};
+  const rawValues = data?.values ?? {};
+
+  // Strip masked sensitive values so form inputs start empty — users enter new values or leave blank to keep existing
+  const values: Record<string, any> = {};
+  for (const [key, value] of Object.entries(rawValues)) {
+    if (SENSITIVE_FIELDS.has(key) && typeof value === "string" && value.includes("*")) {
+      // Don't populate form with masked value — it would be saved literally
+      continue;
+    }
+    values[key] = value;
+  }
 
   const handleSave = (formValues: Record<string, any>) => {
     // Only send fields that have a value
@@ -94,6 +104,13 @@ export default function HashicorpVault() {
         ? [{ type: "url" as const, message: "Please enter a valid URL" }]
         : undefined;
 
+    const isSensitive = SENSITIVE_FIELDS.has(fieldName);
+    const maskedValue = rawValues[fieldName];
+    const hasExistingValue = isSensitive && typeof maskedValue === "string" && maskedValue.includes("*");
+    const placeholder = hasExistingValue
+      ? `Current: ${maskedValue}`
+      : fieldSchema?.description;
+
     return (
       <Form.Item
         key={fieldName}
@@ -101,8 +118,8 @@ export default function HashicorpVault() {
         label={FIELD_LABELS[fieldName] ?? fieldName}
         rules={rules}
       >
-        {SENSITIVE_FIELDS.has(fieldName) ? (
-          <Input.Password placeholder={fieldSchema?.description} />
+        {isSensitive ? (
+          <Input.Password placeholder={placeholder} />
         ) : (
           <Input placeholder={fieldSchema?.description} />
         )}
@@ -128,7 +145,7 @@ export default function HashicorpVault() {
             </Typography.Paragraph>
           )}
 
-          <Form layout="vertical" initialValues={values} onFinish={handleSave}>
+          <Form key={JSON.stringify(values)} layout="vertical" initialValues={values} onFinish={handleSave}>
             {FIELD_GROUPS.map((group, index) => (
               <div key={group.title}>
                 {index > 0 && <Divider />}

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
@@ -24,6 +24,7 @@ const FIELD_LABELS: Record<string, string> = {
   approle_mount_path: "Mount Path",
   client_cert: "Client Certificate",
   client_key: "Client Key",
+  vault_cert_role: "Certificate Role",
 };
 
 interface FieldGroup {
@@ -50,7 +51,7 @@ const FIELD_GROUPS: FieldGroup[] = [
   {
     title: "TLS",
     subtitle: "Optional client certificate for mTLS.",
-    fields: ["client_cert", "client_key"],
+    fields: ["client_cert", "client_key", "vault_cert_role"],
   },
 ];
 
@@ -66,11 +67,10 @@ export default function HashicorpVault() {
   const properties = schema?.properties ?? {};
   const rawValues = data?.values ?? {};
 
-  // Strip masked sensitive values so form inputs start empty — users enter new values or leave blank to keep existing
+  // Never populate sensitive fields in the form — backend returns masked values that would be saved literally
   const values: Record<string, any> = {};
   for (const [key, value] of Object.entries(rawValues)) {
-    if (SENSITIVE_FIELDS.has(key) && typeof value === "string" && value.includes("*")) {
-      // Don't populate form with masked value — it would be saved literally
+    if (SENSITIVE_FIELDS.has(key)) {
       continue;
     }
     values[key] = value;
@@ -101,14 +101,14 @@ export default function HashicorpVault() {
 
     const rules =
       fieldName === "vault_addr"
-        ? [{ type: "url" as const, message: "Please enter a valid URL" }]
+        ? [{ pattern: /^https?:\/\/.+/, message: "Must start with http:// or https://" }]
         : undefined;
 
     const isSensitive = SENSITIVE_FIELDS.has(fieldName);
-    const maskedValue = rawValues[fieldName];
-    const hasExistingValue = isSensitive && typeof maskedValue === "string" && maskedValue.includes("*");
+    const existingValue = rawValues[fieldName];
+    const hasExistingValue = isSensitive && existingValue != null && existingValue !== "";
     const placeholder = hasExistingValue
-      ? `Current: ${maskedValue}`
+      ? "Leave blank to keep existing"
       : fieldSchema?.description;
 
     return (
@@ -144,6 +144,25 @@ export default function HashicorpVault() {
               {schema.description}
             </Typography.Paragraph>
           )}
+          <Alert
+            type="info"
+            showIcon
+            message="Secrets must be stored with the field name &quot;key&quot;"
+            description={
+              <>
+                <Typography.Text code>
+                  vault kv put secret/SECRET_NAME key=secret_value
+                </Typography.Text>
+                <br />
+                <Typography.Link
+                  href="https://docs.litellm.ai/docs/secret_managers/hashicorp_vault"
+                  target="_blank"
+                >
+                  View documentation
+                </Typography.Link>
+              </>
+            }
+          />
 
           <Form key={JSON.stringify(values)} layout="vertical" initialValues={values} onFinish={handleSave}>
             {FIELD_GROUPS.map((group, index) => (

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
@@ -4,7 +4,7 @@ import { useHashicorpVaultConfig } from "@/app/(dashboard)/hooks/configOverrides
 import { useUpdateHashicorpVaultConfig } from "@/app/(dashboard)/hooks/configOverrides/useUpdateHashicorpVaultConfig";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import NotificationManager from "@/components/molecules/notifications_manager";
-import { Alert, Button, Card, Form, Input, Skeleton, Space, Typography } from "antd";
+import { Alert, Button, Card, Divider, Form, Input, Skeleton, Space, Typography } from "antd";
 
 const SENSITIVE_FIELDS = new Set([
   "vault_token",
@@ -12,6 +12,47 @@ const SENSITIVE_FIELDS = new Set([
   "approle_secret_id",
   "client_key",
 ]);
+
+const FIELD_LABELS: Record<string, string> = {
+  vault_addr: "Vault Address",
+  vault_namespace: "Namespace",
+  vault_mount_name: "KV Mount Name",
+  vault_path_prefix: "Path Prefix",
+  vault_token: "Token",
+  approle_role_id: "Role ID",
+  approle_secret_id: "Secret ID",
+  approle_mount_path: "Mount Path",
+  client_cert: "Client Certificate",
+  client_key: "Client Key",
+};
+
+interface FieldGroup {
+  title: string;
+  subtitle?: string;
+  fields: string[];
+}
+
+const FIELD_GROUPS: FieldGroup[] = [
+  {
+    title: "Connection",
+    fields: ["vault_addr", "vault_namespace", "vault_mount_name", "vault_path_prefix"],
+  },
+  {
+    title: "Token Authentication",
+    subtitle: "Use a Vault token to authenticate. Only one auth method is required.",
+    fields: ["vault_token"],
+  },
+  {
+    title: "AppRole Authentication",
+    subtitle: "Use AppRole credentials to authenticate. Only one auth method is required.",
+    fields: ["approle_role_id", "approle_secret_id", "approle_mount_path"],
+  },
+  {
+    title: "TLS",
+    subtitle: "Optional client certificate for mTLS.",
+    fields: ["client_cert", "client_key"],
+  },
+];
 
 export default function HashicorpVault() {
   const { accessToken } = useAuthorized();
@@ -45,6 +86,25 @@ export default function HashicorpVault() {
     });
   };
 
+  const renderField = (fieldName: string) => {
+    const fieldSchema = properties[fieldName];
+    if (!fieldSchema) return null;
+
+    return (
+      <Form.Item
+        key={fieldName}
+        name={fieldName}
+        label={FIELD_LABELS[fieldName] ?? fieldName}
+      >
+        {SENSITIVE_FIELDS.has(fieldName) ? (
+          <Input.Password placeholder={fieldSchema?.description} />
+        ) : (
+          <Input placeholder={fieldSchema?.description} />
+        )}
+      </Form.Item>
+    );
+  };
+
   return (
     <Card title="Hashicorp Vault">
       {isLoading ? (
@@ -72,25 +132,22 @@ export default function HashicorpVault() {
           )}
 
           <Form layout="vertical" initialValues={values} onFinish={handleSave}>
-            {Object.entries(properties).map(([fieldName, fieldSchema]: [string, any]) => (
-              <Form.Item
-                key={fieldName}
-                name={fieldName}
-                label={
-                  <Typography.Text strong>
-                    {fieldName}
-                  </Typography.Text>
-                }
-                help={fieldSchema?.description}
-              >
-                {SENSITIVE_FIELDS.has(fieldName) ? (
-                  <Input.Password placeholder={fieldName} />
-                ) : (
-                  <Input placeholder={fieldName} />
+            {FIELD_GROUPS.map((group, index) => (
+              <div key={group.title}>
+                {index > 0 && <Divider />}
+                <Typography.Title level={5} style={{ marginBottom: 4 }}>
+                  {group.title}
+                </Typography.Title>
+                {group.subtitle && (
+                  <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
+                    {group.subtitle}
+                  </Typography.Paragraph>
                 )}
-              </Form.Item>
+                {group.fields.map(renderField)}
+              </div>
             ))}
 
+            <Divider />
             <Form.Item>
               <Button type="primary" htmlType="submit" loading={isUpdating}>
                 Save

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useHashicorpVaultConfig } from "@/app/(dashboard)/hooks/configOverrides/useHashicorpVaultConfig";
+import { useUpdateHashicorpVaultConfig } from "@/app/(dashboard)/hooks/configOverrides/useUpdateHashicorpVaultConfig";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import NotificationManager from "@/components/molecules/notifications_manager";
+import { Alert, Button, Card, Form, Input, Skeleton, Space, Typography } from "antd";
+
+const SENSITIVE_FIELDS = new Set([
+  "vault_token",
+  "approle_role_id",
+  "approle_secret_id",
+  "client_key",
+]);
+
+export default function HashicorpVault() {
+  const { accessToken } = useAuthorized();
+  const { data, isLoading, isError, error } = useHashicorpVaultConfig();
+  const {
+    mutate: updateConfig,
+    isPending: isUpdating,
+    error: updateError,
+  } = useUpdateHashicorpVaultConfig(accessToken);
+
+  const schema = data?.field_schema;
+  const properties = schema?.properties ?? {};
+  const values = data?.values ?? {};
+
+  const handleSave = (formValues: Record<string, any>) => {
+    // Only send fields that have a value
+    const config: Record<string, any> = {};
+    for (const [key, value] of Object.entries(formValues)) {
+      if (value !== undefined && value !== null && value !== "") {
+        config[key] = value;
+      }
+    }
+
+    updateConfig(config, {
+      onSuccess: () => {
+        NotificationManager.success("Hashicorp Vault configuration updated successfully");
+      },
+      onError: (err) => {
+        NotificationManager.fromBackend(err);
+      },
+    });
+  };
+
+  return (
+    <Card title="Hashicorp Vault">
+      {isLoading ? (
+        <Skeleton active />
+      ) : isError ? (
+        <Alert
+          type="error"
+          message="Could not load Hashicorp Vault configuration"
+          description={error instanceof Error ? error.message : undefined}
+        />
+      ) : (
+        <Space direction="vertical" size="large" style={{ width: "100%" }}>
+          {schema?.description && (
+            <Typography.Paragraph style={{ marginBottom: 0 }}>
+              {schema.description}
+            </Typography.Paragraph>
+          )}
+
+          {updateError && (
+            <Alert
+              type="error"
+              message="Could not update Hashicorp Vault configuration"
+              description={updateError instanceof Error ? updateError.message : undefined}
+            />
+          )}
+
+          <Form layout="vertical" initialValues={values} onFinish={handleSave}>
+            {Object.entries(properties).map(([fieldName, fieldSchema]: [string, any]) => (
+              <Form.Item
+                key={fieldName}
+                name={fieldName}
+                label={
+                  <Typography.Text strong>
+                    {fieldName}
+                  </Typography.Text>
+                }
+                help={fieldSchema?.description}
+              >
+                {SENSITIVE_FIELDS.has(fieldName) ? (
+                  <Input.Password placeholder={fieldName} />
+                ) : (
+                  <Input placeholder={fieldName} />
+                )}
+              </Form.Item>
+            ))}
+
+            <Form.Item>
+              <Button type="primary" htmlType="submit" loading={isUpdating}>
+                Save
+              </Button>
+            </Form.Item>
+          </Form>
+        </Space>
+      )}
+    </Card>
+  );
+}

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -9697,8 +9697,11 @@ export const updateHashicorpVaultConfig = async (
   });
   if (!response.ok) {
     const errorData = await response.json();
-    const raw = deriveErrorMessage(errorData);
-    const errorMessage = typeof raw === "string" ? raw : JSON.stringify(raw);
+    const detail = errorData?.detail;
+    const errorMessage =
+      (typeof detail === "object" && detail?.error) ||
+      (typeof detail === "string" && detail) ||
+      deriveErrorMessage(errorData);
     throw new Error(errorMessage);
   }
   const data = await response.json();

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -9659,6 +9659,51 @@ export const updateUiSettings = async (accessToken: string, settings: Record<str
   return data;
 };
 
+export const getHashicorpVaultConfig = async (accessToken: string) => {
+  const proxyBaseUrl = getProxyBaseUrl();
+  const url = proxyBaseUrl
+    ? `${proxyBaseUrl}/config_overrides/hashicorp_vault`
+    : `/config_overrides/hashicorp_vault`;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+    },
+  });
+  if (!response.ok) {
+    const errorData = await response.json();
+    const errorMessage = deriveErrorMessage(errorData);
+    throw new Error(errorMessage);
+  }
+  const data = await response.json();
+  return data;
+};
+
+export const updateHashicorpVaultConfig = async (
+  accessToken: string,
+  config: Record<string, any>,
+) => {
+  const proxyBaseUrl = getProxyBaseUrl();
+  const url = proxyBaseUrl
+    ? `${proxyBaseUrl}/config_overrides/hashicorp_vault`
+    : `/config_overrides/hashicorp_vault`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(config),
+  });
+  if (!response.ok) {
+    const errorData = await response.json();
+    const errorMessage = deriveErrorMessage(errorData);
+    throw new Error(errorMessage);
+  }
+  const data = await response.json();
+  return data;
+};
+
 // ============================================================
 // Claude Code Marketplace Networking Functions
 // ============================================================

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -9697,7 +9697,8 @@ export const updateHashicorpVaultConfig = async (
   });
   if (!response.ok) {
     const errorData = await response.json();
-    const errorMessage = deriveErrorMessage(errorData);
+    const raw = deriveErrorMessage(errorData);
+    const errorMessage = typeof raw === "string" ? raw : JSON.stringify(raw);
     throw new Error(errorMessage);
   }
   const data = await response.json();


### PR DESCRIPTION
## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Screenshots

### UI 

<img width="1078" height="955" alt="Screenshot 2026-03-04 at 4 52 51 PM" src="https://github.com/user-attachments/assets/fea65318-7d2a-4cb8-92f4-375438fb2b2f" />

<img width="1083" height="956" alt="Screenshot 2026-03-04 at 4 53 21 PM" src="https://github.com/user-attachments/assets/77cd693a-c8c3-4ab6-bdf1-271cce2d301f" />

<img width="1092" height="712" alt="Screenshot 2026-03-04 at 4 56 54 PM" src="https://github.com/user-attachments/assets/f27d2579-9fc6-4710-b7e9-53fbcffbf79b" />

<img width="757" height="428" alt="Screenshot 2026-03-04 at 4 46 58 PM" src="https://github.com/user-attachments/assets/f62f7257-b070-4ebd-9646-016b2f5a658f" />

<img width="630" height="761" alt="Screenshot 2026-03-04 at 4 50 05 PM" src="https://github.com/user-attachments/assets/927c202d-f20b-41ba-9216-454e09c6a2ae" />

- Confirmed the vault key is being used with litellm requests (need to follow the [documentation](https://docs.litellm.ai/docs/secret_managers/hashicorp_vault) and make sure its put in with key field and not something else) 
- Secrets masked in network tab 

## Changes

- Added a table for config overrides in the backend so that any future UI config overrides can go in. 

 Backend (config_override_endpoints.py):
  - POST /config_overrides/hashicorp_vault — Validates config, sets HCP_VAULT_* env vars,
  initializes the HashicorpSecretManager to verify connectivity, encrypts sensitive fields (token, AppRole credentials, client key), and persists to DB. Rolls back env vars on failure so a bad config never gets saved.
  - GET /config_overrides/hashicorp_vault — Returns the saved config with sensitive fields redacted.
  - Validation: requires vault_addr (must be a valid URL) + at least one auth method (token or AppRole role_id + secret_id).

  Startup / multi-pod sync (proxy_server.py):
  - _init_hashicorp_vault_config_override() runs on the existing ~30s background polling loop. It loads the vault config from DB, decrypts sensitive fields, sets env vars, and initializes the secret manager — so all proxy pods pick up the config without restart.
  
  - Tests: encryption/decryption roundtrips, env var setting, validation (missing addr, missing auth, invalid URL), partial updates, admin-only access control, non-sensitive field plaintext storage

  1. Admin opens Settings → Admin Settings → Hashicorp Vault tab
  2. Fills in vault address + auth credentials, clicks Save
  3. Backend validates, test-initializes the secret manager, encrypts & saves to DB
  4. All proxy pods pick up the config within ~30s via background job
  5. Any os.environ/SECRET_NAME references in model configs now resolve through Vault