### PR TITLE
fix: update vertex AI tests for function_response role=user

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/test_vertex.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex.py
@@ -393,6 +393,7 @@ def test_multiple_function_call():
                     ],
                 },
                 {
+                    "role": "user",
                     "parts": [
                         {
                             "function_response": {
@@ -498,6 +499,7 @@ def test_multiple_function_call_changed_text_pos():
                 ],
             },
             {
+                "role": "user",
                 "parts": [
                     {
                         "function_response": {


### PR DESCRIPTION
## Summary
- Updates `test_multiple_function_call` and `test_multiple_function_call_changed_text_pos` to expect `"role": "user"` on function_response content blocks
- The Gemini API requires `role="user"` on function_response messages (added in commit 273cf12afa), but these tests were never updated

## Test plan
- [x] `poetry run pytest tests/test_litellm/llms/vertex_ai/test_vertex.py::test_multiple_function_call -v` passes
- [x] `poetry run pytest tests/test_litellm/llms/vertex_ai/test_vertex.py::test_multiple_function_call_changed_text_pos -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)