### PR TITLE
fix: add video_tokens to completion_tokens_details test

### DIFF
--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -120,7 +120,8 @@ def test_usage_completion_tokens_details_text_tokens():
         'reasoning_tokens': 65,
         'rejected_prediction_tokens': None,
         'text_tokens': 12,
-        'image_tokens': None
+        'image_tokens': None,
+        'video_tokens': None
     }
     assert dump_result['completion_tokens_details'] == expected_completion_details
     


### PR DESCRIPTION
## Summary
- Adds `video_tokens: None` to the expected `completion_tokens_details` dict in `test_usage_completion_tokens_details_text_tokens`
- The `CompletionTokensDetailsWrapper` type gained a `video_tokens` field but this test was not updated

## Test plan
- [x] `poetry run pytest tests/test_litellm/types/test_types_utils.py::test_usage_completion_tokens_details_text_tokens -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)