### PR TITLE
fix: use direct AsyncMock in JWT OIDC discovery tests

### DIFF
--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -1514,7 +1514,7 @@ async def test_resolve_jwks_url_resolves_oidc_discovery_document():
     A .well-known/openid-configuration URL should be fetched and its
     jwks_uri returned.
     """
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, MagicMock
 
     from litellm.caching.dual_cache import DualCache
 
@@ -1533,8 +1533,10 @@ async def test_resolve_jwks_url_resolves_oidc_discovery_document():
     mock_response.status_code = 200
     mock_response.json.return_value = {"jwks_uri": jwks_url, "issuer": "https://..."}
 
-    with patch.object(handler.http_handler, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
-        result = await handler._resolve_jwks_url(discovery_url)
+    mock_get = AsyncMock(return_value=mock_response)
+    handler.http_handler.get = mock_get
+
+    result = await handler._resolve_jwks_url(discovery_url)
 
     assert result == jwks_url
     mock_get.assert_called_once_with(discovery_url)

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -1543,7 +1543,7 @@ async def test_resolve_jwks_url_resolves_oidc_discovery_document():
 @pytest.mark.asyncio
 async def test_resolve_jwks_url_caches_resolved_jwks_uri():
     """Resolved jwks_uri is cached — second call does not hit the network."""
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, MagicMock
 
     from litellm.caching.dual_cache import DualCache
 
@@ -1562,9 +1562,11 @@ async def test_resolve_jwks_url_caches_resolved_jwks_uri():
     mock_response.status_code = 200
     mock_response.json.return_value = {"jwks_uri": jwks_url}
 
-    with patch.object(handler.http_handler, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
-        first = await handler._resolve_jwks_url(discovery_url)
-        second = await handler._resolve_jwks_url(discovery_url)
+    mock_get = AsyncMock(return_value=mock_response)
+    handler.http_handler.get = mock_get
+
+    first = await handler._resolve_jwks_url(discovery_url)
+    second = await handler._resolve_jwks_url(discovery_url)
 
     assert first == jwks_url
     assert second == jwks_url
@@ -1575,7 +1577,7 @@ async def test_resolve_jwks_url_caches_resolved_jwks_uri():
 @pytest.mark.asyncio
 async def test_resolve_jwks_url_raises_if_no_jwks_uri_in_discovery_doc():
     """Raise a helpful error if the discovery document has no jwks_uri."""
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, MagicMock
 
     from litellm.caching.dual_cache import DualCache
 
@@ -1591,9 +1593,10 @@ async def test_resolve_jwks_url_raises_if_no_jwks_uri_in_discovery_doc():
     mock_response.status_code = 200
     mock_response.json.return_value = {"issuer": "https://example.com"}  # no jwks_uri
 
-    with patch.object(handler.http_handler, "get", new_callable=AsyncMock, return_value=mock_response):
-        with pytest.raises(Exception, match="jwks_uri"):
-            await handler._resolve_jwks_url(discovery_url)
+    handler.http_handler.get = AsyncMock(return_value=mock_response)
+
+    with pytest.raises(Exception, match="jwks_uri"):
+        await handler._resolve_jwks_url(discovery_url)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replaces `patch.object(handler.http_handler, "get", new_callable=AsyncMock, return_value=mock_response)` with direct `handler.http_handler.get = AsyncMock(return_value=mock_response)` assignment
- The `patch.object` with `new_callable=AsyncMock` can behave inconsistently across Python versions, causing `mock_response.status_code` to return a MagicMock object instead of `200`

## Test plan
- [x] `poetry run pytest tests/test_litellm/proxy/auth/test_handle_jwt.py::test_resolve_jwks_url_caches_resolved_jwks_uri -v` passes
- [x] `poetry run pytest tests/test_litellm/proxy/auth/test_handle_jwt.py::test_resolve_jwks_url_raises_if_no_jwks_uri_in_discovery_doc -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)