### PR TITLE
fix: account for vertex_ai schema diff in response_format test

### DIFF
--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1139,20 +1139,25 @@ def test_pre_process_non_default_params(model, custom_llm_provider):
         provider_config=provider_config,
     )
     print(processed_non_default_params)
+    # Vertex AI / Gemini uses Pydantic's model_json_schema() which doesn't
+    # include additionalProperties: False (Gemini rejects it).  Other
+    # providers use OpenAI's to_strict_json_schema() which does.
+    expected_schema = {
+        "properties": {
+            "x": {"title": "X", "type": "string"},
+            "y": {"title": "Y", "type": "string"},
+        },
+        "required": ["x", "y"],
+        "title": "ResponseFormat",
+        "type": "object",
+    }
+    if custom_llm_provider not in ("vertex_ai", "vertex_ai_beta", "gemini"):
+        expected_schema["additionalProperties"] = False
     assert processed_non_default_params == {
         "response_format": {
             "type": "json_schema",
             "json_schema": {
-                "schema": {
-                    "properties": {
-                        "x": {"title": "X", "type": "string"},
-                        "y": {"title": "Y", "type": "string"},
-                    },
-                    "required": ["x", "y"],
-                    "title": "ResponseFormat",
-                    "type": "object",
-                    "additionalProperties": False,
-                },
+                "schema": expected_schema,
                 "name": "ResponseFormat",
                 "strict": True,
             },


### PR DESCRIPTION
## Summary
- Vertex AI / Gemini intentionally uses `model_json_schema()` instead of OpenAI's `to_strict_json_schema()` to avoid nesting depth errors (see #21014)
- This means Gemini schemas omit `additionalProperties: False`, which is correct behavior
- The test expected identical schemas for all providers; now it conditionally checks for `additionalProperties` based on provider

## Test plan
- [x] All 3 parametrized variants pass: openai, bedrock, vertex_ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)