### PR TITLE
fix: use real State in mock_request for proxy_utils tests

### DIFF
--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 
 import pytest
 from fastapi import Request
+from starlette.datastructures import State
 
 from litellm.proxy.utils import _get_docs_url, _get_redoc_url
 
@@ -32,6 +33,7 @@ def mock_request(monkeypatch):
     mock_request = Mock(spec=Request)
     mock_request.query_params = {}  # Set mock query_params to an empty dictionary
     mock_request.headers = {"traceparent": "test_traceparent"}
+    mock_request.state = State()  # Real State so _safe_get_request_headers caching works
     monkeypatch.setattr(
         "litellm.proxy.litellm_pre_call_utils.add_litellm_data_to_request", mock_request
     )
@@ -810,6 +812,7 @@ async def test_add_litellm_data_to_request_duplicate_tags(
     mock_request.url.path = "/chat/completions"
     mock_request.query_params = {}
     mock_request.headers = {}
+    mock_request.state = State()
 
     # Setup key with tags in metadata
     user_api_key_dict = UserAPIKeyAuth(


### PR DESCRIPTION
## Summary
- Adds `mock_request.state = State()` to both `Mock(spec=Request)` instances in `test_proxy_utils.py`
- The `_safe_get_request_headers` caching (commit e7175a52) checks `request.state._cached_headers`, but `Mock(spec=Request)` returns a Mock for `state`, causing `getattr(state, "_cached_headers", None)` to return a Mock (truthy) instead of `None`
- `RedactedDict` then receives a Mock and fails with `Mock.keys() returned a non-iterable`

## Test plan
- [x] All 169 tests in `tests/proxy_unit_tests/test_proxy_utils.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)