### PR TITLE
Fix ProxyException string representation - returns empty string instead of message

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3231,6 +3231,9 @@ class ProxyException(Exception):
                     headers[k] = str(v)
         self.headers = headers or {}
         self.provider_specific_fields = provider_specific_fields
+        # Call parent constructor with message so str(exception) returns the message
+        # Fixes: https://github.com/BerriAI/litellm/issues/22644
+        super().__init__(self.message)
         # rules for proxyExceptions
         # Litellm router.py returns "No healthy deployment available" when there are no deployments available
         # Should map to 429 errors https://github.com/BerriAI/litellm/issues/2487


### PR DESCRIPTION
## Summary

Fixes #22644

When `ProxyException` is converted to a string, it was returning an empty string instead of the error message.

## Problem

```python
from litellm.proxy._types import ProxyException, ProxyErrorTypes

exc = ProxyException(
    message="this is an error",
    type=ProxyErrorTypes.bad_request_error.value,
    param="key_alias"
)
print(str(exc))  # Output: '' (empty string)
```

## Root Cause

The `ProxyException.__init__` method stores the message in `self.message` but never calls `super().__init__(message)`. This means the base `Exception` class doesn't have access to the message, so `str(exception)` returns an empty string.

## Solution

Added `super().__init__(self.message)` call in the `__init__` method to properly initialize the parent `Exception` class with the message.

## Testing

```python
# Before fix
exc = ProxyException(message="this is an error", type="bad_request_error", param="key_alias")
print(str(exc))  # Output: ''

# After fix  
print(str(exc))  # Output: 'this is an error'
```

## Impact

- **Low risk**: Minimal change, only adds parent constructor call
- **Backwards compatible**: All existing functionality preserved
- **High value**: Fixes a critical debugging/logging issue in a 37k star production library
- **No breaking changes**: `to_dict()` and all attributes work exactly as before