### PR TITLE
fix(proxy): preserve interactions agent field semantics

### DIFF
--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -277,13 +277,11 @@ async def create_interaction(
 
     data = await _read_request_body(request=request)
 
-    # `agent` and `model` are mutually exclusive in the Interactions API.
-    # Sending both is ambiguous - reject early with a clear error.
+    # When both `agent` and `model` are provided, `agent` takes precedence
+    # for routing. Drop `model` so downstream code doesn't send a conflicting
+    # field to the provider.
     if data.get("agent") and data.get("model"):
-        raise HTTPException(
-            status_code=400,
-            detail="'agent' and 'model' are mutually exclusive. Provide one or the other, not both.",
-        )
+        data.pop("model")
 
     # Default to gemini provider for interactions
     if "custom_llm_provider" not in data:
@@ -307,8 +305,8 @@ async def create_interaction(
             # If we pass an agent id via `model`, downstream transformation
             # sends `{"model": "deep-research-..."}` instead of
             # `{"agent": "deep-research-..."}`, which Google rejects.
-            # When both are present, `model` is used for routing; `agent`
-            # remains in `data` and is forwarded as-is to the provider.
+            # When `agent` is set it takes precedence: `model` is dropped
+            # above, so data.get("model") returns None for agent requests.
             model=data.get("model"),
             user_model=user_model,
             user_temperature=user_temperature,

--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -293,7 +293,13 @@ async def create_interaction(
             general_settings=general_settings,
             proxy_config=proxy_config,
             select_data_generator=select_data_generator,
-            model=data.get("model") or data.get("agent"),
+            # IMPORTANT: Do not map `agent` into `model`.
+            #
+            # Google Interactions API requires these as distinct mutually-exclusive
+            # fields. If we pass an agent id via `model`, downstream transformation
+            # sends `{"model": "deep-research-..."}` instead of
+            # `{"agent": "deep-research-..."}`, which Google rejects.
+            model=data.get("model"),
             user_model=user_model,
             user_temperature=user_temperature,
             user_request_timeout=user_request_timeout,

--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -277,6 +277,14 @@ async def create_interaction(
 
     data = await _read_request_body(request=request)
 
+    # `agent` and `model` are mutually exclusive in the Interactions API.
+    # Sending both is ambiguous - reject early with a clear error.
+    if data.get("agent") and data.get("model"):
+        raise HTTPException(
+            status_code=400,
+            detail="'agent' and 'model' are mutually exclusive. Provide one or the other, not both.",
+        )
+
     # Default to gemini provider for interactions
     if "custom_llm_provider" not in data:
         data["custom_llm_provider"] = "gemini"

--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -295,10 +295,12 @@ async def create_interaction(
             select_data_generator=select_data_generator,
             # IMPORTANT: Do not map `agent` into `model`.
             #
-            # Google Interactions API requires these as distinct mutually-exclusive
-            # fields. If we pass an agent id via `model`, downstream transformation
+            # Google Interactions API treats these as distinct fields.
+            # If we pass an agent id via `model`, downstream transformation
             # sends `{"model": "deep-research-..."}` instead of
             # `{"agent": "deep-research-..."}`, which Google rejects.
+            # When both are present, `model` is used for routing; `agent`
+            # remains in `data` and is forwarded as-is to the provider.
             model=data.get("model"),
             user_model=user_model,
             user_temperature=user_temperature,

--- a/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
@@ -1,8 +1,8 @@
 """
 Regression tests for Google Interactions endpoint parameter handling.
 
-These tests ensure agent and model are handled correctly for
-create interaction calls, including mutual exclusivity validation.
+Tests that agent and model are handled correctly for create interaction
+calls. When both are provided, agent takes precedence (non-breaking).
 """
 
 import sys
@@ -25,7 +25,6 @@ def _build_test_client():
 
     app = FastAPI()
     app.include_router(google_router)
-    # Override auth dependency so tests do not require a real API key
     app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(api_key="fake-key")
     return TestClient(app)
 
@@ -50,14 +49,10 @@ def _patch_endpoint_dependencies():
 
 class TestInteractionsAgentParameter:
 
-    def test_route_type_in_skip_model_routing_list(self):
-        skip = ["acreate_interaction", "aget_interaction", "adelete_interaction", "acancel_interaction"]
-        assert "acreate_interaction" in skip
-
     @pytest.mark.parametrize(
         "request_body, expected_model",
         [
-            pytest.param({"agent": "deep-research-pro-preview-12-2025", "input": "Research", "background": True}, None, id="agent-only"),
+            pytest.param({"agent": "deep-research-pro-preview-12-2025", "input": "Research", "background": True}, "deep-research-pro-preview-12-2025", id="agent-only"),
             pytest.param({"model": "gemini/gemini-2.5-flash", "input": "Hello"}, "gemini/gemini-2.5-flash", id="model-only"),
             pytest.param({"input": "Test"}, None, id="neither"),
         ],
@@ -73,12 +68,18 @@ class TestInteractionsAgentParameter:
             assert response.status_code == 200
             assert mock.call_args.kwargs["model"] == expected_model
 
-    def test_both_agent_and_model_returns_400(self):
+    def test_both_agent_and_model_agent_takes_precedence(self):
+        """When both agent and model are provided, agent wins (non-breaking)."""
         client = _build_test_client()
-        with _patch_endpoint_dependencies():
+        with _patch_endpoint_dependencies(), patch(
+            "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request",
+            new_callable=AsyncMock,
+        ) as mock:
+            mock.return_value = {"id": "int_test", "status": "created"}
             response = client.post(
                 "/v1beta/interactions",
                 json={"model": "gemini/gemini-2.5-flash", "agent": "deep-research-pro-preview-12-2025", "input": "Test"},
                 headers={"Authorization": "Bearer sk-test"},
             )
-            assert response.status_code == 400
+            assert response.status_code == 200
+            assert mock.call_args.kwargs["model"] == "deep-research-pro-preview-12-2025"

--- a/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
@@ -4,13 +4,13 @@ Regression tests for Google Interactions endpoint parameter handling.
 These tests ensure `agent` is NOT remapped into `model` for create interaction calls.
 """
 
-import os
 import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../.."))
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
 
 def _build_test_client():
@@ -49,88 +49,46 @@ def _patch_proxy_server_dependencies():
     )
 
 
-def test_interactions_agent_only_keeps_model_none():
-    """
-    If request contains only `agent`, endpoint must pass `model=None` to processing.
-
-    This prevents accidental payload translation to `{"model": "deep-research-..."}`.
-    """
+@pytest.mark.parametrize(
+    "request_body, expected_model",
+    [
+        pytest.param(
+            {"agent": "deep-research-pro-preview-12-2025", "input": "Research quantum computing", "background": True},
+            None,
+            id="agent-only-model-none",
+        ),
+        pytest.param(
+            {"model": "gemini/gemini-2.5-flash", "input": "Hello world"},
+            "gemini/gemini-2.5-flash",
+            id="model-only-forwarded",
+        ),
+        pytest.param(
+            {"model": "gemini/gemini-2.5-flash", "agent": "deep-research-pro-preview-12-2025", "input": "Test both"},
+            "gemini/gemini-2.5-flash",
+            id="both-model-takes-precedence",
+        ),
+        pytest.param(
+            {"input": "Test with no model or agent"},
+            None,
+            id="neither-model-is-none",
+        ),
+    ],
+)
+def test_interactions_model_routing(request_body, expected_model):
+    """Verify model kwarg passed to base_process_llm_request for various inputs."""
     client = _build_test_client()
 
     with _patch_proxy_server_dependencies(), patch(
         "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request",
         new_callable=AsyncMock,
     ) as mock_base_process:
-        mock_base_process.return_value = {"id": "int_123", "status": "created"}
+        mock_base_process.return_value = {"id": "int_test", "status": "created"}
 
         response = client.post(
             "/v1beta/interactions",
-            json={
-                "agent": "deep-research-pro-preview-12-2025",
-                "input": "Research quantum computing",
-                "background": True,
-            },
+            json=request_body,
             headers={"Authorization": "Bearer sk-test-key"},
         )
 
         assert response.status_code == 200
-        assert response.json() == {"id": "int_123", "status": "created"}
-
-        call_kwargs = mock_base_process.call_args.kwargs
-
-        assert call_kwargs["route_type"] == "acreate_interaction"
-        assert call_kwargs["model"] is None
-
-
-def test_interactions_model_is_forwarded_when_provided():
-    """If request contains `model`, endpoint must forward it as processing model."""
-    client = _build_test_client()
-
-    with _patch_proxy_server_dependencies(), patch(
-        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request",
-        new_callable=AsyncMock,
-    ) as mock_base_process:
-        mock_base_process.return_value = {"id": "int_456", "status": "created"}
-
-        response = client.post(
-            "/v1beta/interactions",
-            json={
-                "model": "gemini/gemini-2.5-flash",
-                "input": "Hello world",
-            },
-            headers={"Authorization": "Bearer sk-test-key"},
-        )
-
-        assert response.status_code == 200
-        assert response.json() == {"id": "int_456", "status": "created"}
-
-        call_kwargs = mock_base_process.call_args.kwargs
-        assert call_kwargs["model"] == "gemini/gemini-2.5-flash"
-
-
-def test_interactions_model_takes_precedence_when_both_present():
-    """If both model and agent are provided, model is the routing model argument."""
-    client = _build_test_client()
-
-    with _patch_proxy_server_dependencies(), patch(
-        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request",
-        new_callable=AsyncMock,
-    ) as mock_base_process:
-        mock_base_process.return_value = {"id": "int_789", "status": "created"}
-
-        response = client.post(
-            "/v1beta/interactions",
-            json={
-                "model": "gemini/gemini-2.5-flash",
-                "agent": "deep-research-pro-preview-12-2025",
-                "input": "Test both",
-            },
-            headers={"Authorization": "Bearer sk-test-key"},
-        )
-
-        assert response.status_code == 200
-        assert response.json() == {"id": "int_789", "status": "created"}
-
-        call_kwargs = mock_base_process.call_args.kwargs
-
-        assert call_kwargs["model"] == "gemini/gemini-2.5-flash"
+        assert mock_base_process.call_args.kwargs["model"] == expected_model

--- a/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
@@ -52,7 +52,7 @@ class TestInteractionsAgentParameter:
     @pytest.mark.parametrize(
         "request_body, expected_model",
         [
-            pytest.param({"agent": "deep-research-pro-preview-12-2025", "input": "Research", "background": True}, "deep-research-pro-preview-12-2025", id="agent-only"),
+            pytest.param({"agent": "deep-research-pro-preview-12-2025", "input": "Research", "background": True}, None, id="agent-only"),
             pytest.param({"model": "gemini/gemini-2.5-flash", "input": "Hello"}, "gemini/gemini-2.5-flash", id="model-only"),
             pytest.param({"input": "Test"}, None, id="neither"),
         ],
@@ -67,9 +67,12 @@ class TestInteractionsAgentParameter:
             response = client.post("/v1beta/interactions", json=request_body, headers={"Authorization": "Bearer sk-test"})
             assert response.status_code == 200
             assert mock.call_args.kwargs["model"] == expected_model
+            # When agent is provided, verify it's preserved in the forwarded data
+            if "agent" in request_body:
+                assert request_body["agent"] in str(mock.call_args)
 
     def test_both_agent_and_model_agent_takes_precedence(self):
-        """When both agent and model are provided, agent wins (non-breaking)."""
+        """When both agent and model are provided, agent wins — model is dropped."""
         client = _build_test_client()
         with _patch_endpoint_dependencies(), patch(
             "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request",
@@ -82,4 +85,7 @@ class TestInteractionsAgentParameter:
                 headers={"Authorization": "Bearer sk-test"},
             )
             assert response.status_code == 200
-            assert mock.call_args.kwargs["model"] == "deep-research-pro-preview-12-2025"
+            # model is dropped when agent is present
+            assert mock.call_args.kwargs["model"] is None
+            # agent must be preserved in forwarded data
+            assert "deep-research-pro-preview-12-2025" in str(mock.call_args)

--- a/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
@@ -50,16 +50,6 @@ def _patch_endpoint_dependencies():
 
 class TestInteractionsAgentParameter:
 
-    def test_agent_parameter_fallback_logic(self):
-        data = {"agent": "deep-research-pro-preview-12-2025", "input": "Research", "background": True}
-        assert (data.get("model") or data.get("agent")) == "deep-research-pro-preview-12-2025"
-
-        data = {"model": "gemini-2.5-flash", "input": "Hello world"}
-        assert (data.get("model") or data.get("agent")) == "gemini-2.5-flash"
-
-        data = {"input": "Test"}
-        assert (data.get("model") or data.get("agent")) is None
-
     def test_route_type_in_skip_model_routing_list(self):
         skip = ["acreate_interaction", "aget_interaction", "adelete_interaction", "acancel_interaction"]
         assert "acreate_interaction" in skip
@@ -67,7 +57,7 @@ class TestInteractionsAgentParameter:
     @pytest.mark.parametrize(
         "request_body, expected_model",
         [
-            pytest.param({"agent": "deep-research-pro-preview-12-2025", "input": "Research", "background": True}, "deep-research-pro-preview-12-2025", id="agent-only"),
+            pytest.param({"agent": "deep-research-pro-preview-12-2025", "input": "Research", "background": True}, None, id="agent-only"),
             pytest.param({"model": "gemini/gemini-2.5-flash", "input": "Hello"}, "gemini/gemini-2.5-flash", id="model-only"),
             pytest.param({"input": "Test"}, None, id="neither"),
         ],

--- a/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
@@ -1,7 +1,8 @@
 """
 Regression tests for Google Interactions endpoint parameter handling.
 
-These tests ensure `agent` is NOT remapped into `model` for create interaction calls.
+These tests ensure agent and model are handled correctly for
+create interaction calls, including mutual exclusivity validation.
 """
 
 import sys
@@ -17,24 +18,22 @@ def _build_test_client():
     try:
         from fastapi import FastAPI
         from fastapi.testclient import TestClient
-
+        from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth, user_api_key_auth
         from litellm.proxy.google_endpoints.endpoints import router as google_router
     except ImportError as e:
         pytest.skip(f"Skipping test due to missing dependency: {e}")
 
     app = FastAPI()
     app.include_router(google_router)
+    # Override auth dependency so tests do not require a real API key
+    app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(api_key="fake-key")
     return TestClient(app)
 
 
-def _patch_proxy_server_dependencies():
-    """
-    Patch proxy_server globals imported inside create_interaction endpoint.
-
-    We patch only to make endpoint invocation deterministic for unit tests.
-    """
+def _patch_endpoint_dependencies():
+    """Patch proxy_server globals on the endpoints module where names are read."""
     return patch.multiple(
-        "litellm.proxy.proxy_server",
+        "litellm.proxy.google_endpoints.endpoints",
         general_settings={},
         llm_router=object(),
         proxy_config=object(),
@@ -49,46 +48,47 @@ def _patch_proxy_server_dependencies():
     )
 
 
-@pytest.mark.parametrize(
-    "request_body, expected_model",
-    [
-        pytest.param(
-            {"agent": "deep-research-pro-preview-12-2025", "input": "Research quantum computing", "background": True},
-            None,
-            id="agent-only-model-none",
-        ),
-        pytest.param(
-            {"model": "gemini/gemini-2.5-flash", "input": "Hello world"},
-            "gemini/gemini-2.5-flash",
-            id="model-only-forwarded",
-        ),
-        pytest.param(
-            {"model": "gemini/gemini-2.5-flash", "agent": "deep-research-pro-preview-12-2025", "input": "Test both"},
-            "gemini/gemini-2.5-flash",
-            id="both-model-takes-precedence",
-        ),
-        pytest.param(
-            {"input": "Test with no model or agent"},
-            None,
-            id="neither-model-is-none",
-        ),
-    ],
-)
-def test_interactions_model_routing(request_body, expected_model):
-    """Verify model kwarg passed to base_process_llm_request for various inputs."""
-    client = _build_test_client()
+class TestInteractionsAgentParameter:
 
-    with _patch_proxy_server_dependencies(), patch(
-        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request",
-        new_callable=AsyncMock,
-    ) as mock_base_process:
-        mock_base_process.return_value = {"id": "int_test", "status": "created"}
+    def test_agent_parameter_fallback_logic(self):
+        data = {"agent": "deep-research-pro-preview-12-2025", "input": "Research", "background": True}
+        assert (data.get("model") or data.get("agent")) == "deep-research-pro-preview-12-2025"
 
-        response = client.post(
-            "/v1beta/interactions",
-            json=request_body,
-            headers={"Authorization": "Bearer sk-test-key"},
-        )
+        data = {"model": "gemini-2.5-flash", "input": "Hello world"}
+        assert (data.get("model") or data.get("agent")) == "gemini-2.5-flash"
 
-        assert response.status_code == 200
-        assert mock_base_process.call_args.kwargs["model"] == expected_model
+        data = {"input": "Test"}
+        assert (data.get("model") or data.get("agent")) is None
+
+    def test_route_type_in_skip_model_routing_list(self):
+        skip = ["acreate_interaction", "aget_interaction", "adelete_interaction", "acancel_interaction"]
+        assert "acreate_interaction" in skip
+
+    @pytest.mark.parametrize(
+        "request_body, expected_model",
+        [
+            pytest.param({"agent": "deep-research-pro-preview-12-2025", "input": "Research", "background": True}, "deep-research-pro-preview-12-2025", id="agent-only"),
+            pytest.param({"model": "gemini/gemini-2.5-flash", "input": "Hello"}, "gemini/gemini-2.5-flash", id="model-only"),
+            pytest.param({"input": "Test"}, None, id="neither"),
+        ],
+    )
+    def test_interactions_model_routing(self, request_body, expected_model):
+        client = _build_test_client()
+        with _patch_endpoint_dependencies(), patch(
+            "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request",
+            new_callable=AsyncMock,
+        ) as mock:
+            mock.return_value = {"id": "int_test", "status": "created"}
+            response = client.post("/v1beta/interactions", json=request_body, headers={"Authorization": "Bearer sk-test"})
+            assert response.status_code == 200
+            assert mock.call_args.kwargs["model"] == expected_model
+
+    def test_both_agent_and_model_returns_400(self):
+        client = _build_test_client()
+        with _patch_endpoint_dependencies():
+            response = client.post(
+                "/v1beta/interactions",
+                json={"model": "gemini/gemini-2.5-flash", "agent": "deep-research-pro-preview-12-2025", "input": "Test"},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert response.status_code == 400

--- a/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py
@@ -1,75 +1,136 @@
 """
-Test for interactions endpoint agent parameter handling.
+Regression tests for Google Interactions endpoint parameter handling.
 
-Tests that the /v1beta/interactions endpoint correctly extracts
-the `agent` parameter as a fallback when `model` is not provided.
+These tests ensure `agent` is NOT remapped into `model` for create interaction calls.
 """
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+sys.path.insert(0, os.path.abspath("../../.."))
 
-class TestInteractionsAgentParameter:
-    """Test agent parameter handling in interactions endpoint."""
 
-    def test_agent_parameter_fallback_logic(self):
-        """
-        Test the core logic: model or agent extraction.
+def _build_test_client():
+    try:
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
 
-        This tests the fix in endpoints.py line ~267:
-        model=data.get("model") or data.get("agent")
-        """
-        # Case 1: Only agent provided (Deep Research use case)
-        data = {
-            "agent": "deep-research-pro-preview-12-2025",
-            "input": "Research quantum computing",
-            "background": True,
-        }
-        model = data.get("model") or data.get("agent")
-        assert model == "deep-research-pro-preview-12-2025"
+        from litellm.proxy.google_endpoints.endpoints import router as google_router
+    except ImportError as e:
+        pytest.skip(f"Skipping test due to missing dependency: {e}")
 
-        # Case 2: Only model provided (normal use case)
-        data = {
-            "model": "gemini-2.5-flash",
-            "input": "Hello world",
-        }
-        model = data.get("model") or data.get("agent")
-        assert model == "gemini-2.5-flash"
+    app = FastAPI()
+    app.include_router(google_router)
+    return TestClient(app)
 
-        # Case 3: Both provided (model takes precedence)
-        data = {
-            "model": "gemini-2.5-flash",
-            "agent": "deep-research-pro-preview-12-2025",
-            "input": "Test",
-        }
-        model = data.get("model") or data.get("agent")
-        assert model == "gemini-2.5-flash"
 
-        # Case 4: Neither provided
-        data = {
-            "input": "Test",
-        }
-        model = data.get("model") or data.get("agent")
-        assert model is None
+def _patch_proxy_server_dependencies():
+    """
+    Patch proxy_server globals imported inside create_interaction endpoint.
 
-    def test_route_type_in_skip_model_routing_list(self):
-        """
-        Test that acreate_interaction is in the list of routes
-        that skip model-based routing.
+    We patch only to make endpoint invocation deterministic for unit tests.
+    """
+    return patch.multiple(
+        "litellm.proxy.proxy_server",
+        general_settings={},
+        llm_router=object(),
+        proxy_config=object(),
+        proxy_logging_obj=object(),
+        select_data_generator=None,
+        user_api_base=None,
+        user_max_tokens=None,
+        user_model=None,
+        user_request_timeout=None,
+        user_temperature=None,
+        version="test-version",
+    )
 
-        This tests the fix in route_llm_request.py.
-        """
-        # The list of routes that skip model routing for interactions
-        skip_model_routing_routes = [
-            "acreate_interaction",
-            "aget_interaction",
-            "adelete_interaction",
-            "acancel_interaction",
-        ]
 
-        # acreate_interaction should be in the list (this is the fix)
-        assert "acreate_interaction" in skip_model_routing_routes
+def test_interactions_agent_only_keeps_model_none():
+    """
+    If request contains only `agent`, endpoint must pass `model=None` to processing.
 
-        # All interaction routes should be covered
-        assert "aget_interaction" in skip_model_routing_routes
-        assert "adelete_interaction" in skip_model_routing_routes
-        assert "acancel_interaction" in skip_model_routing_routes
+    This prevents accidental payload translation to `{"model": "deep-research-..."}`.
+    """
+    client = _build_test_client()
+
+    with _patch_proxy_server_dependencies(), patch(
+        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request",
+        new_callable=AsyncMock,
+    ) as mock_base_process:
+        mock_base_process.return_value = {"id": "int_123", "status": "created"}
+
+        response = client.post(
+            "/v1beta/interactions",
+            json={
+                "agent": "deep-research-pro-preview-12-2025",
+                "input": "Research quantum computing",
+                "background": True,
+            },
+            headers={"Authorization": "Bearer sk-test-key"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"id": "int_123", "status": "created"}
+
+        call_kwargs = mock_base_process.call_args.kwargs
+
+        assert call_kwargs["route_type"] == "acreate_interaction"
+        assert call_kwargs["model"] is None
+
+
+def test_interactions_model_is_forwarded_when_provided():
+    """If request contains `model`, endpoint must forward it as processing model."""
+    client = _build_test_client()
+
+    with _patch_proxy_server_dependencies(), patch(
+        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request",
+        new_callable=AsyncMock,
+    ) as mock_base_process:
+        mock_base_process.return_value = {"id": "int_456", "status": "created"}
+
+        response = client.post(
+            "/v1beta/interactions",
+            json={
+                "model": "gemini/gemini-2.5-flash",
+                "input": "Hello world",
+            },
+            headers={"Authorization": "Bearer sk-test-key"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"id": "int_456", "status": "created"}
+
+        call_kwargs = mock_base_process.call_args.kwargs
+        assert call_kwargs["model"] == "gemini/gemini-2.5-flash"
+
+
+def test_interactions_model_takes_precedence_when_both_present():
+    """If both model and agent are provided, model is the routing model argument."""
+    client = _build_test_client()
+
+    with _patch_proxy_server_dependencies(), patch(
+        "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing.base_process_llm_request",
+        new_callable=AsyncMock,
+    ) as mock_base_process:
+        mock_base_process.return_value = {"id": "int_789", "status": "created"}
+
+        response = client.post(
+            "/v1beta/interactions",
+            json={
+                "model": "gemini/gemini-2.5-flash",
+                "agent": "deep-research-pro-preview-12-2025",
+                "input": "Test both",
+            },
+            headers={"Authorization": "Bearer sk-test-key"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"id": "int_789", "status": "created"}
+
+        call_kwargs = mock_base_process.call_args.kwargs
+
+        assert call_kwargs["model"] == "gemini/gemini-2.5-flash"


### PR DESCRIPTION
## Summary
- Fix Google Interactions create endpoint to avoid mapping agent into model
- Preserve agent-only requests so payloads are sent with agent field (not model)
- Add endpoint-level regression tests for agent-only/model-only/both cases

## Why
Deep Research agent requests were being converted to model=<agent-id>, which Google rejects with: This requested model refers to an agent, but was provided in the model field.

## Validation
- pytest tests/test_litellm/proxy/google_endpoints/test_interactions_agent_param.py -q -rA
- pytest tests/test_litellm/proxy/google_endpoints -q

Closes #22694