### PR TITLE
fix(mcp): preserve ProxyException status/details in handlers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2447,7 +2447,7 @@ if MCP_AVAILABLE:
                 verbose_logger.exception(
                     f"Failed to send ProxyException error response: {response_error}"
                 )
-                raise
+                raise e from response_error
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Instead of re-raising, try to send a graceful error response
@@ -2466,7 +2466,7 @@ if MCP_AVAILABLE:
                     f"Failed to send error response: {response_error}"
                 )
                 # If we can't send a proper response, re-raise the original error
-                raise
+                raise e from response_error
 
     app = FastAPI(
         title=LITELLM_MCP_SERVER_NAME,

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2262,7 +2262,7 @@ if MCP_AVAILABLE:
         HTTP 500 responses in MCP handlers.
         """
         try:
-            status_code = int(str(e.code))
+            status_code = int(e.code)
         except (TypeError, ValueError):
             status_code = 500
 
@@ -2376,7 +2376,7 @@ if MCP_AVAILABLE:
                 verbose_logger.exception(
                     f"Failed to send ProxyException error response: {response_error}"
                 )
-                raise e
+                raise
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Try to send a graceful error response for non-HTTP exceptions
@@ -2394,7 +2394,7 @@ if MCP_AVAILABLE:
                     f"Failed to send error response: {response_error}"
                 )
                 # If we can't send a proper response, re-raise the original error
-                raise e
+                raise
 
     async def handle_sse_mcp(scope: Scope, receive: Receive, send: Send) -> None:
         """Handle MCP requests through SSE."""
@@ -2433,6 +2433,8 @@ if MCP_AVAILABLE:
                 await asyncio.sleep(0.1)
 
             await sse_session_manager.handle_request(scope, receive, send)
+        except HTTPException:
+            raise
         except ProxyException as e:
             verbose_logger.warning(
                 "MCP request failed with ProxyException: %s",
@@ -2445,7 +2447,7 @@ if MCP_AVAILABLE:
                 verbose_logger.exception(
                     f"Failed to send ProxyException error response: {response_error}"
                 )
-                raise e
+                raise
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Instead of re-raising, try to send a graceful error response
@@ -2464,7 +2466,7 @@ if MCP_AVAILABLE:
                     f"Failed to send error response: {response_error}"
                 )
                 # If we can't send a proper response, re-raise the original error
-                raise e
+                raise
 
     app = FastAPI(
         title=LITELLM_MCP_SERVER_NAME,

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -44,7 +44,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     add_server_prefix_to_name,
     get_server_prefix,
 )
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 from litellm.proxy.litellm_pre_call_utils import (
     LiteLLMProxyRequestSetup,
@@ -2254,6 +2254,29 @@ if MCP_AVAILABLE:
         ]
         return False
 
+    def _build_proxy_exception_response(e: ProxyException) -> JSONResponse:
+        """
+        Convert ProxyException to JSONResponse while preserving status + payload.
+
+        This prevents auth/business ProxyExceptions from being rewritten to generic
+        HTTP 500 responses in MCP handlers.
+        """
+        try:
+            status_code = int(str(e.code))
+        except (TypeError, ValueError):
+            status_code = 500
+
+        response = JSONResponse(
+            status_code=status_code,
+            content={"error": e.to_dict()},
+        )
+
+        if e.headers:
+            for header_key, header_value in e.headers.items():
+                response.headers[header_key] = header_value
+
+        return response
+
     async def handle_streamable_http_mcp(
         scope: Scope, receive: Receive, send: Send
     ) -> None:
@@ -2341,6 +2364,19 @@ if MCP_AVAILABLE:
         except HTTPException:
             # Re-raise HTTP exceptions to preserve status codes and details
             raise
+        except ProxyException as e:
+            verbose_logger.warning(
+                "MCP request failed with ProxyException: %s",
+                getattr(e, "message", str(e)),
+            )
+            try:
+                error_response = _build_proxy_exception_response(e)
+                await error_response(scope, receive, send)
+            except Exception as response_error:
+                verbose_logger.exception(
+                    f"Failed to send ProxyException error response: {response_error}"
+                )
+                raise e
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Try to send a graceful error response for non-HTTP exceptions
@@ -2397,6 +2433,19 @@ if MCP_AVAILABLE:
                 await asyncio.sleep(0.1)
 
             await sse_session_manager.handle_request(scope, receive, send)
+        except ProxyException as e:
+            verbose_logger.warning(
+                "MCP request failed with ProxyException: %s",
+                getattr(e, "message", str(e)),
+            )
+            try:
+                error_response = _build_proxy_exception_response(e)
+                await error_response(scope, receive, send)
+            except Exception as response_error:
+                verbose_logger.exception(
+                    f"Failed to send ProxyException error response: {response_error}"
+                )
+                raise e
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Instead of re-raising, try to send a graceful error response

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2374,9 +2374,9 @@ if MCP_AVAILABLE:
                 await error_response(scope, receive, send)
             except Exception as response_error:
                 verbose_logger.exception(
-                    f"Failed to send ProxyException error response: {response_error}"
+                    "Error building response: %s", response_error
                 )
-                raise
+                raise e from response_error  # re-raise original ProxyException
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Try to send a graceful error response for non-HTTP exceptions

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2394,7 +2394,7 @@ if MCP_AVAILABLE:
                     f"Failed to send error response: {response_error}"
                 )
                 # If we can't send a proper response, re-raise the original error
-                raise
+                raise e from response_error
 
     async def handle_sse_mcp(scope: Scope, receive: Receive, send: Send) -> None:
         """Handle MCP requests through SSE."""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_proxy_exception_handling.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_proxy_exception_handling.py
@@ -69,7 +69,7 @@ async def test_streamable_http_preserves_proxy_exception_status_and_payload():
     payload = json.loads(body_msg["body"].decode())
     assert payload["error"]["message"] == "Forbidden by custom auth"
     assert payload["error"]["type"] == "auth_error"
-    assert payload["error"]["code"] == "403"
+    assert int(payload["error"]["code"]) == 403
 
 
 @pytest.mark.asyncio
@@ -112,4 +112,4 @@ async def test_sse_handler_preserves_proxy_exception_status_and_payload():
     payload = json.loads(body_msg["body"].decode())
     assert payload["error"]["message"] == "OAuth token expired"
     assert payload["error"]["type"] == "auth_error"
-    assert payload["error"]["code"] == "401"
+    assert int(payload["error"]["code"]) == 401

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_proxy_exception_handling.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_proxy_exception_handling.py
@@ -1,0 +1,115 @@
+"""
+Regression tests for MCP handler ProxyException response behavior (Issue #22706).
+
+Ensures custom/auth ProxyExceptions are not rewritten to generic 500 responses.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from litellm.proxy._types import ProxyException
+
+
+def _base_scope(path: str = "/mcp"):
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "headers": [(b"content-type", b"application/json")],
+    }
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_preserves_proxy_exception_status_and_payload():
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            handle_streamable_http_mcp,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    scope = _base_scope("/mcp")
+    receive = AsyncMock()
+    sent_messages = []
+
+    async def send(message):
+        sent_messages.append(message)
+
+    proxy_exc = ProxyException(
+        message="Forbidden by custom auth",
+        type="auth_error",
+        param="api_key",
+        code=403,
+        headers={"www-authenticate": "Bearer realm=litellm"},
+    )
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+        new_callable=AsyncMock,
+        side_effect=proxy_exc,
+    ):
+        await handle_streamable_http_mcp(scope, receive, send)
+
+    assert len(sent_messages) >= 2
+
+    start_msg = sent_messages[0]
+    body_msg = sent_messages[1]
+
+    assert start_msg["type"] == "http.response.start"
+    assert start_msg["status"] == 403
+
+    response_headers = {
+        k.decode().lower(): v.decode() for k, v in start_msg.get("headers", [])
+    }
+    assert response_headers.get("www-authenticate") == "Bearer realm=litellm"
+
+    assert body_msg["type"] == "http.response.body"
+    payload = json.loads(body_msg["body"].decode())
+    assert payload["error"]["message"] == "Forbidden by custom auth"
+    assert payload["error"]["type"] == "auth_error"
+    assert payload["error"]["code"] == "403"
+
+
+@pytest.mark.asyncio
+async def test_sse_handler_preserves_proxy_exception_status_and_payload():
+    try:
+        from litellm.proxy._experimental.mcp_server.server import handle_sse_mcp
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    scope = _base_scope("/sse")
+    receive = AsyncMock()
+    sent_messages = []
+
+    async def send(message):
+        sent_messages.append(message)
+
+    proxy_exc = ProxyException(
+        message="OAuth token expired",
+        type="auth_error",
+        param="authorization",
+        code=401,
+    )
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+        new_callable=AsyncMock,
+        side_effect=proxy_exc,
+    ):
+        await handle_sse_mcp(scope, receive, send)
+
+    assert len(sent_messages) >= 2
+
+    start_msg = sent_messages[0]
+    body_msg = sent_messages[1]
+
+    assert start_msg["type"] == "http.response.start"
+    assert start_msg["status"] == 401
+
+    assert body_msg["type"] == "http.response.body"
+    payload = json.loads(body_msg["body"].decode())
+    assert payload["error"]["message"] == "OAuth token expired"
+    assert payload["error"]["type"] == "auth_error"
+    assert payload["error"]["code"] == "401"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_proxy_exception_handling.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_proxy_exception_handling.py
@@ -15,9 +15,15 @@ from litellm.proxy._types import ProxyException
 def _base_scope(path: str = "/mcp"):
     return {
         "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
         "method": "POST",
         "path": path,
         "headers": [(b"content-type", b"application/json")],
+        "query_string": b"",
+        "root_path": "",
+        "server": ("localhost", 8000),
+        "client": ("127.0.0.1", 0),
     }
 
 


### PR DESCRIPTION
## Summary
- Add explicit ProxyException handling in MCP streamable HTTP and SSE handlers
- Preserve original ProxyException status code, error payload, and headers instead of rewriting to generic 500
- Add regression tests for both handlers to validate preserved status/details behavior

## Why
Issue #22706 reports MCP requests converting custom/auth ProxyExceptions into generic 500 responses. This patch preserves intended auth/business semantics (for example 401/403) for MCP requests.

## Validation
- pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_proxy_exception_handling.py -q -rA
- pytest tests/test_litellm/proxy/_experimental/mcp_server -q

Closes #22706