### PR TITLE
fix(agentcore): avoid premature stop on metadata events

### DIFF
--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -543,6 +543,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                             )
                         ]
                         yield chunk
+                        return
 
                 except json.JSONDecodeError:
                     verbose_logger.debug(f"Skipping non-JSON SSE line: {line[:100]}")
@@ -723,6 +724,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                             )
                         ]
                         yield chunk
+                        return
 
                 except json.JSONDecodeError:
                     verbose_logger.debug(f"Skipping non-JSON SSE line: {line[:100]}")

--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -450,7 +450,6 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         """
         Internal sync generator that parses SSE and yields ModelResponse chunks.
         """
-        stop_emitted = False
         buffer = ""
         for text_chunk in response.iter_text():
             buffer += text_chunk
@@ -526,9 +525,8 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                             ))
                             yield chunk
 
-                    # Process final message
+                    # Process final message — exit generator immediately.
                     if "message" in data_obj and isinstance(data_obj["message"], dict):
-                        stop_emitted = True
                         chunk = ModelResponseStream(
                             id=f"chatcmpl-{uuid.uuid4()}",
                             created=0,
@@ -551,21 +549,20 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
 
         # Defensive fallback: emit a stop chunk if the stream ended without
         # a final `message` event (e.g. partial streams, connectivity drops).
-        if not stop_emitted:
-            fallback = ModelResponseStream(
-                id=f"chatcmpl-{uuid.uuid4()}",
-                created=0,
-                model=model,
-                object="chat.completion.chunk",
+        fallback = ModelResponseStream(
+            id=f"chatcmpl-{uuid.uuid4()}",
+            created=0,
+            model=model,
+            object="chat.completion.chunk",
+        )
+        fallback.choices = [
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(),
             )
-            fallback.choices = [
-                StreamingChoices(
-                    finish_reason="stop",
-                    index=0,
-                    delta=Delta(),
-                )
-            ]
-            yield fallback
+        ]
+        yield fallback
 
     def get_sync_custom_stream_wrapper(
         self,
@@ -631,7 +628,6 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         """
         Internal async generator that parses SSE and yields ModelResponse chunks.
         """
-        stop_emitted = False
         buffer = ""
         async for text_chunk in response.aiter_text():
             buffer += text_chunk
@@ -707,9 +703,8 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                             ))
                             yield chunk
 
-                    # Process final message
+                    # Process final message — exit generator immediately.
                     if "message" in data_obj and isinstance(data_obj["message"], dict):
-                        stop_emitted = True
                         chunk = ModelResponseStream(
                             id=f"chatcmpl-{uuid.uuid4()}",
                             created=0,
@@ -732,21 +727,20 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
 
         # Defensive fallback: emit a stop chunk if the stream ended without
         # a final `message` event (e.g. partial streams, connectivity drops).
-        if not stop_emitted:
-            fallback = ModelResponseStream(
-                id=f"chatcmpl-{uuid.uuid4()}",
-                created=0,
-                model=model,
-                object="chat.completion.chunk",
+        fallback = ModelResponseStream(
+            id=f"chatcmpl-{uuid.uuid4()}",
+            created=0,
+            model=model,
+            object="chat.completion.chunk",
+        )
+        fallback.choices = [
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(),
             )
-            fallback.choices = [
-                StreamingChoices(
-                    finish_reason="stop",
-                    index=0,
-                    delta=Delta(),
-                )
-            ]
-            yield fallback
+        ]
+        yield fallback
 
     async def get_async_custom_stream_wrapper(
         self,

--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -450,6 +450,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         """
         Internal sync generator that parses SSE and yields ModelResponse chunks.
         """
+        stop_emitted = False
         buffer = ""
         for text_chunk in response.iter_text():
             buffer += text_chunk
@@ -527,6 +528,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
 
                     # Process final message
                     if "message" in data_obj and isinstance(data_obj["message"], dict):
+                        stop_emitted = True
                         chunk = ModelResponseStream(
                             id=f"chatcmpl-{uuid.uuid4()}",
                             created=0,
@@ -545,6 +547,24 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                 except json.JSONDecodeError:
                     verbose_logger.debug(f"Skipping non-JSON SSE line: {line[:100]}")
                     continue
+
+        # Defensive fallback: emit a stop chunk if the stream ended without
+        # a final `message` event (e.g. partial streams, connectivity drops).
+        if not stop_emitted:
+            fallback = ModelResponseStream(
+                id=f"chatcmpl-{uuid.uuid4()}",
+                created=0,
+                model=model,
+                object="chat.completion.chunk",
+            )
+            fallback.choices = [
+                StreamingChoices(
+                    finish_reason="stop",
+                    index=0,
+                    delta=Delta(),
+                )
+            ]
+            yield fallback
 
     def get_sync_custom_stream_wrapper(
         self,
@@ -610,6 +630,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         """
         Internal async generator that parses SSE and yields ModelResponse chunks.
         """
+        stop_emitted = False
         buffer = ""
         async for text_chunk in response.aiter_text():
             buffer += text_chunk
@@ -687,6 +708,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
 
                     # Process final message
                     if "message" in data_obj and isinstance(data_obj["message"], dict):
+                        stop_emitted = True
                         chunk = ModelResponseStream(
                             id=f"chatcmpl-{uuid.uuid4()}",
                             created=0,
@@ -705,6 +727,24 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                 except json.JSONDecodeError:
                     verbose_logger.debug(f"Skipping non-JSON SSE line: {line[:100]}")
                     continue
+
+        # Defensive fallback: emit a stop chunk if the stream ended without
+        # a final `message` event (e.g. partial streams, connectivity drops).
+        if not stop_emitted:
+            fallback = ModelResponseStream(
+                id=f"chatcmpl-{uuid.uuid4()}",
+                created=0,
+                model=model,
+                object="chat.completion.chunk",
+            )
+            fallback.choices = [
+                StreamingChoices(
+                    finish_reason="stop",
+                    index=0,
+                    delta=Delta(),
+                )
+            ]
+            yield fallback
 
     async def get_async_custom_stream_wrapper(
         self,

--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -499,6 +499,11 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                         # Process metadata/usage
                         metadata = event_payload.get("metadata")
                         if metadata and "usage" in metadata:
+                            # NOTE:
+                            # Metadata events can appear mid-stream (e.g. around
+                            # toolUse/toolResult phases). Marking them as
+                            # finish_reason="stop" can prematurely terminate
+                            # streaming before final content arrives.
                             chunk = ModelResponseStream(
                                 id=f"chatcmpl-{uuid.uuid4()}",
                                 created=0,
@@ -507,7 +512,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                             )
                             chunk.choices = [
                                 StreamingChoices(
-                                    finish_reason="stop",
+                                    finish_reason=None,
                                     index=0,
                                     delta=Delta(),
                                 )
@@ -654,6 +659,11 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                         # Process metadata/usage
                         metadata = event_payload.get("metadata")
                         if metadata and "usage" in metadata:
+                            # NOTE:
+                            # Metadata events can appear mid-stream (e.g. around
+                            # toolUse/toolResult phases). Marking them as
+                            # finish_reason="stop" can prematurely terminate
+                            # streaming before final content arrives.
                             chunk = ModelResponseStream(
                                 id=f"chatcmpl-{uuid.uuid4()}",
                                 created=0,
@@ -662,7 +672,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                             )
                             chunk.choices = [
                                 StreamingChoices(
-                                    finish_reason="stop",
+                                    finish_reason=None,
                                     index=0,
                                     delta=Delta(),
                                 )

--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -149,6 +149,13 @@ class TestAgentCoreStreamingToolFlow:
         for chunk in chunks[:-1]:
             assert chunk.choices[0].finish_reason is None
 
+        # Verify toolUse event doesn't produce unexpected finish_reason
+        assert not any(
+            getattr(c.choices[0], "finish_reason", None) == "tool_use"
+            for c in chunks
+            if c.choices
+        )
+
         content_parts = [
             chunk.choices[0].delta.content
             for chunk in chunks
@@ -183,9 +190,18 @@ class TestAgentCoreStreamingToolFlow:
         for chunk in chunks[:-1]:
             assert chunk.choices[0].finish_reason is None
 
+        # Verify toolUse event doesn't produce unexpected finish_reason
+        assert not any(
+            getattr(c.choices[0], "finish_reason", None) == "tool_use"
+            for c in chunks
+            if c.choices
+        )
+
         content_parts = [
             chunk.choices[0].delta.content
             for chunk in chunks
             if chunk.choices[0].delta.content
         ]
         assert "".join(content_parts) == "Let me check weather. Here are results."
+
+        assert any(getattr(chunk, "usage", None) is not None for chunk in chunks)

--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -134,7 +134,9 @@ class TestAgentCoreStreamingToolFlow:
         ):
             chunks.append(chunk)
 
-        assert len(chunks) >= 3
+        # 2 content deltas + 1 metadata + 1 final message = 4 chunks;
+        # toolUse event should not produce an extra chunk.
+        assert len(chunks) == 4
 
         stop_indices = [
             i
@@ -142,6 +144,10 @@ class TestAgentCoreStreamingToolFlow:
             if chunk.choices[0].finish_reason == "stop"
         ]
         assert stop_indices == [len(chunks) - 1]
+
+        # Ensure toolUse event does not produce a chunk with unexpected finish_reason
+        for chunk in chunks[:-1]:
+            assert chunk.choices[0].finish_reason is None
 
         content_parts = [
             chunk.choices[0].delta.content
@@ -163,7 +169,8 @@ class TestAgentCoreStreamingToolFlow:
             )
         )
 
-        assert len(chunks) >= 3
+        # 2 content deltas + 1 metadata + 1 final message = 4 chunks
+        assert len(chunks) == 4
 
         stop_indices = [
             i
@@ -171,6 +178,10 @@ class TestAgentCoreStreamingToolFlow:
             if chunk.choices[0].finish_reason == "stop"
         ]
         assert stop_indices == [len(chunks) - 1]
+
+        # Ensure toolUse event does not produce a chunk with unexpected finish_reason
+        for chunk in chunks[:-1]:
+            assert chunk.choices[0].finish_reason is None
 
         content_parts = [
             chunk.choices[0].delta.content

--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -205,3 +205,50 @@ class TestAgentCoreStreamingToolFlow:
         assert "".join(content_parts) == "Let me check weather. Here are results."
 
         assert any(getattr(chunk, "usage", None) is not None for chunk in chunks)
+
+
+class TestAgentCoreStreamFallbackStop:
+    """Verify a synthetic stop chunk is emitted when the stream ends without a `message` event."""
+
+    @pytest.fixture
+    def config(self):
+        return AmazonAgentCoreConfig()
+
+    @staticmethod
+    def _build_no_message_sse() -> str:
+        """SSE payload that has content and metadata but no final `message` event."""
+        return (
+            'data: {"event":{"contentBlockDelta":{"delta":{"text":"partial output"}}}}\n'
+            'data: {"event":{"metadata":{"usage":{"inputTokens":5,"outputTokens":2,"totalTokens":7}}}}\n'
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_fallback_stop_on_missing_message(self, config):
+        """Async stream emits a fallback finish_reason='stop' when no message event arrives."""
+        response = _FakeAsyncTextResponse([self._build_no_message_sse()])
+
+        chunks = []
+        async for chunk in config._stream_agentcore_response(
+            response=response,
+            model="bedrock/agentcore/test-runtime",
+        ):
+            chunks.append(chunk)
+
+        assert len(chunks) == 3  # content + metadata + fallback stop
+        assert chunks[-1].choices[0].finish_reason == "stop"
+        assert chunks[-1].choices[0].delta.content is None
+
+    def test_sync_fallback_stop_on_missing_message(self, config):
+        """Sync stream emits a fallback finish_reason='stop' when no message event arrives."""
+        response = _FakeSyncTextResponse([self._build_no_message_sse()])
+
+        chunks = list(
+            config._stream_agentcore_response_sync(
+                response=response,
+                model="bedrock/agentcore/test-runtime",
+            )
+        )
+
+        assert len(chunks) == 3  # content + metadata + fallback stop
+        assert chunks[-1].choices[0].finish_reason == "stop"
+        assert chunks[-1].choices[0].delta.content is None

--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -20,6 +20,24 @@ import litellm
 from litellm.llms.bedrock.chat.agentcore.transformation import AmazonAgentCoreConfig
 
 
+class _FakeAsyncTextResponse:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def aiter_text(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeSyncTextResponse:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def iter_text(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
 class TestAgentCoreAcceptHeader:
     """Tests for Accept header in AgentCore requests."""
 
@@ -81,3 +99,82 @@ class TestAgentCoreAcceptHeader:
             headers = mock_post.call_args.kwargs["headers"]
             assert "Accept" in headers
             assert headers["Accept"] == "application/json, text/event-stream"
+
+
+class TestAgentCoreStreamingToolFlow:
+    """Regression tests for tool-flow streaming ordering in AgentCore."""
+
+    @pytest.fixture
+    def config(self):
+        return AmazonAgentCoreConfig()
+
+    def _build_tool_flow_sse(self) -> str:
+        return (
+            'data: {"event":{"contentBlockDelta":{"delta":{"text":"Let me check weather. "}}}}\n'
+            'data: {"event":{"metadata":{"usage":{"inputTokens":10,"outputTokens":3,"totalTokens":13}}}}\n'
+            'data: {"event":{"toolUse":{"toolUseId":"tool-1","name":"get_weather","input":{"city":"Paris"}}}}\n'
+            'data: {"event":{"contentBlockDelta":{"delta":{"text":"Here are results."}}}}\n'
+            'data: {"message":{"role":"assistant","content":[{"text":"Let me check weather. Here are results."}]}}\n'
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_stream_does_not_stop_on_intermediate_metadata(self, config):
+        """
+        Metadata can appear before final tool-result content.
+
+        Ensure intermediate metadata does not emit finish_reason='stop', which
+        would prematurely terminate streaming before final content arrives.
+        """
+        response = _FakeAsyncTextResponse([self._build_tool_flow_sse()])
+
+        chunks = []
+        async for chunk in config._stream_agentcore_response(
+            response=response,
+            model="bedrock/agentcore/test-runtime",
+        ):
+            chunks.append(chunk)
+
+        assert len(chunks) >= 3
+
+        stop_indices = [
+            i
+            for i, chunk in enumerate(chunks)
+            if chunk.choices[0].finish_reason == "stop"
+        ]
+        assert stop_indices == [len(chunks) - 1]
+
+        content_parts = [
+            chunk.choices[0].delta.content
+            for chunk in chunks
+            if chunk.choices[0].delta.content
+        ]
+        assert "".join(content_parts) == "Let me check weather. Here are results."
+
+        assert any(getattr(chunk, "usage", None) is not None for chunk in chunks)
+
+    def test_sync_stream_does_not_stop_on_intermediate_metadata(self, config):
+        """Same regression coverage for sync streaming path."""
+        response = _FakeSyncTextResponse([self._build_tool_flow_sse()])
+
+        chunks = list(
+            config._stream_agentcore_response_sync(
+                response=response,
+                model="bedrock/agentcore/test-runtime",
+            )
+        )
+
+        assert len(chunks) >= 3
+
+        stop_indices = [
+            i
+            for i, chunk in enumerate(chunks)
+            if chunk.choices[0].finish_reason == "stop"
+        ]
+        assert stop_indices == [len(chunks) - 1]
+
+        content_parts = [
+            chunk.choices[0].delta.content
+            for chunk in chunks
+            if chunk.choices[0].delta.content
+        ]
+        assert "".join(content_parts) == "Let me check weather. Here are results."


### PR DESCRIPTION
## Summary
- Prevent AgentCore metadata events from being emitted with finish_reason=stop
- Keep stream alive through toolUse/toolResult phases until final message arrives
- Add async+sync regression tests for tool-flow event ordering

## Why
Issue #22686 reports streaming stopping after initial reasoning for AgentCore tool flows. A likely root cause is intermediate metadata events being marked as final stop chunks.

## Validation
- pytest tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py -q -rA
- pytest tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py -q
- pytest tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py -q

Closes #22686