### PR TITLE
[Fix] UI - Tool Policies: Add missing ToolRow properties

### DIFF
--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -10138,6 +10138,8 @@ export interface ToolRow {
   updated_at?: string;
   created_by?: string;
   updated_by?: string;
+  user_agent?: string;
+  last_used_at?: string;
 }
 
 export interface ToolPolicyOption {


### PR DESCRIPTION
## Summary

Fixed TypeScript build error in ToolDetail component by adding missing optional properties to the `ToolRow` interface.

## Changes

Added `user_agent` and `last_used_at` optional properties to the `ToolRow` type definition in `networking.tsx`. These properties are accessed by the ToolDetail component on lines 267 and 279 for displaying tool metadata (user agent and last used timestamp).

## Type

🐛 Bug Fix