### PR TITLE
fix(auth): remove implicit UI budget cap from CLI JWT

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -383,6 +383,8 @@ except ValueError:
         f"LITELLM_CLI_JWT_MAX_BUDGET={_cli_budget_env!r} is not a valid number; ignoring."
     )
     max_cli_session_budget = None
+    del _w
+del _cli_budget_env
 internal_user_budget_duration: Optional[str] = None
 tag_budget_config: Optional[Dict[str, "BudgetConfig"]] = None
 max_end_user_budget: Optional[float] = None

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -372,7 +372,10 @@ max_user_budget: Optional[float] = None
 default_max_internal_user_budget: Optional[float] = None
 max_internal_user_budget: Optional[float] = None
 max_ui_session_budget: Optional[float] = 0.25  # $0.25 USD budgets for UI Chat sessions
-max_cli_session_budget: Optional[float] = None  # Optional budget cap for CLI JWT sessions
+# CLI JWT session budget: controlled via LITELLM_CLI_JWT_MAX_BUDGET env var.
+# Defaults to None (no cap).  Set the env var to a float value to enforce a cap.
+_cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET")
+max_cli_session_budget: Optional[float] = float(_cli_budget_env) if _cli_budget_env is not None else None
 internal_user_budget_duration: Optional[str] = None
 tag_budget_config: Optional[Dict[str, "BudgetConfig"]] = None
 max_end_user_budget: Optional[float] = None

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -372,6 +372,7 @@ max_user_budget: Optional[float] = None
 default_max_internal_user_budget: Optional[float] = None
 max_internal_user_budget: Optional[float] = None
 max_ui_session_budget: Optional[float] = 0.25  # $0.25 USD budgets for UI Chat sessions
+max_cli_session_budget: Optional[float] = None  # Optional budget cap for CLI JWT sessions
 internal_user_budget_duration: Optional[str] = None
 tag_budget_config: Optional[Dict[str, "BudgetConfig"]] = None
 max_end_user_budget: Optional[float] = None

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -375,7 +375,14 @@ max_ui_session_budget: Optional[float] = 0.25  # $0.25 USD budgets for UI Chat s
 # CLI JWT session budget: controlled via LITELLM_CLI_JWT_MAX_BUDGET env var.
 # Defaults to None (no cap).  Set the env var to a float value to enforce a cap.
 _cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
-max_cli_session_budget: Optional[float] = float(_cli_budget_env) if _cli_budget_env else None
+try:
+    max_cli_session_budget: Optional[float] = float(_cli_budget_env) if _cli_budget_env else None
+except ValueError:
+    import warnings as _w
+    _w.warn(
+        f"LITELLM_CLI_JWT_MAX_BUDGET={_cli_budget_env!r} is not a valid number; ignoring."
+    )
+    max_cli_session_budget = None
 internal_user_budget_duration: Optional[str] = None
 tag_budget_config: Optional[Dict[str, "BudgetConfig"]] = None
 max_end_user_budget: Optional[float] = None

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -374,17 +374,22 @@ max_internal_user_budget: Optional[float] = None
 max_ui_session_budget: Optional[float] = 0.25  # $0.25 USD budgets for UI Chat sessions
 # CLI JWT session budget: controlled via LITELLM_CLI_JWT_MAX_BUDGET env var.
 # Defaults to None (no cap).  Set the env var to a float value to enforce a cap.
-_cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
-try:
-    max_cli_session_budget: Optional[float] = float(_cli_budget_env) if _cli_budget_env else None
-except ValueError:
-    import warnings as _w
-    _w.warn(
-        f"LITELLM_CLI_JWT_MAX_BUDGET={_cli_budget_env!r} is not a valid number; ignoring."
-    )
-    max_cli_session_budget = None
-    del _w
-del _cli_budget_env
+def _parse_cli_budget_env() -> Optional[float]:
+    """Parse LITELLM_CLI_JWT_MAX_BUDGET env var into a float or None."""
+    raw = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        import warnings as _w
+        _w.warn(
+            f"LITELLM_CLI_JWT_MAX_BUDGET={raw!r} is not a valid number; ignoring."
+        )
+        del _w
+        return None
+
+max_cli_session_budget: Optional[float] = _parse_cli_budget_env()
 internal_user_budget_duration: Optional[str] = None
 tag_budget_config: Optional[Dict[str, "BudgetConfig"]] = None
 max_end_user_budget: Optional[float] = None

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -374,8 +374,8 @@ max_internal_user_budget: Optional[float] = None
 max_ui_session_budget: Optional[float] = 0.25  # $0.25 USD budgets for UI Chat sessions
 # CLI JWT session budget: controlled via LITELLM_CLI_JWT_MAX_BUDGET env var.
 # Defaults to None (no cap).  Set the env var to a float value to enforce a cap.
-_cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET")
-max_cli_session_budget: Optional[float] = float(_cli_budget_env) if _cli_budget_env is not None else None
+_cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
+max_cli_session_budget: Optional[float] = float(_cli_budget_env) if _cli_budget_env else None
 internal_user_budget_duration: Optional[str] = None
 tag_budget_config: Optional[Dict[str, "BudgetConfig"]] = None
 max_end_user_budget: Optional[float] = None

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2003,12 +2003,11 @@ class ExperimentalUIJWTToken:
             token=CLI_JWT_TOKEN_NAME,
             key_name=CLI_JWT_TOKEN_NAME,
             key_alias=CLI_JWT_TOKEN_NAME,
-            # Do NOT inherit UI session budget caps for CLI JWT tokens.
-            #
-            # UI budget defaults (often 0.25) are intended for short-lived UI
-            # sessions and can unexpectedly trigger BudgetExceededError for CLI
-            # users who did not explicitly configure key budgets.
-            max_budget=None,
+            # Explicit CLI budget policy:
+            # - default: no CLI cap (None)
+            # - optional: set litellm.max_cli_session_budget to enforce a cap
+            # This remains decoupled from UI session defaults.
+            max_budget=litellm.max_cli_session_budget,
             expires=expires,
             user_id=user_info.user_id,
             team_id=_team_id,

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2001,10 +2001,9 @@ class ExperimentalUIJWTToken:
 
         _budget = litellm.max_cli_session_budget
         if _budget is None:
-            verbose_proxy_logger.info(
+            verbose_proxy_logger.debug(
                 "CLI JWT session created with no budget cap. "
-                "Set LITELLM_CLI_JWT_MAX_BUDGET env var to enforce a cap "
-                "(previously the default was $0.25 via max_ui_session_budget)."
+                "Set LITELLM_CLI_JWT_MAX_BUDGET env var to enforce a cap."
             )
 
         valid_token = UserAPIKeyAuth(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1999,15 +1999,24 @@ class ExperimentalUIJWTToken:
             # Use first team if user has teams
             _team_id = user_info.teams[0] if len(user_info.teams) > 0 else None
 
+        _budget = litellm.max_cli_session_budget
+        if _budget is None:
+            verbose_proxy_logger.info(
+                "CLI JWT session created with no budget cap. "
+                "Set LITELLM_CLI_JWT_MAX_BUDGET env var to enforce a cap "
+                "(previously the default was $0.25 via max_ui_session_budget)."
+            )
+
         valid_token = UserAPIKeyAuth(
             token=CLI_JWT_TOKEN_NAME,
             key_name=CLI_JWT_TOKEN_NAME,
             key_alias=CLI_JWT_TOKEN_NAME,
             # Explicit CLI budget policy:
             # - default: no CLI cap (None)
-            # - optional: set litellm.max_cli_session_budget to enforce a cap
+            # - optional: set LITELLM_CLI_JWT_MAX_BUDGET env var or
+            #   litellm.max_cli_session_budget to enforce a cap.
             # This remains decoupled from UI session defaults.
-            max_budget=litellm.max_cli_session_budget,
+            max_budget=_budget,
             expires=expires,
             user_id=user_info.user_id,
             team_id=_team_id,

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2003,7 +2003,12 @@ class ExperimentalUIJWTToken:
             token=CLI_JWT_TOKEN_NAME,
             key_name=CLI_JWT_TOKEN_NAME,
             key_alias=CLI_JWT_TOKEN_NAME,
-            max_budget=litellm.max_ui_session_budget,
+            # Do NOT inherit UI session budget caps for CLI JWT tokens.
+            #
+            # UI budget defaults (often 0.25) are intended for short-lived UI
+            # sessions and can unexpectedly trigger BudgetExceededError for CLI
+            # users who did not explicitly configure key budgets.
+            max_budget=None,
             expires=expires,
             user_id=user_info.user_id,
             team_id=_team_id,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2836,6 +2836,8 @@ class ProxyConfig:
                     )
                 elif key == "max_internal_user_budget":
                     litellm.max_internal_user_budget = float(value)  # type: ignore
+                elif key == "max_cli_session_budget":
+                    litellm.max_cli_session_budget = float(value)  # type: ignore
                 elif key == "default_max_internal_user_budget":
                     litellm.default_max_internal_user_budget = float(value)
                     if litellm.max_internal_user_budget is None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2837,7 +2837,13 @@ class ProxyConfig:
                 elif key == "max_internal_user_budget":
                     litellm.max_internal_user_budget = float(value)  # type: ignore
                 elif key == "max_cli_session_budget":
-                    litellm.max_cli_session_budget = float(value)  # type: ignore
+                    try:
+                        litellm.max_cli_session_budget = float(value)  # type: ignore
+                    except (TypeError, ValueError) as e:
+                        raise ValueError(
+                            f"Invalid value for 'max_cli_session_budget': {value!r}. "
+                            "Expected a numeric value (e.g., 0.25)."
+                        ) from e
                 elif key == "default_max_internal_user_budget":
                     litellm.default_max_internal_user_budget = float(value)
                     if litellm.max_internal_user_budget is None:

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -315,6 +315,23 @@ def test_get_cli_jwt_auth_token_custom_expiration(
     assert expires <= get_utc_datetime() + timedelta(hours=48, minutes=1)
 
 
+def test_get_cli_jwt_auth_token_respects_explicit_cli_budget(
+    valid_sso_user_defined_values, monkeypatch
+):
+    """CLI JWT should include max_budget only when max_cli_session_budget is set."""
+    monkeypatch.setattr(litellm, "max_cli_session_budget", 3.5)
+
+    token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(valid_sso_user_defined_values)
+
+    decrypted_token = decrypt_value_helper(
+        token, key="ui_hash_key", exception_type="debug"
+    )
+    assert decrypted_token is not None
+    token_data = json.loads(decrypted_token)
+
+    assert token_data["max_budget"] == 3.5
+
+
 
 @pytest.mark.asyncio
 async def test_default_internal_user_params_with_get_user_object(monkeypatch):

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -269,7 +269,7 @@ def test_get_cli_jwt_auth_token_default_expiration(valid_sso_user_defined_values
     assert token_data["user_id"] == "test_user"
     assert token_data["user_role"] == LitellmUserRoles.PROXY_ADMIN.value
     assert token_data["models"] == ["gpt-3.5-turbo"]
-    assert token_data["max_budget"] == litellm.max_ui_session_budget
+    assert "max_budget" not in token_data
 
     # Verify expiration time is set to 24 hours (default)
     assert "expires" in token_data
@@ -304,6 +304,9 @@ def test_get_cli_jwt_auth_token_custom_expiration(
     )
     assert decrypted_token is not None
     token_data = json.loads(decrypted_token)
+
+    # CLI JWT should not inherit UI session budget cap by default
+    assert "max_budget" not in token_data
 
     # Verify expiration time is set to 48 hours
     assert "expires" in token_data

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1657,60 +1657,32 @@ async def test_custom_auth_common_checks_opt_in():
 def test_litellm_cli_jwt_max_budget_env_var_parsing(monkeypatch):
     """
     Test LITELLM_CLI_JWT_MAX_BUDGET environment variable parsing.
-    Tests valid float values, invalid values, and empty strings.
+    Exercises the real _parse_cli_budget_env helper from litellm/__init__.py.
     """
-    import importlib
-    import sys
+    import warnings
+
+    from litellm import _parse_cli_budget_env
 
     # Test 1: Valid float value
     monkeypatch.setenv("LITELLM_CLI_JWT_MAX_BUDGET", "10.5")
-    
-    # We need to reload the module to pick up the new env var
-    if "litellm" in sys.modules:
-        # Save the current value
-        original_budget = getattr(litellm, "max_cli_session_budget", None)
-    
-    # Simulate what happens in __init__.py
-    import os
-    import warnings
-    
-    _cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
-    try:
-        max_cli_session_budget = float(_cli_budget_env) if _cli_budget_env else None
-    except ValueError:
-        max_cli_session_budget = None
-    
-    assert max_cli_session_budget == 10.5, f"Expected 10.5, got {max_cli_session_budget}"
+    assert _parse_cli_budget_env() == 10.5
 
     # Test 2: Invalid value (non-numeric) should fall back to None with a warning
     monkeypatch.setenv("LITELLM_CLI_JWT_MAX_BUDGET", "abc")
-    
-    _cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
-    try:
-        max_cli_session_budget = float(_cli_budget_env) if _cli_budget_env else None
-    except ValueError:
-        max_cli_session_budget = None
-    
-    assert max_cli_session_budget is None, f"Expected None for invalid value, got {max_cli_session_budget}"
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = _parse_cli_budget_env()
+    assert result is None
+    assert any("abc" in str(warning.message) for warning in w)
 
     # Test 3: Empty string should result in None
     monkeypatch.setenv("LITELLM_CLI_JWT_MAX_BUDGET", "")
-    
-    _cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
-    try:
-        max_cli_session_budget = float(_cli_budget_env) if _cli_budget_env else None
-    except ValueError:
-        max_cli_session_budget = None
-    
-    assert max_cli_session_budget is None, f"Expected None for empty string, got {max_cli_session_budget}"
+    assert _parse_cli_budget_env() is None
 
     # Test 4: Unset env var should result in None
     monkeypatch.delenv("LITELLM_CLI_JWT_MAX_BUDGET", raising=False)
-    
-    _cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
-    try:
-        max_cli_session_budget = float(_cli_budget_env) if _cli_budget_env else None
-    except ValueError:
-        max_cli_session_budget = None
-    
-    assert max_cli_session_budget is None, f"Expected None when env var unset, got {max_cli_session_budget}"
+    assert _parse_cli_budget_env() is None
+
+    # Test 5: Whitespace-only string should result in None
+    monkeypatch.setenv("LITELLM_CLI_JWT_MAX_BUDGET", "   ")
+    assert _parse_cli_budget_env() is None

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1652,3 +1652,65 @@ async def test_custom_auth_common_checks_opt_in():
             parent_otel_span=None,
         )
         mock_common.assert_called_once()
+
+
+def test_litellm_cli_jwt_max_budget_env_var_parsing(monkeypatch):
+    """
+    Test LITELLM_CLI_JWT_MAX_BUDGET environment variable parsing.
+    Tests valid float values, invalid values, and empty strings.
+    """
+    import importlib
+    import sys
+
+    # Test 1: Valid float value
+    monkeypatch.setenv("LITELLM_CLI_JWT_MAX_BUDGET", "10.5")
+    
+    # We need to reload the module to pick up the new env var
+    if "litellm" in sys.modules:
+        # Save the current value
+        original_budget = getattr(litellm, "max_cli_session_budget", None)
+    
+    # Simulate what happens in __init__.py
+    import os
+    import warnings
+    
+    _cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
+    try:
+        max_cli_session_budget = float(_cli_budget_env) if _cli_budget_env else None
+    except ValueError:
+        max_cli_session_budget = None
+    
+    assert max_cli_session_budget == 10.5, f"Expected 10.5, got {max_cli_session_budget}"
+
+    # Test 2: Invalid value (non-numeric) should fall back to None with a warning
+    monkeypatch.setenv("LITELLM_CLI_JWT_MAX_BUDGET", "abc")
+    
+    _cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
+    try:
+        max_cli_session_budget = float(_cli_budget_env) if _cli_budget_env else None
+    except ValueError:
+        max_cli_session_budget = None
+    
+    assert max_cli_session_budget is None, f"Expected None for invalid value, got {max_cli_session_budget}"
+
+    # Test 3: Empty string should result in None
+    monkeypatch.setenv("LITELLM_CLI_JWT_MAX_BUDGET", "")
+    
+    _cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
+    try:
+        max_cli_session_budget = float(_cli_budget_env) if _cli_budget_env else None
+    except ValueError:
+        max_cli_session_budget = None
+    
+    assert max_cli_session_budget is None, f"Expected None for empty string, got {max_cli_session_budget}"
+
+    # Test 4: Unset env var should result in None
+    monkeypatch.delenv("LITELLM_CLI_JWT_MAX_BUDGET", raising=False)
+    
+    _cli_budget_env = os.environ.get("LITELLM_CLI_JWT_MAX_BUDGET", "").strip()
+    try:
+        max_cli_session_budget = float(_cli_budget_env) if _cli_budget_env else None
+    except ValueError:
+        max_cli_session_budget = None
+    
+    assert max_cli_session_budget is None, f"Expected None when env var unset, got {max_cli_session_budget}"

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -255,8 +255,9 @@ async def test_get_key_object_should_raise_if_reconnect_fails_on_db_connection_e
     assert mock_prisma_client.get_data.await_count == 1
 
 
-def test_get_cli_jwt_auth_token_default_expiration(valid_sso_user_defined_values):
+def test_get_cli_jwt_auth_token_default_expiration(valid_sso_user_defined_values, monkeypatch):
     """Test generating CLI JWT token with default 24-hour expiration"""
+    monkeypatch.setattr(litellm, "max_cli_session_budget", None)
     token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(valid_sso_user_defined_values)
 
     # Decrypt and verify token contents
@@ -287,6 +288,8 @@ def test_get_cli_jwt_auth_token_custom_expiration(
 
     from litellm import constants
     from litellm.proxy.auth import auth_checks
+
+    monkeypatch.setattr(litellm, "max_cli_session_budget", None)
 
     # Set custom expiration to 48 hours
     monkeypatch.setenv("LITELLM_CLI_JWT_EXPIRATION_HOURS", "48")


### PR DESCRIPTION
## Summary
- Stop assigning UI session budget cap to CLI JWT tokens by default
- Keep Experimental UI token budget behavior unchanged
- Update CLI JWT auth tests to assert no implicit max_budget field

## Why
Issue #22726 reports BudgetExceededError despite no explicit budget being set. A likely source is CLI JWT tokens inheriting the UI session default cap (often 0.25), which can unexpectedly enforce budget limits.

## Validation
- pytest /Users/giulioleone/litellm/tests/test_litellm/proxy/auth/test_auth_checks.py -q -rA -k "test_get_cli_jwt_auth_token_default_expiration or test_get_cli_jwt_auth_token_custom_expiration"
- pytest /Users/giulioleone/litellm/tests/test_litellm/proxy/auth -q -rA --ignore /Users/giulioleone/litellm/tests/test_litellm/proxy/auth/test_auth_exception_handler.py

Notes:
- Broader auth run is largely green; 2 failures are unrelated environment dependency issues around missing prisma during reconnect-path tests.

Closes #22726
