### PR TITLE
fix(mcp): normalize mounted path server extraction

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2150,7 +2150,7 @@ if MCP_AVAILABLE:
     async def extract_mcp_auth_context(scope, path):
         """
         Extracts mcp_servers from the path and processes the MCP request for auth context.
-        Returns: (user_api_key_auth, mcp_auth_header, mcp_servers, mcp_server_auth_headers)
+        Returns: (user_api_key_auth, mcp_auth_header, mcp_servers, mcp_server_auth_headers, oauth2_headers, raw_headers)
         """
         mcp_servers_from_path = _get_mcp_servers_in_path(path)
         if mcp_servers_from_path is None:

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2135,7 +2135,7 @@ if MCP_AVAILABLE:
         # Supports server names containing one slash (e.g. custom_solutions/user_123)
         if mcp_servers_from_path is None:
             scoped_mount_match = re.match(
-                r"^/([^/]+(?:/[^/]+)?)/mcp(?:/.*)?(?:\?.*)?(?:#.*)?$", path
+                r"^/(?!mcp(?:/|$))([^/]+(?:/[^/]+)?)/mcp(?:/.*)?(?:\?.*)?(?:#.*)?$", path
             )
             if scoped_mount_match:
                 mcp_servers_from_path = [scoped_mount_match.group(1)]

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2096,6 +2096,11 @@ if MCP_AVAILABLE:
         # Match /mcp/<servers_and_maybe_path>
         # Where servers can be comma-separated list of server names
         # Server names can contain slashes (e.g., "custom_solutions/user_123")
+        #
+        # Note on ambiguous paths like /a/mcp/mcp: the regex anchors on the
+        # leading /mcp/ prefix, so "/a/mcp/mcp" does NOT match (it starts with
+        # "/a/", not "/mcp/").  Only paths starting with exactly "/mcp/" enter
+        # the server-name extraction logic.
         mcp_path_match = re.match(r"^/mcp/([^?#]+)(?:\?.*)?(?:#.*)?$", path)
         if mcp_path_match:
             servers_and_path = mcp_path_match.group(1)

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2130,6 +2130,16 @@ if MCP_AVAILABLE:
                         mcp_servers_from_path = [server_name]
                     else:
                         mcp_servers_from_path = [servers_and_path]
+
+        # Match server-scoped mount form: /<server_name>/mcp[/...]
+        # Supports server names containing one slash (e.g. custom_solutions/user_123)
+        if mcp_servers_from_path is None:
+            scoped_mount_match = re.match(
+                r"^/([^/]+(?:/[^/]+)?)/mcp(?:/.*)?(?:\?.*)?(?:#.*)?$", path
+            )
+            if scoped_mount_match:
+                mcp_servers_from_path = [scoped_mount_match.group(1)]
+
         return mcp_servers_from_path
 
     async def extract_mcp_auth_context(scope, path):
@@ -2138,6 +2148,14 @@ if MCP_AVAILABLE:
         Returns: (user_api_key_auth, mcp_auth_header, mcp_servers, mcp_server_auth_headers)
         """
         mcp_servers_from_path = _get_mcp_servers_in_path(path)
+        if mcp_servers_from_path is None:
+            # When mounted at /mcp, ASGI path is often stripped (e.g. "/github_onprem")
+            # while root_path contains the mount prefix (e.g. "/mcp"). Reconstruct full
+            # path to preserve consistent server extraction across endpoint forms.
+            root_path = scope.get("root_path")
+            if isinstance(root_path, str) and root_path:
+                combined_path = f"{root_path.rstrip('/')}/{path.lstrip('/')}"
+                mcp_servers_from_path = _get_mcp_servers_in_path(combined_path)
         if mcp_servers_from_path is not None:
             (
                 user_api_key_auth,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -902,7 +902,7 @@ def test_get_mcp_servers_in_path_supports_server_scoped_mount_form():
     ]
 
     # Negative cases: these must NOT match the server-scoped mount regex
-    assert _get_mcp_servers_in_path("/mcp") is None or _get_mcp_servers_in_path("/mcp") != ["mcp"]
+    assert _get_mcp_servers_in_path("/mcp") is None
     assert _get_mcp_servers_in_path("/github_onprem/not_mcp") is None
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -888,6 +888,62 @@ async def test_mcp_routing_with_conflicting_alias_and_group_name():
     ), "Should have contacted the specific server alias, not the group."
 
 
+@pytest.mark.no_parallel
+def test_get_mcp_servers_in_path_supports_server_scoped_mount_form():
+    """Regression: support /<server>/mcp path form for server extraction."""
+    try:
+        from litellm.proxy._experimental.mcp_server.server import _get_mcp_servers_in_path
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    assert _get_mcp_servers_in_path("/github_onprem/mcp") == ["github_onprem"]
+    assert _get_mcp_servers_in_path("/custom_solutions/user_123/mcp") == [
+        "custom_solutions/user_123"
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_parallel
+async def test_extract_mcp_auth_context_reconstructs_mounted_mcp_path():
+    """
+    Regression: when mounted under /mcp, ASGI path can be stripped (e.g. /github_onprem).
+    Ensure auth context reconstructs full path via root_path to extract mcp_servers.
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server.server import extract_mcp_auth_context
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    scope = {
+        "path": "/github_onprem",
+        "root_path": "/mcp",
+        "headers": [],
+    }
+
+    mock_auth = UserAPIKeyAuth(api_key="sk-test", user_id="user-1")
+    process_mock = AsyncMock(return_value=(mock_auth, None, None, None, None, None))
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.MCPRequestHandler.process_mcp_request",
+        process_mock,
+    ):
+        (
+            user_auth,
+            mcp_auth_header,
+            mcp_servers,
+            mcp_server_auth_headers,
+            user_api_key_dict,
+            mcp_info,
+        ) = await extract_mcp_auth_context(scope=scope, path="/github_onprem")
+
+    assert user_auth == mock_auth
+    assert mcp_auth_header is None
+    assert mcp_servers == ["github_onprem"]
+    assert mcp_server_auth_headers is None
+    assert user_api_key_dict is None
+    assert mcp_info is None
+
+
 @pytest.mark.asyncio
 @pytest.mark.no_parallel
 async def test_oauth2_headers_passed_to_mcp_client():

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -901,13 +901,18 @@ def test_get_mcp_servers_in_path_supports_server_scoped_mount_form():
         "custom_solutions/user_123"
     ]
 
+    # Negative cases: these must NOT match the server-scoped mount regex
+    assert _get_mcp_servers_in_path("/mcp") is None or _get_mcp_servers_in_path("/mcp") != ["mcp"]
+    assert _get_mcp_servers_in_path("/github_onprem/not_mcp") is None
+
 
 @pytest.mark.asyncio
 @pytest.mark.no_parallel
 async def test_extract_mcp_auth_context_reconstructs_mounted_mcp_path():
     """
     Regression: when mounted under /mcp, ASGI path can be stripped (e.g. /github_onprem).
-    Ensure auth context reconstructs full path via root_path to extract mcp_servers.
+    Ensure auth context reconstructs full path via root_path (/mcp/github_onprem) so
+    that the /mcp/<server> regex pattern extracts the server correctly.
     """
     try:
         from litellm.proxy._experimental.mcp_server.server import extract_mcp_auth_context

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -905,6 +905,9 @@ def test_get_mcp_servers_in_path_supports_server_scoped_mount_form():
     assert _get_mcp_servers_in_path("/mcp") is None
     assert _get_mcp_servers_in_path("/github_onprem/not_mcp") is None
 
+    # Deep paths: /a/mcp/mcp should treat 'a/mcp' as 2-segment server name
+    assert _get_mcp_servers_in_path("/a/mcp/mcp") == ["a/mcp"]
+
 
 @pytest.mark.asyncio
 @pytest.mark.no_parallel


### PR DESCRIPTION
## Summary
- Normalize MCP server extraction for mounted/stripped path forms
- Support server-scoped mount path form /<server>/mcp
- Reconstruct full path from root_path + path when needed in auth context extraction
- Add regression tests for mounted path extraction consistency

## Why
Issue #22670 reports inconsistent list_tools/call_tool name behavior between /mcp and /mcp/<server> style endpoints (notably GitHub OnPrem). Path extraction inconsistencies can cause server scoping/prefix behavior to diverge by endpoint shape.

## Validation
- pytest /Users/giulioleone/litellm/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py::test_get_mcp_servers_in_path_supports_server_scoped_mount_form /Users/giulioleone/litellm/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py::test_extract_mcp_auth_context_reconstructs_mounted_mcp_path -q -rA
- pytest /Users/giulioleone/litellm/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py -q

Closes #22670
