### PR TITLE
fix(redis): skip SSLConnection when ssl=False in connection pool

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -476,8 +476,8 @@ def get_redis_connection_pool(**env_overrides):
     connection_class = async_redis.Connection
     if redis_kwargs.get("ssl"):
         connection_class = async_redis.SSLConnection
-        redis_kwargs.pop("ssl", None)
-        redis_kwargs["connection_class"] = connection_class
+    redis_kwargs.pop("ssl", None)
+    redis_kwargs["connection_class"] = connection_class
     redis_kwargs.pop("startup_nodes", None)
     return async_redis.BlockingConnectionPool(
         timeout=REDIS_CONNECTION_POOL_TIMEOUT, **redis_kwargs

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -474,7 +474,7 @@ def get_redis_connection_pool(**env_overrides):
                 )
         return async_redis.BlockingConnectionPool.from_url(**pool_kwargs)
     connection_class = async_redis.Connection
-    if "ssl" in redis_kwargs:
+    if redis_kwargs.get("ssl"):
         connection_class = async_redis.SSLConnection
         redis_kwargs.pop("ssl", None)
         redis_kwargs["connection_class"] = connection_class

--- a/tests/test_litellm/caching/test_redis_connection_pool.py
+++ b/tests/test_litellm/caching/test_redis_connection_pool.py
@@ -129,3 +129,12 @@ async def test_disconnect_idempotent():
     await cache.disconnect()  # should not raise
 
 
+def test_ssl_false_does_not_use_ssl_connection(monkeypatch):
+    """When REDIS_SSL=False, get_redis_connection_pool should not use SSLConnection."""
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("REDIS_SSL", "False")
+
+    pool = get_redis_connection_pool()
+
+    assert pool.connection_class is not async_redis.SSLConnection

--- a/tests/test_litellm/caching/test_redis_connection_pool.py
+++ b/tests/test_litellm/caching/test_redis_connection_pool.py
@@ -130,7 +130,9 @@ async def test_disconnect_idempotent():
 
 
 def test_ssl_false_does_not_use_ssl_connection(monkeypatch):
-    """When REDIS_SSL=False, get_redis_connection_pool should not use SSLConnection."""
+    """When REDIS_SSL=False, get_redis_connection_pool should not use SSLConnection
+    and ssl must not be leaked into connection_kwargs (would cause TypeError at
+    connection time since Connection.__init__() does not accept an ssl param)."""
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
     monkeypatch.setenv("REDIS_SSL", "False")
@@ -138,3 +140,4 @@ def test_ssl_false_does_not_use_ssl_connection(monkeypatch):
     pool = get_redis_connection_pool()
 
     assert pool.connection_class is not async_redis.SSLConnection
+    assert "ssl" not in pool.connection_kwargs


### PR DESCRIPTION
`get_redis_connection_pool` was checking `if "ssl" in redis_kwargs` without checking the actual value, causing SSLConnection to be used even when `REDIS_SSL=False` was explicitly set.

Changed to `if redis_kwargs.get("ssl")` so SSLConnection is only used when ssl is explicitly truthy.

## Relevant issues

Fixes #17320 #16587

## Pre-Submission checklist
- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5**

## Type
🐛 Bug Fix

## Changes
- `litellm/_redis.py`: changed `if "ssl" in redis_kwargs` to `if redis_kwargs.get("ssl")` in `get_redis_connection_pool`