### PR TITLE
fix(pass-through): avoid adapter registry overwrite

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -84,7 +84,7 @@ _registered_pass_through_routes: Dict[
 # 2. On config reload, adapter UUIDs are regenerated, so stale routes may
 #    accumulate in _registered_pass_through_routes until the process
 #    restarts.  A full clear-and-rebuild strategy would fix this.
-_seen_adapter_targets: set = set()
+_seen_adapter_targets: dict = {}
 
 
 def get_response_body(response: httpx.Response) -> Optional[dict]:
@@ -1116,26 +1116,25 @@ def create_pass_through_route(
             adapter = target
         else:
             adapter = get_instance_fn(value=target)
-        adapter_id = str(uuid.uuid4())
-
-        # Thread safety note: this runs at startup during config loading,
-        # so concurrent access is not a concern here.
-        if not isinstance(litellm.adapters, list):
-            verbose_proxy_logger.warning(
-                "litellm.adapters was %s, coercing to list",
-                type(litellm.adapters).__name__,
-            )
-            litellm.adapters = list(litellm.adapters)
-
-        # Deduplicate: skip if an adapter for this endpoint path already exists.
-        # Track by target key in a module-level set so the adapter dict stays
-        # compliant with the AdapterItem TypedDict (id + adapter only).
-        # NOTE: qualname-based dedup may silently drop a second adapter of the
-        # same class — see _seen_adapter_targets doc comment for details.
+        # Deduplicate: reuse existing adapter_id when the same target is
+        # registered more than once (e.g. exact path + subpath routes).
         _target_key = target if isinstance(target, str) else type(target).__qualname__
-        if _target_key not in _seen_adapter_targets:
-            _seen_adapter_targets.add(_target_key)
+        if _target_key in _seen_adapter_targets:
+            adapter_id = _seen_adapter_targets[_target_key]
+        else:
+            adapter_id = str(uuid.uuid4())
+
+            # Thread safety note: this runs at startup during config loading,
+            # so concurrent access is not a concern here.
+            if not isinstance(litellm.adapters, list):
+                verbose_proxy_logger.warning(
+                    "litellm.adapters was %s, coercing to list",
+                    type(litellm.adapters).__name__,
+                )
+                litellm.adapters = list(litellm.adapters)
+
             litellm.adapters.append({"id": adapter_id, "adapter": adapter})
+            _seen_adapter_targets[_target_key] = adapter_id
 
         async def endpoint_func(  # type: ignore
             request: Request,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1106,7 +1106,11 @@ def create_pass_through_route(
         else:
             adapter = get_instance_fn(value=target)
         adapter_id = str(uuid.uuid4())
-        litellm.adapters = [{"id": adapter_id, "adapter": adapter}]
+
+        if not isinstance(litellm.adapters, list):
+            litellm.adapters = []
+
+        litellm.adapters.append({"id": adapter_id, "adapter": adapter})
 
         async def endpoint_func(  # type: ignore
             request: Request,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -75,7 +75,15 @@ _registered_pass_through_routes: Dict[
     str, Dict[str, Union[str, List[str], Dict[str, Any]]]
 ] = {}
 
-# Tracks adapter targets already registered to prevent duplicate entries
+# Tracks adapter targets already registered to prevent duplicate entries.
+# Known limitations (TODO):
+# 1. Dedup-by-qualname means two *distinct instances* of the same adapter
+#    class (e.g. two AnthropicAdapter with different configs) will be
+#    collapsed into one.  Supporting multi-instance requires keying on
+#    (qualname + config hash) or a user-supplied unique ID.
+# 2. On config reload, adapter UUIDs are regenerated, so stale routes may
+#    accumulate in _registered_pass_through_routes until the process
+#    restarts.  A full clear-and-rebuild strategy would fix this.
 _seen_adapter_targets: set = set()
 
 
@@ -1122,6 +1130,8 @@ def create_pass_through_route(
         # Deduplicate: skip if an adapter for this endpoint path already exists.
         # Track by target key in a module-level set so the adapter dict stays
         # compliant with the AdapterItem TypedDict (id + adapter only).
+        # NOTE: qualname-based dedup may silently drop a second adapter of the
+        # same class — see _seen_adapter_targets doc comment for details.
         _target_key = target if isinstance(target, str) else type(target).__qualname__
         if _target_key not in _seen_adapter_targets:
             _seen_adapter_targets.add(_target_key)

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1117,11 +1117,12 @@ def create_pass_through_route(
             litellm.adapters = list(litellm.adapters)
 
         # Deduplicate: skip if an adapter for this endpoint path already exists
+        _target_key = target if isinstance(target, str) else type(target).__qualname__
         if not any(
-            isinstance(a, dict) and a.get("id") == adapter_id
+            isinstance(a, dict) and a.get("_target") == _target_key
             for a in litellm.adapters
         ):
-            litellm.adapters.append({"id": adapter_id, "adapter": adapter})
+            litellm.adapters.append({"id": adapter_id, "adapter": adapter, "_target": _target_key})
 
         async def endpoint_func(  # type: ignore
             request: Request,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -76,14 +76,9 @@ _registered_pass_through_routes: Dict[
 ] = {}
 
 # Tracks adapter targets already registered to prevent duplicate entries.
-# Known limitations (TODO):
-# 1. Dedup-by-qualname means two *distinct instances* of the same adapter
-#    class (e.g. two AnthropicAdapter with different configs) will be
-#    collapsed into one.  Supporting multi-instance requires keying on
-#    (qualname + config hash) or a user-supplied unique ID.
-# 2. On config reload, adapter UUIDs are regenerated, so stale routes may
-#    accumulate in _registered_pass_through_routes until the process
-#    restarts.  A full clear-and-rebuild strategy would fix this.
+# Uses object identity (id) for adapter instances so that:
+# - The SAME adapter object registered twice (exact + subpath) is deduped correctly
+# - Different instances of the same class get separate registrations
 _seen_adapter_targets: dict = {}
 
 
@@ -1118,7 +1113,7 @@ def create_pass_through_route(
             adapter = get_instance_fn(value=target)
         # Deduplicate: reuse existing adapter_id when the same target is
         # registered more than once (e.g. exact path + subpath routes).
-        _target_key = target if isinstance(target, str) else type(target).__qualname__
+        _target_key = target if isinstance(target, str) else id(target)
         if _target_key in _seen_adapter_targets:
             adapter_id = _seen_adapter_targets[_target_key]
         else:

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -76,9 +76,15 @@ _registered_pass_through_routes: Dict[
 ] = {}
 
 # Tracks adapter targets already registered to prevent duplicate entries.
-# Uses object identity (id) for adapter instances so that:
-# - The SAME adapter object registered twice (exact + subpath) is deduped correctly
-# - Different instances of the same class get separate registrations
+# Implements different dedup strategies based on target type:
+# - String targets (URLs): deduplicated by string value. Two endpoints with identical
+#   URL strings intentionally share one adapter instance (e.g., "https://api.example.com")
+# - Object targets (adapter classes): deduplicated by object identity (id(target)).
+#   Different instances of the same adapter class each get their own adapter_id,
+#   allowing independent configurations and lifecycle management.
+# This ensures that:
+#   - exact + subpath route pairs for the same adapter share a single registration
+#   - multiple distinct adapter instances are not accidentally collapsed together
 _seen_adapter_targets: dict = {}
 
 
@@ -1111,8 +1117,13 @@ def create_pass_through_route(
             adapter = target
         else:
             adapter = get_instance_fn(value=target)
-        # Deduplicate: reuse existing adapter_id when the same target is
-        # registered more than once (e.g. exact path + subpath routes).
+        # Deduplicate adapters based on target type:
+        # - String targets (URLs): deduplicated by string identity (e.g., "https://api.example.com")
+        #   Multiple endpoints with identical URL strings intentionally share one adapter instance.
+        # - Object targets (adapter classes): deduplicated by object identity using id(target)
+        #   Different instances of the same adapter class get separate registrations.
+        # This reuses existing adapter_id when the same target is registered more than once
+        # (e.g. exact path + subpath routes for the same adapter object/string).
         _target_key = target if isinstance(target, str) else id(target)
         if _target_key in _seen_adapter_targets:
             adapter_id = _seen_adapter_targets[_target_key]

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -75,6 +75,9 @@ _registered_pass_through_routes: Dict[
     str, Dict[str, Union[str, List[str], Dict[str, Any]]]
 ] = {}
 
+# Tracks adapter targets already registered to prevent duplicate entries
+_seen_adapter_targets: set = set()
+
 
 def get_response_body(response: httpx.Response) -> Optional[dict]:
     try:
@@ -1116,13 +1119,13 @@ def create_pass_through_route(
             )
             litellm.adapters = list(litellm.adapters)
 
-        # Deduplicate: skip if an adapter for this endpoint path already exists
+        # Deduplicate: skip if an adapter for this endpoint path already exists.
+        # Track by target key in a module-level set so the adapter dict stays
+        # compliant with the AdapterItem TypedDict (id + adapter only).
         _target_key = target if isinstance(target, str) else type(target).__qualname__
-        if not any(
-            isinstance(a, dict) and a.get("_target") == _target_key
-            for a in litellm.adapters
-        ):
-            litellm.adapters.append({"id": adapter_id, "adapter": adapter, "_target": _target_key})
+        if _target_key not in _seen_adapter_targets:
+            _seen_adapter_targets.add(_target_key)
+            litellm.adapters.append({"id": adapter_id, "adapter": adapter})
 
         async def endpoint_func(  # type: ignore
             request: Request,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1137,7 +1137,14 @@ def create_pass_through_route(
                     "litellm.adapters was %s, coercing to list",
                     type(litellm.adapters).__name__,
                 )
-                litellm.adapters = list(litellm.adapters)
+                try:
+                    litellm.adapters = list(litellm.adapters)
+                except TypeError:
+                    verbose_proxy_logger.error(
+                        "litellm.adapters is not iterable (%s), resetting to empty list",
+                        type(litellm.adapters).__name__,
+                    )
+                    litellm.adapters = []
 
             litellm.adapters.append({"id": adapter_id, "adapter": adapter})
             _seen_adapter_targets[_target_key] = adapter_id

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1107,10 +1107,21 @@ def create_pass_through_route(
             adapter = get_instance_fn(value=target)
         adapter_id = str(uuid.uuid4())
 
+        # Thread safety note: this runs at startup during config loading,
+        # so concurrent access is not a concern here.
         if not isinstance(litellm.adapters, list):
-            litellm.adapters = []
+            verbose_proxy_logger.warning(
+                "litellm.adapters was %s, coercing to list",
+                type(litellm.adapters).__name__,
+            )
+            litellm.adapters = list(litellm.adapters)
 
-        litellm.adapters.append({"id": adapter_id, "adapter": adapter})
+        # Deduplicate: skip if an adapter for this endpoint path already exists
+        if not any(
+            isinstance(a, dict) and a.get("id") == adapter_id
+            for a in litellm.adapters
+        ):
+            litellm.adapters.append({"id": adapter_id, "adapter": adapter})
 
         async def endpoint_func(  # type: ignore
             request: Request,

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -2298,27 +2298,27 @@ def test_is_registered_pass_through_route_with_custom_root():
         "headers": {},
     }
 
-    with patch("litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_server_root_path") as mock_get_root:
-        # Test with custom root path /proxy
-        mock_get_root.return_value = "/proxy"
+    try:
+        with patch("litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_server_root_path") as mock_get_root:
+            # Test with custom root path /proxy
+            mock_get_root.return_value = "/proxy"
 
-        # Should match when request route includes the root path
-        assert InitPassThroughEndpointHelpers.is_registered_pass_through_route("/proxy/api/endpoint") is True
+            # Should match when request route includes the root path
+            assert InitPassThroughEndpointHelpers.is_registered_pass_through_route("/proxy/api/endpoint") is True
 
-        # Should not match when request route doesn't include root path
-        assert InitPassThroughEndpointHelpers.is_registered_pass_through_route("/api/endpoint") is False
+            # Should not match when request route doesn't include root path
+            assert InitPassThroughEndpointHelpers.is_registered_pass_through_route("/api/endpoint") is False
 
-        # Test with default root path
-        mock_get_root.return_value = "/"
+            # Test with default root path
+            mock_get_root.return_value = "/"
 
-        # Should match with default root
-        assert InitPassThroughEndpointHelpers.is_registered_pass_through_route("/api/endpoint") is True
+            # Should match with default root
+            assert InitPassThroughEndpointHelpers.is_registered_pass_through_route("/api/endpoint") is True
 
-        # Should not match with root prepended when root is /
-        assert InitPassThroughEndpointHelpers.is_registered_pass_through_route("/proxy/api/endpoint") is False
-
-    # Clean up
-    _registered_pass_through_routes.clear()
+            # Should not match with root prepended when root is /
+            assert InitPassThroughEndpointHelpers.is_registered_pass_through_route("/proxy/api/endpoint") is False
+    finally:
+        _registered_pass_through_routes.clear()
 
 
 def test_get_registered_pass_through_route_with_custom_root():
@@ -2347,30 +2347,30 @@ def test_get_registered_pass_through_route_with_custom_root():
     route_key = f"{endpoint_id}:exact:{path}"
     _registered_pass_through_routes[route_key] = target_config
 
-    with patch("litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_server_root_path") as mock_get_root:
-        # Test with custom root path /litellm
-        mock_get_root.return_value = "/litellm"
+    try:
+        with patch("litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_server_root_path") as mock_get_root:
+            # Test with custom root path /litellm
+            mock_get_root.return_value = "/litellm"
 
-        # Should return config when request route includes root path
-        result = InitPassThroughEndpointHelpers.get_registered_pass_through_route("/litellm/chat/completions")
-        assert result is not None
-        assert result["target"] == "http://api.example.com/v1/chat/completions"
-        assert result["headers"]["Authorization"] == "Bearer token123"
+            # Should return config when request route includes root path
+            result = InitPassThroughEndpointHelpers.get_registered_pass_through_route("/litellm/chat/completions")
+            assert result is not None
+            assert result["target"] == "http://api.example.com/v1/chat/completions"
+            assert result["headers"]["Authorization"] == "Bearer token123"
 
-        # Should return None when route doesn't match
-        result = InitPassThroughEndpointHelpers.get_registered_pass_through_route("/chat/completions")
-        assert result is None
+            # Should return None when route doesn't match
+            result = InitPassThroughEndpointHelpers.get_registered_pass_through_route("/chat/completions")
+            assert result is None
 
-        # Test with default root path
-        mock_get_root.return_value = "/"
+            # Test with default root path
+            mock_get_root.return_value = "/"
 
-        # Should return config with default root
-        result = InitPassThroughEndpointHelpers.get_registered_pass_through_route("/chat/completions")
-        assert result is not None
-        assert result["target"] == "http://api.example.com/v1/chat/completions"
-
-    # Clean up
-    _registered_pass_through_routes.clear()
+            # Should return config with default root
+            result = InitPassThroughEndpointHelpers.get_registered_pass_through_route("/chat/completions")
+            assert result is not None
+            assert result["target"] == "http://api.example.com/v1/chat/completions"
+    finally:
+        _registered_pass_through_routes.clear()
 
 
 def test_create_pass_through_route_accumulates_multiple_adapters(monkeypatch):

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -2381,37 +2381,45 @@ def test_create_pass_through_route_accumulates_multiple_adapters(monkeypatch):
     """
     import litellm
 
-    class DummyLogger(CustomLogger):
+    class DummyLoggerA(CustomLogger):
+        pass
+
+    class DummyLoggerB(CustomLogger):
         pass
 
     monkeypatch.setattr(litellm, "adapters", [])
 
-    create_pass_through_route(
-        endpoint="/v1/first-endpoint",
-        target=DummyLogger(),
-        custom_headers=None,
-        _forward_headers=False,
-        _merge_query_params=False,
-        dependencies=None,
-    )
-
-    create_pass_through_route(
-        endpoint="/v1/second-endpoint",
-        target=DummyLogger(),
-        custom_headers=None,
-        _forward_headers=False,
-        _merge_query_params=False,
-        dependencies=None,
-    )
-
-    assert isinstance(litellm.adapters, list)
-    assert len(litellm.adapters) == 2
-
-    adapter_ids = [entry["id"] for entry in litellm.adapters]
-    assert len(set(adapter_ids)) == 2
-
-    # Cleanup: clear registered routes to prevent leakage into other tests
     from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
         _registered_pass_through_routes,
+        _seen_adapter_targets,
     )
     _registered_pass_through_routes.clear()
+    _seen_adapter_targets.clear()
+
+    try:
+        create_pass_through_route(
+            endpoint="/v1/first-endpoint",
+            target=DummyLoggerA(),
+            custom_headers=None,
+            _forward_headers=False,
+            _merge_query_params=False,
+            dependencies=None,
+        )
+
+        create_pass_through_route(
+            endpoint="/v1/second-endpoint",
+            target=DummyLoggerB(),
+            custom_headers=None,
+            _forward_headers=False,
+            _merge_query_params=False,
+            dependencies=None,
+        )
+
+        assert isinstance(litellm.adapters, list)
+        assert len(litellm.adapters) == 2
+
+        adapter_ids = [entry["id"] for entry in litellm.adapters]
+        assert len(set(adapter_ids)) == 2
+    finally:
+        _registered_pass_through_routes.clear()
+        _seen_adapter_targets.clear()

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -2409,3 +2409,9 @@ def test_create_pass_through_route_accumulates_multiple_adapters(monkeypatch):
 
     adapter_ids = [entry["id"] for entry in litellm.adapters]
     assert len(set(adapter_ids)) == 2
+
+    # Cleanup: clear registered routes to prevent leakage into other tests
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        _registered_pass_through_routes,
+    )
+    _registered_pass_through_routes.clear()

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -14,8 +14,10 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
+from litellm.integrations.custom_logger import CustomLogger
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     HttpPassThroughEndpointHelpers,
+    create_pass_through_route,
     pass_through_request,
 )
 from litellm.proxy.pass_through_endpoints.success_handler import (
@@ -2369,3 +2371,41 @@ def test_get_registered_pass_through_route_with_custom_root():
 
     # Clean up
     _registered_pass_through_routes.clear()
+
+
+def test_create_pass_through_route_accumulates_multiple_adapters(monkeypatch):
+    """
+    Regression for #22645:
+    registering multiple object-target pass-through endpoints must append adapters
+    instead of overwriting previously registered entries.
+    """
+    import litellm
+
+    class DummyLogger(CustomLogger):
+        pass
+
+    monkeypatch.setattr(litellm, "adapters", [])
+
+    create_pass_through_route(
+        endpoint="/v1/first-endpoint",
+        target=DummyLogger(),
+        custom_headers=None,
+        _forward_headers=False,
+        _merge_query_params=False,
+        dependencies=None,
+    )
+
+    create_pass_through_route(
+        endpoint="/v1/second-endpoint",
+        target=DummyLogger(),
+        custom_headers=None,
+        _forward_headers=False,
+        _merge_query_params=False,
+        dependencies=None,
+    )
+
+    assert isinstance(litellm.adapters, list)
+    assert len(litellm.adapters) == 2
+
+    adapter_ids = [entry["id"] for entry in litellm.adapters]
+    assert len(set(adapter_ids)) == 2

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -2474,9 +2474,60 @@ def test_subpath_reuses_adapter_id(monkeypatch):
 
         # Still only one adapter entry (no duplicate)
         assert len(litellm.adapters) == 1
-        # The seen dict should map to the same adapter_id
-        target_key = type(adapter_instance).__qualname__
+        # The seen dict should map to the same adapter_id (keyed by object identity)
+        target_key = id(adapter_instance)
         assert _seen_adapter_targets[target_key] == first_adapter_id
+    finally:
+        _registered_pass_through_routes.clear()
+        _seen_adapter_targets.clear()
+
+
+def test_same_class_different_instances_get_separate_adapters(monkeypatch):
+    """
+    Two distinct instances of the same adapter class targeting different
+    endpoints must each get their own adapter_id (no qualname collision).
+    """
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        _registered_pass_through_routes,
+        _seen_adapter_targets,
+        create_pass_through_route,
+    )
+
+    import litellm
+
+    class SharedAdapter(CustomLogger):
+        pass
+
+    monkeypatch.setattr(litellm, "adapters", [])
+    _registered_pass_through_routes.clear()
+    _seen_adapter_targets.clear()
+
+    try:
+        instance_a = SharedAdapter()
+        instance_b = SharedAdapter()
+
+        create_pass_through_route(
+            endpoint="/v1/endpoint-a",
+            target=instance_a,
+            custom_headers=None,
+            _forward_headers=False,
+            _merge_query_params=False,
+            dependencies=None,
+        )
+
+        create_pass_through_route(
+            endpoint="/v1/endpoint-b",
+            target=instance_b,
+            custom_headers=None,
+            _forward_headers=False,
+            _merge_query_params=False,
+            dependencies=None,
+        )
+
+        # Two different instances → two separate adapter entries
+        assert len(litellm.adapters) == 2
+        adapter_ids = [entry["id"] for entry in litellm.adapters]
+        assert len(set(adapter_ids)) == 2, "Same-class instances must get distinct IDs"
     finally:
         _registered_pass_through_routes.clear()
         _seen_adapter_targets.clear()

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -2423,3 +2423,60 @@ def test_create_pass_through_route_accumulates_multiple_adapters(monkeypatch):
     finally:
         _registered_pass_through_routes.clear()
         _seen_adapter_targets.clear()
+
+
+def test_subpath_reuses_adapter_id(monkeypatch):
+    """
+    Regression for #22746:
+    When include_subpath=True, create_pass_through_route is called twice for the
+    same target (exact path + wildcard).  The second call must reuse the existing
+    adapter_id instead of generating a new unregistered one.
+    """
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        _registered_pass_through_routes,
+        _seen_adapter_targets,
+        create_pass_through_route,
+    )
+
+    import litellm
+
+    class DummyAdapter(CustomLogger):
+        pass
+
+    monkeypatch.setattr(litellm, "adapters", [])
+    _registered_pass_through_routes.clear()
+    _seen_adapter_targets.clear()
+
+    try:
+        adapter_instance = DummyAdapter()
+
+        create_pass_through_route(
+            endpoint="/v1/test-endpoint",
+            target=adapter_instance,
+            custom_headers=None,
+            _forward_headers=False,
+            _merge_query_params=False,
+            dependencies=None,
+        )
+
+        # Capture state after first registration
+        assert len(litellm.adapters) == 1
+        first_adapter_id = litellm.adapters[0]["id"]
+
+        create_pass_through_route(
+            endpoint="/v1/test-endpoint/{subpath:path}",
+            target=adapter_instance,
+            custom_headers=None,
+            _forward_headers=False,
+            _merge_query_params=False,
+            dependencies=None,
+        )
+
+        # Still only one adapter entry (no duplicate)
+        assert len(litellm.adapters) == 1
+        # The seen dict should map to the same adapter_id
+        target_key = type(adapter_instance).__qualname__
+        assert _seen_adapter_targets[target_key] == first_adapter_id
+    finally:
+        _registered_pass_through_routes.clear()
+        _seen_adapter_targets.clear()


### PR DESCRIPTION
## Summary
- Fix pass-through adapter registration to append entries instead of overwriting global adapter list
- Preserve multiple registered adapters across multiple endpoint initializations
- Add regression test verifying two object-target endpoint registrations produce two adapters

## Why
Issue #22645 reports that custom callback registration in multi-endpoint adapter flows causes adapter overwrites and callback resolution errors because only the last adapter remains registered.

## Validation
- pytest /Users/giulioleone/litellm/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py::test_create_pass_through_route_accumulates_multiple_adapters -q -rA
- pytest /Users/giulioleone/litellm/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py -q

Closes #22645
