### PR TITLE
fix(cache): preserve embedding indices on cache merges

### DIFF
--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -507,7 +507,9 @@ class LLMCachingHandler:
         final_data_list = []
         for item in _caching_handler_response.final_embedding_cached_response.data:
             if item is None and embedding_response.data is not None:
-                final_data_list.append(embedding_response.data[idx])
+                api_item = embedding_response.data[idx]
+                api_item.index = len(final_data_list)
+                final_data_list.append(api_item)
                 idx += 1
             else:
                 final_data_list.append(item)

--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -15,6 +15,7 @@ In each method it will call the appropriate method from caching.py
 """
 
 import asyncio
+import copy
 import datetime
 import inspect
 import time
@@ -514,7 +515,6 @@ class LLMCachingHandler:
                     api_item_copy["index"] = len(final_data_list)
                     final_data_list.append(api_item_copy)
                 else:
-                    import copy
                     api_item_copy = copy.copy(api_item)
                     api_item_copy.index = len(final_data_list)
                     final_data_list.append(api_item_copy)

--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -508,8 +508,14 @@ class LLMCachingHandler:
         for item in _caching_handler_response.final_embedding_cached_response.data:
             if item is None and embedding_response.data is not None:
                 api_item = embedding_response.data[idx]
-                api_item.index = len(final_data_list)
-                final_data_list.append(api_item)
+                # api_item can be either a dict or an object (e.g., Embedding).
+                if isinstance(api_item, dict):
+                    api_item_copy = dict(api_item)
+                    api_item_copy["index"] = len(final_data_list)
+                    final_data_list.append(api_item_copy)
+                else:
+                    api_item.index = len(final_data_list)
+                    final_data_list.append(api_item)
                 idx += 1
             else:
                 final_data_list.append(item)

--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -511,11 +511,11 @@ class LLMCachingHandler:
                 api_item = embedding_response.data[idx]
                 # api_item can be either a dict or an object (e.g., Embedding).
                 if isinstance(api_item, dict):
-                    api_item_copy = dict(api_item)
+                    api_item_copy = copy.deepcopy(api_item)
                     api_item_copy["index"] = len(final_data_list)
                     final_data_list.append(api_item_copy)
                 else:
-                    api_item_copy = copy.copy(api_item)
+                    api_item_copy = copy.deepcopy(api_item)
                     api_item_copy.index = len(final_data_list)
                     final_data_list.append(api_item_copy)
                 idx += 1

--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -514,8 +514,10 @@ class LLMCachingHandler:
                     api_item_copy["index"] = len(final_data_list)
                     final_data_list.append(api_item_copy)
                 else:
-                    api_item.index = len(final_data_list)
-                    final_data_list.append(api_item)
+                    import copy
+                    api_item_copy = copy.copy(api_item)
+                    api_item_copy.index = len(final_data_list)
+                    final_data_list.append(api_item_copy)
                 idx += 1
             else:
                 final_data_list.append(item)

--- a/tests/test_litellm/caching/test_embedding_cache_merge_indices.py
+++ b/tests/test_litellm/caching/test_embedding_cache_merge_indices.py
@@ -1,0 +1,78 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from litellm.caching.caching_handler import LLMCachingHandler
+
+
+def test_embedding_cache_merge_preserves_global_indices_on_miss_merge():
+    """
+    Regression for #22659:
+    when combining cached + non-cached embedding results, merged output indices
+    must match original input positions (not local API result positions).
+    """
+    llm_caching_handler = LLMCachingHandler(
+        original_function=MagicMock(),
+        request_kwargs={},
+        start_time=datetime.now(),
+    )
+
+    # First input is cache hit, second is cache miss
+    cached_result = [
+        {
+            "embedding": [0.1, 0.2],
+            "model": "text-embedding-3-small",
+        },
+        None,
+    ]
+
+    kwargs = {
+        "model": "text-embedding-3-small",
+        "input": ["cached-input", "new-input"],
+    }
+
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.async_success_handler = MagicMock()
+
+    (
+        final_embedding_cached_response,
+        embedding_all_elements_cache_hit,
+    ) = llm_caching_handler._process_async_embedding_cached_response(
+        final_embedding_cached_response=None,
+        cached_result=cached_result,
+        kwargs=kwargs,
+        logging_obj=mock_logging_obj,
+        start_time=datetime.now(),
+        model="text-embedding-3-small",
+    )
+
+    assert embedding_all_elements_cache_hit is False
+    assert kwargs["input"] == ["new-input"]
+
+    api_embedding_item = MagicMock()
+    api_embedding_item.embedding = [0.3, 0.4]
+    api_embedding_item.index = 0  # provider-local index before merge
+    api_embedding_item.object = "embedding"
+
+    mock_api_response = MagicMock()
+    mock_api_response.model = "text-embedding-3-small"
+    mock_api_response.usage = None
+    mock_api_response.data = [api_embedding_item]
+
+    caching_handler_response = MagicMock()
+    caching_handler_response.final_embedding_cached_response = (
+        final_embedding_cached_response
+    )
+    caching_handler_response.embedding_all_elements_cache_hit = (
+        embedding_all_elements_cache_hit
+    )
+
+    response = llm_caching_handler._combine_cached_embedding_response_with_api_result(
+        _caching_handler_response=caching_handler_response,
+        embedding_response=mock_api_response,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+
+    assert len(response.data) == 2
+    assert response.data[0].index == 0
+    assert response.data[1].index == 1

--- a/tests/test_litellm/caching/test_embedding_cache_merge_indices.py
+++ b/tests/test_litellm/caching/test_embedding_cache_merge_indices.py
@@ -77,7 +77,37 @@ def test_embedding_cache_merge_preserves_global_indices_on_miss_merge():
     assert response.data[0].index == 0
     assert response.data[1].index == 1
 
-    # Also verify behavior when the API response data contains dict items
+    # Also verify behavior when the API response data contains dict items.
+    # Create a fresh caching_handler_response to avoid reusing mutated state.
+    (
+        final_embedding_cached_response2,
+        embedding_all_elements_cache_hit2,
+    ) = llm_caching_handler._process_async_embedding_cached_response(
+        final_embedding_cached_response=None,
+        cached_result=[
+            {
+                "embedding": [0.1, 0.2],
+                "model": "text-embedding-3-small",
+            },
+            None,
+        ],
+        kwargs={
+            "model": "text-embedding-3-small",
+            "input": ["cached-input", "new-input"],
+        },
+        logging_obj=mock_logging_obj,
+        start_time=datetime.now(),
+        model="text-embedding-3-small",
+    )
+
+    caching_handler_response2 = MagicMock()
+    caching_handler_response2.final_embedding_cached_response = (
+        final_embedding_cached_response2
+    )
+    caching_handler_response2.embedding_all_elements_cache_hit = (
+        embedding_all_elements_cache_hit2
+    )
+
     dict_api_response = MagicMock()
     dict_api_response.model = "text-embedding-3-small"
     dict_api_response.usage = None
@@ -91,7 +121,7 @@ def test_embedding_cache_merge_preserves_global_indices_on_miss_merge():
 
     response_with_dicts = (
         llm_caching_handler._combine_cached_embedding_response_with_api_result(
-            _caching_handler_response=caching_handler_response,
+            _caching_handler_response=caching_handler_response2,
             embedding_response=dict_api_response,
             start_time=datetime.now(),
             end_time=datetime.now(),

--- a/tests/test_litellm/caching/test_embedding_cache_merge_indices.py
+++ b/tests/test_litellm/caching/test_embedding_cache_merge_indices.py
@@ -129,5 +129,6 @@ def test_embedding_cache_merge_preserves_global_indices_on_miss_merge():
     )
 
     assert len(response_with_dicts.data) == 2
-    assert response_with_dicts.data[0]["index"] == 0
+    # data[0] is an Embedding object (from cache), data[1] is a dict (from API)
+    assert response_with_dicts.data[0].index == 0
     assert response_with_dicts.data[1]["index"] == 1

--- a/tests/test_litellm/caching/test_embedding_cache_merge_indices.py
+++ b/tests/test_litellm/caching/test_embedding_cache_merge_indices.py
@@ -76,3 +76,28 @@ def test_embedding_cache_merge_preserves_global_indices_on_miss_merge():
     assert len(response.data) == 2
     assert response.data[0].index == 0
     assert response.data[1].index == 1
+
+    # Also verify behavior when the API response data contains dict items
+    dict_api_response = MagicMock()
+    dict_api_response.model = "text-embedding-3-small"
+    dict_api_response.usage = None
+    dict_api_response.data = [
+        {
+            "embedding": [0.3, 0.4],
+            "index": 0,
+            "object": "embedding",
+        }
+    ]
+
+    response_with_dicts = (
+        llm_caching_handler._combine_cached_embedding_response_with_api_result(
+            _caching_handler_response=caching_handler_response,
+            embedding_response=dict_api_response,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+    )
+
+    assert len(response_with_dicts.data) == 2
+    assert response_with_dicts.data[0]["index"] == 0
+    assert response_with_dicts.data[1]["index"] == 1


### PR DESCRIPTION
## Summary
- Fix embedding cache merge to reindex API miss results to original input positions
- Prevent mixed cache-hit/miss embedding batches from returning local miss indices (e.g. duplicate index 0)
- Add standalone regression test for mixed cache hit/miss index ordering

## Why
Issue #22659 reports incorrect behavior when embedding batches mix cached and non-cached elements, especially with identical/related vectors and custom cache-key usage. The merge step was preserving provider-local indices for misses instead of restoring global input-order indices.

## Validation
- pytest /Users/giulioleone/litellm/tests/test_litellm/caching/test_embedding_cache_merge_indices.py -q -rA
- pytest /Users/giulioleone/litellm/tests/test_litellm/caching/test_embedding_cache_merge_indices.py /Users/giulioleone/litellm/tests/test_litellm/caching/test_llm_caching_handler.py -q

Closes #22659
