### PR TITLE
fix: preserve ProxyException status codes in MCP server handler

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -24,11 +24,11 @@ from fastapi import FastAPI, HTTPException
 from pydantic import AnyUrl, ConfigDict
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import JSONResponse
+from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
 from starlette.types import Receive, Scope, Send
 
 from litellm._logging import verbose_logger
 from litellm.constants import MAXIMUM_TRACEBACK_LINES_TO_LOG
-from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
     MCPRequestHandler,
@@ -2108,8 +2108,12 @@ if MCP_AVAILABLE:
             # Re-raise HTTP exceptions to preserve status codes and details
             raise
         except ProxyException as e:
+            try:
+                status_code = int(e.code)
+            except (ValueError, TypeError):
+                status_code = 500
             error_response = JSONResponse(
-                status_code=int(e.code) if e.code else 500,
+                status_code=status_code,
                 content={"error": e.message, "type": e.type},
             )
             await error_response(scope, receive, send)
@@ -2167,14 +2171,17 @@ if MCP_AVAILABLE:
 
             await sse_session_manager.handle_request(scope, receive, send)
 
-        except HTTPException:
-            raise
         except ProxyException as e:
+            try:
+                status_code = int(e.code)
+            except (ValueError, TypeError):
+                status_code = 500
             error_response = JSONResponse(
-                status_code=int(e.code) if e.code else 500,
+                status_code=status_code,
                 content={"error": e.message, "type": e.type},
             )
             await error_response(scope, receive, send)
+
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Instead of re-raising, try to send a graceful error response

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2112,11 +2112,17 @@ if MCP_AVAILABLE:
                 status_code = int(e.code)
             except (ValueError, TypeError):
                 status_code = 500
-            error_response = JSONResponse(
-                status_code=status_code,
-                content={"error": e.message, "type": e.type},
-            )
-            await error_response(scope, receive, send)
+            try:
+                error_response = JSONResponse(
+                    status_code=status_code,
+                    content={"error": e.message, "type": e.type},
+                )
+                await error_response(scope, receive, send)
+            except Exception as response_error:
+                verbose_logger.exception(
+                    f"Failed to send ProxyException error response: {response_error}"
+                )
+                raise e
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Try to send a graceful error response for non-HTTP exceptions
@@ -2176,18 +2182,21 @@ if MCP_AVAILABLE:
                 status_code = int(e.code)
             except (ValueError, TypeError):
                 status_code = 500
-            error_response = JSONResponse(
-                status_code=status_code,
-                content={"error": e.message, "type": e.type},
-            )
-            await error_response(scope, receive, send)
-
+            try:
+                error_response = JSONResponse(
+                    status_code=status_code,
+                    content={"error": e.message, "type": e.type},
+                )
+                await error_response(scope, receive, send)
+            except Exception as response_error:
+                verbose_logger.exception(
+                    f"Failed to send ProxyException error response: {response_error}"
+                )
+                raise e
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
-            # Instead of re-raising, try to send a graceful error response
+            # Try to send a graceful error response for non-HTTP exceptions
             try:
-                # Send a proper HTTP error response instead of letting the exception bubble up
-
                 error_response = JSONResponse(
                     status_code=HTTP_500_INTERNAL_SERVER_ERROR,
                     content={"error": "MCP request failed", "details": str(e)},

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -28,6 +28,7 @@ from starlette.types import Receive, Scope, Send
 
 from litellm._logging import verbose_logger
 from litellm.constants import MAXIMUM_TRACEBACK_LINES_TO_LOG
+from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
     MCPRequestHandler,
@@ -41,7 +42,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     LITELLM_MCP_SERVER_NAME,
     LITELLM_MCP_SERVER_VERSION,
 )
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import UserAPIKeyAuth, ProxyException
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 from litellm.proxy.litellm_pre_call_utils import (
     LiteLLMProxyRequestSetup,
@@ -392,6 +393,12 @@ if MCP_AVAILABLE:
             verbose_logger.error(f"HTTPException in MCP tool call: {str(e)}")
             return CallToolResult(
                 content=[TextContent(text=f"Error: {str(e.detail)}", type="text")],
+                isError=True,
+            )
+        except ProxyException as e:
+            verbose_logger.error(f"ProxyException in MCP tool call: {str(e)}")
+            return CallToolResult(
+                content=[TextContent(text=f"Error: {str(e.message)}", type="text")],
                 isError=True,
             )
         except Exception as e:
@@ -2100,13 +2107,16 @@ if MCP_AVAILABLE:
         except HTTPException:
             # Re-raise HTTP exceptions to preserve status codes and details
             raise
+        except ProxyException as e:
+            error_response = JSONResponse(
+                status_code=int(e.code) if e.code else 500,
+                content={"error": e.message, "type": e.type},
+            )
+            await error_response(scope, receive, send)
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Try to send a graceful error response for non-HTTP exceptions
             try:
-                from starlette.responses import JSONResponse
-                from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
-
                 error_response = JSONResponse(
                     status_code=HTTP_500_INTERNAL_SERVER_ERROR,
                     content={"error": "MCP request failed", "details": str(e)},
@@ -2156,13 +2166,20 @@ if MCP_AVAILABLE:
                 await asyncio.sleep(0.1)
 
             await sse_session_manager.handle_request(scope, receive, send)
+
+        except HTTPException:
+            raise
+        except ProxyException as e:
+            error_response = JSONResponse(
+                status_code=int(e.code) if e.code else 500,
+                content={"error": e.message, "type": e.type},
+            )
+            await error_response(scope, receive, send)
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Instead of re-raising, try to send a graceful error response
             try:
                 # Send a proper HTTP error response instead of letting the exception bubble up
-                from starlette.responses import JSONResponse
-                from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
 
                 error_response = JSONResponse(
                     status_code=HTTP_500_INTERNAL_SERVER_ERROR,

--- a/tests/mcp_tests/test_mcp_proxy_exception.py
+++ b/tests/mcp_tests/test_mcp_proxy_exception.py
@@ -60,3 +60,47 @@ async def test_proxy_exception_preserves_status_code_in_mcp():
         f"Expected 403 but got {start_msg['status']} - "
         "ProxyException status code is being lost and converted to 500"
     )
+
+@pytest.mark.asyncio
+async def test_proxy_exception_preserves_status_code_in_sse_mcp():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/22706
+    ProxyException raised during SSE MCP auth should preserve status code, not return 500.
+    """
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy._experimental.mcp_server.server import handle_sse_mcp
+
+    scope: Scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": [],
+        "query_string": b"",
+    }
+    receive: Receive = AsyncMock()
+    sent_responses = []
+
+    async def mock_send(message):
+        sent_responses.append(message)
+
+    proxy_exc = ProxyException(
+        message="Forbidden - token expired",
+        type="auth_error",
+        param=None,
+        code=403,
+    )
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+        new=AsyncMock(side_effect=proxy_exc),
+    ):
+        await handle_sse_mcp(scope, receive, mock_send)
+
+    assert len(sent_responses) > 0, "No response was sent"
+    start_msg = next(
+        (m for m in sent_responses if m.get("type") == "http.response.start"), None
+    )
+    assert start_msg is not None, "No http.response.start message found"
+    assert start_msg["status"] == 403, (
+        f"Expected 403 but got {start_msg['status']}"
+    )

--- a/tests/mcp_tests/test_mcp_proxy_exception.py
+++ b/tests/mcp_tests/test_mcp_proxy_exception.py
@@ -104,3 +104,4 @@ async def test_proxy_exception_preserves_status_code_in_sse_mcp():
     assert start_msg["status"] == 403, (
         f"Expected 403 but got {start_msg['status']}"
     )
+    

--- a/tests/mcp_tests/test_mcp_proxy_exception.py
+++ b/tests/mcp_tests/test_mcp_proxy_exception.py
@@ -1,0 +1,62 @@
+"""
+Regression test for https://github.com/BerriAI/litellm/issues/22706
+ProxyException raised during MCP auth should preserve status code, not return 500.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+from starlette.types import Scope, Receive, Send
+
+
+@pytest.mark.asyncio
+async def test_proxy_exception_preserves_status_code_in_mcp():
+    """
+    When a ProxyException (e.g. 403) is raised during MCP auth,
+    the response should return 403 - not 500.
+    """
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy._experimental.mcp_server.server import handle_streamable_http_mcp
+
+    # Minimal ASGI scope for an MCP request
+    scope: Scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": [],
+        "query_string": b"",
+    }
+    receive: Receive = AsyncMock()
+
+    # Capture what status code was sent in the response
+    sent_responses = []
+
+    async def mock_send(message):
+        sent_responses.append(message)
+
+    # Simulate custom auth raising a 403 ProxyException
+    proxy_exc = ProxyException(
+        message="Forbidden - token expired",
+        type="auth_error",
+        param=None,
+        code=403,
+    )
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+        new=AsyncMock(side_effect=proxy_exc),
+    ):
+        await handle_streamable_http_mcp(scope, receive, mock_send)
+
+    # Should have sent a response (not re-raised as 500)
+    assert len(sent_responses) > 0, "No response was sent"
+
+    # Find the http.response.start message which contains the status code
+    start_msg = next(
+        (m for m in sent_responses if m.get("type") == "http.response.start"), None
+    )
+    assert start_msg is not None, "No http.response.start message found"
+
+    # THIS IS THE BUG - before fix this will be 500, after fix it should be 403
+    assert start_msg["status"] == 403, (
+        f"Expected 403 but got {start_msg['status']} - "
+        "ProxyException status code is being lost and converted to 500"
+    )

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -14,7 +14,7 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     MCPServer,
     MCPTransport,
 )
-from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+from litellm.proxy._types import LiteLLM_ObjectPermissionTable, UserAPIKeyAuth
 from mcp.types import Tool as MCPTool, CallToolResult, ListToolsResult
 from mcp.types import TextContent
 
@@ -414,12 +414,15 @@ async def test_streamable_http_mcp_handler_mock():
     mock_send = AsyncMock()
 
     with patch(
-        "litellm.proxy._experimental.mcp_server.server._SESSION_MANAGERS_INITIALIZED",
-        True,
-    ), patch(
-        "litellm.proxy._experimental.mcp_server.server.session_manager",
-        mock_session_manager,
-    ):
+    "litellm.proxy._experimental.mcp_server.server._SESSION_MANAGERS_INITIALIZED",
+    True,
+), patch(
+    "litellm.proxy._experimental.mcp_server.server.session_manager",
+    mock_session_manager,
+), patch(
+    "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+    new=AsyncMock(return_value=(UserAPIKeyAuth(), None, [], {}, {}, {})),
+):
         from litellm.proxy._experimental.mcp_server.server import (
             handle_streamable_http_mcp,
         )

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -414,15 +414,15 @@ async def test_streamable_http_mcp_handler_mock():
     mock_send = AsyncMock()
 
     with patch(
-    "litellm.proxy._experimental.mcp_server.server._SESSION_MANAGERS_INITIALIZED",
-    True,
-), patch(
-    "litellm.proxy._experimental.mcp_server.server.session_manager",
-    mock_session_manager,
-), patch(
-    "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
-    new=AsyncMock(return_value=(UserAPIKeyAuth(), None, [], {}, {}, {})),
-):
+        "litellm.proxy._experimental.mcp_server.server._SESSION_MANAGERS_INITIALIZED",
+        True,
+    ), patch(
+        "litellm.proxy._experimental.mcp_server.server.session_manager",
+        mock_session_manager,
+    ), patch(
+        "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+        new=AsyncMock(return_value=(UserAPIKeyAuth(), None, [], {}, {}, {})),
+    ):
         from litellm.proxy._experimental.mcp_server.server import (
             handle_streamable_http_mcp,
         )


### PR DESCRIPTION
## Relevant issues
Fixes #22706

## Pre-Submission checklist
- [x] I have added testing in the [`tests/mcp_tests/`](https://github.com/BerriAI/litellm/tree/main/tests/mcp_tests) directory
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ x] I have requested a Greptile review by commenting `@greptileai`

## CI (LiteLLM team)
- [ ] **Branch creation CI run** Link:
- [ ] **CI run for the last commit** Link:
- [ ] **Merge / cherry-pick CI run** Links:

## Type
🐛 Bug Fix

## Changes
- Added `except ProxyException` handler in `handle_streamable_http_mcp` and `handle_sse_mcp` to preserve original status code instead of returning 500
- Added `except ProxyException` handler in `mcp_server_tool_call`
- Moved imports to top-level, removed redundant local imports inside except blocks
- Added regression tests for both handlers