### PR TITLE
fix(responses): pass extra_body through responses-to-completion bridge

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -215,6 +215,7 @@ class LiteLLMCompletionResponsesConfig:
             # litellm specific params
             "custom_llm_provider": custom_llm_provider,
             "extra_headers": extra_headers,
+            "extra_body": kwargs.get("extra_body"),
         }
 
         # Responses API `Completed` events require usage, we pass `stream_options` to litellm.completion to include usage

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1774,3 +1774,53 @@ class TestStreamingIDConsistency:
         # Verify it matches the cached ID
         assert iterator._cached_item_id is not None
         assert iterator._cached_item_id == text_done_id
+
+
+class TestExtraBodyPassthrough:
+    """Test cases for extra_body parameter passthrough to completion request"""
+
+    def test_extra_body_passed_through_to_completion_request(self):
+        """Test that extra_body is passed through to the completion request"""
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="openrouter/moonshotai/kimi-k2.5",
+            input="Tell me a story.",
+            responses_api_request={},
+            extra_body={
+                "provider": {
+                    "order": ["Together"],
+                    "allow_fallbacks": False,
+                }
+            },
+        )
+
+        assert "extra_body" in result
+        assert result["extra_body"] == {
+            "provider": {
+                "order": ["Together"],
+                "allow_fallbacks": False,
+            }
+        }
+
+    def test_extra_body_none_is_filtered_out(self):
+        """Test that extra_body is None when not provided"""
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="gpt-4",
+            input="Hello",
+            responses_api_request={},
+        )
+
+        # extra_body should be None when not provided
+        assert result.get("extra_body") is None
+
+    def test_extra_body_and_extra_headers_passed_together(self):
+        """Test that both extra_body and extra_headers can be passed together"""
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="openrouter/anthropic/claude-3.5-sonnet",
+            input="Test input",
+            responses_api_request={},
+            extra_headers={"X-Custom-Header": "custom-value"},
+            extra_body={"custom_param": "custom_value"},
+        )
+
+        assert result["extra_headers"] == {"X-Custom-Header": "custom-value"}
+        assert result["extra_body"] == {"custom_param": "custom_value"}


### PR DESCRIPTION
## Summary

Fixes #20982

Pass the `extra_body` parameter through to the chat completion request when using the Responses API with models that require the completion bridge transformation (e.g., OpenRouter models).

## Problem

When using `litellm.responses()` with models that don't have native Responses API support and need to go through the responses-to-completion bridge, the `extra_body` parameter was being silently dropped.

For example, when calling:
```python
response = litellm.responses(
    model="openrouter/moonshotai/kimi-k2.5",
    input="Tell me a story.",
    extra_body={
        "provider": {
            "order": ["Together"],
            "allow_fallbacks": False,
        }
    },
)
```

The `extra_body` was not forwarded to the underlying `litellm.completion()` call, causing provider-specific settings to be ignored.

## Solution

Extract `extra_body` from `kwargs` and include it in the `litellm_completion_request` dict, following the same pattern used for `metadata` and `service_tier` (via `kwargs.get()`). No interface changes required.

## Changes

- `litellm/responses/litellm_completion_transformation/transformation.py`:
  - Added `"extra_body": kwargs.get("extra_body")` to the returned request dictionary

- `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py`:
  - Added `TestExtraBodyPassthrough` class with 3 new tests:
    - `test_extra_body_passed_through_to_completion_request` - verifies extra_body is passed through
    - `test_extra_body_none_is_filtered_out` - verifies None values are handled correctly
    - `test_extra_body_and_extra_headers_passed_together` - verifies both work together

## Testing

All tests pass:
```
pytest tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py -v
# 59 passed

pytest tests/test_litellm/llms/hosted_vllm/responses/test_hosted_vllm_responses.py -v
# 7 passed
```

Linting passes on modified file:
```
ruff check litellm/responses/litellm_completion_transformation/transformation.py
# All checks passed!
```