### PR TITLE
fix(openrouter): remove usage injection that causes TypeError on OpenAI SDK path

### DIFF
--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -207,7 +207,7 @@ class OpenrouterConfig(OpenAIGPTConfig):
         )
 
         # Extract cost from OpenRouter response body
-        # OpenRouter returns cost information in the usage object when usage.include=true
+        # OpenRouter returns cost information in the usage object by default
         try:
             response_json = raw_response.json()
             if "usage" in response_json and response_json["usage"]:

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -167,11 +167,6 @@ class OpenrouterConfig(OpenAIGPTConfig):
         )
         response.update(extra_body)
 
-        # ALWAYS add usage parameter to get cost data from OpenRouter
-        # This ensures cost tracking works for all OpenRouter models
-        if "usage" not in response:
-            response["usage"] = {"include": True}
-
         return response
 
     def transform_response(

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -373,7 +373,7 @@ def test_openrouter_cost_tracking_non_streaming():
     Test OpenRouter cost tracking for non-streaming completions.
 
     Verifies:
-    1. Request includes usage.include=true to get cost data
+    1. Request does NOT inject usage parameter (OpenRouter returns cost data by default)
     2. Response extracts cost from usage.cost and stores in _hidden_params
     """
     from unittest.mock import Mock, patch
@@ -381,7 +381,7 @@ def test_openrouter_cost_tracking_non_streaming():
 
     config = OpenrouterConfig()
 
-    # Test request adds usage parameter
+    # Verify request does NOT add usage parameter — OpenRouter returns cost by default
     transformed_request = config.transform_request(
         model="openrouter/anthropic/claude-sonnet-4.5",
         messages=[{"role": "user", "content": "Hello"}],
@@ -389,8 +389,7 @@ def test_openrouter_cost_tracking_non_streaming():
         litellm_params={},
         headers={},
     )
-    assert "usage" in transformed_request
-    assert transformed_request["usage"] == {"include": True}
+    assert "usage" not in transformed_request
 
     # Test response extracts cost
     mock_response = Mock(spec=httpx.Response)
@@ -434,13 +433,13 @@ def test_openrouter_cost_tracking_streaming():
     Test OpenRouter cost tracking for streaming completions.
 
     Verifies:
-    1. Request includes usage.include=true (same as non-streaming)
+    1. Request does NOT inject usage parameter (OpenRouter returns cost data by default)
     2. Streaming chunks preserve usage/cost data in the final chunk
     3. Cost field is accessible in the usage object
     """
     config = OpenrouterConfig()
 
-    # Test request adds usage parameter for streaming
+    # Verify request does NOT add usage parameter — OpenRouter returns cost by default
     transformed_request = config.transform_request(
         model="openrouter/anthropic/claude-sonnet-4.5",
         messages=[{"role": "user", "content": "Hello"}],
@@ -448,8 +447,7 @@ def test_openrouter_cost_tracking_streaming():
         litellm_params={},
         headers={},
     )
-    assert "usage" in transformed_request
-    assert transformed_request["usage"] == {"include": True}
+    assert "usage" not in transformed_request
 
     # Test streaming chunks preserve cost data
     handler = OpenRouterChatCompletionStreamingHandler(


### PR DESCRIPTION
## Summary
- Remove the `usage: {include: true}` injection from OpenRouter's `transform_request`
- This parameter was added in #9747 for cost tracking, but it causes `TypeError: AsyncCompletions.create() got an unexpected keyword argument 'usage'` when requests route through the OpenAI SDK code path
- OpenRouter now returns cost data (token counts, cost, cost_details) by default in all responses — the `usage` request parameter is no longer needed

## Problem
The `transform_request` method adds `"usage": {"include": True}` to the top-level request dict. When LiteLLM routes through `litellm/llms/openai/openai.py`, this dict gets unpacked as `**data` into `AsyncCompletions.create()`, which doesn't accept `usage` as a keyword argument:

```
TypeError: AsyncCompletions.create() got an unexpected keyword argument 'usage'
```

This is the same class of parameter-leaking bug as #14137 (`reasoning`) and #6857 (`provider`).

## Verification
Tested against OpenRouter's API directly — responses with and without `usage: {include: true}` return identical cost data:

```
WITHOUT usage param → cost: 1.92e-05, keys: [prompt_tokens, completion_tokens, total_tokens, cost, is_byok, ...]
WITH usage param    → cost: 1.92e-05, keys: [prompt_tokens, completion_tokens, total_tokens, cost, is_byok, ...]
```

## Test plan
- [x] Verified OpenRouter returns cost data without the `usage` parameter
- [x] Verified fix resolves the TypeError on the OpenAI SDK code path
- [x] Updated/removed tests that asserted `usage` was in the transformed request