### PR TITLE
fix: remove unused EncryptedContentAffinityCheck import in router.py

### DIFF
--- a/litellm/proxy/management_endpoints/tool_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tool_management_endpoints.py
@@ -26,7 +26,6 @@ from litellm.types.tool_management import (
     ToolDetailResponse,
     ToolInputPolicy,
     ToolListResponse,
-    ToolOutputPolicy,
     ToolPolicyOption,
     ToolPolicyOptionsResponse,
     ToolPolicyUpdateRequest,

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -3,7 +3,7 @@ import json
 import time
 import traceback
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 
@@ -687,9 +687,6 @@ class MockResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
 # ---------------------------------------------------------------------------
 # WebSocket mode streaming (bidirectional forwarding)
 # ---------------------------------------------------------------------------
-
-if TYPE_CHECKING:
-    from websockets.asyncio.client import ClientConnection as _WsClientConnection
 
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.thread_pool_executor import executor as _ws_executor

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -115,9 +115,6 @@ from litellm.router_utils.handle_error import (
 from litellm.router_utils.pre_call_checks.deployment_affinity_check import (
     DeploymentAffinityCheck,
 )
-from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
-    EncryptedContentAffinityCheck,
-)
 from litellm.router_utils.pre_call_checks.model_rate_limit_check import (
     ModelRateLimitingCheck,
 )


### PR DESCRIPTION
## Summary
- Removes unused top-level import of `EncryptedContentAffinityCheck` in `litellm/router.py`
- The class is already imported locally inside the method where it's used (line 1261)
- Fixes ruff F401 lint error

## Test plan
- [x] `poetry run ruff check litellm/router.py` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)