### PR TITLE
Exclude aresponses_websocket from Azure SDK client init test

### DIFF
--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -425,6 +425,7 @@ def test_select_azure_base_url_called(setup_mocks):
             "add_message",
             "arun_thread_stream",
             "aresponses",
+            "aresponses_websocket",
             "alist_input_items",
             "acreate_fine_tuning_job",
             "acancel_fine_tuning_job",


### PR DESCRIPTION
## Summary
- Add `aresponses_websocket` to the exclusion list in `test_ensure_initialize_azure_sdk_client_always_used`
- This CallType uses WebSocket passthrough (not Azure SDK client initialization), so it correctly doesn't call `initialize_azure_sdk_client`

## Test plan
- [x] All 20 parameterized tests pass (+ 22 skipped)
- [x] Single file change, scoped fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)