### PR TITLE
Fix A2A message context_id access when message is a dict

### DIFF
--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -271,8 +271,13 @@ async def asend_message(
     card_url = getattr(agent_card, "url", None) if agent_card else None
 
     context_id = trace_id or str(uuid.uuid4())
-    if request.params.message.context_id is None:
-        request.params.message.context_id = context_id
+    message = request.params.message
+    if isinstance(message, dict):
+        if message.get("context_id") is None:
+            message["context_id"] = context_id
+    else:
+        if getattr(message, "context_id", None) is None:
+            message.context_id = context_id
 
     # Retry loop: if connection fails due to localhost URL in agent card, retry with fixed URL
     a2a_response = None


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'dict' object has no attribute 'context_id'` in `asend_message`
- The code accessed `request.params.message.context_id` with attribute syntax, but message can be a dict
- Added `isinstance(message, dict)` check, using dict access for dicts and `getattr`/`setattr` for objects
- Matches existing pattern in `litellm/a2a_protocol/utils.py`

## Test plan
- [x] `test_asend_message_uses_input_output_cost_per_token` passes
- [x] All 14 A2A protocol tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)