### PR TITLE
Add missing migration for LiteLLM_ToolTable policy changes

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260303000000_update_tool_table_policies/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260303000000_update_tool_table_policies/migration.sql
@@ -1,0 +1,20 @@
+-- Rename call_policy to input_policy
+ALTER TABLE "LiteLLM_ToolTable" RENAME COLUMN "call_policy" TO "input_policy";
+
+-- Add output_policy column
+ALTER TABLE "LiteLLM_ToolTable" ADD COLUMN "output_policy" TEXT NOT NULL DEFAULT 'untrusted';
+
+-- Add user_agent column
+ALTER TABLE "LiteLLM_ToolTable" ADD COLUMN "user_agent" TEXT;
+
+-- Add last_used_at column
+ALTER TABLE "LiteLLM_ToolTable" ADD COLUMN "last_used_at" TIMESTAMP(3);
+
+-- Drop old index on call_policy
+DROP INDEX IF EXISTS "LiteLLM_ToolTable_call_policy_idx";
+
+-- CreateIndex
+CREATE INDEX "LiteLLM_ToolTable_input_policy_idx" ON "LiteLLM_ToolTable"("input_policy");
+
+-- CreateIndex
+CREATE INDEX "LiteLLM_ToolTable_output_policy_idx" ON "LiteLLM_ToolTable"("output_policy");


### PR DESCRIPTION
## Summary
- PR #22732 changed the `LiteLLM_ToolTable` schema but didn't include a migration for it
- Schema changes: renamed `call_policy` → `input_policy`, added `output_policy`, `user_agent`, `last_used_at` columns, updated indexes
- This caused `test_aaaasschema_migration_check` to fail ("Schema changes detected - new migration required")

## Migration details
```sql
ALTER TABLE "LiteLLM_ToolTable" RENAME COLUMN "call_policy" TO "input_policy";
ALTER TABLE "LiteLLM_ToolTable" ADD COLUMN "output_policy" TEXT NOT NULL DEFAULT 'untrusted';
ALTER TABLE "LiteLLM_ToolTable" ADD COLUMN "user_agent" TEXT;
ALTER TABLE "LiteLLM_ToolTable" ADD COLUMN "last_used_at" TIMESTAMP(3);
DROP INDEX IF EXISTS "LiteLLM_ToolTable_call_policy_idx";
CREATE INDEX "LiteLLM_ToolTable_input_policy_idx" ON "LiteLLM_ToolTable"("input_policy");
CREATE INDEX "LiteLLM_ToolTable_output_policy_idx" ON "LiteLLM_ToolTable"("output_policy");
```

## Test plan
- [x] Migration SQL matches the schema diff between the old and new `LiteLLM_ToolTable`
- [x] All 3 schema files (root, proxy, proxy-extras) are already in sync for this model
- [ ] `test_aaaasschema_migration_check` should pass in CI (requires PostgreSQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)