### PR TITLE
Fix responses ID security test for new request_cache parameter

### DIFF
--- a/tests/test_litellm/test_responses_id_security.py
+++ b/tests/test_litellm/test_responses_id_security.py
@@ -545,7 +545,7 @@ class TestAsyncPostCallSuccessHook:
                 response=mock_response,
             )
 
-            mock_encrypt.assert_called_once_with(mock_response, mock_user_api_key_dict)
+            mock_encrypt.assert_called_once_with(mock_response, mock_user_api_key_dict, request_cache=None)
             assert result == mock_response
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `_encrypt_response_id` now receives `request_cache=None` as a keyword argument
- Updated mock assertion in `test_async_post_call_success_hook_encrypts_response` to expect this parameter

## Test plan
- [x] `test_async_post_call_success_hook_encrypts_response` passes
- [x] Single line change

🤖 Generated with [Claude Code](https://claude.com/claude-code)