### PR TITLE
Guard tenacity import in e2e Azure batch tests

### DIFF
--- a/tests/proxy_e2e_azure_batches_tests/test_managed_files_base.py
+++ b/tests/proxy_e2e_azure_batches_tests/test_managed_files_base.py
@@ -12,6 +12,8 @@ import httpx
 import openai
 import psycopg2
 import pytest
+
+tenacity = pytest.importorskip("tenacity", reason="tenacity required for e2e batch tests")
 from tenacity import Retrying, stop_after_delay, wait_fixed
 
 sys.path.insert(0, os.path.abspath("../.."))

--- a/tests/proxy_e2e_azure_batches_tests/test_proxy_e2e_azure_batches.py
+++ b/tests/proxy_e2e_azure_batches_tests/test_proxy_e2e_azure_batches.py
@@ -7,6 +7,8 @@ import warnings
 import httpx
 import openai
 import pytest
+
+tenacity = pytest.importorskip("tenacity", reason="tenacity required for e2e batch tests")
 from tenacity import RetryError
 
 sys.path.insert(0, os.path.abspath("../.."))


### PR DESCRIPTION
## Summary
- `tenacity` is not in `pyproject.toml` dependencies, causing `ModuleNotFoundError` during test collection
- Added `pytest.importorskip("tenacity")` to both `test_proxy_e2e_azure_batches.py` and `test_managed_files_base.py`
- Tests will gracefully skip when tenacity is not installed instead of failing with ImportError

## Test plan
- [x] Tests skip cleanly when tenacity is not available
- [x] Tests still work when tenacity is installed (e2e CI environments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)