### PR TITLE
fix: update Okta SSO docs and custom SSO handler example

### DIFF
--- a/docs/my-website/docs/proxy/admin_ui_sso.md
+++ b/docs/my-website/docs/proxy/admin_ui_sso.md
@@ -41,11 +41,37 @@ After creating the app, copy your **Client ID** and **Client Secret** from the a
 
 Ensure users are assigned to the app in the **Assignments** tab. If Federation Broker Mode is enabled, you may need to disable it to assign users manually.
 
-#### Step 3: Configure Authorization Server Access Policy
+#### Step 3: Set Environment Variables
 
-:::warning Important
-This step is required. Without an Access Policy for your app, users will get a `no_matching_policy` error when attempting to log in.
+Set the following environment variables. The only difference between the two Okta authorization servers is the endpoint URLs:
+
+**Org Authorization Server** (available on all Okta plans, no additional SKU required):
+```bash
+GENERIC_CLIENT_ID="<your-client-id>"
+GENERIC_CLIENT_SECRET="<your-client-secret>"
+GENERIC_AUTHORIZATION_ENDPOINT="https://<your-okta-domain>/oauth2/v1/authorize"
+GENERIC_TOKEN_ENDPOINT="https://<your-okta-domain>/oauth2/v1/token"
+GENERIC_USERINFO_ENDPOINT="https://<your-okta-domain>/oauth2/v1/userinfo"
+PROXY_BASE_URL="https://<your-proxy-base-url>"
+```
+
+**Custom Authorization Server** (requires the Okta API Access Management SKU):
+```bash
+GENERIC_CLIENT_ID="<your-client-id>"
+GENERIC_CLIENT_SECRET="<your-client-secret>"
+GENERIC_AUTHORIZATION_ENDPOINT="https://<your-okta-domain>/oauth2/default/v1/authorize"
+GENERIC_TOKEN_ENDPOINT="https://<your-okta-domain>/oauth2/default/v1/token"
+GENERIC_USERINFO_ENDPOINT="https://<your-okta-domain>/oauth2/default/v1/userinfo"
+PROXY_BASE_URL="https://<your-proxy-base-url>"
+```
+
+:::tip
+You can find all OAuth endpoints at `https://<your-okta-domain>/.well-known/openid-configuration`
 :::
+
+#### Step 3a: Configure Access Policy (Custom Authorization Server only)
+
+If you are using the Custom Authorization Server, you must configure an Access Policy. Without it, users will get a `no_matching_policy` error. Skip this step if you are using the Org Authorization Server.
 
 1. Go to **Security** → **API**
 
@@ -62,21 +88,21 @@ This step is required. Without an Access Policy for your app, users will get a `
 
 See [Okta's Access Policy documentation](https://help.okta.com/en-us/content/topics/security/api-access-management/access-policies.htm) for more details.
 
-#### Step 4: Configure LiteLLM Environment Variables
+#### Step 4: Configure Okta Security Settings
+
+**GENERIC_CLIENT_STATE** is recommended for Okta to prevent CSRF attacks:
 
 ```bash
-GENERIC_CLIENT_ID="<your-client-id>"
-GENERIC_CLIENT_SECRET="<your-client-secret>"
-GENERIC_AUTHORIZATION_ENDPOINT="https://<your-okta-domain>/oauth2/default/v1/authorize"
-GENERIC_TOKEN_ENDPOINT="https://<your-okta-domain>/oauth2/default/v1/token"
-GENERIC_USERINFO_ENDPOINT="https://<your-okta-domain>/oauth2/default/v1/userinfo"
 GENERIC_CLIENT_STATE="random-string"
-PROXY_BASE_URL="https://<your-proxy-base-url>"
 ```
 
-:::tip
-You can find all OAuth endpoints at `https://<your-okta-domain>/.well-known/openid-configuration`
-:::
+**PKCE (Proof Key for Code Exchange)** — If your Okta application is configured to require PKCE, enable it by setting:
+
+```bash
+GENERIC_CLIENT_USE_PKCE="true"
+```
+
+LiteLLM will automatically handle PKCE parameter generation and verification during the OAuth flow.
 
 #### Step 5: Test the SSO Flow
 
@@ -91,7 +117,7 @@ You can find all OAuth endpoints at `https://<your-okta-domain>/.well-known/open
 |-------|-------|----------|
 | `redirect_uri` error | Redirect URI not configured | Add `<proxy_base_url>/sso/callback` to Sign-in redirect URIs in Okta |
 | `access_denied` | User not assigned to app | Assign the user in the Assignments tab |
-| `no_matching_policy` | Missing Access Policy | Create an Access Policy in the Authorization Server (see Step 3) |
+| `no_matching_policy` | Missing Access Policy (Custom Authorization Server only) | Create an Access Policy in the Authorization Server (see Step 3a) |
 
 </TabItem>
 <TabItem value="google" label="Google SSO">
@@ -456,23 +482,9 @@ PROXY_BASE_URL=http://litellm.platform.com
 PROXY_BASE_URL=litellm.platform.com
 ```
 
-**2. For Okta specifically, ensure GENERIC_CLIENT_STATE is set**
+**2. For Okta specifically, ensure `GENERIC_CLIENT_STATE` is set and PKCE is configured if required**
 
-Okta requires the `GENERIC_CLIENT_STATE` parameter:
-
-```bash
-GENERIC_CLIENT_STATE="random-string" # Required for Okta
-```
-
-### Okta PKCE
-
-If your Okta application is configured to require PKCE (Proof Key for Code Exchange), enable it by setting:
-
-```bash
-GENERIC_CLIENT_USE_PKCE="true"
-```
-
-This is required when your Okta app settings enforce PKCE for enhanced security. LiteLLM will automatically handle PKCE parameter generation and verification during the OAuth flow.
+See [Okta SSO — Step 4: Configure Okta Security Settings](#step-4-configure-okta-security-settings) for details on `GENERIC_CLIENT_STATE` and PKCE configuration.
 
 ### Common Configuration Issues
 

--- a/docs/my-website/docs/proxy/custom_sso.md
+++ b/docs/my-website/docs/proxy/custom_sso.md
@@ -121,15 +121,14 @@ Use this if you want to run your own code **after** a user signs on to the LiteL
 Make sure the response type follows the `SSOUserDefinedValues` pydantic object. This is used for logging the user into the Admin UI:
 
 ```python
-from fastapi import Request
 from fastapi_sso.sso.base import OpenID
 
 from litellm.proxy._types import LitellmUserRoles, SSOUserDefinedValues
-from litellm.proxy.management_endpoints.internal_user_endpoints import (
-    new_user,
-    user_info,
-)
-from litellm.proxy.management_endpoints.team_endpoints import add_new_member
+from litellm.proxy import proxy_server
+
+# These imports are available if you need to create users or manage team membership:
+# from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
+# from litellm.proxy.management_endpoints.team_endpoints import add_new_member
 
 
 async def custom_sso_handler(userIDPInfo: OpenID) -> SSOUserDefinedValues:
@@ -158,8 +157,9 @@ async def custom_sso_handler(userIDPInfo: OpenID) -> SSOUserDefinedValues:
         #################################################
         # Run your custom code / logic here
         # check if user exists in litellm proxy DB
-        _user_info = await user_info(user_id=userIDPInfo.id)
-        print("_user_info from litellm DB ", _user_info)  # noqa
+        if proxy_server.prisma_client is not None:
+            _user_info = await proxy_server.prisma_client.get_data(user_id=userIDPInfo.id)
+            print("_user_info from litellm DB ", _user_info)  # noqa
         #################################################
 
         return SSOUserDefinedValues(

--- a/litellm/proxy/custom_sso.py
+++ b/litellm/proxy/custom_sso.py
@@ -20,8 +20,6 @@ from litellm.proxy import proxy_server
 
 async def custom_sso_handler(userIDPInfo: OpenID) -> SSOUserDefinedValues:
     try:
-        print("inside custom sso handler")  # noqa
-        print(f"userIDPInfo: {userIDPInfo}")  # noqa
 
         if userIDPInfo.id is None:
             raise ValueError(f"No ID found for user. userIDPInfo.id is None {userIDPInfo}")
@@ -34,7 +32,6 @@ async def custom_sso_handler(userIDPInfo: OpenID) -> SSOUserDefinedValues:
         # check if user exists in litellm proxy DB
         if proxy_server.prisma_client is not None:
             _user_info = await proxy_server.prisma_client.get_data(user_id=userIDPInfo.id)
-            print("_user_info from litellm DB ", _user_info)  # noqa
 
         return SSOUserDefinedValues(
             models=[],

--- a/litellm/proxy/custom_sso.py
+++ b/litellm/proxy/custom_sso.py
@@ -15,7 +15,7 @@ Flow:
 from fastapi_sso.sso.base import OpenID
 
 from litellm.proxy._types import LitellmUserRoles, SSOUserDefinedValues
-from litellm.proxy.management_endpoints.internal_user_endpoints import user_info
+from litellm.proxy import proxy_server
 
 
 async def custom_sso_handler(userIDPInfo: OpenID) -> SSOUserDefinedValues:
@@ -32,8 +32,9 @@ async def custom_sso_handler(userIDPInfo: OpenID) -> SSOUserDefinedValues:
         # user_groups = extra_fields.get("group", [])
 
         # check if user exists in litellm proxy DB
-        _user_info = await user_info(user_id=userIDPInfo.id)
-        print("_user_info from litellm DB ", _user_info)  # noqa
+        if proxy_server.prisma_client is not None:
+            _user_info = await proxy_server.prisma_client.get_data(user_id=userIDPInfo.id)
+            print("_user_info from litellm DB ", _user_info)  # noqa
 
         return SSOUserDefinedValues(
             models=[],


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


📖 Documentation

## Changes
- Okta SSO docs: Document both Org Auth Server (free) and Custom Auth Server (paid SKU) as tabbed options in Step 3. Move GENERIC_CLIENT_STATE and PKCE config into the main guide (Step 4) instead of burying them in troubleshooting.
- Custom SSO handler: Replace broken user_info() call with prisma_client.get_data() in both custom_sso.py and custom_sso.md. The user_info() function is now a FastAPI route handler and can't be called directly.