### PR TITLE
feat(proxy): add /skill endpoints with virtual key scoping

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260304000000_add_skill_table_and_skill_permissions/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260304000000_add_skill_table_and_skill_permissions/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "LiteLLM_SkillTable" (
+    "skill_name" TEXT NOT NULL,
+    "description" TEXT,
+    "content" TEXT NOT NULL,
+    "metadata" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LiteLLM_SkillTable_pkey" PRIMARY KEY ("skill_name")
+);
+
+-- AlterTable
+ALTER TABLE "LiteLLM_ObjectPermissionTable" ADD COLUMN     "skills" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -260,6 +260,7 @@ model LiteLLM_ObjectPermissionTable {
   vector_stores         String[]       @default([])
   agents                String[]       @default([])
   agent_access_groups   String[]       @default([])
+  skills                String[]       @default([])
   blocked_tools         String[]       @default([]) // Tool names blocked for any key/team/user with this permission
   teams                 LiteLLM_TeamTable[]
   projects              LiteLLM_ProjectTable[]
@@ -463,6 +464,16 @@ model LiteLLM_TagTable {
   created_at DateTime @default(now()) @map("created_at")
   created_by String?
   updated_at DateTime @default(now()) @updatedAt @map("updated_at")
+}
+
+model LiteLLM_SkillTable {
+  skill_name  String   @id
+  description String?
+  content     String           // Full raw SKILL.md (frontmatter + body)
+  metadata    Json?            // Parsed YAML frontmatter as JSON
+  created_at  DateTime @default(now()) @map("created_at")
+  created_by  String?
+  updated_at  DateTime @default(now()) @updatedAt @map("updated_at")
 }
 
 // store proxy config.yaml

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -650,6 +650,9 @@ class LiteLLMRoutes(enum.Enum):
         "/invitation/delete",
         # Team guardrail submission - requires team-scoped key; endpoint enforces team_id
         "/guardrails/register",
+        # Skill read routes - endpoint enforces scoping via object_permission.skills
+        "/skill/list",
+        "/skill/{skill_name}",
     ]  # routes that manage their own allowed/disallowed logic
 
     ## Org Admin Routes ##
@@ -842,6 +845,7 @@ class LiteLLM_ObjectPermissionBase(LiteLLMPydanticObjectBase):
     vector_stores: Optional[List[str]] = None
     agents: Optional[List[str]] = None
     agent_access_groups: Optional[List[str]] = None
+    skills: Optional[List[str]] = None
 
 
 class GenerateRequestBase(LiteLLMPydanticObjectBase):
@@ -1725,6 +1729,7 @@ class LiteLLM_ObjectPermissionTable(LiteLLMPydanticObjectBase):
     vector_stores: Optional[List[str]] = []
     agents: Optional[List[str]] = []
     agent_access_groups: Optional[List[str]] = []
+    skills: Optional[List[str]] = []
 
 
 class LiteLLM_TeamTable(TeamBase):

--- a/litellm/proxy/management_endpoints/skill_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/skill_management_endpoints.py
@@ -318,6 +318,8 @@ async def list_skills(
             )
 
         return results
+    except HTTPException:
+        raise
     except Exception as e:
         verbose_proxy_logger.exception(f"Error listing skills: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/litellm/proxy/management_endpoints/skill_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/skill_management_endpoints.py
@@ -1,0 +1,364 @@
+"""
+SKILL MANAGEMENT
+
+Provider-agnostic SKILL.md storage and retrieval.
+Skills are scoped to virtual keys via object_permission.skills on LiteLLM_ObjectPermissionTable.
+
+/skill/new              - POST - Create a skill (admin)
+/skill/update           - POST - Update a skill (admin)
+/skill/delete           - POST - Delete a skill (admin)
+/skill/list             - GET  - List skills visible to the calling key (frontmatter only)
+/skill/{skill_name}     - GET  - Get full skill content (key-scoped)
+"""
+
+import json
+
+import yaml
+from fastapi import APIRouter, Depends, HTTPException
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.management_endpoints.skill_permission_handler import (
+    SkillPermissionHandler,
+)
+from litellm.types.skill_management import (
+    SkillConfig,
+    SkillDeleteRequest,
+    SkillFullConfig,
+    SkillNewRequest,
+    SkillUpdateRequest,
+)
+
+router = APIRouter()
+
+
+def _parse_frontmatter(content: str) -> dict:
+    """
+    Parse YAML frontmatter from a SKILL.md string.
+
+    Expects the document to start with '---', followed by YAML,
+    followed by '---', followed by the markdown body.
+    Returns the parsed YAML as a dict, or {} if no frontmatter found.
+    """
+    content = content.strip()
+    if not content.startswith("---"):
+        return {}
+    # Find the closing '---' (skip the opening one)
+    end_idx = content.find("---", 3)
+    if end_idx == -1:
+        return {}
+    frontmatter_str = content[3:end_idx].strip()
+    try:
+        return yaml.safe_load(frontmatter_str) or {}
+    except yaml.YAMLError:
+        return {}
+
+
+
+@router.post(
+    "/skill/new",
+    tags=["skill management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def new_skill(
+    skill: SkillNewRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Create a new skill from a SKILL.md document.
+
+    Parameters:
+    - name: str        - Unique skill identifier (used as DB primary key)
+    - description: Optional[str] - Short description (overrides frontmatter if set)
+    - content: str     - Full SKILL.md content (YAML frontmatter + markdown body)
+    """
+    from litellm.proxy._types import CommonProxyErrors
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail=CommonProxyErrors.db_not_connected_error.value,
+        )
+
+    try:
+        existing = await prisma_client.db.litellm_skilltable.find_unique(
+            where={"skill_name": skill.name}
+        )
+        if existing is not None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Skill '{skill.name}' already exists",
+            )
+
+        parsed_meta = _parse_frontmatter(skill.content)
+        description = skill.description or parsed_meta.get("description")
+
+        record = await prisma_client.db.litellm_skilltable.create(
+            data={
+                "skill_name": skill.name,
+                "description": description,
+                "content": skill.content,
+                "metadata": json.dumps(parsed_meta),
+                "created_by": user_api_key_dict.user_id,
+            }
+        )
+
+        return {
+            "message": f"Skill '{skill.name}' created successfully",
+            "skill": SkillConfig(
+                name=record.skill_name,
+                description=record.description,
+                metadata=parsed_meta,
+                created_at=record.created_at.isoformat(),
+                updated_at=record.updated_at.isoformat(),
+                created_by=record.created_by,
+            ),
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        verbose_proxy_logger.exception(f"Error creating skill: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/skill/update",
+    tags=["skill management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def update_skill(
+    skill: SkillUpdateRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Update an existing skill.
+
+    Parameters:
+    - name: str - The skill to update (must already exist)
+    - description: Optional[str] - Updated description
+    - content: Optional[str] - Replacement SKILL.md content
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(status_code=500, detail="Database not connected")
+
+    try:
+        existing = await prisma_client.db.litellm_skilltable.find_unique(
+            where={"skill_name": skill.name}
+        )
+        if existing is None:
+            raise HTTPException(
+                status_code=404, detail=f"Skill '{skill.name}' not found"
+            )
+
+        update_data = {}
+        if skill.content is not None:
+            update_data["content"] = skill.content
+            parsed_meta = _parse_frontmatter(skill.content)
+            update_data["metadata"] = json.dumps(parsed_meta)
+            if skill.description is None:
+                update_data["description"] = parsed_meta.get("description", "")
+
+        if skill.description is not None:
+            update_data["description"] = skill.description
+
+        if not update_data:
+            raise HTTPException(
+                status_code=400,
+                detail="No fields to update. Provide 'content' or 'description'.",
+            )
+
+        record = await prisma_client.db.litellm_skilltable.update(
+            where={"skill_name": skill.name},
+            data=update_data,
+        )
+
+        metadata = {}
+        if record.metadata:
+            metadata = (
+                json.loads(record.metadata)
+                if isinstance(record.metadata, str)
+                else record.metadata
+            )
+
+        return {
+            "message": f"Skill '{skill.name}' updated successfully",
+            "skill": SkillConfig(
+                name=record.skill_name,
+                description=record.description,
+                metadata=metadata,
+                created_at=record.created_at.isoformat(),
+                updated_at=record.updated_at.isoformat(),
+                created_by=record.created_by,
+            ),
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        verbose_proxy_logger.exception(f"Error updating skill: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/skill/delete",
+    tags=["skill management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def delete_skill(
+    data: SkillDeleteRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Delete a skill by name.
+
+    Parameters:
+    - name: str - The skill name to delete
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(status_code=500, detail="Database not connected")
+
+    try:
+        existing = await prisma_client.db.litellm_skilltable.find_unique(
+            where={"skill_name": data.name}
+        )
+        if existing is None:
+            raise HTTPException(
+                status_code=404, detail=f"Skill '{data.name}' not found"
+            )
+
+        await prisma_client.db.litellm_skilltable.delete(
+            where={"skill_name": data.name}
+        )
+
+        return {"message": f"Skill '{data.name}' deleted successfully"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        verbose_proxy_logger.exception(f"Error deleting skill: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+
+@router.get(
+    "/skill/list",
+    tags=["skill management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def list_skills(
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    List all skills the calling key is allowed to access.
+    Returns frontmatter/metadata only (not the full SKILL.md body).
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(status_code=500, detail="Database not connected")
+
+    try:
+        allowed = await SkillPermissionHandler.get_allowed_skills(
+            user_api_key_auth=user_api_key_dict,
+        )
+
+        # Query only allowed skills if scoped, otherwise get all
+        # Semantics: [] = all allowed, non-empty = restricted
+        if allowed:
+            records = await prisma_client.db.litellm_skilltable.find_many(
+                where={"skill_name": {"in": allowed}}
+            )
+        else:
+            records = await prisma_client.db.litellm_skilltable.find_many()
+
+        results = []
+        for record in records:
+            metadata = {}
+            if record.metadata:
+                metadata = (
+                    json.loads(record.metadata)
+                    if isinstance(record.metadata, str)
+                    else record.metadata
+                )
+
+            results.append(
+                SkillConfig(
+                    name=record.skill_name,
+                    description=record.description,
+                    metadata=metadata,
+                    created_at=record.created_at.isoformat(),
+                    updated_at=record.updated_at.isoformat(),
+                    created_by=record.created_by,
+                ).model_dump()
+            )
+
+        return results
+    except Exception as e:
+        verbose_proxy_logger.exception(f"Error listing skills: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/skill/{skill_name}",
+    tags=["skill management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def get_skill(
+    skill_name: str,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Get full skill content by name (key-scoped).
+
+    Returns the complete SKILL.md content plus parsed metadata.
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(status_code=500, detail="Database not connected")
+
+    # Enforce scoping via object_permission.skills
+    if not await SkillPermissionHandler.is_skill_allowed(
+        skill_name=skill_name,
+        user_api_key_auth=user_api_key_dict,
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Skill '{skill_name}' is not allowed for this API key.",
+        )
+
+    try:
+        record = await prisma_client.db.litellm_skilltable.find_unique(
+            where={"skill_name": skill_name}
+        )
+        if record is None:
+            raise HTTPException(
+                status_code=404, detail=f"Skill '{skill_name}' not found"
+            )
+
+        metadata = {}
+        if record.metadata:
+            metadata = (
+                json.loads(record.metadata)
+                if isinstance(record.metadata, str)
+                else record.metadata
+            )
+
+        return SkillFullConfig(
+            name=record.skill_name,
+            description=record.description,
+            content=record.content,
+            metadata=metadata,
+            created_at=record.created_at.isoformat(),
+            updated_at=record.updated_at.isoformat(),
+            created_by=record.created_by,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        verbose_proxy_logger.exception(f"Error getting skill: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/litellm/proxy/management_endpoints/skill_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/skill_management_endpoints.py
@@ -17,7 +17,7 @@ import yaml
 from fastapi import APIRouter, Depends, HTTPException
 
 from litellm._logging import verbose_proxy_logger
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.management_endpoints.skill_permission_handler import (
     SkillPermissionHandler,
@@ -31,6 +31,23 @@ from litellm.types.skill_management import (
 )
 
 router = APIRouter()
+
+
+def _check_skill_management_permission(user_api_key_dict: UserAPIKeyAuth) -> None:
+    """
+    Raises HTTP 403 if the caller does not have permission to create, update,
+    or delete skills.  Only PROXY_ADMIN users are allowed to perform these
+    write operations.
+    """
+    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "Only proxy admins can create, update, or delete skills. Your role={}".format(
+                    user_api_key_dict.user_role
+                )
+            },
+        )
 
 
 def _parse_frontmatter(content: str) -> dict:
@@ -55,7 +72,6 @@ def _parse_frontmatter(content: str) -> dict:
         return {}
 
 
-
 @router.post(
     "/skill/new",
     tags=["skill management"],
@@ -75,6 +91,8 @@ async def new_skill(
     """
     from litellm.proxy._types import CommonProxyErrors
     from litellm.proxy.proxy_server import prisma_client
+
+    _check_skill_management_permission(user_api_key_dict)
 
     if prisma_client is None:
         raise HTTPException(
@@ -141,6 +159,8 @@ async def update_skill(
     - content: Optional[str] - Replacement SKILL.md content
     """
     from litellm.proxy.proxy_server import prisma_client
+
+    _check_skill_management_permission(user_api_key_dict)
 
     if prisma_client is None:
         raise HTTPException(status_code=500, detail="Database not connected")
@@ -219,6 +239,8 @@ async def delete_skill(
     """
     from litellm.proxy.proxy_server import prisma_client
 
+    _check_skill_management_permission(user_api_key_dict)
+
     if prisma_client is None:
         raise HTTPException(status_code=500, detail="Database not connected")
 
@@ -241,7 +263,6 @@ async def delete_skill(
     except Exception as e:
         verbose_proxy_logger.exception(f"Error deleting skill: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
-
 
 
 @router.get(

--- a/litellm/proxy/management_endpoints/skill_permission_handler.py
+++ b/litellm/proxy/management_endpoints/skill_permission_handler.py
@@ -1,0 +1,171 @@
+"""
+Skill Permission Handler for LiteLLM Proxy.
+
+Handles skill permission checking for keys and teams using object_permission.skills.
+Follows the same pattern as AgentRequestHandler in agent_endpoints/auth/agent_permission_handler.py.
+"""
+
+from typing import List, Optional
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import (
+    LiteLLM_ObjectPermissionTable,
+    LiteLLM_TeamTable,
+    UserAPIKeyAuth,
+)
+
+
+class SkillPermissionHandler:
+    """
+    Class to handle skill permission checking, including:
+    1. Key-level skill permissions
+    2. Team-level skill permissions
+
+    Follows the same inheritance logic as agents/MCP:
+    - If team has restrictions and key has restrictions: use intersection
+    - If team has restrictions and key has none: inherit from team
+    - If team has no restrictions: use key restrictions
+    - If no restrictions: allow all skills
+    """
+
+    @staticmethod
+    async def get_allowed_skills(
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> List[str]:
+        """
+        Get list of allowed skill names for the given user/key based on permissions.
+
+        Returns:
+            List[str]: List of allowed skill names. Empty list means no restrictions (allow all).
+        """
+        try:
+            allowed_skills_for_key = SkillPermissionHandler._get_allowed_skills_for_key(
+                user_api_key_auth
+            )
+            allowed_skills_for_team = (
+                await SkillPermissionHandler._get_allowed_skills_for_team(
+                    user_api_key_auth
+                )
+            )
+
+            # If team has skill restrictions, handle inheritance and intersection logic
+            if len(allowed_skills_for_team) > 0:
+                if len(allowed_skills_for_key) > 0:
+                    # Key has its own skill permissions - use intersection with team
+                    allowed_skills = [
+                        s
+                        for s in allowed_skills_for_key
+                        if s in allowed_skills_for_team
+                    ]
+                else:
+                    # Key has no skill permissions - inherit from team
+                    allowed_skills = allowed_skills_for_team
+            else:
+                allowed_skills = allowed_skills_for_key
+
+            return list(set(allowed_skills))
+        except Exception as e:
+            verbose_proxy_logger.warning(f"Failed to get allowed skills: {str(e)}")
+            return []
+
+    @staticmethod
+    async def is_skill_allowed(
+        skill_name: str,
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> bool:
+        """
+        Check if a specific skill is allowed for the given user/key.
+
+        Args:
+            skill_name: The skill name to check
+            user_api_key_auth: User authentication info
+
+        Returns:
+            bool: True if skill is allowed, False otherwise
+        """
+        allowed_skills = await SkillPermissionHandler.get_allowed_skills(
+            user_api_key_auth
+        )
+
+        # Empty list means no restrictions - allow all
+        if len(allowed_skills) == 0:
+            return True
+
+        return skill_name in allowed_skills
+
+    @staticmethod
+    def _get_key_object_permission(
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> Optional[LiteLLM_ObjectPermissionTable]:
+        """
+        Get key object_permission - already loaded by get_key_object() in main auth flow.
+        """
+        if not user_api_key_auth:
+            return None
+
+        return user_api_key_auth.object_permission
+
+    @staticmethod
+    async def _get_team_object_permission(
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> Optional[LiteLLM_ObjectPermissionTable]:
+        """
+        Get team object_permission - automatically loaded by get_team_object() in main auth flow.
+        """
+        from litellm.proxy.auth.auth_checks import get_team_object
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        if not user_api_key_auth or not user_api_key_auth.team_id or not prisma_client:
+            return None
+
+        team_obj: Optional[LiteLLM_TeamTable] = await get_team_object(
+            team_id=user_api_key_auth.team_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=user_api_key_auth.parent_otel_span,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
+        if not team_obj:
+            return None
+
+        return team_obj.object_permission
+
+    @staticmethod
+    def _get_allowed_skills_for_key(
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> List[str]:
+        """
+        Get allowed skills for a key from its object_permission.
+
+        Note: object_permission is already loaded by get_key_object() in main auth flow.
+        """
+        if user_api_key_auth is None:
+            return []
+
+        key_object_permission = SkillPermissionHandler._get_key_object_permission(
+            user_api_key_auth
+        )
+        if key_object_permission is not None:
+            return key_object_permission.skills or []
+
+        return []
+
+    @staticmethod
+    async def _get_allowed_skills_for_team(
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> List[str]:
+        """
+        Get allowed skills for a team from its object_permission.
+        """
+        team_object_permission = (
+            await SkillPermissionHandler._get_team_object_permission(user_api_key_auth)
+        )
+        if team_object_permission is not None:
+            return team_object_permission.skills or []
+
+        return []

--- a/litellm/proxy/management_endpoints/skill_permission_handler.py
+++ b/litellm/proxy/management_endpoints/skill_permission_handler.py
@@ -65,8 +65,8 @@ class SkillPermissionHandler:
 
             return list(set(allowed_skills))
         except Exception as e:
-            verbose_proxy_logger.warning(f"Failed to get allowed skills: {str(e)}")
-            return []
+            verbose_proxy_logger.exception(f"Failed to get allowed skills: {str(e)}")
+            raise
 
     @staticmethod
     async def is_skill_allowed(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -402,6 +402,9 @@ from litellm.proxy.management_endpoints.router_settings_endpoints import (
     router as router_settings_router,
 )
 from litellm.proxy.management_endpoints.scim.scim_v2 import scim_router
+from litellm.proxy.management_endpoints.skill_management_endpoints import (
+    router as skill_management_router,
+)
 from litellm.proxy.management_endpoints.tag_management_endpoints import (
     router as tag_management_router,
 )
@@ -13008,6 +13011,7 @@ app.include_router(budget_management_router)
 app.include_router(model_management_router)
 app.include_router(model_access_group_management_router)
 app.include_router(tag_management_router)
+app.include_router(skill_management_router)
 app.include_router(tool_management_router)
 app.include_router(cost_tracking_settings_router)
 app.include_router(router_settings_router)

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -260,6 +260,7 @@ model LiteLLM_ObjectPermissionTable {
   vector_stores         String[]       @default([])
   agents                String[]       @default([])
   agent_access_groups   String[]       @default([])
+  skills                String[]       @default([])
   blocked_tools         String[]       @default([]) // Tool names blocked for any key/team/user with this permission
   teams                 LiteLLM_TeamTable[]
   projects              LiteLLM_ProjectTable[]
@@ -463,6 +464,16 @@ model LiteLLM_TagTable {
   created_at DateTime @default(now()) @map("created_at")
   created_by String?
   updated_at DateTime @default(now()) @updatedAt @map("updated_at")
+}
+
+model LiteLLM_SkillTable {
+  skill_name  String   @id
+  description String?
+  content     String           // Full raw SKILL.md (frontmatter + body)
+  metadata    Json?            // Parsed YAML frontmatter as JSON
+  created_at  DateTime @default(now()) @map("created_at")
+  created_by  String?
+  updated_at  DateTime @default(now()) @updatedAt @map("updated_at")
 }
 
 // store proxy config.yaml

--- a/litellm/types/skill_management.py
+++ b/litellm/types/skill_management.py
@@ -1,0 +1,41 @@
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel
+
+
+class SkillBase(BaseModel):
+    name: str
+    description: Optional[str] = None
+
+
+class SkillNewRequest(SkillBase):
+    """Request body for POST /skill/new."""
+
+    content: str  # Full raw SKILL.md (YAML frontmatter + markdown body)
+
+
+class SkillUpdateRequest(SkillBase):
+    """Request body for POST /skill/update."""
+
+    content: Optional[str] = None  # If provided, replaces the full content
+
+
+class SkillDeleteRequest(BaseModel):
+    """Request body for POST /skill/delete."""
+
+    name: str
+
+
+class SkillConfig(SkillBase):
+    """List response - frontmatter only, no body."""
+
+    metadata: Optional[Dict[str, Any]] = None
+    created_at: str
+    updated_at: str
+    created_by: Optional[str] = None
+
+
+class SkillFullConfig(SkillConfig):
+    """Single-skill response - includes full content."""
+
+    content: str

--- a/schema.prisma
+++ b/schema.prisma
@@ -260,6 +260,7 @@ model LiteLLM_ObjectPermissionTable {
   vector_stores         String[]       @default([])
   agents                String[]       @default([])
   agent_access_groups   String[]       @default([])
+  skills                String[]       @default([])
   blocked_tools         String[]       @default([]) // Tool names blocked for any key/team/user with this permission
   teams                 LiteLLM_TeamTable[]
   projects              LiteLLM_ProjectTable[]
@@ -463,6 +464,16 @@ model LiteLLM_TagTable {
   created_at DateTime @default(now()) @map("created_at")
   created_by String?
   updated_at DateTime @default(now()) @updatedAt @map("updated_at")
+}
+
+model LiteLLM_SkillTable {
+  skill_name  String   @id
+  description String?
+  content     String           // Full raw SKILL.md (frontmatter + body)
+  metadata    Json?            // Parsed YAML frontmatter as JSON
+  created_at  DateTime @default(now()) @map("created_at")
+  created_by  String?
+  updated_at  DateTime @default(now()) @updatedAt @map("updated_at")
 }
 
 // store proxy config.yaml

--- a/tests/test_litellm/proxy/management_endpoints/test_skill_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_skill_management_endpoints.py
@@ -1,0 +1,545 @@
+import json
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+
+from unittest.mock import AsyncMock, Mock, patch
+
+from litellm.proxy._types import (
+    LiteLLM_ObjectPermissionTable,
+    LitellmUserRoles,
+    UserAPIKeyAuth,
+)
+from litellm.proxy.proxy_server import app
+
+client = TestClient(app)
+
+SAMPLE_SKILL_MD = """---
+name: Frontend Design
+description: Create production-grade frontend interfaces
+version: "1.0"
+---
+
+# Frontend Design
+
+Best practices for building modern frontend applications.
+"""
+
+SAMPLE_SKILL_MD_UPDATED = """---
+name: Frontend Design
+description: Updated frontend design guidelines
+version: "2.0"
+---
+
+# Frontend Design v2
+
+Updated best practices for building modern frontend applications.
+"""
+
+
+def _make_object_permission(skills=None):
+    """Helper to create a mock LiteLLM_ObjectPermissionTable with skills."""
+    return LiteLLM_ObjectPermissionTable(
+        object_permission_id="test-perm-id",
+        skills=skills or [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_skill():
+    """
+    Test creation of a new skill with valid SKILL.md content.
+    Verifies frontmatter is parsed and stored correctly.
+    """
+    from datetime import datetime
+
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+
+            # Skill doesn't exist yet
+            mock_db.litellm_skilltable.find_unique = AsyncMock(return_value=None)
+
+            # Mock create
+            created_skill = Mock()
+            created_skill.skill_name = "frontend-design"
+            created_skill.description = "Create production-grade frontend interfaces"
+            created_skill.content = SAMPLE_SKILL_MD
+            created_skill.metadata = json.dumps(
+                {
+                    "name": "Frontend Design",
+                    "description": "Create production-grade frontend interfaces",
+                    "version": "1.0",
+                }
+            )
+            created_skill.created_at = datetime.now()
+            created_skill.updated_at = datetime.now()
+            created_skill.created_by = "test-user-123"
+            mock_db.litellm_skilltable.create = AsyncMock(return_value=created_skill)
+
+            skill_data = {
+                "name": "frontend-design",
+                "content": SAMPLE_SKILL_MD,
+            }
+            headers = {"Authorization": "Bearer sk-1234"}
+
+            response = client.post("/skill/new", json=skill_data, headers=headers)
+            assert response.status_code == 200
+            result = response.json()
+            assert result["message"] == "Skill 'frontend-design' created successfully"
+            assert result["skill"]["name"] == "frontend-design"
+            assert (
+                result["skill"]["description"]
+                == "Create production-grade frontend interfaces"
+            )
+            assert result["skill"]["metadata"]["version"] == "1.0"
+
+            # Verify create was called with parsed frontmatter
+            create_call = mock_db.litellm_skilltable.create.call_args
+            assert create_call[1]["data"]["skill_name"] == "frontend-design"
+            assert (
+                create_call[1]["data"]["description"]
+                == "Create production-grade frontend interfaces"
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_create_skill_duplicate():
+    """
+    Test that creating a skill with an existing name returns 400.
+    """
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+
+            # Skill already exists
+            existing_skill = Mock()
+            existing_skill.skill_name = "frontend-design"
+            mock_db.litellm_skilltable.find_unique = AsyncMock(
+                return_value=existing_skill
+            )
+
+            skill_data = {
+                "name": "frontend-design",
+                "content": SAMPLE_SKILL_MD,
+            }
+            headers = {"Authorization": "Bearer sk-1234"}
+
+            response = client.post("/skill/new", json=skill_data, headers=headers)
+            assert response.status_code == 400
+            assert "already exists" in response.json()["detail"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_list_skills_all():
+    """
+    Test listing all skills when object_permission has no skill restrictions.
+    SkillPermissionHandler returns [] (no restrictions) -> all skills returned.
+    """
+    from datetime import datetime
+
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        object_permission=None,  # no object_permission = unrestricted
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+
+            skill_a = Mock()
+            skill_a.skill_name = "skill-a"
+            skill_a.description = "Skill A"
+            skill_a.metadata = json.dumps({"name": "Skill A"})
+            skill_a.created_at = datetime.now()
+            skill_a.updated_at = datetime.now()
+            skill_a.created_by = "admin"
+
+            skill_b = Mock()
+            skill_b.skill_name = "skill-b"
+            skill_b.description = "Skill B"
+            skill_b.metadata = json.dumps({"name": "Skill B"})
+            skill_b.created_at = datetime.now()
+            skill_b.updated_at = datetime.now()
+            skill_b.created_by = "admin"
+
+            mock_db.litellm_skilltable.find_many = AsyncMock(
+                return_value=[skill_a, skill_b]
+            )
+
+            headers = {"Authorization": "Bearer sk-1234"}
+            response = client.get("/skill/list", headers=headers)
+            assert response.status_code == 200
+            result = response.json()
+            assert len(result) == 2
+            names = [s["name"] for s in result]
+            assert "skill-a" in names
+            assert "skill-b" in names
+
+            # Verify content is NOT included in list response
+            for skill in result:
+                assert "content" not in skill
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_list_skills_scoped():
+    """
+    Test listing skills with object_permission.skills restriction.
+    Only allowed skills should be returned.
+    """
+    from datetime import datetime
+
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-456",
+        object_permission=_make_object_permission(skills=["skill-a"]),
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+
+            skill_a = Mock()
+            skill_a.skill_name = "skill-a"
+            skill_a.description = "Skill A"
+            skill_a.metadata = json.dumps({"name": "Skill A"})
+            skill_a.created_at = datetime.now()
+            skill_a.updated_at = datetime.now()
+            skill_a.created_by = "admin"
+
+            mock_db.litellm_skilltable.find_many = AsyncMock(return_value=[skill_a])
+
+            headers = {"Authorization": "Bearer sk-1234"}
+            response = client.get("/skill/list", headers=headers)
+            assert response.status_code == 200
+            result = response.json()
+            assert len(result) == 1
+            assert result[0]["name"] == "skill-a"
+
+            # Verify prisma was queried with the filter
+            find_many_call = mock_db.litellm_skilltable.find_many.call_args
+            assert find_many_call[1]["where"]["skill_name"]["in"] == ["skill-a"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_list_skills_empty_means_all():
+    """
+    Test listing skills when object_permission.skills is empty list
+    (all skills allowed, matching how agents/MCP works in LiteLLM).
+    """
+    from datetime import datetime
+
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-789",
+        object_permission=_make_object_permission(skills=[]),  # empty = all allowed
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+
+            skill_a = Mock()
+            skill_a.skill_name = "skill-a"
+            skill_a.description = "Skill A"
+            skill_a.metadata = "{}"
+            skill_a.created_at = datetime.now()
+            skill_a.updated_at = datetime.now()
+            skill_a.created_by = "admin"
+
+            mock_db.litellm_skilltable.find_many = AsyncMock(return_value=[skill_a])
+
+            headers = {"Authorization": "Bearer sk-1234"}
+            response = client.get("/skill/list", headers=headers)
+            assert response.status_code == 200
+            result = response.json()
+            assert len(result) == 1
+
+            # Verify prisma was queried without filter (all skills)
+            mock_db.litellm_skilltable.find_many.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_get_skill_content():
+    """
+    Test getting full skill content by name (unrestricted key).
+    """
+    from datetime import datetime
+
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        object_permission=None,  # unrestricted
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+
+            skill_record = Mock()
+            skill_record.skill_name = "frontend-design"
+            skill_record.description = "Create production-grade frontend interfaces"
+            skill_record.content = SAMPLE_SKILL_MD
+            skill_record.metadata = json.dumps(
+                {
+                    "name": "Frontend Design",
+                    "description": "Create production-grade frontend interfaces",
+                }
+            )
+            skill_record.created_at = datetime.now()
+            skill_record.updated_at = datetime.now()
+            skill_record.created_by = "admin"
+
+            mock_db.litellm_skilltable.find_unique = AsyncMock(
+                return_value=skill_record
+            )
+
+            headers = {"Authorization": "Bearer sk-1234"}
+            response = client.get("/skill/frontend-design", headers=headers)
+            assert response.status_code == 200
+            result = response.json()
+            assert result["name"] == "frontend-design"
+            assert result["content"] == SAMPLE_SKILL_MD
+            assert (
+                result["description"] == "Create production-grade frontend interfaces"
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_get_skill_forbidden():
+    """
+    Test that accessing a skill not in object_permission.skills returns 403.
+    """
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-456",
+        object_permission=_make_object_permission(
+            skills=["skill-a"]
+        ),  # only skill-a allowed
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+
+            headers = {"Authorization": "Bearer sk-1234"}
+            response = client.get("/skill/skill-b", headers=headers)
+            assert response.status_code == 403
+            assert "not allowed" in response.json()["detail"]
+
+            # Verify prisma was NOT queried (rejected before DB call)
+            mock_db.litellm_skilltable.find_unique.assert_not_called()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_update_skill():
+    """
+    Test updating an existing skill's content.
+    """
+    from datetime import datetime
+
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+
+            # Skill exists
+            existing_skill = Mock()
+            existing_skill.skill_name = "frontend-design"
+            mock_db.litellm_skilltable.find_unique = AsyncMock(
+                return_value=existing_skill
+            )
+
+            # Mock update
+            updated_skill = Mock()
+            updated_skill.skill_name = "frontend-design"
+            updated_skill.description = "Updated frontend design guidelines"
+            updated_skill.content = SAMPLE_SKILL_MD_UPDATED
+            updated_skill.metadata = json.dumps(
+                {
+                    "name": "Frontend Design",
+                    "description": "Updated frontend design guidelines",
+                    "version": "2.0",
+                }
+            )
+            updated_skill.created_at = datetime.now()
+            updated_skill.updated_at = datetime.now()
+            updated_skill.created_by = "admin"
+            mock_db.litellm_skilltable.update = AsyncMock(return_value=updated_skill)
+
+            update_data = {
+                "name": "frontend-design",
+                "content": SAMPLE_SKILL_MD_UPDATED,
+            }
+            headers = {"Authorization": "Bearer sk-1234"}
+
+            response = client.post("/skill/update", json=update_data, headers=headers)
+            assert response.status_code == 200
+            result = response.json()
+            assert result["message"] == "Skill 'frontend-design' updated successfully"
+            assert (
+                result["skill"]["description"] == "Updated frontend design guidelines"
+            )
+            assert result["skill"]["metadata"]["version"] == "2.0"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_delete_skill():
+    """
+    Test deleting a skill.
+    """
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+
+            # Skill exists
+            existing_skill = Mock()
+            existing_skill.skill_name = "frontend-design"
+            mock_db.litellm_skilltable.find_unique = AsyncMock(
+                return_value=existing_skill
+            )
+            mock_db.litellm_skilltable.delete = AsyncMock(return_value=existing_skill)
+
+            delete_data = {"name": "frontend-design"}
+            headers = {"Authorization": "Bearer sk-1234"}
+
+            response = client.post("/skill/delete", json=delete_data, headers=headers)
+            assert response.status_code == 200
+            result = response.json()
+            assert result["message"] == "Skill 'frontend-design' deleted successfully"
+
+            mock_db.litellm_skilltable.delete.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_parse_frontmatter():
+    """
+    Unit test for the _parse_frontmatter helper function.
+    """
+    from litellm.proxy.management_endpoints.skill_management_endpoints import (
+        _parse_frontmatter,
+    )
+
+    # Valid frontmatter
+    result = _parse_frontmatter(SAMPLE_SKILL_MD)
+    assert result["name"] == "Frontend Design"
+    assert result["description"] == "Create production-grade frontend interfaces"
+    assert result["version"] == "1.0"
+
+    # No frontmatter
+    result = _parse_frontmatter("# Just a markdown file\n\nNo frontmatter here.")
+    assert result == {}
+
+    # Empty frontmatter
+    result = _parse_frontmatter("---\n---\n# Content")
+    assert result == {}
+
+    # Frontmatter with only name
+    result = _parse_frontmatter("---\nname: My Skill\n---\n# Body")
+    assert result["name"] == "My Skill"
+    assert result.get("description") is None
+
+
+def test_skill_permission_handler():
+    """
+    Unit test for SkillPermissionHandler - verify it reads from object_permission.skills.
+    """
+    from litellm.proxy.management_endpoints.skill_permission_handler import (
+        SkillPermissionHandler,
+    )
+
+    # No object_permission -> empty list (unrestricted)
+    auth_none = UserAPIKeyAuth(user_id="test", object_permission=None)
+    result = SkillPermissionHandler._get_allowed_skills_for_key(auth_none)
+    assert result == []
+
+    # object_permission with empty skills -> empty list (unrestricted)
+    auth_empty = UserAPIKeyAuth(
+        user_id="test",
+        object_permission=_make_object_permission(skills=[]),
+    )
+    result = SkillPermissionHandler._get_allowed_skills_for_key(auth_empty)
+    assert result == []
+
+    # object_permission with specific skills -> those skills
+    auth_scoped = UserAPIKeyAuth(
+        user_id="test",
+        object_permission=_make_object_permission(skills=["skill-a", "skill-b"]),
+    )
+    result = SkillPermissionHandler._get_allowed_skills_for_key(auth_scoped)
+    assert sorted(result) == ["skill-a", "skill-b"]

--- a/tests/test_litellm/proxy/management_endpoints/test_skill_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_skill_management_endpoints.py
@@ -487,6 +487,92 @@ async def test_delete_skill():
         app.dependency_overrides.clear()
 
 
+@pytest.mark.asyncio
+async def test_create_skill_non_admin_forbidden():
+    """
+    Test that non-admin users cannot create skills (HTTP 403).
+    """
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+
+            skill_data = {
+                "name": "frontend-design",
+                "content": SAMPLE_SKILL_MD,
+            }
+            headers = {"Authorization": "Bearer sk-1234"}
+
+            response = client.post("/skill/new", json=skill_data, headers=headers)
+            assert response.status_code == 403
+            assert "Only proxy admins" in response.json()["detail"]["error"]
+
+            # Verify prisma was NOT queried (rejected before DB call)
+            mock_db.litellm_skilltable.find_unique.assert_not_called()
+            mock_db.litellm_skilltable.create.assert_not_called()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_update_skill_non_admin_forbidden():
+    """
+    Test that non-admin users cannot update skills (HTTP 403).
+    """
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        update_data = {
+            "name": "frontend-design",
+            "content": SAMPLE_SKILL_MD_UPDATED,
+        }
+        headers = {"Authorization": "Bearer sk-1234"}
+
+        response = client.post("/skill/update", json=update_data, headers=headers)
+        assert response.status_code == 403
+        assert "Only proxy admins" in response.json()["detail"]["error"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_delete_skill_non_admin_forbidden():
+    """
+    Test that non-admin users cannot delete skills (HTTP 403).
+    """
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        delete_data = {"name": "frontend-design"}
+        headers = {"Authorization": "Bearer sk-1234"}
+
+        response = client.post("/skill/delete", json=delete_data, headers=headers)
+        assert response.status_code == 403
+        assert "Only proxy admins" in response.json()["detail"]["error"]
+    finally:
+        app.dependency_overrides.clear()
+
+
 def test_parse_frontmatter():
     """
     Unit test for the _parse_frontmatter helper function.


### PR DESCRIPTION
Proposal: Provider-agnostic skill storage with virtual key scoping
This is a working proof-of-concept — happy to iterate on the design if there's interest.

What it does
Adds /skill management endpoints that store SKILL.md files and scope access per virtual key, the same way models, MCP servers, and agents are scoped today.

POST /skill/new, /skill/update, /skill/delete — admin CRUD
GET /skill/list — frontmatter only, filtered by calling key's permissions
GET /skill/{skill_name} — full SKILL.md content, 403 if key lacks access
Why
[Agent Skills](https://github.com/anthropics/skills) (SKILL.md) are an open standard adopted by Anthropic, OpenAI (Codex), Cursor, Gemini CLI, and others. The pattern is simple: frontmatter goes in the system prompt, full content loads on demand via tool call. Nothing model-specific — it works with any provider behind LiteLLM.

The existing /v1/skills endpoint is an Anthropic API passthrough. This is different: provider-agnostic storage with virtual key scoping. LiteLLM owns inventory and access control, the developer owns injection logic.

How it follows existing patterns
Scoping: skills field on LiteLLM_ObjectPermissionTable alongside mcp_servers and agents
Permission logic: SkillPermissionHandler mirrors AgentRequestHandler (key/team intersection)
Route auth: read endpoints in self_managed_routes (same as /prompt/list)
DB table: LiteLLM_SkillTable with skill_name as @id (same as LiteLLM_TagTable)
Not included (possible follow-ups)
?ids= filter on list endpoint
Config YAML seeding (skill_list: in proxy config)
MCP load_skill tool for automatic integration with MCP-compatible agents
Test plan
 11 unit tests in tests/test_litellm/proxy/management_endpoints/test_skill_management_endpoints.py
 Tested live against Docker instance (unrestricted key, restricted key, 403 on forbidden)
 Migration SQL verified against prisma migrate diff output

## Relevant issues

https://github.com/BerriAI/litellm/discussions/22754

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
