### PR TITLE
Add tenacity to e2e Azure batch CI and revert importorskip

### DIFF
--- a/.github/workflows/test-proxy-e2e-azure-batches.yml
+++ b/.github/workflows/test-proxy-e2e-azure-batches.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           poetry config virtualenvs.in-project true
           poetry install --with dev,proxy-dev --extras "proxy"
-          poetry run pip install psycopg2-binary uvicorn fastapi httpx
+          poetry run pip install psycopg2-binary uvicorn fastapi httpx tenacity
 
       - name: Setup litellm-enterprise
         run: |

--- a/tests/proxy_e2e_azure_batches_tests/test_managed_files_base.py
+++ b/tests/proxy_e2e_azure_batches_tests/test_managed_files_base.py
@@ -12,8 +12,6 @@ import httpx
 import openai
 import psycopg2
 import pytest
-
-tenacity = pytest.importorskip("tenacity", reason="tenacity required for e2e batch tests")
 from tenacity import Retrying, stop_after_delay, wait_fixed
 
 sys.path.insert(0, os.path.abspath("../.."))

--- a/tests/proxy_e2e_azure_batches_tests/test_proxy_e2e_azure_batches.py
+++ b/tests/proxy_e2e_azure_batches_tests/test_proxy_e2e_azure_batches.py
@@ -7,8 +7,6 @@ import warnings
 import httpx
 import openai
 import pytest
-
-tenacity = pytest.importorskip("tenacity", reason="tenacity required for e2e batch tests")
 from tenacity import RetryError
 
 sys.path.insert(0, os.path.abspath("../.."))


### PR DESCRIPTION
## Summary
- PR #22785 used `pytest.importorskip` which causes pytest exit code 5 (all tests skipped) in CI
- Reverts `importorskip` in test files, restores direct `from tenacity import ...`
- Adds `tenacity` to the pip install step in `.github/workflows/test-proxy-e2e-azure-batches.yml`

## Test plan
- [x] Tests will import tenacity directly (no skip)
- [x] CI workflow now installs tenacity before running tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)