### PR TITLE
Remove incompatible openai==1.100.1 pin from linting CI

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -32,7 +32,6 @@ jobs:
       run: |
         poetry lock
         poetry install --with dev
-        poetry run pip install openai==1.100.1
 
     - name: Run Black formatting
       run: |


### PR DESCRIPTION
## Summary
- The linting CI workflow (`test-linting.yml`) force-installed `openai==1.100.1` after `poetry install`
- This conflicts with litellm's requirement of `openai>=2.8.0`, causing pip dependency resolver errors
- Removed the pin — poetry already installs a compatible openai version

## Test plan
- [x] Single line removal from CI workflow
- [x] `poetry install --with dev` already resolves openai>=2.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)