### PR TITLE
fix(caching): check REDIS_CLUSTER_NODES env var in Cache and Router class selection

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -166,6 +166,14 @@ class Cache:
             None. Cache is set as a litellm param
         """
         if type == LiteLLMCacheType.REDIS:
+            # Check REDIS_CLUSTER_NODES env var if no explicit startup nodes
+            if not redis_startup_nodes:
+                _env_cluster_nodes = litellm.get_secret("REDIS_CLUSTER_NODES")
+                if _env_cluster_nodes is not None and isinstance(
+                    _env_cluster_nodes, str
+                ):
+                    redis_startup_nodes = json.loads(_env_cluster_nodes)
+
             if redis_startup_nodes:
                 # Only pass GCP parameters if they are provided
                 cluster_kwargs = {

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -731,8 +731,18 @@ class Router:
         """
         Initializes either a RedisCache or RedisClusterCache based on the cache_config.
         """
-        if cache_config.get("startup_nodes"):
-            return RedisClusterCache(**cache_config)
+        startup_nodes = cache_config.get("startup_nodes")
+        if not startup_nodes:
+            _env_cluster_nodes = get_secret("REDIS_CLUSTER_NODES")
+            if _env_cluster_nodes is not None and isinstance(
+                _env_cluster_nodes, str
+            ):
+                startup_nodes = json.loads(_env_cluster_nodes)
+
+        if startup_nodes:
+            return RedisClusterCache(
+                **{**cache_config, "startup_nodes": startup_nodes}
+            )
         else:
             return RedisCache(**cache_config)
 

--- a/tests/test_litellm/caching/test_redis_cluster_cache.py
+++ b/tests/test_litellm/caching/test_redis_cluster_cache.py
@@ -10,6 +10,7 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
+from litellm.caching.redis_cache import RedisCache
 from litellm.caching.redis_cluster_cache import RedisClusterCache
 
 
@@ -64,3 +65,117 @@ async def test_redis_cluster_async_batch_get(mock_init_redis_cluster):
     # Verify mget_nonatomic was called instead of mget
     mock_redis.mget_nonatomic.assert_called_once()
     assert not mock_redis.mget.called
+
+
+@patch("litellm._redis.get_redis_connection_pool")
+@patch("litellm._redis.get_redis_client")
+@patch("litellm.caching.redis_cache.RedisCache._setup_health_pings")
+def test_cache_init_creates_cluster_cache_from_env_var(
+    mock_health, mock_get_client, mock_get_pool, monkeypatch
+):
+    """
+    Test that Cache() creates RedisClusterCache when REDIS_CLUSTER_NODES env var is set.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/22748
+    """
+    from litellm.caching.caching import Cache
+
+    startup_nodes = [{"host": "127.0.0.1", "port": "7001"}]
+    monkeypatch.setenv("REDIS_CLUSTER_NODES", json.dumps(startup_nodes))
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.delenv("REDIS_PORT", raising=False)
+    monkeypatch.delenv("REDIS_PASSWORD", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    mock_get_client.return_value = MagicMock()
+    mock_get_pool.return_value = MagicMock()
+
+    cache = Cache(type="redis")
+    assert isinstance(cache.cache, RedisClusterCache)
+
+
+@patch("litellm._redis.get_redis_connection_pool")
+@patch("litellm._redis.get_redis_client")
+@patch("litellm.caching.redis_cache.RedisCache._setup_health_pings")
+def test_cache_init_creates_redis_cache_without_cluster_config(
+    mock_health, mock_get_client, mock_get_pool, monkeypatch
+):
+    """
+    Test that Cache() creates RedisCache when no cluster config is present.
+
+    Ensures backward compatibility: without REDIS_CLUSTER_NODES or
+    redis_startup_nodes, the standard RedisCache is still used.
+    """
+    from litellm.caching.caching import Cache
+
+    monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    mock_get_client.return_value = MagicMock()
+    mock_get_pool.return_value = MagicMock()
+
+    cache = Cache(type="redis")
+    assert isinstance(cache.cache, RedisCache)
+    assert not isinstance(cache.cache, RedisClusterCache)
+
+
+@pytest.mark.parametrize(
+    "startup_nodes, env_var, expected_cache_type",
+    [
+        pytest.param(
+            [dict(host="node1.localhost", port=6379)],
+            None,
+            RedisClusterCache,
+            id="cluster-via-explicit-startup-nodes",
+        ),
+        pytest.param(
+            None,
+            '[{"host": "node1.localhost", "port": 6379}]',
+            RedisClusterCache,
+            id="cluster-via-env-var",
+        ),
+        pytest.param(
+            None,
+            None,
+            RedisCache,
+            id="standard-redis-when-no-cluster-config",
+        ),
+        pytest.param(
+            [dict(host="explicit-node.localhost", port=6379)],
+            '[{"host": "env-node.localhost", "port": 6379}]',
+            RedisClusterCache,
+            id="explicit-startup-nodes-takes-precedence-over-env-var",
+        ),
+    ],
+)
+def test_router_create_redis_cache_cluster_detection(
+    startup_nodes, env_var, expected_cache_type, monkeypatch
+):
+    """
+    Test that Router._create_redis_cache() creates RedisClusterCache when
+    either startup_nodes is in config or REDIS_CLUSTER_NODES env var is set.
+    Also verifies that explicit startup_nodes take precedence over env var.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/22748
+    """
+    from litellm import Router
+
+    cache_config = dict(
+        host="mockhost",
+        port=6379,
+        password="mock-password",
+        startup_nodes=startup_nodes,
+    )
+
+    if env_var is not None:
+        monkeypatch.setenv("REDIS_CLUSTER_NODES", env_var)
+    else:
+        monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+
+    def _mock_redis_cache_init(*args, **kwargs): ...
+
+    with patch.object(RedisCache, "__init__", _mock_redis_cache_init):
+        redis_cache = Router._create_redis_cache(cache_config)
+        assert isinstance(redis_cache, expected_cache_type)


### PR DESCRIPTION
When Redis Cluster is configured via the REDIS_CLUSTER_NODES environment variable, Cache.__init__() and Router._create_redis_cache() ignored the env var and always created RedisCache instead of RedisClusterCache. This caused the v3 rate limiter's cluster detection (_is_redis_cluster()) to return False, skipping hash-slot key grouping. The resulting CROSSLOT errors were silently caught, falling back to per-instance in-memory counting — breaking RPM/TPM enforcement across multiple proxy instances.

Add REDIS_CLUSTER_NODES env var detection to both Cache.__init__() and Router._create_redis_cache(), matching the existing pattern in _redis.py:215-220. When the env var is set and no explicit startup_nodes parameter is provided, parse it and create RedisClusterCache.

## Relevant issues

Fixes #22748
Related to #20836

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

### Problem

When Redis Cluster is configured via the `REDIS_CLUSTER_NODES` environment variable, `Cache.__init__()` and `Router._create_redis_cache()` don't check this env var. They always create `RedisCache` instead of `RedisClusterCache`, even though the low-level factory in `_redis.py:215-220` already handles it.

This causes the v3 rate limiter's `_is_redis_cluster()` check to return `False`, skipping hash-slot key grouping. The Lua script then receives keys from multiple hash slots → CROSSLOT error → silent fallback to per-instance in-memory counting → RPM/TPM limits not enforced across proxy instances.

### Fix

Add `REDIS_CLUSTER_NODES` env var detection to both entry points, matching the existing pattern in `_redis.py:215-220`:

- **`litellm/caching/caching.py`** — `Cache.__init__()`: check env var via `litellm.get_secret("REDIS_CLUSTER_NODES")` before the class selection branch. If set and no explicit `redis_startup_nodes` parameter, parse and create `RedisClusterCache`.
- **`litellm/router.py`** — `Router._create_redis_cache()`: same check via `get_secret("REDIS_CLUSTER_NODES")`. Creates a new dict to avoid mutating the shared `cache_config`.

Explicit `startup_nodes` / `redis_startup_nodes` parameters always take precedence over the env var. Users without `REDIS_CLUSTER_NODES` set see zero behavior change.

### Tests added (`tests/test_litellm/caching/test_redis_cluster_cache.py`)

- `test_cache_init_creates_cluster_cache_from_env_var` — env var triggers `RedisClusterCache`
- `test_cache_init_creates_redis_cache_without_cluster_config` — backward compatibility (no cluster → `RedisCache`)
- `test_router_create_redis_cache_cluster_detection` — 4 parametrized cases: explicit nodes, env var, no cluster config, explicit-takes-precedence-over-env-var