### PR TITLE
fix(ci): fix Mock.keys() failure in proxy_utils test

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -799,7 +799,7 @@ class LiteLLMProxyRequestSetup:
         Add team-based callbacks from the config
         """
         team_config = proxy_config.load_team_config(team_id=team_id)
-        if not isinstance(team_config, dict) or len(team_config.keys()) == 0:
+        if len(team_config.keys()) == 0:
             return None
 
         callback_vars_dict = {**team_config.get("callback_vars", team_config)}

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -799,7 +799,7 @@ class LiteLLMProxyRequestSetup:
         Add team-based callbacks from the config
         """
         team_config = proxy_config.load_team_config(team_id=team_id)
-        if len(team_config.keys()) == 0:
+        if not isinstance(team_config, dict) or len(team_config.keys()) == 0:
             return None
 
         callback_vars_dict = {**team_config.get("callback_vars", team_config)}

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -178,6 +178,7 @@ async def test_add_key_or_team_level_spend_logs_metadata_to_request(
         team_metadata=team_metadata,
     )
     proxy_config = Mock()
+    proxy_config.load_team_config.return_value = {}
 
     data = {"metadata": {}}
     if request_tags is not None:


### PR DESCRIPTION
## Summary
- Fix `test_add_key_or_team_level_spend_logs_metadata_to_request` failing with `TypeError: Mock.keys() returned a non-iterable (type Mock)`
- The `proxy_config` Mock's `load_team_config()` was returning a bare Mock instead of a dict, causing `.keys()` to fail in `add_team_based_callbacks_from_config`
- Fix: configure `proxy_config.load_team_config.return_value = {}`

## Test plan
- [ ] All 64 parametrized variants of `test_add_key_or_team_level_spend_logs_metadata_to_request` should pass
- [ ] `proxy-unit-b4` CI job should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)