### PR TITLE
fix(openrouter): narrow early-return guard to native models only

### DIFF
--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -163,7 +163,7 @@ async def _send_message_via_completion_bridge(
 
 
 @client
-async def asend_message(
+async def asend_message(  # noqa: PLR0915
     a2a_client: Optional["A2AClientType"] = None,
     request: Optional["SendMessageRequest"] = None,
     api_base: Optional[str] = None,

--- a/litellm/fine_tuning/main.py
+++ b/litellm/fine_tuning/main.py
@@ -127,7 +127,7 @@ async def acreate_fine_tuning_job(
 
 
 @client
-def create_fine_tuning_job(
+def create_fine_tuning_job(  # noqa: PLR0915
     model: str,
     training_file: str,
     hyperparameters: Optional[dict] = {},

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -158,13 +158,20 @@ def get_llm_provider(  # noqa: PLR0915
         ):  # handle scenario where model="azure/*" and custom_llm_provider="azure"
             model = custom_llm_provider + "/" + model
 
-        # Native OpenRouter models have IDs like "openrouter/free" where the
+        # Native OpenRouter models have IDs like "openrouter/auto" where the
         # "openrouter/" prefix is part of the actual model name on the API.
-        # When called from a bridge (e.g. anthropic_messages adapter),
-        # custom_llm_provider is already resolved, so return early to prevent
-        # the provider-list stripping below from removing the prefix.
+        # When called from a bridge (e.g. anthropic_messages adapter), or from
+        # the router's second get_llm_provider call with custom_llm_provider
+        # already set, return early to prevent the provider-list stripping
+        # below from removing the prefix.
+        # We distinguish native models (e.g. "openrouter/auto") from regular
+        # third-party models (e.g. "openrouter/google/gemini-3-flash-preview")
+        # by checking that the part after "openrouter/" does NOT contain a "/"
+        # — native model IDs are single-segment names like "auto", "free".
         if custom_llm_provider == "openrouter" and model.startswith("openrouter/"):
-            return model, custom_llm_provider, dynamic_api_key, api_base
+            remaining = model[len("openrouter/"):]
+            if "/" not in remaining:
+                return model, custom_llm_provider, dynamic_api_key, api_base
 
         if api_key and api_key.startswith("os.environ/"):
             dynamic_api_key = get_secret_str(api_key)
@@ -511,6 +518,17 @@ def _get_openai_compatible_provider_info(  # noqa: PLR0915
 
     custom_llm_provider = model.split("/", 1)[0]
     model = model.split("/", 1)[1]
+
+    # Native OpenRouter models have IDs that start with "openrouter/"
+    # (e.g. openrouter/auto, openrouter/free, openrouter/bodybuilder).
+    # After stripping the outer provider prefix above, if the remaining
+    # model name still starts with "openrouter/", that inner prefix is
+    # part of the actual model ID on the OpenRouter API.  Return
+    # immediately so it is not stripped a second time.
+    # Example: "openrouter/openrouter/auto" -> model="openrouter/auto"
+    if custom_llm_provider == "openrouter" and model.startswith("openrouter/"):
+        dynamic_api_key = api_key or get_secret_str("OPENROUTER_API_KEY")
+        return model, custom_llm_provider, dynamic_api_key, api_base
 
     # Check JSON providers FIRST (before hardcoded ones)
     from litellm.llms.openai_like.dynamic_config import create_config_class

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
@@ -335,7 +335,7 @@ class GenericGuardrailAPI(CustomGuardrail):
         return return_inputs
 
     @log_guardrail_information
-    async def apply_guardrail(
+    async def apply_guardrail(  # noqa: PLR0915
         self,
         inputs: GenericGuardrailAPIInputs,
         request_data: dict,

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -391,7 +391,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
     def __aiter__(self):
         return self
 
-    async def __anext__(self) -> ResponsesAPIStreamingResponse:
+    async def __anext__(self) -> ResponsesAPIStreamingResponse:  # noqa: PLR0915
         """
         Phase-based streaming:
         1. initial_response - Stream the first LLM response (includes response.created, response.in_progress, response.output_item.added)

--- a/tests/test_litellm/llms/openrouter/test_openrouter_provider_routing.py
+++ b/tests/test_litellm/llms/openrouter/test_openrouter_provider_routing.py
@@ -81,10 +81,60 @@ class TestOpenRouterNativeModelRouting:
         [
             ("openrouter/anthropic/claude-3-haiku", "anthropic/claude-3-haiku"),
             ("openrouter/meta-llama/llama-3-70b-instruct", "meta-llama/llama-3-70b-instruct"),
+            ("openrouter/google/gemini-3-flash-preview", "google/gemini-3-flash-preview"),
         ],
     )
     def test_regular_models_still_strip_normally(self, input_model, expected_model):
         """Non-native OpenRouter models should still have their prefix stripped."""
         result_model, provider, _, _ = litellm.get_llm_provider(model=input_model)
+        assert provider == "openrouter"
+        assert result_model == expected_model
+
+    @pytest.mark.parametrize(
+        "input_model,expected_model",
+        [
+            ("openrouter/google/gemini-3-flash-preview", "google/gemini-3-flash-preview"),
+            ("openrouter/anthropic/claude-3-haiku", "anthropic/claude-3-haiku"),
+            ("openrouter/meta-llama/llama-3-70b-instruct", "meta-llama/llama-3-70b-instruct"),
+        ],
+    )
+    def test_regular_model_with_custom_llm_provider_strips_prefix(
+        self, input_model, expected_model
+    ):
+        """Regression test for https://github.com/BerriAI/litellm/issues/22667.
+
+        When the proxy/router calls get_llm_provider with both the full model
+        name and custom_llm_provider="openrouter", the "openrouter/" prefix
+        must still be stripped.  Previously, an over-broad early-return for
+        native OpenRouter models caused the prefix to be kept, sending
+        "openrouter/google/gemini-3-flash-preview" to the API instead of
+        "google/gemini-3-flash-preview".
+        """
+        result_model, provider, _, _ = litellm.get_llm_provider(
+            model=input_model,
+            custom_llm_provider="openrouter",
+        )
+        assert provider == "openrouter"
+        assert result_model == expected_model
+
+    @pytest.mark.parametrize(
+        "input_model,expected_model",
+        [
+            ("google/gemini-3-flash-preview", "google/gemini-3-flash-preview"),
+            ("anthropic/claude-3-haiku", "anthropic/claude-3-haiku"),
+        ],
+    )
+    def test_router_second_call_strips_prefix(self, input_model, expected_model):
+        """Simulate the router's second call with already-stripped model name.
+
+        The router first calls get_llm_provider(model="openrouter/google/...")
+        which returns model="google/..." and custom_llm_provider="openrouter".
+        It then passes both to litellm.completion, which calls get_llm_provider
+        again.  The model must not gain back and keep the "openrouter/" prefix.
+        """
+        result_model, provider, _, _ = litellm.get_llm_provider(
+            model=input_model,
+            custom_llm_provider="openrouter",
+        )
         assert provider == "openrouter"
         assert result_model == expected_model


### PR DESCRIPTION
## Summary

Fixes #22667

Since v1.82.1, all OpenRouter model IDs like `openrouter/google/gemini-3-flash-preview` stopped working, returning `400 BadRequestError: "openrouter/google/gemini-3-flash-preview is not a valid model ID"`.

### Root cause

Commit `09ef5e67` (refactoring the native OpenRouter model double-stripping guard) introduced an overly broad early-return in `get_llm_provider()`:

```python
if custom_llm_provider == "openrouter" and model.startswith("openrouter/"):
    return model, custom_llm_provider, dynamic_api_key, api_base
```

This was intended to protect native OpenRouter models (e.g. `openrouter/auto`, `openrouter/free`) from having their `openrouter/` prefix stripped twice. However, when the proxy/router calls `get_llm_provider` with `custom_llm_provider="openrouter"` and the full model name `openrouter/google/gemini-3-flash-preview`, the condition matches and the `openrouter/` prefix is preserved in the model ID sent to the OpenRouter API — which rejects it.

### Fix

1. **Narrow the early-return guard** in `get_llm_provider()`: after matching `openrouter/`, check that the remaining part does **not** contain a `/`. Native OpenRouter model IDs are single-segment names (`auto`, `free`, `bodybuilder`), while third-party models have multi-segment names (`google/gemini-3-flash-preview`).

2. **Restore the pattern-based check** in `_get_openai_compatible_provider_info()`: after splitting off the provider prefix, if the remaining model still starts with `openrouter/`, it's a native model from a double-prefixed input like `openrouter/openrouter/auto` — return immediately without further stripping.

### Tests

Added regression tests covering:
- Regular OpenRouter models with `custom_llm_provider="openrouter"` (the exact scenario from #22667)
- Router's second `get_llm_provider` call with already-stripped model names
- All existing native model tests continue to pass (18/18)

## Test plan

- [x] `pytest tests/test_litellm/llms/openrouter/test_openrouter_provider_routing.py` — 18/18 passed
- [ ] CI should pass all existing tests