### PR TITLE
fix(bedrock): strip output_config from Bedrock Invoke requests

### DIFF
--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -425,6 +425,18 @@ class AmazonAnthropicClaudeMessagesConfig(
         # Ref: https://github.com/BerriAI/litellm/issues/22847
         remove_custom_field_from_tools(anthropic_messages_request)
 
+        # 5b. Convert `output_config` to inline schema (Bedrock invoke doesn't support output_config)
+        # output_config may contain "format" (same structure as output_format) and/or "effort"
+        output_config = anthropic_messages_request.pop("output_config", None)
+        if output_config and isinstance(output_config, dict):
+            output_config_format = output_config.get("format")
+            if output_config_format and not output_format:
+                # Only convert if output_format wasn't already handled above
+                self._convert_output_format_to_inline_schema(
+                    output_format=output_config_format,
+                    anthropic_messages_request=anthropic_messages_request,
+                )
+
         # 6. AUTO-INJECT beta headers based on features used
         anthropic_model_info = AnthropicModelInfo()
         tools = anthropic_messages_optional_request_params.get("tools")

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
@@ -386,6 +386,174 @@ def test_opus_4_5_model_detection():
 #         f"computer-use beta should be kept, got: {anthropic_beta}"
 
 
+def test_output_config_conversion_to_inline_schema():
+    """
+    Test that output_config with format is converted to inline schema for Bedrock Invoke.
+
+    Bedrock Invoke doesn't support output_config, so the format.schema inside it
+    should be embedded into the user message content, similar to output_format handling.
+
+    Fixes: https://github.com/BerriAI/litellm/issues/22797
+    """
+    from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
+        AmazonAnthropicClaudeMessagesConfig,
+    )
+
+    config = AmazonAnthropicClaudeMessagesConfig()
+
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "Hello"}]}
+    ]
+
+    output_config_schema = {
+        "type": "object",
+        "properties": {
+            "isNewTopic": {"type": "boolean"},
+            "title": {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        },
+        "required": ["isNewTopic", "title"],
+        "additionalProperties": False
+    }
+
+    anthropic_messages_optional_request_params = {
+        "max_tokens": 4096,
+        "output_config": {
+            "format": {
+                "type": "json_schema",
+                "schema": output_config_schema
+            }
+        }
+    }
+
+    result = config.transform_anthropic_messages_request(
+        model="anthropic.claude-3-haiku-20240307-v1:0",
+        messages=messages,
+        anthropic_messages_optional_request_params=anthropic_messages_optional_request_params,
+        litellm_params={},
+        headers={},
+    )
+
+    # Verify output_config was removed from the request
+    assert "output_config" not in result, "output_config should be removed from request body"
+
+    # Verify the schema was added to the last user message content
+    last_user_message = result["messages"][0]
+    content = last_user_message["content"]
+    assert isinstance(content, list)
+    assert len(content) == 2, "content should have 2 items (original text + schema)"
+
+    # Check original text is preserved
+    assert content[0]["type"] == "text"
+    assert content[0]["text"] == "Hello"
+
+    # Check schema was added as JSON string
+    assert content[1]["type"] == "text"
+    parsed_schema = json.loads(content[1]["text"])
+    assert parsed_schema["type"] == "object"
+    assert "isNewTopic" in parsed_schema["properties"]
+    assert "title" in parsed_schema["properties"]
+
+
+def test_output_config_with_effort_only():
+    """
+    Test that output_config with only effort (no format) is stripped without error.
+
+    Bedrock Invoke doesn't support output_config, so it should be removed even
+    when it only contains the 'effort' field.
+    """
+    from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
+        AmazonAnthropicClaudeMessagesConfig,
+    )
+
+    config = AmazonAnthropicClaudeMessagesConfig()
+
+    messages = [
+        {"role": "user", "content": "Hello"}
+    ]
+
+    anthropic_messages_optional_request_params = {
+        "max_tokens": 1024,
+        "output_config": {
+            "effort": "high"
+        }
+    }
+
+    result = config.transform_anthropic_messages_request(
+        model="anthropic.claude-3-haiku-20240307-v1:0",
+        messages=messages,
+        anthropic_messages_optional_request_params=anthropic_messages_optional_request_params,
+        litellm_params={},
+        headers={},
+    )
+
+    # Verify output_config was removed
+    assert "output_config" not in result, "output_config should be removed from request body"
+
+    # Content should remain unchanged (no schema to embed)
+    last_user_message = result["messages"][0]
+    assert isinstance(last_user_message["content"], str)
+    assert last_user_message["content"] == "Hello"
+
+
+def test_output_config_not_used_when_output_format_present():
+    """
+    Test that when both output_format and output_config are present,
+    only output_format's schema is used (to avoid duplicating the schema).
+    """
+    from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
+        AmazonAnthropicClaudeMessagesConfig,
+    )
+
+    config = AmazonAnthropicClaudeMessagesConfig()
+
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "Hello"}]}
+    ]
+
+    output_format_schema = {
+        "type": "object",
+        "properties": {"from_output_format": {"type": "string"}}
+    }
+
+    output_config_schema = {
+        "type": "object",
+        "properties": {"from_output_config": {"type": "string"}}
+    }
+
+    anthropic_messages_optional_request_params = {
+        "max_tokens": 1024,
+        "output_format": {
+            "type": "json_schema",
+            "schema": output_format_schema
+        },
+        "output_config": {
+            "format": {
+                "type": "json_schema",
+                "schema": output_config_schema
+            }
+        }
+    }
+
+    result = config.transform_anthropic_messages_request(
+        model="anthropic.claude-3-haiku-20240307-v1:0",
+        messages=messages,
+        anthropic_messages_optional_request_params=anthropic_messages_optional_request_params,
+        litellm_params={},
+        headers={},
+    )
+
+    # Both should be removed from the request
+    assert "output_format" not in result
+    assert "output_config" not in result
+
+    # Only output_format's schema should be embedded (not output_config's)
+    content = result["messages"][0]["content"]
+    assert len(content) == 2, "should have original text + one schema"
+    parsed_schema = json.loads(content[1]["text"])
+    assert "from_output_format" in parsed_schema["properties"]
+    assert "from_output_config" not in parsed_schema["properties"]
+
+
 def test_output_format_removed_from_bedrock_invoke_request():
     """
     Test that output_format parameter is removed from Bedrock Invoke requests.


### PR DESCRIPTION
## Summary

Fixes #22797

Bedrock Invoke API does not support the `output_config` parameter (added in v1.18.12-stable.2 for direct Anthropic API calls). When `output_config` is included in a request routed through Bedrock Invoke, it causes a 400 error:

```
extraneous key [output_config] is not permitted
```

This PR adds handling in the Bedrock Invoke transformation layer to:

- **Pop `output_config`** from the request before sending to Bedrock (same pattern as `output_format`)
- **Convert `output_config.format.schema`** to inline schema embedded in the user message content (only when `output_format` is not already present, to avoid duplication)
- **Gracefully handle `effort`-only `output_config`** by simply stripping it

### Changes

- `litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py` — Added step 5b to pop and transform `output_config`, mirroring the existing `output_format` handling
- `tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py` — Added 3 unit tests:
  - `test_output_config_conversion_to_inline_schema` — schema from `output_config.format` is embedded in message content
  - `test_output_config_with_effort_only` — `output_config` with only `effort` is stripped without error
  - `test_output_config_not_used_when_output_format_present` — `output_format` takes precedence when both are present

## Test plan

- [x] All 10 unit tests pass (`pytest tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py`)
- [x] Existing `output_format` tests still pass (no regression)
- [ ] Manual test: send request with `output_config` to Bedrock Invoke via proxy — should no longer return 400 error