### PR TITLE
feat(ui): add time to first token (TTFT) to logs

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -258,6 +258,12 @@ function GuardrailLabel({ label, maskedCount }: { label: string; maskedCount: nu
 }
 
 function MetricsSection({ logEntry, metadata }: { logEntry: LogEntry; metadata: Record<string, any> }) {
+  const completionStartTime = logEntry.completionStartTime;
+  const ttftMs =
+    completionStartTime && completionStartTime !== logEntry.endTime
+      ? new Date(completionStartTime).getTime() - new Date(logEntry.startTime).getTime()
+      : null;
+
   const hasCacheActivity =
     logEntry.cache_hit ||
     (metadata?.additional_usage_values?.cache_read_input_tokens &&
@@ -284,6 +290,9 @@ function MetricsSection({ logEntry, metadata }: { logEntry: LogEntry; metadata: 
           </Descriptions.Item>
           <Descriptions.Item label="Cost">${formatNumberWithCommas(logEntry.spend || 0, 8)}</Descriptions.Item>
           <Descriptions.Item label="Duration">{logEntry.request_duration_ms != null ? (logEntry.request_duration_ms / 1000).toFixed(3) : "-"} s</Descriptions.Item>
+          {ttftMs != null && ttftMs > 0 && (
+            <Descriptions.Item label="Time to First Token">{(ttftMs / 1000).toFixed(3)} s</Descriptions.Item>
+          )}
 
           {hasCacheActivity && (
             <>

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -62,6 +62,7 @@ export type LogEntry = {
   proxy_server_request?: string | any[] | Record<string, any>;
   session_id?: string;
   status?: string;
+  completionStartTime?: string;
   request_duration_ms?: number;
   session_total_count?: number;
   session_total_spend?: number;
@@ -266,6 +267,25 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
       return (
         <Tooltip title={`${ms}ms`}>
           <span className="max-w-[15ch] truncate block">{seconds}</span>
+        </Tooltip>
+      );
+    },
+  },
+  {
+    header: "TTFT (s)",
+    accessorKey: "completionStartTime",
+    cell: (info: any) => {
+      const row = info.row.original;
+      const completionStartTime = info.getValue();
+      if (!completionStartTime) return <span>-</span>;
+      // For non-streaming, completionStartTime == endTime so TTFT is not meaningful
+      if (completionStartTime === row.endTime) return <span>-</span>;
+      const ttftMs = new Date(completionStartTime).getTime() - new Date(row.startTime).getTime();
+      if (ttftMs <= 0) return <span>-</span>;
+      const ttftSeconds = (ttftMs / 1000).toFixed(2);
+      return (
+        <Tooltip title={`${ttftMs}ms`}>
+          <span className="max-w-[15ch] truncate block">{ttftSeconds}</span>
         </Tooltip>
       );
     },


### PR DESCRIPTION
## Relevant issues

Surfaces TTFT in the UI logs.

## Changes

- Added a **TTFT (s)** column to the Request Logs table (only shows for streaming requests where `completionStartTime` differs from `endTime`, shows `-` for non-streaming)
- Added **Time to First Token** row in the Metrics section of the log detail drawer

The backend already stored `completionStartTime` in `LiteLLM_SpendLogs` and returns it in the `/spend/logs/ui` endpoint — this is purely a UI change.

## Pre-Submission Checklist

- [ ] I have not broken any existing functionality
- [ ] My PR is focused — it does one thing

## Type

- [ ] New Feature