### PR TITLE
fix: add missing spec_path column to LiteLLM_MCPServerTable schema

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -277,6 +277,7 @@ model LiteLLM_MCPServerTable {
   alias        String?
   description  String?
   url          String?
+  spec_path    String?
   transport    String         @default("sse")
   auth_type    String?        
   credentials  Json?          @default("{}")

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -277,6 +277,7 @@ model LiteLLM_MCPServerTable {
   alias        String?
   description  String?
   url          String?
+  spec_path    String?
   transport    String         @default("sse")
   auth_type    String?        
   credentials  Json?          @default("{}")

--- a/schema.prisma
+++ b/schema.prisma
@@ -277,6 +277,7 @@ model LiteLLM_MCPServerTable {
   alias        String?
   description  String?
   url          String?
+  spec_path    String?
   transport    String         @default("sse")
   auth_type    String?        
   credentials  Json?          @default("{}")


### PR DESCRIPTION
## Summary

- Adds missing `spec_path String?` column to `LiteLLM_MCPServerTable` in all three Prisma schema files (root, `litellm/proxy`, `litellm-proxy-extras`)
- The OpenAPI-to-MCP feature (PR #21575) added `spec_path` to the Python types and MCP server manager code but missed adding the actual DB column to the schema files
- Without this fix, creating OpenAPI-based MCP servers fails with: `"Could not find field at createOneLiteLLM_MCPServerTable.data.spec_path"`

## Test plan
- [x] Verified locally: creating a petStore MCP with `spec_path: "https://petstore3.swagger.io/api/v3/openapi.json"` succeeds and lists 19 tools
- [x] `prisma db push` applies cleanly
- [ ] CI passes


Made with [Cursor](https://cursor.com)