### PR TITLE
[Feat]  UI remove required model field when making keys 

### DIFF
--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -772,21 +772,17 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey }) => {
                 label={
                   <span>
                     Models{" "}
-                    <Tooltip title="Select which models this key can access. Choose 'All Team Models' to grant access to all models available to the team">
+                    <Tooltip title="Select which models this key can access. Choose 'All Team Models' to grant access to all models available to the team. Leave empty to allow access to all models.">
                       <InfoCircleOutlined style={{ marginLeft: "4px" }} />
                     </Tooltip>
                   </span>
                 }
                 name="models"
-                rules={
-                  keyType === "management" || keyType === "read_only"
-                    ? []
-                    : [{ required: true, message: "Please select a model" }]
-                }
+                rules={[]}
                 help={
                   keyType === "management" || keyType === "read_only"
                     ? "Models field is disabled for this key type"
-                    : "required"
+                    : "optional - leave empty to allow access to all models"
                 }
                 className="mt-4"
               >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

## UI remove required model field when making keys 

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/d7fa6ffb-9c17-4e8f-9c56-30370d624b49" />

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes

This PR removes the requirement to select models when creating a virtual key in the LiteLLM Dashboard.

Previously, the UI enforced model selection, even though the backend supports an empty model list (which grants access to all models). This change allows users to create virtual keys specifically for MCP (Model Context Protocol) access without needing to specify any LLM models. The help text for the models field has also been updated to clarify that leaving it empty is an option to allow access to all models.

---
[Slack Thread](https://berriaillm.slack.com/archives/C07Q2CUDA57/p1772666860670999?thread_ts=1772666860.670999&cid=C07Q2CUDA57)

<p><a href="https://cursor.com/agents/bc-a9cb71cb-ae0d-51df-abb2-2d222f5cc61e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9cb71cb-ae0d-51df-abb2-2d222f5cc61e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->