### PR TITLE
[Fix] Docs build broken due to mismatched @docusaurus package versions

### DIFF
--- a/docs/my-website/package-lock.json
+++ b/docs/my-website/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.8.1",
-        "@docusaurus/plugin-google-gtag": "^3.5.2",
+        "@docusaurus/plugin-google-gtag": "3.8.1",
         "@docusaurus/plugin-ideal-image": "3.8.1",
-        "@docusaurus/preset-classic": "^3.5.2",
-        "@docusaurus/theme-mermaid": "^3.5.2",
+        "@docusaurus/preset-classic": "3.8.1",
+        "@docusaurus/theme-mermaid": "3.8.1",
         "@inkeep/cxkit-docusaurus": "^0.5.89",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^1.2.1",
@@ -91,30 +91,6 @@
         "algoliasearch": ">= 4.9.1 < 6"
       }
     },
-    "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.27.0.tgz",
-      "integrity": "sha512-YGog2s57sO20lvpa+hv5XLAAmiTI1kHsCMRtPVfiaOdIQnvRla21lfH08onqEbZihOPVI8GULwt79zQB2ymKzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/cache-common": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/cache-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.27.0.tgz",
-      "integrity": "sha512-Sr8zjNXj82p6lO4W9CdzfF0m0/9h/H6VAdSHOTtimm/cTzXIYXRI2IZq7+Nt2ljJ7Ukx+7dIFcxQjE57eQSPsw==",
-      "license": "MIT"
-    },
-    "node_modules/@algolia/cache-in-memory": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.27.0.tgz",
-      "integrity": "sha512-abgMRTcVD0IllNvMM9JFhxtyLn1v6Ey7mQ7+BGS3JCzvkCX7KZqlS0BIuVUDgx9sPIfOeNsG/awGzMmP50TwZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/cache-common": "4.27.0"
-      }
-    },
     "node_modules/@algolia/client-abtesting": {
       "version": "5.49.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.49.1.tgz",
@@ -130,69 +106,19 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/client-account": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.27.0.tgz",
-      "integrity": "sha512-sSHxwrKTKJrwfoR/LcQJZfmiWJcM5d9Rp7afMChxOcdGdkSdIwrNBC8SCcHRenA3GsZ6mg+j6px7KWYxJ34btA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/transporter": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/client-account/node_modules/@algolia/client-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.27.0.tgz",
-      "integrity": "sha512-ZrT6l/YPQgyIUuBCxcYPeXol2VBLUMuNb1rKXrm6z1f/iTiwqtnEEb16/6CC11+Re0ZGXrdcMVrgDRrzveQ1aQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/client-account/node_modules/@algolia/client-search": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.27.0.tgz",
-      "integrity": "sha512-qmX/f67ay0eZ4V5Io8fWWOcUVo/gqre2yei1PnmEhQU2Gul6ushg25QnNrfu4BODiRrw1rwYveZaLCiHvcUxrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
-      }
-    },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.27.0.tgz",
-      "integrity": "sha512-MqIDyxODljn9ZC4oqjQD0kez2a4zjIJ9ywA/b7cIiUiK/tDjZNTVjYd9WXMKQlXnWUwfrfXJZClVVqN1iCXS+Q==",
+      "version": "5.49.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.49.1.tgz",
+      "integrity": "sha512-048T9/Z8OeLmTk8h76QUqaNFp7Rq2VgS2Zm6Y2tNMYGQ1uNuzePY/udB5l5krlXll7ZGflyCjFvRiOtlPZpE9g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/client-analytics/node_modules/@algolia/client-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.27.0.tgz",
-      "integrity": "sha512-ZrT6l/YPQgyIUuBCxcYPeXol2VBLUMuNb1rKXrm6z1f/iTiwqtnEEb16/6CC11+Re0ZGXrdcMVrgDRrzveQ1aQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/client-analytics/node_modules/@algolia/client-search": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.27.0.tgz",
-      "integrity": "sha512-qmX/f67ay0eZ4V5Io8fWWOcUVo/gqre2yei1PnmEhQU2Gul6ushg25QnNrfu4BODiRrw1rwYveZaLCiHvcUxrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.49.1",
+        "@algolia/requester-browser-xhr": "5.49.1",
+        "@algolia/requester-fetch": "5.49.1",
+        "@algolia/requester-node-http": "5.49.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
@@ -220,24 +146,18 @@
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.27.0.tgz",
-      "integrity": "sha512-OZqaFFVm+10hAlmxpiTWi/o2n+YKBESbSqSy2yXAumPH/kaK4moJHFblbh8IkV3KZR0lLm4hzPtn8Q2nWNiDUA==",
+      "version": "5.49.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.49.1.tgz",
+      "integrity": "sha512-v+4DN+lkYfBd01Hbnb9ZrCHe7l+mvihyx218INRX/kaCXROIWUDIT1cs3urQxfE7kXBFnLsqYeOflQALv/gA5w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/client-personalization/node_modules/@algolia/client-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.27.0.tgz",
-      "integrity": "sha512-ZrT6l/YPQgyIUuBCxcYPeXol2VBLUMuNb1rKXrm6z1f/iTiwqtnEEb16/6CC11+Re0ZGXrdcMVrgDRrzveQ1aQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/client-common": "5.49.1",
+        "@algolia/requester-browser-xhr": "5.49.1",
+        "@algolia/requester-fetch": "5.49.1",
+        "@algolia/requester-node-http": "5.49.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
@@ -291,21 +211,6 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/logger-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.27.0.tgz",
-      "integrity": "sha512-pIrmQRXtDV+zTMVXKtKCosC2rWhn0F0TdUeb9etA6RiAz6jY6bY6f0+JX7YekDK09SnmZMLIyUa7Jci+Ied9bw==",
-      "license": "MIT"
-    },
-    "node_modules/@algolia/logger-console": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.27.0.tgz",
-      "integrity": "sha512-UWvta8BxsR/u5z9eI088mOSLQaGtmoCtXeN3DYJurlxAdJwPuKtEb5+433kxA6/E9f2/JgoW89KZ1vNP9pcHBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/logger-common": "4.27.0"
-      }
-    },
     "node_modules/@algolia/monitoring": {
       "version": "1.49.1",
       "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.49.1.tgz",
@@ -322,61 +227,18 @@
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.27.0.tgz",
-      "integrity": "sha512-CFy54xDjrsazPi3KN04yPmLRDT72AKokc3RLOdWQvG0/uEUjj7dhWqe9qenxpL4ydsjO7S1eY5YqmX+uMGonlg==",
+      "version": "5.49.1",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.49.1.tgz",
+      "integrity": "sha512-h2yz3AGeGkQwNgbLmoe3bxYs8fac4An1CprKTypYyTU/k3Q+9FbIvJ8aS1DoBKaTjSRZVoyQS7SZQio6GaHbZw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.27.0",
-        "@algolia/cache-common": "4.27.0",
-        "@algolia/cache-in-memory": "4.27.0",
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/logger-common": "4.27.0",
-        "@algolia/logger-console": "4.27.0",
-        "@algolia/requester-browser-xhr": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/requester-node-http": "4.27.0",
-        "@algolia/transporter": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/recommend/node_modules/@algolia/client-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.27.0.tgz",
-      "integrity": "sha512-ZrT6l/YPQgyIUuBCxcYPeXol2VBLUMuNb1rKXrm6z1f/iTiwqtnEEb16/6CC11+Re0ZGXrdcMVrgDRrzveQ1aQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/recommend/node_modules/@algolia/client-search": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.27.0.tgz",
-      "integrity": "sha512-qmX/f67ay0eZ4V5Io8fWWOcUVo/gqre2yei1PnmEhQU2Gul6ushg25QnNrfu4BODiRrw1rwYveZaLCiHvcUxrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/recommend/node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.27.0.tgz",
-      "integrity": "sha512-dTenMBIIpyp5o3C2ZnfbsuSlD/lL9jPkk6T+2+qm38fyw2nf49ANbcHFE79NgiGrnmw7QrYveCs9NIP3Wk4v6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.27.0"
-      }
-    },
-    "node_modules/@algolia/recommend/node_modules/@algolia/requester-node-http": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.27.0.tgz",
-      "integrity": "sha512-y8nUqaUQeSOQ5oaNo0b2QPznyBFW9LoIwljyUphJ+gUZpU6O/j2/C8ovoqDpIe6J0etqHg5RCcBizrCFZuLpyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.27.0"
+        "@algolia/client-common": "5.49.1",
+        "@algolia/requester-browser-xhr": "5.49.1",
+        "@algolia/requester-fetch": "5.49.1",
+        "@algolia/requester-node-http": "5.49.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
@@ -390,12 +252,6 @@
       "engines": {
         "node": ">= 14.0.0"
       }
-    },
-    "node_modules/@algolia/requester-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.27.0.tgz",
-      "integrity": "sha512-VC3prAQVgWTubMStb3mJz6i61Hqbtagi2LeIbgNtoFJFff3XZDcAaO1D5r0GYl2+DrB2VzUHnQXbkiuI+HHYyg==",
-      "license": "MIT"
     },
     "node_modules/@algolia/requester-fetch": {
       "version": "5.49.1",
@@ -419,17 +275,6 @@
       },
       "engines": {
         "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/transporter": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.27.0.tgz",
-      "integrity": "sha512-PvSbELU4VjN3xSX79ki+zIdOGhTxyJXWvRDzkUjfTx2iNfPWDdTjzKbP1o+268coJztxrkuBwJz90Urek7o1Kw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/cache-common": "4.27.0",
-        "@algolia/logger-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -3572,76 +3417,6 @@
         }
       }
     },
-    "node_modules/@docsearch/react/node_modules/@algolia/client-analytics": {
-      "version": "5.49.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.49.1.tgz",
-      "integrity": "sha512-048T9/Z8OeLmTk8h76QUqaNFp7Rq2VgS2Zm6Y2tNMYGQ1uNuzePY/udB5l5krlXll7ZGflyCjFvRiOtlPZpE9g==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.49.1",
-        "@algolia/requester-browser-xhr": "5.49.1",
-        "@algolia/requester-fetch": "5.49.1",
-        "@algolia/requester-node-http": "5.49.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@docsearch/react/node_modules/@algolia/client-personalization": {
-      "version": "5.49.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.49.1.tgz",
-      "integrity": "sha512-v+4DN+lkYfBd01Hbnb9ZrCHe7l+mvihyx218INRX/kaCXROIWUDIT1cs3urQxfE7kXBFnLsqYeOflQALv/gA5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.49.1",
-        "@algolia/requester-browser-xhr": "5.49.1",
-        "@algolia/requester-fetch": "5.49.1",
-        "@algolia/requester-node-http": "5.49.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@docsearch/react/node_modules/@algolia/recommend": {
-      "version": "5.49.1",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.49.1.tgz",
-      "integrity": "sha512-h2yz3AGeGkQwNgbLmoe3bxYs8fac4An1CprKTypYyTU/k3Q+9FbIvJ8aS1DoBKaTjSRZVoyQS7SZQio6GaHbZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.49.1",
-        "@algolia/requester-browser-xhr": "5.49.1",
-        "@algolia/requester-fetch": "5.49.1",
-        "@algolia/requester-node-http": "5.49.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@docsearch/react/node_modules/algoliasearch": {
-      "version": "5.49.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.49.1.tgz",
-      "integrity": "sha512-X3Pp2aRQhg4xUC6PQtkubn5NpRKuUPQ9FPDQlx36SmpFwwH2N0/tw4c+NXV3nw3PsgeUs+BuWGP0gjz3TvENLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/abtesting": "1.15.1",
-        "@algolia/client-abtesting": "5.49.1",
-        "@algolia/client-analytics": "5.49.1",
-        "@algolia/client-common": "5.49.1",
-        "@algolia/client-insights": "5.49.1",
-        "@algolia/client-personalization": "5.49.1",
-        "@algolia/client-query-suggestions": "5.49.1",
-        "@algolia/client-search": "5.49.1",
-        "@algolia/ingestion": "1.49.1",
-        "@algolia/monitoring": "1.49.1",
-        "@algolia/recommend": "5.49.1",
-        "@algolia/requester-browser-xhr": "5.49.1",
-        "@algolia/requester-fetch": "5.49.1",
-        "@algolia/requester-node-http": "5.49.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
     "node_modules/@docusaurus/babel": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.1.tgz",
@@ -3859,7 +3634,6 @@
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.1.tgz",
       "integrity": "sha512-6xhvAJiXzsaq3JdosS7wbRt/PwEPWHr9eM4YNYqVlbgG1hSK3uQDXTVvQktasp3VO6BmfYWPozueLWuj4gB+vg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@docusaurus/types": "3.8.1",
@@ -3876,24 +3650,24 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.5.2.tgz",
-      "integrity": "sha512-R7ghWnMvjSf+aeNDH0K4fjyQnt5L0KzUEnUhmf1e3jZrv3wogeytZNN6n7X8yHcMsuZHPOrctQhXWnmxu+IRRg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.1.tgz",
+      "integrity": "sha512-vNTpMmlvNP9n3hGEcgPaXyvTljanAKIUkuG9URQ1DeuDup0OR7Ltvoc8yrmH+iMZJbcQGhUJF+WjHLwuk8HSdw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/theme-common": "3.5.2",
-        "@docusaurus/types": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
-        "reading-time": "^1.5.0",
+        "schema-dts": "^1.1.2",
         "srcset": "^4.0.0",
         "tslib": "^2.6.0",
         "unist-util-visit": "^5.0.0",
@@ -3905,336 +3679,31 @@
       },
       "peerDependencies": {
         "@docusaurus/plugin-content-docs": "*",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.5.2.tgz",
-      "integrity": "sha512-Bt+OXn/CPtVqM3Di44vHjE7rPCEsRCB/DMo2qoOuozB9f7+lsdrHvD0QCHdBs0uhz6deYJDppAr2VgqybKPlVQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.1.tgz",
+      "integrity": "sha512-oByRkSZzeGNQByCMaX+kif5Nl2vmtj2IHQI2fWjCfCootsdKZDPFLonhIp5s3IGJO7PLUfe0POyw0Xh/RrGXJA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/module-type-aliases": "3.5.2",
-        "@docusaurus/theme-common": "3.5.2",
-        "@docusaurus/types": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
+        "schema-dts": "^1.1.2",
         "tslib": "^2.6.0",
         "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
@@ -4243,346 +3712,21 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.5.2.tgz",
-      "integrity": "sha512-Z+Xu3+2rvKef/YKTMxZHsEXp1y92ac0ngjDiExRdqGTmEKtCUpkbNYH8v5eXo5Ls+dnW88n6WTa+Q54kLOkwPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.5.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.5.2.tgz",
-      "integrity": "sha512-WzhHjNpoQAUz/ueO10cnundRz+VUtkjFhhaQ9jApyv1a46FPURO4cef89pyNIOMny1fjDz/NUN2z6Yi+5WUrCw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.8.1.tgz",
+      "integrity": "sha512-a+V6MS2cIu37E/m7nDJn3dcxpvXb6TvgdNI22vJX8iUTp8eoMoPa0VArEbWvCxMY/xdC26WzNv4wZ6y0iIni/w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/types": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -4591,977 +3735,75 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
+    "node_modules/@docusaurus/plugin-css-cascade-layers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.8.1.tgz",
+      "integrity": "sha512-VQ47xRxfNKjHS5ItzaVXpxeTm7/wJLFMOPo1BkmoMG4Cuz4nuI+Hs62+RMk1OqVog68Swz66xVPK8g9XTrBKRw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.5.2.tgz",
-      "integrity": "sha512-kBK6GlN0itCkrmHuCS6aX1wmoWc5wpd5KJlqQ1FyrF0cLDnvsYSnh7+ftdwzt7G6lGBho8lrVwkkL9/iQvaSOA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.8.1.tgz",
+      "integrity": "sha512-nT3lN7TV5bi5hKMB7FK8gCffFTBSsBsAfV84/v293qAmnHOyg1nr9okEw8AiwcO3bl9vije5nsUvP0aRl2lpaw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/types": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "fs-extra": "^11.1.1",
-        "react-json-view-lite": "^1.2.0",
+        "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.5.2.tgz",
-      "integrity": "sha512-rjEkJH/tJ8OXRE9bwhV2mb/WP93V441rD6XnM6MIluu7rk8qg38iSxS43ga2V2Q/2ib53PcqbDEJDG/yWQRJhQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.8.1.tgz",
+      "integrity": "sha512-Hrb/PurOJsmwHAsfMDH6oVpahkEGsx7F8CWMjyP/dw1qjqmdS9rcV1nYCGlM8nOtD3Wk/eaThzUB5TSZsGz+7Q==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/types": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.5.2.tgz",
-      "integrity": "sha512-lm8XL3xLkTPHFKKjLjEEAHUrW0SZBSHBE1I+i/tmYMBsjCcUB5UJ52geS5PSiOCFVR74tbPGcPHEV/gaaxFeSA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.8.1.tgz",
+      "integrity": "sha512-tKE8j1cEZCh8KZa4aa80zpSTxsC2/ZYqjx6AAfd8uA8VHZVw79+7OTEP2PoWi0uL5/1Is0LF5Vwxd+1fz5HlKg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/types": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -5569,639 +3811,27 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.5.2.tgz",
-      "integrity": "sha512-QkpX68PMOMu10Mvgvr5CfZAzZQFx8WLlOiUQ/Qmmcl6mjGK6H21WLT5x7xDmcpCoKA/3CegsqIqBR+nA137lQg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.8.1.tgz",
+      "integrity": "sha512-iqe3XKITBquZq+6UAXdb1vI0fPY5iIOitVjPQ581R1ZKpHr0qe+V6gVOrrcOHixPDD/BUKdYwkxFjpNiEN+vBw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/types": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-ideal-image": {
@@ -6235,17 +3865,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.5.2.tgz",
-      "integrity": "sha512-DnlqYyRAdQ4NHY28TfHuVk414ft2uruP4QWCH//jzpHjqvKyXjj2fmDtI8RPUBh9K8iZKFMHRnLtzJKySPWvFA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.1.tgz",
+      "integrity": "sha512-+9YV/7VLbGTq8qNkjiugIelmfUEVkTyLe6X8bWq7K5qPvGXAjno27QAfFq63mYfFFbJc7z+pudL63acprbqGzw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/types": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -6254,648 +3884,61 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
+    "node_modules/@docusaurus/plugin-svgr": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.8.1.tgz",
+      "integrity": "sha512-rW0LWMDsdlsgowVwqiMb/7tANDodpy1wWPwCcamvhY7OECReN3feoFwLjd/U4tKjNY3encj0AJSTxJA+Fpe+Gw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
+        "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
         "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
       },
       "engines": {
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.5.2.tgz",
-      "integrity": "sha512-3ihfXQ95aOHiLB5uCu+9PRy2gZCeSZoDcqpnDvf3B+sTrMvMTr8qRUzBvWkoIqc82yG5prCboRjk1SVILKx6sg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.8.1.tgz",
+      "integrity": "sha512-yJSjYNHXD8POMGc2mKQuj3ApPrN+eG0rO1UPgSx7jySpYU+n4WjBikbrA2ue5ad9A7aouEtMWUoiSRXTH/g7KQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/plugin-content-blog": "3.5.2",
-        "@docusaurus/plugin-content-docs": "3.5.2",
-        "@docusaurus/plugin-content-pages": "3.5.2",
-        "@docusaurus/plugin-debug": "3.5.2",
-        "@docusaurus/plugin-google-analytics": "3.5.2",
-        "@docusaurus/plugin-google-gtag": "3.5.2",
-        "@docusaurus/plugin-google-tag-manager": "3.5.2",
-        "@docusaurus/plugin-sitemap": "3.5.2",
-        "@docusaurus/theme-classic": "3.5.2",
-        "@docusaurus/theme-common": "3.5.2",
-        "@docusaurus/theme-search-algolia": "3.5.2",
-        "@docusaurus/types": "3.5.2"
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/plugin-css-cascade-layers": "3.8.1",
+        "@docusaurus/plugin-debug": "3.8.1",
+        "@docusaurus/plugin-google-analytics": "3.8.1",
+        "@docusaurus/plugin-google-gtag": "3.8.1",
+        "@docusaurus/plugin-google-tag-manager": "3.8.1",
+        "@docusaurus/plugin-sitemap": "3.8.1",
+        "@docusaurus/plugin-svgr": "3.8.1",
+        "@docusaurus/theme-classic": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-search-algolia": "3.8.1",
+        "@docusaurus/types": "3.8.1"
       },
       "engines": {
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/responsive-loader": {
@@ -6923,30 +3966,31 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.5.2.tgz",
-      "integrity": "sha512-XRpinSix3NBv95Rk7xeMF9k4safMkwnpSgThn0UNQNumKvmcIYjfkwfh2BhwYh/BxMXQHJ/PdmNh22TQFpIaYg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.8.1.tgz",
+      "integrity": "sha512-bqDUCNqXeYypMCsE1VcTXSI1QuO4KXfx8Cvl6rYfY0bhhqN6d2WZlRkyLg/p6pm+DzvanqHOyYlqdPyP0iz+iw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/module-type-aliases": "3.5.2",
-        "@docusaurus/plugin-content-blog": "3.5.2",
-        "@docusaurus/plugin-content-docs": "3.5.2",
-        "@docusaurus/plugin-content-pages": "3.5.2",
-        "@docusaurus/theme-common": "3.5.2",
-        "@docusaurus/theme-translations": "3.5.2",
-        "@docusaurus/types": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
-        "infima": "0.2.0-alpha.44",
+        "infima": "0.2.0-alpha.45",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
-        "postcss": "^8.4.26",
+        "postcss": "^8.5.4",
         "prism-react-renderer": "^2.3.0",
         "prismjs": "^1.29.0",
         "react-router-dom": "^5.3.4",
@@ -6958,293 +4002,8 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.5.2.tgz",
-      "integrity": "sha512-Z+Xu3+2rvKef/YKTMxZHsEXp1y92ac0ngjDiExRdqGTmEKtCUpkbNYH8v5eXo5Ls+dnW88n6WTa+Q54kLOkwPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.5.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/theme-translations": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.5.2.tgz",
-      "integrity": "sha512-GPZLcu4aT1EmqSTmbdpVrDENGR2yObFEX8ssEFYTCiAIVc0EihNSdOIBTazUvgNqwvnoU1A8vIs1xyzc3LITTw==",
-      "license": "MIT",
-      "dependencies": {
-        "fs-extra": "^11.1.1",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/theme-classic/node_modules/clsx": {
@@ -7254,27 +4013,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "node_modules/@docusaurus/theme-classic/node_modules/prism-react-renderer": {
@@ -7290,48 +4028,16 @@
         "react": ">=16.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
-      }
-    },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.5.2.tgz",
-      "integrity": "sha512-QXqlm9S6x9Ibwjs7I2yEDgsCocp708DrCrgHgKwg2n2AY0YQ6IjU0gAK35lHRLOvAoJUfCKpQAwUykB0R7+Eew==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.8.1.tgz",
+      "integrity": "sha512-UswMOyTnPEVRvN5Qzbo+l8k4xrd5fTFu2VPPfD6FcW/6qUtVLmJTQCktbAL3KJ0BVXGm5aJXz/ZrzqFuZERGPw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/module-type-aliases": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -7346,178 +4052,8 @@
       },
       "peerDependencies": {
         "@docusaurus/plugin-content-docs": "*",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.5.2.tgz",
-      "integrity": "sha512-Z+Xu3+2rvKef/YKTMxZHsEXp1y92ac0ngjDiExRdqGTmEKtCUpkbNYH8v5eXo5Ls+dnW88n6WTa+Q54kLOkwPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.5.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/theme-common/node_modules/clsx": {
@@ -7527,21 +4063,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "node_modules/@docusaurus/theme-common/node_modules/prism-react-renderer": {
@@ -7557,383 +4078,44 @@
         "react": ">=16.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-common/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-mermaid": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.5.2.tgz",
-      "integrity": "sha512-7vWCnIe/KoyTN1Dc55FIyqO5hJ3YaV08Mr63Zej0L0mX1iGzt+qKSmeVUAJ9/aOalUhF0typV0RmNUSy5FAmCg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.8.1.tgz",
+      "integrity": "sha512-IWYqjyTPjkNnHsFFu9+4YkeXS7PD1xI3Bn2shOhBq+f95mgDfWInkpfBN4aYvx4fTT67Am6cPtohRdwh4Tidtg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/module-type-aliases": "3.5.2",
-        "@docusaurus/theme-common": "3.5.2",
-        "@docusaurus/types": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "mermaid": "^10.4.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
+        "mermaid": ">=11.6.0",
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.5.2.tgz",
-      "integrity": "sha512-Z+Xu3+2rvKef/YKTMxZHsEXp1y92ac0ngjDiExRdqGTmEKtCUpkbNYH8v5eXo5Ls+dnW88n6WTa+Q54kLOkwPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.5.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/types": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
-      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.5.2.tgz",
-      "integrity": "sha512-qW53kp3VzMnEqZGjakaV90sst3iN1o32PH+nawv1uepROO8aEGxptcq2R5rsv7aBShSRbZwIobdvSYKsZ5pqvA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.8.1.tgz",
+      "integrity": "sha512-NBFH5rZVQRAQM087aYSRKQ9yGEK9eHd+xOxQjqNpxMiV85OhJDD4ZGz6YJIod26Fbooy54UWVdzNU0TFeUUUzQ==",
       "license": "MIT",
       "dependencies": {
-        "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/plugin-content-docs": "3.5.2",
-        "@docusaurus/theme-common": "3.5.2",
-        "@docusaurus/theme-translations": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "algoliasearch": "^4.18.0",
-        "algoliasearch-helper": "^3.13.3",
+        "@docsearch/react": "^3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
+        "algoliasearch": "^5.17.1",
+        "algoliasearch-helper": "^3.22.6",
         "clsx": "^2.0.0",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
@@ -7945,253 +4127,8 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/core": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
-      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.2",
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/mdx-loader": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
-      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/logger": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
-      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
-      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-validation": "3.5.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/theme-translations": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.5.2.tgz",
-      "integrity": "sha512-GPZLcu4aT1EmqSTmbdpVrDENGR2yObFEX8ssEFYTCiAIVc0EihNSdOIBTazUvgNqwvnoU1A8vIs1xyzc3LITTw==",
-      "license": "MIT",
-      "dependencies": {
-        "fs-extra": "^11.1.1",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/utils": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
-      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
-      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
-      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.2",
-        "@docusaurus/utils": "3.5.2",
-        "@docusaurus/utils-common": "3.5.2",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia/node_modules/clsx": {
@@ -8201,59 +4138,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/webpackbar": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-5.0.2.tgz",
-      "integrity": "sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
       }
     },
     "node_modules/@docusaurus/theme-translations": {
@@ -12063,12 +7947,6 @@
         "form-data": "^4.0.4"
       }
     },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "license": "MIT"
-    },
     "node_modules/@types/prismjs": {
       "version": "1.26.5",
       "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
@@ -12636,26 +8514,28 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.27.0.tgz",
-      "integrity": "sha512-C88C5grLa5VOCp9eYZJt+q99ik7yNdm92l7Q9+4XK0Md8kL05Lg8l2v9ZVX0uMW3mH9pAFxMMXlLOvqNumA4lw==",
+      "version": "5.49.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.49.1.tgz",
+      "integrity": "sha512-X3Pp2aRQhg4xUC6PQtkubn5NpRKuUPQ9FPDQlx36SmpFwwH2N0/tw4c+NXV3nw3PsgeUs+BuWGP0gjz3TvENLQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.27.0",
-        "@algolia/cache-common": "4.27.0",
-        "@algolia/cache-in-memory": "4.27.0",
-        "@algolia/client-account": "4.27.0",
-        "@algolia/client-analytics": "4.27.0",
-        "@algolia/client-common": "4.27.0",
-        "@algolia/client-personalization": "4.27.0",
-        "@algolia/client-search": "4.27.0",
-        "@algolia/logger-common": "4.27.0",
-        "@algolia/logger-console": "4.27.0",
-        "@algolia/recommend": "4.27.0",
-        "@algolia/requester-browser-xhr": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/requester-node-http": "4.27.0",
-        "@algolia/transporter": "4.27.0"
+        "@algolia/abtesting": "1.15.1",
+        "@algolia/client-abtesting": "5.49.1",
+        "@algolia/client-analytics": "5.49.1",
+        "@algolia/client-common": "5.49.1",
+        "@algolia/client-insights": "5.49.1",
+        "@algolia/client-personalization": "5.49.1",
+        "@algolia/client-query-suggestions": "5.49.1",
+        "@algolia/client-search": "5.49.1",
+        "@algolia/ingestion": "1.49.1",
+        "@algolia/monitoring": "1.49.1",
+        "@algolia/recommend": "5.49.1",
+        "@algolia/requester-browser-xhr": "5.49.1",
+        "@algolia/requester-fetch": "5.49.1",
+        "@algolia/requester-node-http": "5.49.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {
@@ -12668,45 +8548,6 @@
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 6"
-      }
-    },
-    "node_modules/algoliasearch/node_modules/@algolia/client-common": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.27.0.tgz",
-      "integrity": "sha512-ZrT6l/YPQgyIUuBCxcYPeXol2VBLUMuNb1rKXrm6z1f/iTiwqtnEEb16/6CC11+Re0ZGXrdcMVrgDRrzveQ1aQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
-      }
-    },
-    "node_modules/algoliasearch/node_modules/@algolia/client-search": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.27.0.tgz",
-      "integrity": "sha512-qmX/f67ay0eZ4V5Io8fWWOcUVo/gqre2yei1PnmEhQU2Gul6ushg25QnNrfu4BODiRrw1rwYveZaLCiHvcUxrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "4.27.0",
-        "@algolia/requester-common": "4.27.0",
-        "@algolia/transporter": "4.27.0"
-      }
-    },
-    "node_modules/algoliasearch/node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.27.0.tgz",
-      "integrity": "sha512-dTenMBIIpyp5o3C2ZnfbsuSlD/lL9jPkk6T+2+qm38fyw2nf49ANbcHFE79NgiGrnmw7QrYveCs9NIP3Wk4v6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.27.0"
-      }
-    },
-    "node_modules/algoliasearch/node_modules/@algolia/requester-node-http": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.27.0.tgz",
-      "integrity": "sha512-y8nUqaUQeSOQ5oaNo0b2QPznyBFW9LoIwljyUphJ+gUZpU6O/j2/C8ovoqDpIe6J0etqHg5RCcBizrCFZuLpyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/requester-common": "4.27.0"
       }
     },
     "node_modules/altcha-lib": {
@@ -12887,15 +8728,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -15359,28 +11191,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "license": "MIT",
-      "dependencies": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -15464,38 +11274,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/detect-port-alt": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
-      "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "address": "^1.0.1",
-        "debug": "^2.6.0"
-      },
-      "bin": {
-        "detect": "bin/detect-port",
-        "detect-port": "bin/detect-port"
-      },
-      "engines": {
-        "node": ">= 4.2.1"
-      }
-    },
-    "node_modules/detect-port-alt/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/detect-port-alt/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -16458,15 +12236,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/filesize": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
-      "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -16571,134 +12340,6 @@
         "debug": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz",
-      "integrity": "sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.8.3",
-        "@types/json-schema": "^7.0.5",
-        "chalk": "^4.1.0",
-        "chokidar": "^3.4.2",
-        "cosmiconfig": "^6.0.0",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^9.0.0",
-        "glob": "^7.1.6",
-        "memfs": "^3.1.2",
-        "minimatch": "^3.0.4",
-        "schema-utils": "2.7.0",
-        "semver": "^7.3.2",
-        "tapable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "yarn": ">=1.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">= 6",
-        "typescript": ">= 2.7",
-        "vue-template-compiler": "*",
-        "webpack": ">= 4"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        },
-        "vue-template-compiler": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-      "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.4",
-        "ajv": "^6.12.2",
-        "ajv-keywords": "^3.4.1"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/tapable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/form-data": {
@@ -16903,23 +12544,6 @@
       "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==",
       "license": "ISC"
     },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -16960,44 +12584,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/global-modules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-      "license": "MIT",
-      "dependencies": {
-        "global-prefix": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/global-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-      "license": "MIT",
-      "dependencies": {
-        "ini": "^1.3.5",
-        "kind-of": "^6.0.2",
-        "which": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/global-prefix/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
       }
     },
     "node_modules/globals": {
@@ -17799,16 +13385,6 @@
         "node": ">=16.x"
       }
     },
-    "node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -17853,9 +13429,9 @@
       }
     },
     "node_modules/infima": {
-      "version": "0.2.0-alpha.44",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.44.tgz",
-      "integrity": "sha512-tuRkUSO/lB3rEhLJk25atwAjgLuzq070+pOW8XcvpHky/YbENnRRdPd85IBkyeTgttmOy5ah+yHYsK1HhUd4lQ==",
+      "version": "0.2.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.45.tgz",
+      "integrity": "sha512-uyH0zfr1erU1OohLk0fT4Rrb94AOhguWNOcD9uGrSpRvNB+6gZXUoJX5J0NtvzBO10YZ9PgvA4NFgt+fYg8ojw==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -17886,15 +13462,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/invariant": {
@@ -18149,15 +13716,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -18198,15 +13756,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-root": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
-      "integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/is-stream": {
@@ -21183,15 +16732,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -21779,15 +17319,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/package-json": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.1.tgz",
@@ -21985,31 +17516,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
@@ -22076,79 +17582,6 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
-      }
-    },
-    "node_modules/pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-up/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/pkijs": {
@@ -23876,15 +19309,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.3"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -23998,132 +19422,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-dev-utils": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
-      "integrity": "sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "address": "^1.1.2",
-        "browserslist": "^4.18.1",
-        "chalk": "^4.1.2",
-        "cross-spawn": "^7.0.3",
-        "detect-port-alt": "^1.1.6",
-        "escape-string-regexp": "^4.0.0",
-        "filesize": "^8.0.6",
-        "find-up": "^5.0.0",
-        "fork-ts-checker-webpack-plugin": "^6.5.0",
-        "global-modules": "^2.0.0",
-        "globby": "^11.0.4",
-        "gzip-size": "^6.0.0",
-        "immer": "^9.0.7",
-        "is-root": "^2.1.0",
-        "loader-utils": "^3.2.0",
-        "open": "^8.4.0",
-        "pkg-up": "^3.1.0",
-        "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.11",
-        "recursive-readdir": "^2.2.2",
-        "shell-quote": "^1.7.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/loader-utils": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
-      "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -24145,12 +19443,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/react-error-overlay": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",
-      "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
-      "license": "MIT"
     },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
@@ -24199,15 +19491,15 @@
       "license": "MIT"
     },
     "node_modules/react-json-view-lite": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.5.0.tgz",
-      "integrity": "sha512-nWqA1E4jKPklL2jvHWs6s+7Na0qNgw9HCP6xehdQJeg6nPBTFZgGwyko9Q0oj+jQWKTTVRS30u0toM5wiuL3iw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.5.0.tgz",
+      "integrity": "sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-loadable": {
@@ -24444,23 +19736,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/reading-time": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
-      "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
-      "license": "MIT"
-    },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
@@ -24526,18 +19801,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/recursive-readdir": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
-      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/reflect-metadata": {
@@ -25000,22 +20263,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
@@ -25033,12 +20280,6 @@
         "points-on-curve": "^0.2.0",
         "points-on-path": "^0.2.1"
       }
-    },
-    "node_modules/rtl-detect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
-      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/rtlcss": {
       "version": "4.3.0",
@@ -25126,10 +20367,13 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-      "license": "BlueOak-1.0.0"
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -25139,6 +20383,12 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/schema-dts": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.5.tgz",
+      "integrity": "sha512-RJr9EaCmsLzBX2NDiO5Z3ux2BVosNZN5jo0gWgsyKvxKIUL5R3swNvoorulAeL9kLB0iTSX7V6aokhla2m7xbg==",
+      "license": "Apache-2.0"
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -25158,13 +20408,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -25578,23 +20821,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/side-channel": {
@@ -26332,12 +21558,6 @@
         "b4a": "^1.6.4"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "license": "MIT"
-    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -26507,20 +21727,6 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/ufo": {
@@ -27728,15 +22934,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",

--- a/docs/my-website/package.json
+++ b/docs/my-website/package.json
@@ -15,10 +15,10 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.8.1",
-    "@docusaurus/plugin-google-gtag": "^3.5.2",
+    "@docusaurus/plugin-google-gtag": "3.8.1",
     "@docusaurus/plugin-ideal-image": "3.8.1",
-    "@docusaurus/preset-classic": "^3.5.2",
-    "@docusaurus/theme-mermaid": "^3.5.2",
+    "@docusaurus/preset-classic": "3.8.1",
+    "@docusaurus/theme-mermaid": "3.8.1",
     "@inkeep/cxkit-docusaurus": "^0.5.89",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^1.2.1",


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)

`@docusaurus/core` was at `3.8.1` but `@docusaurus/plugin-google-gtag`, `@docusaurus/preset-classic`, and `@docusaurus/theme-mermaid` were pinned to `^3.5.2`. The lock file resolved these to `3.5.2`, causing Docusaurus's version check to fail at build time with:

```
Error: Invalid name=docusaurus-plugin-content-docs version number=3.5.2.
All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=3.8.1).
```

### Fix

Updated `@docusaurus/plugin-google-gtag`, `@docusaurus/preset-classic`, and `@docusaurus/theme-mermaid` from `^3.5.2` to `3.8.1` in `docs/my-website/package.json` to match `@docusaurus/core`. Regenerated `package-lock.json`.

## Testing

Ran `npx docusaurus build` locally — build completes successfully.

## Type

🐛 Bug Fix