### PR TITLE
fix(auth): prevent BudgetExceeded when no budget is set

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2001,7 +2001,6 @@ class ExperimentalUIJWTToken:
             token=CLI_JWT_TOKEN_NAME,
             key_name=CLI_JWT_TOKEN_NAME,
             key_alias=CLI_JWT_TOKEN_NAME,
-            max_budget=litellm.max_ui_session_budget,
             expires=expires,
             user_id=user_info.user_id,
             team_id=_team_id,

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -269,7 +269,8 @@ def test_get_cli_jwt_auth_token_default_expiration(valid_sso_user_defined_values
     assert token_data["user_id"] == "test_user"
     assert token_data["user_role"] == LitellmUserRoles.PROXY_ADMIN.value
     assert token_data["models"] == ["gpt-3.5-turbo"]
-    assert token_data["max_budget"] == litellm.max_ui_session_budget
+    # CLI tokens should NOT inherit the UI session budget cap (#22726)
+    assert "max_budget" not in token_data
 
     # Verify expiration time is set to 24 hours (default)
     assert "expires" in token_data


### PR DESCRIPTION
## Summary

Fixes #22726

CLI JWT tokens were inheriting `litellm.max_ui_session_budget` ($0.25) as their `max_budget`, causing unexpected `BudgetExceededError` for CLI users who never configured any budget limit.

The error message showed "Max budget: 0.25" despite no explicit budget being set, because `get_cli_jwt_auth_token()` hard-coded `max_budget=litellm.max_ui_session_budget` when creating the CLI token.

## Changes

- **`litellm/proxy/auth/auth_checks.py`**: Remove the `max_budget=litellm.max_ui_session_budget` parameter from CLI JWT token creation in `get_cli_jwt_auth_token()`. This lets `max_budget` default to `None`, so `_virtual_key_max_budget_check()` correctly skips the budget check for CLI users.
- **`tests/test_litellm/proxy/auth/test_auth_checks.py`**: Update the CLI JWT token test to assert that `max_budget` is **not** present in the token payload.

UI session tokens remain unchanged — they still use `max_ui_session_budget` ($0.25).

## Test plan

- [x] `test_get_cli_jwt_auth_token_default_expiration` — verifies CLI JWT no longer includes `max_budget`
- [x] `test_get_experimental_ui_login_jwt_auth_token` — verifies UI token still includes `max_budget=0.25`
- [ ] Manual: confirm no `BudgetExceededError` when using CLI without explicit budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)