### PR TITLE
[Fix] UI - MCP Servers: Current Team spacing alignment

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -348,7 +348,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
               />
             ) : (
               <div className="w-full h-full">
-                <div className="w-full px-6">
+                <div className="w-full">
                   <div className="flex flex-col space-y-4">
                     <div className="flex items-center justify-between bg-gray-50 rounded-lg p-4 border-2 border-gray-200">
                       <div className="flex items-center gap-4">

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -401,7 +401,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
                     </div>
                   </div>
                 </div>
-                <div className="w-full px-6 mt-6">
+                <div className="w-full mt-6">
                   <DataTable
                     data={filteredServers}
                     columns={columns}


### PR DESCRIPTION
## Summary

The "Current Team:" filter section on the MCP Servers page had a `px-6` padding wrapper that caused it to be misaligned with the tab bar directly above it.

### Fix

Removed the `px-6` horizontal padding from the wrapper div so the "Current Team:" section aligns flush with the tabs.

## Type

🐛 Bug Fix