### PR TITLE
[Fix] UI - Keys: Organization always shows Not Set

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -210,7 +210,7 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
     },
     {
       id: "organization_id",
-      accessorKey: "organization_id",
+      accessorKey: "org_id",
       header: "Organization ID",
       size: 140,
       enableSorting: false,

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_helpers.ts
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_helpers.ts
@@ -22,7 +22,7 @@ const processKeysIntoOptions = (
     if (alias && typeof alias === "string") {
       keyAliases.add(alias.trim());
     }
-    const orgId = key?.organization_id;
+    const orgId = key?.organization_id ?? key?.org_id;
     if (orgId && typeof orgId === "string") {
       organizationIds.add(orgId.trim());
     }

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.tsx
@@ -96,7 +96,7 @@ export function useFilterLogic({
 
     // Apply Organization ID filter
     if (filters["Organization ID"]) {
-      result = result.filter((key) => key.organization_id === filters["Organization ID"]);
+      result = result.filter((key) => (key.organization_id ?? key.org_id) === filters["Organization ID"]);
     }
 
     setFilteredKeys(result);

--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -47,6 +47,7 @@ export interface KeyResponse {
   blocked: boolean;
   litellm_budget_table: Record<string, unknown>;
   organization_id: string | null;
+  org_id?: string | null;
   created_at: string;
   updated_at: string;
   last_active: string | null;

--- a/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
@@ -91,7 +91,7 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
     if (!orgId) return kList;
     return kList.map((k: KeyResponse) => ({
       ...k,
-      organization_id: k.organization_id || orgId,
+      organization_id: (k.organization_id ?? k.org_id) || orgId,
     }));
   }, [keys?.keys, organization?.organization_id]);
 

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -644,7 +644,7 @@ export default function KeyInfoView({
 
                   <div>
                     <Text className="font-medium">Organization</Text>
-                    <Text>{currentKeyData.organization_id || "Not Set"}</Text>
+                    <Text>{(currentKeyData.organization_id ?? currentKeyData.org_id) || "Not Set"}</Text>
                   </div>
 
                   <div>


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)

`/key/list` returns key objects with `org_id` (the Pydantic field name in `LiteLLM_VerificationToken`). The UI was reading `organization_id` everywhere, which was always `undefined`, causing the Organization column and detail view to always show "Not Set" and the Organization ID filter to never match any keys.

Root cause: `LiteLLM_VerificationTokenView.__init__` maps the DB column `organization_id` → Pydantic field `org_id`, so JSON output uses `org_id`.

### Fix

Added `org_id` fallback in the four frontend locations that read the organization from a key object:
- `key_info_view.tsx`: reads `organization_id ?? org_id` for the detail view display
- `filter_logic.tsx`: filters on `organization_id ?? org_id` for the Organization ID filter
- `VirtualKeysTable.tsx`: changed `accessorKey` from `"organization_id"` to `"org_id"` for the table column
- `key_list.tsx`: added `org_id?: string | null` to the `KeyResponse` interface

## Testing

Verify in the UI that keys with an `org_id` set now display the correct organization in the key detail view, the keys table, and that the Organization ID filter correctly filters keys.

## Type

🐛 Bug Fix