### PR TITLE
[Feature] RBAC for Vector Stores and Agents

### DIFF
--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -16,6 +16,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import CommonProxyErrors, LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.rbac_utils import check_feature_access_for_user
 from litellm.proxy.management_endpoints.common_daily_activity import get_daily_activity
 from litellm.types.agents import (
     AgentConfig,
@@ -69,6 +70,8 @@ async def get_agents(
     Returns: List[AgentResponse]
 
     """
+    await check_feature_access_for_user(user_api_key_dict, "agents")
+
     from litellm.proxy.agent_endpoints.agent_registry import global_agent_registry
     from litellm.proxy.agent_endpoints.auth.agent_permission_handler import (
         AgentRequestHandler,
@@ -179,6 +182,8 @@ async def create_agent(
         }'
     ```
     """
+    await check_feature_access_for_user(user_api_key_dict, "agents")
+
     from litellm.proxy.proxy_server import prisma_client
 
     _check_agent_management_permission(user_api_key_dict)
@@ -233,7 +238,10 @@ async def create_agent(
     dependencies=[Depends(user_api_key_auth)],
     response_model=AgentResponse,
 )
-async def get_agent_by_id(agent_id: str):
+async def get_agent_by_id(
+    agent_id: str,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
     """
     Get a specific agent by ID
 
@@ -243,6 +251,8 @@ async def get_agent_by_id(agent_id: str):
         -H "Authorization: Bearer <your_api_key>"
     ```
     """
+    await check_feature_access_for_user(user_api_key_dict, "agents")
+
     from litellm.proxy.proxy_server import prisma_client
 
     if prisma_client is None:
@@ -319,6 +329,8 @@ async def update_agent(
         }'
     ```
     """
+    await check_feature_access_for_user(user_api_key_dict, "agents")
+
     from litellm.proxy.proxy_server import prisma_client
 
     _check_agent_management_permission(user_api_key_dict)
@@ -410,6 +422,8 @@ async def patch_agent(
         }'
     ```
     """
+    await check_feature_access_for_user(user_api_key_dict, "agents")
+
     from litellm.proxy.proxy_server import prisma_client
 
     _check_agent_management_permission(user_api_key_dict)
@@ -484,6 +498,8 @@ async def delete_agent(
     }
     ```
     """
+    await check_feature_access_for_user(user_api_key_dict, "agents")
+
     from litellm.proxy.proxy_server import prisma_client
 
     _check_agent_management_permission(user_api_key_dict)
@@ -763,6 +779,8 @@ async def get_agent_daily_activity(
     """
     Get daily activity for specific agents or all accessible agents.
     """
+    await check_feature_access_for_user(user_api_key_dict, "agents")
+
     from litellm.proxy.proxy_server import prisma_client
 
     if prisma_client is None:

--- a/litellm/proxy/common_utils/rbac_utils.py
+++ b/litellm/proxy/common_utils/rbac_utils.py
@@ -1,0 +1,126 @@
+"""
+RBAC utility helpers for feature-level access control.
+
+These helpers are used by agent and vector store endpoints to enforce
+proxy-admin-configurable toggles that restrict access for internal users.
+"""
+
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import LiteLLM_TeamTable, LitellmUserRoles, UserAPIKeyAuth
+
+if TYPE_CHECKING:
+    pass
+
+
+def _is_user_team_admin_for_any_team(
+    user_api_key_dict: UserAPIKeyAuth,
+    teams: list,
+) -> bool:
+    """
+    Return True if the user is an admin member in at least one of the given teams.
+
+    Args:
+        user_api_key_dict: The authenticated user.
+        teams: List of Prisma team records (from litellm_teamtable.find_many).
+    """
+    for team in teams:
+        team_obj = LiteLLM_TeamTable(**team.model_dump())
+        for member in team_obj.members_with_roles:
+            if (
+                member.user_id is not None
+                and member.user_id == user_api_key_dict.user_id
+                and member.role == "admin"
+            ):
+                return True
+    return False
+
+
+async def check_feature_access_for_user(
+    user_api_key_dict: UserAPIKeyAuth,
+    feature_name: str,
+) -> None:
+    """
+    Raise HTTP 403 if the user's role is blocked from accessing the given feature
+    by the UI settings stored in general_settings.
+
+    Args:
+        user_api_key_dict: The authenticated user.
+        feature_name: Either "agents" or "vector_stores".
+    """
+    # Proxy admins (and view-only admins) are never blocked.
+    if user_api_key_dict.user_role in (
+        LitellmUserRoles.PROXY_ADMIN,
+        LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+        LitellmUserRoles.PROXY_ADMIN.value,
+        LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY.value,
+    ):
+        return
+
+    from litellm.proxy.proxy_server import general_settings
+
+    disable_flag = f"disable_{feature_name}_for_internal_users"
+    allow_team_admins_flag = f"allow_{feature_name}_for_team_admins"
+
+    if not general_settings.get(disable_flag, False):
+        # Feature is not disabled — allow all authenticated users.
+        return
+
+    # Feature is disabled.  Check if team admins are exempted.
+    if general_settings.get(allow_team_admins_flag, False):
+        is_team_admin = await _check_if_team_admin(user_api_key_dict)
+        if is_team_admin:
+            return
+
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "error": f"Access to {feature_name} is disabled for your role. Contact your proxy admin."
+        },
+    )
+
+
+async def _check_if_team_admin(user_api_key_dict: UserAPIKeyAuth) -> bool:
+    """
+    Return True if the user is a team admin in any team.
+    Mirrors the logic in management_endpoints/common_utils._user_has_admin_privileges
+    but scoped to team-admin check only.
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None or user_api_key_dict.user_id is None:
+        return False
+
+    from litellm.caching import DualCache
+    from litellm.proxy.auth.auth_checks import get_user_object
+
+    try:
+        user_obj = await get_user_object(
+            user_id=user_api_key_dict.user_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=DualCache(),
+            user_id_upsert=False,
+            proxy_logging_obj=None,
+        )
+
+        if user_obj is None:
+            return False
+
+        if user_obj.teams is None or len(user_obj.teams) == 0:
+            return False
+
+        teams = await prisma_client.db.litellm_teamtable.find_many(
+            where={"team_id": {"in": user_obj.teams}}
+        )
+
+        return _is_user_team_admin_for_any_team(user_api_key_dict, teams)
+
+    except Exception as e:
+        verbose_proxy_logger.debug(
+            f"rbac_utils: error checking team admin status for user "
+            f"{user_api_key_dict.user_id}: {e}"
+        )
+        return False

--- a/litellm/proxy/common_utils/rbac_utils.py
+++ b/litellm/proxy/common_utils/rbac_utils.py
@@ -5,38 +5,9 @@ These helpers are used by agent and vector store endpoints to enforce
 proxy-admin-configurable toggles that restrict access for internal users.
 """
 
-from typing import TYPE_CHECKING
-
 from fastapi import HTTPException
 
-from litellm._logging import verbose_proxy_logger
-from litellm.proxy._types import LiteLLM_TeamTable, LitellmUserRoles, UserAPIKeyAuth
-
-if TYPE_CHECKING:
-    pass
-
-
-def _is_user_team_admin_for_any_team(
-    user_api_key_dict: UserAPIKeyAuth,
-    teams: list,
-) -> bool:
-    """
-    Return True if the user is an admin member in at least one of the given teams.
-
-    Args:
-        user_api_key_dict: The authenticated user.
-        teams: List of Prisma team records (from litellm_teamtable.find_many).
-    """
-    for team in teams:
-        team_obj = LiteLLM_TeamTable(**team.model_dump())
-        for member in team_obj.members_with_roles:
-            if (
-                member.user_id is not None
-                and member.user_id == user_api_key_dict.user_id
-                and member.role == "admin"
-            ):
-                return True
-    return False
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 
 
 async def check_feature_access_for_user(
@@ -60,7 +31,7 @@ async def check_feature_access_for_user(
     ):
         return
 
-    from litellm.proxy.proxy_server import general_settings
+    from litellm.proxy.proxy_server import general_settings, prisma_client, user_api_key_cache
 
     disable_flag = f"disable_{feature_name}_for_internal_users"
     allow_team_admins_flag = f"allow_{feature_name}_for_team_admins"
@@ -69,10 +40,16 @@ async def check_feature_access_for_user(
         # Feature is not disabled — allow all authenticated users.
         return
 
-    # Feature is disabled.  Check if team admins are exempted.
+    # Feature is disabled.  Check if team/org admins are exempted.
     if general_settings.get(allow_team_admins_flag, False):
-        is_team_admin = await _check_if_team_admin(user_api_key_dict)
-        if is_team_admin:
+        from litellm.proxy.management_endpoints.common_utils import _user_has_admin_privileges
+
+        is_admin = await _user_has_admin_privileges(
+            user_api_key_dict=user_api_key_dict,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+        )
+        if is_admin:
             return
 
     raise HTTPException(
@@ -81,46 +58,3 @@ async def check_feature_access_for_user(
             "error": f"Access to {feature_name} is disabled for your role. Contact your proxy admin."
         },
     )
-
-
-async def _check_if_team_admin(user_api_key_dict: UserAPIKeyAuth) -> bool:
-    """
-    Return True if the user is a team admin in any team.
-    Mirrors the logic in management_endpoints/common_utils._user_has_admin_privileges
-    but scoped to team-admin check only.
-    """
-    from litellm.proxy.proxy_server import prisma_client
-
-    if prisma_client is None or user_api_key_dict.user_id is None:
-        return False
-
-    from litellm.caching import DualCache
-    from litellm.proxy.auth.auth_checks import get_user_object
-
-    try:
-        user_obj = await get_user_object(
-            user_id=user_api_key_dict.user_id,
-            prisma_client=prisma_client,
-            user_api_key_cache=DualCache(),
-            user_id_upsert=False,
-            proxy_logging_obj=None,
-        )
-
-        if user_obj is None:
-            return False
-
-        if user_obj.teams is None or len(user_obj.teams) == 0:
-            return False
-
-        teams = await prisma_client.db.litellm_teamtable.find_many(
-            where={"team_id": {"in": user_obj.teams}}
-        )
-
-        return _is_user_team_admin_for_any_team(user_api_key_dict, teams)
-
-    except Exception as e:
-        verbose_proxy_logger.debug(
-            f"rbac_utils: error checking team admin status for user "
-            f"{user_api_key_dict.user_id}: {e}"
-        )
-        return False

--- a/litellm/proxy/common_utils/rbac_utils.py
+++ b/litellm/proxy/common_utils/rbac_utils.py
@@ -5,14 +5,18 @@ These helpers are used by agent and vector store endpoints to enforce
 proxy-admin-configurable toggles that restrict access for internal users.
 """
 
+from typing import Literal
+
 from fastapi import HTTPException
 
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 
+FeatureName = Literal["agents", "vector_stores"]
+
 
 async def check_feature_access_for_user(
     user_api_key_dict: UserAPIKeyAuth,
-    feature_name: str,
+    feature_name: FeatureName,
 ) -> None:
     """
     Raise HTTP 403 if the user's role is blocked from accessing the given feature

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -885,6 +885,9 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
 
         await ProxyStartupEvent._update_default_team_member_budget()
 
+        ## SYNC UI SETTINGS ##
+        await ProxyStartupEvent._sync_ui_settings_to_general_settings()
+
     # Start background health checks AFTER models are loaded and index is built
     if use_background_health_checks:
         asyncio.create_task(
@@ -5637,6 +5640,41 @@ class ProxyStartupEvent:
             teams_pydantic_obj = [NewUserRequestTeam(**team) for team in _teams]
             await update_default_team_member_budget(
                 teams=teams_pydantic_obj, user_api_key_dict=UserAPIKeyAuth(token=hash_token(master_key))  # type: ignore
+            )
+
+    @classmethod
+    async def _sync_ui_settings_to_general_settings(cls):
+        """
+        Load persisted UI settings from the database and sync runtime flags
+        into general_settings so they take effect immediately after startup.
+        """
+        try:
+            import json
+
+            from litellm.proxy.ui_crud_endpoints.proxy_setting_endpoints import (
+                _RUNTIME_GENERAL_SETTINGS_FLAGS,
+            )
+
+            db_record = await prisma_client.db.litellm_uisettings.find_unique(
+                where={"id": "ui_settings"}
+            )
+            if db_record and db_record.ui_settings:
+                raw = db_record.ui_settings
+                ui_settings = json.loads(raw) if isinstance(raw, str) else dict(raw)
+                flags_to_sync = {
+                    k: ui_settings[k]
+                    for k in _RUNTIME_GENERAL_SETTINGS_FLAGS
+                    if k in ui_settings
+                }
+                if flags_to_sync:
+                    general_settings.update(flags_to_sync)
+                    verbose_proxy_logger.info(
+                        "Synced UI settings to general_settings on startup: %s",
+                        list(flags_to_sync.keys()),
+                    )
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                "UI settings sync on startup skipped or failed: %s", e
             )
 
     @classmethod

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -1061,12 +1061,25 @@ async def update_ui_settings(
             },
         )
 
-    settings_dict = settings.model_dump(exclude_none=True)
+    # Only include fields the caller actually sent (not Pydantic defaults).
+    settings_dict = settings.model_dump(exclude_unset=True)
 
     # Enforce allowlist and drop anything unexpected
-    ui_settings = {
+    incoming = {
         k: v for k, v in settings_dict.items() if k in ALLOWED_UI_SETTINGS_FIELDS
     }
+
+    # Merge with existing persisted settings so a partial PATCH doesn't
+    # overwrite fields the caller didn't send.
+    existing: dict = {}
+    db_existing = await prisma_client.db.litellm_uisettings.find_unique(
+        where={"id": "ui_settings"}
+    )
+    if db_existing and db_existing.ui_settings:
+        raw = db_existing.ui_settings
+        existing = json.loads(raw) if isinstance(raw, str) else dict(raw)
+
+    ui_settings = {**existing, **incoming}
 
     await prisma_client.db.litellm_uisettings.upsert(
         where={"id": "ui_settings"},

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -145,6 +145,16 @@ ALLOWED_UI_SETTINGS_FIELDS = {
     "allow_vector_stores_for_team_admins",
 }
 
+# Flags that must be synced from the persisted UISettings into
+# general_settings at runtime (on both read and write).
+_RUNTIME_GENERAL_SETTINGS_FLAGS = [
+    "forward_client_headers_to_llm_api",
+    "disable_agents_for_internal_users",
+    "allow_agents_for_team_admins",
+    "disable_vector_stores_for_internal_users",
+    "allow_vector_stores_for_team_admins",
+]
+
 
 class MCPSemanticFilterSettings(BaseModel):
     """Configuration for MCP Semantic Tool Filter"""
@@ -1002,14 +1012,7 @@ async def get_ui_settings():
 
     # Sync runtime flags into general_settings so the proxy picks them up
     # at runtime (covers server restart scenarios).
-    _runtime_flags = [
-        "forward_client_headers_to_llm_api",
-        "disable_agents_for_internal_users",
-        "allow_agents_for_team_admins",
-        "disable_vector_stores_for_internal_users",
-        "allow_vector_stores_for_team_admins",
-    ]
-    _flags_to_sync = {k: ui_settings[k] for k in _runtime_flags if k in ui_settings}
+    _flags_to_sync = {k: ui_settings[k] for k in _RUNTIME_GENERAL_SETTINGS_FLAGS if k in ui_settings}
     if _flags_to_sync:
         from litellm.proxy.proxy_server import general_settings
 
@@ -1080,14 +1083,7 @@ async def update_ui_settings(
 
     # Sync runtime flags to general_settings so the proxy picks them up
     # at runtime (general_settings is checked in pre-call utils).
-    _runtime_flags = [
-        "forward_client_headers_to_llm_api",
-        "disable_agents_for_internal_users",
-        "allow_agents_for_team_admins",
-        "disable_vector_stores_for_internal_users",
-        "allow_vector_stores_for_team_admins",
-    ]
-    _flags_to_sync = {k: ui_settings[k] for k in _runtime_flags if k in ui_settings}
+    _flags_to_sync = {k: ui_settings[k] for k in _RUNTIME_GENERAL_SETTINGS_FLAGS if k in ui_settings}
     if _flags_to_sync:
         from litellm.proxy.proxy_server import general_settings
 

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -104,6 +104,26 @@ class UISettings(BaseModel):
         description="If enabled, shows the Projects feature in the UI sidebar and the project field in key management.",
     )
 
+    disable_agents_for_internal_users: bool = Field(
+        default=False,
+        description="If true, internal users cannot access agent management endpoints or the Agents page in the UI.",
+    )
+
+    allow_agents_for_team_admins: bool = Field(
+        default=False,
+        description="If true, team admins are exempt from the agents disable restriction (only takes effect when disable_agents_for_internal_users is true).",
+    )
+
+    disable_vector_stores_for_internal_users: bool = Field(
+        default=False,
+        description="If true, internal users cannot access vector store management endpoints or the Vector Stores page in the UI.",
+    )
+
+    allow_vector_stores_for_team_admins: bool = Field(
+        default=False,
+        description="If true, team admins are exempt from the vector stores disable restriction (only takes effect when disable_vector_stores_for_internal_users is true).",
+    )
+
 
 class UISettingsResponse(SettingsResponse):
     """Response model for UI settings"""
@@ -119,6 +139,10 @@ ALLOWED_UI_SETTINGS_FIELDS = {
     "require_auth_for_public_ai_hub",
     "forward_client_headers_to_llm_api",
     "enable_projects_ui",
+    "disable_agents_for_internal_users",
+    "allow_agents_for_team_admins",
+    "disable_vector_stores_for_internal_users",
+    "allow_vector_stores_for_team_admins",
 }
 
 
@@ -976,14 +1000,20 @@ async def get_ui_settings():
         k: v for k, v in ui_settings.items() if k in ALLOWED_UI_SETTINGS_FIELDS
     }
 
-    # Sync forward_client_headers_to_llm_api into general_settings so the proxy
-    # picks it up at runtime (covers server restart scenarios).
-    if "forward_client_headers_to_llm_api" in ui_settings:
+    # Sync runtime flags into general_settings so the proxy picks them up
+    # at runtime (covers server restart scenarios).
+    _runtime_flags = [
+        "forward_client_headers_to_llm_api",
+        "disable_agents_for_internal_users",
+        "allow_agents_for_team_admins",
+        "disable_vector_stores_for_internal_users",
+        "allow_vector_stores_for_team_admins",
+    ]
+    _flags_to_sync = {k: ui_settings[k] for k in _runtime_flags if k in ui_settings}
+    if _flags_to_sync:
         from litellm.proxy.proxy_server import general_settings
 
-        general_settings["forward_client_headers_to_llm_api"] = ui_settings[
-            "forward_client_headers_to_llm_api"
-        ]
+        general_settings.update(_flags_to_sync)
 
     # Build config-like object for schema helper
     config: Dict[str, Any] = {"litellm_settings": {"ui_settings": ui_settings}}
@@ -1048,14 +1078,20 @@ async def update_ui_settings(
         },
     )
 
-    # Sync forward_client_headers_to_llm_api to general_settings so the proxy
-    # picks it up at runtime (general_settings is checked in pre-call utils).
-    if "forward_client_headers_to_llm_api" in ui_settings:
+    # Sync runtime flags to general_settings so the proxy picks them up
+    # at runtime (general_settings is checked in pre-call utils).
+    _runtime_flags = [
+        "forward_client_headers_to_llm_api",
+        "disable_agents_for_internal_users",
+        "allow_agents_for_team_admins",
+        "disable_vector_stores_for_internal_users",
+        "allow_vector_stores_for_team_admins",
+    ]
+    _flags_to_sync = {k: ui_settings[k] for k in _runtime_flags if k in ui_settings}
+    if _flags_to_sync:
         from litellm.proxy.proxy_server import general_settings
 
-        general_settings["forward_client_headers_to_llm_api"] = ui_settings[
-            "forward_client_headers_to_llm_api"
-        ]
+        general_settings.update(_flags_to_sync)
 
     return {
         "message": "UI settings updated successfully",

--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -24,6 +24,7 @@ from litellm.proxy._types import (
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.encrypt_decrypt_utils import decrypt_value_helper
+from litellm.proxy.common_utils.rbac_utils import check_feature_access_for_user
 from litellm.secret_managers.main import get_secret
 from litellm.types.vector_stores import (
     LiteLLM_ManagedVectorStore,
@@ -439,6 +440,8 @@ async def new_vector_store(
     - vector_store_description: Optional[str] - Description of the vector store
     - vector_store_metadata: Optional[Dict] - Additional metadata for the vector store
     """
+    await check_feature_access_for_user(user_api_key_dict, "vector_stores")
+
     from litellm.proxy.proxy_server import prisma_client
 
     try:
@@ -506,6 +509,8 @@ async def list_vector_stores(
     - page: int - Page number for pagination (default: 1)
     - page_size: int - Number of items per page (default: 100)
     """
+    await check_feature_access_for_user(user_api_key_dict, "vector_stores")
+
     from litellm.proxy.proxy_server import prisma_client
 
     vector_store_map: Dict[str, LiteLLM_ManagedVectorStore] = {}
@@ -605,6 +610,8 @@ async def delete_vector_store(
     Parameters:
     - vector_store_id: str - ID of the vector store to delete
     """
+    await check_feature_access_for_user(user_api_key_dict, "vector_stores")
+
     from litellm.proxy.proxy_server import prisma_client
 
     if prisma_client is None:
@@ -687,6 +694,8 @@ async def get_vector_store_info(
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """Return a single vector store's details"""
+    await check_feature_access_for_user(user_api_key_dict, "vector_stores")
+
     from litellm.proxy.proxy_server import prisma_client
 
     if prisma_client is None:
@@ -770,6 +779,8 @@ async def update_vector_store(
     Update vector store details in both database and in-memory registry.
     The updated data is immediately synchronized to the in-memory registry.
     """
+    await check_feature_access_for_user(user_api_key_dict, "vector_stores")
+
     from litellm.proxy.proxy_server import prisma_client
     from litellm.types.router import GenericLiteLLMParams
 

--- a/tests/litellm/proxy/agent_endpoints/test_agent_rbac.py
+++ b/tests/litellm/proxy/agent_endpoints/test_agent_rbac.py
@@ -1,0 +1,84 @@
+"""
+Tests for RBAC enforcement on agent endpoints.
+
+Verifies that check_feature_access_for_user is called and that a 403 is
+raised when agents are disabled for internal users.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+
+
+def _make_internal_user(user_id: str = "user-1") -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        user_id=user_id,
+    )
+
+
+def _make_admin_user(user_id: str = "admin-1") -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN.value,
+        user_id=user_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_agents
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_agents_blocked_for_internal_user_when_disabled():
+    """get_agents should raise 403 when agents are disabled for internal users."""
+    from litellm.proxy.agent_endpoints.endpoints import get_agents
+
+    user = _make_internal_user()
+    gs = {"disable_agents_for_internal_users": True, "allow_agents_for_team_admins": False}
+
+    request_mock = MagicMock()
+    with patch.dict("litellm.proxy.proxy_server.general_settings", gs, clear=True):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_agents(request=request_mock, user_api_key_dict=user)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_agents_allowed_when_not_disabled():
+    """get_agents should not raise RBAC 403 when agents are not disabled."""
+    from litellm.proxy.agent_endpoints.endpoints import get_agents
+
+    user = _make_internal_user()
+    request_mock = MagicMock()
+
+    with patch.dict("litellm.proxy.proxy_server.general_settings", {}, clear=True):
+        with patch(
+            "litellm.proxy.agent_endpoints.agent_registry.global_agent_registry",
+            MagicMock(get_agent_list=MagicMock(return_value=[])),
+        ):
+            with patch(
+                "litellm.proxy.agent_endpoints.auth.agent_permission_handler.AgentRequestHandler.get_allowed_agents",
+                new=AsyncMock(return_value=[]),
+            ):
+                result = await get_agents(request=request_mock, user_api_key_dict=user)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_agent_daily_activity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_agent_daily_activity_blocked_when_disabled():
+    from litellm.proxy.agent_endpoints.endpoints import get_agent_daily_activity
+
+    user = _make_internal_user()
+    gs = {"disable_agents_for_internal_users": True, "allow_agents_for_team_admins": False}
+
+    with patch.dict("litellm.proxy.proxy_server.general_settings", gs, clear=True):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_agent_daily_activity(user_api_key_dict=user)
+    assert exc_info.value.status_code == 403

--- a/tests/litellm/proxy/common_utils/test_rbac_utils.py
+++ b/tests/litellm/proxy/common_utils/test_rbac_utils.py
@@ -101,7 +101,7 @@ async def test_agents_disabled_team_admin_allowed():
         clear=True,
     ):
         with patch(
-            "litellm.proxy.common_utils.rbac_utils._check_if_team_admin",
+            "litellm.proxy.management_endpoints.common_utils._user_has_admin_privileges",
             new=AsyncMock(return_value=True),
         ):
             await check_feature_access_for_user(user, "agents")
@@ -116,7 +116,7 @@ async def test_agents_disabled_non_team_admin_blocked():
         clear=True,
     ):
         with patch(
-            "litellm.proxy.common_utils.rbac_utils._check_if_team_admin",
+            "litellm.proxy.management_endpoints.common_utils._user_has_admin_privileges",
             new=AsyncMock(return_value=False),
         ):
             with pytest.raises(HTTPException) as exc_info:
@@ -133,7 +133,7 @@ async def test_vector_stores_disabled_team_admin_allowed():
         clear=True,
     ):
         with patch(
-            "litellm.proxy.common_utils.rbac_utils._check_if_team_admin",
+            "litellm.proxy.management_endpoints.common_utils._user_has_admin_privileges",
             new=AsyncMock(return_value=True),
         ):
             await check_feature_access_for_user(user, "vector_stores")
@@ -148,7 +148,7 @@ async def test_vector_stores_disabled_non_team_admin_blocked():
         clear=True,
     ):
         with patch(
-            "litellm.proxy.common_utils.rbac_utils._check_if_team_admin",
+            "litellm.proxy.management_endpoints.common_utils._user_has_admin_privileges",
             new=AsyncMock(return_value=False),
         ):
             with pytest.raises(HTTPException) as exc_info:

--- a/tests/litellm/proxy/common_utils/test_rbac_utils.py
+++ b/tests/litellm/proxy/common_utils/test_rbac_utils.py
@@ -1,0 +1,156 @@
+"""
+Tests for litellm/proxy/common_utils/rbac_utils.py
+
+Covers check_feature_access_for_user for agents and vector_stores features.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.common_utils.rbac_utils import check_feature_access_for_user
+
+
+def _make_user(role: str, user_id: str = "user-1") -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(user_role=role, user_id=user_id)
+
+
+# general_settings is imported from litellm.proxy.proxy_server inside the
+# function, so we patch it via patch.dict on the original dict.
+_GS_PATH = "litellm.proxy.proxy_server.general_settings"
+
+
+# ---------------------------------------------------------------------------
+# Proxy admin is always allowed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_proxy_admin_always_allowed():
+    user = _make_user(LitellmUserRoles.PROXY_ADMIN.value)
+    with patch.dict(_GS_PATH, {"disable_agents_for_internal_users": True}):
+        await check_feature_access_for_user(user, "agents")
+
+
+@pytest.mark.asyncio
+async def test_proxy_admin_view_only_always_allowed():
+    user = _make_user(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY.value)
+    with patch.dict(_GS_PATH, {"disable_agents_for_internal_users": True}):
+        await check_feature_access_for_user(user, "agents")
+
+
+# ---------------------------------------------------------------------------
+# Feature not disabled — everyone allowed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_feature_not_disabled_allows_internal_user():
+    user = _make_user(LitellmUserRoles.INTERNAL_USER.value)
+    with patch.dict(_GS_PATH, {}, clear=True):
+        await check_feature_access_for_user(user, "agents")
+
+
+@pytest.mark.asyncio
+async def test_feature_not_disabled_allows_vector_stores():
+    user = _make_user(LitellmUserRoles.INTERNAL_USER.value)
+    with patch.dict(_GS_PATH, {"disable_vector_stores_for_internal_users": False}, clear=True):
+        await check_feature_access_for_user(user, "vector_stores")
+
+
+# ---------------------------------------------------------------------------
+# Feature disabled, team-admin exemption OFF — internal user blocked
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_agents_disabled_blocks_internal_user():
+    user = _make_user(LitellmUserRoles.INTERNAL_USER.value)
+    with patch.dict(
+        _GS_PATH,
+        {"disable_agents_for_internal_users": True, "allow_agents_for_team_admins": False},
+        clear=True,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await check_feature_access_for_user(user, "agents")
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_vector_stores_disabled_blocks_internal_user():
+    user = _make_user(LitellmUserRoles.INTERNAL_USER.value)
+    with patch.dict(
+        _GS_PATH,
+        {"disable_vector_stores_for_internal_users": True, "allow_vector_stores_for_team_admins": False},
+        clear=True,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await check_feature_access_for_user(user, "vector_stores")
+    assert exc_info.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Feature disabled, allow_team_admins ON — team admin allowed, non-admin blocked
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_agents_disabled_team_admin_allowed():
+    user = _make_user(LitellmUserRoles.INTERNAL_USER.value, user_id="team-admin-user")
+    with patch.dict(
+        _GS_PATH,
+        {"disable_agents_for_internal_users": True, "allow_agents_for_team_admins": True},
+        clear=True,
+    ):
+        with patch(
+            "litellm.proxy.common_utils.rbac_utils._check_if_team_admin",
+            new=AsyncMock(return_value=True),
+        ):
+            await check_feature_access_for_user(user, "agents")
+
+
+@pytest.mark.asyncio
+async def test_agents_disabled_non_team_admin_blocked():
+    user = _make_user(LitellmUserRoles.INTERNAL_USER.value, user_id="regular-user")
+    with patch.dict(
+        _GS_PATH,
+        {"disable_agents_for_internal_users": True, "allow_agents_for_team_admins": True},
+        clear=True,
+    ):
+        with patch(
+            "litellm.proxy.common_utils.rbac_utils._check_if_team_admin",
+            new=AsyncMock(return_value=False),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await check_feature_access_for_user(user, "agents")
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_vector_stores_disabled_team_admin_allowed():
+    user = _make_user(LitellmUserRoles.INTERNAL_USER.value, user_id="team-admin-user")
+    with patch.dict(
+        _GS_PATH,
+        {"disable_vector_stores_for_internal_users": True, "allow_vector_stores_for_team_admins": True},
+        clear=True,
+    ):
+        with patch(
+            "litellm.proxy.common_utils.rbac_utils._check_if_team_admin",
+            new=AsyncMock(return_value=True),
+        ):
+            await check_feature_access_for_user(user, "vector_stores")
+
+
+@pytest.mark.asyncio
+async def test_vector_stores_disabled_non_team_admin_blocked():
+    user = _make_user(LitellmUserRoles.INTERNAL_USER.value, user_id="regular-user")
+    with patch.dict(
+        _GS_PATH,
+        {"disable_vector_stores_for_internal_users": True, "allow_vector_stores_for_team_admins": True},
+        clear=True,
+    ):
+        with patch(
+            "litellm.proxy.common_utils.rbac_utils._check_if_team_admin",
+            new=AsyncMock(return_value=False),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await check_feature_access_for_user(user, "vector_stores")
+    assert exc_info.value.status_code == 403

--- a/tests/litellm/proxy/vector_store_endpoints/test_vector_store_rbac.py
+++ b/tests/litellm/proxy/vector_store_endpoints/test_vector_store_rbac.py
@@ -53,7 +53,6 @@ async def test_list_vector_stores_allowed_when_not_disabled():
     mock_prisma = MagicMock()
     mock_prisma.db.litellm_managedvectorstorestable.find_many = AsyncMock(return_value=[])
 
-    raised_403 = False
     with patch.dict("litellm.proxy.proxy_server.general_settings", _ENABLED_GS, clear=True):
         with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
             with patch.object(litellm, "vector_store_registry", None):
@@ -61,12 +60,9 @@ async def test_list_vector_stores_allowed_when_not_disabled():
                     "litellm.proxy.vector_store_endpoints.management_endpoints.VectorStoreRegistry._get_vector_stores_from_db",
                     new=AsyncMock(return_value=[]),
                 ):
-                    try:
-                        await list_vector_stores(user_api_key_dict=user)
-                    except HTTPException as e:
-                        if e.status_code == 403:
-                            raised_403 = True
-    assert not raised_403, "Should not raise 403 when vector stores are not disabled"
+                    # Must not raise any HTTPException — if mocking is incomplete the
+                    # test should fail loudly rather than silently swallowing errors.
+                    await list_vector_stores(user_api_key_dict=user)
 
 
 # ---------------------------------------------------------------------------
@@ -105,7 +101,6 @@ async def test_list_vector_stores_admin_not_blocked():
     mock_prisma = MagicMock()
     mock_prisma.db.litellm_managedvectorstorestable.find_many = AsyncMock(return_value=[])
 
-    raised_403 = False
     with patch.dict("litellm.proxy.proxy_server.general_settings", _DISABLED_GS, clear=True):
         with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
             with patch.object(litellm, "vector_store_registry", None):
@@ -113,9 +108,5 @@ async def test_list_vector_stores_admin_not_blocked():
                     "litellm.proxy.vector_store_endpoints.management_endpoints.VectorStoreRegistry._get_vector_stores_from_db",
                     new=AsyncMock(return_value=[]),
                 ):
-                    try:
-                        await list_vector_stores(user_api_key_dict=admin)
-                    except HTTPException as e:
-                        if e.status_code == 403:
-                            raised_403 = True
-    assert not raised_403, "Admin should not be blocked even when vector stores are disabled"
+                    # Must not raise any HTTPException — admin is always allowed.
+                    await list_vector_stores(user_api_key_dict=admin)

--- a/tests/litellm/proxy/vector_store_endpoints/test_vector_store_rbac.py
+++ b/tests/litellm/proxy/vector_store_endpoints/test_vector_store_rbac.py
@@ -1,0 +1,121 @@
+"""
+Tests for RBAC enforcement on vector store management endpoints.
+
+Verifies that check_feature_access_for_user is called and that a 403 is
+raised when vector stores are disabled for internal users.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+
+
+def _make_internal_user(user_id: str = "user-1") -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        user_id=user_id,
+    )
+
+
+_DISABLED_GS = {
+    "disable_vector_stores_for_internal_users": True,
+    "allow_vector_stores_for_team_admins": False,
+}
+
+_ENABLED_GS: dict = {}
+
+
+# ---------------------------------------------------------------------------
+# list_vector_stores
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_vector_stores_blocked_when_disabled():
+    from litellm.proxy.vector_store_endpoints.management_endpoints import list_vector_stores
+
+    user = _make_internal_user()
+    with patch.dict("litellm.proxy.proxy_server.general_settings", _DISABLED_GS, clear=True):
+        with pytest.raises(HTTPException) as exc_info:
+            await list_vector_stores(user_api_key_dict=user)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_vector_stores_allowed_when_not_disabled():
+    """list_vector_stores should not raise 403 when vector stores are not disabled."""
+    from litellm.proxy.vector_store_endpoints.management_endpoints import list_vector_stores
+
+    import litellm
+    user = _make_internal_user()
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_managedvectorstorestable.find_many = AsyncMock(return_value=[])
+
+    raised_403 = False
+    with patch.dict("litellm.proxy.proxy_server.general_settings", _ENABLED_GS, clear=True):
+        with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+            with patch.object(litellm, "vector_store_registry", None):
+                with patch(
+                    "litellm.proxy.vector_store_endpoints.management_endpoints.VectorStoreRegistry._get_vector_stores_from_db",
+                    new=AsyncMock(return_value=[]),
+                ):
+                    try:
+                        await list_vector_stores(user_api_key_dict=user)
+                    except HTTPException as e:
+                        if e.status_code == 403:
+                            raised_403 = True
+    assert not raised_403, "Should not raise 403 when vector stores are not disabled"
+
+
+# ---------------------------------------------------------------------------
+# new_vector_store
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_new_vector_store_blocked_when_disabled():
+    from litellm.proxy.vector_store_endpoints.management_endpoints import new_vector_store
+    from litellm.types.vector_stores import LiteLLM_ManagedVectorStore
+
+    user = _make_internal_user()
+    vs = LiteLLM_ManagedVectorStore(vector_store_id="vs-1", custom_llm_provider="openai")  # type: ignore[call-arg]
+
+    with patch.dict("litellm.proxy.proxy_server.general_settings", _DISABLED_GS, clear=True):
+        with pytest.raises(HTTPException) as exc_info:
+            await new_vector_store(vector_store=vs, user_api_key_dict=user)
+    assert exc_info.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Admin user is never blocked
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_vector_stores_admin_not_blocked():
+    """Proxy admin should never be blocked, even when vector stores are disabled."""
+    from litellm.proxy.vector_store_endpoints.management_endpoints import list_vector_stores
+
+    import litellm
+    admin = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN.value,
+        user_id="admin-1",
+    )
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_managedvectorstorestable.find_many = AsyncMock(return_value=[])
+
+    raised_403 = False
+    with patch.dict("litellm.proxy.proxy_server.general_settings", _DISABLED_GS, clear=True):
+        with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+            with patch.object(litellm, "vector_store_registry", None):
+                with patch(
+                    "litellm.proxy.vector_store_endpoints.management_endpoints.VectorStoreRegistry._get_vector_stores_from_db",
+                    new=AsyncMock(return_value=[]),
+                ):
+                    try:
+                        await list_vector_stores(user_api_key_dict=admin)
+                    except HTTPException as e:
+                        if e.status_code == 403:
+                            raised_403 = True
+    assert not raised_403, "Admin should not be blocked even when vector stores are disabled"

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -867,6 +867,7 @@ class TestProxySettingEndpoints:
         monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
         mock_prisma = MagicMock()
         mock_prisma.db.litellm_uisettings.upsert = AsyncMock()
+        mock_prisma.db.litellm_uisettings.find_unique = AsyncMock(return_value=None)
         monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
 
         payload = {"disable_model_add_for_internal_users": True}
@@ -908,6 +909,7 @@ class TestProxySettingEndpoints:
         monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
         mock_prisma = MagicMock()
         mock_prisma.db.litellm_uisettings.upsert = AsyncMock()
+        mock_prisma.db.litellm_uisettings.find_unique = AsyncMock(return_value=None)
         monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
 
         payload = {

--- a/ui/litellm-dashboard/src/app/(dashboard)/components/SidebarProvider.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/components/SidebarProvider.tsx
@@ -16,7 +16,9 @@ const SidebarProvider = ({ setPage, defaultSelectedKey, sidebarCollapsed }: Side
   const [enabledPagesInternalUsers, setEnabledPagesInternalUsers] = useState<string[] | null>(null);
   const [enableProjectsUI, setEnableProjectsUI] = useState<boolean>(false);
   const [disableAgentsForInternalUsers, setDisableAgentsForInternalUsers] = useState<boolean>(false);
+  const [allowAgentsForTeamAdmins, setAllowAgentsForTeamAdmins] = useState<boolean>(false);
   const [disableVectorStoresForInternalUsers, setDisableVectorStoresForInternalUsers] = useState<boolean>(false);
+  const [allowVectorStoresForTeamAdmins, setAllowVectorStoresForTeamAdmins] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchUISettings = async () => {
@@ -46,8 +48,16 @@ const SidebarProvider = ({ setPage, defaultSelectedKey, sidebarCollapsed }: Side
           setDisableAgentsForInternalUsers(Boolean(settings.values.disable_agents_for_internal_users));
         }
 
+        if (settings?.values?.allow_agents_for_team_admins !== undefined) {
+          setAllowAgentsForTeamAdmins(Boolean(settings.values.allow_agents_for_team_admins));
+        }
+
         if (settings?.values?.disable_vector_stores_for_internal_users !== undefined) {
           setDisableVectorStoresForInternalUsers(Boolean(settings.values.disable_vector_stores_for_internal_users));
+        }
+
+        if (settings?.values?.allow_vector_stores_for_team_admins !== undefined) {
+          setAllowVectorStoresForTeamAdmins(Boolean(settings.values.allow_vector_stores_for_team_admins));
         }
       } catch (error) {
         console.error("[SidebarProvider] Failed to fetch UI settings:", error);
@@ -65,7 +75,9 @@ const SidebarProvider = ({ setPage, defaultSelectedKey, sidebarCollapsed }: Side
       enabledPagesInternalUsers={enabledPagesInternalUsers}
       enableProjectsUI={enableProjectsUI}
       disableAgentsForInternalUsers={disableAgentsForInternalUsers}
+      allowAgentsForTeamAdmins={allowAgentsForTeamAdmins}
       disableVectorStoresForInternalUsers={disableVectorStoresForInternalUsers}
+      allowVectorStoresForTeamAdmins={allowVectorStoresForTeamAdmins}
     />
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/components/SidebarProvider.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/components/SidebarProvider.tsx
@@ -15,6 +15,8 @@ const SidebarProvider = ({ setPage, defaultSelectedKey, sidebarCollapsed }: Side
   const { accessToken } = useAuthorized();
   const [enabledPagesInternalUsers, setEnabledPagesInternalUsers] = useState<string[] | null>(null);
   const [enableProjectsUI, setEnableProjectsUI] = useState<boolean>(false);
+  const [disableAgentsForInternalUsers, setDisableAgentsForInternalUsers] = useState<boolean>(false);
+  const [disableVectorStoresForInternalUsers, setDisableVectorStoresForInternalUsers] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchUISettings = async () => {
@@ -39,6 +41,14 @@ const SidebarProvider = ({ setPage, defaultSelectedKey, sidebarCollapsed }: Side
         if (settings?.values?.enable_projects_ui !== undefined) {
           setEnableProjectsUI(Boolean(settings.values.enable_projects_ui));
         }
+
+        if (settings?.values?.disable_agents_for_internal_users !== undefined) {
+          setDisableAgentsForInternalUsers(Boolean(settings.values.disable_agents_for_internal_users));
+        }
+
+        if (settings?.values?.disable_vector_stores_for_internal_users !== undefined) {
+          setDisableVectorStoresForInternalUsers(Boolean(settings.values.disable_vector_stores_for_internal_users));
+        }
       } catch (error) {
         console.error("[SidebarProvider] Failed to fetch UI settings:", error);
       }
@@ -54,6 +64,8 @@ const SidebarProvider = ({ setPage, defaultSelectedKey, sidebarCollapsed }: Side
       collapsed={sidebarCollapsed}
       enabledPagesInternalUsers={enabledPagesInternalUsers}
       enableProjectsUI={enableProjectsUI}
+      disableAgentsForInternalUsers={disableAgentsForInternalUsers}
+      disableVectorStoresForInternalUsers={disableVectorStoresForInternalUsers}
     />
   );
 };

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
@@ -19,9 +19,15 @@ export default function UISettings() {
   const forwardClientHeadersProperty = schema?.properties?.forward_client_headers_to_llm_api;
   const enableProjectsUIProperty = schema?.properties?.enable_projects_ui;
   const enabledPagesProperty = schema?.properties?.enabled_ui_pages_internal_users;
+  const disableAgentsProperty = schema?.properties?.disable_agents_for_internal_users;
+  const allowAgentsTeamAdminsProperty = schema?.properties?.allow_agents_for_team_admins;
+  const disableVectorStoresProperty = schema?.properties?.disable_vector_stores_for_internal_users;
+  const allowVectorStoresTeamAdminsProperty = schema?.properties?.allow_vector_stores_for_team_admins;
   const values = data?.values ?? {};
   const isDisabledForInternalUsers = Boolean(values.disable_model_add_for_internal_users);
   const isDisabledTeamAdminDeleteTeamUser = Boolean(values.disable_team_admin_delete_team_user);
+  const isAgentsDisabled = Boolean(values.disable_agents_for_internal_users);
+  const isVectorStoresDisabled = Boolean(values.disable_vector_stores_for_internal_users);
 
   const handleToggle = (checked: boolean) => {
     updateSettings(
@@ -94,6 +100,62 @@ export default function UISettings() {
   const handleToggleRequireAuthForPublicAIHub = (checked: boolean) => {
     updateSettings(
       { require_auth_for_public_ai_hub: checked },
+      {
+        onSuccess: () => {
+          NotificationManager.success("UI settings updated successfully");
+        },
+        onError: (error) => {
+          NotificationManager.fromBackend(error);
+        },
+      },
+    );
+  };
+
+  const handleToggleDisableAgents = (checked: boolean) => {
+    updateSettings(
+      { disable_agents_for_internal_users: checked },
+      {
+        onSuccess: () => {
+          NotificationManager.success("UI settings updated successfully");
+        },
+        onError: (error) => {
+          NotificationManager.fromBackend(error);
+        },
+      },
+    );
+  };
+
+  const handleToggleAllowAgentsTeamAdmins = (checked: boolean) => {
+    updateSettings(
+      { allow_agents_for_team_admins: checked },
+      {
+        onSuccess: () => {
+          NotificationManager.success("UI settings updated successfully");
+        },
+        onError: (error) => {
+          NotificationManager.fromBackend(error);
+        },
+      },
+    );
+  };
+
+  const handleToggleDisableVectorStores = (checked: boolean) => {
+    updateSettings(
+      { disable_vector_stores_for_internal_users: checked },
+      {
+        onSuccess: () => {
+          NotificationManager.success("UI settings updated successfully");
+        },
+        onError: (error) => {
+          NotificationManager.fromBackend(error);
+        },
+      },
+    );
+  };
+
+  const handleToggleAllowVectorStoresTeamAdmins = (checked: boolean) => {
+    updateSettings(
+      { allow_vector_stores_for_team_admins: checked },
       {
         onSuccess: () => {
           NotificationManager.success("UI settings updated successfully");
@@ -206,6 +268,80 @@ export default function UISettings() {
                 {enableProjectsUIProperty?.description ??
                   "If enabled, shows the Projects feature in the UI sidebar and the project field in key management."}
               </Typography.Text>
+            </Space>
+          </Space>
+
+          <Divider />
+
+          {/* Agents access control */}
+          <Space align="start" size="middle">
+            <Switch
+              checked={isAgentsDisabled}
+              disabled={isUpdating}
+              loading={isUpdating}
+              onChange={handleToggleDisableAgents}
+              aria-label={disableAgentsProperty?.description ?? "Disable agents for internal users"}
+            />
+            <Space direction="vertical" size={4}>
+              <Typography.Text strong>Disable agents for internal users</Typography.Text>
+              {disableAgentsProperty?.description && (
+                <Typography.Text type="secondary">{disableAgentsProperty.description}</Typography.Text>
+              )}
+            </Space>
+          </Space>
+
+          <Space align="start" size="middle" style={{ marginLeft: 32 }}>
+            <Switch
+              checked={Boolean(values.allow_agents_for_team_admins)}
+              disabled={isUpdating || !isAgentsDisabled}
+              loading={isUpdating}
+              onChange={handleToggleAllowAgentsTeamAdmins}
+              aria-label={allowAgentsTeamAdminsProperty?.description ?? "Allow agents for team admins"}
+            />
+            <Space direction="vertical" size={4}>
+              <Typography.Text strong type={!isAgentsDisabled ? "secondary" : undefined}>
+                Allow agents for team admins
+              </Typography.Text>
+              {allowAgentsTeamAdminsProperty?.description && (
+                <Typography.Text type="secondary">{allowAgentsTeamAdminsProperty.description}</Typography.Text>
+              )}
+            </Space>
+          </Space>
+
+          <Divider />
+
+          {/* Vector Stores access control */}
+          <Space align="start" size="middle">
+            <Switch
+              checked={isVectorStoresDisabled}
+              disabled={isUpdating}
+              loading={isUpdating}
+              onChange={handleToggleDisableVectorStores}
+              aria-label={disableVectorStoresProperty?.description ?? "Disable vector stores for internal users"}
+            />
+            <Space direction="vertical" size={4}>
+              <Typography.Text strong>Disable vector stores for internal users</Typography.Text>
+              {disableVectorStoresProperty?.description && (
+                <Typography.Text type="secondary">{disableVectorStoresProperty.description}</Typography.Text>
+              )}
+            </Space>
+          </Space>
+
+          <Space align="start" size="middle" style={{ marginLeft: 32 }}>
+            <Switch
+              checked={Boolean(values.allow_vector_stores_for_team_admins)}
+              disabled={isUpdating || !isVectorStoresDisabled}
+              loading={isUpdating}
+              onChange={handleToggleAllowVectorStoresTeamAdmins}
+              aria-label={allowVectorStoresTeamAdminsProperty?.description ?? "Allow vector stores for team admins"}
+            />
+            <Space direction="vertical" size={4}>
+              <Typography.Text strong type={!isVectorStoresDisabled ? "secondary" : undefined}>
+                Allow vector stores for team admins
+              </Typography.Text>
+              {allowVectorStoresTeamAdminsProperty?.description && (
+                <Typography.Text type="secondary">{allowVectorStoresTeamAdminsProperty.description}</Typography.Text>
+              )}
             </Space>
           </Space>
 

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -1,4 +1,5 @@
 import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
+import { useTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import {
   ApiOutlined,
@@ -29,7 +30,7 @@ import {
 import type { MenuProps } from "antd";
 import { ConfigProvider, Layout, Menu } from "antd";
 import { useMemo } from "react";
-import { all_admin_roles, internalUserRoles, isAdminRole, rolesWithWriteAccess } from "../utils/roles";
+import { all_admin_roles, internalUserRoles, isAdminRole, isUserTeamAdminForAnyTeam, rolesWithWriteAccess } from "../utils/roles";
 import NewBadge from "./common_components/NewBadge";
 import type { Organization } from "./networking";
 import UsageIndicator from "./UsageIndicator";
@@ -43,7 +44,9 @@ interface SidebarProps {
   enabledPagesInternalUsers?: string[] | null;
   enableProjectsUI?: boolean;
   disableAgentsForInternalUsers?: boolean;
+  allowAgentsForTeamAdmins?: boolean;
   disableVectorStoresForInternalUsers?: boolean;
+  allowVectorStoresForTeamAdmins?: boolean;
 }
 
 // Menu item configuration
@@ -356,9 +359,10 @@ const menuGroups: MenuGroup[] = [
   },
 ];
 
-const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapsed = false, enabledPagesInternalUsers, enableProjectsUI, disableAgentsForInternalUsers, disableVectorStoresForInternalUsers }) => {
+const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapsed = false, enabledPagesInternalUsers, enableProjectsUI, disableAgentsForInternalUsers, allowAgentsForTeamAdmins, disableVectorStoresForInternalUsers, allowVectorStoresForTeamAdmins }) => {
   const { userId, accessToken, userRole } = useAuthorized();
   const { data: organizations } = useOrganizations();
+  const { data: teams } = useTeams();
 
   // Check if user is an org_admin
   const isOrgAdmin = useMemo(() => {
@@ -367,6 +371,9 @@ const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapse
       org.members?.some((member) => member.user_id === userId && member.user_role === "org_admin"),
     );
   }, [userId, organizations]);
+
+  // Check if user is a team admin for any team
+  const isTeamAdmin = useMemo(() => isUserTeamAdminForAnyTeam(teams ?? null, userId ?? ""), [teams, userId]);
 
   // Navigate to page helper
   const navigateToPage = (page: string) => {
@@ -452,9 +459,10 @@ const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapse
         // Hide Projects page if enableProjectsUI is not enabled
         if (item.key === "projects" && !enableProjectsUI) return false;
 
-        // Hide agents and vector-stores pages for non-admin users when disabled
-        if (!isAdmin && item.key === "agents" && disableAgentsForInternalUsers) return false;
-        if (!isAdmin && item.key === "vector-stores" && disableVectorStoresForInternalUsers) return false;
+        // Hide agents and vector-stores pages for non-admin users when disabled,
+        // unless allow_*_for_team_admins is on and the user is a team admin.
+        if (!isAdmin && item.key === "agents" && disableAgentsForInternalUsers && !(allowAgentsForTeamAdmins && isTeamAdmin)) return false;
+        if (!isAdmin && item.key === "vector-stores" && disableVectorStoresForInternalUsers && !(allowVectorStoresForTeamAdmins && isTeamAdmin)) return false;
 
         // Existing role check
         if (item.roles && !item.roles.includes(userRole)) return false;

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -42,6 +42,8 @@ interface SidebarProps {
   collapsed?: boolean;
   enabledPagesInternalUsers?: string[] | null;
   enableProjectsUI?: boolean;
+  disableAgentsForInternalUsers?: boolean;
+  disableVectorStoresForInternalUsers?: boolean;
 }
 
 // Menu item configuration
@@ -354,7 +356,7 @@ const menuGroups: MenuGroup[] = [
   },
 ];
 
-const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapsed = false, enabledPagesInternalUsers, enableProjectsUI }) => {
+const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapsed = false, enabledPagesInternalUsers, enableProjectsUI, disableAgentsForInternalUsers, disableVectorStoresForInternalUsers }) => {
   const { userId, accessToken, userRole } = useAuthorized();
   const { data: organizations } = useOrganizations();
 
@@ -449,6 +451,10 @@ const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapse
 
         // Hide Projects page if enableProjectsUI is not enabled
         if (item.key === "projects" && !enableProjectsUI) return false;
+
+        // Hide agents and vector-stores pages for non-admin users when disabled
+        if (!isAdmin && item.key === "agents" && disableAgentsForInternalUsers) return false;
+        if (!isAdmin && item.key === "vector-stores" && disableVectorStoresForInternalUsers) return false;
 
         // Existing role check
         if (item.roles && !item.roles.includes(userRole)) return false;


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Summary

Users need the ability to restrict internal users (and optionally team admins) from accessing agent and vector store management features. Today, agent write operations are PROXY_ADMIN-only but reads are open, and vector store management has no role-based restrictions at all.

### Changes

Adds 4 proxy-admin-configurable toggles in UI Settings:
- `disable_agents_for_internal_users` / `allow_agents_for_team_admins`
- `disable_vector_stores_for_internal_users` / `allow_vector_stores_for_team_admins`

The "allow for team admins" toggle only takes effect when the corresponding disable toggle is ON, exempting team admins from the block.

**Backend:**
- New `litellm/proxy/common_utils/rbac_utils.py` with a reusable `check_feature_access_for_user()` helper that raises HTTP 403 based on `general_settings` flags. Proxy admins and view-only admins are never blocked; team admin exemption is checked via the DB when the `allow_*_for_team_admins` flag is enabled.
- `UISettings` model gains 4 new fields (persisted to DB and synced to `general_settings` on read/update, matching the existing `forward_client_headers_to_llm_api` pattern).
- RBAC check added to all agent endpoints (`get_agents`, `create_agent`, `get_agent_by_id`, `update_agent`, `patch_agent`, `delete_agent`, `get_agent_daily_activity`) and all vector store management endpoints (`new_vector_store`, `list_vector_stores`, `delete_vector_store`, `get_vector_store_info`, `update_vector_store`). OpenAI-compatible LLM API routes are unaffected.

**UI:**
- 4 new Switch toggles in UI Settings (agents and vector stores sections, with sub-toggles visually disabled when the parent is off).
- `SidebarProvider` reads the two disable flags and passes them to the Sidebar; `leftnav.tsx` filters out the `agents` and `vector-stores` menu items for non-admin users when the respective flag is enabled.

## Testing

17 new unit tests across 3 files:
- `tests/litellm/proxy/common_utils/test_rbac_utils.py` — covers all role/flag combinations for `check_feature_access_for_user`
- `tests/litellm/proxy/agent_endpoints/test_agent_rbac.py` — 403 on `get_agents` and `get_agent_daily_activity` when disabled; no block when not disabled
- `tests/litellm/proxy/vector_store_endpoints/test_vector_store_rbac.py` — 403 on `list_vector_stores` and `new_vector_store` when disabled; admin not blocked

## Type

🆕 New Feature
✅ Test

## Screenshot
UI:
<img width="1087" height="418" alt="image" src="https://github.com/user-attachments/assets/4ed7cc00-e3b8-4628-80a0-2bb022bc7393" />

API:
List Agents with Internal User Key:
<img width="1101" height="441" alt="image" src="https://github.com/user-attachments/assets/2e3e66d7-06a2-430e-a389-749d7f11f0af" />

List Vector Stores with Internal User Key:
<img width="1090" height="417" alt="image" src="https://github.com/user-attachments/assets/987fd35e-7763-4c31-ac13-ea9f2fbd436e" />
