### PR TITLE
fix(v1/messages): preserve tool_result with unrecognized content types

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -61,6 +61,7 @@ def create_tool_name_mapping(
             mapping[truncated_name] = original_name
     return mapping
 
+
 from openai.types.chat.chat_completion_chunk import Choice as OpenAIStreamingChoice
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
@@ -172,10 +173,11 @@ class AnthropicAdapter:
             model=model, messages=messages, **kwargs
         )
 
-        translated_body, tool_name_mapping = (
-            LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
-                anthropic_message_request=request_body
-            )
+        (
+            translated_body,
+            tool_name_mapping,
+        ) = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+            anthropic_message_request=request_body
         )
 
         return translated_body, tool_name_mapping
@@ -283,7 +285,11 @@ class LiteLLMAnthropicMessagesAdapter:
             model: Model name to check if cache_control should be preserved
         """
         # TypedDict objects are dicts at runtime, so .get() works
-        cache_control = source.get("cache_control") if isinstance(source, dict) else getattr(source, "cache_control", None)
+        cache_control = (
+            source.get("cache_control")
+            if isinstance(source, dict)
+            else getattr(source, "cache_control", None)
+        )
         if cache_control and model and self.is_anthropic_claude_model(model):
             # TypedDict objects support dict operations at runtime
             # Use type ignore consistent with codebase pattern (see anthropic/chat/transformation.py:432)
@@ -297,7 +303,15 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         Which anthropic params, we need to translate to the openai format.
         """
-        return ["messages", "metadata", "system", "tool_choice", "tools", "thinking", "output_format"]
+        return [
+            "messages",
+            "metadata",
+            "system",
+            "tool_choice",
+            "tools",
+            "thinking",
+            "output_format",
+        ]
 
     def _is_web_search_tool(self, tool: Dict[str, Any]) -> bool:
         """
@@ -350,13 +364,17 @@ class LiteLLMAnthropicMessagesAdapter:
                             text_obj = ChatCompletionTextObject(
                                 type="text", text=content.get("text", "")
                             )
-                            self._add_cache_control_if_applicable(content, text_obj, model)
+                            self._add_cache_control_if_applicable(
+                                content, text_obj, model
+                            )
                             new_user_content_list.append(text_obj)  # type: ignore
                         elif content.get("type") == "image":
                             # Convert Anthropic image format to OpenAI format
                             source = content.get("source", {})
                             openai_image_url = (
-                                self._translate_anthropic_image_to_openai(cast(dict, source))
+                                self._translate_anthropic_image_to_openai(
+                                    cast(dict, source)
+                                )
                             )
 
                             if openai_image_url:
@@ -366,13 +384,17 @@ class LiteLLMAnthropicMessagesAdapter:
                                 image_obj = ChatCompletionImageObject(
                                     type="image_url", image_url=image_url_obj
                                 )
-                                self._add_cache_control_if_applicable(content, image_obj, model)
+                                self._add_cache_control_if_applicable(
+                                    content, image_obj, model
+                                )
                                 new_user_content_list.append(image_obj)  # type: ignore
                         elif content.get("type") == "document":
                             # Convert Anthropic document format (PDF, etc.) to OpenAI format
                             source = content.get("source", {})
                             openai_image_url = (
-                                self._translate_anthropic_image_to_openai(cast(dict, source))
+                                self._translate_anthropic_image_to_openai(
+                                    cast(dict, source)
+                                )
                             )
 
                             if openai_image_url:
@@ -382,7 +404,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                 doc_obj = ChatCompletionImageObject(
                                     type="image_url", image_url=image_url_obj
                                 )
-                                self._add_cache_control_if_applicable(content, doc_obj, model)
+                                self._add_cache_control_if_applicable(
+                                    content, doc_obj, model
+                                )
                                 new_user_content_list.append(doc_obj)  # type: ignore
                         elif content.get("type") == "tool_result":
                             if "content" not in content:
@@ -391,7 +415,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                     tool_call_id=content.get("tool_use_id", ""),
                                     content="",
                                 )
-                                self._add_cache_control_if_applicable(content, tool_result, model)
+                                self._add_cache_control_if_applicable(
+                                    content, tool_result, model
+                                )
                                 tool_message_list.append(tool_result)  # type: ignore[arg-type]
                             elif isinstance(content.get("content"), str):
                                 tool_result = ChatCompletionToolMessage(
@@ -399,7 +425,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                     tool_call_id=content.get("tool_use_id", ""),
                                     content=str(content.get("content", "")),
                                 )
-                                self._add_cache_control_if_applicable(content, tool_result, model)
+                                self._add_cache_control_if_applicable(
+                                    content, tool_result, model
+                                )
                                 tool_message_list.append(tool_result)  # type: ignore[arg-type]
                             elif isinstance(content.get("content"), list):
                                 # Combine all content items into a single tool message
@@ -416,7 +444,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                             tool_call_id=content.get("tool_use_id", ""),
                                             content=c,
                                         )
-                                        self._add_cache_control_if_applicable(content, tool_result, model)
+                                        self._add_cache_control_if_applicable(
+                                            content, tool_result, model
+                                        )
                                         tool_message_list.append(tool_result)  # type: ignore[arg-type]
                                     elif isinstance(c, dict):
                                         if c.get("type") == "text":
@@ -427,7 +457,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                                 ),
                                                 content=c.get("text", ""),
                                             )
-                                            self._add_cache_control_if_applicable(content, tool_result, model)
+                                            self._add_cache_control_if_applicable(
+                                                content, tool_result, model
+                                            )
                                             tool_message_list.append(tool_result)  # type: ignore[arg-type]
                                         elif c.get("type") == "image":
                                             source = c.get("source", {})
@@ -444,7 +476,23 @@ class LiteLLMAnthropicMessagesAdapter:
                                                 ),
                                                 content=openai_image_url,
                                             )
-                                            self._add_cache_control_if_applicable(content, tool_result, model)
+                                            self._add_cache_control_if_applicable(
+                                                content, tool_result, model
+                                            )
+                                            tool_message_list.append(tool_result)  # type: ignore[arg-type]
+                                        else:
+                                            # Preserve unrecognized content types
+                                            # (e.g. tool_reference) by serializing to JSON text
+                                            tool_result = ChatCompletionToolMessage(
+                                                role="tool",
+                                                tool_call_id=content.get(
+                                                    "tool_use_id", ""
+                                                ),
+                                                content=json.dumps(c),
+                                            )
+                                            self._add_cache_control_if_applicable(
+                                                content, tool_result, model
+                                            )
                                             tool_message_list.append(tool_result)  # type: ignore[arg-type]
                                 else:
                                     # For multiple content items, combine into a single tool message
@@ -487,6 +535,15 @@ class LiteLLMAnthropicMessagesAdapter:
                                                             ),
                                                         )
                                                     )
+                                            else:
+                                                # Preserve unrecognized content types
+                                                # (e.g. tool_reference) by serializing to JSON text
+                                                combined_content_parts.append(
+                                                    ChatCompletionTextObject(
+                                                        type="text",
+                                                        text=json.dumps(c),
+                                                    )
+                                                )
                                     # Create a single tool message with combined content
                                     if combined_content_parts:
                                         tool_result = ChatCompletionToolMessage(
@@ -494,7 +551,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                             tool_call_id=content.get("tool_use_id", ""),
                                             content=combined_content_parts,  # type: ignore
                                         )
-                                        self._add_cache_control_if_applicable(content, tool_result, model)
+                                        self._add_cache_control_if_applicable(
+                                            content, tool_result, model
+                                        )
                                         tool_message_list.append(tool_result)  # type: ignore[arg-type]
 
             if len(tool_message_list) > 0:
@@ -508,7 +567,9 @@ class LiteLLMAnthropicMessagesAdapter:
 
             ## ASSISTANT MESSAGE ##
             assistant_message_str: Optional[str] = None
-            assistant_content_list: List[Dict[str, Any]] = []  # For content blocks with cache_control
+            assistant_content_list: List[Dict[str, Any]] = (
+                []
+            )  # For content blocks with cache_control
             has_cache_control_in_text = False
             tool_calls: List[ChatCompletionAssistantToolCall] = []
             thinking_blocks: List[
@@ -527,7 +588,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                     "type": "text",
                                     "text": content.get("text", ""),
                                 }
-                                self._add_cache_control_if_applicable(content, text_block, model)
+                                self._add_cache_control_if_applicable(
+                                    content, text_block, model
+                                )
                                 if "cache_control" in text_block:
                                     has_cache_control_in_text = True
                                 assistant_content_list.append(text_block)
@@ -561,7 +624,9 @@ class LiteLLMAnthropicMessagesAdapter:
                                     type="function",
                                     function=function_chunk,
                                 )
-                                self._add_cache_control_if_applicable(content, tool_call, model)
+                                self._add_cache_control_if_applicable(
+                                    content, tool_call, model
+                                )
                                 tool_calls.append(tool_call)
                             elif content.get("type") == "thinking":
                                 thinking_block = ChatCompletionThinkingBlock(
@@ -615,7 +680,7 @@ class LiteLLMAnthropicMessagesAdapter:
 
     @staticmethod
     def translate_anthropic_thinking_to_reasoning_effort(
-        thinking: Dict[str, Any]
+        thinking: Dict[str, Any],
     ) -> Optional[str]:
         """
         Translate Anthropic's thinking parameter to OpenAI's reasoning_effort.
@@ -660,10 +725,7 @@ class LiteLLMAnthropicMessagesAdapter:
         - vertex_ai/*claude* models
         """
         model_lower = model.lower()
-        return (
-            "anthropic" in model_lower
-            or "claude" in model_lower
-        )
+        return "anthropic" in model_lower or "claude" in model_lower
 
     @staticmethod
     def translate_thinking_for_model(
@@ -751,7 +813,9 @@ class LiteLLMAnthropicMessagesAdapter:
             for k, v in tool.items():
                 if k not in mapped_tool_params:  # pass additional computer kwargs
                     function_chunk.setdefault("parameters", {}).update({k: v})
-            tool_param = ChatCompletionToolParam(type="function", function=function_chunk)
+            tool_param = ChatCompletionToolParam(
+                type="function", function=function_chunk
+            )
             self._add_cache_control_if_applicable(tool, tool_param, model)
             new_tools.append(tool_param)  # type: ignore[arg-type]
 
@@ -907,9 +971,11 @@ class LiteLLMAnthropicMessagesAdapter:
 
                 # Only translate regular tools (non-web-search)
                 if regular_tools:
-                    new_kwargs["tools"], tool_name_mapping = self.translate_anthropic_tools_to_openai(
-                        tools=cast(List[AllAnthropicToolsValues], regular_tools),
-                        model=new_kwargs.get("model"),
+                    new_kwargs["tools"], tool_name_mapping = (
+                        self.translate_anthropic_tools_to_openai(
+                            tools=cast(List[AllAnthropicToolsValues], regular_tools),
+                            model=new_kwargs.get("model"),
+                        )
                     )
 
         ## CONVERT THINKING
@@ -920,8 +986,10 @@ class LiteLLMAnthropicMessagesAdapter:
                 if self.is_anthropic_claude_model(model):
                     new_kwargs["thinking"] = thinking  # type: ignore
                 else:
-                    reasoning_effort = self.translate_anthropic_thinking_to_reasoning_effort(
-                        cast(Dict[str, Any], thinking)
+                    reasoning_effort = (
+                        self.translate_anthropic_thinking_to_reasoning_effort(
+                            cast(Dict[str, Any], thinking)
+                        )
                     )
                     if reasoning_effort:
                         new_kwargs["reasoning_effort"] = reasoning_effort
@@ -1108,15 +1176,22 @@ class LiteLLMAnthropicMessagesAdapter:
         uncached_input_tokens = usage.prompt_tokens or 0
         cached_tokens = 0
         if hasattr(usage, "prompt_tokens_details") and usage.prompt_tokens_details:
-            cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
+            cached_tokens = (
+                getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
+            )
             uncached_input_tokens -= cached_tokens
 
         anthropic_usage = AnthropicUsage(
             input_tokens=uncached_input_tokens,
             output_tokens=usage.completion_tokens or 0,
         )
-        if hasattr(usage, "_cache_creation_input_tokens") and usage._cache_creation_input_tokens > 0:
-            anthropic_usage["cache_creation_input_tokens"] = usage._cache_creation_input_tokens
+        if (
+            hasattr(usage, "_cache_creation_input_tokens")
+            and usage._cache_creation_input_tokens > 0
+        ):
+            anthropic_usage["cache_creation_input_tokens"] = (
+                usage._cache_creation_input_tokens
+            )
         if cached_tokens > 0:
             anthropic_usage["cache_read_input_tokens"] = cached_tokens
 
@@ -1272,16 +1347,31 @@ class LiteLLMAnthropicMessagesAdapter:
             if litellm_usage_chunk is not None:
                 uncached_input_tokens = litellm_usage_chunk.prompt_tokens or 0
                 cached_tokens = 0
-                if hasattr(litellm_usage_chunk, "prompt_tokens_details") and litellm_usage_chunk.prompt_tokens_details:
-                    cached_tokens = getattr(litellm_usage_chunk.prompt_tokens_details, "cached_tokens", 0) or 0
+                if (
+                    hasattr(litellm_usage_chunk, "prompt_tokens_details")
+                    and litellm_usage_chunk.prompt_tokens_details
+                ):
+                    cached_tokens = (
+                        getattr(
+                            litellm_usage_chunk.prompt_tokens_details,
+                            "cached_tokens",
+                            0,
+                        )
+                        or 0
+                    )
                     uncached_input_tokens -= cached_tokens
 
                 usage_delta = UsageDelta(
                     input_tokens=uncached_input_tokens,
                     output_tokens=litellm_usage_chunk.completion_tokens or 0,
                 )
-                if hasattr(litellm_usage_chunk, "_cache_creation_input_tokens") and litellm_usage_chunk._cache_creation_input_tokens > 0:
-                    usage_delta["cache_creation_input_tokens"] = litellm_usage_chunk._cache_creation_input_tokens
+                if (
+                    hasattr(litellm_usage_chunk, "_cache_creation_input_tokens")
+                    and litellm_usage_chunk._cache_creation_input_tokens > 0
+                ):
+                    usage_delta["cache_creation_input_tokens"] = (
+                        litellm_usage_chunk._cache_creation_input_tokens
+                    )
                 if cached_tokens > 0:
                     usage_delta["cache_read_input_tokens"] = cached_tokens
             else:

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1984,3 +1984,123 @@ def test_translate_anthropic_to_openai_with_mixed_tools():
 
     # tool_name_mapping should be empty for short tool names
     assert tool_name_mapping == {}
+
+
+def test_translate_tool_result_with_unrecognized_content_type():
+    """
+    Test that tool_result messages with unrecognized content types
+    (e.g. tool_reference) are preserved and not silently dropped.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/22841
+    """
+    adapter = LiteLLMAnthropicMessagesAdapter()
+
+    # Multiple unrecognized content items inside tool_result
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "content": [
+                        {"type": "tool_reference", "tool_name": "WebFetch"},
+                        {"type": "tool_reference", "tool_name": "Bash"},
+                    ],
+                    "tool_use_id": "toolu_bdrk_01VF2YzMxv46Vya6iG1MfL34",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        }
+    ]
+
+    result = adapter.translate_anthropic_messages_to_openai(messages)
+
+    # The tool_result must NOT be dropped
+    assert len(result) == 1, (
+        f"Expected 1 message but got {len(result)} – tool_result was dropped"
+    )
+    msg = result[0]
+    assert msg["role"] == "tool"
+    assert msg["tool_call_id"] == "toolu_bdrk_01VF2YzMxv46Vya6iG1MfL34"
+
+    # Content should be a list with 2 text parts (serialised JSON)
+    assert isinstance(msg["content"], list)
+    assert len(msg["content"]) == 2
+    for part in msg["content"]:
+        assert part["type"] == "text"
+        assert "tool_reference" in part["text"]
+
+
+def test_translate_tool_result_single_unrecognized_content_type():
+    """
+    When tool_result has a single-element content list with an unrecognized
+    type, the message must still be preserved.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/22841
+    """
+    adapter = LiteLLMAnthropicMessagesAdapter()
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "content": [
+                        {"type": "tool_reference", "tool_name": "WebFetch"},
+                    ],
+                    "tool_use_id": "toolu_xxx",
+                }
+            ],
+        }
+    ]
+
+    result = adapter.translate_anthropic_messages_to_openai(messages)
+
+    assert len(result) == 1
+    msg = result[0]
+    assert msg["role"] == "tool"
+    assert msg["tool_call_id"] == "toolu_xxx"
+    # Single item: content is a plain JSON string
+    assert isinstance(msg["content"], str)
+    assert "tool_reference" in msg["content"]
+
+
+def test_translate_tool_result_mixed_known_and_unknown_content():
+    """
+    When tool_result content mixes known types (text) with unknown types,
+    all items must be preserved.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/22841
+    """
+    adapter = LiteLLMAnthropicMessagesAdapter()
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "content": [
+                        {"type": "text", "text": "some result"},
+                        {"type": "tool_reference", "tool_name": "WebFetch"},
+                    ],
+                    "tool_use_id": "toolu_yyy",
+                }
+            ],
+        }
+    ]
+
+    result = adapter.translate_anthropic_messages_to_openai(messages)
+
+    assert len(result) == 1
+    msg = result[0]
+    assert msg["role"] == "tool"
+    assert isinstance(msg["content"], list)
+    assert len(msg["content"]) == 2
+    # First part is the known text
+    assert msg["content"][0]["type"] == "text"
+    assert msg["content"][0]["text"] == "some result"
+    # Second part is the serialised unknown content
+    assert msg["content"][1]["type"] == "text"
+    assert "tool_reference" in msg["content"][1]["text"]


### PR DESCRIPTION
## Summary

Fixes #22841

When using the `/v1/messages` endpoint with a non-Anthropic model (routed through the adapter path), `tool_result` content blocks containing unrecognized types (e.g. `tool_reference`) were silently dropped during the Anthropic-to-OpenAI message translation. This caused the entire `tool_result` message to be lost, preventing the model from receiving tool call results.

**Root cause:** `translate_anthropic_messages_to_openai()` in the adapter only handled `text` and `image` content types inside `tool_result` blocks. Any other content type was ignored, and if all content items were unrecognized, `combined_content_parts` remained empty, causing the tool message to be skipped entirely.

**Fix:** Added fallback handling for unrecognized content types by serializing them as JSON text. This ensures no information is lost during translation, regardless of the content type.

## Changes

- `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`:
  - Added `else` branch for single-item unrecognized content (serializes to JSON string)
  - Added `else` branch for multi-item unrecognized content (serializes to `ChatCompletionTextObject` with JSON text)

## Test plan

- [x] Added `test_translate_tool_result_with_unrecognized_content_type` — verifies multi-item `tool_reference` content is preserved
- [x] Added `test_translate_tool_result_single_unrecognized_content_type` — verifies single-item unknown type is preserved
- [x] Added `test_translate_tool_result_mixed_known_and_unknown_content` — verifies mixed `text` + unknown types are all preserved
- [x] All 58 existing tests in the file still pass (no regressions)