### PR TITLE
chore: remove webhook-test.com references from generic API examples

### DIFF
--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -2099,7 +2099,7 @@ litellm_settings:
 | `GENERIC_LOGGER_HEADERS`  | Optional: Set headers to be sent to the custom API endpoint | No, this is optional |
 
 ```shell showLineNumbers title=".env"
-GENERIC_LOGGER_ENDPOINT="https://webhook-test.com/30343bc33591bc5e6dc44217ceae3e0a"
+GENERIC_LOGGER_ENDPOINT="https://example.com/litellm-webhook"
 
 
 # Optional: Set headers to be sent to the custom API endpoint

--- a/litellm/litellm_core_utils/logging_callback_manager.py
+++ b/litellm/litellm_core_utils/logging_callback_manager.py
@@ -206,7 +206,7 @@ class LoggingCallbackManager:
         callback_settings:
             custom_callback_name:
                 callback_type: generic_api
-                endpoint: https://webhook-test.com/30343bc33591bc5e6dc44217ceae3e0a
+                endpoint: https://example.com/litellm-webhook
                 headers:
                 Authorization: Bearer sk-1234
         """


### PR DESCRIPTION
  ## Relevant issues

  Closes #18722

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/
  test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://
  docs.litellm.ai/docs/extras/contributing_code) (N/A: docs/comment example change only)
  - [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  (not run for this docs-only change)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
  - [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at
  least 4/5** before requesting a maintainer review

  ## CI (LiteLLM team)

  - [ ] **Branch creation CI run**
         Link:

  - [ ] **CI run for the last commit**
         Link:

  - [ ] **Merge / cherry-pick CI run**
         Links:

  ## Type

  📖 Documentation
  🧹 Refactoring

  ## Changes

  - Replaced `webhook-test.com` example endpoint in:
    - `litellm/litellm_core_utils/logging_callback_manager.py`
    - `docs/my-website/docs/proxy/logging.md`
  - Updated both to a neutral placeholder endpoint:
    - `https://example.com/litellm-webhook`

  ## Why

  `webhook-test.com` is deprecated/shutdown and the previously hardcoded sample URL could be mistaken as a safe
  default endpoint.
  This update avoids accidental data leakage to third-party webhooks.
