### PR TITLE
fix(ui): add api_base field to Anthropic provider credentials

### DIFF
--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -215,6 +215,16 @@
     "litellm_provider": "anthropic",
     "credential_fields": [
       {
+        "key": "api_base",
+        "label": "API Base",
+        "placeholder": "https://api.anthropic.com",
+        "tooltip": "Optional. Set a custom base URL for Anthropic API calls.",
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": null
+      },
+      {
         "key": "api_key",
         "label": "API Key",
         "placeholder": "sk-",

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -509,6 +509,28 @@ def test_build_endpoints_empty_providers_returns_empty():
     assert result == []
 
 
+def test_anthropic_provider_has_api_base_field():
+    """Test that Anthropic provider has an api_base credential field so users can set a custom base URL."""
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/public/providers/fields")
+    providers = response.json()
+
+    anthropic = next((p for p in providers if p["provider"] == "Anthropic"), None)
+    assert anthropic is not None
+
+    field_keys = [f["key"] for f in anthropic["credential_fields"]]
+    assert "api_base" in field_keys, "Anthropic provider should have an api_base field"
+    assert "api_key" in field_keys, "Anthropic provider should have an api_key field"
+
+    # Verify api_base field properties
+    api_base_field = next(f for f in anthropic["credential_fields"] if f["key"] == "api_base")
+    assert api_base_field["required"] is False
+    assert api_base_field["field_type"] == "text"
+
+
 def test_clean_display_name_strips_suffix():
     assert _clean_display_name("OpenAI (`openai`)") == "OpenAI"
     assert _clean_display_name("AI/ML API (`aiml`)") == "AI/ML API"


### PR DESCRIPTION
## Relevant issues

Fixes #22856

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The Anthropic provider in the Admin UI's "Add Credential" form was missing the `api_base` field, which prevented users from setting a custom base URL for Anthropic API calls (e.g., when using an Anthropic-compatible proxy endpoint).

### Root Cause

In `litellm/proxy/public_endpoints/provider_create_fields.json`, the Anthropic provider only had an `api_key` credential field defined. Other providers like OpenAI and Anthropic Text already included an `api_base` field.

### Fix

Added an optional `api_base` text field to the Anthropic provider's `credential_fields` array in `provider_create_fields.json`. The field:
- Is not required (optional)
- Has a placeholder of `https://api.anthropic.com`
- Includes a tooltip explaining its purpose
- Follows the same pattern used by other providers (OpenAI, Ai21, etc.)

### Test

Added `test_anthropic_provider_has_api_base_field` in `tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py` to verify the Anthropic provider includes the `api_base` field with correct properties.