### PR TITLE
fix(ui): allow deselecting all MCP servers to make them private

### DIFF
--- a/ui/litellm-dashboard/src/components/AIHub/forms/MakeMCPPublicForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/forms/MakeMCPPublicForm.test.tsx
@@ -252,7 +252,9 @@ describe("MakeMCPPublicForm", () => {
     expect(checkboxes[2]).not.toBeChecked();
   });
 
-  it("should show error when no servers selected", async () => {
+  it("should allow proceeding with no servers selected to make all private", async () => {
+    mockMakeMCPPublicCall.mockResolvedValueOnce({});
+
     render(<MakeMCPPublicForm {...mockProps} />);
 
     // Deselect all servers first
@@ -268,8 +270,23 @@ describe("MakeMCPPublicForm", () => {
       fireEvent.click(nextButton);
     });
 
-    // Should stay on same step
-    expect(screen.getByText("Select MCP Servers to Make Public")).toBeInTheDocument();
+    // Should move to confirmation step with "make all private" messaging
+    await waitFor(() => {
+      expect(screen.getByText("Confirm Making All MCP Servers Private")).toBeInTheDocument();
+    });
+
+    // Submit button should say "Make All Private"
+    const submitButton = screen.getByRole("button", { name: "Make All Private" });
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+
+    // Should call API with empty array
+    await waitFor(() => {
+      expect(mockMakeMCPPublicCall).toHaveBeenCalledWith("test-token", []);
+      expect(mockProps.onSuccess).toHaveBeenCalled();
+      expect(mockProps.onClose).toHaveBeenCalled();
+    });
   });
 
   it("should display empty state when no servers are available", () => {

--- a/ui/litellm-dashboard/src/components/AIHub/forms/MakeMCPPublicForm.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/forms/MakeMCPPublicForm.tsx
@@ -36,10 +36,6 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
 
   const handleNext = () => {
     if (currentStep === 0) {
-      if (selectedServers.size === 0) {
-        NotificationsManager.fromBackend("Please select at least one MCP server to make public");
-        return;
-      }
       setCurrentStep(1);
     }
   };
@@ -83,11 +79,6 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
   }, [visible]); // Only re-run when modal visibility changes, not when mcpHubData updates
 
   const handleSubmit = async () => {
-    if (selectedServers.size === 0) {
-      NotificationsManager.fromBackend("Please select at least one MCP server to make public");
-      return;
-    }
-
     setLoading(true);
     try {
       const serverIdsToMakePublic = Array.from(selectedServers);
@@ -95,12 +86,16 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
       // Make batch API call for all servers
       await makeMCPPublicCall(accessToken, serverIdsToMakePublic);
 
-      NotificationsManager.success(`Successfully made ${serverIdsToMakePublic.length} MCP server(s) public!`);
+      if (serverIdsToMakePublic.length === 0) {
+        NotificationsManager.success("All MCP servers are now private.");
+      } else {
+        NotificationsManager.success(`Successfully made ${serverIdsToMakePublic.length} MCP server(s) public!`);
+      }
       handleClose();
       onSuccess();
     } catch (error) {
       console.error("Error making MCP servers public:", error);
-      NotificationsManager.fromBackend("Failed to make MCP servers public. Please try again.");
+      NotificationsManager.fromBackend("Failed to update MCP server visibility. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -207,6 +202,27 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
   };
 
   const renderStep2Content = () => {
+    if (selectedServers.size === 0) {
+      return (
+        <div className="space-y-4">
+          <Title>Confirm Making All MCP Servers Private</Title>
+
+          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+            <Text className="text-sm text-yellow-800">
+              <strong>Note:</strong> No MCP servers are selected. All MCP servers will be set to private and will no
+              longer be visible on the public model hub.
+            </Text>
+          </div>
+
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+            <Text className="text-sm text-blue-800">
+              All MCP servers will be made <strong>private</strong>
+            </Text>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div className="space-y-4">
         <Title>Confirm Making MCP Servers Public</Title>
@@ -289,14 +305,14 @@ const MakeMCPPublicForm: React.FC<MakeMCPPublicFormProps> = ({
 
         <div className="flex space-x-2">
           {currentStep === 0 && (
-            <Button onClick={handleNext} disabled={selectedServers.size === 0}>
+            <Button onClick={handleNext} disabled={mcpHubData.length === 0}>
               Next
             </Button>
           )}
 
           {currentStep === 1 && (
             <Button onClick={handleSubmit} loading={loading}>
-              Make Public
+              {selectedServers.size === 0 ? "Make All Private" : "Make Public"}
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Summary

Fixes #22852

When a user tries to deselect all MCP servers to set them all back to private, the UI currently shows "Please select at least one MCP server to make public" and blocks the operation. This PR removes that validation so users can submit an empty selection, which the backend already supports (it sets `public_mcp_servers` to an empty list).

### Changes

- **Remove empty-selection guard in `handleNext`** — users can now proceed to the confirmation step with zero servers selected
- **Remove empty-selection guard in `handleSubmit`** — the API call is made with an empty array, making all servers private
- **Update Next button `disabled` condition** — only disabled when there are no MCP servers at all (`mcpHubData.length === 0`), not when none are selected
- **Add "make all private" confirmation UI** — when no servers are selected, step 2 shows clear messaging that all servers will become private, and the submit button reads "Make All Private"
- **Update success notification** — shows "All MCP servers are now private." when submitting an empty selection
- **Update test** — replaced the old "should show error when no servers selected" test with a new test that verifies the full empty-selection flow works end-to-end

### How to Test

1. Open the Admin UI
2. Go to AI Hub → click "Select MCP Servers to Make Public"
3. Deselect all servers (or never select any)
4. Click Next — should proceed to step 2 with "Confirm Making All MCP Servers Private" messaging
5. Click "Make All Private" — should succeed and show a success notification

All 15 existing tests pass.