### PR TITLE
fix(proxy): make PUT /v1/mcp/server support partial updates

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -27,6 +27,10 @@ def _prepare_mcp_server_data(
     Helper function to prepare MCP server data for database operations.
     Handles JSON field serialization for mcp_info and env fields.
 
+    For UpdateMCPServerRequest, only fields explicitly provided by the caller
+    are included (via exclude_none=True). This enables true partial updates
+    so that omitted fields preserve their existing database values.
+
     Args:
         data: NewMCPServerRequest or UpdateMCPServerRequest object
 
@@ -35,11 +39,18 @@ def _prepare_mcp_server_data(
     """
     from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
-    # Convert model to dict
+    is_update = isinstance(data, UpdateMCPServerRequest)
+
+    # Convert model to dict, excluding None fields.
+    # For updates this means only user-supplied fields are included.
     data_dict = data.model_dump(exclude_none=True)
-    # Ensure alias is always present in the dict (even if None)
-    if "alias" not in data_dict:
-        data_dict["alias"] = getattr(data, "alias", None)
+
+    # For create operations, ensure alias is always present in the dict
+    # (even if None) so the DB column is explicitly set.
+    # For updates, only include alias if it was explicitly provided.
+    if not is_update:
+        if "alias" not in data_dict:
+            data_dict["alias"] = getattr(data, "alias", None)
 
     # Handle credentials serialization
     credentials = data_dict.get("credentials")
@@ -63,15 +74,21 @@ def _prepare_mcp_server_data(
 
     # Handle tool name override serialization
     if data.tool_name_to_display_name is not None:
-        data_dict["tool_name_to_display_name"] = safe_dumps(data.tool_name_to_display_name)
+        data_dict["tool_name_to_display_name"] = safe_dumps(
+            data.tool_name_to_display_name
+        )
     if data.tool_name_to_description is not None:
-        data_dict["tool_name_to_description"] = safe_dumps(data.tool_name_to_description)
+        data_dict["tool_name_to_description"] = safe_dumps(
+            data.tool_name_to_description
+        )
 
     # mcp_access_groups is already List[str], no serialization needed
 
-    # Force include is_byok even when False (exclude_none=True would not drop it,
-    # but be explicit to ensure a False value is always written to the DB).
-    data_dict["is_byok"] = getattr(data, "is_byok", False)
+    # For create operations, force include is_byok even when False to ensure
+    # the value is always written to the DB.
+    # For update operations, only include is_byok if explicitly provided.
+    if not is_update:
+        data_dict["is_byok"] = getattr(data, "is_byok", False)
 
     return data_dict
 
@@ -128,12 +145,12 @@ async def get_mcp_server(
     """
     Returns the matching mcp server from the db iff exists
     """
-    mcp_server: Optional[
-        LiteLLM_MCPServerTable
-    ] = await prisma_client.db.litellm_mcpservertable.find_unique(
-        where={
-            "server_id": server_id,
-        }
+    mcp_server: Optional[LiteLLM_MCPServerTable] = (
+        await prisma_client.db.litellm_mcpservertable.find_unique(
+            where={
+                "server_id": server_id,
+            }
+        )
     )
     return mcp_server
 
@@ -144,12 +161,12 @@ async def get_mcp_servers(
     """
     Returns the matching mcp servers from the db with the server_ids
     """
-    _mcp_servers: List[
-        LiteLLM_MCPServerTable
-    ] = await prisma_client.db.litellm_mcpservertable.find_many(
-        where={
-            "server_id": {"in": server_ids},
-        }
+    _mcp_servers: List[LiteLLM_MCPServerTable] = (
+        await prisma_client.db.litellm_mcpservertable.find_many(
+            where={
+                "server_id": {"in": server_ids},
+            }
+        )
     )
     final_mcp_servers: List[LiteLLM_MCPServerTable] = []
     for _mcp_server in _mcp_servers:
@@ -338,10 +355,17 @@ async def update_mcp_server(
     prisma_client: PrismaClient, data: UpdateMCPServerRequest, touched_by: str
 ) -> LiteLLM_MCPServerTable:
     """
-    Update a new mcp server record in the db
+    Update an existing mcp server record in the db.
+
+    Only fields explicitly provided in the request are updated;
+    omitted fields retain their current database values.
     """
     # Use helper to prepare data with proper JSON serialization
     data_dict = _prepare_mcp_server_data(data)
+
+    # Remove server_id from the data dict — it is used in the WHERE clause,
+    # not as a value to update.
+    data_dict.pop("server_id", None)
 
     # Add audit fields
     data_dict["updated_by"] = touched_by

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -873,9 +873,9 @@ class GenerateRequestBase(LiteLLMPydanticObjectBase):
     allowed_cache_controls: Optional[list] = []
     config: Optional[dict] = {}
     permissions: Optional[dict] = {}
-    model_max_budget: Optional[
-        dict
-    ] = {}  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
+    model_max_budget: Optional[dict] = (
+        {}
+    )  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
 
     model_config = ConfigDict(protected_namespaces=())
     model_rpm_limit: Optional[dict] = None
@@ -1016,9 +1016,9 @@ class RegenerateKeyRequest(GenerateKeyRequest):
     spend: Optional[float] = None
     metadata: Optional[dict] = None
     new_master_key: Optional[str] = None
-    grace_period: Optional[
-        str
-    ] = None  # Duration to keep old key valid (e.g. "24h", "2d"); None = immediate revoke
+    grace_period: Optional[str] = (
+        None  # Duration to keep old key valid (e.g. "24h", "2d"); None = immediate revoke
+    )
 
 
 class ResetSpendRequest(LiteLLMPydanticObjectBase):
@@ -1142,17 +1142,26 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
 
 
 class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
+    """
+    Request model for updating an MCP server.
+
+    All fields except server_id are optional so that callers can perform
+    partial updates (i.e. only supply the fields they want to change).
+    Fields that are not provided (None) will be excluded from the database
+    update and the existing values will be preserved.
+    """
+
     server_id: str
     server_name: Optional[str] = None
     alias: Optional[str] = None
     description: Optional[str] = None
-    transport: MCPTransportType = MCPTransport.sse
+    transport: Optional[MCPTransportType] = None
     auth_type: Optional[MCPAuthType] = None
     credentials: Optional[MCPCredentials] = None
     url: Optional[str] = None
     spec_path: Optional[str] = None
     mcp_info: Optional[MCPInfo] = None
-    mcp_access_groups: List[str] = Field(default_factory=list)
+    mcp_access_groups: Optional[List[str]] = None
     allowed_tools: Optional[List[str]] = None
     tool_name_to_display_name: Optional[Dict[str, str]] = None
     tool_name_to_description: Optional[Dict[str, str]] = None
@@ -1160,20 +1169,21 @@ class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
     static_headers: Optional[Dict[str, str]] = None
     # Stdio-specific fields
     command: Optional[str] = None
-    args: List[str] = Field(default_factory=list)
-    env: Dict[str, str] = Field(default_factory=dict)
+    args: Optional[List[str]] = None
+    env: Optional[Dict[str, str]] = None
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
     registration_url: Optional[str] = None
-    allow_all_keys: bool = False
-    available_on_public_internet: bool = True
-    is_byok: bool = False
-    byok_description: List[str] = Field(default_factory=list)
+    allow_all_keys: Optional[bool] = None
+    available_on_public_internet: Optional[bool] = None
+    is_byok: Optional[bool] = None
+    byok_description: Optional[List[str]] = None
     byok_api_key_help_url: Optional[str] = None
 
     @model_validator(mode="before")
     @classmethod
     def validate_transport_fields(cls, values):
+        """Only validate transport-specific requirements when transport is explicitly provided."""
         if isinstance(values, dict):
             transport = values.get("transport")
             if transport == MCPTransport.stdio:
@@ -1452,12 +1462,12 @@ class NewCustomerRequest(BudgetNewRequest):
     blocked: bool = False  # allow/disallow requests for this end-user
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
     spend: Optional[float] = None
-    allowed_model_region: Optional[
-        AllowedModelRegion
-    ] = None  # require all user requests to use models in this specific region
-    default_model: Optional[
-        str
-    ] = None  # if no equivalent model in allowed region - default all requests to this model
+    allowed_model_region: Optional[AllowedModelRegion] = (
+        None  # require all user requests to use models in this specific region
+    )
+    default_model: Optional[str] = (
+        None  # if no equivalent model in allowed region - default all requests to this model
+    )
     object_permission: Optional[LiteLLM_ObjectPermissionBase] = None
 
     @model_validator(mode="before")
@@ -1480,12 +1490,12 @@ class UpdateCustomerRequest(LiteLLMPydanticObjectBase):
     blocked: bool = False  # allow/disallow requests for this end-user
     max_budget: Optional[float] = None
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
-    allowed_model_region: Optional[
-        AllowedModelRegion
-    ] = None  # require all user requests to use models in this specific region
-    default_model: Optional[
-        str
-    ] = None  # if no equivalent model in allowed region - default all requests to this model
+    allowed_model_region: Optional[AllowedModelRegion] = (
+        None  # require all user requests to use models in this specific region
+    )
+    default_model: Optional[str] = (
+        None  # if no equivalent model in allowed region - default all requests to this model
+    )
     object_permission: Optional[LiteLLM_ObjectPermissionBase] = None
 
 
@@ -1575,15 +1585,15 @@ class NewTeamRequest(TeamBase):
     ] = None  # raise an error if 'guaranteed_throughput' is set and we're overallocating tpm
 
     model_tpm_limit: Optional[Dict[str, int]] = None
-    team_member_budget: Optional[
-        float
-    ] = None  # allow user to set a budget for all team members
-    team_member_rpm_limit: Optional[
-        int
-    ] = None  # allow user to set RPM limit for all team members
-    team_member_tpm_limit: Optional[
-        int
-    ] = None  # allow user to set TPM limit for all team members
+    team_member_budget: Optional[float] = (
+        None  # allow user to set a budget for all team members
+    )
+    team_member_rpm_limit: Optional[int] = (
+        None  # allow user to set RPM limit for all team members
+    )
+    team_member_tpm_limit: Optional[int] = (
+        None  # allow user to set TPM limit for all team members
+    )
     team_member_key_duration: Optional[str] = None  # e.g. "1d", "1w", "1m"
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
     enforced_batch_output_expires_after: Optional[dict] = None
@@ -1679,9 +1689,9 @@ class BlockKeyRequest(LiteLLMPydanticObjectBase):
 
 class AddTeamCallback(LiteLLMPydanticObjectBase):
     callback_name: str
-    callback_type: Optional[
-        Literal["success", "failure", "success_and_failure"]
-    ] = "success_and_failure"
+    callback_type: Optional[Literal["success", "failure", "success_and_failure"]] = (
+        "success_and_failure"
+    )
     callback_vars: Dict[str, str]
 
     @model_validator(mode="before")
@@ -2021,9 +2031,9 @@ class ConfigList(LiteLLMPydanticObjectBase):
     stored_in_db: Optional[bool]
     field_default_value: Any
     premium_field: bool = False
-    nested_fields: Optional[
-        List[FieldDetail]
-    ] = None  # For nested dictionary or Pydantic fields
+    nested_fields: Optional[List[FieldDetail]] = (
+        None  # For nested dictionary or Pydantic fields
+    )
 
 
 class UserHeaderMapping(LiteLLMPydanticObjectBase):
@@ -2487,9 +2497,9 @@ class LiteLLM_OrganizationMembershipTable(LiteLLMPydanticObjectBase):
     budget_id: Optional[str] = None
     created_at: datetime
     updated_at: datetime
-    user: Optional[
-        Any
-    ] = None  # You might want to replace 'Any' with a more specific type if available
+    user: Optional[Any] = (
+        None  # You might want to replace 'Any' with a more specific type if available
+    )
     litellm_budget_table: Optional[LiteLLM_BudgetTable] = None
     user_email: Optional[str] = None
 
@@ -3637,9 +3647,9 @@ class TeamModelDeleteRequest(BaseModel):
 # Organization Member Requests
 class OrganizationMemberAddRequest(OrgMemberAddRequest):
     organization_id: str
-    max_budget_in_organization: Optional[
-        float
-    ] = None  # Users max budget within the organization
+    max_budget_in_organization: Optional[float] = (
+        None  # Users max budget within the organization
+    )
 
 
 class OrganizationMemberDeleteRequest(MemberDeleteRequest):
@@ -3890,9 +3900,9 @@ class ProviderBudgetResponse(LiteLLMPydanticObjectBase):
     Maps provider names to their budget configs.
     """
 
-    providers: Dict[
-        str, ProviderBudgetResponseObject
-    ] = {}  # Dictionary mapping provider names to their budget configurations
+    providers: Dict[str, ProviderBudgetResponseObject] = (
+        {}
+    )  # Dictionary mapping provider names to their budget configurations
 
 
 class ProxyStateVariables(TypedDict):
@@ -4036,9 +4046,9 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
     enforce_rbac: bool = False
     roles_jwt_field: Optional[str] = None  # v2 on role mappings
     role_mappings: Optional[List[RoleMapping]] = None
-    object_id_jwt_field: Optional[
-        str
-    ] = None  # can be either user / team, inferred from the role mapping
+    object_id_jwt_field: Optional[str] = (
+        None  # can be either user / team, inferred from the role mapping
+    )
     scope_mappings: Optional[List[ScopeMapping]] = None
     enforce_scope_based_access: bool = False
     enforce_team_based_model_access: bool = False

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -670,12 +670,15 @@ class TestListMCPServers:
             return_value=[server_1, server_2]
         )
 
-        with patch(
-            "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
-            mock_manager,
-        ), patch(
-            "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
-            AsyncMock(return_value=[mock_user_auth]),
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[mock_user_auth]),
+            ),
         ):
             from litellm.proxy.management_endpoints.mcp_management_endpoints import (
                 fetch_all_mcp_servers,
@@ -1220,6 +1223,257 @@ class TestUpdateMCPServer:
             # Verify the result includes extra_headers
             assert result.extra_headers == ["X-Custom-Header", "X-Another-Header"]
             assert result.alias == "Updated Test Server"
+
+
+class TestUpdateMCPServerPartialUpdate:
+    """
+    Test suite for partial update behavior of MCP servers.
+
+    Verifies that PUT /v1/mcp/server only modifies fields explicitly
+    provided in the request, preserving existing values for omitted fields.
+
+    Fixes: https://github.com/BerriAI/litellm/issues/22854
+    """
+
+    def test_update_request_only_includes_provided_fields(self):
+        """
+        UpdateMCPServerRequest with only server_id and description should
+        serialize to a dict containing only those two fields (plus no defaults).
+        """
+        request = UpdateMCPServerRequest(
+            server_id="test-server-1",
+            description="Your new description here",
+        )
+        data = request.model_dump(exclude_none=True)
+        # Only server_id and description should be in the dict
+        assert data == {
+            "server_id": "test-server-1",
+            "description": "Your new description here",
+        }
+
+    def test_update_request_does_not_include_default_transport(self):
+        """
+        When transport is not provided, it should not appear in the
+        serialized dict so existing transport value is preserved.
+        """
+        request = UpdateMCPServerRequest(
+            server_id="test-server-1",
+            alias="New Alias",
+        )
+        data = request.model_dump(exclude_none=True)
+        assert "transport" not in data
+        assert "allow_all_keys" not in data
+        assert "is_byok" not in data
+        assert "available_on_public_internet" not in data
+        assert "mcp_access_groups" not in data
+        assert "args" not in data
+        assert "env" not in data
+
+    def test_update_request_includes_fields_when_explicitly_set(self):
+        """
+        When fields are explicitly provided, they should appear in the dict.
+        """
+        request = UpdateMCPServerRequest(
+            server_id="test-server-1",
+            description="Updated desc",
+            transport=MCPTransport.http,
+            url="https://new-url.example.com/mcp",
+            allow_all_keys=True,
+            is_byok=False,
+        )
+        data = request.model_dump(exclude_none=True)
+        assert data["transport"] == MCPTransport.http
+        assert data["url"] == "https://new-url.example.com/mcp"
+        assert data["allow_all_keys"] is True
+        assert data["is_byok"] is False
+
+    def test_prepare_mcp_server_data_partial_update(self):
+        """
+        _prepare_mcp_server_data for an UpdateMCPServerRequest should only
+        include user-provided fields, not force defaults like is_byok=False.
+        """
+        from litellm.proxy._experimental.mcp_server.db import _prepare_mcp_server_data
+
+        request = UpdateMCPServerRequest(
+            server_id="test-server-1",
+            description="New description",
+        )
+        data_dict = _prepare_mcp_server_data(request)
+
+        # Should contain only server_id and description
+        assert data_dict["server_id"] == "test-server-1"
+        assert data_dict["description"] == "New description"
+        # Should NOT contain default values that were not provided
+        assert "transport" not in data_dict
+        assert "is_byok" not in data_dict
+        assert "allow_all_keys" not in data_dict
+        assert "mcp_access_groups" not in data_dict
+        assert "alias" not in data_dict
+
+    def test_prepare_mcp_server_data_create_includes_defaults(self):
+        """
+        _prepare_mcp_server_data for a NewMCPServerRequest should still
+        include default values like is_byok=False and alias=None.
+        """
+        from litellm.proxy._experimental.mcp_server.db import _prepare_mcp_server_data
+
+        request = NewMCPServerRequest(
+            server_id="test-server-1",
+            url="https://example.com/mcp",
+        )
+        data_dict = _prepare_mcp_server_data(request)
+
+        # Create should include defaults
+        assert "is_byok" in data_dict
+        assert data_dict["is_byok"] is False
+        assert "alias" in data_dict
+
+    @pytest.mark.asyncio
+    async def test_edit_mcp_server_partial_update_preserves_existing(self):
+        """
+        End-to-end test: calling edit_mcp_server with only server_id and
+        description should update only the description, not overwrite
+        transport, url, or other fields with defaults.
+        """
+        existing_server = generate_mock_mcp_server_db_record(
+            server_id="test-server-1",
+            alias="Original Server",
+            url="https://original.example.com/mcp",
+            transport="http",
+        )
+        existing_server.allow_all_keys = True
+        existing_server.is_byok = True
+
+        # User only wants to update the description
+        update_request = UpdateMCPServerRequest(
+            server_id="test-server-1",
+            description="Your new description here",
+        )
+
+        # Updated server returned from DB (simulating the result after update)
+        updated_server = generate_mock_mcp_server_db_record(
+            server_id="test-server-1",
+            alias="Original Server",
+            url="https://original.example.com/mcp",
+            transport="http",
+        )
+        updated_server.description = "Your new description here"
+        updated_server.allow_all_keys = True
+        updated_server.is_byok = True
+
+        mock_prisma_client = MagicMock()
+        mock_user_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.PROXY_ADMIN
+        )
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=mock_prisma_client,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.validate_and_normalize_mcp_server_payload",
+                MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.update_mcp_server",
+                AsyncMock(return_value=updated_server),
+            ) as mock_update,
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                MagicMock(
+                    update_server=AsyncMock(),
+                    reload_servers_from_database=AsyncMock(),
+                ),
+            ),
+        ):
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                edit_mcp_server,
+            )
+
+            result = await edit_mcp_server(
+                payload=update_request, user_api_key_dict=mock_user_auth
+            )
+
+            # Verify update_mcp_server was called
+            mock_update.assert_awaited_once()
+            called_payload = mock_update.call_args[0][1]
+
+            # The payload should only contain the fields the user provided
+            payload_dict = called_payload.model_dump(exclude_none=True)
+            assert "server_id" in payload_dict
+            assert "description" in payload_dict
+            # These fields should NOT be in the payload (not provided by user)
+            assert "transport" not in payload_dict
+            assert "url" not in payload_dict
+            assert "allow_all_keys" not in payload_dict
+            assert "is_byok" not in payload_dict
+
+            # Verify the result preserves original values
+            assert result.alias == "Original Server"
+            assert result.url == "https://original.example.com/mcp"
+            assert result.allow_all_keys is True
+            assert result.is_byok is True
+            assert result.description == "Your new description here"
+
+    @pytest.mark.asyncio
+    async def test_update_mcp_server_db_only_updates_provided_fields(self):
+        """
+        Test that update_mcp_server in db.py passes only user-provided fields
+        to prisma update, excluding server_id from the data dict.
+        """
+        from litellm.proxy._experimental.mcp_server.db import update_mcp_server
+
+        request = UpdateMCPServerRequest(
+            server_id="test-server-1",
+            description="Updated description only",
+        )
+
+        mock_prisma_client = MagicMock()
+        mock_updated_record = generate_mock_mcp_server_db_record(
+            server_id="test-server-1",
+            alias="Original Server",
+            url="https://original.example.com/mcp",
+            transport="http",
+        )
+        mock_updated_record.description = "Updated description only"
+        mock_prisma_client.db.litellm_mcpservertable.update = AsyncMock(
+            return_value=mock_updated_record
+        )
+
+        result = await update_mcp_server(
+            mock_prisma_client, request, touched_by="test-admin"
+        )
+
+        # Verify the data passed to prisma update
+        update_call = mock_prisma_client.db.litellm_mcpservertable.update
+        update_call.assert_awaited_once()
+        call_kwargs = update_call.call_args
+        data_arg = call_kwargs.kwargs.get("data") or call_kwargs[1].get("data")
+        if data_arg is None:
+            # Try positional/keyword hybrid
+            data_arg = call_kwargs.kwargs.get(
+                "data",
+                call_kwargs[1].get("data") if len(call_kwargs) > 1 else None,
+            )
+
+        where_arg = call_kwargs.kwargs.get("where") or call_kwargs[1].get("where")
+        if where_arg is None:
+            where_arg = call_kwargs.kwargs.get(
+                "where",
+                call_kwargs[1].get("where") if len(call_kwargs) > 1 else None,
+            )
+
+        # server_id should only be in the WHERE clause, not in the data
+        assert where_arg == {"server_id": "test-server-1"}
+        assert "server_id" not in data_arg
+        # Only description and updated_by should be in the data
+        assert data_arg["description"] == "Updated description only"
+        assert data_arg["updated_by"] == "test-admin"
+        # Default fields should NOT be present
+        assert "transport" not in data_arg
+        assert "is_byok" not in data_arg
+        assert "allow_all_keys" not in data_arg
 
 
 class TestHealthCheckServers:


### PR DESCRIPTION
## Summary

Fixes #22854

The `PUT /v1/mcp/server` endpoint was overwriting unmodified fields with default values when performing partial updates. For example, sending only `{"server_id": "...", "description": "new desc"}` would reset `transport` to `sse`, `is_byok` to `false`, `allow_all_keys` to `false`, and `mcp_access_groups` to `[]` — effectively corrupting the server configuration even though the API returned 200 OK.

**Root cause:** `UpdateMCPServerRequest` used non-Optional fields with default values (e.g. `transport: MCPTransportType = MCPTransport.sse`, `is_byok: bool = False`). When `model_dump(exclude_none=True)` was called, these defaults were included in the dict and written to the database, overwriting existing values.

**Changes:**
- Make all fields in `UpdateMCPServerRequest` (except `server_id`) `Optional[...] = None` so that `model_dump(exclude_none=True)` only serializes user-provided fields
- Update `_prepare_mcp_server_data()` to only force-include `alias` and `is_byok` defaults for create operations, not updates
- Remove `server_id` from the update data dict (it belongs in the WHERE clause, not the data payload)
- Add 7 comprehensive unit tests covering partial update behavior at the model, DB helper, and endpoint layers

## Test plan

- [x] `TestUpdateMCPServerPartialUpdate::test_update_request_only_includes_provided_fields` — verifies `model_dump` only includes user-provided fields
- [x] `TestUpdateMCPServerPartialUpdate::test_update_request_does_not_include_default_transport` — verifies default fields like transport, is_byok, etc. are excluded
- [x] `TestUpdateMCPServerPartialUpdate::test_update_request_includes_fields_when_explicitly_set` — verifies explicitly set fields are included
- [x] `TestUpdateMCPServerPartialUpdate::test_prepare_mcp_server_data_partial_update` — verifies `_prepare_mcp_server_data` for partial update
- [x] `TestUpdateMCPServerPartialUpdate::test_prepare_mcp_server_data_create_includes_defaults` — verifies create operations still include defaults
- [x] `TestUpdateMCPServerPartialUpdate::test_edit_mcp_server_partial_update_preserves_existing` — end-to-end test of the edit endpoint
- [x] `TestUpdateMCPServerPartialUpdate::test_update_mcp_server_db_only_updates_provided_fields` — verifies DB layer only sends user-provided fields to Prisma