### PR TITLE
fix(presidio): add output unmask path when output_parse_pii is enabled

### DIFF
--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -111,6 +111,7 @@ class A2AGuardrailHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process A2A output response by applying guardrails to text content.

--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -168,7 +168,7 @@ class A2AGuardrailHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts in batch
         # Create a request_data dict with response info and user API key metadata
-        request_data: dict = {"response": response_dict}
+        request_data: dict = {**(request_data or {}), "response": response_dict}
 
         # Add user API key metadata with prefixed keys
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
@@ -214,6 +214,7 @@ class A2AGuardrailHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> List[Any]:
         """
         Process A2A streaming output by applying guardrails to accumulated text.
@@ -259,7 +260,7 @@ class A2AGuardrailHandler(BaseTranslation):
         if not combined_text:
             return responses_so_far
 
-        request_data: dict = {"responses_so_far": responses_so_far}
+        request_data: dict = {**(request_data or {}), "responses_so_far": responses_so_far}
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
             request_data["litellm_metadata"] = user_metadata

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -243,6 +243,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -316,7 +316,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -83,6 +83,8 @@ class BaseTranslation(ABC):
             guardrail_to_apply: The guardrail instance to apply
             litellm_logging_obj: Optional logging object
             user_api_key_dict: User API key metadata (passed separately since response doesn't contain it)
+            request_data: Full request context dict from the input phase
+                          (e.g. pii_tokens from masking), or None if not available.
         """
         pass
 
@@ -92,9 +94,18 @@ class BaseTranslation(ABC):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output streaming response with guardrails.
+
+        Args:
+            responses_so_far: Accumulated streaming chunks to process
+            guardrail_to_apply: The guardrail instance to apply
+            litellm_logging_obj: Optional logging object
+            user_api_key_dict: User API key metadata
+            request_data: Full request context dict from the input phase
+                          (e.g. pii_tokens from masking), or None if not available.
 
         Optional to override in subclasses.
         """

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -73,6 +73,7 @@ class BaseTranslation(ABC):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response with guardrails.

--- a/litellm/llms/cohere/rerank/guardrail_translation/handler.py
+++ b/litellm/llms/cohere/rerank/guardrail_translation/handler.py
@@ -83,6 +83,7 @@ class CohereRerankHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - not applicable for rerank.

--- a/litellm/llms/mistral/ocr/guardrail_translation/handler.py
+++ b/litellm/llms/mistral/ocr/guardrail_translation/handler.py
@@ -91,6 +91,7 @@ class OCRHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process OCR output by applying guardrails to extracted page text.

--- a/litellm/llms/mistral/ocr/guardrail_translation/handler.py
+++ b/litellm/llms/mistral/ocr/guardrail_translation/handler.py
@@ -137,7 +137,7 @@ class OCRHandler(BaseTranslation):
 
         guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data={},
+            request_data=request_data or {},
             input_type="response",
             logging_obj=litellm_logging_obj,
         )

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -310,7 +310,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         # Step 2: Apply guardrail to all texts and tool calls in batch
         if texts_to_check or tool_calls_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
@@ -365,6 +365,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> List["ModelResponseStream"]:
         """
         Process output streaming responses by applying guardrails to text content.
@@ -403,6 +404,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 guardrail_to_apply=guardrail_to_apply,
                 litellm_logging_obj=litellm_logging_obj,
                 user_api_key_dict=user_api_key_dict,
+                request_data=request_data,
             )
 
             return responses_so_far
@@ -438,7 +440,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         # Step 3: Apply guardrail to all combined texts in batch
         if texts_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"responses": responses_so_far}
+            request_data: dict = {**(request_data or {}), "responses": responses_so_far}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -260,6 +260,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content.

--- a/litellm/llms/openai/completion/guardrail_translation/handler.py
+++ b/litellm/llms/openai/completion/guardrail_translation/handler.py
@@ -157,7 +157,7 @@ class OpenAITextCompletionHandler(BaseTranslation):
         # Apply guardrails in batch
         if texts_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/openai/completion/guardrail_translation/handler.py
+++ b/litellm/llms/openai/completion/guardrail_translation/handler.py
@@ -125,6 +125,7 @@ class OpenAITextCompletionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to completion text.

--- a/litellm/llms/openai/embeddings/guardrail_translation/handler.py
+++ b/litellm/llms/openai/embeddings/guardrail_translation/handler.py
@@ -155,6 +155,7 @@ class OpenAIEmbeddingsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - embeddings responses contain vectors, not text.

--- a/litellm/llms/openai/image_generation/guardrail_translation/handler.py
+++ b/litellm/llms/openai/image_generation/guardrail_translation/handler.py
@@ -87,6 +87,7 @@ class OpenAIImageGenerationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - typically not needed for image generation.

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -399,7 +399,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -342,6 +342,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.

--- a/litellm/llms/openai/speech/guardrail_translation/handler.py
+++ b/litellm/llms/openai/speech/guardrail_translation/handler.py
@@ -85,6 +85,7 @@ class OpenAITextToSpeechHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output - not applicable for text-to-speech.

--- a/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
+++ b/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
@@ -81,7 +81,7 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
         if isinstance(response.text, str):
             original_text = response.text
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
+++ b/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
@@ -58,6 +58,7 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output transcription by applying guardrails to transcribed text.

--- a/litellm/llms/pass_through/guardrail_translation/handler.py
+++ b/litellm/llms/pass_through/guardrail_translation/handler.py
@@ -185,7 +185,10 @@ class PassThroughEndpointHandler(BaseTranslation):
         if user_metadata:
             effective_request_data["litellm_metadata"] = user_metadata
 
-        # Apply guardrail (pass-through doesn't modify the text, just checks it)
+        # Apply guardrail — pass-through supports rejection guardrails only (which raise
+        # exceptions). Text mutation (e.g. PII unmasking) is not applied back to the
+        # response because pass-through payloads use arbitrary JSON structures with no
+        # generic field injection mechanism.
         inputs = GenericGuardrailAPIInputs(texts=[text_to_check])
         # Include model information from the response if available
         response_model = response.get("model") if isinstance(response, dict) else None

--- a/litellm/llms/pass_through/guardrail_translation/handler.py
+++ b/litellm/llms/pass_through/guardrail_translation/handler.py
@@ -173,17 +173,17 @@ class PassThroughEndpointHandler(BaseTranslation):
             return response
 
         # Merge caller's request_data (contains pii_tokens from input masking)
-        # with response info and user API key metadata.
-        # Note: response is always a dict here (non-dict returns early above).
-        request_data: dict = {
+        # with response info. Nesting response under "response" key matches the
+        # pattern used by all other handlers and avoids key collisions.
+        effective_request_data: dict = {
             **(request_data or {}),
-            **response,
+            "response": response,
         }
 
         # Add user API key metadata with prefixed keys
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
-            request_data["litellm_metadata"] = user_metadata
+            effective_request_data["litellm_metadata"] = user_metadata
 
         # Apply guardrail (pass-through doesn't modify the text, just checks it)
         inputs = GenericGuardrailAPIInputs(texts=[text_to_check])
@@ -193,7 +193,7 @@ class PassThroughEndpointHandler(BaseTranslation):
             inputs["model"] = response_model
         _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data=request_data,
+            request_data=effective_request_data,
             input_type="response",
             logging_obj=litellm_logging_obj,
         )

--- a/litellm/llms/pass_through/guardrail_translation/handler.py
+++ b/litellm/llms/pass_through/guardrail_translation/handler.py
@@ -172,12 +172,13 @@ class PassThroughEndpointHandler(BaseTranslation):
         if not text_to_check:
             return response
 
-        # Create a request_data dict with response info and user API key metadata
-        request_data: dict = (
-            {"response": response}
-            if not isinstance(response, dict)
-            else response.copy()
-        )
+        # Merge caller's request_data (contains pii_tokens from input masking)
+        # with response info and user API key metadata.
+        # Note: response is always a dict here (non-dict returns early above).
+        request_data: dict = {
+            **(request_data or {}),
+            **response,
+        }
 
         # Add user API key metadata with prefixed keys
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)

--- a/litellm/llms/pass_through/guardrail_translation/handler.py
+++ b/litellm/llms/pass_through/guardrail_translation/handler.py
@@ -139,6 +139,7 @@ class PassThroughEndpointHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to targeted fields.

--- a/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
+++ b/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
@@ -92,6 +92,7 @@ class MCPGuardrailTranslationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         verbose_proxy_logger.debug(
             "MCP Guardrail: Output processing not implemented for MCP tools",

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1189,6 +1189,18 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             1. If the connection to the guardrail is working
             2. When Testing the guardrail with some text, this function will be called with the input text and returns a text after applying the guardrail
         """
+        # --- PII unmasking path (output_parse_pii=True, response phase) ---
+        # When output_parse_pii is enabled, the LLM's response text contains PII
+        # tokens (e.g. "<PERSON>_a1b2c3d4e5f6") that must be replaced with the
+        # original values before the response is returned to the caller.
+        # pii_tokens is a dict {token: original_text} built during the input
+        # (masking) phase and forwarded via request_data by the unified guardrail.
+        if input_type == "response" and self.output_parse_pii:
+            pii_tokens: Dict[str, str] = (request_data or {}).get("pii_tokens", {})
+            texts = inputs.get("texts", [])
+            inputs["texts"] = [self._unmask_pii_text(t, pii_tokens) for t in texts]
+            return inputs
+
         texts = inputs.get("texts", [])
 
         new_texts = []

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1197,6 +1197,11 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         # (masking) phase and forwarded via request_data by the unified guardrail.
         if input_type == "response" and self.output_parse_pii:
             pii_tokens: Dict[str, str] = (request_data or {}).get("pii_tokens", {})
+            if not pii_tokens:
+                verbose_proxy_logger.debug(
+                    "output_parse_pii enabled but no pii_tokens in request_data; "
+                    "returning texts unmodified"
+                )
             texts = inputs.get("texts", [])
             inputs["texts"] = [self._unmask_pii_text(t, pii_tokens) for t in texts]
             return inputs

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1202,6 +1202,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     "output_parse_pii enabled but no pii_tokens in request_data; "
                     "returning texts unmodified"
                 )
+                return inputs
             texts = inputs.get("texts", [])
             inputs["texts"] = [self._unmask_pii_text(t, pii_tokens) for t in texts]
             return inputs

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -399,6 +399,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                         guardrail_to_apply=guardrail_to_apply,
                         litellm_logging_obj=request_data.get("litellm_logging_obj"),
                         user_api_key_dict=user_api_key_dict,
+                        request_data=request_data,
                     )
                 except HTTPException as e:
                     # Response already started (we already yielded chunks); cannot send 400.
@@ -459,6 +460,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                     guardrail_to_apply=guardrail_to_apply,
                     litellm_logging_obj=request_data.get("litellm_logging_obj"),
                     user_api_key_dict=user_api_key_dict,
+                    request_data=request_data,
                 )
             except HTTPException as e:
                 if call_type is not None and CallTypes(call_type) in A2A_CALL_TYPES:

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -248,6 +248,7 @@ class UnifiedLLMGuardrails(CustomLogger):
             guardrail_to_apply=guardrail_to_apply,
             litellm_logging_obj=data.get("litellm_logging_obj"),
             user_api_key_dict=user_api_key_dict,
+            request_data=data,
         )
         # Add guardrail to applied guardrails header
         add_guardrail_to_applied_guardrails_header(

--- a/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
+++ b/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
@@ -42,6 +42,7 @@ def test_all_handler_implementations_accept_request_data():
         "litellm.llms.openai.completion.guardrail_translation.handler",
     ]
 
+    validated_count = 0
     for module_path in handlers:
         try:
             mod = importlib.import_module(module_path)
@@ -64,3 +65,8 @@ def test_all_handler_implementations_accept_request_data():
                 f"{module_path}.{name}.process_output_response() "
                 f"must accept 'request_data' to match BaseTranslation."
             )
+            validated_count += 1
+
+    assert validated_count > 0, (
+        "No handler classes were validated — all imports failed or no matching classes found."
+    )

--- a/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
+++ b/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
@@ -46,7 +46,7 @@ def test_all_handler_implementations_accept_request_data():
         try:
             mod = importlib.import_module(module_path)
         except ImportError:
-            pytest.skip(f"Module {module_path} not available")
+            continue  # module not installed in this environment; check next handler
 
         # Find the class that implements process_output_response
         for name, obj in inspect.getmembers(mod, inspect.isclass):

--- a/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
+++ b/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
@@ -1,0 +1,66 @@
+"""
+Tests for fix/guardrail-request-data-passthrough
+
+Verifies that BaseTranslation.process_output_response() declares request_data
+so implementing classes are type-consistent with the abstract interface.
+
+Related issue: https://github.com/BerriAI/litellm/issues/22821
+"""
+
+import inspect
+import pytest
+from litellm.llms.base_llm.guardrail_translation.base_translation import BaseTranslation
+
+
+def test_base_translation_process_output_response_has_request_data_param():
+    """
+    All concrete implementations of process_output_response() accept a
+    request_data keyword argument, but the abstract base did not declare it.
+    This test ensures the abstract signature matches the implementations.
+    """
+    sig = inspect.signature(BaseTranslation.process_output_response)
+    assert "request_data" in sig.parameters, (
+        "BaseTranslation.process_output_response() must declare a 'request_data' "
+        "parameter so all implementations are type-consistent with the interface."
+    )
+    param = sig.parameters["request_data"]
+    assert param.default is None, (
+        "'request_data' must default to None for backwards compatibility."
+    )
+
+
+def test_all_handler_implementations_accept_request_data():
+    """
+    Verify a representative set of concrete handler implementations also
+    accept request_data (ensuring they conform to the updated abstract sig).
+    """
+    import importlib
+
+    handlers = [
+        "litellm.llms.openai.chat.guardrail_translation.handler",
+        "litellm.llms.anthropic.chat.guardrail_translation.handler",
+        "litellm.llms.openai.completion.guardrail_translation.handler",
+    ]
+
+    for module_path in handlers:
+        try:
+            mod = importlib.import_module(module_path)
+        except ImportError:
+            pytest.skip(f"Module {module_path} not available")
+
+        # Find the class that implements process_output_response
+        for name, obj in inspect.getmembers(mod, inspect.isclass):
+            if not hasattr(obj, "process_output_response"):
+                continue
+            # Skip the abstract base itself
+            if obj is BaseTranslation:
+                continue
+            # Only check classes from this module
+            if obj.__module__ != module_path:
+                continue
+
+            sig = inspect.signature(obj.process_output_response)
+            assert "request_data" in sig.parameters, (
+                f"{module_path}.{name}.process_output_response() "
+                f"must accept 'request_data' to match BaseTranslation."
+            )

--- a/tests/guardrails_tests/test_presidio_output_unmask.py
+++ b/tests/guardrails_tests/test_presidio_output_unmask.py
@@ -31,13 +31,8 @@ fix/guardrail-request-data-passthrough (PR 1, BerriAI/litellm#22821) addresses.
 Without PR 1, request_data will be empty and unmasking silently no-ops.  The two
 fixes together form the complete end-to-end unmask pipeline.
 """
-import os
-import sys
-
 import pytest
 from unittest.mock import AsyncMock, patch
-
-sys.path.insert(0, os.path.abspath("../.."))
 
 from litellm.proxy.guardrails.guardrail_hooks.presidio import _OPTIONAL_PresidioPIIMasking
 

--- a/tests/guardrails_tests/test_presidio_output_unmask.py
+++ b/tests/guardrails_tests/test_presidio_output_unmask.py
@@ -1,0 +1,153 @@
+"""
+Regression test for: fix(presidio): add output unmask path when output_parse_pii
+is enabled.
+
+Root cause
+----------
+apply_guardrail() always runs check_pii() (masking) regardless of whether it is
+processing an input (request) or an output (response).  With output_parse_pii=True:
+
+  - Input phase (input_type="request"):  PII is masked; tokens stored in
+    request_data["pii_tokens"].
+  - Output phase (input_type="response"): apply_guardrail() should RESTORE the
+    original PII by replacing tokens with their original values.
+
+Without the fix, apply_guardrail() calls check_pii() on the output as well —
+which re-masks the already-masked response (or leaves it with <PERSON> tokens
+unchanged because there is no fresh PII to detect), so the caller never sees the
+original values.
+
+Fix
+---
+apply_guardrail() now detects input_type=="response" && output_parse_pii and
+takes an early-return path that calls _unmask_pii_text() for each text in
+inputs["texts"], restoring the tokens using the pii_tokens dict from request_data.
+
+Dependency
+----------
+Receiving pii_tokens in request_data requires the unified guardrail to forward
+request_data to process_output_response() — which is what
+fix/guardrail-request-data-passthrough (PR 1, BerriAI/litellm#22821) addresses.
+Without PR 1, request_data will be empty and unmasking silently no-ops.  The two
+fixes together form the complete end-to-end unmask pipeline.
+"""
+import os
+import sys
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from litellm.proxy.guardrails.guardrail_hooks.presidio import _OPTIONAL_PresidioPIIMasking
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_guardrail(output_parse_pii: bool = True) -> _OPTIONAL_PresidioPIIMasking:
+    return _OPTIONAL_PresidioPIIMasking(
+        pii_entities_config={},
+        output_parse_pii=output_parse_pii,
+        presidio_analyzer_api_base="http://mock-analyzer",
+        presidio_anonymizer_api_base="http://mock-anonymizer",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_unmasks_response_when_output_parse_pii_enabled() -> None:
+    """With output_parse_pii=True and input_type='response', tokens are restored.
+
+    Simulates the output phase of a round-trip:
+      1. Input masked "John Smith" → "<PERSON>_abc123456789"
+      2. LLM echoes the token back: "Hello, <PERSON>_abc123456789"
+      3. apply_guardrail() with input_type="response" should restore the original
+         name, returning "Hello, John Smith".
+    """
+    guardrail = _make_guardrail(output_parse_pii=True)
+
+    token = "<PERSON>_abc123456789"
+    pii_tokens = {token: "John Smith"}
+
+    # request_data carries the token→original mapping from the input phase.
+    request_data = {"pii_tokens": pii_tokens}
+
+    inputs = {"texts": [f"Hello, {token}. How are you today?"]}
+
+    result = await guardrail.apply_guardrail(
+        inputs=inputs,  # type: ignore[arg-type]
+        request_data=request_data,
+        input_type="response",
+    )
+
+    assert result["texts"] == ["Hello, John Smith. How are you today?"], (
+        "apply_guardrail() must restore PII tokens in response text"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_response_noop_when_no_pii_tokens() -> None:
+    """With output_parse_pii=True but empty pii_tokens, text is returned unchanged."""
+    guardrail = _make_guardrail(output_parse_pii=True)
+
+    original_text = "Hello, how are you?"
+    inputs = {"texts": [original_text]}
+
+    result = await guardrail.apply_guardrail(
+        inputs=inputs,  # type: ignore[arg-type]
+        request_data={},  # no pii_tokens
+        input_type="response",
+    )
+
+    assert result["texts"] == [original_text], (
+        "apply_guardrail() with empty pii_tokens should return text unchanged"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_request_phase_still_masks() -> None:
+    """With input_type='request', masking (check_pii) still runs as before."""
+    guardrail = _make_guardrail(output_parse_pii=True)
+
+    # Patch check_pii so we avoid a live Presidio instance.
+    with patch.object(
+        guardrail,
+        "check_pii",
+        new=AsyncMock(return_value="Hello, <PERSON>_masked"),
+    ):
+        result = await guardrail.apply_guardrail(
+            inputs={"texts": ["Hello, John Smith"]},  # type: ignore[arg-type]
+            request_data={},
+            input_type="request",
+        )
+
+    assert result["texts"] == ["Hello, <PERSON>_masked"], (
+        "apply_guardrail() with input_type='request' must still run check_pii masking"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_response_calls_check_pii_when_output_parse_pii_disabled() -> None:
+    """Without output_parse_pii, the response path falls through to check_pii."""
+    guardrail = _make_guardrail(output_parse_pii=False)
+
+    with patch.object(
+        guardrail,
+        "check_pii",
+        new=AsyncMock(return_value="unchanged"),
+    ) as mock_check_pii:
+        await guardrail.apply_guardrail(
+            inputs={"texts": ["some text"]},  # type: ignore[arg-type]
+            request_data={},
+            input_type="response",
+        )
+
+    mock_check_pii.assert_called_once(), (
+        "check_pii should be called for response phase when output_parse_pii=False"
+    )

--- a/tests/guardrails_tests/test_presidio_output_unmask.py
+++ b/tests/guardrails_tests/test_presidio_output_unmask.py
@@ -148,6 +148,4 @@ async def test_apply_guardrail_response_calls_check_pii_when_output_parse_pii_di
             input_type="response",
         )
 
-    mock_check_pii.assert_called_once(), (
-        "check_pii should be called for response phase when output_parse_pii=False"
-    )
+    mock_check_pii.assert_called_once()


### PR DESCRIPTION
## Problem

With `output_parse_pii: true`, `apply_guardrail()` is called for both the
input phase (masking) and the output phase (should unmask). However only a
masking path exists — the response text is either re-masked or passed through
unchanged. PII tokens stored during input masking are never restored.

**Symptom:** send "My name is John Smith, say hello back" →
response contains `<PERSON>` instead of `John Smith`.

Part of #22821.

## Reproducer

1. Presidio guardrail with `output_parse_pii: true` and `default_on: true`
2. `POST /chat/completions` with: `"My name is John Smith, say hello back"`
3. Expected: response contains `John Smith`
4. Actual: response contains `<PERSON>_<uuid>`

## Fix

Add an early-return block at the top of `apply_guardrail()`: when
`input_type == "response"` and `self.output_parse_pii` is `True`, retrieve
`pii_tokens` from `request_data` and run `_unmask_pii_text()` on each text,
then return without running the masking path.

## Dependency

For `pii_tokens` to be present in `request_data`, #22879
(`fix/guardrail-request-data-passthrough`) must be merged first.
The fix is otherwise self-contained.

## Testing

`tests/guardrails_tests/test_presidio_output_unmask.py` — four tests:
- token → original text round-trip
- no-op when `pii_tokens` is empty
- request phase still runs the masking path
- response phase falls through to `check_pii` when `output_parse_pii=False`