### PR TITLE
fix(presidio): handle Anthropic native SSE bytes in streaming unmask hook

### DIFF
--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -111,6 +111,7 @@ class A2AGuardrailHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process A2A output response by applying guardrails to text content.

--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -168,7 +168,7 @@ class A2AGuardrailHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts in batch
         # Create a request_data dict with response info and user API key metadata
-        request_data: dict = {"response": response_dict}
+        request_data: dict = {**(request_data or {}), "response": response_dict}
 
         # Add user API key metadata with prefixed keys
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
@@ -214,6 +214,7 @@ class A2AGuardrailHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> List[Any]:
         """
         Process A2A streaming output by applying guardrails to accumulated text.
@@ -259,7 +260,7 @@ class A2AGuardrailHandler(BaseTranslation):
         if not combined_text:
             return responses_so_far
 
-        request_data: dict = {"responses_so_far": responses_so_far}
+        request_data: dict = {**(request_data or {}), "responses_so_far": responses_so_far}
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
             request_data["litellm_metadata"] = user_metadata

--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -168,18 +168,18 @@ class A2AGuardrailHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts in batch
         # Create a request_data dict with response info and user API key metadata
-        request_data: dict = {**(request_data or {}), "response": response_dict}
+        effective_request_data: dict = {**(request_data or {}), "response": response_dict}
 
         # Add user API key metadata with prefixed keys
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
-            request_data["litellm_metadata"] = user_metadata
+            effective_request_data["litellm_metadata"] = user_metadata
 
         inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
 
         guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data=request_data,
+            request_data=effective_request_data,
             input_type="response",
             logging_obj=litellm_logging_obj,
         )
@@ -260,15 +260,15 @@ class A2AGuardrailHandler(BaseTranslation):
         if not combined_text:
             return responses_so_far
 
-        request_data: dict = {**(request_data or {}), "responses_so_far": responses_so_far}
+        effective_request_data: dict = {**(request_data or {}), "responses_so_far": responses_so_far}
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
-            request_data["litellm_metadata"] = user_metadata
+            effective_request_data["litellm_metadata"] = user_metadata
 
         inputs = GenericGuardrailAPIInputs(texts=[combined_text])
         guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data=request_data,
+            request_data=effective_request_data,
             input_type="response",
             logging_obj=litellm_logging_obj,
         )

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -243,6 +243,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -319,14 +319,14 @@ class AnthropicMessagesHandler(BaseTranslation):
             # from the input masking phase) with response info.  The "response" key
             # is always set to the current response object so downstream guardrails
             # can inspect it.
-            request_data: dict = {**(request_data or {}), "response": response}
+            effective_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                effective_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -344,7 +344,7 @@ class AnthropicMessagesHandler(BaseTranslation):
 
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=effective_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -315,7 +315,10 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
-            # Create a request_data dict with response info and user API key metadata
+            # Build request_data, merging caller's dict (which may carry pii_tokens
+            # from the input masking phase) with response info.  The "response" key
+            # is always set to the current response object so downstream guardrails
+            # can inspect it.
             request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -316,7 +316,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -83,6 +83,8 @@ class BaseTranslation(ABC):
             guardrail_to_apply: The guardrail instance to apply
             litellm_logging_obj: Optional logging object
             user_api_key_dict: User API key metadata (passed separately since response doesn't contain it)
+            request_data: Full request context dict from the input phase
+                          (e.g. pii_tokens from masking), or None if not available.
         """
         pass
 
@@ -92,9 +94,18 @@ class BaseTranslation(ABC):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output streaming response with guardrails.
+
+        Args:
+            responses_so_far: Accumulated streaming chunks to process
+            guardrail_to_apply: The guardrail instance to apply
+            litellm_logging_obj: Optional logging object
+            user_api_key_dict: User API key metadata
+            request_data: Full request context dict from the input phase
+                          (e.g. pii_tokens from masking), or None if not available.
 
         Optional to override in subclasses.
         """

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -73,6 +73,7 @@ class BaseTranslation(ABC):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response with guardrails.

--- a/litellm/llms/cohere/rerank/guardrail_translation/handler.py
+++ b/litellm/llms/cohere/rerank/guardrail_translation/handler.py
@@ -83,6 +83,7 @@ class CohereRerankHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - not applicable for rerank.

--- a/litellm/llms/mistral/ocr/guardrail_translation/handler.py
+++ b/litellm/llms/mistral/ocr/guardrail_translation/handler.py
@@ -91,6 +91,7 @@ class OCRHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process OCR output by applying guardrails to extracted page text.

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -310,14 +310,14 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         # Step 2: Apply guardrail to all texts and tool calls in batch
         if texts_to_check or tool_calls_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {**(request_data or {}), "response": response}
+            effective_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                effective_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -330,7 +330,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=effective_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )
@@ -440,14 +440,14 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         # Step 3: Apply guardrail to all combined texts in batch
         if texts_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {**(request_data or {}), "responses": responses_so_far}
+            effective_request_data: dict = {**(request_data or {}), "responses": responses_so_far}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                effective_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -461,7 +461,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 inputs["model"] = responses_so_far[0].model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=effective_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -310,7 +310,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         # Step 2: Apply guardrail to all texts and tool calls in batch
         if texts_to_check or tool_calls_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
@@ -365,6 +365,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> List["ModelResponseStream"]:
         """
         Process output streaming responses by applying guardrails to text content.
@@ -403,6 +404,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 guardrail_to_apply=guardrail_to_apply,
                 litellm_logging_obj=litellm_logging_obj,
                 user_api_key_dict=user_api_key_dict,
+                request_data=request_data,
             )
 
             return responses_so_far
@@ -438,7 +440,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         # Step 3: Apply guardrail to all combined texts in batch
         if texts_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"responses": responses_so_far}
+            request_data: dict = {**(request_data or {}), "responses": responses_so_far}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -260,6 +260,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content.

--- a/litellm/llms/openai/completion/guardrail_translation/handler.py
+++ b/litellm/llms/openai/completion/guardrail_translation/handler.py
@@ -157,7 +157,7 @@ class OpenAITextCompletionHandler(BaseTranslation):
         # Apply guardrails in batch
         if texts_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/openai/completion/guardrail_translation/handler.py
+++ b/litellm/llms/openai/completion/guardrail_translation/handler.py
@@ -125,6 +125,7 @@ class OpenAITextCompletionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to completion text.

--- a/litellm/llms/openai/completion/guardrail_translation/handler.py
+++ b/litellm/llms/openai/completion/guardrail_translation/handler.py
@@ -157,14 +157,14 @@ class OpenAITextCompletionHandler(BaseTranslation):
         # Apply guardrails in batch
         if texts_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {**(request_data or {}), "response": response}
+            effective_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                effective_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             # Include model information from the response if available
@@ -172,7 +172,7 @@ class OpenAITextCompletionHandler(BaseTranslation):
                 inputs["model"] = response.model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=effective_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/llms/openai/embeddings/guardrail_translation/handler.py
+++ b/litellm/llms/openai/embeddings/guardrail_translation/handler.py
@@ -155,6 +155,7 @@ class OpenAIEmbeddingsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - embeddings responses contain vectors, not text.

--- a/litellm/llms/openai/image_generation/guardrail_translation/handler.py
+++ b/litellm/llms/openai/image_generation/guardrail_translation/handler.py
@@ -87,6 +87,7 @@ class OpenAIImageGenerationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - typically not needed for image generation.

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -399,7 +399,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -342,6 +342,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -399,14 +399,14 @@ class OpenAIResponsesHandler(BaseTranslation):
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {**(request_data or {}), "response": response}
+            effective_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                effective_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -424,7 +424,7 @@ class OpenAIResponsesHandler(BaseTranslation):
 
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=effective_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/llms/openai/speech/guardrail_translation/handler.py
+++ b/litellm/llms/openai/speech/guardrail_translation/handler.py
@@ -85,6 +85,7 @@ class OpenAITextToSpeechHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output - not applicable for text-to-speech.

--- a/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
+++ b/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
@@ -81,14 +81,14 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
         if isinstance(response.text, str):
             original_text = response.text
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {**(request_data or {}), "response": response}
+            effective_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                effective_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=[original_text])
             # Include model information from the response if available
@@ -96,7 +96,7 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
                 inputs["model"] = response.model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=effective_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
+++ b/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
@@ -81,7 +81,7 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
         if isinstance(response.text, str):
             original_text = response.text
             # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
+++ b/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
@@ -58,6 +58,7 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output transcription by applying guardrails to transcribed text.

--- a/litellm/llms/pass_through/guardrail_translation/handler.py
+++ b/litellm/llms/pass_through/guardrail_translation/handler.py
@@ -139,6 +139,7 @@ class PassThroughEndpointHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to targeted fields.

--- a/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
+++ b/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
@@ -92,6 +92,7 @@ class MCPGuardrailTranslationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         verbose_proxy_logger.debug(
             "MCP Guardrail: Output processing not implemented for MCP tools",

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1133,10 +1133,12 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             if remaining_bytes_chunks and remaining_chunks:
                 verbose_proxy_logger.warning(
                     "PII streaming unmask: mixed bytes (%d) and model (%d) chunks; "
-                    "bytes chunks will be discarded",
+                    "bytes chunks passed through unmodified",
                     len(remaining_bytes_chunks),
                     len(remaining_chunks),
                 )
+                for chunk in remaining_bytes_chunks:
+                    yield chunk  # type: ignore[misc]
 
             if remaining_bytes_chunks and not remaining_chunks:
                 combined = b"".join(remaining_bytes_chunks)

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1110,10 +1110,77 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             return
 
         remaining_chunks: List[ModelResponseStream] = []
+        remaining_bytes_chunks: List[bytes] = []
         try:
             async for chunk in response:
                 if isinstance(chunk, ModelResponseStream):
                     remaining_chunks.append(chunk)
+                elif isinstance(chunk, bytes):
+                    remaining_bytes_chunks.append(chunk)
+
+            # --- Anthropic native SSE path ---
+            # When the LLM is called via the Anthropic native API path (not OpenAI
+            # compat), response chunks arrive as raw SSE bytes rather than
+            # ModelResponseStream objects. stream_chunk_builder() cannot handle
+            # bytes, so we parse the SSE events directly, reassemble all text
+            # deltas, apply _unmask_pii_text(), then yield the rebuilt SSE as a
+            # single bytes chunk.
+            #
+            # Trade-off: progressive streaming output is replaced by a single
+            # delivery at response completion when output_parse_pii is enabled.
+            # This is unavoidable for correct PII token restoration because tokens
+            # may span multiple delta events.
+            if remaining_bytes_chunks and not remaining_chunks:
+                combined = b"".join(remaining_bytes_chunks)
+                # Split on double-newline SSE event boundaries
+                raw_events = [e for e in combined.split(b"\n\n") if e.strip()]
+
+                text_parts: List[str] = []
+                non_text_events: List[bytes] = []
+
+                for raw_event in raw_events:
+                    lines = raw_event.split(b"\n")
+                    data_line = next(
+                        (ln for ln in lines if ln.startswith(b"data:")), None
+                    )
+                    if data_line is None:
+                        non_text_events.append(raw_event)
+                        continue
+                    try:
+                        payload = json.loads(data_line[len(b"data:"):].strip())
+                    except (json.JSONDecodeError, ValueError):
+                        non_text_events.append(raw_event)
+                        continue
+
+                    delta = payload.get("delta") if isinstance(payload, dict) else None
+                    if (
+                        payload.get("type") == "content_block_delta"
+                        and isinstance(delta, dict)
+                        and delta.get("type") == "text_delta"
+                    ):
+                        text_parts.append(delta.get("text", ""))
+                    else:
+                        non_text_events.append(raw_event)
+
+                # Unmask the full concatenated text in one pass so that tokens
+                # which span multiple delta events are correctly restored.
+                combined_text = "".join(text_parts)
+                unmasked_text = self._unmask_pii_text(combined_text, pii_tokens)
+
+                # Rebuild: emit all non-text events, then a single text_delta
+                # containing the fully unmasked text.
+                text_delta_payload = {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": unmasked_text},
+                }
+                text_delta_event = (
+                    b"event: content_block_delta\n"
+                    b"data: " + json.dumps(text_delta_payload).encode() + b"\n"
+                )
+                rebuilt = b"\n\n".join(non_text_events + [text_delta_event]) + b"\n\n"
+                yield rebuilt  # type: ignore[misc]
+                return
 
             if not remaining_chunks:
                 return
@@ -1153,6 +1220,8 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             verbose_proxy_logger.error(f"Error in PII streaming processing: {str(e)}")
             for chunk in remaining_chunks:
                 yield chunk
+            for chunk in remaining_bytes_chunks:  # type: ignore[misc]
+                yield chunk  # type: ignore[misc]
 
     def get_presidio_settings_from_request_data(
         self, data: dict

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1130,13 +1130,27 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             # delivery at response completion when output_parse_pii is enabled.
             # This is unavoidable for correct PII token restoration because tokens
             # may span multiple delta events.
+            if remaining_bytes_chunks and remaining_chunks:
+                verbose_proxy_logger.warning(
+                    "PII streaming unmask: mixed bytes (%d) and model (%d) chunks; "
+                    "bytes chunks will be discarded",
+                    len(remaining_bytes_chunks),
+                    len(remaining_chunks),
+                )
+
             if remaining_bytes_chunks and not remaining_chunks:
                 combined = b"".join(remaining_bytes_chunks)
                 # Split on double-newline SSE event boundaries
                 raw_events = [e for e in combined.split(b"\n\n") if e.strip()]
 
+                # Pass 1: classify events; record original slot positions so we
+                # can re-insert the merged text_delta at the position of the FIRST
+                # original text_delta rather than appending it after non-text
+                # events (which would put message_stop before text content).
                 text_parts: List[str] = []
-                non_text_events: List[bytes] = []
+                # Each entry: (raw_event_bytes, is_text_delta)
+                event_slots: List[tuple] = []
+                last_text_delta_index: int = 0
 
                 for raw_event in raw_events:
                     lines = raw_event.split(b"\n")
@@ -1144,12 +1158,12 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         (ln for ln in lines if ln.startswith(b"data:")), None
                     )
                     if data_line is None:
-                        non_text_events.append(raw_event)
+                        event_slots.append((raw_event, False))
                         continue
                     try:
                         payload = json.loads(data_line[len(b"data:"):].strip())
                     except (json.JSONDecodeError, ValueError):
-                        non_text_events.append(raw_event)
+                        event_slots.append((raw_event, False))
                         continue
 
                     delta = payload.get("delta") if isinstance(payload, dict) else None
@@ -1159,26 +1173,43 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         and delta.get("type") == "text_delta"
                     ):
                         text_parts.append(delta.get("text", ""))
+                        last_text_delta_index = payload.get("index", 0)
+                        event_slots.append((raw_event, True))
                     else:
-                        non_text_events.append(raw_event)
+                        event_slots.append((raw_event, False))
 
                 # Unmask the full concatenated text in one pass so that tokens
                 # which span multiple delta events are correctly restored.
                 combined_text = "".join(text_parts)
                 unmasked_text = self._unmask_pii_text(combined_text, pii_tokens)
 
-                # Rebuild: emit all non-text events, then a single text_delta
-                # containing the fully unmasked text.
+                # Build the merged text_delta event, preserving the original
+                # `index` value from the last text_delta (not hardcoded 0).
                 text_delta_payload = {
                     "type": "content_block_delta",
-                    "index": 0,
+                    "index": last_text_delta_index,
                     "delta": {"type": "text_delta", "text": unmasked_text},
                 }
                 text_delta_event = (
                     b"event: content_block_delta\n"
                     b"data: " + json.dumps(text_delta_payload).encode() + b"\n"
                 )
-                rebuilt = b"\n\n".join(non_text_events + [text_delta_event]) + b"\n\n"
+
+                # Pass 2: rebuild event stream in original order.
+                # The merged text_delta is placed at the slot of the FIRST
+                # original text_delta; all subsequent text_delta slots are dropped.
+                merged_events: List[bytes] = []
+                first_text_delta_placed = False
+                for raw_event, is_text_delta in event_slots:
+                    if is_text_delta:
+                        if not first_text_delta_placed:
+                            merged_events.append(text_delta_event)
+                            first_text_delta_placed = True
+                        # skip remaining text_delta slots
+                    else:
+                        merged_events.append(raw_event)
+
+                rebuilt = b"\n\n".join(merged_events) + b"\n\n"
                 yield rebuilt  # type: ignore[misc]
                 return
 

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1058,10 +1058,24 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         # --- Output masking path (apply_to_output=True) ---
         if self.apply_to_output:
             all_chunks: List[ModelResponseStream] = []
+            all_bytes_chunks: List[bytes] = []
             try:
                 async for chunk in response:
                     if isinstance(chunk, ModelResponseStream):
                         all_chunks.append(chunk)
+                    elif isinstance(chunk, bytes):
+                        all_bytes_chunks.append(chunk)
+
+                # Anthropic native SSE arrives as raw bytes — Presidio masking cannot
+                # be applied to unparsed SSE, so pass the stream through unmodified.
+                if all_bytes_chunks and not all_chunks:
+                    verbose_proxy_logger.warning(
+                        "PII masking: received bytes-only stream (Anthropic native SSE); "
+                        "output masking cannot be applied, passing through unmodified"
+                    )
+                    for chunk in all_bytes_chunks:
+                        yield chunk  # type: ignore[misc]
+                    return
 
                 if not all_chunks:
                     return
@@ -1096,6 +1110,8 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 # If we collected chunks before the error, replay those.
                 for chunk in all_chunks:
                     yield chunk
+                for chunk in all_bytes_chunks:  # type: ignore[misc]
+                    yield chunk  # type: ignore[misc]
                 return
 
         # --- PII unmasking path (output_parse_pii=True) ---

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1077,6 +1077,16 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         yield chunk  # type: ignore[misc]
                     return
 
+                if all_bytes_chunks and all_chunks:
+                    verbose_proxy_logger.warning(
+                        "PII masking: mixed bytes (%d) and model (%d) chunks; "
+                        "bytes chunks passed through unmodified",
+                        len(all_bytes_chunks),
+                        len(all_chunks),
+                    )
+                    for chunk in all_bytes_chunks:
+                        yield chunk  # type: ignore[misc]
+
                 if not all_chunks:
                     return
 

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1152,7 +1152,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 text_parts: List[str] = []
                 # Each entry: (raw_event_bytes, is_text_delta)
                 event_slots: List[tuple] = []
-                last_text_delta_index: int = 0
+                # Lock onto the first text content block index to avoid merging
+                # text from distinct content blocks (e.g. thinking + reply).
+                first_text_delta_index: Optional[int] = None
 
                 for raw_event in raw_events:
                     lines = raw_event.split(b"\n")
@@ -1174,9 +1176,15 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         and isinstance(delta, dict)
                         and delta.get("type") == "text_delta"
                     ):
-                        text_parts.append(delta.get("text", ""))
-                        last_text_delta_index = payload.get("index", 0)
-                        event_slots.append((raw_event, True))
+                        event_index = payload.get("index", 0)
+                        if first_text_delta_index is None:
+                            first_text_delta_index = event_index  # lock onto first text block
+                        if event_index == first_text_delta_index:
+                            text_parts.append(delta.get("text", ""))
+                            event_slots.append((raw_event, True))
+                        else:
+                            # Different content block — pass through unchanged
+                            event_slots.append((raw_event, False))
                     else:
                         event_slots.append((raw_event, False))
 
@@ -1186,10 +1194,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 unmasked_text = self._unmask_pii_text(combined_text, pii_tokens)
 
                 # Build the merged text_delta event, preserving the original
-                # `index` value from the last text_delta (not hardcoded 0).
+                # `index` value from the first text_delta (not hardcoded 0).
                 text_delta_payload = {
                     "type": "content_block_delta",
-                    "index": last_text_delta_index,
+                    "index": first_text_delta_index if first_text_delta_index is not None else 0,
                     "delta": {"type": "text_delta", "text": unmasked_text},
                 }
                 text_delta_event = (
@@ -1211,8 +1219,8 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     else:
                         merged_events.append(raw_event)
 
-                rebuilt = b"\n\n".join(merged_events) + b"\n\n"
-                yield rebuilt  # type: ignore[misc]
+                for event in merged_events:
+                    yield event + b"\n\n"  # type: ignore[misc]
                 return
 
             if not remaining_chunks:

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -399,6 +399,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                         guardrail_to_apply=guardrail_to_apply,
                         litellm_logging_obj=request_data.get("litellm_logging_obj"),
                         user_api_key_dict=user_api_key_dict,
+                        request_data=request_data,
                     )
                 except HTTPException as e:
                     # Response already started (we already yielded chunks); cannot send 400.
@@ -459,6 +460,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                     guardrail_to_apply=guardrail_to_apply,
                     litellm_logging_obj=request_data.get("litellm_logging_obj"),
                     user_api_key_dict=user_api_key_dict,
+                    request_data=request_data,
                 )
             except HTTPException as e:
                 if call_type is not None and CallTypes(call_type) in A2A_CALL_TYPES:

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -248,6 +248,7 @@ class UnifiedLLMGuardrails(CustomLogger):
             guardrail_to_apply=guardrail_to_apply,
             litellm_logging_obj=data.get("litellm_logging_obj"),
             user_api_key_dict=user_api_key_dict,
+            request_data=data,
         )
         # Add guardrail to applied guardrails header
         add_guardrail_to_applied_guardrails_header(

--- a/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
+++ b/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
@@ -42,6 +42,7 @@ def test_all_handler_implementations_accept_request_data():
         "litellm.llms.openai.completion.guardrail_translation.handler",
     ]
 
+    validated_count = 0
     for module_path in handlers:
         try:
             mod = importlib.import_module(module_path)
@@ -64,3 +65,8 @@ def test_all_handler_implementations_accept_request_data():
                 f"{module_path}.{name}.process_output_response() "
                 f"must accept 'request_data' to match BaseTranslation."
             )
+            validated_count += 1
+
+    assert validated_count > 0, (
+        "No handler classes were validated — all imports failed or no matching classes found."
+    )

--- a/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
+++ b/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
@@ -46,7 +46,7 @@ def test_all_handler_implementations_accept_request_data():
         try:
             mod = importlib.import_module(module_path)
         except ImportError:
-            pytest.skip(f"Module {module_path} not available")
+            continue  # module not installed in this environment; check next handler
 
         # Find the class that implements process_output_response
         for name, obj in inspect.getmembers(mod, inspect.isclass):

--- a/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
+++ b/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
@@ -1,0 +1,66 @@
+"""
+Tests for fix/guardrail-request-data-passthrough
+
+Verifies that BaseTranslation.process_output_response() declares request_data
+so implementing classes are type-consistent with the abstract interface.
+
+Related issue: https://github.com/BerriAI/litellm/issues/22821
+"""
+
+import inspect
+import pytest
+from litellm.llms.base_llm.guardrail_translation.base_translation import BaseTranslation
+
+
+def test_base_translation_process_output_response_has_request_data_param():
+    """
+    All concrete implementations of process_output_response() accept a
+    request_data keyword argument, but the abstract base did not declare it.
+    This test ensures the abstract signature matches the implementations.
+    """
+    sig = inspect.signature(BaseTranslation.process_output_response)
+    assert "request_data" in sig.parameters, (
+        "BaseTranslation.process_output_response() must declare a 'request_data' "
+        "parameter so all implementations are type-consistent with the interface."
+    )
+    param = sig.parameters["request_data"]
+    assert param.default is None, (
+        "'request_data' must default to None for backwards compatibility."
+    )
+
+
+def test_all_handler_implementations_accept_request_data():
+    """
+    Verify a representative set of concrete handler implementations also
+    accept request_data (ensuring they conform to the updated abstract sig).
+    """
+    import importlib
+
+    handlers = [
+        "litellm.llms.openai.chat.guardrail_translation.handler",
+        "litellm.llms.anthropic.chat.guardrail_translation.handler",
+        "litellm.llms.openai.completion.guardrail_translation.handler",
+    ]
+
+    for module_path in handlers:
+        try:
+            mod = importlib.import_module(module_path)
+        except ImportError:
+            pytest.skip(f"Module {module_path} not available")
+
+        # Find the class that implements process_output_response
+        for name, obj in inspect.getmembers(mod, inspect.isclass):
+            if not hasattr(obj, "process_output_response"):
+                continue
+            # Skip the abstract base itself
+            if obj is BaseTranslation:
+                continue
+            # Only check classes from this module
+            if obj.__module__ != module_path:
+                continue
+
+            sig = inspect.signature(obj.process_output_response)
+            assert "request_data" in sig.parameters, (
+                f"{module_path}.{name}.process_output_response() "
+                f"must accept 'request_data' to match BaseTranslation."
+            )

--- a/tests/guardrails_tests/test_presidio_sse_unmask.py
+++ b/tests/guardrails_tests/test_presidio_sse_unmask.py
@@ -1,0 +1,261 @@
+"""
+Tests for PR 4: fix/presidio-anthropic-sse-unmask
+
+Covers:
+  - Patch 6a/6b: AnthropicMessagesHandler.process_output_response() accepts
+    request_data and merges it so pii_tokens are preserved.
+  - Patch 3: async_post_call_streaming_iterator_hook() detects Anthropic native
+    SSE bytes chunks and unmasks PII tokens in them.
+"""
+
+import json
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_guardrail(output_parse_pii: bool = True):
+    """Return a minimal _OPTIONAL_PresidioPIIMasking instance (no live Presidio)."""
+    from litellm.proxy.guardrails.guardrail_hooks.presidio import (
+        _OPTIONAL_PresidioPIIMasking,
+    )
+
+    guardrail = _OPTIONAL_PresidioPIIMasking.__new__(_OPTIONAL_PresidioPIIMasking)
+    guardrail.output_parse_pii = output_parse_pii
+    guardrail.apply_to_output = False
+    guardrail.presidio_analyzer_api_base = "http://fake"
+    guardrail.presidio_anonymizer_api_base = "http://fake"
+    guardrail.mock_testing = False
+    return guardrail
+
+
+def _make_sse_bytes(text: str, index: int = 0) -> bytes:
+    """Build a minimal Anthropic SSE bytes payload containing one text_delta event."""
+    delta_payload = {
+        "type": "content_block_delta",
+        "index": index,
+        "delta": {"type": "text_delta", "text": text},
+    }
+    delta_event = (
+        b"event: content_block_delta\n"
+        b"data: " + json.dumps(delta_payload).encode() + b"\n"
+    )
+    stop_event = b"event: message_stop\ndata: " + json.dumps({"type": "message_stop"}).encode() + b"\n"
+    return delta_event + b"\n\n" + stop_event + b"\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Test 1: process_output_response merges caller request_data (Patch 6a/6b)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_handler_merges_request_data_with_pii_tokens():
+    """
+    AnthropicMessagesHandler.process_output_response() should preserve pii_tokens
+    from the caller-supplied request_data so that apply_guardrail() can unmask them.
+    """
+    from litellm.llms.anthropic.chat.guardrail_translation.handler import (
+        AnthropicMessagesHandler,
+    )
+
+    handler = AnthropicMessagesHandler()
+
+    # Simulate the token map built during input masking
+    pii_token = "<PERSON>_abc123456789"
+    pii_tokens = {pii_token: "Jane Doe"}
+
+    # A fake guardrail that records what request_data it received
+    received_request_data = {}
+
+    async def fake_apply_guardrail(inputs, request_data, input_type, logging_obj=None):
+        received_request_data.update(request_data or {})
+        # Return texts unchanged so the handler can still run its text-update logic
+        return dict(inputs)
+
+    mock_guardrail = MagicMock()
+    mock_guardrail.apply_guardrail = AsyncMock(side_effect=fake_apply_guardrail)
+
+    # Build a minimal dict-style Anthropic response with a text content block
+    response = {
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-3-5-sonnet-20241022",
+        "content": [{"type": "text", "text": f"Hello {pii_token}"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 5, "output_tokens": 10},
+    }
+
+    # Pass caller request_data that includes pii_tokens
+    caller_request_data = {"pii_tokens": pii_tokens, "messages": []}
+
+    await handler.process_output_response(
+        response=response,
+        guardrail_to_apply=mock_guardrail,
+        request_data=caller_request_data,
+    )
+
+    assert "pii_tokens" in received_request_data, (
+        "pii_tokens should be forwarded from caller request_data into apply_guardrail()"
+    )
+    assert received_request_data["pii_tokens"] == pii_tokens
+    # "response" key must also be set (local requirement)
+    assert "response" in received_request_data
+
+
+# ---------------------------------------------------------------------------
+# Test 2: streaming hook handles bytes chunks and unmasks PII (Patch 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_hook_unmasks_anthropic_sse_bytes():
+    """
+    async_post_call_streaming_iterator_hook() should detect Anthropic native SSE
+    bytes chunks, extract text_delta text, unmask pii_tokens, and yield a rebuilt
+    SSE bytes chunk with the original text restored.
+    """
+    guardrail = _make_guardrail(output_parse_pii=True)
+
+    pii_token = "<PERSON>_deadbeef0000"
+    original_name = "Alice Smith"
+    pii_tokens = {pii_token: original_name}
+
+    # Build SSE bytes with the PII token embedded in the text
+    masked_text = f"Hello, {pii_token}! Nice to meet you."
+    sse_bytes = _make_sse_bytes(masked_text)
+
+    # The response async generator yields the bytes chunk
+    async def fake_response():
+        yield sse_bytes
+
+    request_data = {"pii_tokens": pii_tokens}
+
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+
+    chunks = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=user_api_key_dict,
+        response=fake_response(),
+        request_data=request_data,
+    ):
+        chunks.append(chunk)
+
+    assert len(chunks) == 1, f"Expected 1 rebuilt SSE chunk, got {len(chunks)}"
+    result = chunks[0]
+    assert isinstance(result, bytes), "Output should be bytes for Anthropic SSE path"
+
+    # The rebuilt SSE must contain the original name, not the PII token
+    result_text = result.decode()
+    assert original_name in result_text, (
+        f"Expected original name '{original_name}' in rebuilt SSE, got: {result_text}"
+    )
+    assert pii_token not in result_text, (
+        f"PII token '{pii_token}' should be replaced in rebuilt SSE"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: streaming hook pass-through when output_parse_pii is False (Patch 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_hook_passthrough_when_output_parse_pii_disabled():
+    """
+    When output_parse_pii=False, bytes chunks should pass through unmodified.
+    """
+    guardrail = _make_guardrail(output_parse_pii=False)
+
+    pii_token = "<PERSON>_deadbeef0000"
+    pii_tokens = {pii_token: "Alice Smith"}
+    sse_bytes = _make_sse_bytes(f"Hello, {pii_token}!")
+
+    async def fake_response():
+        yield sse_bytes
+
+    request_data = {"pii_tokens": pii_tokens}
+
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+
+    chunks = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=user_api_key_dict,
+        response=fake_response(),
+        request_data=request_data,
+    ):
+        chunks.append(chunk)
+
+    # output_parse_pii=False → no processing, chunks pass through
+    assert chunks == [sse_bytes], (
+        "SSE bytes should pass through unchanged when output_parse_pii is disabled"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: streaming hook with multi-chunk token spanning (Patch 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_hook_unmasks_token_split_across_chunks():
+    """
+    PII token strings can be split across multiple SSE delta events.
+    _unmask_pii_text() is called on the concatenated text so the token is
+    correctly restored even when split.
+    """
+    guardrail = _make_guardrail(output_parse_pii=True)
+
+    pii_token = "<PERSON>_splittoken01"
+    original_name = "Bob Jones"
+    pii_tokens = {pii_token: original_name}
+
+    # Split the token across two SSE chunks
+    half = len(pii_token) // 2
+    first_half = pii_token[:half]
+    second_half = pii_token[half:]
+
+    def _raw_delta(text: str, index: int = 0) -> bytes:
+        payload = {
+            "type": "content_block_delta",
+            "index": index,
+            "delta": {"type": "text_delta", "text": text},
+        }
+        return b"event: content_block_delta\ndata: " + json.dumps(payload).encode() + b"\n"
+
+    chunk1 = _raw_delta(f"Hello, {first_half}") + b"\n\n"
+    chunk2 = _raw_delta(second_half) + b"\n\n"
+
+    async def fake_response():
+        yield chunk1
+        yield chunk2
+
+    request_data = {"pii_tokens": pii_tokens}
+
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+
+    chunks = []
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=user_api_key_dict,
+        response=fake_response(),
+        request_data=request_data,
+    ):
+        chunks.append(chunk)
+
+    assert len(chunks) == 1
+    result_text = chunks[0].decode()
+    assert original_name in result_text, (
+        f"Split token should be reassembled and unmasked. Got: {result_text}"
+    )
+    assert pii_token not in result_text

--- a/tests/guardrails_tests/test_presidio_sse_unmask.py
+++ b/tests/guardrails_tests/test_presidio_sse_unmask.py
@@ -42,9 +42,9 @@ def _make_sse_bytes(text: str, index: int = 0) -> bytes:
     }
     delta_event = (
         b"event: content_block_delta\n"
-        b"data: " + json.dumps(delta_payload).encode() + b"\n"
+        b"data: " + json.dumps(delta_payload).encode()
     )
-    stop_event = b"event: message_stop\ndata: " + json.dumps({"type": "message_stop"}).encode() + b"\n"
+    stop_event = b"event: message_stop\ndata: " + json.dumps({"type": "message_stop"}).encode()
     return delta_event + b"\n\n" + stop_event + b"\n\n"
 
 

--- a/tests/guardrails_tests/test_presidio_sse_unmask.py
+++ b/tests/guardrails_tests/test_presidio_sse_unmask.py
@@ -148,12 +148,14 @@ async def test_streaming_hook_unmasks_anthropic_sse_bytes():
     ):
         chunks.append(chunk)
 
-    assert len(chunks) == 1, f"Expected 1 rebuilt SSE chunk, got {len(chunks)}"
-    result = chunks[0]
-    assert isinstance(result, bytes), "Output should be bytes for Anthropic SSE path"
+    # The hook yields one chunk per SSE event: the merged text_delta event and
+    # the original message_stop event, so 2 chunks total.
+    assert len(chunks) == 2, f"Expected 2 rebuilt SSE chunks, got {len(chunks)}"
+    text_delta_chunk = chunks[0]
+    assert isinstance(text_delta_chunk, bytes), "Output should be bytes for Anthropic SSE path"
 
-    # The rebuilt SSE must contain the original name, not the PII token
-    result_text = result.decode()
+    # The rebuilt text_delta chunk must contain the original name, not the PII token
+    result_text = text_delta_chunk.decode()
     assert original_name in result_text, (
         f"Expected original name '{original_name}' in rebuilt SSE, got: {result_text}"
     )


### PR DESCRIPTION
## Problem

Two related issues prevent PII unmasking from working on the Anthropic native
streaming path:

**1. Wrong chunk type in streaming hook**

`async_post_call_streaming_iterator_hook` assembles chunks with
`stream_chunk_builder()`, which expects `ModelResponseStream` objects. With the
Anthropic native API path, chunks are raw SSE `bytes`. The hook silently
yields them unprocessed — PII tokens in the response text are never restored.

**2. `pii_tokens` discarded in non-streaming output handler**

`AnthropicMessagesHandler.process_output_response()` builds a fresh local
`request_data = {"response": response}`, discarding any `pii_tokens` the
unified guardrail forwarded from the input masking phase (via #22879).

Part of #22821.

## Approach and trade-off

PII unmasking requires the complete response text before tokens can be
restored — token strings may span multiple SSE delta events. This
implementation buffers all chunks, detects the format (`bytes` vs
`ModelResponseStream`), and for Anthropic native SSE:

1. Parses SSE events (split on `\n\n`)
2. Collects all `text_delta` texts
3. Concatenates and runs `_unmask_pii_text()` in one pass
4. Emits non-text events unchanged, followed by a single `content_block_delta`
   containing the fully unmasked text

**Known trade-off:** when `output_parse_pii` is enabled, progressive streaming
output is replaced by a single delivery at response completion. This is
unavoidable for correct PII token restoration.

## Changes

**`presidio.py` — streaming hook (Patch 3)**
- Collect `bytes` chunks alongside `ModelResponseStream` in the accumulation loop
- Add Anthropic native SSE branch: buffer → parse → unmask → rebuild → yield
- Extend the exception fallback to replay buffered bytes chunks

**`anthropic/chat/guardrail_translation/handler.py` (Patches 6a + 6b)**
- Accept `request_data: Optional[dict] = None` in `process_output_response()`
- Merge caller's dict: `request_data = {**(request_data or {}), "response": response}`
  so `pii_tokens` forwarded by the unified guardrail are preserved

## Dependency

Requires #22879 (`fix/guardrail-request-data-passthrough`) for `pii_tokens`
plumbing through the unified guardrail layer.

## Testing

`tests/guardrails_tests/test_presidio_sse_unmask.py` — four tests:
- `process_output_response()` merges caller `request_data` including `pii_tokens`
- Streaming hook unmasks PII in Anthropic native SSE bytes
- Pass-through unchanged when `output_parse_pii=False`
- Tokens split across multiple delta events are correctly reassembled