### PR TITLE
fix(test): add 'realtime' to model mode enum in schema validation

### DIFF
--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -677,6 +677,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                         "video_generation",
                         "moderation",
                         "rerank",
+                        "realtime",
                         "responses",
                         "ocr",
                         "search",


### PR DESCRIPTION
## Summary

`test_aaamodel_prices_and_context_window_json_is_valid` was failing because `gemini/gemini-live-2.5-flash-preview-native-audio-09-2025` has `mode: 'realtime'` in `model_prices_and_context_window.json`, but the JSON schema in the test did not include `'realtime'` as a valid enum value.

**Not related to PR #22822** (PLR0915 lint fixes) — this is a pre-existing schema gap.

## Test plan

- [ ] `test_aaamodel_prices_and_context_window_json_is_valid` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)