### PR TITLE
fix(schema): remove duplicate spec_path field in LiteLLM_MCPServerTable

### DIFF
--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -305,7 +305,6 @@ model LiteLLM_MCPServerTable {
   registration_url   String?
   allow_all_keys Boolean @default(false)
   available_on_public_internet Boolean @default(true)
-  spec_path             String?
   is_byok               Boolean  @default(false)
   byok_description      String[] @default([])
   byok_api_key_help_url String?


### PR DESCRIPTION
## Summary

- Removes the duplicate `spec_path String?` field declaration from `LiteLLM_MCPServerTable` in `schema.prisma`

## Root Cause

PR #22850 (BYOK MCP servers with OAuth 2.1 PKCE) added `spec_path` near the BYOK-related fields at line 308, but this field was already declared at line 280 by PR #22820. This caused Prisma to fail with:

```
Error code: P1012
error: Field "spec_path" is already defined on model "LiteLLM_MCPServerTable".
```

## Test plan

- [ ] `prisma validate` passes on the updated schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)