### PR TITLE
feat(cost): add azure_ai/mistral-document-ai-2512 to model cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5817,6 +5817,15 @@
         ],
         "source": "https://devblogs.microsoft.com/foundry/whats-new-in-azure-ai-foundry-august-2025/#mistral-document-ai-(ocr)-%E2%80%94-serverless-in-foundry"
     },
+    "azure_ai/mistral-document-ai-2512": {
+        "litellm_provider": "azure_ai",
+        "ocr_cost_per_page": 0.003,
+        "mode": "ocr",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/"
+    },
     "azure_ai/doc-intelligence/prebuilt-read": {
         "litellm_provider": "azure_ai",
         "ocr_cost_per_page": 0.0015,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5817,6 +5817,15 @@
         ],
         "source": "https://devblogs.microsoft.com/foundry/whats-new-in-azure-ai-foundry-august-2025/#mistral-document-ai-(ocr)-%E2%80%94-serverless-in-foundry"
     },
+    "azure_ai/mistral-document-ai-2512": {
+        "litellm_provider": "azure_ai",
+        "ocr_cost_per_page": 0.003,
+        "mode": "ocr",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/"
+    },
     "azure_ai/doc-intelligence/prebuilt-read": {
         "litellm_provider": "azure_ai",
         "ocr_cost_per_page": 0.0015,


### PR DESCRIPTION
Adds `azure_ai/mistral-document-ai-2512` (Mistral Document AI OCR - Global Standard) to the model cost map.

- **Pricing:** $3 per 1K pages ($0.003 per page)
- **Deployment:** Global Standard
- **Availability:** Public Preview (Sweden Central, US East2)

Made with [Cursor](https://cursor.com)