### PR TITLE
fix(azure): prevent vector_store_ids leak into extra_body passthrough

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4661,6 +4661,10 @@ def add_provider_specific_params_to_optional_params(
         in ["openai", "azure", "text-completion-openai"]
         + litellm.openai_compatible_providers
     ):
+        litellm_internal_passthrough_blocklist = {
+            "vector_store_id",
+            "vector_store_ids",
+        }
         # for openai, azure we should pass the extra/passed params within `extra_body` https://github.com/openai/openai-python/blob/ac33853ba10d13ac149b1fa3ca6dba7d613065c9/src/openai/resources/models.py#L46
         if (
             _should_drop_param(
@@ -4670,7 +4674,11 @@ def add_provider_specific_params_to_optional_params(
         ):
             extra_body = passed_params.pop("extra_body", None) or {}
             for k in passed_params.keys():
-                if k not in openai_params and passed_params[k] is not None:
+                if (
+                    k not in openai_params
+                    and k not in litellm_internal_passthrough_blocklist
+                    and passed_params[k] is not None
+                ):
                     extra_body[k] = passed_params[k]
             if not isinstance(optional_params.get("extra_body"), dict):
                 optional_params["extra_body"] = {}

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3422,6 +3422,43 @@ class TestAdditionalDropParamsForNonOpenAIProviders:
         assert result.get("prompt_cache_key") == "test_key"
         assert result.get("custom_param") == "value"
 
+    def test_openai_compatible_params_do_not_forward_vector_store_ids(self):
+        from litellm.utils import add_provider_specific_params_to_optional_params
+
+        optional_params = {}
+        passed_params = {
+            "temperature": 0.3,
+            "vector_store_ids": ["vs_123"],
+            "vector_store_id": "vs_legacy",
+            "custom_param": "keep_me",
+        }
+
+        result = add_provider_specific_params_to_optional_params(
+            optional_params=optional_params,
+            passed_params=passed_params,
+            custom_llm_provider="azure",
+            openai_params=["temperature", "model"],
+            additional_drop_params=None,
+        )
+
+        assert "extra_body" in result
+        assert result["extra_body"].get("custom_param") == "keep_me"
+        assert "vector_store_ids" not in result["extra_body"]
+        assert "vector_store_id" not in result["extra_body"]
+
+    def test_get_optional_params_azure_gpt5_drops_vector_store_ids_from_extra_body(self):
+        from litellm.utils import get_optional_params
+
+        optional_params = get_optional_params(
+            model="gpt-5.2",
+            custom_llm_provider="azure",
+            temperature=1,
+            vector_store_ids=["vs_123"],
+        )
+
+        assert "extra_body" in optional_params
+        assert "vector_store_ids" not in optional_params["extra_body"]
+
 
 class TestDropParamsWithPromptCacheKey:
     """


### PR DESCRIPTION
## Summary
- prevent LiteLLM internal `vector_store_id(s)` params from being forwarded into `extra_body` for openai/azure/openai-compatible providers
- keep non-internal unknown params pass-through behavior unchanged
- add regression tests for Azure GPT-5.2 optional param construction path

## Why
Azure GPT-5.2 chat rejects `vector_store_ids` as unknown top-level input when it leaks via `extra_body` passthrough.

Fixes #22898.

## Test
- `poetry run pytest tests/test_litellm/test_utils.py -k "vector_store_ids or get_optional_params_azure_gpt5" -vv`
- `poetry run pytest tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py -vv`