### PR TITLE
fix(lint): fix 6 ruff errors breaking CI on main

### DIFF
--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -163,7 +163,7 @@ async def _send_message_via_completion_bridge(
 
 
 @client
-async def asend_message(
+async def asend_message(  # noqa: PLR0915
     a2a_client: Optional["A2AClientType"] = None,
     request: Optional["SendMessageRequest"] = None,
     api_base: Optional[str] = None,

--- a/litellm/fine_tuning/main.py
+++ b/litellm/fine_tuning/main.py
@@ -127,7 +127,7 @@ async def acreate_fine_tuning_job(
 
 
 @client
-def create_fine_tuning_job(
+def create_fine_tuning_job(  # noqa: PLR0915
     model: str,
     training_file: str,
     hyperparameters: Optional[dict] = {},

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1644,7 +1644,7 @@ if MCP_AVAILABLE:
                 },
             )
 
-    async def execute_mcp_tool(
+    async def execute_mcp_tool(  # noqa: PLR0915
         name: str,
         arguments: Dict[str, Any],
         allowed_mcp_servers: List[MCPServer],

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
@@ -335,7 +335,7 @@ class GenericGuardrailAPI(CustomGuardrail):
         return return_inputs
 
     @log_guardrail_information
-    async def apply_guardrail(
+    async def apply_guardrail(  # noqa: PLR0915
         self,
         inputs: GenericGuardrailAPIInputs,
         request_data: dict,

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -81,7 +81,6 @@ if MCP_AVAILABLE:
         delete_user_credential,
         get_all_mcp_servers_for_user,
         get_mcp_server,
-        get_user_credential,
         store_user_credential,
         update_mcp_server,
     )

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -391,7 +391,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
     def __aiter__(self):
         return self
 
-    async def __anext__(self) -> ResponsesAPIStreamingResponse:
+    async def __anext__(self) -> ResponsesAPIStreamingResponse:  # noqa: PLR0915
         """
         Phase-based streaming:
         1. initial_response - Stream the first LLM response (includes response.created, response.in_progress, response.output_item.added)


### PR DESCRIPTION
## Summary

The `LiteLLM Linting` CI workflow has been failing on `main` due to 6 ruff errors. This PR fixes all of them:

- **F401**: Remove unused import `get_user_credential` in `mcp_management_endpoints.py`
- **PLR0915**: Suppress "too many statements" on 5 complex functions that are not practical to split without behavior changes:
  - `a2a_protocol/main.py::asend_message`
  - `fine_tuning/main.py::create_fine_tuning_job`
  - `proxy/_experimental/mcp_server/server.py::execute_mcp_tool`
  - `proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py::apply_guardrail`
  - `responses/mcp/mcp_streaming_iterator.py::__anext__`

## Pre-Submission checklist

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix (CI)

## Test plan

- `cd litellm && ruff check .` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)