### PR TITLE
fix(cost_calc): update custom_llm_provider when base_model has different provider prefix

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -38,7 +38,6 @@ from litellm.types.llms.openai import (
     ResponsesAPIStreamEvents,
 )
 from litellm.types.utils import GenericStreamingChunk, ModelResponseStream
-from litellm.utils import supports_reasoning
 
 if TYPE_CHECKING:
     from openai.types.responses import ResponseInputImageParam
@@ -323,10 +322,8 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         if instructions:
             responses_api_request["instructions"] = instructions
 
-        custom_llm_provider = litellm_params.get("custom_llm_provider")
         self._map_optional_params_to_responses_api_request(
-            optional_params, responses_api_request,
-            model=model, custom_llm_provider=custom_llm_provider,
+            optional_params, responses_api_request
         )
 
         stream = optional_params.get("stream") or litellm_params.get("stream", False)

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -38,6 +38,7 @@ from litellm.types.llms.openai import (
     ResponsesAPIStreamEvents,
 )
 from litellm.types.utils import GenericStreamingChunk, ModelResponseStream
+from litellm.utils import supports_reasoning
 
 if TYPE_CHECKING:
     from openai.types.responses import ResponseInputImageParam
@@ -322,8 +323,10 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         if instructions:
             responses_api_request["instructions"] = instructions
 
+        custom_llm_provider = litellm_params.get("custom_llm_provider")
         self._map_optional_params_to_responses_api_request(
-            optional_params, responses_api_request
+            optional_params, responses_api_request,
+            model=model, custom_llm_provider=custom_llm_provider,
         )
 
         stream = optional_params.get("stream") or litellm_params.get("stream", False)

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1093,6 +1093,14 @@ def completion_cost(  # noqa: PLR0915
             router_model_id=router_model_id,
         )
 
+        # When base_model overrides model and carries its own provider prefix
+        # (e.g. base_model="gemini/gemini-2.0-flash" on an anthropic deployment),
+        # align custom_llm_provider so cost_per_token builds the correct key.
+        if base_model is not None and selected_model is not None:
+            _parts = selected_model.split("/", 1)
+            if len(_parts) > 1 and _parts[0] in LlmProvidersSet:
+                custom_llm_provider = _parts[0]
+
         potential_model_names = [
             selected_model,
             _get_response_model(completion_response),

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1096,10 +1096,13 @@ def completion_cost(  # noqa: PLR0915
         # When base_model overrides model and carries its own provider prefix
         # (e.g. base_model="gemini/gemini-2.0-flash" on an anthropic deployment),
         # align custom_llm_provider so cost_per_token builds the correct key.
-        if base_model is not None and selected_model is not None:
+        # Skip when custom_pricing is True (base_model is ignored in that path).
+        if base_model is not None and selected_model is not None and not custom_pricing:
             _parts = selected_model.split("/", 1)
             if len(_parts) > 1 and _parts[0] in LlmProvidersSet:
-                custom_llm_provider = _parts[0]
+                extracted = _parts[0]
+                if extracted != custom_llm_provider:
+                    custom_llm_provider = extracted
 
         potential_model_names = [
             selected_model,

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1097,12 +1097,14 @@ def completion_cost(  # noqa: PLR0915
         # (e.g. base_model="gemini/gemini-2.0-flash" on an anthropic deployment),
         # align custom_llm_provider so cost_per_token builds the correct key.
         # Skip when custom_pricing is True (base_model is ignored in that path).
+        _provider_overridden = False
         if base_model is not None and selected_model is not None and not custom_pricing:
             _parts = selected_model.split("/", 1)
             if len(_parts) > 1 and _parts[0] in LlmProvidersSet:
                 extracted = _parts[0]
                 if extracted != custom_llm_provider:
                     custom_llm_provider = extracted
+                    _provider_overridden = True
 
         potential_model_names = [
             selected_model,
@@ -1185,9 +1187,10 @@ def completion_cost(  # noqa: PLR0915
 
                     hidden_params = getattr(completion_response, "_hidden_params", None)
                     if hidden_params is not None:
-                        custom_llm_provider = hidden_params.get(
-                            "custom_llm_provider", custom_llm_provider or None
-                        )
+                        if not _provider_overridden:
+                            custom_llm_provider = hidden_params.get(
+                                "custom_llm_provider", custom_llm_provider or None
+                            )
                         region_name = hidden_params.get("region_name", region_name)
 
                         # For Gemini/Vertex AI responses, trafficType is stored in

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -2945,3 +2945,18 @@ def test_batch_cost_calculator():
 
     cost = completion_cost(**args)
     assert cost > 0
+
+
+def test_cost_calculator_base_model_cross_provider():
+    """
+    When base_model has a different provider prefix than the deployment,
+    custom_llm_provider should be updated so cost_per_token builds the
+    correct model key.  Regression test for #22257.
+    """
+    resp = litellm.completion(
+        model="anthropic/my-custom-deployment",
+        messages=[{"role": "user", "content": "Hello"}],
+        base_model="gemini/gemini-2.0-flash",
+        mock_response="Hi there!",
+    )
+    assert resp._hidden_params["response_cost"] > 0

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -2960,3 +2960,38 @@ def test_cost_calculator_base_model_cross_provider():
         mock_response="Hi there!",
     )
     assert resp._hidden_params["response_cost"] > 0
+
+
+def test_cost_calculator_base_model_cross_provider_direct():
+    """
+    Direct completion_cost unit test for cross-provider base_model override.
+    Verifies that completion_cost correctly routes to the base_model provider.
+    """
+    from litellm import ModelResponse, Usage
+
+    resp = ModelResponse(
+        id="chatcmpl-test",
+        model="gemini/gemini-2.0-flash",
+        usage=Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+    )
+    cost = completion_cost(
+        model="anthropic/my-custom-deployment",
+        completion_response=resp,
+        base_model="gemini/gemini-2.0-flash",
+        custom_llm_provider="anthropic",
+    )
+    assert cost > 0
+
+
+def test_cost_calculator_base_model_same_provider_no_regression():
+    """
+    When base_model has the same provider prefix as the deployment,
+    custom_llm_provider should remain unchanged (no-regression).
+    """
+    resp = litellm.completion(
+        model="openai/my-custom-deployment",
+        messages=[{"role": "user", "content": "Hello"}],
+        base_model="openai/gpt-4o",
+        mock_response="Hi there!",
+    )
+    assert resp._hidden_params["response_cost"] > 0

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -2983,6 +2983,30 @@ def test_cost_calculator_base_model_cross_provider_direct():
     assert cost > 0
 
 
+def test_cost_calculator_base_model_cross_provider_hidden_params_guard():
+    """
+    Verify that hidden_params.custom_llm_provider does not undo the
+    base_model provider override when the response carries a stale provider.
+    """
+    from litellm import ModelResponse, Usage
+
+    resp = ModelResponse(
+        id="chatcmpl-guard",
+        model="gemini/gemini-2.0-flash",
+        usage=Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+    )
+    # Simulate hidden_params carrying the original (wrong) provider
+    resp._hidden_params = {"custom_llm_provider": "anthropic"}
+
+    cost = completion_cost(
+        model="anthropic/my-custom-deployment",
+        completion_response=resp,
+        base_model="gemini/gemini-2.0-flash",
+        custom_llm_provider="anthropic",
+    )
+    assert cost > 0
+
+
 def test_cost_calculator_base_model_same_provider_no_regression():
     """
     When base_model has the same provider prefix as the deployment,


### PR DESCRIPTION
## Summary

Fixes #22257

When `base_model` carries a provider prefix that differs from the deployment provider (e.g. `base_model="gemini/gemini-2.0-flash"` on an `anthropic/` deployment), the `custom_llm_provider` was not updated after `_select_model_name_for_cost_calc()` resolved the model name from `base_model`. This caused `cost_per_token()` to build an invalid model key like `anthropic/gemini/gemini-2.0-flash`, which would never be found in `model_cost`, resulting in a cost of 0.

## Fix

After `_select_model_name_for_cost_calc()` returns in `completion_cost()`, if `base_model` was provided and the selected model contains a known provider prefix, extract it and update `custom_llm_provider` so the downstream cost lookup uses the correct provider.

**Changed file:** `litellm/cost_calculator.py`

## Test

Added `test_cost_calculator_base_model_cross_provider` which uses `base_model="gemini/gemini-2.0-flash"` on an `anthropic/` deployment and asserts `response_cost > 0`.