### PR TITLE
fix(github_copilot): check only last message for initiator determination

### DIFF
--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -126,11 +126,11 @@ class GithubCopilotConfig(OpenAIConfig):
 
     def _determine_initiator(self, messages: List[AllMessageValues]) -> str:
         """
-        Determine if request is user or agent initiated based on message roles.
-        Returns 'agent' if any message has role 'tool' or 'assistant', otherwise 'user'.
+        Determine if request is user or agent initiated based on the last message role.
+        Returns 'agent' if the last message has role 'tool' or 'assistant', otherwise 'user'.
         """
-        for message in messages:
-            role = message.get("role")
+        if messages:
+            role = messages[-1].get("role")
             if role in ["tool", "assistant"]:
                 return "agent"
         return "user"

--- a/litellm/llms/github_copilot/responses/transformation.py
+++ b/litellm/llms/github_copilot/responses/transformation.py
@@ -239,10 +239,10 @@ class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):
 
     def _get_initiator(self, input_param: Union[str, ResponseInputParam]) -> str:
         """
-        Determine X-Initiator header value based on input analysis.
+        Determine X-Initiator header value based on the last input item.
 
         Based on copilot-api's hasAgentInitiator logic:
-        - Returns "agent" if input contains assistant role or items without role
+        - Returns "agent" if the last input item has assistant role or no role
         - Returns "user" otherwise
 
         Args:
@@ -255,12 +255,10 @@ class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):
         if isinstance(input_param, str):
             return "user"
 
-        # If input is a list, analyze items
-        if isinstance(input_param, list):
-            for item in input_param:
-                if not isinstance(item, dict):
-                    continue
-
+        # If input is a list, check only the last item
+        if isinstance(input_param, list) and input_param:
+            item = input_param[-1]
+            if isinstance(item, dict):
                 # Check if item has no role (agent-initiated)
                 if "role" not in item or not item.get("role"):
                     return "agent"

--- a/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
@@ -165,6 +165,19 @@ class TestGithubCopilotResponsesAPITransformation:
         initiator = config._get_initiator("Hello, how are you?")
         assert initiator == "user", "Should return 'user' for string input"
 
+    def test_get_initiator_multi_turn_last_message_user(self):
+        """Test _get_initiator checks only last item — multi-turn ending with user should be 'user'.
+        Regression test for #18155: previously iterated all items causing overcounting."""
+        config = GithubCopilotResponsesAPIConfig()
+
+        input_multi_turn = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+            {"role": "user", "content": "Follow-up question"},
+        ]
+        initiator = config._get_initiator(input_multi_turn)
+        assert initiator == "user", "Multi-turn ending with user should return 'user'"
+
     def test_has_vision_input_with_input_image(self):
         """Test _has_vision_input detects input_image type"""
         config = GithubCopilotResponsesAPIConfig()

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -509,3 +509,38 @@ def test_copilot_vision_request_header_with_type_image_url():
     
     assert headers["Copilot-Vision-Request"] == "true"
     assert headers["X-Initiator"] == "user"
+
+
+class TestDetermineInitiator:
+    """Tests for _determine_initiator — should check only the last message."""
+
+    def test_single_user_message(self):
+        config = GithubCopilotConfig()
+        assert config._determine_initiator([{"role": "user", "content": "Hi"}]) == "user"
+
+    def test_single_assistant_message(self):
+        config = GithubCopilotConfig()
+        assert config._determine_initiator([{"role": "assistant", "content": "Hi"}]) == "agent"
+
+    def test_multi_turn_ending_with_user(self):
+        """Regression test for #18155: multi-turn ending with user should be 'user'."""
+        config = GithubCopilotConfig()
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+            {"role": "user", "content": "Follow-up"},
+        ]
+        assert config._determine_initiator(messages) == "user"
+
+    def test_multi_turn_ending_with_tool(self):
+        config = GithubCopilotConfig()
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Let me check"},
+            {"role": "tool", "content": "result"},
+        ]
+        assert config._determine_initiator(messages) == "agent"
+
+    def test_empty_messages(self):
+        config = GithubCopilotConfig()
+        assert config._determine_initiator([]) == "user"


### PR DESCRIPTION
## Summary

Fixes #18155

`_determine_initiator()` in `chat/transformation.py` and `_get_initiator()` in `responses/transformation.py` previously iterated **all** messages/items and returned `"agent"` if **any** had role `assistant` or `tool`. In multi-turn conversations, this always marked requests as agent-initiated, causing premium request overcounting.

## Fix

Changed both methods to check **only the last message/item**, which correctly reflects whether the current turn is user- or agent-initiated.

**Changed files:**
- `litellm/llms/github_copilot/chat/transformation.py` — `_determine_initiator()`
- `litellm/llms/github_copilot/responses/transformation.py` — `_get_initiator()`

## Tests

- Added `TestDetermineInitiator` class with 5 tests (chat)
- Added `test_get_initiator_multi_turn_last_message_user` (responses)
- All existing initiator tests continue to pass