### PR TITLE
fix(ui): parse YAML and update state in blocklist file upload handler

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -21119,7 +21119,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21127,9 +21127,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",
@@ -21168,7 +21167,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21176,9 +21175,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21119,7 +21119,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21127,9 +21127,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",
@@ -21168,7 +21167,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21176,9 +21175,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -609,6 +609,24 @@ def test_responses_api_bridge_check_strips_responses_prefix():
         assert model_info["mode"] == "responses"
 
 
+def test_responses_api_bridge_check_gpt_5_4_pro():
+    """Test that gpt-5.4-pro routes through responses API bridge, not chat completions.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/23014
+    gpt-5.4-pro is a responses-only model and must not be sent to /v1/chat/completions.
+    """
+    from litellm.main import responses_api_bridge_check
+
+    for model_name in ["gpt-5.4-pro", "gpt-5.4-pro-2026-03-05"]:
+        model_info, model = responses_api_bridge_check(
+            model=model_name,
+            custom_llm_provider="openai",
+        )
+        assert model_info.get("mode") == "responses", (
+            f"{model_name} should have mode='responses', got '{model_info.get('mode')}'"
+        )
+
+
 def test_responses_api_bridge_check_handles_exception():
     """Test that responses_api_bridge_check handles exceptions and still processes responses/ models."""
     from litellm.main import responses_api_bridge_check

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -57,6 +57,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/babel__traverse": "^7.28.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/lodash": "^4.17.15",
     "@types/node": "^20",
     "@types/react": "18.2.48",

--- a/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.test.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.test.tsx
@@ -28,6 +28,7 @@ vi.mock("./ContentFilterConfiguration", () => ({
     onPatternRemove,
     onBlockedWordAdd,
     onBlockedWordRemove,
+    onFileUpload,
     selectedPatterns,
     blockedWords,
   }: {
@@ -35,10 +36,13 @@ vi.mock("./ContentFilterConfiguration", () => ({
     onPatternRemove: (id: string) => void;
     onBlockedWordAdd: (w: object) => void;
     onBlockedWordRemove: (id: string) => void;
+    onFileUpload?: (content: string) => void;
     selectedPatterns: { id: string }[];
     blockedWords: { id: string }[];
   }) => (
     <div data-testid="content-filter-config">
+      <span data-testid="blocked-word-count">{blockedWords.length}</span>
+      <span data-testid="blocked-word-keywords">{blockedWords.map((w: any) => w.keyword).join(",")}</span>
       <button
         type="button"
         onClick={() =>
@@ -64,6 +68,18 @@ vi.mock("./ContentFilterConfiguration", () => ({
       >
         Add keyword
       </button>
+      {onFileUpload && (
+        <button
+          type="button"
+          onClick={() =>
+            onFileUpload(
+              "blocked_words:\n  - keyword: \"uploaded\"\n    action: \"BLOCK\"\n  - keyword: \"bad\"\n    action: \"MASK\"\n    description: \"bad word\""
+            )
+          }
+        >
+          Upload file
+        </button>
+      )}
       {selectedPatterns[0] && (
         <button
           type="button"
@@ -504,5 +520,37 @@ describe("formatContentFilterDataForAPI", () => {
         severity_threshold: "medium",
       },
     ]);
+  });
+});
+
+describe("ContentFilterManager YAML file upload", () => {
+  it("should parse uploaded YAML and merge blocked words into state", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+
+    render(
+      <ContentFilterManager
+        guardrailData={CONTENT_FILTER_GUARDRAIL_DATA}
+        guardrailSettings={GUARDRAIL_SETTINGS}
+        onSave={onSave}
+        accessToken="test-token"
+        isEditing={true}
+      />
+    );
+
+    // Verify initial state: 1 blocked word ("test") from guardrailData
+    expect(screen.getByTestId("blocked-word-count").textContent).toBe("1");
+
+    // Click "Upload file" button from mock which triggers onFileUpload with YAML
+    const uploadBtn = await screen.findByText("Upload file");
+    await user.click(uploadBtn);
+
+    // After upload, should have 3 blocked words (1 original + 2 uploaded)
+    await waitFor(() => {
+      expect(screen.getByTestId("blocked-word-count").textContent).toBe("3");
+      const keywords = screen.getByTestId("blocked-word-keywords").textContent;
+      expect(keywords).toContain("uploaded");
+      expect(keywords).toContain("bad");
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.test.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.test.tsx
@@ -22,6 +22,9 @@ const GUARDRAIL_SETTINGS = {
   },
 };
 
+// Store callbacks to allow tests to trigger them
+let capturedOnFileUpload: ((content: string) => void) | undefined;
+
 vi.mock("./ContentFilterConfiguration", () => ({
   default: ({
     onPatternAdd,
@@ -39,65 +42,70 @@ vi.mock("./ContentFilterConfiguration", () => ({
     onFileUpload?: (content: string) => void;
     selectedPatterns: { id: string }[];
     blockedWords: { id: string }[];
-  }) => (
-    <div data-testid="content-filter-config">
-      <span data-testid="blocked-word-count">{blockedWords.length}</span>
-      <span data-testid="blocked-word-keywords">{blockedWords.map((w: any) => w.keyword).join(",")}</span>
-      <button
-        type="button"
-        onClick={() =>
-          onPatternAdd({
-            id: "pattern-new",
-            type: "prebuilt",
-            name: "ssn",
-            action: "BLOCK",
-          })
-        }
-      >
-        Add pattern
-      </button>
-      <button
-        type="button"
-        onClick={() =>
-          onBlockedWordAdd({
-            id: "word-new",
-            keyword: "secret",
-            action: "MASK",
-          })
-        }
-      >
-        Add keyword
-      </button>
-      {onFileUpload && (
+  }) => {
+    // Capture the callback for testing
+    capturedOnFileUpload = onFileUpload;
+    
+    return (
+      <div data-testid="content-filter-config">
+        <span data-testid="blocked-word-count">{blockedWords.length}</span>
+        <span data-testid="blocked-word-keywords">{blockedWords.map((w: any) => w.keyword).join(",")}</span>
         <button
           type="button"
           onClick={() =>
-            onFileUpload(
-              "blocked_words:\n  - keyword: \"uploaded\"\n    action: \"BLOCK\"\n  - keyword: \"bad\"\n    action: \"MASK\"\n    description: \"bad word\""
-            )
+            onPatternAdd({
+              id: "pattern-new",
+              type: "prebuilt",
+              name: "ssn",
+              action: "BLOCK",
+            })
           }
         >
-          Upload file
+          Add pattern
         </button>
-      )}
-      {selectedPatterns[0] && (
         <button
           type="button"
-          onClick={() => onPatternRemove(selectedPatterns[0].id)}
+          onClick={() =>
+            onBlockedWordAdd({
+              id: "word-new",
+              keyword: "secret",
+              action: "MASK",
+            })
+          }
         >
-          Remove pattern
+          Add keyword
         </button>
-      )}
-      {blockedWords[0] && (
-        <button
-          type="button"
-          onClick={() => onBlockedWordRemove(blockedWords[0].id)}
-        >
-          Remove keyword
-        </button>
-      )}
-    </div>
-  ),
+        {onFileUpload && (
+          <button
+            type="button"
+            onClick={() =>
+              onFileUpload(
+                "blocked_words:\n  - keyword: \"uploaded\"\n    action: \"BLOCK\"\n  - keyword: \"bad\"\n    action: \"MASK\"\n    description: \"bad word\""
+              )
+            }
+          >
+            Upload file
+          </button>
+        )}
+        {selectedPatterns[0] && (
+          <button
+            type="button"
+            onClick={() => onPatternRemove(selectedPatterns[0].id)}
+          >
+            Remove pattern
+          </button>
+        )}
+        {blockedWords[0] && (
+          <button
+            type="button"
+            onClick={() => onBlockedWordRemove(blockedWords[0].id)}
+          >
+            Remove keyword
+          </button>
+        )}
+      </div>
+    );
+  },
 }));
 
 vi.mock("./ContentFilterDisplay", () => ({
@@ -524,6 +532,10 @@ describe("formatContentFilterDataForAPI", () => {
 });
 
 describe("ContentFilterManager YAML file upload", () => {
+  afterEach(() => {
+    capturedOnFileUpload = undefined;
+  });
+
   it("should parse uploaded YAML and merge blocked words into state", async () => {
     const user = userEvent.setup();
     render(
@@ -549,5 +561,71 @@ describe("ContentFilterManager YAML file upload", () => {
       expect(keywords).toContain("uploaded");
       expect(keywords).toContain("bad");
     });
+  });
+
+  it("should handle invalid YAML gracefully with error message in catch block", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    
+    render(
+      <ContentFilterManager
+        guardrailData={CONTENT_FILTER_GUARDRAIL_DATA}
+        guardrailSettings={GUARDRAIL_SETTINGS}
+        accessToken="test-token"
+        isEditing={true}
+      />
+    );
+
+    // Verify initial state
+    await waitFor(() => {
+      expect(screen.getByTestId("blocked-word-count").textContent).toBe("1");
+    });
+
+    // Call the captured callback with invalid YAML (triggers catch block)
+    expect(capturedOnFileUpload).toBeDefined();
+    if (capturedOnFileUpload) {
+      // This should trigger the catch block in onFileUpload (ContentFilterManager.tsx:284-287)
+      capturedOnFileUpload("{ invalid yaml: [unclosed");
+    }
+
+    // Verify error was logged
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Failed to parse YAML:",
+        expect.any(Error)
+      );
+    });
+
+    // State should remain unchanged (1 blocked word)
+    expect(screen.getByTestId("blocked-word-count").textContent).toBe("1");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should silently ignore valid YAML without blocked_words key", async () => {
+    render(
+      <ContentFilterManager
+        guardrailData={CONTENT_FILTER_GUARDRAIL_DATA}
+        guardrailSettings={GUARDRAIL_SETTINGS}
+        accessToken="test-token"
+        isEditing={true}
+      />
+    );
+
+    // Verify initial state: 1 blocked word from guardrailData
+    await waitFor(() => {
+      expect(screen.getByTestId("blocked-word-count").textContent).toBe("1");
+    });
+
+    // Call the captured callback with YAML that has no blocked_words key
+    // This tests the missing key case (ContentFilterManager.tsx:271)
+    expect(capturedOnFileUpload).toBeDefined();
+    if (capturedOnFileUpload) {
+      // Valid YAML but no blocked_words key - should be silently ignored
+      capturedOnFileUpload("patterns:\n  - name: email\n  - name: ssn");
+    }
+
+    // State should remain unchanged (still 1 blocked word)
+    expect(screen.getByTestId("blocked-word-count").textContent).toBe("1");
+    expect(screen.getByTestId("blocked-word-keywords").textContent).toBe("test");
   });
 });

--- a/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.test.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.test.tsx
@@ -535,6 +535,10 @@ describe("formatContentFilterDataForAPI", () => {
 });
 
 describe("ContentFilterManager YAML file upload", () => {
+  beforeEach(() => {
+    mockMessageError.mockReset();
+  });
+
   afterEach(() => {
     capturedOnFileUpload = undefined;
   });

--- a/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.test.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.test.tsx
@@ -526,13 +526,10 @@ describe("formatContentFilterDataForAPI", () => {
 describe("ContentFilterManager YAML file upload", () => {
   it("should parse uploaded YAML and merge blocked words into state", async () => {
     const user = userEvent.setup();
-    const onSave = vi.fn();
-
     render(
       <ContentFilterManager
         guardrailData={CONTENT_FILTER_GUARDRAIL_DATA}
         guardrailSettings={GUARDRAIL_SETTINGS}
-        onSave={onSave}
         accessToken="test-token"
         isEditing={true}
       />

--- a/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.test.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.test.tsx
@@ -123,10 +123,13 @@ vi.mock("./ContentFilterDisplay", () => ({
   ),
 }));
 
+const mockMessageError = vi.fn();
+
 vi.mock("antd", async (importOriginal) => {
   const actual = await importOriginal<typeof import("antd")>();
   return {
     ...actual,
+    message: { error: mockMessageError, success: vi.fn(), warning: vi.fn(), info: vi.fn() },
     Divider: ({ children }: { children: React.ReactNode }) => (
       <div data-testid="divider">{children}</div>
     ),
@@ -594,6 +597,11 @@ describe("ContentFilterManager YAML file upload", () => {
         expect.any(Error)
       );
     });
+
+    // Verify user-facing error notification was shown
+    expect(mockMessageError).toHaveBeenCalledWith(
+      "Failed to parse uploaded YAML. Please check the file format."
+    );
 
     // State should remain unchanged (1 blocked word)
     expect(screen.getByTestId("blocked-word-count").textContent).toBe("1");

--- a/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.tsx
@@ -271,13 +271,14 @@ const ContentFilterManager: React.FC<ContentFilterManagerProps> = ({
                 if (parsed && Array.isArray(parsed.blocked_words)) {
                   const newWords: BlockedWord[] = parsed.blocked_words.map(
                     (w: any, index: number) => ({
-                      id: `uploaded-${Date.now()}-${index}`,
+                      id: `uploaded-${typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : Date.now() + "-" + Math.random().toString(36).slice(2)}-${index}`,
                       keyword: w.keyword || "",
                       action: w.action || "BLOCK",
                       description: w.description || undefined,
                     })
                   );
-                  setBlockedWords((prev) => [...prev, ...newWords]);
+                  const validWords = newWords.filter((w) => w.keyword?.trim());
+                  setBlockedWords((prev) => [...prev, ...validWords]);
                 }
               } catch (e) {
                 console.error("Failed to parse YAML:", e);

--- a/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.tsx
@@ -269,11 +269,12 @@ const ContentFilterManager: React.FC<ContentFilterManagerProps> = ({
               try {
                 const parsed = yaml.load(content) as Record<string, any>;
                 if (parsed && Array.isArray(parsed.blocked_words)) {
+                  const VALID_ACTIONS = new Set(["BLOCK", "MASK"]);
                   const newWords: BlockedWord[] = parsed.blocked_words.map(
                     (w: any, index: number) => ({
                       id: `uploaded-${typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : Date.now() + "-" + Math.random().toString(36).slice(2)}-${index}`,
                       keyword: w.keyword || "",
-                      action: w.action || "BLOCK",
+                      action: VALID_ACTIONS.has(w.action) ? w.action : "BLOCK",
                       description: w.description || undefined,
                     })
                   );

--- a/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.tsx
@@ -1,5 +1,6 @@
 import { Alert, Divider, Typography } from "antd";
 import React, { useEffect, useState } from "react";
+import yaml from "js-yaml";
 import ContentFilterConfiguration from "./ContentFilterConfiguration";
 import ContentFilterDisplay from "./ContentFilterDisplay";
 import type { CompetitorIntentConfig } from "./CompetitorIntentConfiguration";
@@ -265,7 +266,22 @@ const ContentFilterManager: React.FC<ContentFilterManagerProps> = ({
               setBlockedWords(blockedWords.map((w) => (w.id === id ? { ...w, [field]: value } : w)))
             }
             onFileUpload={(content: string) => {
-              console.log("File uploaded:", content);
+              try {
+                const parsed = yaml.load(content) as Record<string, any>;
+                if (parsed && Array.isArray(parsed.blocked_words)) {
+                  const newWords: BlockedWord[] = parsed.blocked_words.map(
+                    (w: any, index: number) => ({
+                      id: `uploaded-${Date.now()}-${index}`,
+                      keyword: w.keyword || "",
+                      action: w.action || "BLOCK",
+                      description: w.description || undefined,
+                    })
+                  );
+                  setBlockedWords([...blockedWords, ...newWords]);
+                }
+              } catch (e) {
+                console.error("Failed to parse YAML:", e);
+              }
             }}
             accessToken={accessToken}
             contentCategories={guardrailSettings.content_filter_settings.content_categories || []}

--- a/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.tsx
@@ -1,4 +1,4 @@
-import { Alert, Divider, Typography } from "antd";
+import { Alert, Divider, Typography, message } from "antd";
 import React, { useEffect, useState } from "react";
 import yaml from "js-yaml";
 import ContentFilterConfiguration from "./ContentFilterConfiguration";
@@ -277,10 +277,11 @@ const ContentFilterManager: React.FC<ContentFilterManagerProps> = ({
                       description: w.description || undefined,
                     })
                   );
-                  setBlockedWords([...blockedWords, ...newWords]);
+                  setBlockedWords((prev) => [...prev, ...newWords]);
                 }
               } catch (e) {
                 console.error("Failed to parse YAML:", e);
+                message.error("Failed to parse uploaded YAML. Please check the file format.");
               }
             }}
             accessToken={accessToken}


### PR DESCRIPTION
## Summary

Fixes #22227

The `onFileUpload` callback in `ContentFilterManager.tsx` only called `console.log("File uploaded:", content)` — the uploaded YAML content was silently discarded without parsing or updating the `blockedWords` state.

## Fix

In `ContentFilterManager.tsx`:
1. Added `import yaml from "js-yaml"` (already a project dependency)
2. In `onFileUpload`, parse the YAML content, extract the `blocked_words` array, convert each entry to a `BlockedWord` object, and merge into existing `blockedWords` state

The YAML format expected matches the backend validation endpoint:
```yaml
blocked_words:
  - keyword: "test"
    action: "BLOCK"
    description: "optional"
```

**Changed file:** `ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.tsx`

## Tests

Updated `ContentFilterManager.test.tsx`:
- Extended mock to expose `onFileUpload` and display blocked word count/keywords
- Added test verifying YAML upload merges words into state (1 existing + 2 uploaded = 3 total)
- All 16 tests pass