### PR TITLE
fix(anthropic): align translate_thinking_for_model with default summary injection + docs

### DIFF
--- a/docs/my-website/docs/reasoning_content.md
+++ b/docs/my-website/docs/reasoning_content.md
@@ -691,3 +691,53 @@ response = await litellm.anthropic.messages.acreate(
 )
 # The summary="concise" is preserved when routing to OpenAI's Responses API
 ```
+
+### Default Summary Injection for `/v1/messages` Adapter
+
+When the Anthropic `/v1/messages` adapter translates `thinking` parameters to OpenAI `reasoning_effort` for non-Claude models, `summary="detailed"` is automatically injected by default. This ensures that reasoning text is returned in the response (matching the Anthropic thinking behavior).
+
+To **disable** this default injection, use the `disable_default_reasoning_summary` flag:
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+import litellm
+
+# Disable default summary="detailed" injection
+litellm.disable_default_reasoning_summary = True
+
+response = await litellm.anthropic.messages.acreate(
+    model="openai/gpt-5.1",
+    messages=[{"role": "user", "content": "Hello"}],
+    max_tokens=8096,
+    thinking={"type": "enabled", "budget_tokens": 5000},
+)
+# No summary will be injected — only reasoning_effort is forwarded
+```
+
+</TabItem>
+
+<TabItem value="env" label="Environment Variable">
+
+```bash
+export LITELLM_DISABLE_DEFAULT_REASONING_SUMMARY=true
+```
+
+</TabItem>
+
+<TabItem value="proxy" label="Proxy Config">
+
+```yaml
+litellm_settings:
+  disable_default_reasoning_summary: true
+```
+
+</TabItem>
+</Tabs>
+
+:::info
+
+This flag only affects the automatic injection of `summary="detailed"` when no user-provided summary is present. If you explicitly pass `thinking.summary` (e.g., `"concise"` or `"auto"`), your value is always preserved regardless of this flag.
+
+:::

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -13,6 +13,10 @@ from typing import (
     cast,
 )
 
+from litellm.llms.anthropic.experimental_pass_through.utils import (
+    is_default_reasoning_summary_disabled,
+)
+
 # OpenAI has a 64-character limit for function/tool names
 # Anthropic does not have this limit, so we need to truncate long names
 OPENAI_MAX_TOOL_NAME_LENGTH = 64
@@ -694,8 +698,11 @@ class LiteLLMAnthropicMessagesAdapter:
             )
             if reasoning_effort:
                 summary = thinking.get("summary") if isinstance(thinking, dict) else None
+                summary_disabled = is_default_reasoning_summary_disabled()
                 if summary:
                     return {"reasoning_effort": {"effort": reasoning_effort, "summary": summary}}
+                elif not summary_disabled:
+                    return {"reasoning_effort": {"effort": reasoning_effort, "summary": "detailed"}}
                 return {"reasoning_effort": reasoning_effort}
             return {}
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -221,8 +221,40 @@ class TestThinkingParameterTransformation:
             model="openai/gpt-5.2",
         )
 
-        assert result == {"reasoning_effort": "minimal"}
+        assert result == {"reasoning_effort": {"effort": "minimal", "summary": "detailed"}}
         assert "thinking" not in result
+
+    def test_translate_thinking_for_model_no_summary_when_disabled(self):
+        """When disable_default_reasoning_summary is True, no summary is injected."""
+        import litellm
+        from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+            LiteLLMAnthropicMessagesAdapter,
+        )
+
+        original = litellm.disable_default_reasoning_summary
+        try:
+            litellm.disable_default_reasoning_summary = True
+            thinking = {"type": "enabled", "budget_tokens": 5000}
+            result = LiteLLMAnthropicMessagesAdapter.translate_thinking_for_model(
+                thinking=thinking,
+                model="openai/gpt-5.2",
+            )
+            assert result == {"reasoning_effort": "medium"}
+        finally:
+            litellm.disable_default_reasoning_summary = original
+
+    def test_translate_thinking_for_model_preserves_user_summary(self):
+        """User-provided summary is always preserved regardless of flag."""
+        from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+            LiteLLMAnthropicMessagesAdapter,
+        )
+
+        thinking = {"type": "enabled", "budget_tokens": 10000, "summary": "concise"}
+        result = LiteLLMAnthropicMessagesAdapter.translate_thinking_for_model(
+            thinking=thinking,
+            model="openai/gpt-5.2",
+        )
+        assert result == {"reasoning_effort": {"effort": "high", "summary": "concise"}}
 
 
 class TestThinkingSummaryPreservation:


### PR DESCRIPTION
## Relevant issues

Follow-up to #22904.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix
📖 Documentation

## Changes

- Updated `translate_thinking_for_model` to use `is_default_reasoning_summary_disabled()` and inject `summary="detailed"` by default (matching the other two code paths).
- Added 2 new tests verifying the flag behavior in this code path.
- Updated existing test assertion to reflect the new default behavior.
- Added docs section "Default Summary Injection for `/v1/messages` Adapter" in `reasoning_content.md` covering SDK, env var, and proxy config usage.