### PR TITLE
fix(ollama): strip endpoint paths from api_base in get_model_info()

### DIFF
--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -238,6 +238,12 @@ class OllamaConfig(BaseConfig):
             or get_secret_str("OLLAMA_API_BASE")
             or "http://localhost:11434"
         )
+        # Strip any endpoint paths that may have been appended by get_complete_url()
+        # to avoid malformed URLs like /api/generate/api/show
+        for endpoint in ["/api/generate", "/api/chat", "/api/embed"]:
+            if api_base.endswith(endpoint):
+                api_base = api_base[: -len(endpoint)]
+                break
         api_key = self.get_api_key()
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
 

--- a/tests/test_litellm/llms/ollama/test_ollama_model_info.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_model_info.py
@@ -219,6 +219,36 @@ class TestOllamaGetModelInfo:
         config.get_model_info("ollama_chat/llama3", api_base="http://localhost:11434")
         assert captured_json[1]["name"] == "llama3"
 
+    def test_get_model_info_strips_endpoint_paths_from_api_base(self, monkeypatch):
+        """When api_base contains endpoint paths like /api/generate, they should be stripped before appending /api/show."""
+        from litellm.llms.ollama.completion.transformation import OllamaConfig
+
+        captured_urls = []
+
+        def mock_post(url, json, headers=None):
+            captured_urls.append(url)
+            return DummyResponse({"template": "", "model_info": {}}, status_code=200)
+
+        monkeypatch.setattr("litellm.module_level_client.post", mock_post)
+
+        config = OllamaConfig()
+
+        # Test with /api/generate endpoint already appended
+        config.get_model_info("llama3", api_base="http://my-server:11434/api/generate")
+        assert captured_urls[0] == "http://my-server:11434/api/show"
+
+        # Test with /api/chat endpoint already appended
+        config.get_model_info("llama3", api_base="http://my-server:11434/api/chat")
+        assert captured_urls[1] == "http://my-server:11434/api/show"
+
+        # Test with /api/embed endpoint already appended
+        config.get_model_info("llama3", api_base="http://my-server:11434/api/embed")
+        assert captured_urls[2] == "http://my-server:11434/api/show"
+
+        # Test with clean base URL (should still work)
+        config.get_model_info("llama3", api_base="http://my-server:11434")
+        assert captured_urls[3] == "http://my-server:11434/api/show"
+
 
 class TestOllamaAuthHeaders:
     """Tests for Ollama authentication header handling in completion calls."""


### PR DESCRIPTION
## Summary                                                                                                                                                                                      

Fix malformed URL construction in `OllamaConfig.get_model_info()` when `api_base` already contains an endpoint path (e.g., `/api/generate`).                                                    
                                                                                                                                                                                                  
## Description                                                                                                                                                                              
                                                                                                                                                                                                  
When calling `litellm.completion()` with a custom `api_base` for Ollama, the `get_model_info()` method constructs a malformed URL by appending `/api/show` to an `api_base` that already contains an endpoint path.                                                                                                                                                                      
                                                                                                                                                                                                  
### Error message                                                                                                                                                                               
                                                                                                                                                                                                  
OllamaError: Could not get model info for glm-4.7-flash from http://server:11434/api/generate.                                                                                          
Error: Client error '404 Not Found' for url 'http://server:11434/api/generate/api/show'                                                                                                 
                                                                                                                                                                                              
### Expected URL                                                                                                                                                                                
`http://<MY_HOST>:11434/api/show`                                                                                                                                                          
                                                                                                                                                                                              
### Actual URL                                                                                                                                                                                  
`http://<MY_HOST>/api/generate/api/show`                                                                                                                                             
                                                                                                                                                                                                  
 ## Root cause analysis                                                                                                                                                                          
                                                                                                                                                                                                  
The issue stems from inconsistent handling of `api_base` between two code paths:                                                                                                                
                                                                                                                                                                                                
1. **`get_complete_url()`** (lines 469-492) correctly transforms `api_base` by appending the endpoint path:                                                                                     
   ```python                                                                                                                                                                                    
   if api_base.endswith("/api/generate"):                                                                                                                                                       
       url = api_base                                                                                                                                                                           
   else:                                                                                                                                                                                        
       url = f"{api_base}/api/generate"                                                                                                                                                         
                                                                                                                                                                                                
2. get_model_info() (lines 226-246) does NOT check if api_base already contains an endpoint path before appending /api/show:
```python                                                                    
response = litellm.module_level_client.post(                                                                                                                                                    
    url=f"{api_base}/api/show",  # BUG: assumes api_base is just host:port                                                                                                                      
    ...                                                                                                                                                                                         
) 
```
                                                                                                                                                                                             
### Flow that triggers the bug                                                                                                                                                                      
0. export OLLAMA_API_BASE=http://server:11434                                                                                                                                                                                      
1. User calls litellm.completion(model="ollama/model", api_base="http://server:11434", ...)                                                                                                     
2. get_complete_url() transforms api_base to http://server:11434/api/generate                                                                                                                   
4. This modified URL propagates through the logging/cost calculation flow                                                                                                                       
5. get_model_info() is called with api_base="http://server:11434/api/generate"                                                                                                                  
6. get_model_info() naively appends /api/show → http://server:11434/api/generate/api/show                                                                                                       
7. Result: 404 Not Found                                                                                                                                                                        
                                                                                                                                                                                              
## Solution                                                                                                                                                                                        
                                                                                                                                                                                              
Strip known endpoint paths from api_base before constructing the /api/show URL, following the same defensive pattern used elsewhere in the codebase.

## Relevant issues

[Fixes #8772](https://github.com/BerriAI/litellm/issues/8772)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

