### PR TITLE
fix(proxy): handle user_email on /key/generate by creating/linking user record

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -931,6 +931,7 @@ class LiteLLMKeyType(str, enum.Enum):
 
 class GenerateKeyRequest(KeyRequestBase):
     soft_budget: Optional[float] = None
+    user_email: Optional[str] = None
     send_invite_email: Optional[bool] = None
     key_type: Optional[LiteLLMKeyType] = Field(
         default=LiteLLMKeyType.DEFAULT,

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2768,6 +2768,14 @@ async def generate_key_helper_fn(  # noqa: PLR0915
                     )
                 )
                 if existing_user is not None:
+                    if user_data.get("user_id") and user_data["user_id"] != existing_user.user_id:
+                        verbose_proxy_logger.debug(
+                            "user_email=%s matched existing user_id=%s, "
+                            "overriding caller-supplied user_id=%s",
+                            user_email,
+                            existing_user.user_id,
+                            user_data["user_id"],
+                        )
                     # Reuse existing user's ID — don't update their record
                     user_data["user_id"] = existing_user.user_id
                     key_data["user_id"] = existing_user.user_id
@@ -2777,9 +2785,24 @@ async def generate_key_helper_fn(  # noqa: PLR0915
                         generated_user_id = str(uuid.uuid4())
                         user_data["user_id"] = generated_user_id
                         key_data["user_id"] = generated_user_id
-                    await prisma_client.insert_data(
-                        data=user_data, table_name="user"
-                    )
+                    try:
+                        await prisma_client.insert_data(
+                            data=user_data, table_name="user"
+                        )
+                    except Exception:
+                        # Handle race condition: concurrent request may have
+                        # created the user between our find_first and insert.
+                        # Re-lookup and link to the existing record.
+                        existing_user = (
+                            await prisma_client.db.litellm_usertable.find_first(
+                                where={"user_email": {"equals": user_email, "mode": "insensitive"}}
+                            )
+                        )
+                        if existing_user is not None:
+                            user_data["user_id"] = existing_user.user_id
+                            key_data["user_id"] = existing_user.user_id
+                        else:
+                            raise
 
             if (
                 table_name is None or table_name == "user"

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2760,16 +2760,23 @@ async def generate_key_helper_fn(  # noqa: PLR0915
             saved_token["expires"] = saved_token["expires"].isoformat()
         if prisma_client is not None:
             # When user_email is explicitly provided during key generation,
-            # look up or create the user record so the key can link to it
+            # look up or create the user record so the key can link to it.
+            # Note: a narrow race window exists where concurrent requests with
+            # the same user_email could create duplicate user records, since
+            # user_email has no unique constraint in LiteLLM_UserTable.
+            # insert_data uses upsert on user_id, which prevents duplicate
+            # keys but not duplicate emails. A schema-level @@unique
+            # constraint on user_email would fully close this gap.
             if user_email is not None and table_name == "key":
-                existing_user = (
-                    await prisma_client.db.litellm_usertable.find_first(
-                        where={"user_email": {"equals": user_email, "mode": "insensitive"}}
-                    )
+                existing_users = await prisma_client.get_data(
+                    table_name="user",
+                    query_type="find_all",
+                    key_val={"user_email": {"equals": user_email, "mode": "insensitive"}},
                 )
+                existing_user = existing_users[0] if existing_users else None
                 if existing_user is not None:
                     if user_data.get("user_id") and user_data["user_id"] != existing_user.user_id:
-                        verbose_proxy_logger.debug(
+                        verbose_proxy_logger.warning(
                             "user_email=%s matched existing user_id=%s, "
                             "overriding caller-supplied user_id=%s",
                             user_email,
@@ -2785,24 +2792,9 @@ async def generate_key_helper_fn(  # noqa: PLR0915
                         generated_user_id = str(uuid.uuid4())
                         user_data["user_id"] = generated_user_id
                         key_data["user_id"] = generated_user_id
-                    try:
-                        await prisma_client.insert_data(
-                            data=user_data, table_name="user"
-                        )
-                    except Exception:
-                        # Handle race condition: concurrent request may have
-                        # created the user between our find_first and insert.
-                        # Re-lookup and link to the existing record.
-                        existing_user = (
-                            await prisma_client.db.litellm_usertable.find_first(
-                                where={"user_email": {"equals": user_email, "mode": "insensitive"}}
-                            )
-                        )
-                        if existing_user is not None:
-                            user_data["user_id"] = existing_user.user_id
-                            key_data["user_id"] = existing_user.user_id
-                        else:
-                            raise
+                    await prisma_client.insert_data(
+                        data=user_data, table_name="user"
+                    )
 
             if (
                 table_name is None or table_name == "user"

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2764,7 +2764,7 @@ async def generate_key_helper_fn(  # noqa: PLR0915
             if user_email is not None and table_name == "key":
                 existing_user = (
                     await prisma_client.db.litellm_usertable.find_first(
-                        where={"user_email": user_email}
+                        where={"user_email": {"equals": user_email, "mode": "insensitive"}}
                     )
                 )
                 if existing_user is not None:

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2759,6 +2759,28 @@ async def generate_key_helper_fn(  # noqa: PLR0915
         ):
             saved_token["expires"] = saved_token["expires"].isoformat()
         if prisma_client is not None:
+            # When user_email is explicitly provided during key generation,
+            # look up or create the user record so the key can link to it
+            if user_email is not None and table_name == "key":
+                existing_user = (
+                    await prisma_client.db.litellm_usertable.find_first(
+                        where={"user_email": user_email}
+                    )
+                )
+                if existing_user is not None:
+                    # Reuse existing user's ID — don't update their record
+                    user_data["user_id"] = existing_user.user_id
+                    key_data["user_id"] = existing_user.user_id
+                else:
+                    # Create a new user record
+                    if not user_data.get("user_id"):
+                        generated_user_id = str(uuid.uuid4())
+                        user_data["user_id"] = generated_user_id
+                        key_data["user_id"] = generated_user_id
+                    await prisma_client.insert_data(
+                        data=user_data, table_name="user"
+                    )
+
             if (
                 table_name is None or table_name == "user"
             ):  # do not auto-create users for `/key/generate`

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6455,3 +6455,147 @@ class TestValidateKeyAliasFormat:
                 _validate_key_alias_format(alias)
             assert str(exc.value.code) == "400"
             assert "Invalid key_alias format" in str(exc.value.message)
+
+
+@pytest.mark.asyncio
+async def test_generate_key_with_user_email_creates_user(monkeypatch):
+    """When user_email is provided to generate_key_helper_fn with table_name='key',
+    a user record should be created and the key should link to it via user_id."""
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.jsonify_object = lambda data: data
+
+    mock_prisma_client.db = MagicMock()
+    mock_prisma_client.db.litellm_usertable = MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=None)
+
+    captured_user_data = {}
+    captured_key_data = {}
+
+    async def _insert_data_side_effect(*args, **kwargs):
+        table_name = kwargs.get("table_name")
+        if table_name == "user":
+            captured_user_data.update(kwargs.get("data", {}))
+            return MagicMock(models=[], spend=0)
+        elif table_name == "key":
+            captured_key_data.update(kwargs.get("data", {}))
+            return MagicMock(
+                token="hashed_token",
+                litellm_budget_table=None,
+                object_permission=None,
+                created_at=None,
+                updated_at=None,
+            )
+        return MagicMock()
+
+    mock_prisma_client.insert_data = AsyncMock(side_effect=_insert_data_side_effect)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    result = await generate_key_helper_fn(
+        request_type="key",
+        table_name="key",
+        user_email="test@example.com",
+    )
+
+    # User record was created
+    assert captured_user_data.get("user_email") == "test@example.com"
+    # user_id was auto-generated (not None)
+    assert captured_user_data.get("user_id") is not None
+    # Key links to the same user_id
+    assert captured_key_data.get("user_id") == captured_user_data.get("user_id")
+
+
+@pytest.mark.asyncio
+async def test_generate_key_with_user_email_reuses_existing_user(monkeypatch):
+    """When user_email matches an existing user, reuse their user_id
+    without creating or updating the user record."""
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.jsonify_object = lambda data: data
+
+    existing_user = MagicMock()
+    existing_user.user_id = "existing-user-id-123"
+
+    mock_prisma_client.db = MagicMock()
+    mock_prisma_client.db.litellm_usertable = MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
+        return_value=existing_user
+    )
+
+    captured_key_data = {}
+
+    async def _insert_data_side_effect(*args, **kwargs):
+        table_name = kwargs.get("table_name")
+        if table_name == "user":
+            raise AssertionError("Should NOT create a new user record")
+        elif table_name == "key":
+            captured_key_data.update(kwargs.get("data", {}))
+            return MagicMock(
+                token="hashed_token",
+                litellm_budget_table=None,
+                object_permission=None,
+                created_at=None,
+                updated_at=None,
+            )
+        return MagicMock()
+
+    mock_prisma_client.insert_data = AsyncMock(side_effect=_insert_data_side_effect)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    result = await generate_key_helper_fn(
+        request_type="key",
+        table_name="key",
+        user_email="test@example.com",
+    )
+
+    # Key links to the existing user's ID
+    assert captured_key_data.get("user_id") == "existing-user-id-123"
+    # find_first was called with the email
+    mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(
+        where={"user_email": "test@example.com"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_key_without_user_email_skips_user_creation(monkeypatch):
+    """When user_email is NOT provided, the existing behavior is preserved:
+    no user record is created for table_name='key'."""
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.jsonify_object = lambda data: data
+
+    mock_prisma_client.db = MagicMock()
+
+    async def _insert_data_side_effect(*args, **kwargs):
+        table_name = kwargs.get("table_name")
+        if table_name == "user":
+            raise AssertionError("Should NOT create a user when user_email is not provided")
+        elif table_name == "key":
+            return MagicMock(
+                token="hashed_token",
+                litellm_budget_table=None,
+                object_permission=None,
+                created_at=None,
+                updated_at=None,
+            )
+        return MagicMock()
+
+    mock_prisma_client.insert_data = AsyncMock(side_effect=_insert_data_side_effect)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    # No user_email — should NOT attempt user creation
+    result = await generate_key_helper_fn(
+        request_type="key",
+        table_name="key",
+        user_id="some-user",
+    )
+
+    # Key was created successfully
+    assert result is not None
+
+
+def test_generate_key_request_accepts_user_email():
+    """GenerateKeyRequest should accept user_email as a valid field."""
+    req = GenerateKeyRequest(user_email="test@example.com")
+    assert req.user_email == "test@example.com"
+
+    # Also verify it's included in model_dump
+    dumped = req.model_dump(exclude_unset=True, exclude_none=True)
+    assert dumped.get("user_email") == "test@example.com"

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6464,9 +6464,8 @@ async def test_generate_key_with_user_email_creates_user(monkeypatch):
     mock_prisma_client = AsyncMock()
     mock_prisma_client.jsonify_object = lambda data: data
 
-    mock_prisma_client.db = MagicMock()
-    mock_prisma_client.db.litellm_usertable = MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=None)
+    # get_data returns empty list (no existing user)
+    mock_prisma_client.get_data = AsyncMock(return_value=[])
 
     captured_user_data = {}
     captured_key_data = {}
@@ -6502,6 +6501,12 @@ async def test_generate_key_with_user_email_creates_user(monkeypatch):
     assert captured_user_data.get("user_id") is not None
     # Key links to the same user_id
     assert captured_key_data.get("user_id") == captured_user_data.get("user_id")
+    # get_data was called with correct params
+    mock_prisma_client.get_data.assert_called_once_with(
+        table_name="user",
+        query_type="find_all",
+        key_val={"user_email": {"equals": "test@example.com", "mode": "insensitive"}},
+    )
 
 
 @pytest.mark.asyncio
@@ -6514,11 +6519,8 @@ async def test_generate_key_with_user_email_reuses_existing_user(monkeypatch):
     existing_user = MagicMock()
     existing_user.user_id = "existing-user-id-123"
 
-    mock_prisma_client.db = MagicMock()
-    mock_prisma_client.db.litellm_usertable = MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        return_value=existing_user
-    )
+    # get_data returns the existing user
+    mock_prisma_client.get_data = AsyncMock(return_value=[existing_user])
 
     captured_key_data = {}
 
@@ -6548,9 +6550,11 @@ async def test_generate_key_with_user_email_reuses_existing_user(monkeypatch):
 
     # Key links to the existing user's ID
     assert captured_key_data.get("user_id") == "existing-user-id-123"
-    # find_first was called with the email
-    mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(
-        where={"user_email": {"equals": "test@example.com", "mode": "insensitive"}}
+    # get_data was called with the email
+    mock_prisma_client.get_data.assert_called_once_with(
+        table_name="user",
+        query_type="find_all",
+        key_val={"user_email": {"equals": "test@example.com", "mode": "insensitive"}},
     )
 
 
@@ -6589,6 +6593,8 @@ async def test_generate_key_without_user_email_skips_user_creation(monkeypatch):
 
     # Key was created successfully
     assert result is not None
+    # get_data should NOT have been called (no email lookup needed)
+    mock_prisma_client.get_data.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -6601,11 +6607,8 @@ async def test_generate_key_with_user_email_overrides_conflicting_user_id(monkey
     existing_user = MagicMock()
     existing_user.user_id = "existing-user-id-123"
 
-    mock_prisma_client.db = MagicMock()
-    mock_prisma_client.db.litellm_usertable = MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        return_value=existing_user
-    )
+    # get_data returns the existing user
+    mock_prisma_client.get_data = AsyncMock(return_value=[existing_user])
 
     captured_key_data = {}
 
@@ -6640,52 +6643,31 @@ async def test_generate_key_with_user_email_overrides_conflicting_user_id(monkey
 
 
 @pytest.mark.asyncio
-async def test_generate_key_with_user_email_handles_race_condition(monkeypatch):
-    """When a concurrent request creates the same user between find_first and
-    insert, the retry lookup should find and reuse the concurrently created user."""
+async def test_generate_key_with_user_email_propagates_insert_errors(monkeypatch):
+    """When user insert fails, the error propagates as HTTP 500
+    (via generate_key_helper_fn's outer exception handler)."""
     mock_prisma_client = AsyncMock()
     mock_prisma_client.jsonify_object = lambda data: data
 
-    concurrent_user = MagicMock()
-    concurrent_user.user_id = "concurrent-user-id-456"
-
-    # First find_first returns None (user doesn't exist yet),
-    # second find_first (after insert fails) returns the concurrently created user
-    mock_prisma_client.db = MagicMock()
-    mock_prisma_client.db.litellm_usertable = MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        side_effect=[None, concurrent_user]
-    )
-
-    captured_key_data = {}
+    # get_data returns empty list (no existing user)
+    mock_prisma_client.get_data = AsyncMock(return_value=[])
 
     async def _insert_data_side_effect(*args, **kwargs):
         table_name = kwargs.get("table_name")
         if table_name == "user":
-            # Simulate race: another request created the user first
-            raise Exception("Unique constraint violation")
-        elif table_name == "key":
-            captured_key_data.update(kwargs.get("data", {}))
-            return MagicMock(
-                token="hashed_token",
-                litellm_budget_table=None,
-                object_permission=None,
-                created_at=None,
-                updated_at=None,
-            )
+            raise RuntimeError("Database connection lost")
         return MagicMock()
 
     mock_prisma_client.insert_data = AsyncMock(side_effect=_insert_data_side_effect)
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
 
-    result = await generate_key_helper_fn(
-        request_type="key",
-        table_name="key",
-        user_email="test@example.com",
-    )
-
-    # Key links to the concurrently created user
-    assert captured_key_data.get("user_id") == "concurrent-user-id-456"
+    with pytest.raises(HTTPException) as exc_info:
+        await generate_key_helper_fn(
+            request_type="key",
+            table_name="key",
+            user_email="test@example.com",
+        )
+    assert exc_info.value.status_code == 500
 
 
 def test_generate_key_request_accepts_user_email():

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6550,7 +6550,7 @@ async def test_generate_key_with_user_email_reuses_existing_user(monkeypatch):
     assert captured_key_data.get("user_id") == "existing-user-id-123"
     # find_first was called with the email
     mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(
-        where={"user_email": "test@example.com"}
+        where={"user_email": {"equals": "test@example.com", "mode": "insensitive"}}
     )
 
 

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6591,6 +6591,103 @@ async def test_generate_key_without_user_email_skips_user_creation(monkeypatch):
     assert result is not None
 
 
+@pytest.mark.asyncio
+async def test_generate_key_with_user_email_overrides_conflicting_user_id(monkeypatch):
+    """When user_email matches an existing user whose user_id differs from the
+    caller-supplied user_id, the existing user's ID takes precedence."""
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.jsonify_object = lambda data: data
+
+    existing_user = MagicMock()
+    existing_user.user_id = "existing-user-id-123"
+
+    mock_prisma_client.db = MagicMock()
+    mock_prisma_client.db.litellm_usertable = MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
+        return_value=existing_user
+    )
+
+    captured_key_data = {}
+
+    async def _insert_data_side_effect(*args, **kwargs):
+        table_name = kwargs.get("table_name")
+        if table_name == "user":
+            raise AssertionError("Should NOT create a new user record")
+        elif table_name == "key":
+            captured_key_data.update(kwargs.get("data", {}))
+            return MagicMock(
+                token="hashed_token",
+                litellm_budget_table=None,
+                object_permission=None,
+                created_at=None,
+                updated_at=None,
+            )
+        return MagicMock()
+
+    mock_prisma_client.insert_data = AsyncMock(side_effect=_insert_data_side_effect)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    # Caller passes a different user_id than the existing user
+    result = await generate_key_helper_fn(
+        request_type="key",
+        table_name="key",
+        user_email="test@example.com",
+        user_id="caller-supplied-id-999",
+    )
+
+    # Key links to the EXISTING user's ID, not the caller-supplied one
+    assert captured_key_data.get("user_id") == "existing-user-id-123"
+
+
+@pytest.mark.asyncio
+async def test_generate_key_with_user_email_handles_race_condition(monkeypatch):
+    """When a concurrent request creates the same user between find_first and
+    insert, the retry lookup should find and reuse the concurrently created user."""
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.jsonify_object = lambda data: data
+
+    concurrent_user = MagicMock()
+    concurrent_user.user_id = "concurrent-user-id-456"
+
+    # First find_first returns None (user doesn't exist yet),
+    # second find_first (after insert fails) returns the concurrently created user
+    mock_prisma_client.db = MagicMock()
+    mock_prisma_client.db.litellm_usertable = MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
+        side_effect=[None, concurrent_user]
+    )
+
+    captured_key_data = {}
+
+    async def _insert_data_side_effect(*args, **kwargs):
+        table_name = kwargs.get("table_name")
+        if table_name == "user":
+            # Simulate race: another request created the user first
+            raise Exception("Unique constraint violation")
+        elif table_name == "key":
+            captured_key_data.update(kwargs.get("data", {}))
+            return MagicMock(
+                token="hashed_token",
+                litellm_budget_table=None,
+                object_permission=None,
+                created_at=None,
+                updated_at=None,
+            )
+        return MagicMock()
+
+    mock_prisma_client.insert_data = AsyncMock(side_effect=_insert_data_side_effect)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    result = await generate_key_helper_fn(
+        request_type="key",
+        table_name="key",
+        user_email="test@example.com",
+    )
+
+    # Key links to the concurrently created user
+    assert captured_key_data.get("user_id") == "concurrent-user-id-456"
+
+
 def test_generate_key_request_accepts_user_email():
     """GenerateKeyRequest should accept user_email as a valid field."""
     req = GenerateKeyRequest(user_email="test@example.com")


### PR DESCRIPTION
When user_email is passed to /key/generate, it was silently discarded because GenerateKeyRequest didn't declare the field (Pydantic dropped it) and generate_key_helper_fn skipped user record creation when table_name="key".

This adds user_email to GenerateKeyRequest and implements a lookup-first pattern in generate_key_helper_fn: if a user with that email exists, reuse their user_id; otherwise create a new user record. The key is linked to the user via user_id. When user_email is not provided, existing behavior is unchanged.

## Relevant issues

Related to #20029

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

- **`litellm/proxy/_types.py`**: Added `user_email: Optional[str] = None` to `GenerateKeyRequest` so the `/key/generate` endpoint accepts the field instead of silently dropping it via Pydantic
- **`litellm/proxy/management_endpoints/key_management_endpoints.py`**: Added user lookup/creation logic in `generate_key_helper_fn` — when `user_email` is provided with `table_name="key"`, uses `prisma_client.get_data()` to look up existing users by email (case-insensitive). Reuses an existing user's `user_id` or creates a new user record (auto-generates `user_id` if needed). Logs a warning when a caller-supplied `user_id` is overridden by an existing user matched by email. Errors from `insert_data` propagate naturally through the outer exception handler. Existing behavior when `user_email` is not provided is unchanged.
- **`tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py`**: Added 6 tests:
  - `test_generate_key_with_user_email_creates_user` — new user record created and key linked via user_id
  - `test_generate_key_with_user_email_reuses_existing_user` — existing user reused, no duplicate created
  - `test_generate_key_without_user_email_skips_user_creation` — backwards compatibility preserved
  - `test_generate_key_with_user_email_overrides_conflicting_user_id` — email takes precedence, warning logged
  - `test_generate_key_with_user_email_propagates_insert_errors` — DB errors propagate as HTTP 500
  - `test_generate_key_request_accepts_user_email` — Pydantic model accepts and passes through `user_email`