### PR TITLE
fix: HuggingFace cost calculation now respects custom input_cost_per_token/output_cost_per_token config

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1127,8 +1127,9 @@ def completion_cost(  # noqa: PLR0915
                         "output_cost_per_token": _output_cost if _output_cost is not None else 0.0,
                     }
                 # Also extract custom_cost_per_second if available
+                # Prefer input_cost_per_second; fall back to output_cost_per_second
                 if custom_cost_per_second is None:
-                    _cost_per_second = _model_info.get("input_cost_per_second")
+                    _cost_per_second = _model_info.get("input_cost_per_second") or _model_info.get("output_cost_per_second")
                     if _cost_per_second is not None:
                         custom_cost_per_second = _cost_per_second
 

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1126,12 +1126,24 @@ def completion_cost(  # noqa: PLR0915
                         "input_cost_per_token": _input_cost if _input_cost is not None else 0.0,
                         "output_cost_per_token": _output_cost if _output_cost is not None else 0.0,
                     }
-                # Also extract custom_cost_per_second if available
+
+        # Extract custom_cost_per_second from litellm_logging_obj when custom_pricing=True
+        # This is independent of the per-token extraction above
+        if (
+            custom_pricing is True
+            and custom_cost_per_second is None
+            and litellm_logging_obj is not None
+        ):
+            _litellm_params = getattr(litellm_logging_obj, "litellm_params", None)
+            if _litellm_params is not None:
+                _metadata = _litellm_params.get("metadata", {}) or {}
+                _model_info = _metadata.get("model_info", {}) or {}
                 # Prefer input_cost_per_second; fall back to output_cost_per_second
-                if custom_cost_per_second is None:
-                    _cost_per_second = _model_info.get("input_cost_per_second") or _model_info.get("output_cost_per_second")
-                    if _cost_per_second is not None:
-                        custom_cost_per_second = _cost_per_second
+                _cost_per_second = _model_info.get(
+                    "input_cost_per_second"
+                ) or _model_info.get("output_cost_per_second")
+                if _cost_per_second is not None:
+                    custom_cost_per_second = _cost_per_second
 
         selected_model = _select_model_name_for_cost_calc(
             model=model,

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1108,47 +1108,33 @@ def completion_cost(  # noqa: PLR0915
             elif isinstance(cost_per_token_usage_object, dict):
                 service_tier = cost_per_token_usage_object.get("service_tier")
 
-        # Extract custom_cost_per_token from litellm_logging_obj when custom_pricing=True
+        # Extract custom pricing from litellm_logging_obj model_info when custom_pricing=True
         # This enables cost calculation for custom/HuggingFace providers with per-deployment pricing
-        if (
-            custom_pricing is True
-            and custom_cost_per_token is None
-            and litellm_logging_obj is not None
-        ):
-            _litellm_params = getattr(litellm_logging_obj, "litellm_params", None)
-            if _litellm_params is not None:
-                _metadata = _litellm_params.get("metadata", {}) or {}
-                _model_info = _metadata.get("model_info", {}) or {}
-                _input_cost = _model_info.get("input_cost_per_token")
-                _output_cost = _model_info.get("output_cost_per_token")
-                if _input_cost is not None or _output_cost is not None:
-                    custom_cost_per_token = {
-                        "input_cost_per_token": _input_cost if _input_cost is not None else 0.0,
-                        "output_cost_per_token": _output_cost if _output_cost is not None else 0.0,
-                    }
-
-        # Extract custom_cost_per_second from litellm_logging_obj when custom_pricing=True
-        # This is independent of the per-token extraction above
-        if (
-            custom_pricing is True
-            and custom_cost_per_second is None
-            and litellm_logging_obj is not None
-        ):
-            _litellm_params = getattr(litellm_logging_obj, "litellm_params", None)
-            if _litellm_params is not None:
-                _metadata = _litellm_params.get("metadata", {}) or {}
-                _model_info = _metadata.get("model_info", {}) or {}
-                # Prefer input_cost_per_second; fall back to output_cost_per_second
-                # Use `is not None` guards to correctly handle explicit 0.0 costs
-                _input_cost_per_second = _model_info.get("input_cost_per_second")
-                _output_cost_per_second = _model_info.get("output_cost_per_second")
-                _cost_per_second = (
-                    _input_cost_per_second
-                    if _input_cost_per_second is not None
-                    else _output_cost_per_second
+        _custom_pricing_model_info: dict = {}
+        if custom_pricing is True and litellm_logging_obj is not None:
+            _lp = getattr(litellm_logging_obj, "litellm_params", None)
+            if _lp is not None:
+                _custom_pricing_model_info = (
+                    (_lp.get("metadata", {}) or {}).get("model_info", {}) or {}
                 )
-                if _cost_per_second is not None:
-                    custom_cost_per_second = _cost_per_second
+
+        if custom_cost_per_token is None and _custom_pricing_model_info:
+            _input_cost = _custom_pricing_model_info.get("input_cost_per_token")
+            _output_cost = _custom_pricing_model_info.get("output_cost_per_token")
+            if _input_cost is not None or _output_cost is not None:
+                custom_cost_per_token = {
+                    "input_cost_per_token": _input_cost if _input_cost is not None else 0.0,
+                    "output_cost_per_token": _output_cost if _output_cost is not None else 0.0,
+                }
+
+        if custom_cost_per_second is None and _custom_pricing_model_info:
+            # Prefer input_cost_per_second; fall back to output_cost_per_second
+            # Use `is not None` guards to correctly handle explicit 0.0 costs
+            _input_cps = _custom_pricing_model_info.get("input_cost_per_second")
+            _output_cps = _custom_pricing_model_info.get("output_cost_per_second")
+            _cost_per_second = _input_cps if _input_cps is not None else _output_cps
+            if _cost_per_second is not None:
+                custom_cost_per_second = _cost_per_second
 
         selected_model = _select_model_name_for_cost_calc(
             model=model,

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1108,6 +1108,30 @@ def completion_cost(  # noqa: PLR0915
             elif isinstance(cost_per_token_usage_object, dict):
                 service_tier = cost_per_token_usage_object.get("service_tier")
 
+        # Extract custom_cost_per_token from litellm_logging_obj when custom_pricing=True
+        # This enables cost calculation for custom/HuggingFace providers with per-deployment pricing
+        if (
+            custom_pricing is True
+            and custom_cost_per_token is None
+            and litellm_logging_obj is not None
+        ):
+            _litellm_params = getattr(litellm_logging_obj, "litellm_params", None)
+            if _litellm_params is not None:
+                _metadata = _litellm_params.get("metadata", {}) or {}
+                _model_info = _metadata.get("model_info", {}) or {}
+                _input_cost = _model_info.get("input_cost_per_token")
+                _output_cost = _model_info.get("output_cost_per_token")
+                if _input_cost is not None or _output_cost is not None:
+                    custom_cost_per_token = {
+                        "input_cost_per_token": _input_cost if _input_cost is not None else 0.0,
+                        "output_cost_per_token": _output_cost if _output_cost is not None else 0.0,
+                    }
+                # Also extract custom_cost_per_second if available
+                if custom_cost_per_second is None:
+                    _cost_per_second = _model_info.get("input_cost_per_second")
+                    if _cost_per_second is not None:
+                        custom_cost_per_second = _cost_per_second
+
         selected_model = _select_model_name_for_cost_calc(
             model=model,
             completion_response=completion_response,

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1139,9 +1139,14 @@ def completion_cost(  # noqa: PLR0915
                 _metadata = _litellm_params.get("metadata", {}) or {}
                 _model_info = _metadata.get("model_info", {}) or {}
                 # Prefer input_cost_per_second; fall back to output_cost_per_second
-                _cost_per_second = _model_info.get(
-                    "input_cost_per_second"
-                ) or _model_info.get("output_cost_per_second")
+                # Use `is not None` guards to correctly handle explicit 0.0 costs
+                _input_cost_per_second = _model_info.get("input_cost_per_second")
+                _output_cost_per_second = _model_info.get("output_cost_per_second")
+                _cost_per_second = (
+                    _input_cost_per_second
+                    if _input_cost_per_second is not None
+                    else _output_cost_per_second
+                )
                 if _cost_per_second is not None:
                     custom_cost_per_second = _cost_per_second
 

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -2096,3 +2096,85 @@ def test_custom_pricing_partial_costs_in_model_info():
     # Expected: (100 * 0.001) + (50 * 0.0) = 0.1
     expected_cost = 100 * 0.001
     assert cost == expected_cost, f"Expected cost {expected_cost}, got {cost}"
+
+
+def test_custom_pricing_per_second_from_model_info():
+    """
+    Test that custom_cost_per_second is correctly extracted from
+    litellm_logging_obj.litellm_params.metadata.model_info when
+    custom_pricing=True and input_cost_per_second is configured.
+
+    The per-second extraction should be independent of per-token extraction.
+    """
+    from unittest.mock import MagicMock
+
+    response = ModelResponse(
+        id="test-id",
+        model="custom/time-based-model",
+        choices=[],
+        usage=Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+    )
+
+    # Configure per-second pricing (no per-token pricing)
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.litellm_params = {
+        "metadata": {
+            "model_info": {
+                "input_cost_per_second": 0.01,  # $0.01 per second
+            }
+        }
+    }
+
+    # Set _response_ms on the response to simulate a 5-second request
+    response._response_ms = 5000.0
+
+    cost = completion_cost(
+        completion_response=response,
+        model="custom/time-based-model",
+        custom_llm_provider="custom",
+        custom_pricing=True,
+        litellm_logging_obj=mock_logging_obj,
+    )
+
+    # Expected: 0.01 * 5000 / 1000 = 0.05
+    expected_cost = 0.01 * 5000.0 / 1000.0
+    assert cost == expected_cost, f"Expected cost {expected_cost}, got {cost}"
+
+
+def test_custom_pricing_per_second_output_fallback():
+    """
+    Test that custom_cost_per_second falls back to output_cost_per_second
+    when input_cost_per_second is not available.
+    """
+    from unittest.mock import MagicMock
+
+    response = ModelResponse(
+        id="test-id",
+        model="custom/output-time-model",
+        choices=[],
+        usage=Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+    )
+
+    # Only output_cost_per_second provided
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.litellm_params = {
+        "metadata": {
+            "model_info": {
+                "output_cost_per_second": 0.02,  # $0.02 per second
+            }
+        }
+    }
+
+    response._response_ms = 3000.0
+
+    cost = completion_cost(
+        completion_response=response,
+        model="custom/output-time-model",
+        custom_llm_provider="custom",
+        custom_pricing=True,
+        litellm_logging_obj=mock_logging_obj,
+    )
+
+    # Expected: 0.02 * 3000 / 1000 = 0.06
+    expected_cost = 0.02 * 3000.0 / 1000.0
+    assert cost == expected_cost, f"Expected cost {expected_cost}, got {cost}"

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1970,3 +1970,129 @@ def test_additional_costs_only_for_azure_ai():
         completion_tokens=50,
     )
     assert result is None, "Vertex AI should have no additional costs"
+
+
+def test_custom_pricing_huggingface_extracts_from_model_info():
+    """
+    Test that custom pricing for HuggingFace (or any custom provider) correctly extracts
+    input_cost_per_token and output_cost_per_token from litellm_logging_obj.litellm_params.metadata.model_info.
+
+    This fixes issue #22863: HuggingFace cost calculation always returns $0.
+
+    When using router.huggingface.co with custom pricing config, the cost should be calculated
+    based on the input_cost_per_token/output_cost_per_token values in model_info.
+    """
+    from unittest.mock import MagicMock
+
+    # Create mock response with usage
+    response = ModelResponse(
+        id="test-id",
+        model="huggingface/my-custom-model",
+        choices=[],
+        usage=Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150),
+    )
+
+    # Create mock litellm_logging_obj with custom pricing in model_info
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.litellm_params = {
+        "metadata": {
+            "model_info": {
+                "input_cost_per_token": 0.0001,  # $0.0001 per input token
+                "output_cost_per_token": 0.0002,  # $0.0002 per output token
+            }
+        }
+    }
+
+    # Calculate cost with custom_pricing=True
+    cost = completion_cost(
+        completion_response=response,
+        model="huggingface/my-custom-model",
+        custom_llm_provider="huggingface",
+        custom_pricing=True,
+        litellm_logging_obj=mock_logging_obj,
+    )
+
+    # Expected: (100 * 0.0001) + (50 * 0.0002) = 0.01 + 0.01 = 0.02
+    expected_cost = (100 * 0.0001) + (50 * 0.0002)
+    assert cost == expected_cost, f"Expected cost {expected_cost}, got {cost}"
+    assert cost > 0, "Cost should be greater than 0 for custom HuggingFace pricing"
+
+
+def test_custom_pricing_unknown_provider_extracts_from_model_info():
+    """
+    Test that any unknown/custom provider with custom_pricing=True correctly uses
+    input_cost_per_token and output_cost_per_token from litellm_logging_obj.
+
+    This is a more general test to ensure the fix works for any custom provider,
+    not just HuggingFace.
+    """
+    from unittest.mock import MagicMock
+
+    # Create mock response
+    response = ModelResponse(
+        id="test-id",
+        model="custom-provider/custom-model",
+        choices=[],
+        usage=Usage(prompt_tokens=200, completion_tokens=100, total_tokens=300),
+    )
+
+    # Create mock litellm_logging_obj
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.litellm_params = {
+        "metadata": {
+            "model_info": {
+                "input_cost_per_token": 0.00005,
+                "output_cost_per_token": 0.00015,
+            }
+        }
+    }
+
+    cost = completion_cost(
+        completion_response=response,
+        model="custom-provider/custom-model",
+        custom_llm_provider="custom_provider",
+        custom_pricing=True,
+        litellm_logging_obj=mock_logging_obj,
+    )
+
+    # Expected: (200 * 0.00005) + (100 * 0.00015) = 0.01 + 0.015 = 0.025
+    expected_cost = (200 * 0.00005) + (100 * 0.00015)
+    assert cost == expected_cost, f"Expected cost {expected_cost}, got {cost}"
+
+
+def test_custom_pricing_partial_costs_in_model_info():
+    """
+    Test that custom pricing works when only one of input/output cost is provided.
+    The missing cost should default to 0.
+    """
+    from unittest.mock import MagicMock
+
+    response = ModelResponse(
+        id="test-id",
+        model="custom/model",
+        choices=[],
+        usage=Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150),
+    )
+
+    # Only input_cost_per_token provided
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.litellm_params = {
+        "metadata": {
+            "model_info": {
+                "input_cost_per_token": 0.001,
+                # output_cost_per_token not provided
+            }
+        }
+    }
+
+    cost = completion_cost(
+        completion_response=response,
+        model="custom/model",
+        custom_llm_provider="custom",
+        custom_pricing=True,
+        litellm_logging_obj=mock_logging_obj,
+    )
+
+    # Expected: (100 * 0.001) + (50 * 0.0) = 0.1
+    expected_cost = 100 * 0.001
+    assert cost == expected_cost, f"Expected cost {expected_cost}, got {cost}"


### PR DESCRIPTION
## Summary

Fixes #22863

When using HuggingFace via router.huggingface.co with custom pricing (`input_cost_per_token`/`output_cost_per_token` in model config), cost tracking was always returning $0.

## Root Cause
The `completion_cost` function wasn't extracting custom pricing from `litellm_logging_obj.litellm_params.metadata.model_info` when `custom_pricing=True`. For unknown providers (like HuggingFace), the code would fall back to the global model cost map, which doesn't contain custom deployments.

## Fix
Added logic to extract `custom_cost_per_token` from `model_info` in the metadata when `custom_pricing=True` and no explicit `custom_cost_per_token` was passed.

Also fixed a subtle bug: replaced `_input_cost or 0.0` with `_input_cost if _input_cost is not None else 0.0` to correctly handle explicit zero costs (free input tokens).

## Test Plan
- [x] `test_custom_pricing_huggingface_extracts_from_model_info` - HuggingFace custom pricing works
- [x] `test_custom_pricing_unknown_provider_extracts_from_model_info` - Any custom provider works
- [x] `test_custom_pricing_partial_costs_in_model_info` - Partial cost config works
- [x] All 36 tests in `test_cost_calculator.py` pass

## Example

**Before fix:**
```python
# response._hidden_params["response_cost"] == 0.0  # BUG
```

**After fix:**
```python
# response._hidden_params["response_cost"] == 0.02  # (100 * 0.0001 + 50 * 0.0002)
```