### PR TITLE
fix(sso): direct PKCE token exchange + Redis wiring for multi-instance SSO

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2549,17 +2549,36 @@ class SSOAuthenticationHandler:
                 # if the exchange fails partway through).
                 token_params["_pkce_cache_key"] = cache_key
             else:
-                # PKCE is enabled (already checked above) but verifier is missing — likely a cross-instance cache miss.
+                # PKCE is enabled (already checked above) but verifier is missing.
+                # Most likely cause: callback landed on a different pod than the login
+                # request, and no shared Redis cache is configured.  Silently falling
+                # through to the non-PKCE path would send the request to the provider
+                # without code_verifier, producing a confusing provider-side error.
+                # Raise immediately with a diagnostic that points to the root cause.
                 active_cache = redis_usage_cache if redis_usage_cache is not None else user_api_key_cache
                 verbose_proxy_logger.error(
                     "PKCE is enabled but no code_verifier found in cache for state '%s'. "
                     "This usually means the authorization and callback were handled by different "
                     "instances without a shared cache. "
-                    "Ensure Redis is configured and GENERIC_CLIENT_USE_PKCE=true. "
+                    "Ensure Redis is configured. "
                     "Cache type: %s. Cache entry present: %s",
                     state,
                     type(active_cache).__name__,
                     cached_data is not None,
+                )
+                redis_hint = (
+                    " Configure Redis and set REDIS_URL so all proxy instances share the PKCE verifier."
+                    if redis_usage_cache is None
+                    else ""
+                )
+                raise ProxyException(
+                    message=(
+                        f"PKCE verifier not found in cache for state '{state}'. "
+                        f"The login and callback requests were likely handled by different instances.{redis_hint}"
+                    ),
+                    type=ProxyErrorTypes.auth_error,
+                    param="PKCE_CACHE_MISS",
+                    code=status.HTTP_401_UNAUTHORIZED,
                 )
         return token_params
 
@@ -2707,11 +2726,14 @@ class SSOAuthenticationHandler:
             )
 
         # Some providers return HTTP 200 with an error body (e.g. expired code, replay attack).
-        if "access_token" not in token_response:
+        # Also guard against JSON `null` for access_token — it passes key-existence checks
+        # but would produce a "Bearer None" Authorization header downstream.
+        access_token_val = token_response.get("access_token")
+        if not isinstance(access_token_val, str) or not access_token_val:
             error = token_response.get("error", "unknown_error")
             error_desc = token_response.get("error_description", "")
             verbose_proxy_logger.error(
-                "Token response missing access_token. error=%s description=%s",
+                "Token response missing or null access_token. error=%s description=%s",
                 error,
                 error_desc,
             )
@@ -2767,7 +2789,7 @@ class SSOAuthenticationHandler:
                             userinfo = resp.json()
                             if not userinfo:
                                 verbose_proxy_logger.warning(
-                                    "Userinfo endpoint returned an empty response ({}). "
+                                    "Userinfo endpoint returned an empty dict. "
                                     "The session will have no identity claims. "
                                     "Check your provider's userinfo endpoint configuration.",
                                 )

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -795,17 +795,19 @@ async def get_generic_sso_response(
         code_verifier = token_exchange_params.pop("code_verifier", None)
         pkce_cache_key = token_exchange_params.pop("_pkce_cache_key", None)
 
-        # Get authorization code from query params
+        # Get authorization code from query params (only used in the PKCE path below;
+        # the non-PKCE path delegates to verify_and_process which handles OAuth error
+        # callbacks — user-denied, CSRF mismatch — internally).
         authorization_code = request.query_params.get("code")
-        if not authorization_code:
-            raise ProxyException(
-                message="Missing authorization code in callback",
-                type=ProxyErrorTypes.auth_error,
-                param="code",
-                code=status.HTTP_400_BAD_REQUEST,
-            )
 
         if code_verifier:
+            if not authorization_code:
+                raise ProxyException(
+                    message="Missing authorization code in callback",
+                    type=ProxyErrorTypes.auth_error,
+                    param="code",
+                    code=status.HTTP_400_BAD_REQUEST,
+                )
             if not generic_token_endpoint:
                 raise ProxyException(
                     message="GENERIC_TOKEN_ENDPOINT must be set when PKCE is enabled",
@@ -813,6 +815,8 @@ async def get_generic_sso_response(
                     param="GENERIC_TOKEN_ENDPOINT",
                     code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
+            # Both guards above raise, so narrowing holds at this point.
+            assert isinstance(authorization_code, str)  # appease static type checker
             combined_response = await SSOAuthenticationHandler._pkce_token_exchange(
                 authorization_code=authorization_code,
                 code_verifier=code_verifier,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2671,7 +2671,7 @@ class SSOAuthenticationHandler:
         token_endpoint: str,
         userinfo_endpoint: Optional[str],
         include_client_id: bool,
-        redirect_url: str,
+        redirect_url: Optional[str],
         additional_headers: Dict[str, str],
     ) -> dict:
         """
@@ -2691,9 +2691,12 @@ class SSOAuthenticationHandler:
         token_data: Dict[str, str] = {
             "grant_type": "authorization_code",
             "code": authorization_code,
-            "redirect_uri": redirect_url,
             "code_verifier": code_verifier,
         }
+        # Only include redirect_uri when set — omitting it avoids sending the
+        # literal string "None" to the provider if the env var is missing.
+        if redirect_url:
+            token_data["redirect_uri"] = redirect_url
 
         post_kwargs: Dict[str, Any] = {
             "data": token_data,
@@ -2716,52 +2719,55 @@ class SSOAuthenticationHandler:
             if client_secret:
                 token_data["client_secret"] = client_secret
 
-        # Keep all response processing inside the async with block so that the
-        # response object (which httpx buffers) is always accessed while the client
-        # is still alive.  Network errors on the POST are caught tightly here; TLS
-        # teardown errors from __aexit__ are NOT classified as token failures.
-        async with httpx.AsyncClient() as http_client:
-            try:
+        # Perform the POST inside async with; response is buffered by httpx so
+        # status_code, text, and json() are safe to access after __aexit__.
+        # Only the POST itself is wrapped in try/except — TLS teardown errors
+        # from __aexit__ propagate as-is and are NOT mis-labelled as "token
+        # endpoint request failed".
+        try:
+            async with httpx.AsyncClient() as http_client:
                 response = await http_client.post(token_endpoint, **post_kwargs)
-            except Exception as exc:
-                # Catch all network-level errors (SSL, DNS, TCP, timeout, etc.) and
-                # wrap them as a clean ProxyException rather than leaking raw httpx/OS
-                # exceptions to callers.
-                verbose_proxy_logger.error("PKCE token endpoint unreachable: %s", exc)
-                raise ProxyException(
-                    message=f"Token endpoint request failed: {exc}",
-                    type=ProxyErrorTypes.auth_error,
-                    param="token_exchange",
-                    code=status.HTTP_401_UNAUTHORIZED,
-                ) from exc
+        except Exception as exc:
+            # Catch network-level errors (SSL, DNS, TCP, timeout, etc.) and
+            # wrap them as a clean ProxyException rather than leaking raw httpx
+            # or OS exceptions to callers.
+            verbose_proxy_logger.error("PKCE token endpoint unreachable: %s", exc)
+            raise ProxyException(
+                message=f"Token endpoint request failed: {exc}",
+                type=ProxyErrorTypes.auth_error,
+                param="token_exchange",
+                code=status.HTTP_401_UNAUTHORIZED,
+            ) from exc
 
-            if response.status_code != 200:
-                verbose_proxy_logger.error(
-                    "PKCE token exchange failed. status=%s body=%s",
-                    response.status_code,
-                    response.text[:500],
-                )
-                raise ProxyException(
-                    message=f"Token exchange failed: {response.status_code} - {response.text[:500]}",
-                    type=ProxyErrorTypes.auth_error,
-                    param="token_exchange",
-                    code=status.HTTP_401_UNAUTHORIZED,
-                )
+        # All response processing happens outside the async with block —
+        # httpx buffers the full response so status_code / text / json() are safe.
+        if response.status_code != 200:
+            verbose_proxy_logger.error(
+                "PKCE token exchange failed. status=%s body=%s",
+                response.status_code,
+                response.text[:500],
+            )
+            raise ProxyException(
+                message=f"Token exchange failed: {response.status_code} - {response.text[:500]}",
+                type=ProxyErrorTypes.auth_error,
+                param="token_exchange",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
 
-            try:
-                token_response: dict = response.json()
-            except Exception as json_err:
-                verbose_proxy_logger.error(
-                    "Failed to parse token response as JSON: %s. Body: %s",
-                    json_err,
-                    response.text[:500],
-                )
-                raise ProxyException(
-                    message=f"Token endpoint returned invalid JSON: {json_err}",
-                    type=ProxyErrorTypes.auth_error,
-                    param="token_exchange",
-                    code=status.HTTP_401_UNAUTHORIZED,
-                )
+        try:
+            token_response: dict = response.json()
+        except Exception as json_err:
+            verbose_proxy_logger.error(
+                "Failed to parse token response as JSON: %s. Body: %s",
+                json_err,
+                response.text[:500],
+            )
+            raise ProxyException(
+                message=f"Token endpoint returned invalid JSON: {json_err}",
+                type=ProxyErrorTypes.auth_error,
+                param="token_exchange",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
 
         # Some providers return HTTP 200 with an error body (e.g. expired code, replay attack).
         # Also guard against JSON `null` for access_token — it passes key-existence checks
@@ -2803,10 +2809,17 @@ class SSOAuthenticationHandler:
         # But bearer credentials (access_token, id_token, refresh_token) must always come
         # from the token endpoint, not from userinfo (non-standard providers occasionally
         # include these fields in userinfo, which would otherwise shadow the real bearer token).
+        # Skip re-insertion when the token_response value is None (e.g. "id_token": null) —
+        # an absent key is a cleaner signal for "not present" than an explicit None and avoids
+        # diverging from the non-PKCE path where these fields are simply absent.
         merged = {**token_response, **userinfo}
         for field in _OAUTH_TOKEN_FIELDS:
-            if field in token_response:
+            if token_response.get(field) is not None:
                 merged[field] = token_response[field]
+            elif field in merged:
+                # Remove the key entirely if token_response had it as null/None so that
+                # callers can use `field in response` as a reliable presence check.
+                del merged[field]
         return merged
 
     @staticmethod

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -893,11 +893,21 @@ async def get_generic_sso_response(
                 code=status.HTTP_401_UNAUTHORIZED,
             )
 
-        verbose_proxy_logger.exception(
-            "Error verifying and processing generic SSO: %s. Passed in headers: %s",
-            e,
-            additional_generic_sso_headers_dict,
-        )
+        # Use .error() (not .exception()) for ProxyException — those are expected,
+        # intentional auth failures; emitting a full stack trace would produce
+        # false-positive alerts and pollute log aggregators.
+        if isinstance(e, ProxyException):
+            verbose_proxy_logger.error(
+                "SSO authentication failed: %s. Passed in headers: %s",
+                e,
+                additional_generic_sso_headers_dict,
+            )
+        else:
+            verbose_proxy_logger.exception(
+                "Error verifying and processing generic SSO: %s. Passed in headers: %s",
+                e,
+                additional_generic_sso_headers_dict,
+            )
         raise e
     verbose_proxy_logger.debug("generic result: %s", result)
     return result or {}, received_response
@@ -2765,9 +2775,14 @@ class SSOAuthenticationHandler:
 
         # Merge: userinfo takes precedence for identity claims (sub, email, name, …) per
         # the OpenID Connect spec (userinfo is the authoritative source for identity).
-        # token_response provides bearer credentials (access_token, id_token, refresh_token,
-        # token_type, expires_in) that userinfo endpoints do not return, so they are preserved.
-        return {**token_response, **userinfo}
+        # But bearer credentials (access_token, id_token, refresh_token) must always come
+        # from the token endpoint, not from userinfo (non-standard providers occasionally
+        # include these fields in userinfo, which would otherwise shadow the real bearer token).
+        merged = {**token_response, **userinfo}
+        for field in _OAUTH_TOKEN_FIELDS:
+            if field in token_response:
+                merged[field] = token_response[field]
+        return merged
 
     @staticmethod
     async def _get_pkce_userinfo(
@@ -2797,11 +2812,15 @@ class SSOAuthenticationHandler:
                         try:
                             userinfo = resp.json()
                             if not userinfo:
+                                # An empty dict means the provider returned 200 but no
+                                # identity claims — the session would be anonymous/broken.
+                                # Treat this as a failure so we attempt the id_token fallback.
                                 verbose_proxy_logger.warning(
-                                    "Userinfo endpoint returned an empty dict. "
-                                    "The session will have no identity claims. "
+                                    "Userinfo endpoint returned an empty dict; "
+                                    "treating as failure and attempting id_token fallback. "
                                     "Check your provider's userinfo endpoint configuration.",
                                 )
+                                userinfo = None
                         except Exception as json_err:
                             verbose_proxy_logger.warning(
                                 "Userinfo endpoint returned non-JSON response (status 200): %s",

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2840,7 +2840,7 @@ class SSOAuthenticationHandler:
             )
 
         try:
-            token_response: dict = response.json()
+            token_response_raw = response.json()
         except Exception as json_err:
             verbose_proxy_logger.error(
                 "Failed to parse token response as JSON: %s. Body: %s",
@@ -2853,6 +2853,25 @@ class SSOAuthenticationHandler:
                 param="token_exchange",
                 code=status.HTTP_401_UNAUTHORIZED,
             )
+
+        # Guard against HTTP 200 with body `null` — response.json() returns Python None
+        # in that case, and calling .get() on None raises AttributeError.
+        if not isinstance(token_response_raw, dict):
+            verbose_proxy_logger.error(
+                "Token endpoint returned non-dict JSON (type=%s). Body: %s",
+                type(token_response_raw).__name__,
+                response.text[:500],
+            )
+            raise ProxyException(
+                message=(
+                    f"Token endpoint returned unexpected response format "
+                    f"(expected JSON object, got {type(token_response_raw).__name__})"
+                ),
+                type=ProxyErrorTypes.auth_error,
+                param="token_exchange",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
+        token_response: dict = token_response_raw
 
         # Some providers return HTTP 200 with an error body (e.g. expired code, replay attack).
         # Also guard against JSON `null` for access_token — it passes key-existence checks
@@ -2920,7 +2939,7 @@ class SSOAuthenticationHandler:
         Fetches user info from the userinfo endpoint.
         Falls back to decoding the id_token if the endpoint is unavailable.
         """
-        # None = request not yet attempted, failed, or returned an empty dict (treated as failure
+        # None = request not yet attempted, failed, or returned empty/null (treated as failure
         # so the id_token fallback can be attempted instead of returning a session with no claims).
         userinfo: Optional[dict] = None
 
@@ -2937,17 +2956,19 @@ class SSOAuthenticationHandler:
                     )
                     if resp.status_code == 200:
                         try:
-                            userinfo = resp.json()
-                            if not userinfo:
-                                # An empty dict means the provider returned 200 but no
-                                # identity claims — the session would be anonymous/broken.
-                                # Treat this as a failure so we attempt the id_token fallback.
+                            userinfo_raw = resp.json()
+                            if not userinfo_raw:
+                                # JSON null (None) or empty dict ({}) — no identity claims.
+                                # Treat as failure so id_token fallback can be attempted.
                                 verbose_proxy_logger.warning(
-                                    "Userinfo endpoint returned an empty dict; "
-                                    "treating as failure and attempting id_token fallback. "
+                                    "Userinfo endpoint returned an empty or null response "
+                                    "(type=%s); treating as failure and attempting id_token fallback. "
                                     "Check your provider's userinfo endpoint configuration.",
+                                    type(userinfo_raw).__name__,
                                 )
                                 userinfo = None
+                            else:
+                                userinfo = userinfo_raw
                         except Exception as json_err:
                             verbose_proxy_logger.warning(
                                 "Userinfo endpoint returned non-JSON response (status 200): %s",
@@ -2964,8 +2985,8 @@ class SSOAuthenticationHandler:
                 )
 
         # Only fall back to id_token when the userinfo request failed (None).
-        # An empty dict ({}) is also treated as a failure (set to None above) since it
-        # contains no identity claims — id_token fallback is attempted in that case too.
+        # Empty dict ({}) and JSON null are both treated as failure (set to None above) since
+        # they contain no identity claims — id_token fallback is attempted in that case too.
         # Explicitly check for a non-empty string to avoid attempting JWT decode on
         # a blank or non-string id_token field from a misbehaving provider.
         if userinfo is None and isinstance(id_token, str) and id_token:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -776,6 +776,9 @@ async def get_generic_sso_response(
                 key, value = header.split("=")
                 additional_generic_sso_headers_dict[key] = value
 
+    # Initialized here so it's visible in the except block for error-hint logic
+    code_verifier: Optional[str] = None
+
     try:
         token_exchange_params = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
             request=request,
@@ -808,14 +811,18 @@ async def get_generic_sso_response(
                 additional_headers=additional_generic_sso_headers_dict,
             )
             result = response_convertor(combined_response, generic_sso)
+            # In the PKCE path verify_and_process is skipped, so generic_sso.access_token
+            # is never set. Read the token directly from the exchange response instead so
+            # process_sso_jwt_access_token can extract JWT-embedded roles/teams.
+            access_token_str: Optional[str] = combined_response.get("access_token")
         else:
             result = await generic_sso.verify_and_process(
                 request,
                 params=token_exchange_params,
                 headers=additional_generic_sso_headers_dict,
             )
+            access_token_str = generic_sso.access_token
 
-        access_token_str: Optional[str] = generic_sso.access_token
         process_sso_jwt_access_token(
             access_token_str, sso_jwt_handler, result, role_mappings=role_mappings
         )
@@ -823,8 +830,12 @@ async def get_generic_sso_response(
     except Exception as e:
         error_message = str(e)
 
-        # Detect PKCE misconfiguration and surface a helpful error
-        if "PKCE" in error_message or "code verifier" in error_message.lower():
+        # Only surface "enable PKCE" advice when PKCE was NOT already in use.
+        # If code_verifier is set, the token exchange itself failed — that's a
+        # provider-side error, not a configuration problem.
+        if code_verifier is None and (
+            "PKCE" in error_message or "code verifier" in error_message.lower()
+        ):
             is_okta = (
                 generic_authorization_endpoint
                 and "okta" in generic_authorization_endpoint.lower()
@@ -2617,6 +2628,22 @@ class SSOAuthenticationHandler:
             )
             raise
 
+        # Some providers return HTTP 200 with an error body (e.g. expired code, replay attack).
+        if "access_token" not in token_response:
+            error = token_response.get("error", "unknown_error")
+            error_desc = token_response.get("error_description", "")
+            verbose_proxy_logger.error(
+                "Token response missing access_token. error=%s description=%s",
+                error,
+                error_desc,
+            )
+            raise ProxyException(
+                message=f"Token exchange error: {error} - {error_desc}",
+                type=ProxyErrorTypes.auth_error,
+                param="token_exchange",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
+
         verbose_proxy_logger.debug(
             "PKCE token exchange successful. access_token=%s id_token=%s",
             bool(token_response.get("access_token")),
@@ -2677,6 +2704,17 @@ class SSOAuthenticationHandler:
                     param="userinfo",
                     code=status.HTTP_401_UNAUTHORIZED,
                 )
+
+        if not userinfo:
+            raise ProxyException(
+                message=(
+                    "SSO user info unavailable: userinfo endpoint failed and no id_token "
+                    "was present in the token response."
+                ),
+                type=ProxyErrorTypes.auth_error,
+                param="userinfo",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
 
         return userinfo
 

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2543,7 +2543,9 @@ class SSOAuthenticationHandler:
         query_params = dict(request.query_params)
         state = query_params.get("state")
 
-        if os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true" and not state:
+        use_pkce = os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true"
+
+        if use_pkce and not state:
             verbose_proxy_logger.warning(
                 "PKCE is enabled (GENERIC_CLIENT_USE_PKCE=true) but no 'state' parameter "
                 "was found in the callback. The PKCE verifier cannot be retrieved without "
@@ -2552,7 +2554,7 @@ class SSOAuthenticationHandler:
                 "in the callback redirect."
             )
 
-        if state and os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true":
+        if state and use_pkce:
             from litellm.proxy.proxy_server import redis_usage_cache, user_api_key_cache
 
             cache_key = f"pkce_verifier:{state}"
@@ -2969,7 +2971,7 @@ class SSOAuthenticationHandler:
             except Exception as decode_err:
                 verbose_proxy_logger.error("Failed to decode id_token: %s", decode_err)
                 raise ProxyException(
-                    message="Failed to get user info from both userinfo endpoint and id_token",
+                    message=f"Failed to decode id_token JWT: {decode_err}",
                     type=ProxyErrorTypes.auth_error,
                     param="userinfo",
                     code=status.HTTP_401_UNAUTHORIZED,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -806,6 +806,13 @@ async def get_generic_sso_response(
             )
 
         if code_verifier:
+            if not generic_token_endpoint:
+                raise ProxyException(
+                    message="GENERIC_TOKEN_ENDPOINT must be set when PKCE is enabled",
+                    type=ProxyErrorTypes.auth_error,
+                    param="GENERIC_TOKEN_ENDPOINT",
+                    code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                )
             combined_response = await SSOAuthenticationHandler._pkce_token_exchange(
                 authorization_code=authorization_code,
                 code_verifier=code_verifier,
@@ -2558,13 +2565,24 @@ class SSOAuthenticationHandler:
 
     @staticmethod
     async def _delete_pkce_verifier(cache_key: str) -> None:
-        """Delete a single-use PKCE verifier from cache after a successful exchange."""
+        """Delete a single-use PKCE verifier from cache after a successful exchange.
+
+        Failure is non-fatal: a leftover verifier is a minor security concern
+        (unused key in cache) but not worth aborting an otherwise-successful login.
+        """
         from litellm.proxy.proxy_server import redis_usage_cache, user_api_key_cache
 
-        if redis_usage_cache is not None:
-            await redis_usage_cache.async_delete_cache(key=cache_key)
-        else:
-            await user_api_key_cache.async_delete_cache(key=cache_key)
+        try:
+            if redis_usage_cache is not None:
+                await redis_usage_cache.async_delete_cache(key=cache_key)
+            else:
+                await user_api_key_cache.async_delete_cache(key=cache_key)
+        except Exception as exc:
+            verbose_proxy_logger.warning(
+                "PKCE: failed to delete verifier cache key '%s' (best-effort cleanup): %s",
+                cache_key,
+                exc,
+            )
 
     @staticmethod
     def generate_pkce_params() -> Tuple[str, str]:
@@ -2764,9 +2782,9 @@ class SSOAuthenticationHandler:
 
         # Only fall back to id_token when the userinfo request failed (None).
         # An empty dict ({}) from the endpoint is a valid response and not retried.
-        # Explicitly check for non-None and non-empty string to avoid attempting
-        # JWT decode on a blank id_token field.
-        if userinfo is None and id_token is not None and id_token != "":
+        # Explicitly check for a non-empty string to avoid attempting JWT decode on
+        # a blank or non-string id_token field from a misbehaving provider.
+        if userinfo is None and isinstance(id_token, str) and id_token:
             try:
                 userinfo = jwt.decode(id_token, options={"verify_signature": False})
             except Exception as decode_err:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -852,6 +852,9 @@ async def get_generic_sso_response(
             # Strip bearer credentials from received_response after conversion.
             # received_response may appear in restricted-group error messages —
             # do not expose tokens to callers.
+            # Note: response_convertor always sets received_response via nonlocal, so it is
+            # non-None here at runtime.  The guard satisfies Pyright's type narrowing since
+            # it cannot track nonlocal mutations inside closures.
             if received_response is not None:
                 received_response = {
                     k: v for k, v in received_response.items() if k not in _OAUTH_TOKEN_FIELDS
@@ -2585,30 +2588,49 @@ class SSOAuthenticationHandler:
                     os.getenv("PKCE_STRICT_CACHE_MISS", "false").lower() == "true"
                 )
                 if strict_cache_miss:
-                    verbose_proxy_logger.error(
-                        "PKCE is enabled but no usable code_verifier found for state '%s'. "
-                        "This usually means the authorization and callback were handled by different "
-                        "instances without a shared cache, or the cached value had an unrecognized format. "
-                        "Ensure Redis is configured. "
-                        "Cache type: %s. Raw cache data present (may be unrecognized format): %s",
-                        state,
-                        type(active_cache).__name__,
-                        cached_data is not None,
-                    )
-                    redis_hint = (
-                        " Configure Redis and set REDIS_URL so all proxy instances share the PKCE verifier."
-                        if redis_usage_cache is None
-                        else ""
-                    )
-                    raise ProxyException(
-                        message=(
-                            f"PKCE verifier not found in cache for state '{state}'. "
-                            f"The login and callback requests were likely handled by different instances.{redis_hint}"
-                        ),
-                        type=ProxyErrorTypes.auth_error,
-                        param="PKCE_CACHE_MISS",
-                        code=status.HTTP_401_UNAUTHORIZED,
-                    )
+                    # Distinguish corrupt-format entries from genuine cache misses
+                    # so operators can investigate the correct root cause.
+                    if cached_data is not None:
+                        # Cache had data but in an unrecognised format (e.g. corrupt Redis value).
+                        verbose_proxy_logger.error(
+                            "PKCE verifier for state '%s' has an unrecognized format (type=%s); "
+                            "treating as a cache miss. Investigate the cached value — it may be "
+                            "a corrupt or stale entry.",
+                            state,
+                            type(cached_data).__name__,
+                        )
+                        raise ProxyException(
+                            message=(
+                                f"PKCE verifier for state '{state}' has an unrecognized format "
+                                f"(type={type(cached_data).__name__}). The cached entry may be corrupt."
+                            ),
+                            type=ProxyErrorTypes.auth_error,
+                            param="PKCE_CACHE_MISS",
+                            code=status.HTTP_401_UNAUTHORIZED,
+                        )
+                    else:
+                        # Genuine cache miss — verifier was never stored or already expired.
+                        verbose_proxy_logger.error(
+                            "PKCE is enabled but no verifier found in cache for state '%s'. "
+                            "The authorization and callback were likely handled by different "
+                            "instances without a shared cache. Cache type: %s.",
+                            state,
+                            type(active_cache).__name__,
+                        )
+                        redis_hint = (
+                            " Configure Redis and set REDIS_URL so all proxy instances share the PKCE verifier."
+                            if redis_usage_cache is None
+                            else ""
+                        )
+                        raise ProxyException(
+                            message=(
+                                f"PKCE verifier not found in cache for state '{state}'. "
+                                f"The login and callback requests were likely handled by different instances.{redis_hint}"
+                            ),
+                            type=ProxyErrorTypes.auth_error,
+                            param="PKCE_CACHE_MISS",
+                            code=status.HTTP_401_UNAUTHORIZED,
+                        )
                 else:
                     verbose_proxy_logger.warning(
                         "PKCE is enabled but verifier not found in cache for state '%s' "

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -815,8 +815,15 @@ async def get_generic_sso_response(
                     param="GENERIC_TOKEN_ENDPOINT",
                     code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
-            # Both guards above raise, so narrowing holds at this point.
-            assert isinstance(authorization_code, str)  # appease static type checker
+            # Both guards above raise, so authorization_code is a non-empty str here.
+            # Use an explicit type guard rather than assert (assert is a no-op with -O).
+            if not isinstance(authorization_code, str):
+                raise ProxyException(
+                    message="Missing authorization code in callback",
+                    type=ProxyErrorTypes.auth_error,
+                    param="code",
+                    code=status.HTTP_400_BAD_REQUEST,
+                )
             combined_response = await SSOAuthenticationHandler._pkce_token_exchange(
                 authorization_code=authorization_code,
                 code_verifier=code_verifier,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2557,11 +2557,11 @@ class SSOAuthenticationHandler:
                 # Raise immediately with a diagnostic that points to the root cause.
                 active_cache = redis_usage_cache if redis_usage_cache is not None else user_api_key_cache
                 verbose_proxy_logger.error(
-                    "PKCE is enabled but no code_verifier found in cache for state '%s'. "
+                    "PKCE is enabled but no usable code_verifier found for state '%s'. "
                     "This usually means the authorization and callback were handled by different "
-                    "instances without a shared cache. "
+                    "instances without a shared cache, or the cached value had an unrecognized format. "
                     "Ensure Redis is configured. "
-                    "Cache type: %s. Cache entry present: %s",
+                    "Cache type: %s. Raw cache data present (may be unrecognized format): %s",
                     state,
                     type(active_cache).__name__,
                     cached_data is not None,
@@ -2685,20 +2685,23 @@ class SSOAuthenticationHandler:
             if client_secret:
                 token_data["client_secret"] = client_secret
 
-        try:
-            async with httpx.AsyncClient() as http_client:
+        # Tighten the try/except to the POST call only, so httpx connection-pool
+        # teardown in __aexit__ (TLS close, etc.) does not get misclassified as a
+        # token-endpoint failure.
+        async with httpx.AsyncClient() as http_client:
+            try:
                 response = await http_client.post(token_endpoint, **post_kwargs)
-        except Exception as exc:
-            # Catch all network-level errors (SSL, DNS, TCP, timeout, etc.) and
-            # wrap them as a clean ProxyException rather than leaking raw httpx/OS
-            # exceptions to callers.
-            verbose_proxy_logger.error("PKCE token endpoint unreachable: %s", exc)
-            raise ProxyException(
-                message=f"Token endpoint request failed: {exc}",
-                type=ProxyErrorTypes.auth_error,
-                param="token_exchange",
-                code=status.HTTP_401_UNAUTHORIZED,
-            ) from exc
+            except Exception as exc:
+                # Catch all network-level errors (SSL, DNS, TCP, timeout, etc.) and
+                # wrap them as a clean ProxyException rather than leaking raw httpx/OS
+                # exceptions to callers.
+                verbose_proxy_logger.error("PKCE token endpoint unreachable: %s", exc)
+                raise ProxyException(
+                    message=f"Token endpoint request failed: {exc}",
+                    type=ProxyErrorTypes.auth_error,
+                    param="token_exchange",
+                    code=status.HTTP_401_UNAUTHORIZED,
+                ) from exc
 
         if response.status_code != 200:
             verbose_proxy_logger.error(

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -813,14 +813,14 @@ async def get_generic_sso_response(
                     message="GENERIC_CLIENT_ID must be set when PKCE is enabled",
                     type=ProxyErrorTypes.auth_error,
                     param="GENERIC_CLIENT_ID",
-                    code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    code=status.HTTP_401_UNAUTHORIZED,
                 )
             if not generic_token_endpoint:
                 raise ProxyException(
                     message="GENERIC_TOKEN_ENDPOINT must be set when PKCE is enabled",
                     type=ProxyErrorTypes.auth_error,
                     param="GENERIC_TOKEN_ENDPOINT",
-                    code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    code=status.HTTP_401_UNAUTHORIZED,
                 )
             # All guards above raise, so authorization_code is a non-empty str here.
             # Use an explicit type guard rather than assert (assert is a no-op with -O).

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -84,6 +84,7 @@ from litellm.proxy.utils import (
     get_server_root_path,
 )
 from litellm.secret_managers.main import get_secret_bool, str_to_bool
+from litellm.types.proxy.management_endpoints.ui_sso import *  # noqa: F403, F401
 from litellm.types.proxy.management_endpoints.ui_sso import (
     DefaultTeamSSOParams,
     MicrosoftGraphAPIUserGroupDirectoryObject,
@@ -92,7 +93,6 @@ from litellm.types.proxy.management_endpoints.ui_sso import (
     RoleMappings,
     TeamMappings,
 )
-from litellm.types.proxy.management_endpoints.ui_sso import *  # noqa: F403, F401
 from litellm.types.proxy.ui_sso import ParsedOpenIDResult
 
 if TYPE_CHECKING:
@@ -775,14 +775,164 @@ async def get_generic_sso_response(
                 additional_generic_sso_headers_dict[key] = value
 
     try:
-        result = await generic_sso.verify_and_process(
-            request,
-            params=await SSOAuthenticationHandler.prepare_token_exchange_parameters(
-                request=request,
-                generic_include_client_id=generic_include_client_id,
-            ),
-            headers=additional_generic_sso_headers_dict,
+        token_exchange_params = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+            request=request,
+            generic_include_client_id=generic_include_client_id,
         )
+
+        # Extract code_verifier before calling fastapi-sso
+        code_verifier = token_exchange_params.pop("code_verifier", None)
+
+        # Get authorization code from query params
+        authorization_code = request.query_params.get("code")
+        if not authorization_code:
+            raise ProxyException(
+                message="Missing authorization code in callback",
+                type=ProxyErrorTypes.auth_error,
+                param="code",
+                code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if code_verifier:
+            verbose_proxy_logger.info(
+                f"✔ PKCE: Performing direct token exchange with code_verifier. "
+                f"Length: {len(code_verifier)}"
+            )
+
+            # Direct token exchange to include code_verifier (fastapi-sso doesn't support PKCE)
+            import httpx
+
+            token_data = {
+                "grant_type": "authorization_code",
+                "code": authorization_code,
+                "redirect_uri": redirect_url,
+                "code_verifier": code_verifier,
+            }
+
+            # Add client credentials
+            if not generic_include_client_id:
+                # Use HTTP Basic Auth for client credentials
+                auth = httpx.BasicAuth(generic_client_id, generic_client_secret)
+            else:
+                # Include client credentials in body
+                token_data["client_id"] = generic_client_id
+                token_data["client_secret"] = generic_client_secret
+                auth = None
+
+            async with httpx.AsyncClient() as client:
+                post_kwargs: dict = {
+                    "data": token_data,
+                    "headers": {
+                        "Content-Type": "application/x-www-form-urlencoded",
+                        "Accept": "application/json",
+                        **additional_generic_sso_headers_dict,
+                    },
+                    "timeout": 30.0,
+                }
+                if auth is not None:
+                    post_kwargs["auth"] = auth
+                response = await client.post(generic_token_endpoint, **post_kwargs)
+
+                response_text = response.text
+
+                if response.status_code != 200:
+                    verbose_proxy_logger.error(
+                        f"Token exchange failed: Status={response.status_code}"
+                    )
+                    verbose_proxy_logger.error(
+                        f"✘ Token exchange FAILED!\n"
+                        f"   Status: {response.status_code}\n"
+                        f"   Full Response:\n{response_text}"
+                    )
+                    raise ProxyException(
+                        message=f"Token exchange failed: {response.status_code} - {response_text[:500]}",
+                        type=ProxyErrorTypes.auth_error,
+                        param="token_exchange",
+                        code=status.HTTP_401_UNAUTHORIZED,
+                    )
+
+                # Parse token response
+                try:
+                    token_response = response.json()
+                    verbose_proxy_logger.info(
+                        f"✔ Token exchange successful! "
+                        f"access_token={bool(token_response.get('access_token'))}, "
+                        f"id_token={bool(token_response.get('id_token'))}"
+                    )
+                except Exception as json_err:
+                    verbose_proxy_logger.error(
+                        f"✘ Failed to parse token response as JSON!\n"
+                        f"   Error: {json_err}\n"
+                        f"   Response text: {response_text}"
+                    )
+                    raise
+
+            # Get user info - try userinfo endpoint first, fallback to id_token
+            access_token = token_response["access_token"]
+            id_token = token_response.get("id_token")
+            userinfo: dict = {}
+
+            try:
+                async with httpx.AsyncClient() as client:
+                    userinfo_response = await client.get(
+                        generic_userinfo_endpoint,
+                        headers={
+                            "Authorization": f"Bearer {access_token}",
+                            **additional_generic_sso_headers_dict,
+                        },
+                        timeout=30.0,
+                    )
+
+                    if userinfo_response.status_code == 200:
+                        userinfo = userinfo_response.json()
+                        verbose_proxy_logger.debug(
+                            "User info retrieved from userinfo endpoint"
+                        )
+                    else:
+                        verbose_proxy_logger.warning(
+                            f"⚠ Userinfo endpoint failed ({userinfo_response.status_code}), "
+                            f"will extract from id_token instead"
+                        )
+            except Exception as userinfo_err:
+                verbose_proxy_logger.warning(
+                    f"⚠ Userinfo endpoint error: {userinfo_err}, will extract from id_token instead"
+                )
+
+            # If userinfo is empty, extract from id_token
+            if not userinfo and id_token:
+                import jwt
+
+                try:
+                    # Decode id_token without verification (we already trust it from token exchange)
+                    id_token_payload = jwt.decode(
+                        id_token,
+                        options={"verify_signature": False},
+                    )
+                    userinfo = id_token_payload
+                    verbose_proxy_logger.debug("User info extracted from id_token")
+                except Exception as decode_err:
+                    verbose_proxy_logger.error(
+                        f"✘ Failed to decode id_token: {decode_err}"
+                    )
+                    raise ProxyException(
+                        message="Failed to get user info from both userinfo endpoint and id_token",
+                        type=ProxyErrorTypes.auth_error,
+                        param="userinfo",
+                        code=status.HTTP_401_UNAUTHORIZED,
+                    )
+
+            # Build combined response for convertor
+            combined_response = {**token_response, **userinfo}
+            result = response_convertor(combined_response, generic_sso)
+
+        else:
+            verbose_proxy_logger.info("No PKCE code_verifier - using standard verify_and_process")
+            # No PKCE, use standard flow
+            result = await generic_sso.verify_and_process(
+                request,
+                params=token_exchange_params,
+                headers=additional_generic_sso_headers_dict,
+            )
 
         access_token_str: Optional[str] = generic_sso.access_token
         process_sso_jwt_access_token(
@@ -790,6 +940,63 @@ async def get_generic_sso_response(
         )
 
     except Exception as e:
+        error_message = str(e)
+
+        # Log detailed error information for debugging
+        verbose_proxy_logger.error(
+            f"Error verifying and processing generic SSO: {error_message}. "
+            f"Error type: {type(e).__name__}. "
+            f"Passed in headers: {additional_generic_sso_headers_dict}"
+        )
+
+        # Check if this is a JSON decode error (provider returned non-JSON response)
+        if "JSONDecodeError" in str(type(e).__name__) or "Expecting value" in error_message:
+            verbose_proxy_logger.error(
+                f"SSO provider returned invalid JSON response during token exchange. "
+                f"This typically means: (1) Token exchange request was rejected by the provider, "
+                f"(2) code_verifier format is incorrect, or (3) provider configuration issue."
+            )
+
+        # Check if this is a PKCE-related error
+        if "PKCE" in error_message or "code verifier" in error_message.lower():
+            # Detect if this is Okta by checking the endpoints
+            is_okta = (
+                generic_authorization_endpoint and "okta" in generic_authorization_endpoint.lower()
+            ) or (
+                generic_token_endpoint and "okta" in generic_token_endpoint.lower()
+            )
+
+            provider_name = "Okta" if is_okta else "Your OAuth provider"
+
+            verbose_proxy_logger.error(
+                f"PKCE error detected: {error_message}. {provider_name} requires PKCE but it's not enabled. "
+                f"Set GENERIC_CLIENT_USE_PKCE=true in your environment variables. "
+                f"See https://docs.litellm.ai/docs/proxy/admin_ui_sso for more details."
+            )
+
+            detailed_message = (
+                f"SSO authentication failed: {provider_name} requires PKCE (Proof Key for Code Exchange) "
+                f"but it's not enabled in your LiteLLM configuration.\n\n"
+                f"SOLUTION: Add this environment variable and restart your proxy:\n"
+                f"  GENERIC_CLIENT_USE_PKCE=true\n\n"
+            )
+
+            if is_okta:
+                detailed_message += (
+                    f"For AWS ECS: Add the environment variable to your task definition.\n"
+                    f"For Docker: Add -e GENERIC_CLIENT_USE_PKCE=true to your docker run command.\n"
+                    f"For .env file: Add GENERIC_CLIENT_USE_PKCE=true to your .env file.\n\n"
+                )
+
+            detailed_message += f"Original error: {error_message}"
+
+            raise ProxyException(
+                message=detailed_message,
+                type=ProxyErrorTypes.auth_error,
+                param="GENERIC_CLIENT_USE_PKCE",
+                code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
         verbose_proxy_logger.exception(
             f"Error verifying and processing generic SSO: {e}. Passed in headers: {additional_generic_sso_headers_dict}"
         )
@@ -1773,21 +1980,25 @@ class SSOAuthenticationHandler:
 
             # If PKCE is enabled, add PKCE parameters to the redirect URL
             if code_verifier and "state" in redirect_params:
-                # Store code_verifier in cache (10 min TTL). Use Redis when available
-                # so callbacks landing on another pod can retrieve it (multi-pod SSO).
+                # Store code_verifier in cache (10 min TTL). Wrap in dict for proper
+                # JSON serialization in Redis. Use Redis when available so callbacks
+                # landing on another pod can retrieve it (multi-pod SSO).
                 cache_key = f"pkce_verifier:{redirect_params['state']}"
                 if redis_usage_cache is not None:
                     await redis_usage_cache.async_set_cache(
                         key=cache_key,
-                        value=code_verifier,
+                        value={"code_verifier": code_verifier},
                         ttl=600,
                     )
                 else:
                     await user_api_key_cache.async_set_cache(
                         key=cache_key,
-                        value=code_verifier,
+                        value={"code_verifier": code_verifier},
                         ttl=600,
                     )
+                verbose_proxy_logger.debug(
+                    "PKCE code_verifier stored in cache (TTL: 600s)"
+                )
 
                 # Add PKCE parameters to the authorization URL
                 if pkce_params:
@@ -1813,9 +2024,6 @@ class SSOAuthenticationHandler:
 
                     # Update the redirect response
                     redirect_response.headers["location"] = new_url
-                    verbose_proxy_logger.debug(
-                        "PKCE parameters added to authorization URL"
-                    )
             return redirect_response
 
     @staticmethod
@@ -1858,7 +2066,9 @@ class SSOAuthenticationHandler:
 
         # Handle PKCE (Proof Key for Code Exchange) if enabled
         # Set GENERIC_CLIENT_USE_PKCE=true to enable PKCE for enhanced OAuth security
-        use_pkce = os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true"
+        pkce_env_value = os.getenv("GENERIC_CLIENT_USE_PKCE", "false")
+        use_pkce = pkce_env_value.lower() == "true"
+
         if use_pkce:
             (
                 code_verifier,
@@ -1866,9 +2076,7 @@ class SSOAuthenticationHandler:
             ) = SSOAuthenticationHandler.generate_pkce_params()
             redirect_params["code_challenge"] = code_challenge
             redirect_params["code_challenge_method"] = "S256"
-            verbose_proxy_logger.debug(
-                "PKCE enabled - code_challenge added to authorization request"
-            )
+            verbose_proxy_logger.info("PKCE enabled for authorization request")
 
         return redirect_params, code_verifier
 
@@ -2405,31 +2613,48 @@ class SSOAuthenticationHandler:
         # Use same cache as store: Redis when available (multi-pod), else in-memory.
         query_params = dict(request.query_params)
         state = query_params.get("state")
+
         if state:
             from litellm.proxy.proxy_server import redis_usage_cache, user_api_key_cache
 
             cache_key = f"pkce_verifier:{state}"
             if redis_usage_cache is not None:
-                code_verifier = await redis_usage_cache.async_get_cache(key=cache_key)
+                cached_data = await redis_usage_cache.async_get_cache(key=cache_key)
             else:
-                code_verifier = await user_api_key_cache.async_get_cache(key=cache_key)
+                cached_data = await user_api_key_cache.async_get_cache(key=cache_key)
+
+            code_verifier = None
+
+            if cached_data:
+                # Extract code_verifier from dict (stored as dict for JSON serialization)
+                if isinstance(cached_data, dict) and "code_verifier" in cached_data:
+                    code_verifier = cached_data["code_verifier"]
+                    verbose_proxy_logger.debug("PKCE code_verifier retrieved from cache")
+                else:
+                    # Handle legacy format (plain string) for backward compatibility
+                    code_verifier = cached_data if isinstance(cached_data, str) else str(cached_data)
+                    verbose_proxy_logger.warning(
+                        "Retrieved code_verifier in legacy format (plain string). "
+                        "Using it but future storage will use dict format."
+                    )
 
             if code_verifier:
-                # Add code_verifier to token exchange parameters (Redis returns decoded string)
-                token_params["code_verifier"] = (
-                    code_verifier
-                    if isinstance(code_verifier, str)
-                    else str(code_verifier)
-                )
-                verbose_proxy_logger.debug(
-                    "PKCE code_verifier retrieved and will be included in token exchange"
-                )
-
+                # Add code_verifier to token exchange parameters
+                token_params["code_verifier"] = code_verifier
                 # Clean up the cache entry (single-use verifier)
                 if redis_usage_cache is not None:
                     await redis_usage_cache.async_delete_cache(key=cache_key)
                 else:
                     await user_api_key_cache.async_delete_cache(key=cache_key)
+            else:
+                verbose_proxy_logger.error(
+                    f"✙ CRITICAL: No PKCE code_verifier found in cache for state '{state}'. "
+                    f"This indicates: (1) authorization request and callback handled by different instances without shared cache, "
+                    f"(2) cache entry expired (TTL: 600s), or (3) Redis serialization error. "
+                    f"SOLUTION: Ensure Redis is configured correctly. "
+                    f"Cache type: {type(user_api_key_cache).__name__}. "
+                    f"Cached data: {cached_data}"
+                )
         return token_params
 
     @staticmethod

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2678,6 +2678,10 @@ class SSOAuthenticationHandler:
                             code=status.HTTP_401_UNAUTHORIZED,
                         )
                 else:
+                    # Best-effort cleanup: if a stale/corrupt entry is present, delete it
+                    # now so it does not linger until TTL expiry (resource hygiene).
+                    if cached_data is not None:
+                        await SSOAuthenticationHandler._delete_pkce_verifier(cache_key)
                     verbose_proxy_logger.warning(
                         "PKCE is enabled but verifier not found in cache for state '%s' "
                         "(cache type: %s, raw data present: %s). "

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2561,39 +2561,45 @@ class SSOAuthenticationHandler:
             else:
                 # PKCE is enabled (already checked above) but verifier is missing.
                 # Most likely cause: callback landed on a different pod than the login
-                # request, and no shared Redis cache is configured.  Silently falling
-                # through to the non-PKCE path would send the request to the provider
-                # without code_verifier, producing a confusing provider-side error.
-                # Raise immediately with a diagnostic that points to the root cause.
+                # request, and no shared Redis cache is configured.
                 active_cache = redis_usage_cache if redis_usage_cache is not None else user_api_key_cache
-                verbose_proxy_logger.error(
-                    "PKCE is enabled but no usable code_verifier found for state '%s'. "
-                    "This usually means the authorization and callback were handled by different "
-                    "instances without a shared cache, or the cached value had an unrecognized format. "
-                    "Ensure Redis is configured. "
-                    "Cache type: %s. Raw cache data present (may be unrecognized format): %s",
-                    state,
-                    type(active_cache).__name__,
-                    cached_data is not None,
+                strict_cache_miss = (
+                    os.getenv("PKCE_STRICT_CACHE_MISS", "false").lower() == "true"
                 )
-                redis_hint = (
-                    " Configure Redis and set REDIS_URL so all proxy instances share the PKCE verifier."
-                    if redis_usage_cache is None
-                    else ""
-                )
-                # Raise immediately — falling through to a non-PKCE flow would only
-                # produce a confusing provider-side error (provider requires code_verifier).
-                # Since PKCE support is new in this release, there is no prior behavior
-                # to preserve: the verifier was never actually used before this PR.
-                raise ProxyException(
-                    message=(
-                        f"PKCE verifier not found in cache for state '{state}'. "
-                        f"The login and callback requests were likely handled by different instances.{redis_hint}"
-                    ),
-                    type=ProxyErrorTypes.auth_error,
-                    param="PKCE_CACHE_MISS",
-                    code=status.HTTP_401_UNAUTHORIZED,
-                )
+                if strict_cache_miss:
+                    verbose_proxy_logger.error(
+                        "PKCE is enabled but no usable code_verifier found for state '%s'. "
+                        "This usually means the authorization and callback were handled by different "
+                        "instances without a shared cache, or the cached value had an unrecognized format. "
+                        "Ensure Redis is configured. "
+                        "Cache type: %s. Raw cache data present (may be unrecognized format): %s",
+                        state,
+                        type(active_cache).__name__,
+                        cached_data is not None,
+                    )
+                    redis_hint = (
+                        " Configure Redis and set REDIS_URL so all proxy instances share the PKCE verifier."
+                        if redis_usage_cache is None
+                        else ""
+                    )
+                    raise ProxyException(
+                        message=(
+                            f"PKCE verifier not found in cache for state '{state}'. "
+                            f"The login and callback requests were likely handled by different instances.{redis_hint}"
+                        ),
+                        type=ProxyErrorTypes.auth_error,
+                        param="PKCE_CACHE_MISS",
+                        code=status.HTTP_401_UNAUTHORIZED,
+                    )
+                else:
+                    verbose_proxy_logger.warning(
+                        "PKCE is enabled but verifier not found in cache for state '%s' "
+                        "(cache type: %s, raw data present: %s). "
+                        "Continuing without code_verifier — set PKCE_STRICT_CACHE_MISS=true to fail fast instead.",
+                        state,
+                        type(active_cache).__name__,
+                        cached_data is not None,
+                    )
         return token_params
 
     @staticmethod
@@ -2847,8 +2853,8 @@ class SSOAuthenticationHandler:
                 )
 
         # Only fall back to id_token when the userinfo request failed (None).
-        # An empty dict ({}) is treated as a failure (userinfo is set to None above)
-        # so we also attempt the id_token fallback in that case.
+        # An empty dict ({}) is also treated as a failure (set to None above) since it
+        # contains no identity claims — id_token fallback is attempted in that case too.
         # Explicitly check for a non-empty string to avoid attempting JWT decode on
         # a blank or non-string id_token field from a misbehaving provider.
         if userinfo is None and isinstance(id_token, str) and id_token:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -1973,7 +1973,7 @@ class SSOAuthenticationHandler:
             ) = SSOAuthenticationHandler.generate_pkce_params()
             redirect_params["code_challenge"] = code_challenge
             redirect_params["code_challenge_method"] = "S256"
-            verbose_proxy_logger.info("PKCE enabled for authorization request")
+            verbose_proxy_logger.debug("PKCE enabled for authorization request")
 
         return redirect_params, code_verifier
 
@@ -2763,9 +2763,11 @@ class SSOAuthenticationHandler:
             additional_headers=additional_headers,
         )
 
-        # Merge with token_response taking precedence so token fields (e.g. access_token)
-        # cannot be overridden by non-standard userinfo fields.
-        return {**userinfo, **token_response}
+        # Merge: userinfo takes precedence for identity claims (sub, email, name, …) per
+        # the OpenID Connect spec (userinfo is the authoritative source for identity).
+        # token_response provides bearer credentials (access_token, id_token, refresh_token,
+        # token_type, expires_in) that userinfo endpoints do not return, so they are preserved.
+        return {**token_response, **userinfo}
 
     @staticmethod
     async def _get_pkce_userinfo(

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -17,6 +17,8 @@ import secrets
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
+import httpx
+import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
 
@@ -794,140 +796,19 @@ async def get_generic_sso_response(
             )
 
         if code_verifier:
-            verbose_proxy_logger.info(
-                f"✔ PKCE: Performing direct token exchange with code_verifier. "
-                f"Length: {len(code_verifier)}"
+            combined_response = await SSOAuthenticationHandler._pkce_token_exchange(
+                authorization_code=authorization_code,
+                code_verifier=code_verifier,
+                client_id=generic_client_id,
+                client_secret=generic_client_secret,
+                token_endpoint=generic_token_endpoint,
+                userinfo_endpoint=generic_userinfo_endpoint,
+                include_client_id=generic_include_client_id,
+                redirect_url=redirect_url,
+                additional_headers=additional_generic_sso_headers_dict,
             )
-
-            # Direct token exchange to include code_verifier (fastapi-sso doesn't support PKCE)
-            import httpx
-
-            token_data = {
-                "grant_type": "authorization_code",
-                "code": authorization_code,
-                "redirect_uri": redirect_url,
-                "code_verifier": code_verifier,
-            }
-
-            # Add client credentials
-            if not generic_include_client_id:
-                # Use HTTP Basic Auth for client credentials
-                auth = httpx.BasicAuth(generic_client_id, generic_client_secret)
-            else:
-                # Include client credentials in body
-                token_data["client_id"] = generic_client_id
-                token_data["client_secret"] = generic_client_secret
-                auth = None
-
-            async with httpx.AsyncClient() as client:
-                post_kwargs: dict = {
-                    "data": token_data,
-                    "headers": {
-                        "Content-Type": "application/x-www-form-urlencoded",
-                        "Accept": "application/json",
-                        **additional_generic_sso_headers_dict,
-                    },
-                    "timeout": 30.0,
-                }
-                if auth is not None:
-                    post_kwargs["auth"] = auth
-                response = await client.post(generic_token_endpoint, **post_kwargs)
-
-                response_text = response.text
-
-                if response.status_code != 200:
-                    verbose_proxy_logger.error(
-                        f"Token exchange failed: Status={response.status_code}"
-                    )
-                    verbose_proxy_logger.error(
-                        f"✘ Token exchange FAILED!\n"
-                        f"   Status: {response.status_code}\n"
-                        f"   Full Response:\n{response_text}"
-                    )
-                    raise ProxyException(
-                        message=f"Token exchange failed: {response.status_code} - {response_text[:500]}",
-                        type=ProxyErrorTypes.auth_error,
-                        param="token_exchange",
-                        code=status.HTTP_401_UNAUTHORIZED,
-                    )
-
-                # Parse token response
-                try:
-                    token_response = response.json()
-                    verbose_proxy_logger.info(
-                        f"✔ Token exchange successful! "
-                        f"access_token={bool(token_response.get('access_token'))}, "
-                        f"id_token={bool(token_response.get('id_token'))}"
-                    )
-                except Exception as json_err:
-                    verbose_proxy_logger.error(
-                        f"✘ Failed to parse token response as JSON!\n"
-                        f"   Error: {json_err}\n"
-                        f"   Response text: {response_text}"
-                    )
-                    raise
-
-            # Get user info - try userinfo endpoint first, fallback to id_token
-            access_token = token_response["access_token"]
-            id_token = token_response.get("id_token")
-            userinfo: dict = {}
-
-            try:
-                async with httpx.AsyncClient() as client:
-                    userinfo_response = await client.get(
-                        generic_userinfo_endpoint,
-                        headers={
-                            "Authorization": f"Bearer {access_token}",
-                            **additional_generic_sso_headers_dict,
-                        },
-                        timeout=30.0,
-                    )
-
-                    if userinfo_response.status_code == 200:
-                        userinfo = userinfo_response.json()
-                        verbose_proxy_logger.debug(
-                            "User info retrieved from userinfo endpoint"
-                        )
-                    else:
-                        verbose_proxy_logger.warning(
-                            f"⚠ Userinfo endpoint failed ({userinfo_response.status_code}), "
-                            f"will extract from id_token instead"
-                        )
-            except Exception as userinfo_err:
-                verbose_proxy_logger.warning(
-                    f"⚠ Userinfo endpoint error: {userinfo_err}, will extract from id_token instead"
-                )
-
-            # If userinfo is empty, extract from id_token
-            if not userinfo and id_token:
-                import jwt
-
-                try:
-                    # Decode id_token without verification (we already trust it from token exchange)
-                    id_token_payload = jwt.decode(
-                        id_token,
-                        options={"verify_signature": False},
-                    )
-                    userinfo = id_token_payload
-                    verbose_proxy_logger.debug("User info extracted from id_token")
-                except Exception as decode_err:
-                    verbose_proxy_logger.error(
-                        f"✘ Failed to decode id_token: {decode_err}"
-                    )
-                    raise ProxyException(
-                        message="Failed to get user info from both userinfo endpoint and id_token",
-                        type=ProxyErrorTypes.auth_error,
-                        param="userinfo",
-                        code=status.HTTP_401_UNAUTHORIZED,
-                    )
-
-            # Build combined response for convertor
-            combined_response = {**token_response, **userinfo}
             result = response_convertor(combined_response, generic_sso)
-
         else:
-            verbose_proxy_logger.info("No PKCE code_verifier - using standard verify_and_process")
-            # No PKCE, use standard flow
             result = await generic_sso.verify_and_process(
                 request,
                 params=token_exchange_params,
@@ -942,37 +823,13 @@ async def get_generic_sso_response(
     except Exception as e:
         error_message = str(e)
 
-        # Log detailed error information for debugging
-        verbose_proxy_logger.error(
-            f"Error verifying and processing generic SSO: {error_message}. "
-            f"Error type: {type(e).__name__}. "
-            f"Passed in headers: {additional_generic_sso_headers_dict}"
-        )
-
-        # Check if this is a JSON decode error (provider returned non-JSON response)
-        if "JSONDecodeError" in str(type(e).__name__) or "Expecting value" in error_message:
-            verbose_proxy_logger.error(
-                f"SSO provider returned invalid JSON response during token exchange. "
-                f"This typically means: (1) Token exchange request was rejected by the provider, "
-                f"(2) code_verifier format is incorrect, or (3) provider configuration issue."
-            )
-
-        # Check if this is a PKCE-related error
+        # Detect PKCE misconfiguration and surface a helpful error
         if "PKCE" in error_message or "code verifier" in error_message.lower():
-            # Detect if this is Okta by checking the endpoints
             is_okta = (
-                generic_authorization_endpoint and "okta" in generic_authorization_endpoint.lower()
-            ) or (
-                generic_token_endpoint and "okta" in generic_token_endpoint.lower()
-            )
-
+                generic_authorization_endpoint
+                and "okta" in generic_authorization_endpoint.lower()
+            ) or (generic_token_endpoint and "okta" in generic_token_endpoint.lower())
             provider_name = "Okta" if is_okta else "Your OAuth provider"
-
-            verbose_proxy_logger.error(
-                f"PKCE error detected: {error_message}. {provider_name} requires PKCE but it's not enabled. "
-                f"Set GENERIC_CLIENT_USE_PKCE=true in your environment variables. "
-                f"See https://docs.litellm.ai/docs/proxy/admin_ui_sso for more details."
-            )
 
             detailed_message = (
                 f"SSO authentication failed: {provider_name} requires PKCE (Proof Key for Code Exchange) "
@@ -980,14 +837,12 @@ async def get_generic_sso_response(
                 f"SOLUTION: Add this environment variable and restart your proxy:\n"
                 f"  GENERIC_CLIENT_USE_PKCE=true\n\n"
             )
-
             if is_okta:
                 detailed_message += (
-                    f"For AWS ECS: Add the environment variable to your task definition.\n"
-                    f"For Docker: Add -e GENERIC_CLIENT_USE_PKCE=true to your docker run command.\n"
-                    f"For .env file: Add GENERIC_CLIENT_USE_PKCE=true to your .env file.\n\n"
+                    "For AWS ECS: Add the environment variable to your task definition.\n"
+                    "For Docker: Add -e GENERIC_CLIENT_USE_PKCE=true to your docker run command.\n"
+                    "For .env file: Add GENERIC_CLIENT_USE_PKCE=true to your .env file.\n\n"
                 )
-
             detailed_message += f"Original error: {error_message}"
 
             raise ProxyException(
@@ -998,7 +853,9 @@ async def get_generic_sso_response(
             )
 
         verbose_proxy_logger.exception(
-            f"Error verifying and processing generic SSO: {e}. Passed in headers: {additional_generic_sso_headers_dict}"
+            "Error verifying and processing generic SSO: %s. Passed in headers: %s",
+            e,
+            additional_generic_sso_headers_dict,
         )
         raise e
     verbose_proxy_logger.debug("generic result: %s", result)
@@ -2684,6 +2541,144 @@ class SSOAuthenticationHandler:
         )
 
         return code_verifier, code_challenge
+
+    @staticmethod
+    async def _pkce_token_exchange(
+        authorization_code: str,
+        code_verifier: str,
+        client_id: str,
+        client_secret: str,
+        token_endpoint: str,
+        userinfo_endpoint: str,
+        include_client_id: bool,
+        redirect_url: str,
+        additional_headers: Dict[str, str],
+    ) -> dict:
+        """
+        Performs a direct OAuth token exchange including the PKCE code_verifier.
+
+        fastapi-sso does not forward code_verifier, so when PKCE is enabled we
+        bypass it and call the token endpoint ourselves, then fetch user info.
+
+        Returns a combined dict of the token response and user info, suitable
+        for passing to a response_convertor.
+        """
+        verbose_proxy_logger.info(
+            "PKCE: performing direct token exchange (code_verifier length=%d)",
+            len(code_verifier),
+        )
+
+        token_data: Dict[str, str] = {
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": redirect_url,
+            "code_verifier": code_verifier,
+        }
+
+        post_kwargs: Dict[str, Any] = {
+            "data": token_data,
+            "headers": {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+                **additional_headers,
+            },
+            "timeout": 30.0,
+        }
+
+        if not include_client_id:
+            post_kwargs["auth"] = httpx.BasicAuth(client_id, client_secret)
+        else:
+            token_data["client_id"] = client_id
+            token_data["client_secret"] = client_secret
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(token_endpoint, **post_kwargs)
+
+        if response.status_code != 200:
+            verbose_proxy_logger.error(
+                "PKCE token exchange failed. status=%s body=%s",
+                response.status_code,
+                response.text[:500],
+            )
+            raise ProxyException(
+                message=f"Token exchange failed: {response.status_code} - {response.text[:500]}",
+                type=ProxyErrorTypes.auth_error,
+                param="token_exchange",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        try:
+            token_response: dict = response.json()
+        except Exception as json_err:
+            verbose_proxy_logger.error(
+                "Failed to parse token response as JSON: %s. Body: %s",
+                json_err,
+                response.text[:500],
+            )
+            raise
+
+        verbose_proxy_logger.debug(
+            "PKCE token exchange successful. access_token=%s id_token=%s",
+            bool(token_response.get("access_token")),
+            bool(token_response.get("id_token")),
+        )
+
+        userinfo = await SSOAuthenticationHandler._get_pkce_userinfo(
+            access_token=token_response["access_token"],
+            id_token=token_response.get("id_token"),
+            userinfo_endpoint=userinfo_endpoint,
+            additional_headers=additional_headers,
+        )
+        return {**token_response, **userinfo}
+
+    @staticmethod
+    async def _get_pkce_userinfo(
+        access_token: str,
+        id_token: Optional[str],
+        userinfo_endpoint: str,
+        additional_headers: Dict[str, str],
+    ) -> dict:
+        """
+        Fetches user info from the userinfo endpoint.
+        Falls back to decoding the id_token if the endpoint is unavailable.
+        """
+        userinfo: dict = {}
+
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    userinfo_endpoint,
+                    headers={
+                        "Authorization": f"Bearer {access_token}",
+                        **additional_headers,
+                    },
+                    timeout=30.0,
+                )
+            if resp.status_code == 200:
+                userinfo = resp.json()
+            else:
+                verbose_proxy_logger.warning(
+                    "Userinfo endpoint returned %s, falling back to id_token",
+                    resp.status_code,
+                )
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                "Userinfo endpoint error: %s, falling back to id_token", e
+            )
+
+        if not userinfo and id_token:
+            try:
+                userinfo = jwt.decode(id_token, options={"verify_signature": False})
+            except Exception as decode_err:
+                verbose_proxy_logger.error("Failed to decode id_token: %s", decode_err)
+                raise ProxyException(
+                    message="Failed to get user info from both userinfo endpoint and id_token",
+                    type=ProxyErrorTypes.auth_error,
+                    param="userinfo",
+                    code=status.HTTP_401_UNAUTHORIZED,
+                )
+
+        return userinfo
 
 
 class MicrosoftSSOHandler:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2747,23 +2747,27 @@ class SSOAuthenticationHandler:
         # but would produce a "Bearer None" Authorization header downstream.
         access_token_val = token_response.get("access_token")
         if not isinstance(access_token_val, str) or not access_token_val:
-            error = token_response.get("error", "unknown_error")
+            error = token_response.get("error")
             error_desc = token_response.get("error_description", "")
+            if error:
+                detail = f"{error} - {error_desc}" if error_desc else error
+            else:
+                detail = (
+                    "token endpoint returned HTTP 200 but no access_token "
+                    f"(response keys: {sorted(token_response.keys())})"
+                )
             verbose_proxy_logger.error(
-                "Token response missing or null access_token. error=%s description=%s",
-                error,
-                error_desc,
+                "Token response missing or null access_token. detail=%s", detail
             )
             raise ProxyException(
-                message=f"Token exchange error: {error} - {error_desc}",
+                message=f"Token exchange failed: {detail}",
                 type=ProxyErrorTypes.auth_error,
                 param="token_exchange",
                 code=status.HTTP_401_UNAUTHORIZED,
             )
 
         verbose_proxy_logger.debug(
-            "PKCE token exchange successful. access_token=%s id_token=%s",
-            bool(token_response.get("access_token")),
+            "PKCE token exchange successful. id_token_present=%s",
             bool(token_response.get("id_token")),
         )
         userinfo = await SSOAuthenticationHandler._get_pkce_userinfo(
@@ -2795,7 +2799,9 @@ class SSOAuthenticationHandler:
         Fetches user info from the userinfo endpoint.
         Falls back to decoding the id_token if the endpoint is unavailable.
         """
-        userinfo: Optional[dict] = None  # None means "request not yet attempted or failed"
+        # None = request not yet attempted, failed, or returned an empty dict (treated as failure
+        # so the id_token fallback can be attempted instead of returning a session with no claims).
+        userinfo: Optional[dict] = None
 
         if userinfo_endpoint:
             try:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2794,14 +2794,10 @@ class SSOAuthenticationHandler:
             if client_secret:
                 token_data["client_secret"] = client_secret
 
-        # Initialize response to None — guards against an UnboundLocalError in the
-        # unlikely case where httpx.AsyncClient() construction itself raises before
-        # the POST is attempted.  The try/except is INSIDE the async with so that
-        # TLS teardown exceptions from __aexit__ propagate as-is and are NOT
-        # mis-labelled as "Token endpoint request failed".  httpx buffers the full
-        # response body before __aexit__, so status_code / text / json() remain
-        # valid after the context exits.
-        response = None
+        # The try/except is INSIDE the async with so that TLS teardown exceptions
+        # from __aexit__ propagate as-is and are NOT mis-labelled as "Token endpoint
+        # request failed".  httpx buffers the full response body before __aexit__,
+        # so status_code / text / json() remain valid after the context exits.
         async with httpx.AsyncClient() as http_client:
             try:
                 response = await http_client.post(token_endpoint, **post_kwargs)
@@ -2816,15 +2812,6 @@ class SSOAuthenticationHandler:
                     param="token_exchange",
                     code=status.HTTP_401_UNAUTHORIZED,
                 ) from exc
-
-        if response is None:
-            # Should never happen in practice — construction failure is unexpected.
-            raise ProxyException(
-                message="Token endpoint request did not return a response",
-                type=ProxyErrorTypes.auth_error,
-                param="token_exchange",
-                code=status.HTTP_401_UNAUTHORIZED,
-            )
 
         # Response processing outside the async with — httpx buffers the full
         # response body so status_code / text / json() remain valid after __aexit__.

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2531,6 +2531,7 @@ class SSOAuthenticationHandler:
                     await user_api_key_cache.async_delete_cache(key=cache_key)
             else:
                 # PKCE is enabled (already checked above) but verifier is missing — likely a cross-instance cache miss.
+                active_cache = redis_usage_cache if redis_usage_cache is not None else user_api_key_cache
                 verbose_proxy_logger.error(
                     "PKCE is enabled but no code_verifier found in cache for state '%s'. "
                     "This usually means the authorization and callback were handled by different "
@@ -2538,7 +2539,7 @@ class SSOAuthenticationHandler:
                     "Ensure Redis is configured and GENERIC_CLIENT_USE_PKCE=true. "
                     "Cache type: %s. Cache entry present: %s",
                     state,
-                    type(user_api_key_cache).__name__,
+                    type(active_cache).__name__,
                     cached_data is not None,
                 )
         return token_params
@@ -2615,10 +2616,15 @@ class SSOAuthenticationHandler:
         }
 
         if not include_client_id:
-            post_kwargs["auth"] = httpx.BasicAuth(client_id, client_secret)
+            # Use Basic Auth only when a secret is available; public PKCE clients omit it.
+            if client_secret:
+                post_kwargs["auth"] = httpx.BasicAuth(client_id, client_secret)
+            else:
+                token_data["client_id"] = client_id
         else:
             token_data["client_id"] = client_id
-            token_data["client_secret"] = client_secret
+            if client_secret:
+                token_data["client_secret"] = client_secret
 
         async with httpx.AsyncClient() as http_client:
             response = await http_client.post(token_endpoint, **post_kwargs)

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -822,7 +822,7 @@ async def get_generic_sso_response(
             # Strip bearer credentials from received_response after conversion.
             # received_response may appear in restricted-group error messages —
             # do not expose tokens to callers.
-            if received_response:
+            if received_response is not None:
                 received_response = {
                     k: v for k, v in received_response.items() if k not in _OAUTH_TOKEN_FIELDS
                 }
@@ -2687,6 +2687,8 @@ class SSOAuthenticationHandler:
                 bool(token_response.get("id_token")),
             )
 
+        # token_response is set inside the async with block above and remains accessible here;
+        # Python's scoping rules guarantee it is defined if no exception was raised.
         userinfo = await SSOAuthenticationHandler._get_pkce_userinfo(
             access_token=token_response["access_token"],
             id_token=token_response.get("id_token"),

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2685,9 +2685,10 @@ class SSOAuthenticationHandler:
             if client_secret:
                 token_data["client_secret"] = client_secret
 
-        # Tighten the try/except to the POST call only, so httpx connection-pool
-        # teardown in __aexit__ (TLS close, etc.) does not get misclassified as a
-        # token-endpoint failure.
+        # Keep all response processing inside the async with block so that the
+        # response object (which httpx buffers) is always accessed while the client
+        # is still alive.  Network errors on the POST are caught tightly here; TLS
+        # teardown errors from __aexit__ are NOT classified as token failures.
         async with httpx.AsyncClient() as http_client:
             try:
                 response = await http_client.post(token_endpoint, **post_kwargs)
@@ -2703,33 +2704,33 @@ class SSOAuthenticationHandler:
                     code=status.HTTP_401_UNAUTHORIZED,
                 ) from exc
 
-        if response.status_code != 200:
-            verbose_proxy_logger.error(
-                "PKCE token exchange failed. status=%s body=%s",
-                response.status_code,
-                response.text[:500],
-            )
-            raise ProxyException(
-                message=f"Token exchange failed: {response.status_code} - {response.text[:500]}",
-                type=ProxyErrorTypes.auth_error,
-                param="token_exchange",
-                code=status.HTTP_401_UNAUTHORIZED,
-            )
+            if response.status_code != 200:
+                verbose_proxy_logger.error(
+                    "PKCE token exchange failed. status=%s body=%s",
+                    response.status_code,
+                    response.text[:500],
+                )
+                raise ProxyException(
+                    message=f"Token exchange failed: {response.status_code} - {response.text[:500]}",
+                    type=ProxyErrorTypes.auth_error,
+                    param="token_exchange",
+                    code=status.HTTP_401_UNAUTHORIZED,
+                )
 
-        try:
-            token_response: dict = response.json()
-        except Exception as json_err:
-            verbose_proxy_logger.error(
-                "Failed to parse token response as JSON: %s. Body: %s",
-                json_err,
-                response.text[:500],
-            )
-            raise ProxyException(
-                message=f"Token endpoint returned invalid JSON: {json_err}",
-                type=ProxyErrorTypes.auth_error,
-                param="token_exchange",
-                code=status.HTTP_401_UNAUTHORIZED,
-            )
+            try:
+                token_response: dict = response.json()
+            except Exception as json_err:
+                verbose_proxy_logger.error(
+                    "Failed to parse token response as JSON: %s. Body: %s",
+                    json_err,
+                    response.text[:500],
+                )
+                raise ProxyException(
+                    message=f"Token endpoint returned invalid JSON: {json_err}",
+                    type=ProxyErrorTypes.auth_error,
+                    param="token_exchange",
+                    code=status.HTTP_401_UNAUTHORIZED,
+                )
 
         # Some providers return HTTP 200 with an error body (e.g. expired code, replay attack).
         # Also guard against JSON `null` for access_token — it passes key-existence checks

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2535,10 +2535,10 @@ class SSOAuthenticationHandler:
                     "This usually means the authorization and callback were handled by different "
                     "instances without a shared cache. "
                     "Ensure Redis is configured and GENERIC_CLIENT_USE_PKCE=true. "
-                    "Cache type: %s. Cached data: %s",
+                    "Cache type: %s. Cache entry present: %s",
                     state,
                     type(user_api_key_cache).__name__,
-                    cached_data,
+                    cached_data is not None,
                 )
         return token_params
 

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -1937,8 +1937,7 @@ class SSOAuthenticationHandler:
 
         # Handle PKCE (Proof Key for Code Exchange) if enabled
         # Set GENERIC_CLIENT_USE_PKCE=true to enable PKCE for enhanced OAuth security
-        pkce_env_value = os.getenv("GENERIC_CLIENT_USE_PKCE", "false")
-        use_pkce = pkce_env_value.lower() == "true"
+        use_pkce = os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true"
 
         if use_pkce:
             (
@@ -2517,14 +2516,17 @@ class SSOAuthenticationHandler:
                     await redis_usage_cache.async_delete_cache(key=cache_key)
                 else:
                     await user_api_key_cache.async_delete_cache(key=cache_key)
-            else:
+            elif os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true":
+                # PKCE is enabled but verifier is missing — likely a cross-instance cache miss.
                 verbose_proxy_logger.error(
-                    f"✙ CRITICAL: No PKCE code_verifier found in cache for state '{state}'. "
-                    f"This indicates: (1) authorization request and callback handled by different instances without shared cache, "
-                    f"(2) cache entry expired (TTL: 600s), or (3) Redis serialization error. "
-                    f"SOLUTION: Ensure Redis is configured correctly. "
-                    f"Cache type: {type(user_api_key_cache).__name__}. "
-                    f"Cached data: {cached_data}"
+                    "PKCE is enabled but no code_verifier found in cache for state '%s'. "
+                    "This usually means the authorization and callback were handled by different "
+                    "instances without a shared cache. "
+                    "Ensure Redis is configured and GENERIC_CLIENT_USE_PKCE=true. "
+                    "Cache type: %s. Cached data: %s",
+                    state,
+                    type(user_api_key_cache).__name__,
+                    cached_data,
                 )
         return token_params
 

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2976,10 +2976,23 @@ class SSOAuthenticationHandler:
                 )
 
         if userinfo is None:
+            id_token_attempted = isinstance(id_token, str) and bool(id_token)
             if userinfo_endpoint:
-                detail = "userinfo endpoint failed and no id_token was present in the token response"
+                if id_token_attempted:
+                    detail = (
+                        "userinfo endpoint failed and id_token was present but "
+                        "decoded to an empty payload — no identity claims available"
+                    )
+                else:
+                    detail = "userinfo endpoint failed and no id_token was present in the token response"
             else:
-                detail = "no userinfo endpoint is configured (GENERIC_USERINFO_ENDPOINT) and no id_token was present"
+                if id_token_attempted:
+                    detail = (
+                        "no userinfo endpoint is configured (GENERIC_USERINFO_ENDPOINT) "
+                        "and id_token decoded to an empty payload — no identity claims available"
+                    )
+                else:
+                    detail = "no userinfo endpoint is configured (GENERIC_USERINFO_ENDPOINT) and no id_token was present"
             raise ProxyException(
                 message=f"SSO user info unavailable: {detail}.",
                 type=ProxyErrorTypes.auth_error,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2529,8 +2529,8 @@ class SSOAuthenticationHandler:
                     await redis_usage_cache.async_delete_cache(key=cache_key)
                 else:
                     await user_api_key_cache.async_delete_cache(key=cache_key)
-            elif os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true":
-                # PKCE is enabled but verifier is missing — likely a cross-instance cache miss.
+            else:
+                # PKCE is enabled (already checked above) but verifier is missing — likely a cross-instance cache miss.
                 verbose_proxy_logger.error(
                     "PKCE is enabled but no code_verifier found in cache for state '%s'. "
                     "This usually means the authorization and callback were handled by different "
@@ -2644,7 +2644,12 @@ class SSOAuthenticationHandler:
                     json_err,
                     response.text[:500],
                 )
-                raise
+                raise ProxyException(
+                    message=f"Token endpoint returned invalid JSON: {json_err}",
+                    type=ProxyErrorTypes.auth_error,
+                    param="token_exchange",
+                    code=status.HTTP_401_UNAUTHORIZED,
+                )
 
             # Some providers return HTTP 200 with an error body (e.g. expired code, replay attack).
             if "access_token" not in token_response:
@@ -2725,7 +2730,12 @@ class SSOAuthenticationHandler:
                     )
             finally:
                 if _own_client:
-                    await _client.aclose()
+                    try:
+                        await _client.aclose()
+                    except Exception as close_err:
+                        verbose_proxy_logger.debug(
+                            "Error closing httpx client in _get_pkce_userinfo: %s", close_err
+                        )
         except Exception as e:
             verbose_proxy_logger.warning(
                 "Userinfo endpoint error: %s, falling back to id_token", e

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -808,6 +808,13 @@ async def get_generic_sso_response(
                     param="code",
                     code=status.HTTP_400_BAD_REQUEST,
                 )
+            if not generic_client_id:
+                raise ProxyException(
+                    message="GENERIC_CLIENT_ID must be set when PKCE is enabled",
+                    type=ProxyErrorTypes.auth_error,
+                    param="GENERIC_CLIENT_ID",
+                    code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                )
             if not generic_token_endpoint:
                 raise ProxyException(
                     message="GENERIC_TOKEN_ENDPOINT must be set when PKCE is enabled",
@@ -815,7 +822,7 @@ async def get_generic_sso_response(
                     param="GENERIC_TOKEN_ENDPOINT",
                     code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
-            # Both guards above raise, so authorization_code is a non-empty str here.
+            # All guards above raise, so authorization_code is a non-empty str here.
             # Use an explicit type guard rather than assert (assert is a no-op with -O).
             if not isinstance(authorization_code, str):
                 raise ProxyException(
@@ -2719,28 +2726,29 @@ class SSOAuthenticationHandler:
             if client_secret:
                 token_data["client_secret"] = client_secret
 
-        # Perform the POST inside async with; response is buffered by httpx so
-        # status_code, text, and json() are safe to access after __aexit__.
-        # Only the POST itself is wrapped in try/except — TLS teardown errors
-        # from __aexit__ propagate as-is and are NOT mis-labelled as "token
-        # endpoint request failed".
-        try:
-            async with httpx.AsyncClient() as http_client:
+        # The try/except is INSIDE the async with so it only covers the POST call.
+        # If TLS teardown in __aexit__ raises, it propagates after the try/except
+        # has already completed — it is NOT caught here and NOT mis-labelled as
+        # "Token endpoint request failed".  httpx buffers the full response body
+        # inside the context, so status_code / text / json() are safe to access
+        # outside the async with block.
+        async with httpx.AsyncClient() as http_client:
+            try:
                 response = await http_client.post(token_endpoint, **post_kwargs)
-        except Exception as exc:
-            # Catch network-level errors (SSL, DNS, TCP, timeout, etc.) and
-            # wrap them as a clean ProxyException rather than leaking raw httpx
-            # or OS exceptions to callers.
-            verbose_proxy_logger.error("PKCE token endpoint unreachable: %s", exc)
-            raise ProxyException(
-                message=f"Token endpoint request failed: {exc}",
-                type=ProxyErrorTypes.auth_error,
-                param="token_exchange",
-                code=status.HTTP_401_UNAUTHORIZED,
-            ) from exc
+            except Exception as exc:
+                # Catch network-level errors (SSL, DNS, TCP, timeout, etc.) and
+                # wrap them as a clean ProxyException rather than leaking raw
+                # httpx or OS exceptions to callers.
+                verbose_proxy_logger.error("PKCE token endpoint unreachable: %s", exc)
+                raise ProxyException(
+                    message=f"Token endpoint request failed: {exc}",
+                    type=ProxyErrorTypes.auth_error,
+                    param="token_exchange",
+                    code=status.HTTP_401_UNAUTHORIZED,
+                ) from exc
 
-        # All response processing happens outside the async with block —
-        # httpx buffers the full response so status_code / text / json() are safe.
+        # Response processing outside the async with — httpx buffers the full
+        # response body so status_code / text / json() remain valid after __aexit__.
         if response.status_code != 200:
             verbose_proxy_logger.error(
                 "PKCE token exchange failed. status=%s body=%s",

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -830,10 +830,13 @@ async def get_generic_sso_response(
     except Exception as e:
         error_message = str(e)
 
-        # Only surface "enable PKCE" advice when PKCE was NOT already in use.
-        # If code_verifier is set, the token exchange itself failed — that's a
-        # provider-side error, not a configuration problem.
-        if code_verifier is None and (
+        # Surface a helpful PKCE misconfiguration hint only when:
+        # 1. The error mentions PKCE/code verifier, AND
+        # 2. PKCE is not currently configured (GENERIC_CLIENT_USE_PKCE != true)
+        # If PKCE IS configured but code_verifier was absent (cross-instance cache miss),
+        # the real fix is shared Redis/sticky sessions — not enabling PKCE (it's already on).
+        pkce_configured = os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true"
+        if not pkce_configured and (
             "PKCE" in error_message or "code verifier" in error_message.lower()
         ):
             is_okta = (

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2619,6 +2619,8 @@ class SSOAuthenticationHandler:
                     # cache misses so operators can investigate the correct root cause.
                     if _empty_value_in_dict:
                         # Dict format was correct but code_verifier was empty/null.
+                        # Best-effort cleanup: remove the corrupt entry before failing.
+                        await SSOAuthenticationHandler._delete_pkce_verifier(cache_key)
                         raise ProxyException(
                             message=(
                                 f"PKCE verifier for state '{state}' was found in cache but "
@@ -2630,6 +2632,8 @@ class SSOAuthenticationHandler:
                         )
                     elif cached_data is not None:
                         # Cache had data but in an unrecognised format (e.g. corrupt Redis value).
+                        # Best-effort cleanup: remove the corrupt entry before failing.
+                        await SSOAuthenticationHandler._delete_pkce_verifier(cache_key)
                         verbose_proxy_logger.error(
                             "PKCE verifier for state '%s' has an unrecognized format (type=%s); "
                             "treating as a cache miss. Investigate the cached value — it may be "

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -104,6 +104,12 @@ else:
 
 router = APIRouter()
 
+# OAuth token credential fields that must not appear in SSO debug responses
+# (received_response is included in restricted-group error messages).
+_OAUTH_TOKEN_FIELDS = frozenset(
+    {"access_token", "id_token", "refresh_token", "token_type", "expires_in", "scope"}
+)
+
 
 def normalize_email(email: Optional[str]) -> Optional[str]:
     """
@@ -810,7 +816,13 @@ async def get_generic_sso_response(
                 redirect_url=redirect_url,
                 additional_headers=additional_generic_sso_headers_dict,
             )
-            result = response_convertor(combined_response, generic_sso)
+            # Strip OAuth token credentials before passing to response_convertor.
+            # combined_response is stored as received_response and may appear in
+            # restricted-group error messages — do not expose tokens to callers.
+            result = response_convertor(
+                {k: v for k, v in combined_response.items() if k not in _OAUTH_TOKEN_FIELDS},
+                generic_sso,
+            )
             # In the PKCE path verify_and_process is skipped, so generic_sso.access_token
             # is never set. Read the token directly from the exchange response instead so
             # process_sso_jwt_access_token can extract JWT-embedded roles/teams.
@@ -2607,60 +2619,63 @@ class SSOAuthenticationHandler:
             token_data["client_id"] = client_id
             token_data["client_secret"] = client_secret
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(token_endpoint, **post_kwargs)
+        async with httpx.AsyncClient() as http_client:
+            response = await http_client.post(token_endpoint, **post_kwargs)
 
-        if response.status_code != 200:
-            verbose_proxy_logger.error(
-                "PKCE token exchange failed. status=%s body=%s",
-                response.status_code,
-                response.text[:500],
-            )
-            raise ProxyException(
-                message=f"Token exchange failed: {response.status_code} - {response.text[:500]}",
-                type=ProxyErrorTypes.auth_error,
-                param="token_exchange",
-                code=status.HTTP_401_UNAUTHORIZED,
+            if response.status_code != 200:
+                verbose_proxy_logger.error(
+                    "PKCE token exchange failed. status=%s body=%s",
+                    response.status_code,
+                    response.text[:500],
+                )
+                raise ProxyException(
+                    message=f"Token exchange failed: {response.status_code} - {response.text[:500]}",
+                    type=ProxyErrorTypes.auth_error,
+                    param="token_exchange",
+                    code=status.HTTP_401_UNAUTHORIZED,
+                )
+
+            try:
+                token_response: dict = response.json()
+            except Exception as json_err:
+                verbose_proxy_logger.error(
+                    "Failed to parse token response as JSON: %s. Body: %s",
+                    json_err,
+                    response.text[:500],
+                )
+                raise
+
+            # Some providers return HTTP 200 with an error body (e.g. expired code, replay attack).
+            if "access_token" not in token_response:
+                error = token_response.get("error", "unknown_error")
+                error_desc = token_response.get("error_description", "")
+                verbose_proxy_logger.error(
+                    "Token response missing access_token. error=%s description=%s",
+                    error,
+                    error_desc,
+                )
+                raise ProxyException(
+                    message=f"Token exchange error: {error} - {error_desc}",
+                    type=ProxyErrorTypes.auth_error,
+                    param="token_exchange",
+                    code=status.HTTP_401_UNAUTHORIZED,
+                )
+
+            verbose_proxy_logger.debug(
+                "PKCE token exchange successful. access_token=%s id_token=%s",
+                bool(token_response.get("access_token")),
+                bool(token_response.get("id_token")),
             )
 
-        try:
-            token_response: dict = response.json()
-        except Exception as json_err:
-            verbose_proxy_logger.error(
-                "Failed to parse token response as JSON: %s. Body: %s",
-                json_err,
-                response.text[:500],
-            )
-            raise
-
-        # Some providers return HTTP 200 with an error body (e.g. expired code, replay attack).
-        if "access_token" not in token_response:
-            error = token_response.get("error", "unknown_error")
-            error_desc = token_response.get("error_description", "")
-            verbose_proxy_logger.error(
-                "Token response missing access_token. error=%s description=%s",
-                error,
-                error_desc,
-            )
-            raise ProxyException(
-                message=f"Token exchange error: {error} - {error_desc}",
-                type=ProxyErrorTypes.auth_error,
-                param="token_exchange",
-                code=status.HTTP_401_UNAUTHORIZED,
+            # Reuse the same client for the userinfo request to avoid a second TCP/TLS handshake.
+            userinfo = await SSOAuthenticationHandler._get_pkce_userinfo(
+                access_token=token_response["access_token"],
+                id_token=token_response.get("id_token"),
+                userinfo_endpoint=userinfo_endpoint,
+                additional_headers=additional_headers,
+                http_client=http_client,
             )
 
-        verbose_proxy_logger.debug(
-            "PKCE token exchange successful. access_token=%s id_token=%s",
-            bool(token_response.get("access_token")),
-            bool(token_response.get("id_token")),
-        )
-
-        userinfo = await SSOAuthenticationHandler._get_pkce_userinfo(
-            access_token=token_response["access_token"],
-            id_token=token_response.get("id_token"),
-            userinfo_endpoint=userinfo_endpoint,
-            additional_headers=additional_headers,
-        )
         return {**token_response, **userinfo}
 
     @staticmethod
@@ -2669,16 +2684,22 @@ class SSOAuthenticationHandler:
         id_token: Optional[str],
         userinfo_endpoint: str,
         additional_headers: Dict[str, str],
+        http_client: Optional[httpx.AsyncClient] = None,
     ) -> dict:
         """
         Fetches user info from the userinfo endpoint.
         Falls back to decoding the id_token if the endpoint is unavailable.
+
+        An existing ``http_client`` may be passed to reuse the connection pool
+        (e.g. from ``_pkce_token_exchange``).
         """
         userinfo: dict = {}
 
         try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(
+            _own_client = http_client is None
+            _client = httpx.AsyncClient() if _own_client else http_client
+            try:
+                resp = await _client.get(
                     userinfo_endpoint,
                     headers={
                         "Authorization": f"Bearer {access_token}",
@@ -2686,13 +2707,16 @@ class SSOAuthenticationHandler:
                     },
                     timeout=30.0,
                 )
-            if resp.status_code == 200:
-                userinfo = resp.json()
-            else:
-                verbose_proxy_logger.warning(
-                    "Userinfo endpoint returned %s, falling back to id_token",
-                    resp.status_code,
-                )
+                if resp.status_code == 200:
+                    userinfo = resp.json()
+                else:
+                    verbose_proxy_logger.warning(
+                        "Userinfo endpoint returned %s, falling back to id_token",
+                        resp.status_code,
+                    )
+            finally:
+                if _own_client:
+                    await _client.aclose()
         except Exception as e:
             verbose_proxy_logger.warning(
                 "Userinfo endpoint error: %s, falling back to id_token", e

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -104,11 +104,11 @@ else:
 
 router = APIRouter()
 
-# OAuth token credential fields that must not appear in SSO debug responses
+# OAuth bearer credential fields that must not appear in SSO debug responses
 # (received_response is included in restricted-group error messages).
-_OAUTH_TOKEN_FIELDS = frozenset(
-    {"access_token", "id_token", "refresh_token", "token_type", "expires_in", "scope"}
-)
+# Metadata fields (token_type, expires_in, scope) are intentionally kept so
+# response convertors see the same fields in the PKCE path as in the non-PKCE path.
+_OAUTH_TOKEN_FIELDS = frozenset({"access_token", "id_token", "refresh_token"})
 
 
 def normalize_email(email: Optional[str]) -> Optional[str]:
@@ -2577,7 +2577,7 @@ class SSOAuthenticationHandler:
         authorization_code: str,
         code_verifier: str,
         client_id: str,
-        client_secret: str,
+        client_secret: Optional[str],
         token_endpoint: str,
         userinfo_endpoint: str,
         include_client_id: bool,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2914,17 +2914,22 @@ class SSOAuthenticationHandler:
         # But bearer credentials (access_token, id_token, refresh_token) must always come
         # from the token endpoint, not from userinfo (non-standard providers occasionally
         # include these fields in userinfo, which would otherwise shadow the real bearer token).
-        # Skip re-insertion when the token_response value is None (e.g. "id_token": null) —
-        # an absent key is a cleaner signal for "not present" than an explicit None and avoids
-        # diverging from the non-PKCE path where these fields are simply absent.
+        #
+        # Three-way merge semantics for each bearer-credential field:
+        #   1. token_response has a non-null value → use it (token endpoint is authoritative)
+        #   2. token_response explicitly sent null  → remove the key so callers get a clean
+        #      absence signal; the null from the token endpoint overrides userinfo too
+        #   3. field absent from token_response     → leave whatever userinfo provided as-is
+        #      (e.g. userinfo-provided id_token from a non-standard provider)
         merged = {**token_response, **userinfo}
         for field in _OAUTH_TOKEN_FIELDS:
             if token_response.get(field) is not None:
+                # Case 1: non-null in token_response — restore authoritative value.
                 merged[field] = token_response[field]
-            elif field in merged:
-                # Remove the key entirely if token_response had it as null/None so that
-                # callers can use `field in response` as a reliable presence check.
-                del merged[field]
+            elif field in token_response:
+                # Case 2: key exists but value is explicitly null — remove from merged.
+                merged.pop(field, None)
+            # Case 3: field absent from token_response — leave userinfo value as-is.
         return merged
 
     @staticmethod

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2755,11 +2755,12 @@ class SSOAuthenticationHandler:
                 )
 
         if userinfo is None:
+            if userinfo_endpoint:
+                detail = "userinfo endpoint failed and no id_token was present in the token response"
+            else:
+                detail = "no userinfo endpoint is configured (GENERIC_USERINFO_ENDPOINT) and no id_token was present"
             raise ProxyException(
-                message=(
-                    "SSO user info unavailable: userinfo endpoint failed and no id_token "
-                    "was present in the token response."
-                ),
+                message=f"SSO user info unavailable: {detail}.",
                 type=ProxyErrorTypes.auth_error,
                 param="userinfo",
                 code=status.HTTP_401_UNAUTHORIZED,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -782,8 +782,7 @@ async def get_generic_sso_response(
                 key, value = header.split("=")
                 additional_generic_sso_headers_dict[key] = value
 
-    # Initialized here so it's visible in the except block for error-hint logic
-    code_verifier: Optional[str] = None
+    code_verifier: Optional[str] = None  # assigned inside try; initialized for type tracking
 
     try:
         token_exchange_params = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
@@ -2905,9 +2904,12 @@ class SSOAuthenticationHandler:
 
         # Merge: userinfo takes precedence for identity claims (sub, email, name, …) per
         # the OpenID Connect spec (userinfo is the authoritative source for identity).
-        # But bearer credentials (access_token, id_token, refresh_token) must always come
-        # from the token endpoint, not from userinfo (non-standard providers occasionally
-        # include these fields in userinfo, which would otherwise shadow the real bearer token).
+        # Bearer credentials (access_token, id_token, refresh_token) from the token endpoint
+        # take precedence over same-named fields in userinfo — non-standard providers sometimes
+        # include token fields in userinfo, which must not shadow the real bearer token.
+        # If a bearer field is absent from the token response, any userinfo-provided value
+        # is preserved as a fallback (useful for non-standard providers that omit id_token
+        # from the token response but include it in userinfo).
         #
         # Three-way merge semantics for each bearer-credential field:
         #   1. token_response has a non-null value → use it (token endpoint is authoritative)

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2673,14 +2673,12 @@ class SSOAuthenticationHandler:
                 bool(token_response.get("id_token")),
             )
 
-            # Reuse the same client for the userinfo request to avoid a second TCP/TLS handshake.
-            userinfo = await SSOAuthenticationHandler._get_pkce_userinfo(
-                access_token=token_response["access_token"],
-                id_token=token_response.get("id_token"),
-                userinfo_endpoint=userinfo_endpoint,
-                additional_headers=additional_headers,
-                http_client=http_client,
-            )
+        userinfo = await SSOAuthenticationHandler._get_pkce_userinfo(
+            access_token=token_response["access_token"],
+            id_token=token_response.get("id_token"),
+            userinfo_endpoint=userinfo_endpoint,
+            additional_headers=additional_headers,
+        )
 
         # Merge with token_response taking precedence so token fields (e.g. access_token)
         # cannot be overridden by non-standard userinfo fields.
@@ -2692,22 +2690,16 @@ class SSOAuthenticationHandler:
         id_token: Optional[str],
         userinfo_endpoint: str,
         additional_headers: Dict[str, str],
-        http_client: Optional[httpx.AsyncClient] = None,
     ) -> dict:
         """
         Fetches user info from the userinfo endpoint.
         Falls back to decoding the id_token if the endpoint is unavailable.
-
-        An existing ``http_client`` may be passed to reuse the connection pool
-        (e.g. from ``_pkce_token_exchange``).
         """
         userinfo: dict = {}
 
         try:
-            _own_client = http_client is None
-            _client = httpx.AsyncClient() if _own_client else http_client
-            try:
-                resp = await _client.get(
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
                     userinfo_endpoint,
                     headers={
                         "Authorization": f"Bearer {access_token}",
@@ -2728,14 +2720,6 @@ class SSOAuthenticationHandler:
                         "Userinfo endpoint returned %s, falling back to id_token",
                         resp.status_code,
                     )
-            finally:
-                if _own_client:
-                    try:
-                        await _client.aclose()
-                    except Exception as close_err:
-                        verbose_proxy_logger.debug(
-                            "Error closing httpx client in _get_pkce_userinfo: %s", close_err
-                        )
         except Exception as e:
             verbose_proxy_logger.warning(
                 "Userinfo endpoint error: %s, falling back to id_token", e

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2688,7 +2688,10 @@ class SSOAuthenticationHandler:
         try:
             async with httpx.AsyncClient() as http_client:
                 response = await http_client.post(token_endpoint, **post_kwargs)
-        except httpx.HTTPError as exc:
+        except Exception as exc:
+            # Catch all network-level errors (SSL, DNS, TCP, timeout, etc.) and
+            # wrap them as a clean ProxyException rather than leaking raw httpx/OS
+            # exceptions to callers.
             verbose_proxy_logger.error("PKCE token endpoint unreachable: %s", exc)
             raise ProxyException(
                 message=f"Token endpoint request failed: {exc}",

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2616,9 +2616,9 @@ class SSOAuthenticationHandler:
         post_kwargs: Dict[str, Any] = {
             "data": token_data,
             "headers": {
-                "Content-Type": "application/x-www-form-urlencoded",
-                "Accept": "application/json",
                 **additional_headers,
+                "Content-Type": "application/x-www-form-urlencoded",  # must not be overridden
+                "Accept": "application/json",
             },
             "timeout": 30.0,
         }
@@ -2719,8 +2719,8 @@ class SSOAuthenticationHandler:
                     resp = await client.get(
                         userinfo_endpoint,
                         headers={
-                            "Authorization": f"Bearer {access_token}",
                             **additional_headers,
+                            "Authorization": f"Bearer {access_token}",  # must not be overridden
                         },
                         timeout=30.0,
                     )

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2748,12 +2748,14 @@ class SSOAuthenticationHandler:
             if client_secret:
                 token_data["client_secret"] = client_secret
 
-        # The try/except is INSIDE the async with so it only covers the POST call.
-        # If TLS teardown in __aexit__ raises, it propagates after the try/except
-        # has already completed — it is NOT caught here and NOT mis-labelled as
-        # "Token endpoint request failed".  httpx buffers the full response body
-        # inside the context, so status_code / text / json() are safe to access
-        # outside the async with block.
+        # Initialize response to None — guards against an UnboundLocalError in the
+        # unlikely case where httpx.AsyncClient() construction itself raises before
+        # the POST is attempted.  The try/except is INSIDE the async with so that
+        # TLS teardown exceptions from __aexit__ propagate as-is and are NOT
+        # mis-labelled as "Token endpoint request failed".  httpx buffers the full
+        # response body before __aexit__, so status_code / text / json() remain
+        # valid after the context exits.
+        response = None
         async with httpx.AsyncClient() as http_client:
             try:
                 response = await http_client.post(token_endpoint, **post_kwargs)
@@ -2768,6 +2770,15 @@ class SSOAuthenticationHandler:
                     param="token_exchange",
                     code=status.HTTP_401_UNAUTHORIZED,
                 ) from exc
+
+        if response is None:
+            # Should never happen in practice — construction failure is unexpected.
+            raise ProxyException(
+                message="Token endpoint request did not return a response",
+                type=ProxyErrorTypes.auth_error,
+                param="token_exchange",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
 
         # Response processing outside the async with — httpx buffers the full
         # response body so status_code / text / json() remain valid after __aexit__.
@@ -2914,6 +2925,14 @@ class SSOAuthenticationHandler:
         if userinfo is None and isinstance(id_token, str) and id_token:
             try:
                 userinfo = jwt.decode(id_token, options={"verify_signature": False})
+                if not userinfo:
+                    # jwt.decode returned an empty dict (payload-free JWT or provider bug).
+                    # Treat this the same as a missing userinfo — the session would have no
+                    # identity claims, which is equivalent to a broken session.
+                    verbose_proxy_logger.warning(
+                        "id_token decoded to an empty payload — treating as failure."
+                    )
+                    userinfo = None
             except Exception as decode_err:
                 verbose_proxy_logger.error("Failed to decode id_token: %s", decode_err)
                 raise ProxyException(

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2592,7 +2592,10 @@ class SSOAuthenticationHandler:
                         "Future storage will use dict format."
                     )
                 else:
-                    verbose_proxy_logger.error(
+                    # Defer the detailed ERROR log to the strict-mode branch below
+                    # (which includes state and a diagnostic message).  Log at DEBUG
+                    # here to avoid duplicate ERROR entries in the same request.
+                    verbose_proxy_logger.debug(
                         "Unexpected PKCE verifier cache format (type=%s); skipping.",
                         type(cached_data).__name__,
                     )

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -791,8 +791,9 @@ async def get_generic_sso_response(
             generic_include_client_id=generic_include_client_id,
         )
 
-        # Extract code_verifier before calling fastapi-sso
+        # Extract code_verifier (and the cache key for deferred deletion) before calling fastapi-sso
         code_verifier = token_exchange_params.pop("code_verifier", None)
+        pkce_cache_key = token_exchange_params.pop("_pkce_cache_key", None)
 
         # Get authorization code from query params
         authorization_code = request.query_params.get("code")
@@ -816,6 +817,10 @@ async def get_generic_sso_response(
                 redirect_url=redirect_url,
                 additional_headers=additional_generic_sso_headers_dict,
             )
+            # Token exchange succeeded — now it is safe to delete the single-use
+            # verifier.  Deleting before the exchange would lose it on retries.
+            if pkce_cache_key:
+                await SSOAuthenticationHandler._delete_pkce_verifier(pkce_cache_key)
             # Pass the full response so custom response_convertor implementations
             # can access all fields (including id_token for claim extraction).
             result = response_convertor(combined_response, generic_sso)
@@ -2530,13 +2535,12 @@ class SSOAuthenticationHandler:
                     )
 
             if code_verifier:
-                # Add code_verifier to token exchange parameters
+                # Add code_verifier to token exchange parameters.
                 token_params["code_verifier"] = code_verifier
-                # Clean up the cache entry (single-use verifier)
-                if redis_usage_cache is not None:
-                    await redis_usage_cache.async_delete_cache(key=cache_key)
-                else:
-                    await user_api_key_cache.async_delete_cache(key=cache_key)
+                # Return the cache key so the caller can delete it *after* a
+                # successful token exchange (avoids losing the verifier on retry
+                # if the exchange fails partway through).
+                token_params["_pkce_cache_key"] = cache_key
             else:
                 # PKCE is enabled (already checked above) but verifier is missing — likely a cross-instance cache miss.
                 active_cache = redis_usage_cache if redis_usage_cache is not None else user_api_key_cache
@@ -2551,6 +2555,16 @@ class SSOAuthenticationHandler:
                     cached_data is not None,
                 )
         return token_params
+
+    @staticmethod
+    async def _delete_pkce_verifier(cache_key: str) -> None:
+        """Delete a single-use PKCE verifier from cache after a successful exchange."""
+        from litellm.proxy.proxy_server import redis_usage_cache, user_api_key_cache
+
+        if redis_usage_cache is not None:
+            await redis_usage_cache.async_delete_cache(key=cache_key)
+        else:
+            await user_api_key_cache.async_delete_cache(key=cache_key)
 
     @staticmethod
     def generate_pkce_params() -> Tuple[str, str]:
@@ -2634,61 +2648,67 @@ class SSOAuthenticationHandler:
             if client_secret:
                 token_data["client_secret"] = client_secret
 
-        async with httpx.AsyncClient() as http_client:
-            response = await http_client.post(token_endpoint, **post_kwargs)
+        try:
+            async with httpx.AsyncClient() as http_client:
+                response = await http_client.post(token_endpoint, **post_kwargs)
+        except httpx.HTTPError as exc:
+            verbose_proxy_logger.error("PKCE token endpoint unreachable: %s", exc)
+            raise ProxyException(
+                message=f"Token endpoint request failed: {exc}",
+                type=ProxyErrorTypes.auth_error,
+                param="token_exchange",
+                code=status.HTTP_401_UNAUTHORIZED,
+            ) from exc
 
-            if response.status_code != 200:
-                verbose_proxy_logger.error(
-                    "PKCE token exchange failed. status=%s body=%s",
-                    response.status_code,
-                    response.text[:500],
-                )
-                raise ProxyException(
-                    message=f"Token exchange failed: {response.status_code} - {response.text[:500]}",
-                    type=ProxyErrorTypes.auth_error,
-                    param="token_exchange",
-                    code=status.HTTP_401_UNAUTHORIZED,
-                )
-
-            try:
-                token_response: dict = response.json()
-            except Exception as json_err:
-                verbose_proxy_logger.error(
-                    "Failed to parse token response as JSON: %s. Body: %s",
-                    json_err,
-                    response.text[:500],
-                )
-                raise ProxyException(
-                    message=f"Token endpoint returned invalid JSON: {json_err}",
-                    type=ProxyErrorTypes.auth_error,
-                    param="token_exchange",
-                    code=status.HTTP_401_UNAUTHORIZED,
-                )
-
-            # Some providers return HTTP 200 with an error body (e.g. expired code, replay attack).
-            if "access_token" not in token_response:
-                error = token_response.get("error", "unknown_error")
-                error_desc = token_response.get("error_description", "")
-                verbose_proxy_logger.error(
-                    "Token response missing access_token. error=%s description=%s",
-                    error,
-                    error_desc,
-                )
-                raise ProxyException(
-                    message=f"Token exchange error: {error} - {error_desc}",
-                    type=ProxyErrorTypes.auth_error,
-                    param="token_exchange",
-                    code=status.HTTP_401_UNAUTHORIZED,
-                )
-
-            verbose_proxy_logger.debug(
-                "PKCE token exchange successful. access_token=%s id_token=%s",
-                bool(token_response.get("access_token")),
-                bool(token_response.get("id_token")),
+        if response.status_code != 200:
+            verbose_proxy_logger.error(
+                "PKCE token exchange failed. status=%s body=%s",
+                response.status_code,
+                response.text[:500],
+            )
+            raise ProxyException(
+                message=f"Token exchange failed: {response.status_code} - {response.text[:500]}",
+                type=ProxyErrorTypes.auth_error,
+                param="token_exchange",
+                code=status.HTTP_401_UNAUTHORIZED,
             )
 
-        # token_response is set inside the async with block above and remains accessible here;
-        # Python's scoping rules guarantee it is defined if no exception was raised.
+        try:
+            token_response: dict = response.json()
+        except Exception as json_err:
+            verbose_proxy_logger.error(
+                "Failed to parse token response as JSON: %s. Body: %s",
+                json_err,
+                response.text[:500],
+            )
+            raise ProxyException(
+                message=f"Token endpoint returned invalid JSON: {json_err}",
+                type=ProxyErrorTypes.auth_error,
+                param="token_exchange",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        # Some providers return HTTP 200 with an error body (e.g. expired code, replay attack).
+        if "access_token" not in token_response:
+            error = token_response.get("error", "unknown_error")
+            error_desc = token_response.get("error_description", "")
+            verbose_proxy_logger.error(
+                "Token response missing access_token. error=%s description=%s",
+                error,
+                error_desc,
+            )
+            raise ProxyException(
+                message=f"Token exchange error: {error} - {error_desc}",
+                type=ProxyErrorTypes.auth_error,
+                param="token_exchange",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        verbose_proxy_logger.debug(
+            "PKCE token exchange successful. access_token=%s id_token=%s",
+            bool(token_response.get("access_token")),
+            bool(token_response.get("id_token")),
+        )
         userinfo = await SSOAuthenticationHandler._get_pkce_userinfo(
             access_token=token_response["access_token"],
             id_token=token_response.get("id_token"),
@@ -2744,7 +2764,9 @@ class SSOAuthenticationHandler:
 
         # Only fall back to id_token when the userinfo request failed (None).
         # An empty dict ({}) from the endpoint is a valid response and not retried.
-        if userinfo is None and id_token:
+        # Explicitly check for non-None and non-empty string to avoid attempting
+        # JWT decode on a blank id_token field.
+        if userinfo is None and id_token is not None and id_token != "":
             try:
                 userinfo = jwt.decode(id_token, options={"verify_signature": False})
             except Exception as decode_err:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -816,13 +816,16 @@ async def get_generic_sso_response(
                 redirect_url=redirect_url,
                 additional_headers=additional_generic_sso_headers_dict,
             )
-            # Strip OAuth token credentials before passing to response_convertor.
-            # combined_response is stored as received_response and may appear in
-            # restricted-group error messages — do not expose tokens to callers.
-            result = response_convertor(
-                {k: v for k, v in combined_response.items() if k not in _OAUTH_TOKEN_FIELDS},
-                generic_sso,
-            )
+            # Pass the full response so custom response_convertor implementations
+            # can access all fields (including id_token for claim extraction).
+            result = response_convertor(combined_response, generic_sso)
+            # Strip bearer credentials from received_response after conversion.
+            # received_response may appear in restricted-group error messages —
+            # do not expose tokens to callers.
+            if received_response:
+                received_response = {
+                    k: v for k, v in received_response.items() if k not in _OAUTH_TOKEN_FIELDS
+                }
             # In the PKCE path verify_and_process is skipped, so generic_sso.access_token
             # is never set. Read the token directly from the exchange response instead so
             # process_sso_jwt_access_token can extract JWT-embedded roles/teams.
@@ -2584,7 +2587,7 @@ class SSOAuthenticationHandler:
         client_id: str,
         client_secret: Optional[str],
         token_endpoint: str,
-        userinfo_endpoint: str,
+        userinfo_endpoint: Optional[str],
         include_client_id: bool,
         redirect_url: str,
         additional_headers: Dict[str, str],
@@ -2699,7 +2702,7 @@ class SSOAuthenticationHandler:
     async def _get_pkce_userinfo(
         access_token: str,
         id_token: Optional[str],
-        userinfo_endpoint: str,
+        userinfo_endpoint: Optional[str],
         additional_headers: Dict[str, str],
     ) -> dict:
         """
@@ -2708,33 +2711,34 @@ class SSOAuthenticationHandler:
         """
         userinfo: Optional[dict] = None  # None means "request not yet attempted or failed"
 
-        try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(
-                    userinfo_endpoint,
-                    headers={
-                        "Authorization": f"Bearer {access_token}",
-                        **additional_headers,
-                    },
-                    timeout=30.0,
-                )
-                if resp.status_code == 200:
-                    try:
-                        userinfo = resp.json()
-                    except Exception as json_err:
-                        verbose_proxy_logger.warning(
-                            "Userinfo endpoint returned non-JSON response (status 200): %s",
-                            json_err,
-                        )
-                else:
-                    verbose_proxy_logger.warning(
-                        "Userinfo endpoint returned %s, falling back to id_token",
-                        resp.status_code,
+        if userinfo_endpoint:
+            try:
+                async with httpx.AsyncClient() as client:
+                    resp = await client.get(
+                        userinfo_endpoint,
+                        headers={
+                            "Authorization": f"Bearer {access_token}",
+                            **additional_headers,
+                        },
+                        timeout=30.0,
                     )
-        except Exception as e:
-            verbose_proxy_logger.warning(
-                "Userinfo endpoint error: %s, falling back to id_token", e
-            )
+                    if resp.status_code == 200:
+                        try:
+                            userinfo = resp.json()
+                        except Exception as json_err:
+                            verbose_proxy_logger.warning(
+                                "Userinfo endpoint returned non-JSON response (status 200): %s",
+                                json_err,
+                            )
+                    else:
+                        verbose_proxy_logger.warning(
+                            "Userinfo endpoint returned %s, falling back to id_token",
+                            resp.status_code,
+                        )
+            except Exception as e:
+                verbose_proxy_logger.warning(
+                    "Userinfo endpoint error: %s, falling back to id_token", e
+                )
 
         # Only fall back to id_token when the userinfo request failed (None).
         # An empty dict ({}) from the endpoint is a valid response and not retried.

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2593,7 +2593,7 @@ class SSOAuthenticationHandler:
         Returns a combined dict of the token response and user info, suitable
         for passing to a response_convertor.
         """
-        verbose_proxy_logger.info(
+        verbose_proxy_logger.debug(
             "PKCE: performing direct token exchange (code_verifier length=%d)",
             len(code_verifier),
         )

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2980,8 +2980,9 @@ class SSOAuthenticationHandler:
                             )
                     else:
                         verbose_proxy_logger.warning(
-                            "Userinfo endpoint returned %s, falling back to id_token",
+                            "Userinfo endpoint returned %s (body: %s), falling back to id_token",
                             resp.status_code,
+                            resp.text[:500],
                         )
             except Exception as e:
                 verbose_proxy_logger.warning(

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2492,11 +2492,12 @@ class SSOAuthenticationHandler:
         token_params: Dict[str, Any] = {"include_client_id": generic_include_client_id}
 
         # Retrieve PKCE code_verifier if PKCE was used in authorization.
-        # Use same cache as store: Redis when available (multi-pod), else in-memory.
+        # Gate on GENERIC_CLIENT_USE_PKCE to avoid an unnecessary Redis round-trip
+        # on every non-PKCE SSO callback.
         query_params = dict(request.query_params)
         state = query_params.get("state")
 
-        if state:
+        if state and os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true":
             from litellm.proxy.proxy_server import redis_usage_cache, user_api_key_cache
 
             cache_key = f"pkce_verifier:{state}"

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2647,23 +2647,30 @@ class SSOAuthenticationHandler:
                         )
                     else:
                         # Genuine cache miss — verifier was never stored or already expired.
+                        # Distinguish the likely cause: cross-instance routing (Redis configured
+                        # but callback landed on a pod that never stored the verifier) vs.
+                        # single-instance issues (TTL expiry, pod restart, or PKCE flow never
+                        # started) when only in-memory cache is available.
+                        if redis_usage_cache is not None:
+                            cause = (
+                                "The authorization and callback were likely handled by different "
+                                "instances — the verifier was stored on one pod but not found on another."
+                            )
+                        else:
+                            cause = (
+                                "The verifier may have expired (TTL), been lost on a pod restart, "
+                                "or the PKCE authorization step was never completed. "
+                                "Configure Redis so all proxy instances share the PKCE verifier."
+                            )
                         verbose_proxy_logger.error(
                             "PKCE is enabled but no verifier found in cache for state '%s'. "
-                            "The authorization and callback were likely handled by different "
-                            "instances without a shared cache. Cache type: %s.",
+                            "%s Cache type: %s.",
                             state,
+                            cause,
                             type(active_cache).__name__,
                         )
-                        redis_hint = (
-                            " Configure Redis and set REDIS_URL so all proxy instances share the PKCE verifier."
-                            if redis_usage_cache is None
-                            else ""
-                        )
                         raise ProxyException(
-                            message=(
-                                f"PKCE verifier not found in cache for state '{state}'. "
-                                f"The login and callback requests were likely handled by different instances.{redis_hint}"
-                            ),
+                            message=f"PKCE verifier not found in cache for state '{state}'. {cause}",
                             type=ProxyErrorTypes.auth_error,
                             param="PKCE_CACHE_MISS",
                             code=status.HTTP_401_UNAUTHORIZED,
@@ -2875,6 +2882,8 @@ class SSOAuthenticationHandler:
             "PKCE token exchange successful. id_token_present=%s",
             bool(token_response.get("id_token")),
         )
+        # Bearer credentials (access_token, id_token, refresh_token) are always sourced
+        # from token_response — not from userinfo — in the merge step below.
         userinfo = await SSOAuthenticationHandler._get_pkce_userinfo(
             access_token=token_response["access_token"],
             id_token=token_response.get("id_token"),

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -845,16 +845,15 @@ async def get_generic_sso_response(
             # Pass the full response so custom response_convertor implementations
             # can access all fields (including id_token for claim extraction).
             result = response_convertor(combined_response, generic_sso)
-            # Strip bearer credentials from received_response after conversion.
-            # received_response may appear in restricted-group error messages —
-            # do not expose tokens to callers.
-            # Note: response_convertor always sets received_response via nonlocal, so it is
-            # non-None here at runtime.  The guard satisfies Pyright's type narrowing since
-            # it cannot track nonlocal mutations inside closures.
-            if received_response is not None:
-                received_response = {
-                    k: v for k, v in received_response.items() if k not in _OAUTH_TOKEN_FIELDS
-                }
+            # Strip bearer credentials from combined_response before storing in
+            # received_response. received_response may appear in restricted-group
+            # error messages — bearer tokens (access_token, id_token, refresh_token)
+            # must not be exposed to callers.
+            # Assign directly rather than relying on nonlocal mutation so that Pyright
+            # can track that received_response is non-None from this point on.
+            received_response = {
+                k: v for k, v in combined_response.items() if k not in _OAUTH_TOKEN_FIELDS
+            }
             # In the PKCE path verify_and_process is skipped, so generic_sso.access_token
             # is never set. Read the token directly from the exchange response instead so
             # process_sso_jwt_access_token can extract JWT-embedded roles/teams.

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2581,6 +2581,10 @@ class SSOAuthenticationHandler:
                     if redis_usage_cache is None
                     else ""
                 )
+                # Raise immediately — falling through to a non-PKCE flow would only
+                # produce a confusing provider-side error (provider requires code_verifier).
+                # Since PKCE support is new in this release, there is no prior behavior
+                # to preserve: the verifier was never actually used before this PR.
                 raise ProxyException(
                     message=(
                         f"PKCE verifier not found in cache for state '{state}'. "
@@ -2843,7 +2847,8 @@ class SSOAuthenticationHandler:
                 )
 
         # Only fall back to id_token when the userinfo request failed (None).
-        # An empty dict ({}) from the endpoint is a valid response and not retried.
+        # An empty dict ({}) is treated as a failure (userinfo is set to None above)
+        # so we also attempt the id_token fallback in that case.
         # Explicitly check for a non-empty string to avoid attempting JWT decode on
         # a blank or non-string id_token field from a misbehaving provider.
         if userinfo is None and isinstance(id_token, str) and id_token:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2513,12 +2513,17 @@ class SSOAuthenticationHandler:
                 if isinstance(cached_data, dict) and "code_verifier" in cached_data:
                     code_verifier = cached_data["code_verifier"]
                     verbose_proxy_logger.debug("PKCE code_verifier retrieved from cache")
-                else:
+                elif isinstance(cached_data, str):
                     # Handle legacy format (plain string) for backward compatibility
-                    code_verifier = cached_data if isinstance(cached_data, str) else str(cached_data)
+                    code_verifier = cached_data
                     verbose_proxy_logger.warning(
-                        "Retrieved code_verifier in legacy format (plain string). "
-                        "Using it but future storage will use dict format."
+                        "Retrieved code_verifier in legacy plain-string format. "
+                        "Future storage will use dict format."
+                    )
+                else:
+                    verbose_proxy_logger.error(
+                        "Unexpected PKCE verifier cache format (type=%s); skipping.",
+                        type(cached_data).__name__,
                     )
 
             if code_verifier:
@@ -2701,7 +2706,7 @@ class SSOAuthenticationHandler:
         Fetches user info from the userinfo endpoint.
         Falls back to decoding the id_token if the endpoint is unavailable.
         """
-        userinfo: dict = {}
+        userinfo: Optional[dict] = None  # None means "request not yet attempted or failed"
 
         try:
             async with httpx.AsyncClient() as client:
@@ -2731,7 +2736,9 @@ class SSOAuthenticationHandler:
                 "Userinfo endpoint error: %s, falling back to id_token", e
             )
 
-        if not userinfo and id_token:
+        # Only fall back to id_token when the userinfo request failed (None).
+        # An empty dict ({}) from the endpoint is a valid response and not retried.
+        if userinfo is None and id_token:
             try:
                 userinfo = jwt.decode(id_token, options={"verify_signature": False})
             except Exception as decode_err:
@@ -2743,7 +2750,7 @@ class SSOAuthenticationHandler:
                     code=status.HTTP_401_UNAUTHORIZED,
                 )
 
-        if not userinfo:
+        if userinfo is None:
             raise ProxyException(
                 message=(
                     "SSO user info unavailable: userinfo endpoint failed and no id_token "

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -875,7 +875,7 @@ async def get_generic_sso_response(
                 message=detailed_message,
                 type=ProxyErrorTypes.auth_error,
                 param="GENERIC_CLIENT_USE_PKCE",
-                code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                code=status.HTTP_401_UNAUTHORIZED,
             )
 
         verbose_proxy_logger.exception(
@@ -2676,7 +2676,9 @@ class SSOAuthenticationHandler:
                 http_client=http_client,
             )
 
-        return {**token_response, **userinfo}
+        # Merge with token_response taking precedence so token fields (e.g. access_token)
+        # cannot be overridden by non-standard userinfo fields.
+        return {**userinfo, **token_response}
 
     @staticmethod
     async def _get_pkce_userinfo(
@@ -2708,7 +2710,13 @@ class SSOAuthenticationHandler:
                     timeout=30.0,
                 )
                 if resp.status_code == 200:
-                    userinfo = resp.json()
+                    try:
+                        userinfo = resp.json()
+                    except Exception as json_err:
+                        verbose_proxy_logger.warning(
+                            "Userinfo endpoint returned non-JSON response (status 200): %s",
+                            json_err,
+                        )
                 else:
                     verbose_proxy_logger.warning(
                         "Userinfo endpoint returned %s, falling back to id_token",

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2543,6 +2543,15 @@ class SSOAuthenticationHandler:
         query_params = dict(request.query_params)
         state = query_params.get("state")
 
+        if os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true" and not state:
+            verbose_proxy_logger.warning(
+                "PKCE is enabled (GENERIC_CLIENT_USE_PKCE=true) but no 'state' parameter "
+                "was found in the callback. The PKCE verifier cannot be retrieved without "
+                "a state value — the token exchange will proceed without code_verifier, "
+                "which the provider may reject. Ensure your OAuth provider returns 'state' "
+                "in the callback redirect."
+            )
+
         if state and os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true":
             from litellm.proxy.proxy_server import redis_usage_cache, user_api_key_cache
 
@@ -2553,12 +2562,25 @@ class SSOAuthenticationHandler:
                 cached_data = await user_api_key_cache.async_get_cache(key=cache_key)
 
             code_verifier = None
+            # Track why code_verifier is absent for accurate strict-mode diagnostics.
+            _empty_value_in_dict = False  # dict format correct but value is empty/null
 
             if cached_data:
                 # Extract code_verifier from dict (stored as dict for JSON serialization)
                 if isinstance(cached_data, dict) and "code_verifier" in cached_data:
                     code_verifier = cached_data["code_verifier"]
-                    verbose_proxy_logger.debug("PKCE code_verifier retrieved from cache")
+                    if not code_verifier:
+                        # Dict format is correct but value is empty or null.  This is
+                        # a distinct case from an unrecognized format — the entry exists
+                        # but was stored with an empty/null verifier (data integrity issue).
+                        _empty_value_in_dict = True
+                        verbose_proxy_logger.warning(
+                            "PKCE verifier dict for state '%s' has an empty/null code_verifier "
+                            "value — may indicate a storage bug. Treating as a cache miss.",
+                            state,
+                        )
+                    else:
+                        verbose_proxy_logger.debug("PKCE code_verifier retrieved from cache")
                 elif isinstance(cached_data, str):
                     # Handle legacy format (plain string) for backward compatibility
                     code_verifier = cached_data
@@ -2588,9 +2610,20 @@ class SSOAuthenticationHandler:
                     os.getenv("PKCE_STRICT_CACHE_MISS", "false").lower() == "true"
                 )
                 if strict_cache_miss:
-                    # Distinguish corrupt-format entries from genuine cache misses
-                    # so operators can investigate the correct root cause.
-                    if cached_data is not None:
+                    # Distinguish empty-value dicts, corrupt-format entries, and genuine
+                    # cache misses so operators can investigate the correct root cause.
+                    if _empty_value_in_dict:
+                        # Dict format was correct but code_verifier was empty/null.
+                        raise ProxyException(
+                            message=(
+                                f"PKCE verifier for state '{state}' was found in cache but "
+                                f"has an empty or null code_verifier value — possible storage bug."
+                            ),
+                            type=ProxyErrorTypes.auth_error,
+                            param="PKCE_CACHE_MISS",
+                            code=status.HTTP_401_UNAUTHORIZED,
+                        )
+                    elif cached_data is not None:
                         # Cache had data but in an unrecognised format (e.g. corrupt Redis value).
                         verbose_proxy_logger.error(
                             "PKCE verifier for state '%s' has an unrecognized format (type=%s); "

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2765,6 +2765,12 @@ class SSOAuthenticationHandler:
                     if resp.status_code == 200:
                         try:
                             userinfo = resp.json()
+                            if not userinfo:
+                                verbose_proxy_logger.warning(
+                                    "Userinfo endpoint returned an empty response ({}). "
+                                    "The session will have no identity claims. "
+                                    "Check your provider's userinfo endpoint configuration.",
+                                )
                         except Exception as json_err:
                             verbose_proxy_logger.warning(
                                 "Userinfo endpoint returned non-JSON response (status 200): %s",

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -842,10 +842,6 @@ async def get_generic_sso_response(
                 redirect_url=redirect_url,
                 additional_headers=additional_generic_sso_headers_dict,
             )
-            # Token exchange succeeded — now it is safe to delete the single-use
-            # verifier.  Deleting before the exchange would lose it on retries.
-            if pkce_cache_key:
-                await SSOAuthenticationHandler._delete_pkce_verifier(pkce_cache_key)
             # Pass the full response so custom response_convertor implementations
             # can access all fields (including id_token for claim extraction).
             result = response_convertor(combined_response, generic_sso)
@@ -874,6 +870,12 @@ async def get_generic_sso_response(
         process_sso_jwt_access_token(
             access_token_str, sso_jwt_handler, result, role_mappings=role_mappings
         )
+        # Delete the single-use PKCE verifier only after all downstream processing
+        # (response_convertor and process_sso_jwt_access_token) has completed
+        # successfully.  Deleting earlier would consume the verifier on a transient
+        # failure, forcing the user to restart the entire OAuth flow from scratch.
+        if pkce_cache_key:
+            await SSOAuthenticationHandler._delete_pkce_verifier(pkce_cache_key)
 
     except Exception as e:
         error_message = str(e)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2473,17 +2473,9 @@ class ProxyConfig:
             ## INIT PROXY REDIS USAGE CLIENT ##
             redis_usage_cache = litellm.cache.cache
 
-            ## CONFIGURE USER API KEY CACHE TO USE REDIS FOR PKCE ##
-            # Only wire Redis when PKCE is explicitly enabled to avoid changing
-            # cache behaviour for deployments that don't use PKCE.
-            global user_api_key_cache
-            use_pkce = os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true"
-            if use_pkce and user_api_key_cache.redis_cache is None:
-                user_api_key_cache.redis_cache = redis_usage_cache
-                verbose_proxy_logger.info(
-                    "Configured user_api_key_cache to use Redis "
-                    "(PKCE enabled — verifiers shared across instances)."
-                )
+            ## INIT PROXY REDIS USAGE CLIENT ##
+            # Note: PKCE verifier storage uses redis_usage_cache directly (not
+            # user_api_key_cache) to avoid routing all API-key lookups through Redis.
 
     def switch_on_llm_response_caching(self):
         """
@@ -3033,28 +3025,19 @@ class ProxyConfig:
                     default_redis_ttl=None,  # PKCE verifiers set explicit TTL on each store; Redis TTL not configured here
                 )
 
-            ### CONFIGURE USER API KEY CACHE TO USE REDIS FOR PKCE (if enabled) ###
-            # Only wire Redis to user_api_key_cache when PKCE is explicitly enabled.
-            # This avoids silently routing API key lookups through Redis for deployments
-            # that use Redis only for LLM response caching and not for session state.
+            ### PKCE MULTI-INSTANCE PREREQUISITE CHECK ###
+            # PKCE verifiers are stored in redis_usage_cache when available so they can
+            # be read back by any instance (not just the one that started the auth flow).
+            # user_api_key_cache is intentionally left in-memory-only to avoid routing
+            # all API-key lookups through Redis.
             use_pkce = os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true"
-            if use_pkce and user_api_key_cache.redis_cache is None:
-                if redis_usage_cache is not None:
-                    # Reuse the existing Redis connection so all advanced connection
-                    # options (SSL, db, timeouts) are inherited rather than re-created
-                    # from a subset of env vars.
-                    user_api_key_cache.redis_cache = redis_usage_cache
-                    verbose_proxy_logger.info(
-                        "Configured user_api_key_cache to use Redis "
-                        "(PKCE enabled — verifiers shared across instances)."
-                    )
-                else:
-                    verbose_proxy_logger.warning(
-                        "GENERIC_CLIENT_USE_PKCE=true but Redis is not configured for LiteLLM caching. "
-                        "PKCE verifiers will not be shared across instances. "
-                        "Configure Redis via the 'cache' section in your proxy config, "
-                        "or enable sticky sessions for multi-instance deployments."
-                    )
+            if use_pkce and redis_usage_cache is None:
+                verbose_proxy_logger.warning(
+                    "GENERIC_CLIENT_USE_PKCE=true but Redis is not configured for LiteLLM caching. "
+                    "PKCE verifiers will not be shared across instances. "
+                    "Configure Redis via the 'cache' section in your proxy config, "
+                    "or enable sticky sessions for multi-instance deployments."
+                )
             ### STORE MODEL IN DB ### feature flag for `/model/new`
             store_model_in_db = general_settings.get("store_model_in_db", False)
             if store_model_in_db is None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3032,9 +3032,12 @@ class ProxyConfig:
             if use_pkce and redis_usage_cache is None:
                 verbose_proxy_logger.warning(
                     "GENERIC_CLIENT_USE_PKCE=true but Redis is not configured for LiteLLM caching. "
-                    "PKCE verifiers will not be shared across instances. "
+                    "PKCE verifiers will not be shared across instances — callbacks may land on a "
+                    "different pod than the login request and fail silently. "
                     "Configure Redis via the 'cache' section in your proxy config, "
-                    "or enable sticky sessions for multi-instance deployments."
+                    "or enable sticky sessions for single-instance deployments. "
+                    "Set PKCE_STRICT_CACHE_MISS=true to fail fast with a 401 on cache misses "
+                    "instead of continuing without a code_verifier."
                 )
             ### STORE MODEL IN DB ### feature flag for `/model/new`
             store_model_in_db = general_settings.get("store_model_in_db", False)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2473,15 +2473,16 @@ class ProxyConfig:
             ## INIT PROXY REDIS USAGE CLIENT ##
             redis_usage_cache = litellm.cache.cache
 
-            ## CONFIGURE USER API KEY CACHE TO USE REDIS ##
-            # This is critical for multi-task deployments (e.g., multiple ECS tasks)
-            # to share cached data like PKCE code_verifiers across all tasks
+            ## CONFIGURE USER API KEY CACHE TO USE REDIS FOR PKCE ##
+            # Only wire Redis when PKCE is explicitly enabled to avoid changing
+            # cache behaviour for deployments that don't use PKCE.
             global user_api_key_cache
-            if user_api_key_cache.redis_cache is None:
+            use_pkce = os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true"
+            if use_pkce and user_api_key_cache.redis_cache is None:
                 user_api_key_cache.redis_cache = redis_usage_cache
                 verbose_proxy_logger.info(
-                    "\u2713 Configured user_api_key_cache to use Redis. "
-                    "PKCE and other cached data will now be shared across all tasks/instances."
+                    "Configured user_api_key_cache to use Redis "
+                    "(PKCE enabled — verifiers shared across instances)."
                 )
 
     def switch_on_llm_response_caching(self):
@@ -3032,17 +3033,18 @@ class ProxyConfig:
                     default_redis_ttl=None,  # will be set below if Redis is available
                 )
 
-            ### CONFIGURE USER API KEY CACHE TO USE REDIS (if available) ###
-            # This is critical for multi-task/multi-instance deployments (e.g., multiple ECS tasks)
-            # to share cached data like PKCE code_verifiers, API keys, etc. across all instances
-            if user_api_key_cache.redis_cache is None:
+            ### CONFIGURE USER API KEY CACHE TO USE REDIS FOR PKCE (if enabled) ###
+            # Only wire Redis to user_api_key_cache when PKCE is explicitly enabled.
+            # This avoids silently routing API key lookups through Redis for deployments
+            # that use Redis only for LLM response caching and not for session state.
+            use_pkce = os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true"
+            if use_pkce and user_api_key_cache.redis_cache is None:
                 redis_host = get_secret("REDIS_HOST", None)
                 redis_port = get_secret("REDIS_PORT", None)
                 redis_password = get_secret("REDIS_PASSWORD", None)
 
                 if redis_host is not None:
                     try:
-                        # Initialize Redis for user_api_key_cache
                         from litellm.caching.caching import RedisCache
 
                         user_redis_cache = RedisCache(
@@ -3053,18 +3055,22 @@ class ProxyConfig:
                         user_api_key_cache.redis_cache = user_redis_cache
 
                         verbose_proxy_logger.info(
-                            f"\u2713 Configured user_api_key_cache to use Redis at {redis_host}:{redis_port}. "
-                            f"PKCE verifiers and other session data will now be shared across all tasks/instances."
+                            "Configured user_api_key_cache to use Redis at %s:%s "
+                            "(PKCE enabled — verifiers shared across instances).",
+                            redis_host,
+                            redis_port,
                         )
                     except Exception as e:
                         verbose_proxy_logger.warning(
-                            f"Failed to configure Redis for user_api_key_cache: {e}. "
-                            f"Falling back to in-memory cache only. Multi-task PKCE will not work."
+                            "Failed to configure Redis for user_api_key_cache: %s. "
+                            "Falling back to in-memory cache. Multi-instance PKCE will not work.",
+                            e,
                         )
                 else:
-                    verbose_proxy_logger.debug(
-                        "REDIS_HOST not configured. user_api_key_cache will use in-memory cache only. "
-                        "For multi-task deployments with PKCE, configure Redis or enable sticky sessions."
+                    verbose_proxy_logger.warning(
+                        "GENERIC_CLIENT_USE_PKCE=true but REDIS_HOST is not set. "
+                        "PKCE verifiers will not be shared across instances. "
+                        "Configure Redis or enable sticky sessions for multi-instance deployments."
                     )
             ### STORE MODEL IN DB ### feature flag for `/model/new`
             store_model_in_db = general_settings.get("store_model_in_db", False)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2472,8 +2472,6 @@ class ProxyConfig:
         ):
             ## INIT PROXY REDIS USAGE CLIENT ##
             redis_usage_cache = litellm.cache.cache
-
-            ## INIT PROXY REDIS USAGE CLIENT ##
             # Note: PKCE verifier storage uses redis_usage_cache directly (not
             # user_api_key_cache) to avoid routing all API-key lookups through Redis.
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -372,6 +372,9 @@ from litellm.proxy.management_endpoints.internal_user_endpoints import (
 from litellm.proxy.management_endpoints.internal_user_endpoints import (
     user_update,
 )
+from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
+    router as jwt_key_mapping_router,
+)
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     delete_verification_tokens,
     duration_in_seconds,
@@ -379,9 +382,6 @@ from litellm.proxy.management_endpoints.key_management_endpoints import (
 )
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     router as key_management_router,
-)
-from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
-    router as jwt_key_mapping_router,
 )
 from litellm.proxy.management_endpoints.mcp_management_endpoints import (
     router as mcp_management_router,
@@ -2473,6 +2473,17 @@ class ProxyConfig:
             ## INIT PROXY REDIS USAGE CLIENT ##
             redis_usage_cache = litellm.cache.cache
 
+            ## CONFIGURE USER API KEY CACHE TO USE REDIS ##
+            # This is critical for multi-task deployments (e.g., multiple ECS tasks)
+            # to share cached data like PKCE code_verifiers across all tasks
+            global user_api_key_cache
+            if user_api_key_cache.redis_cache is None:
+                user_api_key_cache.redis_cache = redis_usage_cache
+                verbose_proxy_logger.info(
+                    "\u2713 Configured user_api_key_cache to use Redis. "
+                    "PKCE and other cached data will now be shared across all tasks/instances."
+                )
+
     def switch_on_llm_response_caching(self):
         """
         Enable caching on the router by setting cache_responses=True.
@@ -3018,8 +3029,43 @@ class ProxyConfig:
             if user_api_key_cache_ttl is not None:
                 user_api_key_cache.update_cache_ttl(
                     default_in_memory_ttl=float(user_api_key_cache_ttl),
-                    default_redis_ttl=None,  # user_api_key_cache is an in-memory cache
+                    default_redis_ttl=None,  # will be set below if Redis is available
                 )
+
+            ### CONFIGURE USER API KEY CACHE TO USE REDIS (if available) ###
+            # This is critical for multi-task/multi-instance deployments (e.g., multiple ECS tasks)
+            # to share cached data like PKCE code_verifiers, API keys, etc. across all instances
+            if user_api_key_cache.redis_cache is None:
+                redis_host = get_secret("REDIS_HOST", None)
+                redis_port = get_secret("REDIS_PORT", None)
+                redis_password = get_secret("REDIS_PASSWORD", None)
+
+                if redis_host is not None:
+                    try:
+                        # Initialize Redis for user_api_key_cache
+                        from litellm.caching.caching import RedisCache
+
+                        user_redis_cache = RedisCache(
+                            host=redis_host,
+                            port=redis_port,
+                            password=redis_password,
+                        )
+                        user_api_key_cache.redis_cache = user_redis_cache
+
+                        verbose_proxy_logger.info(
+                            f"\u2713 Configured user_api_key_cache to use Redis at {redis_host}:{redis_port}. "
+                            f"PKCE verifiers and other session data will now be shared across all tasks/instances."
+                        )
+                    except Exception as e:
+                        verbose_proxy_logger.warning(
+                            f"Failed to configure Redis for user_api_key_cache: {e}. "
+                            f"Falling back to in-memory cache only. Multi-task PKCE will not work."
+                        )
+                else:
+                    verbose_proxy_logger.debug(
+                        "REDIS_HOST not configured. user_api_key_cache will use in-memory cache only. "
+                        "For multi-task deployments with PKCE, configure Redis or enable sticky sessions."
+                    )
             ### STORE MODEL IN DB ### feature flag for `/model/new`
             store_model_in_db = general_settings.get("store_model_in_db", False)
             if store_model_in_db is None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3039,38 +3039,21 @@ class ProxyConfig:
             # that use Redis only for LLM response caching and not for session state.
             use_pkce = os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true"
             if use_pkce and user_api_key_cache.redis_cache is None:
-                redis_host = get_secret("REDIS_HOST", None)
-                redis_port = get_secret("REDIS_PORT", None)
-                redis_password = get_secret("REDIS_PASSWORD", None)
-
-                if redis_host is not None:
-                    try:
-                        from litellm.caching.caching import RedisCache
-
-                        user_redis_cache = RedisCache(
-                            host=redis_host,
-                            port=redis_port,
-                            password=redis_password,
-                        )
-                        user_api_key_cache.redis_cache = user_redis_cache
-
-                        verbose_proxy_logger.info(
-                            "Configured user_api_key_cache to use Redis at %s:%s "
-                            "(PKCE enabled — verifiers shared across instances).",
-                            redis_host,
-                            redis_port,
-                        )
-                    except Exception as e:
-                        verbose_proxy_logger.warning(
-                            "Failed to configure Redis for user_api_key_cache: %s. "
-                            "Falling back to in-memory cache. Multi-instance PKCE will not work.",
-                            e,
-                        )
+                if redis_usage_cache is not None:
+                    # Reuse the existing Redis connection so all advanced connection
+                    # options (SSL, db, timeouts) are inherited rather than re-created
+                    # from a subset of env vars.
+                    user_api_key_cache.redis_cache = redis_usage_cache
+                    verbose_proxy_logger.info(
+                        "Configured user_api_key_cache to use Redis "
+                        "(PKCE enabled — verifiers shared across instances)."
+                    )
                 else:
                     verbose_proxy_logger.warning(
-                        "GENERIC_CLIENT_USE_PKCE=true but REDIS_HOST is not set. "
+                        "GENERIC_CLIENT_USE_PKCE=true but Redis is not configured for LiteLLM caching. "
                         "PKCE verifiers will not be shared across instances. "
-                        "Configure Redis or enable sticky sessions for multi-instance deployments."
+                        "Configure Redis via the 'cache' section in your proxy config, "
+                        "or enable sticky sessions for multi-instance deployments."
                     )
             ### STORE MODEL IN DB ### feature flag for `/model/new`
             store_model_in_db = general_settings.get("store_model_in_db", False)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1494,7 +1494,8 @@ native_background_mode: List[
 polling_cache_ttl: int = 3600  # Default 1 hour TTL for polling cache
 user_custom_auth = None
 user_custom_key_generate = None
-# Sentinel: prevents PKCE-no-Redis advisory from re-logging on config hot-reload
+# Sentinel: prevents PKCE-no-Redis advisory from re-logging on config hot-reload.
+# Tests that need to reset it can patch 'litellm.proxy.proxy_server._pkce_no_redis_warning_emitted'.
 _pkce_no_redis_warning_emitted: bool = False
 user_custom_sso = None
 user_custom_ui_sso_sign_in_handler = None

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3030,7 +3030,7 @@ class ProxyConfig:
             if user_api_key_cache_ttl is not None:
                 user_api_key_cache.update_cache_ttl(
                     default_in_memory_ttl=float(user_api_key_cache_ttl),
-                    default_redis_ttl=None,  # will be set below if Redis is available
+                    default_redis_ttl=None,  # PKCE verifiers set explicit TTL on each store; Redis TTL not configured here
                 )
 
             ### CONFIGURE USER API KEY CACHE TO USE REDIS FOR PKCE (if enabled) ###

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1494,6 +1494,8 @@ native_background_mode: List[
 polling_cache_ttl: int = 3600  # Default 1 hour TTL for polling cache
 user_custom_auth = None
 user_custom_key_generate = None
+# Sentinel: prevents PKCE-no-Redis advisory from re-logging on config hot-reload
+_pkce_no_redis_warning_emitted: bool = False
 user_custom_sso = None
 user_custom_ui_sso_sign_in_handler = None
 use_background_health_checks = None
@@ -3030,15 +3032,18 @@ class ProxyConfig:
             # all API-key lookups through Redis.
             use_pkce = os.getenv("GENERIC_CLIENT_USE_PKCE", "false").lower() == "true"
             if use_pkce and redis_usage_cache is None:
-                verbose_proxy_logger.warning(
-                    "GENERIC_CLIENT_USE_PKCE=true but Redis is not configured for LiteLLM caching. "
-                    "PKCE verifiers will not be shared across instances — callbacks may land on a "
-                    "different pod than the login request and fail silently. "
-                    "Configure Redis via the 'cache' section in your proxy config, "
-                    "or enable sticky sessions for single-instance deployments. "
-                    "Set PKCE_STRICT_CACHE_MISS=true to fail fast with a 401 on cache misses "
-                    "instead of continuing without a code_verifier."
-                )
+                global _pkce_no_redis_warning_emitted
+                if not _pkce_no_redis_warning_emitted:
+                    _pkce_no_redis_warning_emitted = True
+                    verbose_proxy_logger.warning(
+                        "GENERIC_CLIENT_USE_PKCE=true but Redis is not configured for LiteLLM caching. "
+                        "PKCE verifiers will not be shared across instances — callbacks may land on a "
+                        "different pod than the login request and fail silently. "
+                        "Configure Redis via the 'cache' section in your proxy config, "
+                        "or enable sticky sessions for single-instance deployments. "
+                        "Set PKCE_STRICT_CACHE_MISS=true to fail fast with a 401 on cache misses "
+                        "instead of continuing without a code_verifier."
+                    )
             ### STORE MODEL IN DB ### feature flag for `/model/new`
             store_model_in_db = general_settings.get("store_model_in_db", False)
             if store_model_in_db is None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3020,7 +3020,7 @@ class ProxyConfig:
             if user_api_key_cache_ttl is not None:
                 user_api_key_cache.update_cache_ttl(
                     default_in_memory_ttl=float(user_api_key_cache_ttl),
-                    default_redis_ttl=None,  # PKCE verifiers set explicit TTL on each store; Redis TTL not configured here
+                    default_redis_ttl=None,  # user_api_key_cache uses in-memory TTL only; Redis not configured for key lookups
                 )
 
             ### PKCE MULTI-INSTANCE PREREQUISITE CHECK ###

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3546,6 +3546,7 @@ class TestPKCEFunctionality:
                 )
 
         assert "invalid_grant" in exc_info.value.message
+        assert str(exc_info.value.code) == "401"
 
 
     @pytest.mark.asyncio
@@ -3631,6 +3632,7 @@ class TestPKCEFunctionality:
                 )
 
         assert "unavailable" in exc_info.value.message.lower()
+        assert str(exc_info.value.code) == "401"
 
 
     @pytest.mark.asyncio
@@ -3775,6 +3777,7 @@ class TestPKCEFunctionality:
                 )
 
         assert "cache" in exc_info.value.message.lower() or "verifier" in exc_info.value.message.lower() or "format" in exc_info.value.message.lower()
+        assert str(exc_info.value.code) == "401"
 
     @pytest.mark.asyncio
     async def test_pkce_cache_miss_non_strict_logs_warning_and_continues(self):
@@ -3844,7 +3847,8 @@ class TestPKCEFunctionality:
                     additional_headers={},
                 )
 
-        assert "401" in exc_info.value.message or "token" in exc_info.value.message.lower()
+        assert "token" in exc_info.value.message.lower()
+        assert str(exc_info.value.code) == "401"
 
     @pytest.mark.asyncio
     async def test_pkce_cache_miss_unexpected_format_non_strict_logs_warning(self):

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3820,9 +3820,10 @@ class TestPKCEFunctionality:
         assert str(exc_info.value.code) == "401"
 
     @pytest.mark.asyncio
-    async def test_pkce_cache_miss_non_strict_logs_warning_and_continues(self):
+    async def test_pkce_cache_miss_non_strict_logs_warning_and_continues(self, caplog):
         """Default (non-strict) cache-miss behavior: logs a warning and returns params
         without code_verifier rather than raising, to preserve backward compatibility."""
+        import logging
         import os
         from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -3839,7 +3840,9 @@ class TestPKCEFunctionality:
         # PKCE_STRICT_CACHE_MISS explicitly set to false — should NOT raise.
         # Use patch.dict with the key set to "false" rather than os.environ.pop()
         # to avoid permanently mutating the test process environment.
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+        with caplog.at_level(logging.WARNING), patch(
+            "litellm.proxy.proxy_server.redis_usage_cache", None
+        ), patch(
             "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
         ), patch.dict(
             os.environ,
@@ -3855,6 +3858,12 @@ class TestPKCEFunctionality:
         assert "_pkce_cache_key" not in result
         # Non-strict mode emits a warning rather than raising
         mock_cache.async_get_cache.assert_called_once()
+        # Verify the warning was actually logged
+        assert any(
+            "verifier not found" in r.message.lower() or "code_verifier" in r.message.lower()
+            for r in caplog.records
+            if r.levelno >= logging.WARNING
+        ), f"Expected a cache-miss warning. Records: {[r.message for r in caplog.records]}"
 
     @pytest.mark.asyncio
     async def test_pkce_token_exchange_non200_raises_proxy_exception(self):
@@ -3893,10 +3902,11 @@ class TestPKCEFunctionality:
         assert str(exc_info.value.code) == "401"
 
     @pytest.mark.asyncio
-    async def test_pkce_cache_miss_unexpected_format_non_strict_logs_warning(self):
+    async def test_pkce_cache_miss_unexpected_format_non_strict_logs_warning(self, caplog):
         """When cached data has an unexpected format (e.g. integer from corrupt Redis)
         in non-strict mode, prepare_token_exchange_parameters logs a warning and
         returns params without code_verifier rather than raising."""
+        import logging
         import os
         from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -3914,7 +3924,9 @@ class TestPKCEFunctionality:
         # Non-strict mode: should log a warning and continue, not raise.
         # Use patch.dict with PKCE_STRICT_CACHE_MISS="false" to avoid permanently
         # mutating the test process environment with os.environ.pop().
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+        with caplog.at_level(logging.WARNING), patch(
+            "litellm.proxy.proxy_server.redis_usage_cache", None
+        ), patch(
             "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
         ), patch.dict(
             os.environ,
@@ -3930,6 +3942,12 @@ class TestPKCEFunctionality:
         assert "_pkce_cache_key" not in result
         # Cache was queried (the unexpected format was retrieved and logged at WARNING)
         mock_cache.async_get_cache.assert_called_once()
+        # Verify a warning was logged about the unexpected format or cache miss
+        assert any(
+            "verifier" in r.message.lower() or "format" in r.message.lower() or "cache" in r.message.lower()
+            for r in caplog.records
+            if r.levelno >= logging.WARNING
+        ), f"Expected a format/cache warning. Records: {[r.message for r in caplog.records]}"
 
     @pytest.mark.asyncio
     async def test_pkce_legacy_string_cache_format_backward_compat(self):

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3383,18 +3383,19 @@ class TestPKCEFunctionality:
         mock_redis = MagicMock()
         mock_in_memory = MagicMock()
 
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", mock_redis):
-            with patch("litellm.proxy.proxy_server.user_api_key_cache", mock_in_memory):
-                mock_request = MagicMock(spec=Request)
-                mock_request.query_params = {}
-                token_params = (
-                    await SSOAuthenticationHandler.prepare_token_exchange_parameters(
-                        request=mock_request, generic_include_client_id=False
-                    )
+        with patch("litellm.proxy.proxy_server.redis_usage_cache", mock_redis), patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", mock_in_memory
+        ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}, clear=False):
+            mock_request = MagicMock(spec=Request)
+            mock_request.query_params = {}
+            token_params = (
+                await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                    request=mock_request, generic_include_client_id=False
                 )
-                assert "code_verifier" not in token_params
-                mock_redis.async_get_cache.assert_not_called()
-                mock_in_memory.async_get_cache.assert_not_called()
+            )
+            assert "code_verifier" not in token_params
+            mock_redis.async_get_cache.assert_not_called()
+            mock_in_memory.async_get_cache.assert_not_called()
 
 
     @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3753,6 +3753,77 @@ class TestPKCEFunctionality:
 
         assert "cache" in exc_info.value.message.lower() or "verifier" in exc_info.value.message.lower()
 
+    @pytest.mark.asyncio
+    async def test_pkce_cache_miss_non_strict_logs_warning_and_continues(self):
+        """Default (non-strict) cache-miss behavior: logs a warning and returns params
+        without code_verifier rather than raising, to preserve backward compatibility."""
+        import os
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from starlette.requests import Request
+
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        mock_cache = MagicMock()
+        mock_cache.async_get_cache = AsyncMock(return_value=None)  # verifier not found
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.query_params = {"state": "missing_state_non_strict"}
+
+        # PKCE_STRICT_CACHE_MISS not set (default false) — should NOT raise
+        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
+        ), patch.dict(
+            os.environ,
+            {"GENERIC_CLIENT_USE_PKCE": "true"},
+            clear=False,
+        ):
+            # Remove PKCE_STRICT_CACHE_MISS if set in environment
+            os.environ.pop("PKCE_STRICT_CACHE_MISS", None)
+            result = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                request=mock_request, generic_include_client_id=False
+            )
+
+        # Should return params without code_verifier (no raise)
+        assert "code_verifier" not in result
+        assert "_pkce_cache_key" not in result
+
+    @pytest.mark.asyncio
+    async def test_pkce_token_exchange_non200_raises_proxy_exception(self):
+        """_pkce_token_exchange raises ProxyException when the token endpoint
+        returns a non-200 status (e.g. 401 Unauthorized from provider)."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+
+        with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ProxyException) as exc_info:
+                await SSOAuthenticationHandler._pkce_token_exchange(
+                    authorization_code="auth_code",
+                    code_verifier="verifier",
+                    client_id="client_id",
+                    client_secret="secret",
+                    token_endpoint="https://example.com/token",
+                    userinfo_endpoint=None,
+                    include_client_id=True,
+                    redirect_url="https://proxy.example.com/callback",
+                    additional_headers={},
+                )
+
+        assert "401" in exc_info.value.message or "token" in exc_info.value.message.lower()
+
+
 # Tests for SSO user team assignment bug (Issue: SSO Users Not Added to Entra-Synced Teams on First Login)
 class TestAddMissingTeamMember:
     """Tests for the add_missing_team_member function"""

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -4805,3 +4805,24 @@ async def test_pkce_token_exchange_public_client_no_secret():
 
     assert result["access_token"] == "tok_public"
     assert result["sub"] == "pubuser"
+
+
+@pytest.mark.asyncio
+async def test_delete_pkce_verifier_swallows_deletion_errors():
+    """_delete_pkce_verifier must not raise when the cache delete fails
+    (best-effort cleanup — a leftover verifier must not abort a successful SSO login)."""
+    import os
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+    failing_cache = MagicMock()
+    failing_cache.async_delete_cache = AsyncMock(side_effect=Exception("Redis down"))
+
+    # Should NOT raise even though the underlying cache delete fails
+    with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+        "litellm.proxy.proxy_server.user_api_key_cache", failing_cache
+    ):
+        await SSOAuthenticationHandler._delete_pkce_verifier("pkce_verifier:test_state")
+
+    failing_cache.async_delete_cache.assert_called_once_with(key="pkce_verifier:test_state")

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3395,6 +3395,359 @@ class TestPKCEFunctionality:
                 mock_in_memory.async_get_cache.assert_not_called()
 
 
+    @pytest.mark.asyncio
+    async def test_pkce_token_exchange_basic_auth(self):
+        """When include_client_id=False, client credentials go via HTTP Basic Auth."""
+        token_resp = {
+            "access_token": "tok_abc",
+            "id_token": None,
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+        userinfo_resp = {"sub": "user1", "email": "user@example.com"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = token_resp
+
+        mock_userinfo_response = MagicMock()
+        mock_userinfo_response.status_code = 200
+        mock_userinfo_response.json.return_value = userinfo_resp
+
+        async def fake_post(*args, **kwargs):
+            # Verify Basic Auth is set
+            assert "auth" in kwargs
+            assert isinstance(kwargs["auth"], httpx.BasicAuth)
+            # Verify code_verifier is in the POST body (essential PKCE field)
+            assert kwargs.get("data", {}).get("code_verifier") == "verifier_abc"
+            return mock_response
+
+        with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=fake_post)
+            mock_client.get = AsyncMock(return_value=mock_userinfo_response)
+            mock_client_cls.return_value = mock_client
+
+            result = await SSOAuthenticationHandler._pkce_token_exchange(
+                authorization_code="auth_code_123",
+                code_verifier="verifier_abc",
+                client_id="my_client",
+                client_secret="my_secret",
+                token_endpoint="https://example.com/token",
+                userinfo_endpoint="https://example.com/userinfo",
+                include_client_id=False,
+                redirect_url="https://proxy.example.com/callback",
+                additional_headers={},
+            )
+
+        assert result["access_token"] == "tok_abc"
+        assert result["email"] == "user@example.com"
+        # Verify userinfo GET used the correct Bearer token header
+        get_call = mock_client.get.call_args
+        assert get_call is not None
+        assert get_call.kwargs["headers"]["Authorization"] == "Bearer tok_abc"
+
+
+    @pytest.mark.asyncio
+    async def test_pkce_token_exchange_credentials_in_body(self):
+        """When include_client_id=True, credentials go in the request body."""
+        token_resp = {
+            "access_token": "tok_body",
+            "id_token": None,
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+        userinfo_resp = {"sub": "user2", "email": "user2@example.com"}
+
+        async def fake_post(*args, **kwargs):
+            assert "auth" not in kwargs, "Should NOT use Basic Auth when include_client_id=True"
+            data = kwargs.get("data", {})
+            assert "client_id" in data
+            assert "client_secret" in data
+            assert data.get("code_verifier") == "verifier_xyz", "code_verifier must be in POST body"
+            mock = MagicMock()
+            mock.status_code = 200
+            mock.json.return_value = token_resp
+            return mock
+
+        with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=fake_post)
+            mock_userinfo = MagicMock()
+            mock_userinfo.status_code = 200
+            mock_userinfo.json.return_value = userinfo_resp
+            mock_client.get = AsyncMock(return_value=mock_userinfo)
+            mock_client_cls.return_value = mock_client
+
+            result = await SSOAuthenticationHandler._pkce_token_exchange(
+                authorization_code="auth_code_456",
+                code_verifier="verifier_xyz",
+                client_id="client_id_value",
+                client_secret="client_secret_value",
+                token_endpoint="https://example.com/token",
+                userinfo_endpoint="https://example.com/userinfo",
+                include_client_id=True,
+                redirect_url="https://proxy.example.com/callback",
+                additional_headers={},
+            )
+
+        assert result["access_token"] == "tok_body"
+        assert result["sub"] == "user2"
+
+
+    @pytest.mark.asyncio
+    async def test_pkce_token_exchange_http200_with_error_body(self):
+        """Provider returns HTTP 200 but with an error field instead of tokens."""
+        from litellm.proxy._types import ProxyException
+
+        error_body = {"error": "invalid_grant", "error_description": "Code already used"}
+
+        with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = error_body
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ProxyException) as exc_info:
+                await SSOAuthenticationHandler._pkce_token_exchange(
+                    authorization_code="expired_code",
+                    code_verifier="verifier",
+                    client_id="cid",
+                    client_secret="csecret",
+                    token_endpoint="https://example.com/token",
+                    userinfo_endpoint="https://example.com/userinfo",
+                    include_client_id=False,
+                    redirect_url="https://proxy.example.com/callback",
+                    additional_headers={},
+                )
+
+        assert "invalid_grant" in exc_info.value.message
+
+
+    @pytest.mark.asyncio
+    async def test_pkce_userinfo_falls_back_to_id_token(self):
+        """When the userinfo endpoint fails, decode the id_token as fallback."""
+        import base64
+        import json as _json
+
+        payload = {"sub": "user_from_jwt", "email": "jwt@example.com"}
+        # Build a minimal JWT (header.payload.signature — signature not verified)
+        encoded_payload = base64.urlsafe_b64encode(
+            _json.dumps(payload).encode()
+        ).rstrip(b"=").decode()
+        fake_id_token = f"eyJhbGciOiJSUzI1NiJ9.{encoded_payload}.fakesig"
+
+        with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_fail = MagicMock()
+            mock_fail.status_code = 503
+            mock_client.get = AsyncMock(return_value=mock_fail)
+            mock_client_cls.return_value = mock_client
+
+            result = await SSOAuthenticationHandler._get_pkce_userinfo(
+                access_token="some_token",
+                id_token=fake_id_token,
+                userinfo_endpoint="https://example.com/userinfo",
+                additional_headers={},
+            )
+
+        assert result["sub"] == "user_from_jwt"
+        assert result["email"] == "jwt@example.com"
+
+
+    @pytest.mark.asyncio
+    async def test_pkce_userinfo_uses_id_token_when_no_endpoint(self):
+        """When userinfo_endpoint is None, fall back to id_token directly without HTTP call."""
+        import base64
+        import json as _json
+
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        payload = {"sub": "id_token_user", "email": "id@example.com"}
+        encoded_payload = (
+            base64.urlsafe_b64encode(_json.dumps(payload).encode()).rstrip(b"=").decode()
+        )
+        fake_id_token = f"eyJhbGciOiJSUzI1NiJ9.{encoded_payload}.fakesig"
+
+        # No httpx call should happen when userinfo_endpoint is None
+        result = await SSOAuthenticationHandler._get_pkce_userinfo(
+            access_token="some_token",
+            id_token=fake_id_token,
+            userinfo_endpoint=None,
+            additional_headers={},
+        )
+
+        assert result["sub"] == "id_token_user"
+        assert result["email"] == "id@example.com"
+
+
+    @pytest.mark.asyncio
+    async def test_pkce_userinfo_raises_when_both_sources_unavailable(self):
+        """When userinfo endpoint fails AND no id_token, raise ProxyException."""
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_fail = MagicMock()
+            mock_fail.status_code = 503
+            mock_client.get = AsyncMock(return_value=mock_fail)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ProxyException) as exc_info:
+                await SSOAuthenticationHandler._get_pkce_userinfo(
+                    access_token="token",
+                    id_token=None,  # no id_token available
+                    userinfo_endpoint="https://example.com/userinfo",
+                    additional_headers={},
+                )
+
+        assert "unavailable" in exc_info.value.message.lower()
+
+
+    @pytest.mark.asyncio
+    async def test_pkce_cache_miss_raises_proxy_exception(self):
+        """prepare_token_exchange_parameters raises ProxyException when PKCE is enabled
+        but no verifier is found in cache (cross-instance cache miss scenario)."""
+        import os
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from starlette.requests import Request
+
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        mock_cache = MagicMock()
+        mock_cache.async_get_cache = AsyncMock(return_value=None)  # verifier not found
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.query_params = {"state": "missing_state_123"}
+
+        with pytest.raises(ProxyException) as exc_info:
+            with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+                "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
+            ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
+                await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                    request=mock_request, generic_include_client_id=False
+                )
+
+        assert "verifier not found" in exc_info.value.message.lower() or "cache" in exc_info.value.message.lower()
+
+
+    @pytest.mark.asyncio
+    async def test_pkce_token_exchange_public_client_no_secret(self):
+        """Public PKCE client (include_client_id=False, no secret) sends client_id in
+        POST body and does NOT include Basic Auth or client_secret."""
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        token_resp = {
+            "access_token": "tok_public",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+        userinfo_resp = {"sub": "pubuser", "email": "pub@example.com"}
+
+        async def fake_post(*args, **kwargs):
+            assert "auth" not in kwargs, "Public client must not use Basic Auth"
+            data = kwargs.get("data", {})
+            assert data.get("client_id") == "public_client_id"
+            assert "client_secret" not in data, "No secret should be sent for public client"
+            assert data.get("code_verifier") == "public_verifier"
+            mock = MagicMock()
+            mock.status_code = 200
+            mock.json.return_value = token_resp
+            return mock
+
+        with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=fake_post)
+            mock_userinfo = MagicMock()
+            mock_userinfo.status_code = 200
+            mock_userinfo.json.return_value = userinfo_resp
+            mock_client.get = AsyncMock(return_value=mock_userinfo)
+            mock_client_cls.return_value = mock_client
+
+            result = await SSOAuthenticationHandler._pkce_token_exchange(
+                authorization_code="auth_pub",
+                code_verifier="public_verifier",
+                client_id="public_client_id",
+                client_secret=None,  # public client — no secret
+                token_endpoint="https://example.com/token",
+                userinfo_endpoint="https://example.com/userinfo",
+                include_client_id=False,
+                redirect_url="https://proxy.example.com/callback",
+                additional_headers={},
+            )
+
+        assert result["access_token"] == "tok_public"
+        assert result["sub"] == "pubuser"
+
+
+    @pytest.mark.asyncio
+    async def test_delete_pkce_verifier_swallows_deletion_errors(self):
+        """_delete_pkce_verifier must not raise when the cache delete fails
+        (best-effort cleanup — a leftover verifier must not abort a successful SSO login)."""
+        import os
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        failing_cache = MagicMock()
+        failing_cache.async_delete_cache = AsyncMock(side_effect=Exception("Redis down"))
+
+        # Should NOT raise even though the underlying cache delete fails
+        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", failing_cache
+        ):
+            await SSOAuthenticationHandler._delete_pkce_verifier("pkce_verifier:test_state")
+
+        failing_cache.async_delete_cache.assert_called_once_with(key="pkce_verifier:test_state")
+
+
+    @pytest.mark.asyncio
+    async def test_pkce_cache_miss_unexpected_format_raises_proxy_exception(self):
+        """When cached data exists but has an unrecognized format (not a dict with
+        code_verifier, not a plain string), prepare_token_exchange_parameters raises
+        ProxyException rather than silently falling through to a non-PKCE flow."""
+        import os
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from starlette.requests import Request
+
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        # Cache returns an integer — unexpected format
+        mock_cache = MagicMock()
+        mock_cache.async_get_cache = AsyncMock(return_value=12345)
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.query_params = {"state": "bad_format_state"}
+
+        with pytest.raises(ProxyException) as exc_info:
+            with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+                "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
+            ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
+                await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                    request=mock_request, generic_include_client_id=False
+                )
+
+        assert "cache" in exc_info.value.message.lower() or "verifier" in exc_info.value.message.lower()
+
 # Tests for SSO user team assignment bug (Issue: SSO Users Not Added to Entra-Synced Teams on First Login)
 class TestAddMissingTeamMember:
     """Tests for the add_missing_team_member function"""
@@ -4501,359 +4854,3 @@ def test_generic_response_convertor_extra_attributes_missing_field(monkeypatch):
     assert result.extra_fields["missing_field"] is None
     assert result.extra_fields["another_missing"] is None
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Tests for SSOAuthenticationHandler PKCE token exchange methods
-# ──────────────────────────────────────────────────────────────────────────────
-
-@pytest.mark.asyncio
-async def test_pkce_token_exchange_basic_auth():
-    """When include_client_id=False, client credentials go via HTTP Basic Auth."""
-    token_resp = {
-        "access_token": "tok_abc",
-        "id_token": None,
-        "token_type": "Bearer",
-        "expires_in": 3600,
-    }
-    userinfo_resp = {"sub": "user1", "email": "user@example.com"}
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = token_resp
-
-    mock_userinfo_response = MagicMock()
-    mock_userinfo_response.status_code = 200
-    mock_userinfo_response.json.return_value = userinfo_resp
-
-    async def fake_post(*args, **kwargs):
-        # Verify Basic Auth is set
-        assert "auth" in kwargs
-        assert isinstance(kwargs["auth"], httpx.BasicAuth)
-        # Verify code_verifier is in the POST body (essential PKCE field)
-        assert kwargs.get("data", {}).get("code_verifier") == "verifier_abc"
-        return mock_response
-
-    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(side_effect=fake_post)
-        mock_client.get = AsyncMock(return_value=mock_userinfo_response)
-        mock_client_cls.return_value = mock_client
-
-        result = await SSOAuthenticationHandler._pkce_token_exchange(
-            authorization_code="auth_code_123",
-            code_verifier="verifier_abc",
-            client_id="my_client",
-            client_secret="my_secret",
-            token_endpoint="https://example.com/token",
-            userinfo_endpoint="https://example.com/userinfo",
-            include_client_id=False,
-            redirect_url="https://proxy.example.com/callback",
-            additional_headers={},
-        )
-
-    assert result["access_token"] == "tok_abc"
-    assert result["email"] == "user@example.com"
-    # Verify userinfo GET used the correct Bearer token header
-    get_call = mock_client.get.call_args
-    assert get_call is not None
-    assert get_call.kwargs["headers"]["Authorization"] == "Bearer tok_abc"
-
-
-@pytest.mark.asyncio
-async def test_pkce_token_exchange_credentials_in_body():
-    """When include_client_id=True, credentials go in the request body."""
-    token_resp = {
-        "access_token": "tok_body",
-        "id_token": None,
-        "token_type": "Bearer",
-        "expires_in": 3600,
-    }
-    userinfo_resp = {"sub": "user2", "email": "user2@example.com"}
-
-    async def fake_post(*args, **kwargs):
-        assert "auth" not in kwargs, "Should NOT use Basic Auth when include_client_id=True"
-        data = kwargs.get("data", {})
-        assert "client_id" in data
-        assert "client_secret" in data
-        assert data.get("code_verifier") == "verifier_xyz", "code_verifier must be in POST body"
-        mock = MagicMock()
-        mock.status_code = 200
-        mock.json.return_value = token_resp
-        return mock
-
-    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(side_effect=fake_post)
-        mock_userinfo = MagicMock()
-        mock_userinfo.status_code = 200
-        mock_userinfo.json.return_value = userinfo_resp
-        mock_client.get = AsyncMock(return_value=mock_userinfo)
-        mock_client_cls.return_value = mock_client
-
-        result = await SSOAuthenticationHandler._pkce_token_exchange(
-            authorization_code="auth_code_456",
-            code_verifier="verifier_xyz",
-            client_id="client_id_value",
-            client_secret="client_secret_value",
-            token_endpoint="https://example.com/token",
-            userinfo_endpoint="https://example.com/userinfo",
-            include_client_id=True,
-            redirect_url="https://proxy.example.com/callback",
-            additional_headers={},
-        )
-
-    assert result["access_token"] == "tok_body"
-    assert result["sub"] == "user2"
-
-
-@pytest.mark.asyncio
-async def test_pkce_token_exchange_http200_with_error_body():
-    """Provider returns HTTP 200 but with an error field instead of tokens."""
-    from litellm.proxy._types import ProxyException
-
-    error_body = {"error": "invalid_grant", "error_description": "Code already used"}
-
-    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = error_body
-        mock_client.post = AsyncMock(return_value=mock_resp)
-        mock_client_cls.return_value = mock_client
-
-        with pytest.raises(ProxyException) as exc_info:
-            await SSOAuthenticationHandler._pkce_token_exchange(
-                authorization_code="expired_code",
-                code_verifier="verifier",
-                client_id="cid",
-                client_secret="csecret",
-                token_endpoint="https://example.com/token",
-                userinfo_endpoint="https://example.com/userinfo",
-                include_client_id=False,
-                redirect_url="https://proxy.example.com/callback",
-                additional_headers={},
-            )
-
-    assert "invalid_grant" in exc_info.value.message
-
-
-@pytest.mark.asyncio
-async def test_pkce_userinfo_falls_back_to_id_token():
-    """When the userinfo endpoint fails, decode the id_token as fallback."""
-    import base64
-    import json as _json
-
-    payload = {"sub": "user_from_jwt", "email": "jwt@example.com"}
-    # Build a minimal JWT (header.payload.signature — signature not verified)
-    encoded_payload = base64.urlsafe_b64encode(
-        _json.dumps(payload).encode()
-    ).rstrip(b"=").decode()
-    fake_id_token = f"eyJhbGciOiJSUzI1NiJ9.{encoded_payload}.fakesig"
-
-    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_fail = MagicMock()
-        mock_fail.status_code = 503
-        mock_client.get = AsyncMock(return_value=mock_fail)
-        mock_client_cls.return_value = mock_client
-
-        result = await SSOAuthenticationHandler._get_pkce_userinfo(
-            access_token="some_token",
-            id_token=fake_id_token,
-            userinfo_endpoint="https://example.com/userinfo",
-            additional_headers={},
-        )
-
-    assert result["sub"] == "user_from_jwt"
-    assert result["email"] == "jwt@example.com"
-
-
-@pytest.mark.asyncio
-async def test_pkce_userinfo_uses_id_token_when_no_endpoint():
-    """When userinfo_endpoint is None, fall back to id_token directly without HTTP call."""
-    import base64
-    import json as _json
-
-    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
-
-    payload = {"sub": "id_token_user", "email": "id@example.com"}
-    encoded_payload = (
-        base64.urlsafe_b64encode(_json.dumps(payload).encode()).rstrip(b"=").decode()
-    )
-    fake_id_token = f"eyJhbGciOiJSUzI1NiJ9.{encoded_payload}.fakesig"
-
-    # No httpx call should happen when userinfo_endpoint is None
-    result = await SSOAuthenticationHandler._get_pkce_userinfo(
-        access_token="some_token",
-        id_token=fake_id_token,
-        userinfo_endpoint=None,
-        additional_headers={},
-    )
-
-    assert result["sub"] == "id_token_user"
-    assert result["email"] == "id@example.com"
-
-
-@pytest.mark.asyncio
-async def test_pkce_userinfo_raises_when_both_sources_unavailable():
-    """When userinfo endpoint fails AND no id_token, raise ProxyException."""
-    from litellm.proxy._types import ProxyException
-    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
-
-    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_fail = MagicMock()
-        mock_fail.status_code = 503
-        mock_client.get = AsyncMock(return_value=mock_fail)
-        mock_client_cls.return_value = mock_client
-
-        with pytest.raises(ProxyException) as exc_info:
-            await SSOAuthenticationHandler._get_pkce_userinfo(
-                access_token="token",
-                id_token=None,  # no id_token available
-                userinfo_endpoint="https://example.com/userinfo",
-                additional_headers={},
-            )
-
-    assert "unavailable" in exc_info.value.message.lower()
-
-
-@pytest.mark.asyncio
-async def test_pkce_cache_miss_raises_proxy_exception():
-    """prepare_token_exchange_parameters raises ProxyException when PKCE is enabled
-    but no verifier is found in cache (cross-instance cache miss scenario)."""
-    import os
-    from unittest.mock import AsyncMock, MagicMock, patch
-
-    from starlette.requests import Request
-
-    from litellm.proxy._types import ProxyException
-    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
-
-    mock_cache = MagicMock()
-    mock_cache.async_get_cache = AsyncMock(return_value=None)  # verifier not found
-
-    mock_request = MagicMock(spec=Request)
-    mock_request.query_params = {"state": "missing_state_123"}
-
-    with pytest.raises(ProxyException) as exc_info:
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
-            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-        ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
-            await SSOAuthenticationHandler.prepare_token_exchange_parameters(
-                request=mock_request, generic_include_client_id=False
-            )
-
-    assert "verifier not found" in exc_info.value.message.lower() or "cache" in exc_info.value.message.lower()
-
-
-@pytest.mark.asyncio
-async def test_pkce_token_exchange_public_client_no_secret():
-    """Public PKCE client (include_client_id=False, no secret) sends client_id in
-    POST body and does NOT include Basic Auth or client_secret."""
-    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
-
-    token_resp = {
-        "access_token": "tok_public",
-        "token_type": "Bearer",
-        "expires_in": 3600,
-    }
-    userinfo_resp = {"sub": "pubuser", "email": "pub@example.com"}
-
-    async def fake_post(*args, **kwargs):
-        assert "auth" not in kwargs, "Public client must not use Basic Auth"
-        data = kwargs.get("data", {})
-        assert data.get("client_id") == "public_client_id"
-        assert "client_secret" not in data, "No secret should be sent for public client"
-        assert data.get("code_verifier") == "public_verifier"
-        mock = MagicMock()
-        mock.status_code = 200
-        mock.json.return_value = token_resp
-        return mock
-
-    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(side_effect=fake_post)
-        mock_userinfo = MagicMock()
-        mock_userinfo.status_code = 200
-        mock_userinfo.json.return_value = userinfo_resp
-        mock_client.get = AsyncMock(return_value=mock_userinfo)
-        mock_client_cls.return_value = mock_client
-
-        result = await SSOAuthenticationHandler._pkce_token_exchange(
-            authorization_code="auth_pub",
-            code_verifier="public_verifier",
-            client_id="public_client_id",
-            client_secret=None,  # public client — no secret
-            token_endpoint="https://example.com/token",
-            userinfo_endpoint="https://example.com/userinfo",
-            include_client_id=False,
-            redirect_url="https://proxy.example.com/callback",
-            additional_headers={},
-        )
-
-    assert result["access_token"] == "tok_public"
-    assert result["sub"] == "pubuser"
-
-
-@pytest.mark.asyncio
-async def test_delete_pkce_verifier_swallows_deletion_errors():
-    """_delete_pkce_verifier must not raise when the cache delete fails
-    (best-effort cleanup — a leftover verifier must not abort a successful SSO login)."""
-    import os
-    from unittest.mock import AsyncMock, MagicMock, patch
-
-    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
-
-    failing_cache = MagicMock()
-    failing_cache.async_delete_cache = AsyncMock(side_effect=Exception("Redis down"))
-
-    # Should NOT raise even though the underlying cache delete fails
-    with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
-        "litellm.proxy.proxy_server.user_api_key_cache", failing_cache
-    ):
-        await SSOAuthenticationHandler._delete_pkce_verifier("pkce_verifier:test_state")
-
-    failing_cache.async_delete_cache.assert_called_once_with(key="pkce_verifier:test_state")
-
-
-@pytest.mark.asyncio
-async def test_pkce_cache_miss_unexpected_format_raises_proxy_exception():
-    """When cached data exists but has an unrecognized format (not a dict with
-    code_verifier, not a plain string), prepare_token_exchange_parameters raises
-    ProxyException rather than silently falling through to a non-PKCE flow."""
-    import os
-    from unittest.mock import AsyncMock, MagicMock, patch
-
-    from starlette.requests import Request
-
-    from litellm.proxy._types import ProxyException
-    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
-
-    # Cache returns an integer — unexpected format
-    mock_cache = MagicMock()
-    mock_cache.async_get_cache = AsyncMock(return_value=12345)
-
-    mock_request = MagicMock(spec=Request)
-    mock_request.query_params = {"state": "bad_format_state"}
-
-    with pytest.raises(ProxyException) as exc_info:
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
-            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-        ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
-            await SSOAuthenticationHandler.prepare_token_exchange_parameters(
-                request=mock_request, generic_include_client_id=False
-            )
-
-    assert "cache" in exc_info.value.message.lower() or "verifier" in exc_info.value.message.lower()

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3791,16 +3791,16 @@ class TestPKCEFunctionality:
         mock_request = MagicMock(spec=Request)
         mock_request.query_params = {"state": "missing_state_non_strict"}
 
-        # PKCE_STRICT_CACHE_MISS not set (default false) — should NOT raise
+        # PKCE_STRICT_CACHE_MISS explicitly set to false — should NOT raise.
+        # Use patch.dict with the key set to "false" rather than os.environ.pop()
+        # to avoid permanently mutating the test process environment.
         with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
             "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
         ), patch.dict(
             os.environ,
-            {"GENERIC_CLIENT_USE_PKCE": "true"},
+            {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "false"},
             clear=False,
         ):
-            # Remove PKCE_STRICT_CACHE_MISS if set in environment
-            os.environ.pop("PKCE_STRICT_CACHE_MISS", None)
             result = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
                 request=mock_request, generic_include_client_id=False
             )
@@ -3863,15 +3863,16 @@ class TestPKCEFunctionality:
         mock_request = MagicMock(spec=Request)
         mock_request.query_params = {"state": "bad_format_non_strict"}
 
-        # Non-strict mode: should log a warning and continue, not raise
+        # Non-strict mode: should log a warning and continue, not raise.
+        # Use patch.dict with PKCE_STRICT_CACHE_MISS="false" to avoid permanently
+        # mutating the test process environment with os.environ.pop().
         with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
             "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
         ), patch.dict(
             os.environ,
-            {"GENERIC_CLIENT_USE_PKCE": "true"},
+            {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "false"},
             clear=False,
         ):
-            os.environ.pop("PKCE_STRICT_CACHE_MISS", None)
             result = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
                 request=mock_request, generic_include_client_id=False
             )

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3663,6 +3663,7 @@ class TestPKCEFunctionality:
                 )
 
         assert "verifier not found" in exc_info.value.message.lower() or "cache" in exc_info.value.message.lower()
+        assert exc_info.value.code == 401
 
 
     @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3424,13 +3424,20 @@ class TestPKCEFunctionality:
             assert kwargs.get("data", {}).get("code_verifier") == "verifier_abc"
             return mock_response
 
+        # Use separate mock clients for token exchange and userinfo —
+        # each httpx.AsyncClient() call gets its own independent mock.
+        mock_token_client = AsyncMock()
+        mock_token_client.__aenter__ = AsyncMock(return_value=mock_token_client)
+        mock_token_client.__aexit__ = AsyncMock(return_value=False)
+        mock_token_client.post = AsyncMock(side_effect=fake_post)
+
+        mock_userinfo_client = AsyncMock()
+        mock_userinfo_client.__aenter__ = AsyncMock(return_value=mock_userinfo_client)
+        mock_userinfo_client.__aexit__ = AsyncMock(return_value=False)
+        mock_userinfo_client.get = AsyncMock(return_value=mock_userinfo_response)
+
         with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(side_effect=fake_post)
-            mock_client.get = AsyncMock(return_value=mock_userinfo_response)
-            mock_client_cls.return_value = mock_client
+            mock_client_cls.side_effect = [mock_token_client, mock_userinfo_client]
 
             result = await SSOAuthenticationHandler._pkce_token_exchange(
                 authorization_code="auth_code_123",
@@ -3447,7 +3454,7 @@ class TestPKCEFunctionality:
         assert result["access_token"] == "tok_abc"
         assert result["email"] == "user@example.com"
         # Verify userinfo GET used the correct Bearer token header
-        get_call = mock_client.get.call_args
+        get_call = mock_userinfo_client.get.call_args
         assert get_call is not None
         assert get_call.kwargs["headers"]["Authorization"] == "Bearer tok_abc"
 
@@ -3474,16 +3481,22 @@ class TestPKCEFunctionality:
             mock.json.return_value = token_resp
             return mock
 
+        mock_userinfo = MagicMock()
+        mock_userinfo.status_code = 200
+        mock_userinfo.json.return_value = userinfo_resp
+
+        mock_token_client = AsyncMock()
+        mock_token_client.__aenter__ = AsyncMock(return_value=mock_token_client)
+        mock_token_client.__aexit__ = AsyncMock(return_value=False)
+        mock_token_client.post = AsyncMock(side_effect=fake_post)
+
+        mock_userinfo_client = AsyncMock()
+        mock_userinfo_client.__aenter__ = AsyncMock(return_value=mock_userinfo_client)
+        mock_userinfo_client.__aexit__ = AsyncMock(return_value=False)
+        mock_userinfo_client.get = AsyncMock(return_value=mock_userinfo)
+
         with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(side_effect=fake_post)
-            mock_userinfo = MagicMock()
-            mock_userinfo.status_code = 200
-            mock_userinfo.json.return_value = userinfo_resp
-            mock_client.get = AsyncMock(return_value=mock_userinfo)
-            mock_client_cls.return_value = mock_client
+            mock_client_cls.side_effect = [mock_token_client, mock_userinfo_client]
 
             result = await SSOAuthenticationHandler._pkce_token_exchange(
                 authorization_code="auth_code_456",
@@ -3675,16 +3688,22 @@ class TestPKCEFunctionality:
             mock.json.return_value = token_resp
             return mock
 
+        mock_userinfo = MagicMock()
+        mock_userinfo.status_code = 200
+        mock_userinfo.json.return_value = userinfo_resp
+
+        mock_token_client = AsyncMock()
+        mock_token_client.__aenter__ = AsyncMock(return_value=mock_token_client)
+        mock_token_client.__aexit__ = AsyncMock(return_value=False)
+        mock_token_client.post = AsyncMock(side_effect=fake_post)
+
+        mock_userinfo_client = AsyncMock()
+        mock_userinfo_client.__aenter__ = AsyncMock(return_value=mock_userinfo_client)
+        mock_userinfo_client.__aexit__ = AsyncMock(return_value=False)
+        mock_userinfo_client.get = AsyncMock(return_value=mock_userinfo)
+
         with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(side_effect=fake_post)
-            mock_userinfo = MagicMock()
-            mock_userinfo.status_code = 200
-            mock_userinfo.json.return_value = userinfo_resp
-            mock_client.get = AsyncMock(return_value=mock_userinfo)
-            mock_client_cls.return_value = mock_client
+            mock_client_cls.side_effect = [mock_token_client, mock_userinfo_client]
 
             result = await SSOAuthenticationHandler._pkce_token_exchange(
                 authorization_code="auth_pub",

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3423,6 +3423,10 @@ class TestPKCEFunctionality:
             assert isinstance(kwargs["auth"], httpx.BasicAuth)
             # Verify code_verifier is in the POST body (essential PKCE field)
             assert kwargs.get("data", {}).get("code_verifier") == "verifier_abc"
+            # Verify credentials are NOT double-sent in the POST body when using Basic Auth
+            post_data = kwargs.get("data", {})
+            assert "client_secret" not in post_data, "client_secret must not appear in POST body when using Basic Auth"
+            assert "client_id" not in post_data, "client_id must not appear in POST body when using Basic Auth (include_client_id=False)"
             return mock_response
 
         # Use separate mock clients for token exchange and userinfo —

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3458,6 +3458,9 @@ class TestPKCEFunctionality:
 
         assert result["access_token"] == "tok_abc"
         assert result["email"] == "user@example.com"
+        # id_token was explicit null in token_response — the merge loop must remove it
+        # rather than leaving "id_token": None in the result.
+        assert "id_token" not in result, "null id_token from token endpoint must be absent in merged result"
         # Verify userinfo GET used the correct Bearer token header
         get_call = mock_userinfo_client.get.call_args
         assert get_call is not None
@@ -3640,6 +3643,35 @@ class TestPKCEFunctionality:
                 )
 
         assert "unavailable" in exc_info.value.message.lower()
+        assert str(exc_info.value.code) == "401"
+
+    @pytest.mark.asyncio
+    async def test_pkce_userinfo_http200_empty_body_no_id_token_raises(self):
+        """When userinfo returns HTTP 200 with an empty/null body and no id_token is
+        available, _get_pkce_userinfo raises ProxyException."""
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = None  # HTTP 200 with null JSON body
+
+        with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ProxyException) as exc_info:
+                await SSOAuthenticationHandler._get_pkce_userinfo(
+                    access_token="access_token",
+                    id_token=None,  # no id_token fallback available
+                    userinfo_endpoint="https://example.com/userinfo",
+                    additional_headers={},
+                )
+
+        assert "unavailable" in exc_info.value.message.lower() or "no userinfo" in exc_info.value.message.lower() or "userinfo" in exc_info.value.message.lower()
         assert str(exc_info.value.code) == "401"
 
 

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -4553,6 +4553,10 @@ async def test_pkce_token_exchange_basic_auth():
 
     assert result["access_token"] == "tok_abc"
     assert result["email"] == "user@example.com"
+    # Verify userinfo GET used the correct Bearer token header
+    get_call = mock_client.get.call_args
+    assert get_call is not None
+    assert get_call.kwargs["headers"]["Authorization"] == "Bearer tok_abc"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3517,6 +3517,10 @@ class TestPKCEFunctionality:
 
         assert result["access_token"] == "tok_body"
         assert result["sub"] == "user2"
+        # Verify userinfo GET used the correct Bearer token header
+        get_call = mock_userinfo_client.get.call_args
+        assert get_call is not None
+        assert get_call.kwargs["headers"]["Authorization"] == "Bearer tok_body"
 
 
     @pytest.mark.asyncio
@@ -3817,6 +3821,8 @@ class TestPKCEFunctionality:
         # Should return params without code_verifier (no raise)
         assert "code_verifier" not in result
         assert "_pkce_cache_key" not in result
+        # Non-strict mode emits a warning rather than raising
+        mock_cache.async_get_cache.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_pkce_token_exchange_non200_raises_proxy_exception(self):
@@ -3890,6 +3896,8 @@ class TestPKCEFunctionality:
         # No raise in non-strict mode; verifier simply absent from params
         assert "code_verifier" not in result
         assert "_pkce_cache_key" not in result
+        # Cache was queried (the unexpected format was retrieved and logged at WARNING)
+        mock_cache.async_get_cache.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_pkce_legacy_string_cache_format_backward_compat(self):

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -4529,7 +4529,7 @@ async def test_pkce_token_exchange_basic_auth():
         assert isinstance(kwargs["auth"], httpx.BasicAuth)
         return mock_response
 
-    with patch("httpx.AsyncClient") as mock_client_cls:
+    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
@@ -4574,7 +4574,7 @@ async def test_pkce_token_exchange_credentials_in_body():
         mock.json.return_value = token_resp
         return mock
 
-    with patch("httpx.AsyncClient") as mock_client_cls:
+    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
@@ -4608,7 +4608,7 @@ async def test_pkce_token_exchange_http200_with_error_body():
 
     error_body = {"error": "invalid_grant", "error_description": "Code already used"}
 
-    with patch("httpx.AsyncClient") as mock_client_cls:
+    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
@@ -4647,7 +4647,7 @@ async def test_pkce_userinfo_falls_back_to_id_token():
     ).rstrip(b"=").decode()
     fake_id_token = f"eyJhbGciOiJSUzI1NiJ9.{encoded_payload}.fakesig"
 
-    with patch("httpx.AsyncClient") as mock_client_cls:
+    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -4529,6 +4529,8 @@ async def test_pkce_token_exchange_basic_auth():
         # Verify Basic Auth is set
         assert "auth" in kwargs
         assert isinstance(kwargs["auth"], httpx.BasicAuth)
+        # Verify code_verifier is in the POST body (essential PKCE field)
+        assert kwargs.get("data", {}).get("code_verifier") == "verifier_abc"
         return mock_response
 
     with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3819,6 +3819,8 @@ class TestPKCEFunctionality:
 
         assert "cache" in exc_info.value.message.lower() or "verifier" in exc_info.value.message.lower() or "format" in exc_info.value.message.lower()
         assert str(exc_info.value.code) == "401"
+        # Strict mode should also clean up the corrupt cache entry before raising
+        mock_cache.async_delete_cache.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_pkce_cache_miss_non_strict_logs_warning_and_continues(self, caplog):

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -4826,3 +4826,34 @@ async def test_delete_pkce_verifier_swallows_deletion_errors():
         await SSOAuthenticationHandler._delete_pkce_verifier("pkce_verifier:test_state")
 
     failing_cache.async_delete_cache.assert_called_once_with(key="pkce_verifier:test_state")
+
+
+@pytest.mark.asyncio
+async def test_pkce_cache_miss_unexpected_format_raises_proxy_exception():
+    """When cached data exists but has an unrecognized format (not a dict with
+    code_verifier, not a plain string), prepare_token_exchange_parameters raises
+    ProxyException rather than silently falling through to a non-PKCE flow."""
+    import os
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from starlette.requests import Request
+
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+    # Cache returns an integer — unexpected format
+    mock_cache = MagicMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=12345)
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.query_params = {"state": "bad_format_state"}
+
+    with pytest.raises(ProxyException) as exc_info:
+        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
+        ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
+            await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                request=mock_request, generic_include_client_id=False
+            )
+
+    assert "cache" in exc_info.value.message.lower() or "verifier" in exc_info.value.message.lower()

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3422,9 +3422,11 @@ class TestPKCEFunctionality:
             assert "auth" in kwargs
             assert isinstance(kwargs["auth"], httpx.BasicAuth)
             # Verify code_verifier is in the POST body (essential PKCE field)
-            assert kwargs.get("data", {}).get("code_verifier") == "verifier_abc"
-            # Verify credentials are NOT double-sent in the POST body when using Basic Auth
             post_data = kwargs.get("data", {})
+            assert post_data.get("code_verifier") == "verifier_abc"
+            # Verify redirect_uri is forwarded (required by strict OAuth providers)
+            assert post_data.get("redirect_uri") == "https://proxy.example.com/callback"
+            # Verify credentials are NOT double-sent in the POST body when using Basic Auth
             assert "client_secret" not in post_data, "client_secret must not appear in POST body when using Basic Auth"
             assert "client_id" not in post_data, "client_id must not appear in POST body when using Basic Auth (include_client_id=False)"
             return mock_response
@@ -3484,6 +3486,7 @@ class TestPKCEFunctionality:
             assert "client_id" in data
             assert "client_secret" in data
             assert data.get("code_verifier") == "verifier_xyz", "code_verifier must be in POST body"
+            assert data.get("redirect_uri") == "https://proxy.example.com/callback", "redirect_uri must be forwarded"
             mock = MagicMock()
             mock.status_code = 200
             mock.json.return_value = token_resp

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3638,7 +3638,10 @@ class TestPKCEFunctionality:
         with pytest.raises(ProxyException) as exc_info:
             with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
                 "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-            ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
+            ), patch.dict(
+                os.environ,
+                {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "true"},
+            ):
                 await SSOAuthenticationHandler.prepare_token_exchange_parameters(
                     request=mock_request, generic_include_client_id=False
                 )
@@ -3701,7 +3704,6 @@ class TestPKCEFunctionality:
     async def test_delete_pkce_verifier_swallows_deletion_errors(self):
         """_delete_pkce_verifier must not raise when the cache delete fails
         (best-effort cleanup — a leftover verifier must not abort a successful SSO login)."""
-        import os
         from unittest.mock import AsyncMock, MagicMock, patch
 
         from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
@@ -3741,7 +3743,10 @@ class TestPKCEFunctionality:
         with pytest.raises(ProxyException) as exc_info:
             with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
                 "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-            ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
+            ), patch.dict(
+                os.environ,
+                {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "true"},
+            ):
                 await SSOAuthenticationHandler.prepare_token_exchange_parameters(
                     request=mock_request, generic_include_client_id=False
                 )

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3142,10 +3142,12 @@ class TestPKCEFunctionality:
         test_state = "test_oauth_state_123"
         mock_request.query_params = {"state": test_state}
 
-        # Mock cache with async methods
+        # Mock cache with async methods — use dict format (primary path)
         mock_cache = MagicMock()
         test_code_verifier = "test_code_verifier_abc123xyz"
-        mock_cache.async_get_cache = AsyncMock(return_value=test_code_verifier)
+        mock_cache.async_get_cache = AsyncMock(
+            return_value={"code_verifier": test_code_verifier}
+        )
         mock_cache.async_delete_cache = AsyncMock()
 
         with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3637,13 +3637,13 @@ class TestPKCEFunctionality:
         mock_request = MagicMock(spec=Request)
         mock_request.query_params = {"state": "missing_state_123"}
 
-        with pytest.raises(ProxyException) as exc_info:
-            with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
-                "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-            ), patch.dict(
-                os.environ,
-                {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "true"},
-            ):
+        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
+        ), patch.dict(
+            os.environ,
+            {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "true"},
+        ):
+            with pytest.raises(ProxyException) as exc_info:
                 await SSOAuthenticationHandler.prepare_token_exchange_parameters(
                     request=mock_request, generic_include_client_id=False
                 )
@@ -3742,18 +3742,18 @@ class TestPKCEFunctionality:
         mock_request = MagicMock(spec=Request)
         mock_request.query_params = {"state": "bad_format_state"}
 
-        with pytest.raises(ProxyException) as exc_info:
-            with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
-                "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-            ), patch.dict(
-                os.environ,
-                {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "true"},
-            ):
+        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
+        ), patch.dict(
+            os.environ,
+            {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "true"},
+        ):
+            with pytest.raises(ProxyException) as exc_info:
                 await SSOAuthenticationHandler.prepare_token_exchange_parameters(
                     request=mock_request, generic_include_client_id=False
                 )
 
-        assert "cache" in exc_info.value.message.lower() or "verifier" in exc_info.value.message.lower()
+        assert "cache" in exc_info.value.message.lower() or "verifier" in exc_info.value.message.lower() or "format" in exc_info.value.message.lower()
 
     @pytest.mark.asyncio
     async def test_pkce_cache_miss_non_strict_logs_warning_and_continues(self):

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -4725,3 +4725,83 @@ async def test_pkce_userinfo_raises_when_both_sources_unavailable():
             )
 
     assert "unavailable" in exc_info.value.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_pkce_cache_miss_raises_proxy_exception():
+    """prepare_token_exchange_parameters raises ProxyException when PKCE is enabled
+    but no verifier is found in cache (cross-instance cache miss scenario)."""
+    import os
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from starlette.requests import Request
+
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+    mock_cache = MagicMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)  # verifier not found
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.query_params = {"state": "missing_state_123"}
+
+    with pytest.raises(ProxyException) as exc_info:
+        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
+        ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
+            await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                request=mock_request, generic_include_client_id=False
+            )
+
+    assert "verifier not found" in exc_info.value.message.lower() or "cache" in exc_info.value.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_pkce_token_exchange_public_client_no_secret():
+    """Public PKCE client (include_client_id=False, no secret) sends client_id in
+    POST body and does NOT include Basic Auth or client_secret."""
+    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+    token_resp = {
+        "access_token": "tok_public",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    userinfo_resp = {"sub": "pubuser", "email": "pub@example.com"}
+
+    async def fake_post(*args, **kwargs):
+        assert "auth" not in kwargs, "Public client must not use Basic Auth"
+        data = kwargs.get("data", {})
+        assert data.get("client_id") == "public_client_id"
+        assert "client_secret" not in data, "No secret should be sent for public client"
+        assert data.get("code_verifier") == "public_verifier"
+        mock = MagicMock()
+        mock.status_code = 200
+        mock.json.return_value = token_resp
+        return mock
+
+    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=fake_post)
+        mock_userinfo = MagicMock()
+        mock_userinfo.status_code = 200
+        mock_userinfo.json.return_value = userinfo_resp
+        mock_client.get = AsyncMock(return_value=mock_userinfo)
+        mock_client_cls.return_value = mock_client
+
+        result = await SSOAuthenticationHandler._pkce_token_exchange(
+            authorization_code="auth_pub",
+            code_verifier="public_verifier",
+            client_id="public_client_id",
+            client_secret=None,  # public client — no secret
+            token_endpoint="https://example.com/token",
+            userinfo_endpoint="https://example.com/userinfo",
+            include_client_id=False,
+            redirect_url="https://proxy.example.com/callback",
+            additional_headers={},
+        )
+
+    assert result["access_token"] == "tok_public"
+    assert result["sub"] == "pubuser"

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -4,6 +4,7 @@ import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import Request
 
@@ -3147,7 +3148,7 @@ class TestPKCEFunctionality:
         mock_cache.async_get_cache = AsyncMock(return_value=test_code_verifier)
         mock_cache.async_delete_cache = AsyncMock()
 
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache):
+        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
             # Act
             token_params = (
                 await SSOAuthenticationHandler.prepare_token_exchange_parameters(
@@ -4503,12 +4504,6 @@ def test_generic_response_convertor_extra_attributes_missing_field(monkeypatch):
 # Tests for SSOAuthenticationHandler PKCE token exchange methods
 # ──────────────────────────────────────────────────────────────────────────────
 
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import httpx
-import pytest
-
-
 @pytest.mark.asyncio
 async def test_pkce_token_exchange_basic_auth():
     """When include_client_id=False, client credentials go via HTTP Basic Auth."""
@@ -4533,9 +4528,6 @@ async def test_pkce_token_exchange_basic_auth():
         assert "auth" in kwargs
         assert isinstance(kwargs["auth"], httpx.BasicAuth)
         return mock_response
-
-    async def fake_get(*args, **kwargs):
-        return mock_userinfo_response
 
     with patch("httpx.AsyncClient") as mock_client_cls:
         mock_client = AsyncMock()

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3195,7 +3195,9 @@ class TestPKCEFunctionality:
         mock_cache.async_set_cache = AsyncMock()
 
         with patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
-            with patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache):
+            with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+                "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
+            ):
                 # Act
                 result = await SSOAuthenticationHandler.get_generic_sso_redirect_response(
                     generic_sso=mock_sso,

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3801,6 +3801,7 @@ class TestPKCEFunctionality:
         # Cache returns an integer — unexpected format
         mock_cache = MagicMock()
         mock_cache.async_get_cache = AsyncMock(return_value=12345)
+        mock_cache.async_delete_cache = AsyncMock()
 
         mock_request = MagicMock(spec=Request)
         mock_request.query_params = {"state": "bad_format_state"}
@@ -3917,6 +3918,7 @@ class TestPKCEFunctionality:
         # Cache returns an integer — unexpected format
         mock_cache = MagicMock()
         mock_cache.async_get_cache = AsyncMock(return_value=12345)
+        mock_cache.async_delete_cache = AsyncMock()
 
         mock_request = MagicMock(spec=Request)
         mock_request.query_params = {"state": "bad_format_non_strict"}
@@ -3948,6 +3950,8 @@ class TestPKCEFunctionality:
             for r in caplog.records
             if r.levelno >= logging.WARNING
         ), f"Expected a format/cache warning. Records: {[r.message for r in caplog.records]}"
+        # Verify cleanup was attempted for the corrupt/stale cache entry
+        mock_cache.async_delete_cache.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_pkce_legacy_string_cache_format_backward_compat(self):

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -4576,6 +4576,7 @@ async def test_pkce_token_exchange_credentials_in_body():
         data = kwargs.get("data", {})
         assert "client_id" in data
         assert "client_secret" in data
+        assert data.get("code_verifier") == "verifier_xyz", "code_verifier must be in POST body"
         mock = MagicMock()
         mock.status_code = 200
         mock.json.return_value = token_resp

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3161,14 +3161,15 @@ class TestPKCEFunctionality:
             # Assert
             assert token_params["include_client_id"] is False
             assert token_params["code_verifier"] == test_code_verifier
+            # Cache key is returned for deferred deletion (after exchange succeeds)
+            assert token_params["_pkce_cache_key"] == f"pkce_verifier:{test_state}"
 
-            # Verify cache was accessed and deleted
+            # Verify cache was read but NOT deleted yet (deletion is deferred to after
+            # successful token exchange to preserve the verifier for retries)
             mock_cache.async_get_cache.assert_called_once_with(
                 key=f"pkce_verifier:{test_state}"
             )
-            mock_cache.async_delete_cache.assert_called_once_with(
-                key=f"pkce_verifier:{test_state}"
-            )
+            mock_cache.async_delete_cache.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_generic_sso_redirect_response_with_pkce(self):
@@ -3292,11 +3293,11 @@ class TestPKCEFunctionality:
                     )
                     assert "code_verifier" in token_params
                     assert token_params["code_verifier"] == stored_dict["code_verifier"]
+                    # Cache key returned for deferred deletion after successful exchange
+                    assert token_params["_pkce_cache_key"] == stored_key
                     mock_in_memory.async_get_cache.assert_not_called()
-                    # delete_cache called; key removed (asserted below)
-
-        # Verifier consumed (single-use); key removed from "Redis"
-        assert "pkce_verifier:multi_pod_state_xyz" not in mock_redis._store
+                    # Deletion is deferred — key still present until exchange succeeds
+                    assert stored_key in mock_redis._store
 
     @pytest.mark.asyncio
     async def test_pkce_fallback_in_memory_roundtrip_when_redis_none(self):
@@ -3361,15 +3362,13 @@ class TestPKCEFunctionality:
                     )
                     assert "code_verifier" in token_params
                     assert token_params["code_verifier"] == stored_value["code_verifier"]
+                    # Cache key returned for deferred deletion after successful exchange
+                    assert token_params["_pkce_cache_key"] == stored_key
                     mock_in_memory.async_get_cache.assert_called_once_with(
                         key=stored_key
                     )
-                    mock_in_memory.async_delete_cache.assert_called_once_with(
-                        key=stored_key
-                    )
-
-        # Verifier consumed; key removed from in-memory
-        assert "pkce_verifier:fallback_state_xyz" not in in_memory_store
+                    # Deletion is deferred — not called by prepare_token_exchange_parameters
+                    mock_in_memory.async_delete_cache.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_pkce_prepare_token_exchange_returns_nothing_when_no_state(self):

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -22,10 +22,10 @@ from litellm.proxy.management_endpoints.ui_sso import (
     GoogleSSOHandler,
     MicrosoftSSOHandler,
     SSOAuthenticationHandler,
+    _setup_team_mappings,
+    determine_role_from_groups,
     normalize_email,
     process_sso_jwt_access_token,
-    determine_role_from_groups,
-    _setup_team_mappings,
 )
 from litellm.types.proxy.management_endpoints.ui_sso import (
     DefaultTeamSSOParams,
@@ -1791,8 +1791,8 @@ class TestCustomUISSO:
                     async def mock_google_login():
                         # This mimics the relevant part of google_login that would trigger the import error
                         try:
-                            from enterprise.litellm_enterprise.proxy.auth.custom_sso_handler import (
-                                EnterpriseCustomSSOHandler,  # noqa: F401
+                            from enterprise.litellm_enterprise.proxy.auth.custom_sso_handler import (  # noqa: F401
+                                EnterpriseCustomSSOHandler,
                             )
 
                             return "success"
@@ -3205,7 +3205,10 @@ class TestPKCEFunctionality:
                 cache_call = mock_cache.async_set_cache.call_args
                 assert cache_call.kwargs["key"] == f"pkce_verifier:{test_state}"
                 assert cache_call.kwargs["ttl"] == 600
-                assert len(cache_call.kwargs["value"]) == 43
+                # Value is stored as dict for proper JSON serialization in Redis
+                cached = cache_call.kwargs["value"]
+                assert isinstance(cached, dict) and "code_verifier" in cached
+                assert len(cached["code_verifier"]) == 43
 
                 # Verify PKCE parameters were added to the redirect URL
                 assert result is not None
@@ -3273,7 +3276,10 @@ class TestPKCEFunctionality:
                     stored_key = "pkce_verifier:multi_pod_state_xyz"
                     assert stored_key in mock_redis._store
                     stored_value = mock_redis._store[stored_key]
-                    assert isinstance(stored_value, str) and len(json.loads(stored_value)) == 43
+                    # Stored as JSON-serialized dict for Redis compatibility
+                    stored_dict = json.loads(stored_value)
+                    assert isinstance(stored_dict, dict) and "code_verifier" in stored_dict
+                    assert len(stored_dict["code_verifier"]) == 43
 
                     # Pod B: callback with same state, retrieve from "Redis"
                     mock_request = MagicMock(spec=Request)
@@ -3282,7 +3288,7 @@ class TestPKCEFunctionality:
                         request=mock_request, generic_include_client_id=False
                     )
                     assert "code_verifier" in token_params
-                    assert token_params["code_verifier"] == json.loads(stored_value)
+                    assert token_params["code_verifier"] == stored_dict["code_verifier"]
                     mock_in_memory.async_get_cache.assert_not_called()
                     # delete_cache called; key removed (asserted below)
 
@@ -3342,7 +3348,7 @@ class TestPKCEFunctionality:
                         "value"
                     ]
                     assert stored_key == "pkce_verifier:fallback_state_xyz"
-                    assert isinstance(stored_value, str) and len(stored_value) == 43
+                    assert isinstance(stored_value, dict) and len(stored_value["code_verifier"]) == 43
 
                     # Same pod: callback retrieves from in-memory cache
                     mock_request = MagicMock(spec=Request)
@@ -3351,7 +3357,7 @@ class TestPKCEFunctionality:
                         request=mock_request, generic_include_client_id=False
                     )
                     assert "code_verifier" in token_params
-                    assert token_params["code_verifier"] == stored_value
+                    assert token_params["code_verifier"] == stored_value["code_verifier"]
                     mock_in_memory.async_get_cache.assert_called_once_with(
                         key=stored_key
                     )
@@ -4492,3 +4498,178 @@ def test_generic_response_convertor_extra_attributes_missing_field(monkeypatch):
     assert result.extra_fields is not None
     assert result.extra_fields["missing_field"] is None
     assert result.extra_fields["another_missing"] is None
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests for SSOAuthenticationHandler PKCE token exchange methods
+# ──────────────────────────────────────────────────────────────────────────────
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_pkce_token_exchange_basic_auth():
+    """When include_client_id=False, client credentials go via HTTP Basic Auth."""
+    token_resp = {
+        "access_token": "tok_abc",
+        "id_token": None,
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    userinfo_resp = {"sub": "user1", "email": "user@example.com"}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = token_resp
+
+    mock_userinfo_response = MagicMock()
+    mock_userinfo_response.status_code = 200
+    mock_userinfo_response.json.return_value = userinfo_resp
+
+    async def fake_post(*args, **kwargs):
+        # Verify Basic Auth is set
+        assert "auth" in kwargs
+        assert isinstance(kwargs["auth"], httpx.BasicAuth)
+        return mock_response
+
+    async def fake_get(*args, **kwargs):
+        return mock_userinfo_response
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=fake_post)
+        mock_client.get = AsyncMock(return_value=mock_userinfo_response)
+        mock_client_cls.return_value = mock_client
+
+        result = await SSOAuthenticationHandler._pkce_token_exchange(
+            authorization_code="auth_code_123",
+            code_verifier="verifier_abc",
+            client_id="my_client",
+            client_secret="my_secret",
+            token_endpoint="https://example.com/token",
+            userinfo_endpoint="https://example.com/userinfo",
+            include_client_id=False,
+            redirect_url="https://proxy.example.com/callback",
+            additional_headers={},
+        )
+
+    assert result["access_token"] == "tok_abc"
+    assert result["email"] == "user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_pkce_token_exchange_credentials_in_body():
+    """When include_client_id=True, credentials go in the request body."""
+    token_resp = {
+        "access_token": "tok_body",
+        "id_token": None,
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    userinfo_resp = {"sub": "user2", "email": "user2@example.com"}
+
+    async def fake_post(*args, **kwargs):
+        assert "auth" not in kwargs, "Should NOT use Basic Auth when include_client_id=True"
+        data = kwargs.get("data", {})
+        assert "client_id" in data
+        assert "client_secret" in data
+        mock = MagicMock()
+        mock.status_code = 200
+        mock.json.return_value = token_resp
+        return mock
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=fake_post)
+        mock_userinfo = MagicMock()
+        mock_userinfo.status_code = 200
+        mock_userinfo.json.return_value = userinfo_resp
+        mock_client.get = AsyncMock(return_value=mock_userinfo)
+        mock_client_cls.return_value = mock_client
+
+        result = await SSOAuthenticationHandler._pkce_token_exchange(
+            authorization_code="auth_code_456",
+            code_verifier="verifier_xyz",
+            client_id="client_id_value",
+            client_secret="client_secret_value",
+            token_endpoint="https://example.com/token",
+            userinfo_endpoint="https://example.com/userinfo",
+            include_client_id=True,
+            redirect_url="https://proxy.example.com/callback",
+            additional_headers={},
+        )
+
+    assert result["access_token"] == "tok_body"
+    assert result["sub"] == "user2"
+
+
+@pytest.mark.asyncio
+async def test_pkce_token_exchange_http200_with_error_body():
+    """Provider returns HTTP 200 but with an error field instead of tokens."""
+    from litellm.proxy._types import ProxyException
+
+    error_body = {"error": "invalid_grant", "error_description": "Code already used"}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = error_body
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(ProxyException) as exc_info:
+            await SSOAuthenticationHandler._pkce_token_exchange(
+                authorization_code="expired_code",
+                code_verifier="verifier",
+                client_id="cid",
+                client_secret="csecret",
+                token_endpoint="https://example.com/token",
+                userinfo_endpoint="https://example.com/userinfo",
+                include_client_id=False,
+                redirect_url="https://proxy.example.com/callback",
+                additional_headers={},
+            )
+
+    assert "invalid_grant" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_pkce_userinfo_falls_back_to_id_token():
+    """When the userinfo endpoint fails, decode the id_token as fallback."""
+    import base64
+    import json as _json
+
+    payload = {"sub": "user_from_jwt", "email": "jwt@example.com"}
+    # Build a minimal JWT (header.payload.signature — signature not verified)
+    encoded_payload = base64.urlsafe_b64encode(
+        _json.dumps(payload).encode()
+    ).rstrip(b"=").decode()
+    fake_id_token = f"eyJhbGciOiJSUzI1NiJ9.{encoded_payload}.fakesig"
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_fail = MagicMock()
+        mock_fail.status_code = 503
+        mock_client.get = AsyncMock(return_value=mock_fail)
+        mock_client_cls.return_value = mock_client
+
+        result = await SSOAuthenticationHandler._get_pkce_userinfo(
+            access_token="some_token",
+            id_token=fake_id_token,
+            userinfo_endpoint="https://example.com/userinfo",
+            additional_headers={},
+        )
+
+    assert result["sub"] == "user_from_jwt"
+    assert result["email"] == "jwt@example.com"

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -4670,6 +4670,32 @@ async def test_pkce_userinfo_falls_back_to_id_token():
 
 
 @pytest.mark.asyncio
+async def test_pkce_userinfo_uses_id_token_when_no_endpoint():
+    """When userinfo_endpoint is None, fall back to id_token directly without HTTP call."""
+    import base64
+    import json as _json
+
+    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+    payload = {"sub": "id_token_user", "email": "id@example.com"}
+    encoded_payload = (
+        base64.urlsafe_b64encode(_json.dumps(payload).encode()).rstrip(b"=").decode()
+    )
+    fake_id_token = f"eyJhbGciOiJSUzI1NiJ9.{encoded_payload}.fakesig"
+
+    # No httpx call should happen when userinfo_endpoint is None
+    result = await SSOAuthenticationHandler._get_pkce_userinfo(
+        access_token="some_token",
+        id_token=fake_id_token,
+        userinfo_endpoint=None,
+        additional_headers={},
+    )
+
+    assert result["sub"] == "id_token_user"
+    assert result["email"] == "id@example.com"
+
+
+@pytest.mark.asyncio
 async def test_pkce_userinfo_raises_when_both_sources_unavailable():
     """When userinfo endpoint fails AND no id_token, raise ProxyException."""
     from litellm.proxy._types import ProxyException

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -4667,3 +4667,29 @@ async def test_pkce_userinfo_falls_back_to_id_token():
 
     assert result["sub"] == "user_from_jwt"
     assert result["email"] == "jwt@example.com"
+
+
+@pytest.mark.asyncio
+async def test_pkce_userinfo_raises_when_both_sources_unavailable():
+    """When userinfo endpoint fails AND no id_token, raise ProxyException."""
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+    with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_fail = MagicMock()
+        mock_fail.status_code = 503
+        mock_client.get = AsyncMock(return_value=mock_fail)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(ProxyException) as exc_info:
+            await SSOAuthenticationHandler._get_pkce_userinfo(
+                access_token="token",
+                id_token=None,  # no id_token available
+                userinfo_endpoint="https://example.com/userinfo",
+                additional_headers={},
+            )
+
+    assert "unavailable" in exc_info.value.message.lower()

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3663,7 +3663,7 @@ class TestPKCEFunctionality:
                 )
 
         assert "verifier not found" in exc_info.value.message.lower() or "cache" in exc_info.value.message.lower()
-        assert exc_info.value.code == 401
+        assert str(exc_info.value.code) == "401"
 
 
     @pytest.mark.asyncio
@@ -3882,6 +3882,103 @@ class TestPKCEFunctionality:
         # No raise in non-strict mode; verifier simply absent from params
         assert "code_verifier" not in result
         assert "_pkce_cache_key" not in result
+
+    @pytest.mark.asyncio
+    async def test_pkce_legacy_string_cache_format_backward_compat(self):
+        """Legacy plain-string cache entries (stored before dict format was introduced)
+        are handled transparently via the backward-compat branch."""
+        import os
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from starlette.requests import Request
+
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        legacy_verifier = "legacy_plain_string_verifier_abc123"
+        mock_cache = MagicMock()
+        mock_cache.async_get_cache = AsyncMock(return_value=legacy_verifier)
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.query_params = {"state": "legacy_state_xyz"}
+
+        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
+        ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}, clear=False):
+            result = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                request=mock_request, generic_include_client_id=False
+            )
+
+        assert result["code_verifier"] == legacy_verifier
+        assert result["_pkce_cache_key"] == "pkce_verifier:legacy_state_xyz"
+
+    @pytest.mark.asyncio
+    async def test_pkce_token_exchange_null_json_body_raises_proxy_exception(self):
+        """HTTP 200 with JSON body `null` raises a clean ProxyException instead of
+        AttributeError when .get() is called on the None return value."""
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = None  # JSON null response body
+            mock_resp.text = "null"
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ProxyException) as exc_info:
+                await SSOAuthenticationHandler._pkce_token_exchange(
+                    authorization_code="some_code",
+                    code_verifier="verifier",
+                    client_id="cid",
+                    client_secret="csecret",
+                    token_endpoint="https://example.com/token",
+                    userinfo_endpoint=None,
+                    include_client_id=False,
+                    redirect_url=None,
+                    additional_headers={},
+                )
+
+        assert "unexpected response format" in exc_info.value.message.lower()
+        assert str(exc_info.value.code) == "401"
+
+    @pytest.mark.asyncio
+    async def test_pkce_token_exchange_http200_no_error_field_no_access_token(self):
+        """HTTP 200 with no error field and no access_token raises ProxyException
+        with a descriptive message showing the actual response keys."""
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        body_without_token = {"token_type": "Bearer", "scope": "openid"}
+
+        with patch("litellm.proxy.management_endpoints.ui_sso.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = body_without_token
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ProxyException) as exc_info:
+                await SSOAuthenticationHandler._pkce_token_exchange(
+                    authorization_code="some_code",
+                    code_verifier="verifier",
+                    client_id="cid",
+                    client_secret="csecret",
+                    token_endpoint="https://example.com/token",
+                    userinfo_endpoint=None,
+                    include_client_id=False,
+                    redirect_url=None,
+                    additional_headers={},
+                )
+
+        assert "no access_token" in exc_info.value.message or "access_token" in exc_info.value.message
+        assert str(exc_info.value.code) == "401"
 
 
 # Tests for SSO user team assignment bug (Issue: SSO Users Not Added to Entra-Synced Teams on First Login)

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3825,6 +3825,42 @@ class TestPKCEFunctionality:
 
         assert "401" in exc_info.value.message or "token" in exc_info.value.message.lower()
 
+    @pytest.mark.asyncio
+    async def test_pkce_cache_miss_unexpected_format_non_strict_logs_warning(self):
+        """When cached data has an unexpected format (e.g. integer from corrupt Redis)
+        in non-strict mode, prepare_token_exchange_parameters logs a warning and
+        returns params without code_verifier rather than raising."""
+        import os
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from starlette.requests import Request
+
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+
+        # Cache returns an integer — unexpected format
+        mock_cache = MagicMock()
+        mock_cache.async_get_cache = AsyncMock(return_value=12345)
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.query_params = {"state": "bad_format_non_strict"}
+
+        # Non-strict mode: should log a warning and continue, not raise
+        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
+            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
+        ), patch.dict(
+            os.environ,
+            {"GENERIC_CLIENT_USE_PKCE": "true"},
+            clear=False,
+        ):
+            os.environ.pop("PKCE_STRICT_CACHE_MISS", None)
+            result = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                request=mock_request, generic_include_client_id=False
+            )
+
+        # No raise in non-strict mode; verifier simply absent from params
+        assert "code_verifier" not in result
+        assert "_pkce_cache_key" not in result
+
 
 # Tests for SSO user team assignment bug (Issue: SSO Users Not Added to Entra-Synced Teams on First Login)
 class TestAddMissingTeamMember:


### PR DESCRIPTION
## Relevant issues

Fixes: PKCE (Proof Key for Code Exchange) token exchange failing with Okta and other PKCE-required providers because fastapi-sso drops the code_verifier parameter.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting \`@greptileai\` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Two fixes for PKCE-based SSO (Okta and other providers):

**1. Direct token exchange when PKCE is enabled**

`fastapi-sso` silently drops `code_verifier` from the token exchange request, causing PKCE-required providers to reject the auth with "invalid_grant". When `GENERIC_CLIENT_USE_PKCE=true` and a `code_verifier` is found in cache, the callback now calls the token endpoint directly via `httpx` — bypassing `fastapi-sso.verify_and_process` — with the full PKCE parameters.

**2. Redis-backed verifier storage for multi-pod deployments**

Previously, `code_verifier` was stored in `user_api_key_cache` (in-memory). In multi-pod deployments, the login and callback can land on different pods, causing a cache miss. Now `redis_usage_cache` is used when available (falling back to in-memory for single-instance deploys).

Additional improvements:
- `PKCE_STRICT_CACHE_MISS=true` opt-in to fail with HTTP 401 on cross-pod cache misses instead of silently proceeding
- Startup warning when `GENERIC_CLIENT_USE_PKCE=true` but Redis is not configured
- Bearer credentials stripped from error messages to prevent credential leakage in 403 responses
- 22 new tests covering all PKCE paths including cache miss scenarios, public clients, id_token fallback, null JSON responses, and credential isolation