### PR TITLE
tests: fix typo in Triton test failure message

### DIFF
--- a/tests/llm_translation/test_triton.py
+++ b/tests/llm_translation/test_triton.py
@@ -34,7 +34,7 @@ def test_split_embedding_by_shape_passes():
         )
         assert split_output_data == [[1, 2, 3], [4, 5, 6]]
     except Exception as e:
-        pytest.fail(f"An exception occured: {e}")
+        pytest.fail(f"An exception occurred: {e}")
 
 
 def test_split_embedding_by_shape_fails_with_shape_value_error():


### PR DESCRIPTION
## Summary
Fixes a typo in a test failure string in `test_triton.py` (`occured` -> `occurred`).

## Why
Keeps test output clean and professional when this failure path is hit.

## Changes
- `tests/llm_translation/test_triton.py`: corrected typo in `pytest.fail` message

No behavior changes besides message spelling.
