### PR TITLE
tests: fix typo in Clarifai test failure message

### DIFF
--- a/tests/llm_translation/test_clarifai_completion.py
+++ b/tests/llm_translation/test_clarifai_completion.py
@@ -59,7 +59,7 @@ def test_completion_clarifai_claude_2_1():
         pass
 
     except Exception as e:
-        pytest.fail(f"Error occured: {e}")
+        pytest.fail(f"Error occurred: {e}")
 
 
 @pytest.mark.skip(reason="Account rate limited")


### PR DESCRIPTION
## Summary
Fixes a typo in a test failure string in `test_clarifai_completion.py` (`occured` -> `occurred`).

## Why
Keeps test failure output clean and consistent.

## Changes
- `tests/llm_translation/test_clarifai_completion.py`: corrected typo in `pytest.fail` message

No runtime behavior changes.
