### PR TITLE
fix(chatgpt): normalize system-role payloads for chat/responses

### DIFF
--- a/litellm/llms/chatgpt/chat/transformation.py
+++ b/litellm/llms/chatgpt/chat/transformation.py
@@ -41,6 +41,17 @@ class ChatGPTConfig(OpenAIConfig):
             )
         return dynamic_api_base, dynamic_api_key, custom_llm_provider
 
+    def _transform_messages(
+        self,
+        messages: List[AllMessageValues],
+        model: str,
+    ) -> List[AllMessageValues]:
+        # ChatGPT backend rejects system-role messages; normalize to user-role.
+        for i, message in enumerate(messages):
+            if isinstance(message, dict) and message.get("role") == "system":
+                messages[i] = {"role": "user", "content": message.get("content", "")}
+        return super()._transform_messages(messages, model)
+
     def validate_environment(
         self,
         headers: dict,

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -73,6 +73,20 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             litellm_params,
             headers,
         )
+
+        def _normalize_system_roles(value: Any) -> Any:
+            if isinstance(value, dict):
+                normalized = dict(value)
+                if normalized.get("role") == "system":
+                    normalized["role"] = "user"
+                for k, v in list(normalized.items()):
+                    normalized[k] = _normalize_system_roles(v)
+                return normalized
+            if isinstance(value, list):
+                return [_normalize_system_roles(v) for v in value]
+            return value
+
+        request["input"] = _normalize_system_roles(request.get("input"))
         base_instructions = get_chatgpt_default_instructions()
         existing_instructions = request.get("instructions")
         if existing_instructions:


### PR DESCRIPTION
## Summary
Normalize `system` role payloads for ChatGPT provider paths to avoid backend failures (`{"detail":"System messages are not allowed"}`).

## Changes
- `litellm/llms/chatgpt/chat/transformation.py`
  - convert `role=system` -> `role=user` in `_transform_messages`
- `litellm/llms/chatgpt/responses/transformation.py`
  - recursively normalize `request["input"]` system roles before request dispatch

## Repro
Using ChatGPT device-code backend with model aliases, calls containing system-role messages fail before this patch and succeed after it.

## Why
Some ChatGPT backend endpoints reject system-role messages entirely; provider-level normalization makes behavior consistent for both chat completions and responses paths.
