### PR TITLE
fix(model_prices): add jp. region prefix for claude-sonnet-4-6

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1269,6 +1269,36 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
     },
+    "jp.anthropic.claude-sonnet-4-6": {
+        "cache_creation_input_token_cost": 4.125e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 8.25e-06,
+        "cache_read_input_token_cost": 3.3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
+        "input_cost_per_token": 3.3e-06,
+        "input_cost_per_token_above_200k_tokens": 6.6e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "output_cost_per_token_above_200k_tokens": 2.475e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346
+    },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -22741,6 +22741,23 @@
         "mode": "rerank",
         "output_cost_per_token": 1.8e-08
     },
+    "jp.amazon.nova-2-lite-v1:0": {
+        "cache_read_input_token_cost": 8.25e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_read_input_token_cost": 3.3e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1269,6 +1269,36 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
     },
+    "jp.anthropic.claude-sonnet-4-6": {
+        "cache_creation_input_token_cost": 4.125e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 8.25e-06,
+        "cache_read_input_token_cost": 3.3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
+        "input_cost_per_token": 3.3e-06,
+        "input_cost_per_token_above_200k_tokens": 6.6e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "output_cost_per_token_above_200k_tokens": 2.475e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346
+    },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -22674,6 +22674,23 @@
         "mode": "rerank",
         "output_cost_per_token": 1.8e-08
     },
+    "jp.amazon.nova-2-lite-v1:0": {
+        "cache_read_input_token_cost": 8.25e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_read_input_token_cost": 3.3e-07,

--- a/tests/test_litellm/test_claude_sonnet_4_6_jp_region.py
+++ b/tests/test_litellm/test_claude_sonnet_4_6_jp_region.py
@@ -1,0 +1,83 @@
+"""
+Test that jp. (Japan) region prefix exists for Claude Sonnet 4.6 in model_prices_and_context_window.json
+https://github.com/BerriAI/litellm/issues/22972
+"""
+
+import json
+import os
+
+import litellm
+
+
+def test_jp_anthropic_claude_sonnet_4_6_exists():
+    """
+    Test that jp.anthropic.claude-sonnet-4-6 exists in model_prices_and_context_window.json
+    with correct configuration matching other regional prefixes (us, eu, au).
+    """
+    json_path = os.path.join(os.path.dirname(__file__), "../../model_prices_and_context_window.json")
+    with open(json_path) as f:
+        model_data = json.load(f)
+
+    assert "jp.anthropic.claude-sonnet-4-6" in model_data, \
+        "Missing Japan region model: jp.anthropic.claude-sonnet-4-6"
+
+    info = model_data["jp.anthropic.claude-sonnet-4-6"]
+
+    # Verify provider and basic config
+    assert info["litellm_provider"] == "bedrock_converse"
+    assert info["mode"] == "chat"
+    assert info["max_input_tokens"] == 200000
+    assert info["max_output_tokens"] == 64000
+    assert info["max_tokens"] == 64000
+
+    # Verify capabilities
+    assert info["supports_assistant_prefill"] is True
+    assert info["supports_computer_use"] is True
+    assert info["supports_function_calling"] is True
+    assert info["supports_pdf_input"] is True
+    assert info["supports_prompt_caching"] is True
+    assert info["supports_reasoning"] is True
+    assert info["supports_response_schema"] is True
+    assert info["supports_tool_choice"] is True
+    assert info["supports_vision"] is True
+    assert info["tool_use_system_prompt_tokens"] == 346
+
+
+def test_jp_claude_sonnet_4_6_matches_other_regions():
+    """
+    Test that jp.anthropic.claude-sonnet-4-6 has the same pricing and config
+    as au.anthropic.claude-sonnet-4-6 (both are non-global regional prefixes).
+    """
+    json_path = os.path.join(os.path.dirname(__file__), "../../model_prices_and_context_window.json")
+    with open(json_path) as f:
+        model_data = json.load(f)
+
+    jp_info = model_data["jp.anthropic.claude-sonnet-4-6"]
+    au_info = model_data["au.anthropic.claude-sonnet-4-6"]
+
+    keys_to_match = [
+        "litellm_provider",
+        "max_input_tokens",
+        "max_output_tokens",
+        "max_tokens",
+        "mode",
+        "input_cost_per_token",
+        "output_cost_per_token",
+        "input_cost_per_token_above_200k_tokens",
+        "output_cost_per_token_above_200k_tokens",
+        "cache_creation_input_token_cost",
+        "cache_creation_input_token_cost_above_200k_tokens",
+        "cache_read_input_token_cost",
+        "cache_read_input_token_cost_above_200k_tokens",
+        "tool_use_system_prompt_tokens",
+    ]
+
+    for key in keys_to_match:
+        assert jp_info[key] == au_info[key], \
+            f"Mismatch for {key}: jp={jp_info[key]}, au={au_info[key]}"
+
+
+def test_jp_claude_sonnet_4_6_registered_in_bedrock_converse():
+    """Test that jp.anthropic.claude-sonnet-4-6 is registered in bedrock_converse_models."""
+    assert "jp.anthropic.claude-sonnet-4-6" in litellm.bedrock_converse_models, \
+        "jp.anthropic.claude-sonnet-4-6 not registered in bedrock_converse_models"

--- a/tests/test_litellm/test_jp_region_bedrock_models.py
+++ b/tests/test_litellm/test_jp_region_bedrock_models.py
@@ -1,5 +1,5 @@
 """
-Test that jp. (Japan) region prefix exists for Claude Sonnet 4.6 in model_prices_and_context_window.json
+Test that jp. (Japan) region prefix exists for Bedrock models in model_prices_and_context_window.json
 https://github.com/BerriAI/litellm/issues/22972
 """
 
@@ -77,7 +77,78 @@ def test_jp_claude_sonnet_4_6_matches_other_regions():
             f"Mismatch for {key}: jp={jp_info[key]}, au={au_info[key]}"
 
 
-def test_jp_claude_sonnet_4_6_registered_in_bedrock_converse():
+def test_jp_claude_sonnet_4_6_registered_in_bedrock_converse(monkeypatch):
     """Test that jp.anthropic.claude-sonnet-4-6 is registered in bedrock_converse_models."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "true")
+    import importlib
+    importlib.reload(litellm)
     assert "jp.anthropic.claude-sonnet-4-6" in litellm.bedrock_converse_models, \
         "jp.anthropic.claude-sonnet-4-6 not registered in bedrock_converse_models"
+
+
+def test_jp_amazon_nova_2_lite_exists():
+    """
+    Test that jp.amazon.nova-2-lite-v1:0 exists in model_prices_and_context_window.json
+    with correct configuration matching apac.amazon.nova-2-lite-v1:0.
+    """
+    json_path = os.path.join(os.path.dirname(__file__), "../../model_prices_and_context_window.json")
+    with open(json_path) as f:
+        model_data = json.load(f)
+
+    assert "jp.amazon.nova-2-lite-v1:0" in model_data, \
+        "Missing Japan region model: jp.amazon.nova-2-lite-v1:0"
+
+    info = model_data["jp.amazon.nova-2-lite-v1:0"]
+
+    # Verify provider and basic config
+    assert info["litellm_provider"] == "bedrock_converse"
+    assert info["mode"] == "chat"
+    assert info["max_input_tokens"] == 1000000
+    assert info["max_output_tokens"] == 64000
+    assert info["max_tokens"] == 64000
+
+    # Verify capabilities
+    assert info["supports_function_calling"] is True
+    assert info["supports_pdf_input"] is True
+    assert info["supports_prompt_caching"] is True
+    assert info["supports_reasoning"] is True
+    assert info["supports_response_schema"] is True
+    assert info["supports_video_input"] is True
+    assert info["supports_vision"] is True
+
+
+def test_jp_amazon_nova_2_lite_matches_apac():
+    """
+    Test that jp.amazon.nova-2-lite-v1:0 has the same pricing and config
+    as apac.amazon.nova-2-lite-v1:0.
+    """
+    json_path = os.path.join(os.path.dirname(__file__), "../../model_prices_and_context_window.json")
+    with open(json_path) as f:
+        model_data = json.load(f)
+
+    jp_info = model_data["jp.amazon.nova-2-lite-v1:0"]
+    apac_info = model_data["apac.amazon.nova-2-lite-v1:0"]
+
+    keys_to_match = [
+        "litellm_provider",
+        "max_input_tokens",
+        "max_output_tokens",
+        "max_tokens",
+        "mode",
+        "input_cost_per_token",
+        "output_cost_per_token",
+        "cache_read_input_token_cost",
+    ]
+
+    for key in keys_to_match:
+        assert jp_info[key] == apac_info[key], \
+            f"Mismatch for {key}: jp={jp_info[key]}, apac={apac_info[key]}"
+
+
+def test_jp_amazon_nova_2_lite_registered_in_bedrock_converse(monkeypatch):
+    """Test that jp.amazon.nova-2-lite-v1:0 is registered in bedrock_converse_models."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "true")
+    import importlib
+    importlib.reload(litellm)
+    assert "jp.amazon.nova-2-lite-v1:0" in litellm.bedrock_converse_models, \
+        "jp.amazon.nova-2-lite-v1:0 not registered in bedrock_converse_models"

--- a/tests/test_litellm/test_jp_region_bedrock_models.py
+++ b/tests/test_litellm/test_jp_region_bedrock_models.py
@@ -77,13 +77,18 @@ def test_jp_claude_sonnet_4_6_matches_other_regions():
             f"Mismatch for {key}: jp={jp_info[key]}, au={au_info[key]}"
 
 
-def test_jp_claude_sonnet_4_6_registered_in_bedrock_converse(monkeypatch):
-    """Test that jp.anthropic.claude-sonnet-4-6 is registered in bedrock_converse_models."""
-    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "true")
-    import importlib
-    importlib.reload(litellm)
+def test_jp_claude_sonnet_4_6_registered_in_bedrock_converse():
+    """Test that jp.anthropic.claude-sonnet-4-6 is registered in bedrock_converse_models via add_known_models."""
+    json_path = os.path.join(os.path.dirname(__file__), "../../model_prices_and_context_window.json")
+    with open(json_path) as f:
+        model_data = json.load(f)
+
+    # Build a fresh set without global side-effects
+    original = litellm.bedrock_converse_models.copy()
+    litellm.add_known_models(model_data)
     assert "jp.anthropic.claude-sonnet-4-6" in litellm.bedrock_converse_models, \
         "jp.anthropic.claude-sonnet-4-6 not registered in bedrock_converse_models"
+    litellm.bedrock_converse_models = original
 
 
 def test_jp_amazon_nova_2_lite_exists():
@@ -145,10 +150,15 @@ def test_jp_amazon_nova_2_lite_matches_apac():
             f"Mismatch for {key}: jp={jp_info[key]}, apac={apac_info[key]}"
 
 
-def test_jp_amazon_nova_2_lite_registered_in_bedrock_converse(monkeypatch):
-    """Test that jp.amazon.nova-2-lite-v1:0 is registered in bedrock_converse_models."""
-    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "true")
-    import importlib
-    importlib.reload(litellm)
+def test_jp_amazon_nova_2_lite_registered_in_bedrock_converse():
+    """Test that jp.amazon.nova-2-lite-v1:0 is registered in bedrock_converse_models via add_known_models."""
+    json_path = os.path.join(os.path.dirname(__file__), "../../model_prices_and_context_window.json")
+    with open(json_path) as f:
+        model_data = json.load(f)
+
+    # Build a fresh set without global side-effects
+    original = litellm.bedrock_converse_models.copy()
+    litellm.add_known_models(model_data)
     assert "jp.amazon.nova-2-lite-v1:0" in litellm.bedrock_converse_models, \
         "jp.amazon.nova-2-lite-v1:0 not registered in bedrock_converse_models"
+    litellm.bedrock_converse_models = original


### PR DESCRIPTION
## Relevant issues

Fixes #22972

## Summary

- Add missing JP region Bedrock inference profiles to `model_prices_and_context_window.json` and the backup JSON
- `jp.anthropic.claude-sonnet-4-6` — other region prefixes (`us.`, `eu.`, `au.`, `global.`) already existed, but `jp.` was missing
- `jp.amazon.nova-2-lite-v1:0` — also confirmed ACTIVE in `ap-northeast-1` via `aws bedrock list-inference-profiles`, but was missing from JSON
- Pricing matches the corresponding regional entries (`au.` for Claude Sonnet 4.6, `apac.` for Nova 2 Lite)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Added `jp.anthropic.claude-sonnet-4-6` to both JSON files
- Added `jp.amazon.nova-2-lite-v1:0` to both JSON files
- Renamed `tests/test_litellm/test_claude_sonnet_4_6_jp_region.py` → `tests/test_litellm/test_jp_region_bedrock_models.py`
- 6 tests total:
  - `jp.anthropic.claude-sonnet-4-6`: entry existence, pricing parity with `au.`, `bedrock_converse_models` registration
  - `jp.amazon.nova-2-lite-v1:0`: entry existence, pricing parity with `apac.`, `bedrock_converse_models` registration