### PR TITLE
fix: add jp. (Japan) region prefix for claude-sonnet-4-6 Bedrock

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1269,6 +1269,36 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
     },
+  "jp.anthropic.claude-sonnet-4-6": {
+        "cache_creation_input_token_cost": 4.125e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 8.25e-06,
+        "cache_read_input_token_cost": 3.3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
+        "input_cost_per_token": 3.3e-06,
+        "input_cost_per_token_above_200k_tokens": 6.6e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "output_cost_per_token_above_200k_tokens": 2.475e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346
+    },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1269,6 +1269,36 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
     },
+  "jp.anthropic.claude-sonnet-4-6": {
+        "cache_creation_input_token_cost": 4.125e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 8.25e-06,
+        "cache_read_input_token_cost": 3.3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
+        "input_cost_per_token": 3.3e-06,
+        "input_cost_per_token_above_200k_tokens": 6.6e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "output_cost_per_token_above_200k_tokens": 2.475e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346
+    },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,


### PR DESCRIPTION
## Description

Adds the missing `jp.anthropic.claude-sonnet-4-6` entry to `model_prices_and_context_window.json`.

## Problem

The Japan (`jp.`) Bedrock cross-region inference profile prefix was missing for `claude-sonnet-4-6`, while all other region prefixes were present:
- `us.anthropic.claude-sonnet-4-6` ✅
- `eu.anthropic.claude-sonnet-4-6` ✅
- `au.anthropic.claude-sonnet-4-6` ✅
- `global.anthropic.claude-sonnet-4-6` ✅
- `jp.anthropic.claude-sonnet-4-6` ❌ ← this PR adds it

## Solution

Added `jp.anthropic.claude-sonnet-4-6` with the same pricing/capabilities structure as `au.anthropic.claude-sonnet-4-6`, consistent with how other JP models are defined (e.g., `jp.anthropic.claude-haiku-4-5-20251001-v1:0`).

Closes #22972