### PR TITLE
fix k8s migration job - create volumes for readonly fs

### DIFF
--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -87,9 +87,19 @@ spec:
             {{- end }}
             - name: DISABLE_SCHEMA_UPDATE
               value: "false" # always run the migration from the Helm PreSync hook, override the value set
-          {{- with .Values.volumeMounts }}
+          {{- if or .Values.securityContext.readOnlyRootFilesystem .Values.volumeMounts }}
           volumeMounts:
+            {{- if .Values.securityContext.readOnlyRootFilesystem }}
+            - name: tmp
+              mountPath: /tmp
+            - name: cache
+              mountPath: /.cache
+            - name: npm
+              mountPath: /.npm
+            {{- end }}
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.migrationJob.resources }}
           resources:
@@ -98,9 +108,22 @@ spec:
       {{- with .Values.migrationJob.extraContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.volumes }}
+      {{- if or .Values.securityContext.readOnlyRootFilesystem .Values.volumes }}
       volumes:
+        {{- if .Values.securityContext.readOnlyRootFilesystem }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: 500Mi
+        - name: cache
+          emptyDir:
+            sizeLimit: 500Mi
+        - name: npm
+          emptyDir:
+            sizeLimit: 500Mi
+        {{- end }}
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       restartPolicy: OnFailure
       {{- with .Values.affinity }}

--- a/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
@@ -125,3 +125,80 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: DATABASE_URL
+
+  - it: should not render volumeMounts or volumes when readOnlyRootFilesystem is false and no volumeMounts are set
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: true
+      securityContext:
+        readOnlyRootFilesystem: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+      - notExists:
+          path: spec.template.spec.volumes
+
+  - it: should render tmp/cache/npm volumeMounts and volumes when readOnlyRootFilesystem is true
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: true
+      securityContext:
+        readOnlyRootFilesystem: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: cache
+            mountPath: /.cache
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: npm
+            mountPath: /.npm
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir:
+              sizeLimit: 500Mi
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: cache
+            emptyDir:
+              sizeLimit: 500Mi
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: npm
+            emptyDir:
+              sizeLimit: 500Mi
+
+  - it: should include both readOnlyRootFilesystem mounts and user-defined volumeMounts when both are set
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: true
+      securityContext:
+        readOnlyRootFilesystem: true
+      volumeMounts:
+        - name: custom-mount
+          mountPath: /custom
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: custom-mount
+            mountPath: /custom


### PR DESCRIPTION
## Relevant issues

Fixes migration job when securityContext.readOnlyRootFilesystem: true
The job fails due to errror: 
```Traceback (most recent call last):  File "/app/litellm/proxy/prisma_migration.py", line 16, in <module>
    run_server(["--skip_server_startup"], standalone_mode=False)
.
.
.
  File "<frozen os>", line 228, in makedirs
OSError: [Errno 30] Read-only file system: '/tmp/tiktoken_cache'
``

env var: using TIKTOKEN_CACHE_DIR did not fix so adding the same directories listed in the deployment.
/tmp/ is the only folder needed but adding all three for consistency.

image litellm-non_root:main-v1.81.12-stable.1

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
