### PR TITLE
Fix batch list showing stale "validating" status after completion

### DIFF
--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -78,8 +78,6 @@ class CheckBatchCost:
                 "status": {"not_in": ["failed", "expired", "cancelled"]}
             }
         )
-        completed_jobs = []
-
         for job in jobs:
             # get the model from the job
             unified_object_id = job.unified_object_id
@@ -237,13 +235,16 @@ class CheckBatchCost:
                 )
 
                 # mark the job as complete
-                completed_jobs.append(job)
-
-                await self.prisma_client.db.litellm_managedobjecttable.update(
-                    where={"id": job.id},
-                    data={
-                        "batch_processed": True,
-                        "status": "complete",
-                        "file_object": response.model_dump_json(),
-                    },
-                )
+                try:
+                    await self.prisma_client.db.litellm_managedobjecttable.update(
+                        where={"id": job.id},
+                        data={
+                            "batch_processed": True,
+                            "status": "complete",
+                            "file_object": response.model_dump_json(),
+                        },
+                    )
+                except Exception as db_err:
+                    verbose_proxy_logger.error(
+                        f"CheckBatchCost: failed to mark job {job.id} complete in DB: {db_err}"
+                    )

--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -239,8 +239,11 @@ class CheckBatchCost:
                 # mark the job as complete
                 completed_jobs.append(job)
 
-            if len(completed_jobs) > 0:
-                await self.prisma_client.db.litellm_managedobjecttable.update_many(
-                    where={"id": {"in": [job.id for job in completed_jobs]}},
-                    data={"batch_processed": True, "status": "complete"},
+                await self.prisma_client.db.litellm_managedobjecttable.update(
+                    where={"id": job.id},
+                    data={
+                        "batch_processed": True,
+                        "status": "complete",
+                        "file_object": response.model_dump_json(),
+                    },
                 )

--- a/tests/test_litellm/enterprise/proxy/test_managed_files_access_check.py
+++ b/tests/test_litellm/enterprise/proxy/test_managed_files_access_check.py
@@ -198,3 +198,12 @@ async def test_check_batch_cost_should_call_afile_content_directly_with_credenti
 
         # managed_files_obj.afile_content should NOT have been called
         mock_managed_files_hook.afile_content.assert_not_called()
+
+        # Verify the DB update writes batch_processed, status, and file_object
+        mock_prisma.db.litellm_managedobjecttable.update.assert_called_once()
+        update_call_kwargs = mock_prisma.db.litellm_managedobjecttable.update.call_args.kwargs
+        assert update_call_kwargs["data"]["batch_processed"] is True
+        assert update_call_kwargs["data"]["status"] == "complete"
+        assert "file_object" in update_call_kwargs["data"], (
+            "file_object must be written to DB so list_batches reads updated status"
+        )

--- a/tests/test_litellm/enterprise/proxy/test_managed_files_access_check.py
+++ b/tests/test_litellm/enterprise/proxy/test_managed_files_access_check.py
@@ -134,7 +134,7 @@ async def test_check_batch_cost_should_call_afile_content_directly_with_credenti
     mock_prisma.db.litellm_managedobjecttable.find_many = AsyncMock(
         return_value=[mock_job]
     )
-    mock_prisma.db.litellm_managedobjecttable.update_many = AsyncMock()
+    mock_prisma.db.litellm_managedobjecttable.update = AsyncMock()
 
     # Mock proxy_logging_obj — should NOT be called for file content
     mock_proxy_logging = MagicMock()


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix


## Changes

CheckBatchCost poller updated the status column but not the file_object JSON column. The list_batches endpoint reads status from file_object, so batches appeared stuck in "validating" even after Azure reported them as completed. Now update file_object alongside status in the per-job DB write.