### PR TITLE
fix(proxy): make async_post_call_response_headers_hook consistent across all endpoints

### DIFF
--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -377,6 +377,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         user_api_key_dict: UserAPIKeyAuth,
         response: Any,
         request_headers: Optional[Dict[str, str]] = None,
+        litellm_call_info: Optional[Dict[str, Any]] = None,
     ) -> Optional[Dict[str, str]]:
         """
         Called after an LLM API call (success or failure) to allow injecting custom HTTP response headers.
@@ -386,6 +387,11 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
             - user_api_key_dict: UserAPIKeyAuth - The user API key dictionary.
             - response: Any - The response object (None for failure cases).
             - request_headers: Optional[Dict[str, str]] - The original request headers.
+            - litellm_call_info: Optional[Dict[str, Any]] - Normalized routing metadata:
+                - custom_llm_provider: str - The LLM provider (e.g. "openai", "azure")
+                - model_info: dict - The model_info from router config
+                - api_base: str - The API base URL used
+                - model_id: str - The deployment model ID
 
         Returns:
             - Optional[Dict[str, str]]: A dictionary of headers to inject into the HTTP response.

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -920,6 +920,7 @@ class ProxyBaseLLMRequestProcessing:
                 data=self.data,
                 user_api_key_dict=user_api_key_dict,
                 response=response,
+                request_headers=dict(request.headers),
             )
             if callback_headers:
                 custom_headers.update(callback_headers)
@@ -1028,6 +1029,7 @@ class ProxyBaseLLMRequestProcessing:
             data=self.data,
             user_api_key_dict=user_api_key_dict,
             response=response,
+            request_headers=dict(request.headers),
         )
         if callback_headers:
             fastapi_response.headers.update(callback_headers)
@@ -1196,6 +1198,7 @@ class ProxyBaseLLMRequestProcessing:
                 data=self.data,
                 user_api_key_dict=user_api_key_dict,
                 response=None,
+                request_headers=self.data.get("proxy_server_request", {}).get("headers", {}),
             )
             if callback_headers:
                 headers.update(callback_headers)

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1198,7 +1198,7 @@ class ProxyBaseLLMRequestProcessing:
                 data=self.data,
                 user_api_key_dict=user_api_key_dict,
                 response=None,
-                request_headers=self.data.get("proxy_server_request", {}).get("headers", {}),
+                request_headers=(self.data.get("proxy_server_request") or {}).get("headers", {}),
             )
             if callback_headers:
                 headers.update(callback_headers)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7367,6 +7367,16 @@ async def audio_transcriptions(
             )
         )
 
+        # Call response headers hook (matches base_process_llm_request behavior)
+        callback_headers = await proxy_logging_obj.post_call_response_headers_hook(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            response=response,
+            request_headers=dict(request.headers),
+        )
+        if callback_headers:
+            fastapi_response.headers.update(callback_headers)
+
         return response
     except Exception as e:
         await proxy_logging_obj.post_call_failure_hook(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -292,7 +292,7 @@ _CALLBACK_ACCEPTS_CALL_INFO: Dict[int, bool] = {}
 
 
 def _accepts_litellm_call_info(cb: CustomLogger) -> bool:
-    key = id(cb)
+    key = id(type(cb))
     if key not in _CALLBACK_ACCEPTS_CALL_INFO:
         sig = inspect.signature(cb.async_post_call_response_headers_hook)
         _CALLBACK_ACCEPTS_CALL_INFO[key] = "litellm_call_info" in sig.parameters

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import hashlib
+import inspect
 import json
 import os
 import smtplib
@@ -1988,7 +1989,8 @@ class ProxyLogging:
                     _callback = callback  # type: ignore
 
                 if _callback is not None and isinstance(_callback, CustomLogger):
-                    try:
+                    sig = inspect.signature(_callback.async_post_call_response_headers_hook)
+                    if "litellm_call_info" in sig.parameters:
                         result = await _callback.async_post_call_response_headers_hook(
                             data=data,
                             user_api_key_dict=user_api_key_dict,
@@ -1996,7 +1998,7 @@ class ProxyLogging:
                             request_headers=request_headers,
                             litellm_call_info=litellm_call_info,
                         )
-                    except TypeError:
+                    else:
                         # Backwards compat: callback doesn't accept litellm_call_info
                         result = await _callback.async_post_call_response_headers_hook(
                             data=data,
@@ -2024,8 +2026,8 @@ class ProxyLogging:
 
         # model_info: check both metadata keys (chat uses "metadata", responses uses "litellm_metadata")
         model_info = (
-            data.get("metadata", {}).get("model_info")
-            or data.get("litellm_metadata", {}).get("model_info")
+            (data.get("metadata") or {}).get("model_info")
+            or (data.get("litellm_metadata") or {}).get("model_info")
             or {}
         )
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -286,6 +286,19 @@ class InternalUsageCache:
 
 
 ### LOGGING ###
+
+# Cache for inspect.signature checks — avoids repeated introspection per request
+_CALLBACK_ACCEPTS_CALL_INFO: Dict[int, bool] = {}
+
+
+def _accepts_litellm_call_info(cb: CustomLogger) -> bool:
+    key = id(cb)
+    if key not in _CALLBACK_ACCEPTS_CALL_INFO:
+        sig = inspect.signature(cb.async_post_call_response_headers_hook)
+        _CALLBACK_ACCEPTS_CALL_INFO[key] = "litellm_call_info" in sig.parameters
+    return _CALLBACK_ACCEPTS_CALL_INFO[key]
+
+
 class ProxyLogging:
     """
     Logging/Custom Handlers for proxy.
@@ -1989,8 +2002,7 @@ class ProxyLogging:
                     _callback = callback  # type: ignore
 
                 if _callback is not None and isinstance(_callback, CustomLogger):
-                    sig = inspect.signature(_callback.async_post_call_response_headers_hook)
-                    if "litellm_call_info" in sig.parameters:
+                    if _accepts_litellm_call_info(_callback):
                         result = await _callback.async_post_call_response_headers_hook(
                             data=data,
                             user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1975,6 +1975,9 @@ class ProxyLogging:
         """
         merged_headers: Dict[str, str] = {}
         try:
+            # Build litellm_call_info — normalized routing metadata for callbacks
+            litellm_call_info = self._build_litellm_call_info(data=data, response=response)
+
             for callback in litellm.callbacks:
                 _callback: Optional[CustomLogger] = None
                 if isinstance(callback, str):
@@ -1985,12 +1988,22 @@ class ProxyLogging:
                     _callback = callback  # type: ignore
 
                 if _callback is not None and isinstance(_callback, CustomLogger):
-                    result = await _callback.async_post_call_response_headers_hook(
-                        data=data,
-                        user_api_key_dict=user_api_key_dict,
-                        response=response,
-                        request_headers=request_headers,
-                    )
+                    try:
+                        result = await _callback.async_post_call_response_headers_hook(
+                            data=data,
+                            user_api_key_dict=user_api_key_dict,
+                            response=response,
+                            request_headers=request_headers,
+                            litellm_call_info=litellm_call_info,
+                        )
+                    except TypeError:
+                        # Backwards compat: callback doesn't accept litellm_call_info
+                        result = await _callback.async_post_call_response_headers_hook(
+                            data=data,
+                            user_api_key_dict=user_api_key_dict,
+                            response=response,
+                            request_headers=request_headers,
+                        )
                     if result is not None:
                         merged_headers.update(result)
         except Exception as e:
@@ -1998,6 +2011,30 @@ class ProxyLogging:
                 "Error in post_call_response_headers_hook: %s", str(e)
             )
         return merged_headers
+
+    @staticmethod
+    def _build_litellm_call_info(
+        data: dict, response: Any
+    ) -> Dict[str, Any]:
+        """
+        Build a normalized dict of routing metadata from response._hidden_params
+        and data, abstracting away the metadata vs litellm_metadata split.
+        """
+        hidden_params = getattr(response, "_hidden_params", {}) or {}
+
+        # model_info: check both metadata keys (chat uses "metadata", responses uses "litellm_metadata")
+        model_info = (
+            data.get("metadata", {}).get("model_info")
+            or data.get("litellm_metadata", {}).get("model_info")
+            or {}
+        )
+
+        return {
+            "custom_llm_provider": hidden_params.get("custom_llm_provider"),
+            "model_info": model_info,
+            "api_base": hidden_params.get("api_base"),
+            "model_id": hidden_params.get("model_id"),
+        }
 
     def is_a2a_streaming_response(self, response: dict) -> bool:
         expected_keys = ["jsonrpc", "id", "result"]

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -507,6 +507,9 @@ async def aresponses(
                 litellm_metadata=kwargs.get("litellm_metadata", {}),
                 custom_llm_provider=custom_llm_provider,
             )
+            # Stamp custom_llm_provider so callbacks can identify the provider
+            # (mirrors litellm/main.py:1371 for chat completions)
+            response._hidden_params["custom_llm_provider"] = custom_llm_provider
 
         if response is None:
             raise ValueError(
@@ -778,6 +781,9 @@ def responses(
                 litellm_metadata=kwargs.get("litellm_metadata", {}),
                 custom_llm_provider=custom_llm_provider,
             )
+            # Stamp custom_llm_provider so callbacks can identify the provider
+            # (mirrors litellm/main.py:1371 for chat completions)
+            response._hidden_params["custom_llm_provider"] = custom_llm_provider
 
         return response
     except Exception as e:

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -83,6 +83,7 @@ class BaseResponsesAPIStreamingIterator:
         self._hidden_params = {
             "model_id": _model_info.get("id", None),
             "api_base": _api_base,
+            "custom_llm_provider": custom_llm_provider,
         }
         self._hidden_params["additional_headers"] = process_response_headers(
             self.response.headers or {}

--- a/tests/test_litellm/proxy/hooks/test_post_call_response_headers_hook.py
+++ b/tests/test_litellm/proxy/hooks/test_post_call_response_headers_hook.py
@@ -195,3 +195,134 @@ async def test_default_hook_returns_none():
         response=None,
     )
     assert result is None
+
+
+# --- Tests for litellm_call_info parameter ---
+
+
+class CallInfoInspectorLogger(CustomLogger):
+    """Logger that captures litellm_call_info for inspection."""
+
+    def __init__(self):
+        self.called = False
+        self.received_call_info = None
+
+    async def async_post_call_response_headers_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+        request_headers: Optional[Dict[str, str]] = None,
+        litellm_call_info: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, str]]:
+        self.called = True
+        self.received_call_info = litellm_call_info
+        return None
+
+
+@pytest.mark.asyncio
+async def test_litellm_call_info_from_hidden_params():
+    """Test that litellm_call_info is built from response._hidden_params."""
+    inspector = CallInfoInspectorLogger()
+
+    class MockResponse:
+        _hidden_params = {
+            "custom_llm_provider": "openai",
+            "api_base": "https://api.openai.com",
+            "model_id": "model-abc",
+        }
+
+    with patch("litellm.callbacks", [inspector]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        await proxy_logging.post_call_response_headers_hook(
+            data={"model": "gpt-4", "metadata": {"model_info": {"id": "model-abc", "provider": "HubSpot"}}},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            response=MockResponse(),
+        )
+
+        assert inspector.called is True
+        assert inspector.received_call_info is not None
+        assert inspector.received_call_info["custom_llm_provider"] == "openai"
+        assert inspector.received_call_info["api_base"] == "https://api.openai.com"
+        assert inspector.received_call_info["model_id"] == "model-abc"
+        assert inspector.received_call_info["model_info"]["provider"] == "HubSpot"
+
+
+@pytest.mark.asyncio
+async def test_litellm_call_info_from_litellm_metadata():
+    """Test that litellm_call_info finds model_info under litellm_metadata (responses API path)."""
+    inspector = CallInfoInspectorLogger()
+
+    class MockResponse:
+        _hidden_params = {
+            "custom_llm_provider": "azure",
+            "api_base": "https://east.openai.azure.com",
+            "model_id": "deploy-xyz",
+        }
+
+    with patch("litellm.callbacks", [inspector]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        await proxy_logging.post_call_response_headers_hook(
+            data={"model": "gpt-4", "litellm_metadata": {"model_info": {"id": "deploy-xyz"}}},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            response=MockResponse(),
+        )
+
+        assert inspector.received_call_info["model_info"]["id"] == "deploy-xyz"
+        assert inspector.received_call_info["custom_llm_provider"] == "azure"
+
+
+@pytest.mark.asyncio
+async def test_litellm_call_info_with_none_response():
+    """Test that litellm_call_info handles None response (failure path)."""
+    inspector = CallInfoInspectorLogger()
+
+    with patch("litellm.callbacks", [inspector]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        await proxy_logging.post_call_response_headers_hook(
+            data={"model": "gpt-4", "metadata": {}},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            response=None,
+        )
+
+        assert inspector.called is True
+        assert inspector.received_call_info is not None
+        assert inspector.received_call_info["custom_llm_provider"] is None
+        assert inspector.received_call_info["model_info"] == {}
+
+
+@pytest.mark.asyncio
+async def test_litellm_call_info_backwards_compatible():
+    """Test that existing callbacks without litellm_call_info parameter still work."""
+    # HeaderInjectorLogger doesn't accept litellm_call_info — must not crash
+    injector = HeaderInjectorLogger(headers={"x-test": "1"})
+
+    class MockResponse:
+        _hidden_params = {"custom_llm_provider": "openai", "api_base": "https://api.openai.com", "model_id": "m1"}
+
+    with patch("litellm.callbacks", [injector]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        result = await proxy_logging.post_call_response_headers_hook(
+            data={"model": "gpt-4", "metadata": {}},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            response=MockResponse(),
+        )
+
+        assert result == {"x-test": "1"}
+        assert injector.called is True


### PR DESCRIPTION
The response headers hook had 5 gaps that prevented callbacks from reliably extracting routing metadata across endpoint types:

1. Hook never fired for /audio/transcriptions (endpoint bypasses base_process_llm_request)
2. custom_llm_provider not accessible in hook data for any endpoint
3. custom_llm_provider not stamped in ResponsesAPIResponse._hidden_params (unlike chat completions)
4. model_info under inconsistent keys (metadata vs litellm_metadata)
5. request_headers always None at all call sites

This adds a litellm_call_info parameter to the hook that normalizes routing metadata (custom_llm_provider, model_info, api_base, model_id) regardless of endpoint type. Also stamps custom_llm_provider on Responses API responses, adds the hook call to the transcription handler, and passes request_headers at all call sites.

Supersedes PR #21385.

## Relevant issues

Fixes #19646

Related PRs: #20083 (original hook feature), #21385 (superseded by this PR)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### `litellm/integrations/custom_logger.py`
- Added optional `litellm_call_info: Optional[Dict[str, Any]]` parameter to `async_post_call_response_headers_hook` signature with docstring describing the fields (`custom_llm_provider`, `model_info`, `api_base`, `model_id`)

### `litellm/proxy/utils.py`
- Added `_build_litellm_call_info()` static method that extracts routing metadata from `response._hidden_params` and normalizes `model_info` lookup across both `data["metadata"]` and `data["litellm_metadata"]`
- Updated `post_call_response_headers_hook()` to build and pass `litellm_call_info` to each callback
- Added `TypeError` fallback for backwards compatibility with existing callbacks that don't accept the new parameter

### `litellm/proxy/common_request_processing.py`
- Added `request_headers=dict(request.headers)` at all 3 hook call sites (streaming success, non-streaming success, failure)

### `litellm/proxy/proxy_server.py`
- Added `post_call_response_headers_hook` call to the `/audio/transcriptions` handler, which previously bypassed the hook entirely

### `litellm/responses/main.py`
- Stamped `custom_llm_provider` into `ResponsesAPIResponse._hidden_params` on both the async (`aresponses`) and sync (`responses`) non-streaming paths, mirroring `litellm/main.py:1371` for chat completions

### `litellm/responses/streaming_iterator.py`
- Added `custom_llm_provider` to `_hidden_params` dict in `BaseResponsesAPIStreamingIterator.__init__`, mirroring `streaming_handler.py:701` for chat completions

### `tests/test_litellm/proxy/hooks/test_post_call_response_headers_hook.py`
- Added 4 new tests:
  - `test_litellm_call_info_from_hidden_params` — verifies `litellm_call_info` is built from `response._hidden_params`
  - `test_litellm_call_info_from_litellm_metadata` — verifies `model_info` is found under `litellm_metadata` (responses API path)
  - `test_litellm_call_info_with_none_response` — verifies graceful handling when response is `None` (failure path)
  - `test_litellm_call_info_backwards_compatible` — verifies existing callbacks without the new parameter still work via `TypeError` fallback