### PR TITLE
fix VLLM cached tokens handling in token cost calculator

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1603,6 +1603,16 @@ class Usage(SafeAttributeModel, CompletionUsage):
         ):
             self._cache_read_input_tokens = params["prompt_cache_hit_tokens"]
 
+        if (
+            _prompt_tokens_details is not None
+            and "cache_read_input_tokens" not in params
+        ):
+            cached = getattr(_prompt_tokens_details, "cached_tokens", None)
+            if cached is not None:
+                self._cache_read_input_tokens = cached
+                params = dict(params)
+                params["cache_read_input_tokens"] = cached
+
         for k, v in params.items():
             setattr(self, k, v)
 

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -223,3 +223,39 @@ def test_chat_completion_token_logprob_invalid_top_logprobs_rejected():
             logprob=-0.31725305,
             top_logprobs="invalid_string",
         )
+
+
+def test_usage_vllm_cached_tokens_mapping():
+    """
+    VLLM returns prompt_tokens_details.cached_tokens but not top-level
+    cache_read_input_tokens. Usage should map cached_tokens to both
+    _cache_read_input_tokens and cache_read_input_tokens for cost calc and UI.
+    """
+    from litellm.types.utils import Usage
+
+    vllm_usage = {
+        "total_tokens": 150687,
+        "prompt_tokens": 150383,
+        "completion_tokens": 304,
+        "prompt_tokens_details": {
+            "text_tokens": None,
+            "audio_tokens": None,
+            "image_tokens": None,
+            "cached_tokens": 149936,
+        },
+        "completion_tokens_details": {
+            "text_tokens": None,
+            "audio_tokens": None,
+            "image_tokens": None,
+            "reasoning_tokens": 15,
+        },
+    }
+
+    usage = Usage(**vllm_usage)
+
+    assert usage.prompt_tokens_details.cached_tokens == 149936
+    assert usage._cache_read_input_tokens == 149936
+    assert usage.get("cache_read_input_tokens") == 149936
+
+    dumped = usage.model_dump()
+    assert dumped.get("cache_read_input_tokens") == 149936


### PR DESCRIPTION
### Short description:

- VLLM returns prompt_tokens_details.cached_tokens but not top-level cache_read_input_tokens, so the cost calculator and proxy UI showed "Cache Read Tokens: 0" even when cached tokens were present.
- This PR maps prompt_tokens_details.cached_tokens to cache_read_input_tokens in Usage.__init__ when it is not already set by other providers.

### Relevant issues: 
Fixes : #22984

- Type: Bug fix