### PR TITLE
fix: LITELLM_DROP_PARAMS / LITELLM_MODIFY_PARAMS env vars always truthy for any non-empty string value

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -200,8 +200,8 @@ token: Optional[str] = (
 )
 telemetry = True
 max_tokens: int = DEFAULT_MAX_TOKENS  # OpenAI Defaults
-drop_params = bool(os.getenv("LITELLM_DROP_PARAMS", False))
-modify_params = bool(os.getenv("LITELLM_MODIFY_PARAMS", False))
+drop_params = os.getenv("LITELLM_DROP_PARAMS", "").lower() in ("1", "true", "yes", "on")
+modify_params = os.getenv("LITELLM_MODIFY_PARAMS", "").lower() in ("1", "true", "yes", "on")
 use_chat_completions_url_for_anthropic_messages: bool = bool(
     os.getenv("LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES", False)
 )  # When True, routes OpenAI /v1/messages requests to chat/completions instead of the Responses API

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -202,9 +202,9 @@ telemetry = True
 max_tokens: int = DEFAULT_MAX_TOKENS  # OpenAI Defaults
 drop_params = os.getenv("LITELLM_DROP_PARAMS", "").lower() in ("1", "true", "yes", "on")
 modify_params = os.getenv("LITELLM_MODIFY_PARAMS", "").lower() in ("1", "true", "yes", "on")
-use_chat_completions_url_for_anthropic_messages: bool = bool(
-    os.getenv("LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES", False)
-)  # When True, routes OpenAI /v1/messages requests to chat/completions instead of the Responses API
+use_chat_completions_url_for_anthropic_messages: bool = (
+    os.getenv("LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES", "").lower() in ("1", "true", "yes", "on")
+)
 retry = True
 ### AUTH ###
 api_key: Optional[str] = None


### PR DESCRIPTION
## Problem

`LITELLM_DROP_PARAMS` and `LITELLM_MODIFY_PARAMS` are read as follows in `litellm/__init__.py`:

```python
drop_params = bool(os.getenv("LITELLM_DROP_PARAMS", False))
modify_params = bool(os.getenv("LITELLM_MODIFY_PARAMS", False))
```

`os.getenv()` always returns a **string** (or `None`), never the boolean `False` passed as the default. This means:

- `LITELLM_DROP_PARAMS=false` → `bool("false")` → **`True`** ❌
- `LITELLM_DROP_PARAMS=0` → `bool("0")` → **`True`** ❌
- `LITELLM_DROP_PARAMS=no` → `bool("no")` → **`True`** ❌

Any non-empty string value enables the feature, making it **impossible to explicitly disable** via environment variable once set.

## Fix

Use the correct boolean env var parsing pattern already present elsewhere in the same file (e.g. `LITELLM_DISABLE_LAZY_LOADING` at line 1641):

```python
drop_params = os.getenv("LITELLM_DROP_PARAMS", "").lower() in ("1", "true", "yes", "on")
modify_params = os.getenv("LITELLM_MODIFY_PARAMS", "").lower() in ("1", "true", "yes", "on")
```

## Impact

- Users who set `LITELLM_DROP_PARAMS=false` in `.env` files (a natural attempt to disable) will silently have the feature **enabled** instead. This is especially confusing for provider-switching workflows where `drop_params` changes model behavior.
- Same issue affects `LITELLM_MODIFY_PARAMS`.
- No other env vars in `__init__.py` use `bool(os.getenv(...))` — scope is limited to these two lines.
