### PR TITLE
feat(key_management): allow @ in key_alias for email-based aliases

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -4991,7 +4991,7 @@ async def test_key_logging(
         )
 
 
-_KEY_ALIAS_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-/\.]{0,253}[a-zA-Z0-9]$")
+_KEY_ALIAS_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-/\.@]{0,253}[a-zA-Z0-9]$")
 
 
 def _validate_key_alias_format(key_alias: Optional[str]) -> None:
@@ -5009,7 +5009,7 @@ def _validate_key_alias_format(key_alias: Optional[str]) -> None:
 
     if not _KEY_ALIAS_PATTERN.match(key_alias):
         raise ProxyException(
-            message="Invalid key_alias format. Must be 2-255 characters, start/end with alphanumeric, and only contain a-zA-Z0-9_-/.",
+            message="Invalid key_alias format. Must be 2-255 characters, start/end with alphanumeric, and only contain a-zA-Z0-9_-/.@.",
             type=ProxyErrorTypes.bad_request_error,
             param="key_alias",
             code=400,

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6460,6 +6460,8 @@ class TestValidateKeyAliasFormat:
         _validate_key_alias_format("valid/alias")
         _validate_key_alias_format("a" * 255)
         _validate_key_alias_format("my-key-123")
+        _validate_key_alias_format("user/user@example.com")
+        _validate_key_alias_format("team/user@example.com")
 
     def test_validate_key_alias_format_invalid(self):
         from litellm.proxy.management_endpoints.key_management_endpoints import _validate_key_alias_format
@@ -6472,7 +6474,7 @@ class TestValidateKeyAliasFormat:
             "!",              # special char
             "-start",         # non-alphanumeric start
             "end-",           # non-alphanumeric end
-            "invalid@char",   # invalid char
+            "invalid#char",   # invalid char
             "a" * 256,        # too long
             "  leading",
             "trailing  ",


### PR DESCRIPTION
## Summary
- Adds `@` to the `_KEY_ALIAS_PATTERN` allowed character set so that key aliases containing email addresses (e.g. `user/user@example.com`) are accepted by `_validate_key_alias_format`.
- Updates the error message to reflect the new allowed characters.
- Adds test cases for email-based aliases and updates the invalid character test from `@` to `#`.

## Motivation
We auto-provision virtual keys per user via `/key/generate` with `key_alias` set to `user/{email}`. This worked before but started getting rejected after `_validate_key_alias_format` was introduced, because `@` is not in the current regex. The `@` character is safe for a Postgres string column and is commonly needed for email-based key aliases.

## Test plan
- [x] Added `user/user@example.com` and `team/user@example.com` to valid alias test cases
- [x] Changed invalid test from `invalid@char` to `invalid#char`
- [x] `pytest tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py::TestValidateKeyAliasFormat -v` passes


Made with [Cursor](https://cursor.com)