### PR TITLE
fix: resolve three bugs in /ask-codebase PR (Greptile findings)

### DIFF
--- a/.claude/commands/deletable_PR_argument.md
+++ b/.claude/commands/deletable_PR_argument.md
@@ -1,6 +1,6 @@
 This is a table of PRs
 
-$ARGUMENT[0]
+$ARGUMENTS[0]
 
 from the above table,
 for each row,

--- a/.claude/commands/error_related_to_PR.md
+++ b/.claude/commands/error_related_to_PR.md
@@ -1,6 +1,6 @@
 Let the value for PR Number equals to $ARGUMENTS[0]
 
-Is this related to my PR [PR_NUMBER]? if yes, fix it; else, create a new PR fixing the issue. Is very IMPORTANT that the PR be as scoped as possible, just touching relevant files that fix the issue, and if required create the fix from the main branch, not just from the PR branch contents: this will guarantee consistency and fixing the error in general.
+Is this related to my PR $ARGUMENTS[0]? if yes, fix it; else, create a new PR fixing the issue. Is very IMPORTANT that the PR be as scoped as possible, just touching relevant files that fix the issue, and if required create the fix from the main branch, not just from the PR branch contents: this will guarantee consistency and fixing the error in general.
 
 The error found is:
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 .venv
 .venv_policy_test
 .env
-.claude
-!.claude/commands
+.claude/settings.local.json
+.claude/__pycache__
 .newenv
 newenv/*
 litellm/proxy/myenv/*


### PR DESCRIPTION
Fixes three issues flagged by Greptile on #22894:

1. **`.gitignore` broken negation** — `!.claude/commands` cannot re-include files inside a fully-excluded parent (`.claude`). Replaced blanket `.claude` rule with specific exclusions so the commands directory is actually tracked.

2. **`error_related_to_PR.md` unreplaced placeholder** — literal `[PR_NUMBER]` on line 3 was never substituted; replaced with `$ARGUMENTS[0]` (already set on line 1).

3. **`deletable_PR_argument.md` wrong argument syntax** — `$ARGUMENT[0]` (singular, non-standard) → `$ARGUMENTS[0]` (plural, Claude Code convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)