### PR TITLE
fix: ProxyException.__str__ returns message instead of empty string

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3276,6 +3276,9 @@ class ProxyException(Exception):
         elif RouterErrors.no_deployments_with_tag_routing.value in self.message:
             self.code = "401"
 
+    def __str__(self) -> str:
+        return self.message
+
     def to_dict(self) -> dict:
         """Converts the ProxyException instance to a dictionary."""
         error_dict: Dict[str, Optional[Union[str, Dict]]] = {

--- a/tests/test_litellm/proxy/test_proxy_exception.py
+++ b/tests/test_litellm/proxy/test_proxy_exception.py
@@ -1,0 +1,27 @@
+"""Tests for ProxyException.__str__.
+
+Related issue: https://github.com/BerriAI/litellm/issues/22644
+"""
+
+from litellm.proxy._types import ProxyException
+
+
+def test_proxy_exception_str_returns_message():
+    exc = ProxyException(
+        message="This is an error",
+        type="invalid_request_error",
+        param="model",
+        code=400,
+    )
+    assert str(exc) == "This is an error"
+
+
+def test_proxy_exception_str_with_non_string_message():
+    exc = ProxyException(
+        message=42,
+        type="server_error",
+        param=None,
+        code=500,
+    )
+    # __init__ already calls str(message)
+    assert str(exc) == "42"


### PR DESCRIPTION
Fixes #22644

## Relevant issues

Fixes #22644

## Pre-Submission checklist

- [x] I have Added testing in the [tests/test_litellm/](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR passes all unit tests on [make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting @greptileai

## Type

Bug Fix

## Changes

Adds __str__ to ProxyException so that str(exc) returns the error message instead of an empty string. Includes tests for string and non-string messages.