### PR TITLE
bump litellm-proxy-extras 0.4.50 → 0.4.51

### DIFF
--- a/litellm-proxy-extras/pyproject.toml
+++ b/litellm-proxy-extras/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "litellm-proxy-extras"
-version = "0.4.50"
+version = "0.4.51"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 authors = ["BerriAI"]
 readme = "README.md"
@@ -22,7 +22,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.commitizen]
-version = "0.4.50"
+version = "0.4.51"
 version_files = [
     "pyproject.toml:version",
     "../requirements.txt:litellm-proxy-extras==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ boto3 = { version = "1.40.76", optional = true }
 redisvl = {version = "^0.4.1", optional = true, markers = "python_version >= '3.9' and python_version < '3.14'"}
 mcp = {version = ">=1.25.0,<2.0.0", optional = true, python = ">=3.10"}
 a2a-sdk = {version = "^0.3.22", optional = true, python = ">=3.10"}
-litellm-proxy-extras = {version = "0.4.50", optional = true}
+litellm-proxy-extras = {version = "0.4.51", optional = true}
 rich = {version = "13.7.1", optional = true}
 litellm-enterprise = {version = "0.1.33", optional = true}
 diskcache = {version = "^5.6.1", optional = true}

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ grpcio>=1.75.0; python_version >= "3.14"
 sentry_sdk==2.21.0 # for sentry error handling
 detect-secrets==1.5.0 # Enterprise - secret detection / masking in LLM requests
 tzdata==2025.1 # IANA time zone database
-litellm-proxy-extras==0.4.50 # for proxy extras - e.g. prisma migrations
+litellm-proxy-extras==0.4.51 # for proxy extras - e.g. prisma migrations
 llm-sandbox==0.3.31 # for skill execution in sandbox
 ### LITELLM PACKAGE DEPENDENCIES
 python-dotenv==1.0.1 # for env


### PR DESCRIPTION
## Summary
- Bumps `litellm-proxy-extras` from 0.4.50 to 0.4.51 in all 3 version files:
  - `litellm-proxy-extras/pyproject.toml` (`[tool.poetry]` and `[tool.commitizen]` sections)
  - `requirements.txt` (line 60)
  - `pyproject.toml` (line 64)

## Test plan
- [ ] Verify version strings are consistent across all 3 files
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)