### PR TITLE
fix(budget): log warning on timezone fallback to UTC

### DIFF
--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -12,6 +12,8 @@ from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Optional, Tuple
 from zoneinfo import ZoneInfo
 
+from litellm._logging import verbose_logger
+
 
 def _extract_from_regex(duration: str) -> Tuple[int, str]:
     match = re.match(r"(\d+)(mo|[smhdw]?)", duration)
@@ -156,7 +158,11 @@ def _setup_timezone(
         else:
             tz = ZoneInfo(timezone_str)
     except Exception:
-        # If timezone is invalid, fall back to UTC
+        verbose_logger.warning(
+            "Failed to load timezone '%s', falling back to UTC. "
+            "Install 'tzdata' package for full timezone support.",
+            timezone_str,
+        )
         tz = timezone.utc
 
     # Convert current_time to the target timezone

--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -160,7 +160,7 @@ def _setup_timezone(
     except Exception:
         verbose_logger.warning(
             "Failed to load timezone '%s', falling back to UTC. "
-            "Install 'tzdata' package for full timezone support.",
+            "Check that the timezone is valid and that the 'tzdata' package is installed.",
             timezone_str,
         )
         tz = timezone.utc

--- a/tests/test_litellm/litellm_core_utils/test_duration_parser.py
+++ b/tests/test_litellm/litellm_core_utils/test_duration_parser.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime, timezone
+from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 from litellm.litellm_core_utils.duration_parser import get_next_standardized_reset_time
@@ -182,6 +183,14 @@ class TestStandardizedResetTime(unittest.TestCase):
         expected = datetime(2023, 3, 13, 0, 0, 0, tzinfo=eastern)
         result = get_next_standardized_reset_time("1d", pre_spring, "US/Eastern")
         self.assertEqual(result, expected)
+
+
+    def test_invalid_timezone_logs_warning(self):
+        """Test that an invalid timezone logs a warning when falling back to UTC."""
+        base_time = datetime(2023, 5, 15, 14, 0, 0, tzinfo=timezone.utc)
+        with patch("litellm.litellm_core_utils.duration_parser.verbose_logger") as mock_logger:
+            get_next_standardized_reset_time("1d", base_time, "NonExistentTimeZone")
+            mock_logger.warning.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/litellm_core_utils/test_duration_parser.py
+++ b/tests/test_litellm/litellm_core_utils/test_duration_parser.py
@@ -191,6 +191,7 @@ class TestStandardizedResetTime(unittest.TestCase):
         with patch("litellm.litellm_core_utils.duration_parser.verbose_logger") as mock_logger:
             get_next_standardized_reset_time("1d", base_time, "NonExistentTimeZone")
             mock_logger.warning.assert_called_once()
+            assert "NonExistentTimeZone" in mock_logger.warning.call_args.args[1]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Relevant issues

Follow-up to #21754

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

In #21754, the hardcoded `timezone_map` was replaced with `ZoneInfo`. On environments without the `tzdata` package, `ZoneInfo` throws an exception and silently falls back to UTC — operators have no way to tell their configured timezone is being ignored.

Rather than adding `tzdata` as a dependency, this PR adds a `verbose_logger.warning()` in the `except` block of `_setup_timezone()` to log when the fallback occurs.

- `litellm/litellm_core_utils/duration_parser.py`: Add warning log on timezone load failure
- No new dependencies, UTC fallback behavior preserved