### PR TITLE
fix(vertex_ai): convert image URLs to base64 for /v1/messages endpoint

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/image_handling.py
+++ b/litellm/litellm_core_utils/prompt_templates/image_handling.py
@@ -16,6 +16,56 @@ MAX_IMGS_IN_MEMORY = 10
 in_memory_cache = InMemoryCache(max_size_in_memory=MAX_IMGS_IN_MEMORY)
 
 
+# Supported image media types for Anthropic/Vertex AI
+SUPPORTED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+
+# Mapping from file extensions to media types
+EXTENSION_TO_MEDIA_TYPE = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "gif": "image/gif",
+    "webp": "image/webp",
+}
+
+
+def _infer_media_type_from_url(url: str) -> str:
+    """
+    Infer media type from URL extension.
+    Handles signed URLs by stripping query parameters before extracting extension.
+    """
+    # Strip query parameters for signed URLs (e.g., ?x-oss-signature=...)
+    url_without_query = url.split("?")[0]
+    extension = url_without_query.split(".")[-1].lower()
+    media_type = EXTENSION_TO_MEDIA_TYPE.get(extension)
+    if media_type is None:
+        raise Exception(
+            f"Error: Unsupported image format. Extension={extension}. "
+            f"Supported types = {list(SUPPORTED_IMAGE_TYPES)}"
+        )
+    return media_type
+
+
+def _get_valid_media_type(content_type: str | None, url: str) -> str:
+    """
+    Get a valid media type from Content-Type header, falling back to URL extension.
+
+    - Strips Content-Type parameters (e.g., 'image/png; charset=utf-8' -> 'image/png')
+    - Validates against supported types
+    - Falls back to URL extension inference if Content-Type is missing or invalid
+    """
+    if content_type is not None:
+        # Strip parameters (e.g., "image/png; charset=utf-8" -> "image/png")
+        media_type = content_type.split(";")[0].strip()
+        if media_type in SUPPORTED_IMAGE_TYPES:
+            return media_type
+        # Content-Type is invalid (e.g., application/octet-stream, application/x-www-form-urlencoded)
+        # Fall through to URL extension inference
+
+    # Fallback to URL extension
+    return _infer_media_type_from_url(url)
+
+
 def _process_image_response(response: Response, url: str) -> str:
     if response.status_code != 200:
         raise litellm.ImageFetchError(
@@ -35,7 +85,7 @@ def _process_image_response(response: Response, url: str) -> str:
     max_bytes = int(MAX_IMAGE_URL_DOWNLOAD_SIZE_MB * 1024 * 1024)
     image_bytes = bytearray()
     bytes_downloaded = 0
-    
+
     for chunk in response.iter_bytes(chunk_size=8192):
         bytes_downloaded += len(chunk)
         if bytes_downloaded > max_bytes:
@@ -44,28 +94,13 @@ def _process_image_response(response: Response, url: str) -> str:
                 f"Error: Image size ({size_mb:.2f}MB) exceeds maximum allowed size ({MAX_IMAGE_URL_DOWNLOAD_SIZE_MB}MB). url={url}"
             )
         image_bytes.extend(chunk)
-    
+
     base64_image = base64.b64encode(image_bytes).decode("utf-8")
 
-    image_type = response.headers.get("Content-Type")
-    if image_type is None:
-        img_type = url.split(".")[-1].lower()
-        _img_type = {
-            "jpg": "image/jpeg",
-            "jpeg": "image/jpeg",
-            "png": "image/png",
-            "gif": "image/gif",
-            "webp": "image/webp",
-        }.get(img_type)
-        if _img_type is None:
-            raise Exception(
-                f"Error: Unsupported image format. Format={_img_type}. Supported types = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']"
-            )
-        img_type = _img_type
-    else:
-        img_type = image_type
+    content_type = response.headers.get("Content-Type")
+    media_type = _get_valid_media_type(content_type, url)
 
-    result = f"data:{img_type};base64,{base64_image}"
+    result = f"data:{media_type};base64,{base64_image}"
     in_memory_cache.set_cache(url, result)
     return result
 

--- a/litellm/litellm_core_utils/prompt_templates/image_handling.py
+++ b/litellm/litellm_core_utils/prompt_templates/image_handling.py
@@ -3,6 +3,7 @@ Helper functions to handle images passed in messages
 """
 
 import base64
+from typing import Optional
 
 from httpx import Response
 
@@ -49,7 +50,7 @@ def _infer_media_type_from_url(url: str) -> str:
     return media_type
 
 
-def _get_valid_media_type(content_type: str | None, url: str) -> str:
+def _get_valid_media_type(content_type: Optional[str], url: str) -> str:
     """
     Get a valid media type from Content-Type header, falling back to URL extension.
 

--- a/litellm/litellm_core_utils/prompt_templates/image_handling.py
+++ b/litellm/litellm_core_utils/prompt_templates/image_handling.py
@@ -36,11 +36,14 @@ def _infer_media_type_from_url(url: str) -> str:
     """
     # Strip query parameters for signed URLs (e.g., ?x-oss-signature=...)
     url_without_query = url.split("?")[0]
-    extension = url_without_query.split(".")[-1].lower()
+    # Only take the last path segment to avoid matching dots in the path
+    last_segment = url_without_query.rstrip("/").split("/")[-1]
+    # Check if the segment contains a dot (has an extension)
+    extension = last_segment.rsplit(".", 1)[-1].lower() if "." in last_segment else ""
     media_type = EXTENSION_TO_MEDIA_TYPE.get(extension)
     if media_type is None:
         raise Exception(
-            f"Error: Unsupported image format. Extension={extension}. "
+            f"Error: Unsupported image format. Could not infer media type from URL '{url}'. "
             f"Supported types = {list(SUPPORTED_IMAGE_TYPES)}"
         )
     return media_type

--- a/litellm/litellm_core_utils/prompt_templates/image_handling.py
+++ b/litellm/litellm_core_utils/prompt_templates/image_handling.py
@@ -43,7 +43,7 @@ def _infer_media_type_from_url(url: str) -> str:
     extension = last_segment.rsplit(".", 1)[-1].lower() if "." in last_segment else ""
     media_type = EXTENSION_TO_MEDIA_TYPE.get(extension)
     if media_type is None:
-        raise Exception(
+        raise litellm.ImageFetchError(
             f"Error: Unsupported image format. Could not infer media type from URL '{url}'. "
             f"Supported types = {list(SUPPORTED_IMAGE_TYPES)}"
         )

--- a/litellm/llms/base_llm/anthropic_messages/transformation.py
+++ b/litellm/llms/base_llm/anthropic_messages/transformation.py
@@ -74,6 +74,28 @@ class BaseAnthropicMessagesConfig(ABC):
     ) -> Dict:
         pass
 
+    async def async_transform_anthropic_messages_request(
+        self,
+        model: str,
+        messages: List[Dict],
+        anthropic_messages_optional_request_params: Dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> Dict:
+        """
+        Async version of transform_anthropic_messages_request.
+
+        Override this method to perform async operations (e.g., fetching image URLs)
+        without blocking the event loop. Default implementation calls the sync version.
+        """
+        return self.transform_anthropic_messages_request(
+            model=model,
+            messages=messages,
+            anthropic_messages_optional_request_params=anthropic_messages_optional_request_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+
     @abstractmethod
     def transform_anthropic_messages_response(
         self,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1905,8 +1905,8 @@ class BaseLLMHTTPHandler:
                     anthropic_messages_optional_request_params, path
                 )
 
-        # Prepare request body
-        request_body = anthropic_messages_provider_config.transform_anthropic_messages_request(
+        # Prepare request body (use async version to avoid blocking event loop)
+        request_body = await anthropic_messages_provider_config.async_transform_anthropic_messages_request(
             model=model,
             messages=messages,
             anthropic_messages_optional_request_params=anthropic_messages_optional_request_params,

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple
 
-from litellm.litellm_core_utils.prompt_templates.image_handling import (
-    convert_url_to_base64,
+from litellm.litellm_core_utils.prompt_templates.factory import (
+    convert_to_anthropic_image_obj,
 )
 from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
@@ -171,30 +171,22 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
                     if isinstance(source, dict) and source.get("type") == "url":
                         url = source.get("url")
                         if url:
-                            # Convert URL to base64
-                            base64_data_url = convert_url_to_base64(url=url)
-                            # Parse the data URL: data:image/jpeg;base64,<data>
-                            if base64_data_url.startswith("data:"):
-                                # Extract media type and data
-                                parts = base64_data_url.split(";base64,", 1)
-                                if len(parts) == 2:
-                                    media_type = parts[0].replace("data:", "")
-                                    data = parts[1]
-                                    new_block = {
-                                        "type": "image",
-                                        "source": {
-                                            "type": "base64",
-                                            "media_type": media_type,
-                                            "data": data,
-                                        },
-                                    }
-                                    # Preserve cache_control if present
-                                    if "cache_control" in block:
-                                        new_block["cache_control"] = block[
-                                            "cache_control"
-                                        ]
-                                    new_content.append(new_block)
-                                    continue
+                            # Convert URL to base64 using existing utility
+                            image_obj = convert_to_anthropic_image_obj(
+                                openai_image_url=url, format=None
+                            )
+                            # Preserve all original block fields (e.g., cache_control)
+                            # while replacing the source
+                            new_block = {
+                                **block,
+                                "source": {
+                                    "type": image_obj["type"],
+                                    "media_type": image_obj["media_type"],
+                                    "data": image_obj["data"],
+                                },
+                            }
+                            new_content.append(new_block)
+                            continue
 
                 new_content.append(block)
 

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -3,6 +3,9 @@ from typing import Any, Dict, List, Optional, Tuple
 from litellm.litellm_core_utils.prompt_templates.factory import (
     convert_to_anthropic_image_obj,
 )
+from litellm.litellm_core_utils.prompt_templates.image_handling import (
+    async_convert_url_to_base64,
+)
 from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
@@ -194,6 +197,107 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
             converted_messages.append(new_message)
 
         return converted_messages
+
+    @staticmethod
+    async def _convert_image_urls_to_base64_async(messages: List[Dict]) -> List[Dict]:
+        """
+        Async version: Convert image URL sources to base64 format for Vertex AI.
+
+        Vertex AI Anthropic does not support URL sources for images.
+        This method converts:
+        {"type": "image", "source": {"type": "url", "url": "https://..."}}
+        to:
+        {"type": "image", "source": {"type": "base64", "media_type": "...", "data": "..."}}
+        """
+        converted_messages = []
+        for message in messages:
+            if not isinstance(message, dict):
+                converted_messages.append(message)
+                continue
+
+            content = message.get("content")
+            if not isinstance(content, list):
+                converted_messages.append(message)
+                continue
+
+            new_content = []
+            for block in content:
+                if not isinstance(block, dict):
+                    new_content.append(block)
+                    continue
+
+                # Check if this is an image block with URL source
+                if block.get("type") == "image":
+                    source = block.get("source", {})
+                    if isinstance(source, dict) and source.get("type") == "url":
+                        url = source.get("url")
+                        if url:
+                            # Convert URL to base64 using async utility
+                            data_uri = await async_convert_url_to_base64(url)
+                            # Parse the data URI to extract media_type and data
+                            # Format: "data:image/jpeg;base64,/9j/..."
+                            media_type_part, base64_data = data_uri.split(
+                                "data:"
+                            )[1].split(";base64,")
+                            # Preserve all original block fields (e.g., cache_control)
+                            # while replacing the source
+                            new_block = {
+                                **block,
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": media_type_part,
+                                    "data": base64_data,
+                                },
+                            }
+                            new_content.append(new_block)
+                            continue
+
+                new_content.append(block)
+
+            new_message = {**message, "content": new_content}
+            converted_messages.append(new_message)
+
+        return converted_messages
+
+    async def async_transform_anthropic_messages_request(
+        self,
+        model: str,
+        messages: List[Dict],
+        anthropic_messages_optional_request_params: Dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> Dict:
+        """
+        Async version of transform_anthropic_messages_request.
+        Uses async image URL to base64 conversion to avoid blocking the event loop.
+        """
+        # Convert image URLs to base64 for Vertex AI using async method
+        # Vertex AI Anthropic does not support URL sources for images
+        converted_messages = await self._convert_image_urls_to_base64_async(messages)
+
+        anthropic_messages_request = super().transform_anthropic_messages_request(
+            model=model,
+            messages=converted_messages,
+            anthropic_messages_optional_request_params=anthropic_messages_optional_request_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+
+        anthropic_messages_request["anthropic_version"] = "vertex-2023-10-16"
+
+        anthropic_messages_request.pop(
+            "model", None
+        )  # do not pass model in request body to vertex ai
+
+        anthropic_messages_request.pop(
+            "output_format", None
+        )  # do not pass output_format in request body to vertex ai - vertex ai does not support output_format as yet
+
+        anthropic_messages_request.pop(
+            "output_config", None
+        )  # do not pass output_config in request body to vertex ai - vertex ai does not support output_config
+
+        return anthropic_messages_request
 
     def transform_anthropic_messages_request(
         self,

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Dict, List, Optional, Tuple
 
 from litellm.litellm_core_utils.prompt_templates.factory import (
@@ -208,9 +209,47 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
         {"type": "image", "source": {"type": "url", "url": "https://..."}}
         to:
         {"type": "image", "source": {"type": "base64", "media_type": "...", "data": "..."}}
+
+        Uses asyncio.gather to download multiple images concurrently.
         """
+        # First pass: collect all image URLs and their positions
+        # Position is (message_idx, block_idx, url, original_block)
+        image_tasks: List[Tuple[int, int, str, Dict]] = []
+
+        for msg_idx, message in enumerate(messages):
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for block_idx, block in enumerate(content):
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") == "image":
+                    source = block.get("source", {})
+                    if isinstance(source, dict) and source.get("type") == "url":
+                        url = source.get("url")
+                        if url:
+                            image_tasks.append((msg_idx, block_idx, url, block))
+
+        # Download all images concurrently
+        if image_tasks:
+            download_coros = [
+                async_convert_url_to_base64(task[2]) for task in image_tasks
+            ]
+            data_uris = await asyncio.gather(*download_coros)
+
+            # Build a lookup: (msg_idx, block_idx) -> (data_uri, original_block)
+            image_results: Dict[Tuple[int, int], Tuple[str, Dict]] = {}
+            for i, task in enumerate(image_tasks):
+                msg_idx, block_idx, _, original_block = task
+                image_results[(msg_idx, block_idx)] = (data_uris[i], original_block)
+        else:
+            image_results = {}
+
+        # Second pass: build the result
         converted_messages = []
-        for message in messages:
+        for msg_idx, message in enumerate(messages):
             if not isinstance(message, dict):
                 converted_messages.append(message)
                 continue
@@ -221,38 +260,28 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
                 continue
 
             new_content = []
-            for block in content:
-                if not isinstance(block, dict):
+            for block_idx, block in enumerate(content):
+                key = (msg_idx, block_idx)
+                if key in image_results:
+                    data_uri, original_block = image_results[key]
+                    # Parse the data URI to extract media_type and data
+                    # Format: "data:image/jpeg;base64,/9j/..."
+                    media_type_part, base64_data = data_uri.split("data:")[1].split(
+                        ";base64,"
+                    )
+                    # Preserve all original block fields (e.g., cache_control)
+                    # while replacing the source
+                    new_block = {
+                        **original_block,
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type_part,
+                            "data": base64_data,
+                        },
+                    }
+                    new_content.append(new_block)
+                else:
                     new_content.append(block)
-                    continue
-
-                # Check if this is an image block with URL source
-                if block.get("type") == "image":
-                    source = block.get("source", {})
-                    if isinstance(source, dict) and source.get("type") == "url":
-                        url = source.get("url")
-                        if url:
-                            # Convert URL to base64 using async utility
-                            data_uri = await async_convert_url_to_base64(url)
-                            # Parse the data URI to extract media_type and data
-                            # Format: "data:image/jpeg;base64,/9j/..."
-                            media_type_part, base64_data = data_uri.split(
-                                "data:"
-                            )[1].split(";base64,")
-                            # Preserve all original block fields (e.g., cache_control)
-                            # while replacing the source
-                            new_block = {
-                                **block,
-                                "source": {
-                                    "type": "base64",
-                                    "media_type": media_type_part,
-                                    "data": base64_data,
-                                },
-                            }
-                            new_content.append(new_block)
-                            continue
-
-                new_content.append(block)
 
             new_message = {**message, "content": new_content}
             converted_messages.append(new_message)

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -1,5 +1,8 @@
 from typing import Any, Dict, List, Optional, Tuple
 
+from litellm.litellm_core_utils.prompt_templates.image_handling import (
+    convert_url_to_base64,
+)
 from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
@@ -33,10 +36,12 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
         """
         vertex_ai_project = VertexBase.safe_get_vertex_ai_project(litellm_params)
         vertex_ai_location = VertexBase.safe_get_vertex_ai_location(litellm_params)
-        
+
         project_id: Optional[str] = None
         if "Authorization" not in headers:
-            vertex_credentials = VertexBase.safe_get_vertex_ai_credentials(litellm_params)
+            vertex_credentials = VertexBase.safe_get_vertex_ai_credentials(
+                litellm_params
+            )
 
             access_token, project_id = self._ensure_access_token(
                 credentials=vertex_credentials,
@@ -62,11 +67,11 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
             )
 
         headers["content-type"] = "application/json"
-        
+
         # Add beta headers for Vertex AI
         tools = optional_params.get("tools", [])
         beta_values: set[str] = set()
-        
+
         # Get existing beta headers if any
         existing_beta = headers.get("anthropic-beta")
         if existing_beta:
@@ -79,36 +84,42 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
             edits = context_management_param.get("edits", [])
             has_compact = False
             has_other = False
-            
+
             for edit in edits:
                 edit_type = edit.get("type", "")
                 if edit_type == "compact_20260112":
                     has_compact = True
                 else:
                     has_other = True
-            
+
             # Add compact header if any compact edits exist
             if has_compact:
                 beta_values.add(ANTHROPIC_BETA_HEADER_VALUES.COMPACT_2026_01_12.value)
-            
+
             # Add context management header if any other edits exist
             if has_other:
-                beta_values.add(ANTHROPIC_BETA_HEADER_VALUES.CONTEXT_MANAGEMENT_2025_06_27.value)
+                beta_values.add(
+                    ANTHROPIC_BETA_HEADER_VALUES.CONTEXT_MANAGEMENT_2025_06_27.value
+                )
 
         # Check for web search tool
         for tool in tools:
-            if isinstance(tool, dict) and tool.get("type", "").startswith(ANTHROPIC_HOSTED_TOOLS.WEB_SEARCH.value):
-                beta_values.add(ANTHROPIC_BETA_HEADER_VALUES.WEB_SEARCH_2025_03_05.value)
+            if isinstance(tool, dict) and tool.get("type", "").startswith(
+                ANTHROPIC_HOSTED_TOOLS.WEB_SEARCH.value
+            ):
+                beta_values.add(
+                    ANTHROPIC_BETA_HEADER_VALUES.WEB_SEARCH_2025_03_05.value
+                )
                 break
-        
+
         # Check for tool search tools - Vertex AI uses different beta header
         anthropic_model_info = AnthropicModelInfo()
         if anthropic_model_info.is_tool_search_used(tools):
             beta_values.add(get_tool_search_beta_header("vertex_ai"))
-        
+
         if beta_values:
             headers["anthropic-beta"] = ",".join(beta_values)
-        
+
         return headers, api_base
 
     def get_complete_url(
@@ -126,6 +137,72 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
             )
         return api_base  # no transformation is needed - handled in validate_environment
 
+    @staticmethod
+    def _convert_image_urls_to_base64(messages: List[Dict]) -> List[Dict]:
+        """
+        Convert image URL sources to base64 format for Vertex AI.
+
+        Vertex AI Anthropic does not support URL sources for images.
+        This method converts:
+        {"type": "image", "source": {"type": "url", "url": "https://..."}}
+        to:
+        {"type": "image", "source": {"type": "base64", "media_type": "...", "data": "..."}}
+        """
+        converted_messages = []
+        for message in messages:
+            if not isinstance(message, dict):
+                converted_messages.append(message)
+                continue
+
+            content = message.get("content")
+            if not isinstance(content, list):
+                converted_messages.append(message)
+                continue
+
+            new_content = []
+            for block in content:
+                if not isinstance(block, dict):
+                    new_content.append(block)
+                    continue
+
+                # Check if this is an image block with URL source
+                if block.get("type") == "image":
+                    source = block.get("source", {})
+                    if isinstance(source, dict) and source.get("type") == "url":
+                        url = source.get("url")
+                        if url:
+                            # Convert URL to base64
+                            base64_data_url = convert_url_to_base64(url=url)
+                            # Parse the data URL: data:image/jpeg;base64,<data>
+                            if base64_data_url.startswith("data:"):
+                                # Extract media type and data
+                                parts = base64_data_url.split(";base64,", 1)
+                                if len(parts) == 2:
+                                    media_type = parts[0].replace("data:", "")
+                                    data = parts[1]
+                                    new_block = {
+                                        "type": "image",
+                                        "source": {
+                                            "type": "base64",
+                                            "media_type": media_type,
+                                            "data": data,
+                                        },
+                                    }
+                                    # Preserve cache_control if present
+                                    if "cache_control" in block:
+                                        new_block["cache_control"] = block[
+                                            "cache_control"
+                                        ]
+                                    new_content.append(new_block)
+                                    continue
+
+                new_content.append(block)
+
+            new_message = {**message, "content": new_content}
+            converted_messages.append(new_message)
+
+        return converted_messages
+
     def transform_anthropic_messages_request(
         self,
         model: str,
@@ -134,9 +211,13 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
         litellm_params: GenericLiteLLMParams,
         headers: dict,
     ) -> Dict:
+        # Convert image URLs to base64 for Vertex AI
+        # Vertex AI Anthropic does not support URL sources for images
+        converted_messages = self._convert_image_urls_to_base64(messages)
+
         anthropic_messages_request = super().transform_anthropic_messages_request(
             model=model,
-            messages=messages,
+            messages=converted_messages,
             anthropic_messages_optional_request_params=anthropic_messages_optional_request_params,
             litellm_params=litellm_params,
             headers=headers,

--- a/tests/test_litellm/litellm_core_utils/test_image_handling.py
+++ b/tests/test_litellm/litellm_core_utils/test_image_handling.py
@@ -6,6 +6,8 @@ from httpx import Request, Response
 import litellm
 from litellm import constants
 from litellm.litellm_core_utils.prompt_templates.image_handling import (
+    _get_valid_media_type,
+    _infer_media_type_from_url,
     convert_url_to_base64,
 )
 
@@ -37,9 +39,7 @@ def test_completion_with_invalid_image_url(monkeypatch):
         }
     ]
     with pytest.raises(litellm.ImageFetchError) as excinfo:
-        litellm.completion(
-            model="gemini/gemini-pro", messages=messages, api_key="test"
-        )
+        litellm.completion(model="gemini/gemini-pro", messages=messages, api_key="test")
     assert excinfo.value.status_code == 400
     assert "Unable to fetch image" in str(excinfo.value)
 
@@ -81,7 +81,7 @@ class StreamingLargeImageClient:
         headers = {"Content-Type": "image/jpeg"}
         if self.include_content_length:
             headers["Content-Length"] = str(size_bytes)
-        
+
         # Create a generator that yields chunks without creating the whole file in memory
         def generate_chunks(total_size, chunk_size=8192):
             bytes_sent = 0
@@ -89,7 +89,7 @@ class StreamingLargeImageClient:
                 chunk = b"x" * min(chunk_size, total_size - bytes_sent)
                 bytes_sent += len(chunk)
                 yield chunk
-        
+
         # Create response with streaming content
         response = Response(
             status_code=200,
@@ -97,7 +97,9 @@ class StreamingLargeImageClient:
             request=Request("GET", url),
         )
         # Mock the iter_bytes method to return our generator
-        response.iter_bytes = lambda chunk_size=8192: generate_chunks(size_bytes, chunk_size)
+        response.iter_bytes = lambda chunk_size=8192: generate_chunks(
+            size_bytes, chunk_size
+        )
         return response
 
 
@@ -121,7 +123,9 @@ def test_image_exceeds_size_limit_without_content_length(monkeypatch):
     This uses the old non-streaming mock for backward compatibility.
     """
     monkeypatch.setattr(
-        litellm, "module_level_client", LargeImageClient(size_mb=100, include_content_length=False)
+        litellm,
+        "module_level_client",
+        LargeImageClient(size_mb=100, include_content_length=False),
     )
 
     with pytest.raises(litellm.ImageFetchError) as excinfo:
@@ -134,7 +138,7 @@ def test_streaming_download_protects_against_huge_files(monkeypatch):
     """
     Test that streaming download aborts early when file exceeds size limit,
     preventing memory exhaustion from huge files (e.g., petabyte-sized files).
-    
+
     This test verifies that the streaming implementation doesn't download the entire
     file into memory before checking size. Instead, it should abort as soon as the
     limit is exceeded during streaming.
@@ -148,7 +152,7 @@ def test_streaming_download_protects_against_huge_files(monkeypatch):
 
     # Verify the error message shows it was caught during streaming
     assert "exceeds maximum allowed size" in str(excinfo.value)
-    
+
     # The error should be raised after downloading just slightly more than the limit
     # not after downloading the full 1GB
 
@@ -187,13 +191,15 @@ def test_streaming_download_handles_petabyte_file(monkeypatch):
     """
     Test that streaming download can handle extremely large file URLs (e.g., petabyte-sized)
     without attempting to download the entire file or causing memory exhaustion.
-    
+
     This simulates what happens if a malicious actor or misconfiguration provides
     a URL to an extremely large file.
     """
     # Simulate a 1 petabyte file (1,000,000 GB)
     # Without streaming protection, this would cause OOM or hang indefinitely
-    client = StreamingLargeImageClient(size_mb=1_000_000_000, include_content_length=False)
+    client = StreamingLargeImageClient(
+        size_mb=1_000_000_000, include_content_length=False
+    )
     monkeypatch.setattr(litellm, "module_level_client", client)
 
     with pytest.raises(litellm.ImageFetchError) as excinfo:
@@ -214,6 +220,205 @@ def test_image_size_limit_disabled(monkeypatch):
 
     with pytest.raises(litellm.ImageFetchError) as excinfo:
         convert_url_to_base64("https://example.com/image.jpg")
-    
+
     assert "Image URL download is disabled" in str(excinfo.value)
     assert "MAX_IMAGE_URL_DOWNLOAD_SIZE_MB=0" in str(excinfo.value)
+
+
+# ============================================================================
+# Tests for Content-Type handling and URL extension inference
+# ============================================================================
+
+
+class TestInferMediaTypeFromUrl:
+    """Tests for _infer_media_type_from_url function."""
+
+    def test_simple_png_url(self):
+        """Test simple PNG URL."""
+        result = _infer_media_type_from_url("https://example.com/image.png")
+        assert result == "image/png"
+
+    def test_simple_jpeg_url(self):
+        """Test simple JPEG URL with .jpeg extension."""
+        result = _infer_media_type_from_url("https://example.com/photo.jpeg")
+        assert result == "image/jpeg"
+
+    def test_jpg_extension(self):
+        """Test JPG extension maps to image/jpeg."""
+        result = _infer_media_type_from_url("https://example.com/photo.jpg")
+        assert result == "image/jpeg"
+
+    def test_gif_url(self):
+        """Test GIF URL."""
+        result = _infer_media_type_from_url("https://example.com/animation.gif")
+        assert result == "image/gif"
+
+    def test_webp_url(self):
+        """Test WebP URL."""
+        result = _infer_media_type_from_url("https://example.com/image.webp")
+        assert result == "image/webp"
+
+    def test_signed_url_with_query_params(self):
+        """Test signed URL (e.g., Aliyun OSS, AWS S3) with query parameters."""
+        result = _infer_media_type_from_url(
+            "https://bucket.oss-cn-hangzhou.aliyuncs.com/image.png"
+            "?Expires=1699999999&OSSAccessKeyId=LTAI5xxx&Signature=xxx"
+        )
+        assert result == "image/png"
+
+    def test_signed_url_complex_query(self):
+        """Test signed URL with complex query string."""
+        result = _infer_media_type_from_url(
+            "https://s3.amazonaws.com/bucket/photos/sunset.jpg"
+            "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=xxx"
+        )
+        assert result == "image/jpeg"
+
+    def test_unsupported_extension_raises(self):
+        """Test that unsupported extension raises an exception."""
+        with pytest.raises(Exception) as excinfo:
+            _infer_media_type_from_url("https://example.com/document.pdf")
+        assert "Unsupported image format" in str(excinfo.value)
+        assert "pdf" in str(excinfo.value)
+
+    def test_case_insensitive_extension(self):
+        """Test that extension matching is case-insensitive."""
+        result = _infer_media_type_from_url("https://example.com/IMAGE.PNG")
+        assert result == "image/png"
+
+
+class TestGetValidMediaType:
+    """Tests for _get_valid_media_type function."""
+
+    def test_valid_content_type_image_png(self):
+        """Test valid Content-Type is returned directly."""
+        result = _get_valid_media_type("image/png", "https://example.com/image.png")
+        assert result == "image/png"
+
+    def test_valid_content_type_image_jpeg(self):
+        """Test valid JPEG Content-Type."""
+        result = _get_valid_media_type("image/jpeg", "https://example.com/image.jpg")
+        assert result == "image/jpeg"
+
+    def test_content_type_with_charset_parameter(self):
+        """Test Content-Type with charset parameter is stripped."""
+        result = _get_valid_media_type(
+            "image/png; charset=utf-8", "https://example.com/image.png"
+        )
+        assert result == "image/png"
+
+    def test_content_type_with_boundary_parameter(self):
+        """Test Content-Type with boundary parameter is stripped."""
+        result = _get_valid_media_type(
+            "image/jpeg; boundary=something", "https://example.com/image.jpg"
+        )
+        assert result == "image/jpeg"
+
+    def test_invalid_content_type_application_octet_stream(self):
+        """Test that application/octet-stream falls back to URL extension."""
+        result = _get_valid_media_type(
+            "application/octet-stream", "https://example.com/image.png"
+        )
+        assert result == "image/png"
+
+    def test_invalid_content_type_urlencoded(self):
+        """
+        Test that application/x-www-form-urlencoded falls back to URL extension.
+        This is a real-world case from Aliyun OSS CDN returning wrong Content-Type.
+        """
+        result = _get_valid_media_type(
+            "application/x-www-form-urlencoded",
+            "https://bucket.oss-cn-hangzhou.aliyuncs.com/image.png"
+            "?Expires=1699999999&Signature=xxx",
+        )
+        assert result == "image/png"
+
+    def test_invalid_content_type_text_html(self):
+        """Test that text/html falls back to URL extension."""
+        result = _get_valid_media_type("text/html", "https://example.com/image.webp")
+        assert result == "image/webp"
+
+    def test_none_content_type(self):
+        """Test that None Content-Type falls back to URL extension."""
+        result = _get_valid_media_type(None, "https://example.com/photo.jpeg")
+        assert result == "image/jpeg"
+
+    def test_empty_content_type_after_strip(self):
+        """Test edge case where Content-Type is empty after stripping."""
+        result = _get_valid_media_type(
+            "; charset=utf-8", "https://example.com/image.gif"
+        )
+        assert result == "image/gif"
+
+
+class InvalidContentTypeClient:
+    """Client that returns an invalid Content-Type."""
+
+    def __init__(self, content_type: str):
+        self.content_type = content_type
+
+    def get(self, url, follow_redirects=True):
+        size_bytes = 1024
+        headers = {
+            "Content-Type": self.content_type,
+            "Content-Length": str(size_bytes),
+        }
+        return Response(
+            status_code=200,
+            headers=headers,
+            content=b"x" * size_bytes,
+            request=Request("GET", url),
+        )
+
+
+def test_convert_url_handles_invalid_content_type(monkeypatch):
+    """
+    Integration test: convert_url_to_base64 handles invalid Content-Type.
+
+    Simulates Aliyun OSS CDN returning application/x-www-form-urlencoded for a .png file.
+    """
+    monkeypatch.setattr(
+        litellm,
+        "module_level_client",
+        InvalidContentTypeClient("application/x-www-form-urlencoded"),
+    )
+
+    result = convert_url_to_base64(
+        "https://bucket.oss-cn-hangzhou.aliyuncs.com/image.png?Expires=xxx"
+    )
+
+    assert result.startswith("data:image/png;base64,")
+
+
+def test_convert_url_handles_content_type_with_params(monkeypatch):
+    """
+    Integration test: convert_url_to_base64 handles Content-Type with parameters.
+
+    Tests that 'image/png; charset=utf-8' is properly stripped to 'image/png'.
+    """
+    monkeypatch.setattr(
+        litellm,
+        "module_level_client",
+        InvalidContentTypeClient("image/png; charset=utf-8"),
+    )
+
+    result = convert_url_to_base64("https://example.com/image.png")
+
+    assert result.startswith("data:image/png;base64,")
+
+
+def test_convert_url_handles_application_octet_stream(monkeypatch):
+    """
+    Integration test: convert_url_to_base64 handles application/octet-stream.
+
+    Some servers return application/octet-stream for binary files including images.
+    """
+    monkeypatch.setattr(
+        litellm,
+        "module_level_client",
+        InvalidContentTypeClient("application/octet-stream"),
+    )
+
+    result = convert_url_to_base64("https://example.com/photo.jpeg")
+
+    assert result.startswith("data:image/jpeg;base64,")

--- a/tests/test_litellm/litellm_core_utils/test_image_handling.py
+++ b/tests/test_litellm/litellm_core_utils/test_image_handling.py
@@ -275,8 +275,8 @@ class TestInferMediaTypeFromUrl:
         assert result == "image/jpeg"
 
     def test_unsupported_extension_raises(self):
-        """Test that unsupported extension raises an exception."""
-        with pytest.raises(Exception) as excinfo:
+        """Test that unsupported extension raises ImageFetchError."""
+        with pytest.raises(litellm.ImageFetchError) as excinfo:
             _infer_media_type_from_url("https://example.com/document.pdf")
         assert "Unsupported image format" in str(excinfo.value)
         assert "pdf" in str(excinfo.value)
@@ -287,9 +287,9 @@ class TestInferMediaTypeFromUrl:
         assert result == "image/png"
 
     def test_url_without_extension_raises_with_clear_message(self):
-        """Test that URL without extension raises an exception with a clear message."""
+        """Test that URL without extension raises ImageFetchError with a clear message."""
         url = "https://cdn.example.com/images/abc123"
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(litellm.ImageFetchError) as excinfo:
             _infer_media_type_from_url(url)
         error_msg = str(excinfo.value)
         assert "Unsupported image format" in error_msg
@@ -298,18 +298,18 @@ class TestInferMediaTypeFromUrl:
         assert "Supported types" in error_msg
 
     def test_url_with_trailing_slash_no_extension(self):
-        """Test URL with trailing slash and no extension."""
+        """Test URL with trailing slash and no extension raises ImageFetchError."""
         url = "https://cdn.example.com/images/abc123/"
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(litellm.ImageFetchError) as excinfo:
             _infer_media_type_from_url(url)
         error_msg = str(excinfo.value)
         assert "Unsupported image format" in error_msg
         assert url in error_msg
 
     def test_url_with_dots_in_path_but_no_image_extension(self):
-        """Test URL with dots in path segments but no valid image extension."""
+        """Test URL with dots in path segments but no valid image extension raises ImageFetchError."""
         url = "https://api.example.com/v1.0/images/get"
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(litellm.ImageFetchError) as excinfo:
             _infer_media_type_from_url(url)
         error_msg = str(excinfo.value)
         assert "Unsupported image format" in error_msg

--- a/tests/test_litellm/litellm_core_utils/test_image_handling.py
+++ b/tests/test_litellm/litellm_core_utils/test_image_handling.py
@@ -286,6 +286,36 @@ class TestInferMediaTypeFromUrl:
         result = _infer_media_type_from_url("https://example.com/IMAGE.PNG")
         assert result == "image/png"
 
+    def test_url_without_extension_raises_with_clear_message(self):
+        """Test that URL without extension raises an exception with a clear message."""
+        url = "https://cdn.example.com/images/abc123"
+        with pytest.raises(Exception) as excinfo:
+            _infer_media_type_from_url(url)
+        error_msg = str(excinfo.value)
+        assert "Unsupported image format" in error_msg
+        # Should show the full URL for clarity, not just a confusing "extension"
+        assert url in error_msg
+        assert "Supported types" in error_msg
+
+    def test_url_with_trailing_slash_no_extension(self):
+        """Test URL with trailing slash and no extension."""
+        url = "https://cdn.example.com/images/abc123/"
+        with pytest.raises(Exception) as excinfo:
+            _infer_media_type_from_url(url)
+        error_msg = str(excinfo.value)
+        assert "Unsupported image format" in error_msg
+        assert url in error_msg
+
+    def test_url_with_dots_in_path_but_no_image_extension(self):
+        """Test URL with dots in path segments but no valid image extension."""
+        url = "https://api.example.com/v1.0/images/get"
+        with pytest.raises(Exception) as excinfo:
+            _infer_media_type_from_url(url)
+        error_msg = str(excinfo.value)
+        assert "Unsupported image format" in error_msg
+        # Should not confuse "0" from "v1.0" as the extension
+        assert url in error_msg
+
 
 class TestGetValidMediaType:
     """Tests for _get_valid_media_type function."""

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_anthropic_image_url_handling.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_anthropic_image_url_handling.py
@@ -392,10 +392,10 @@ class TestVertexAIAnthropicPassThroughImageURLHandling:
     """
 
     @patch(
-        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_to_anthropic_image_obj"
     )
     def test_vertex_ai_messages_converts_image_url_to_base64(
-        self, mock_convert_url: MagicMock
+        self, mock_convert_obj: MagicMock
     ):
         """
         Test that the /v1/messages endpoint converts image URLs to base64 for Vertex AI.
@@ -403,9 +403,11 @@ class TestVertexAIAnthropicPassThroughImageURLHandling:
         When using Anthropic native format with URL source type,
         Vertex AI should convert it to base64.
         """
-        mock_convert_url.return_value = (
-            "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQ=="
-        )
+        mock_convert_obj.return_value = {
+            "type": "base64",
+            "media_type": "image/jpeg",
+            "data": "/9j/4AAQSkZJRgABAQAAAQ==",
+        }
 
         messages = [
             {
@@ -426,8 +428,10 @@ class TestVertexAIAnthropicPassThroughImageURLHandling:
         config = VertexAIPartnerModelsAnthropicMessagesConfig()
         converted = config._convert_image_urls_to_base64(messages)
 
-        # Verify convert_url_to_base64 was called
-        mock_convert_url.assert_called_once_with(url="https://example.com/image.jpg")
+        # Verify convert_to_anthropic_image_obj was called
+        mock_convert_obj.assert_called_once_with(
+            openai_image_url="https://example.com/image.jpg", format=None
+        )
 
         # Check the result has base64 source type
         user_message = converted[0]
@@ -439,7 +443,7 @@ class TestVertexAIAnthropicPassThroughImageURLHandling:
         assert image_content["source"]["data"] == "/9j/4AAQSkZJRgABAQAAAQ=="
 
     @patch(
-        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_to_anthropic_image_obj"
     )
     def test_vertex_ai_messages_preserves_base64_images(
         self, mock_convert_url: MagicMock
@@ -477,17 +481,19 @@ class TestVertexAIAnthropicPassThroughImageURLHandling:
         assert image_content["source"]["data"] == "iVBORw0KGgo="
 
     @patch(
-        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_to_anthropic_image_obj"
     )
     def test_vertex_ai_messages_preserves_cache_control(
-        self, mock_convert_url: MagicMock
+        self, mock_convert_obj: MagicMock
     ):
         """
         Test that cache_control is preserved when converting image URLs.
         """
-        mock_convert_url.return_value = (
-            "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQ=="
-        )
+        mock_convert_obj.return_value = {
+            "type": "base64",
+            "media_type": "image/jpeg",
+            "data": "/9j/4AAQSkZJRgABAQAAAQ==",
+        }
 
         messages = [
             {
@@ -514,7 +520,7 @@ class TestVertexAIAnthropicPassThroughImageURLHandling:
         assert image_content["cache_control"] == {"type": "ephemeral"}
 
     @patch(
-        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_to_anthropic_image_obj"
     )
     def test_vertex_ai_messages_handles_text_only_messages(
         self, mock_convert_url: MagicMock
@@ -542,7 +548,7 @@ class TestVertexAIAnthropicPassThroughImageURLHandling:
         assert converted[0]["content"][0]["text"] == "Hello, how are you?"
 
     @patch(
-        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_to_anthropic_image_obj"
     )
     def test_vertex_ai_messages_handles_string_content(
         self, mock_convert_url: MagicMock
@@ -567,17 +573,17 @@ class TestVertexAIAnthropicPassThroughImageURLHandling:
         assert converted[0]["content"] == "Hello, how are you?"
 
     @patch(
-        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_to_anthropic_image_obj"
     )
     def test_vertex_ai_messages_converts_multiple_images(
-        self, mock_convert_url: MagicMock
+        self, mock_convert_obj: MagicMock
     ):
         """
         Test that multiple image URLs in a message are all converted.
         """
-        mock_convert_url.side_effect = [
-            "data:image/jpeg;base64,/9j/image1",
-            "data:image/png;base64,iVBORw0image2",
+        mock_convert_obj.side_effect = [
+            {"type": "base64", "media_type": "image/jpeg", "data": "/9j/image1"},
+            {"type": "base64", "media_type": "image/png", "data": "iVBORw0image2"},
         ]
 
         messages = [
@@ -607,7 +613,7 @@ class TestVertexAIAnthropicPassThroughImageURLHandling:
         converted = config._convert_image_urls_to_base64(messages)
 
         # Verify both URLs were converted
-        assert mock_convert_url.call_count == 2
+        assert mock_convert_obj.call_count == 2
 
         # Check both images are converted to base64
         image1 = converted[0]["content"][1]

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_anthropic_image_url_handling.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_anthropic_image_url_handling.py
@@ -625,3 +625,219 @@ class TestVertexAIAnthropicPassThroughImageURLHandling:
         assert image2["source"]["type"] == "base64"
         assert image2["source"]["media_type"] == "image/png"
         assert image2["source"]["data"] == "iVBORw0image2"
+
+
+class TestVertexAIAnthropicPassThroughImageURLHandlingAsync:
+    """
+    Test the async version of image URL to base64 conversion for /v1/messages endpoint.
+
+    Issue: https://github.com/BerriAI/litellm/issues/23026
+    The sync version blocks the event loop. The async version uses async_convert_url_to_base64.
+    """
+
+    @patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.async_convert_url_to_base64"
+    )
+    def test_async_convert_image_urls_to_base64(self, mock_async_convert: MagicMock):
+        """
+        Test that the async version correctly converts image URLs to base64.
+        """
+        import asyncio
+
+        async def async_mock_return(url):
+            return "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQ=="
+
+        mock_async_convert.side_effect = async_mock_return
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "url",
+                            "url": "https://example.com/image.jpg",
+                        },
+                    },
+                ],
+            }
+        ]
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        converted = asyncio.run(config._convert_image_urls_to_base64_async(messages))
+
+        # Verify async_convert_url_to_base64 was called
+        mock_async_convert.assert_called_once_with("https://example.com/image.jpg")
+
+        # Check the result has base64 source type
+        user_message = converted[0]
+        assert user_message["role"] == "user"
+        image_content = user_message["content"][1]
+        assert image_content["type"] == "image"
+        assert image_content["source"]["type"] == "base64"
+        assert image_content["source"]["media_type"] == "image/jpeg"
+        assert image_content["source"]["data"] == "/9j/4AAQSkZJRgABAQAAAQ=="
+
+    @patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.async_convert_url_to_base64"
+    )
+    def test_async_preserves_base64_images(self, mock_async_convert: MagicMock):
+        """
+        Test that async version preserves images already in base64 format.
+        """
+        import asyncio
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "iVBORw0KGgo=",
+                        },
+                    },
+                ],
+            }
+        ]
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        converted = asyncio.run(config._convert_image_urls_to_base64_async(messages))
+
+        # async_convert_url_to_base64 should NOT be called for base64 images
+        mock_async_convert.assert_not_called()
+
+        # Check the image is unchanged
+        image_content = converted[0]["content"][1]
+        assert image_content["source"]["type"] == "base64"
+        assert image_content["source"]["media_type"] == "image/png"
+        assert image_content["source"]["data"] == "iVBORw0KGgo="
+
+    @patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.async_convert_url_to_base64"
+    )
+    def test_async_preserves_cache_control(self, mock_async_convert: MagicMock):
+        """
+        Test that async version preserves cache_control when converting image URLs.
+        """
+        import asyncio
+
+        async def async_mock_return(url):
+            return "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQ=="
+
+        mock_async_convert.side_effect = async_mock_return
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "url",
+                            "url": "https://example.com/image.jpg",
+                        },
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                ],
+            }
+        ]
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        converted = asyncio.run(config._convert_image_urls_to_base64_async(messages))
+
+        # Check cache_control is preserved
+        image_content = converted[0]["content"][0]
+        assert image_content["source"]["type"] == "base64"
+        assert image_content["cache_control"] == {"type": "ephemeral"}
+
+    @patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.async_convert_url_to_base64"
+    )
+    def test_async_converts_multiple_images(self, mock_async_convert: MagicMock):
+        """
+        Test that async version converts multiple image URLs in a message.
+        """
+        import asyncio
+
+        call_count = [0]
+        async def async_mock_return(url):
+            results = [
+                "data:image/jpeg;base64,/9j/image1",
+                "data:image/png;base64,iVBORw0image2",
+            ]
+            result = results[call_count[0]]
+            call_count[0] += 1
+            return result
+
+        mock_async_convert.side_effect = async_mock_return
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Compare these images"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "url",
+                            "url": "https://example.com/image1.jpg",
+                        },
+                    },
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "url",
+                            "url": "https://example.com/image2.png",
+                        },
+                    },
+                ],
+            }
+        ]
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        converted = asyncio.run(config._convert_image_urls_to_base64_async(messages))
+
+        # Verify both URLs were converted
+        assert mock_async_convert.call_count == 2
+
+        # Check both images are converted to base64
+        image1 = converted[0]["content"][1]
+        assert image1["source"]["type"] == "base64"
+        assert image1["source"]["media_type"] == "image/jpeg"
+        assert image1["source"]["data"] == "/9j/image1"
+
+        image2 = converted[0]["content"][2]
+        assert image2["source"]["type"] == "base64"
+        assert image2["source"]["media_type"] == "image/png"
+        assert image2["source"]["data"] == "iVBORw0image2"
+
+    @patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.async_convert_url_to_base64"
+    )
+    def test_async_handles_string_content(self, mock_async_convert: MagicMock):
+        """
+        Test that async version handles messages with string content correctly.
+        """
+        import asyncio
+
+        messages = [
+            {
+                "role": "user",
+                "content": "Hello, how are you?",
+            }
+        ]
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        converted = asyncio.run(config._convert_image_urls_to_base64_async(messages))
+
+        # async_convert_url_to_base64 should NOT be called for string content
+        mock_async_convert.assert_not_called()
+
+        # Check the message is unchanged
+        assert converted[0]["content"] == "Hello, how are you?"

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_anthropic_image_url_handling.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_anthropic_image_url_handling.py
@@ -4,7 +4,11 @@ Tests for Vertex AI Anthropic image URL handling.
 Issue: https://github.com/BerriAI/litellm/issues/18430
 Vertex AI Anthropic models don't support URL sources for images.
 LiteLLM should convert image URLs to base64 when using Vertex AI Anthropic.
+
+Issue: https://github.com/BerriAI/litellm/issues/23016
+/v1/messages endpoint with Vertex AI Anthropic should also convert image URLs to base64.
 """
+
 import os
 import sys
 from unittest.mock import patch, MagicMock
@@ -19,6 +23,9 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     anthropic_messages_pt,
     convert_to_anthropic_tool_result,
     create_anthropic_image_param,
+)
+from litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation import (
+    VertexAIPartnerModelsAnthropicMessagesConfig,
 )
 
 
@@ -35,7 +42,9 @@ class TestVertexAIAnthropicImageURLHandling:
         For regular Anthropic, HTTPS URLs are passed through as URL type.
         For Vertex AI Anthropic, HTTPS URLs should be converted to base64.
         """
-        mock_convert_url.return_value = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQ=="
+        mock_convert_url.return_value = (
+            "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQ=="
+        )
 
         messages = [
             {
@@ -108,9 +117,7 @@ class TestVertexAIAnthropicImageURLHandling:
         assert image_content["source"]["url"] == "https://example.com/image.jpg"
 
     @patch("litellm.litellm_core_utils.prompt_templates.factory.convert_url_to_base64")
-    def test_vertex_ai_beta_also_converts_to_base64(
-        self, mock_convert_url: MagicMock
-    ):
+    def test_vertex_ai_beta_also_converts_to_base64(self, mock_convert_url: MagicMock):
         """
         Test that vertex_ai_beta provider also converts image URLs to base64.
         """
@@ -210,7 +217,9 @@ class TestToolMessageImageURLHandling:
 
         result = convert_to_anthropic_tool_result(tool_message, force_base64=True)
 
-        mock_convert_url.assert_called_once_with(url="https://example.com/tool_result.jpg")
+        mock_convert_url.assert_called_once_with(
+            url="https://example.com/tool_result.jpg"
+        )
         assert result["type"] == "tool_result"
         assert result["tool_use_id"] == "call_123"
 
@@ -303,7 +312,10 @@ class TestToolMessageImageURLHandling:
         for msg in result:
             if msg.get("role") == "user":
                 for content_item in msg.get("content", []):
-                    if isinstance(content_item, dict) and content_item.get("type") == "tool_result":
+                    if (
+                        isinstance(content_item, dict)
+                        and content_item.get("type") == "tool_result"
+                    ):
                         tool_content = content_item.get("content", [])
                         for item in tool_content:
                             if isinstance(item, dict) and item.get("type") == "image":
@@ -312,9 +324,7 @@ class TestToolMessageImageURLHandling:
         pytest.fail("Could not find image in tool result")
 
     @patch("litellm.litellm_core_utils.prompt_templates.factory.convert_url_to_base64")
-    def test_regular_anthropic_tool_message_uses_url(
-        self, mock_convert_url: MagicMock
-    ):
+    def test_regular_anthropic_tool_message_uses_url(self, mock_convert_url: MagicMock):
         """
         Test that regular Anthropic API uses URL type for tool result images.
         """
@@ -362,10 +372,250 @@ class TestToolMessageImageURLHandling:
         for msg in result:
             if msg.get("role") == "user":
                 for content_item in msg.get("content", []):
-                    if isinstance(content_item, dict) and content_item.get("type") == "tool_result":
+                    if (
+                        isinstance(content_item, dict)
+                        and content_item.get("type") == "tool_result"
+                    ):
                         tool_content = content_item.get("content", [])
                         for item in tool_content:
                             if isinstance(item, dict) and item.get("type") == "image":
                                 assert item["source"]["type"] == "url"
                                 return
         pytest.fail("Could not find image in tool result")
+
+
+class TestVertexAIAnthropicPassThroughImageURLHandling:
+    """
+    Test that /v1/messages endpoint (pass-through) converts image URLs to base64 for Vertex AI.
+
+    Issue: https://github.com/BerriAI/litellm/issues/23016
+    """
+
+    @patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+    )
+    def test_vertex_ai_messages_converts_image_url_to_base64(
+        self, mock_convert_url: MagicMock
+    ):
+        """
+        Test that the /v1/messages endpoint converts image URLs to base64 for Vertex AI.
+
+        When using Anthropic native format with URL source type,
+        Vertex AI should convert it to base64.
+        """
+        mock_convert_url.return_value = (
+            "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQ=="
+        )
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "url",
+                            "url": "https://example.com/image.jpg",
+                        },
+                    },
+                ],
+            }
+        ]
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        converted = config._convert_image_urls_to_base64(messages)
+
+        # Verify convert_url_to_base64 was called
+        mock_convert_url.assert_called_once_with(url="https://example.com/image.jpg")
+
+        # Check the result has base64 source type
+        user_message = converted[0]
+        assert user_message["role"] == "user"
+        image_content = user_message["content"][1]
+        assert image_content["type"] == "image"
+        assert image_content["source"]["type"] == "base64"
+        assert image_content["source"]["media_type"] == "image/jpeg"
+        assert image_content["source"]["data"] == "/9j/4AAQSkZJRgABAQAAAQ=="
+
+    @patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+    )
+    def test_vertex_ai_messages_preserves_base64_images(
+        self, mock_convert_url: MagicMock
+    ):
+        """
+        Test that images already in base64 format are not modified.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "iVBORw0KGgo=",
+                        },
+                    },
+                ],
+            }
+        ]
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        converted = config._convert_image_urls_to_base64(messages)
+
+        # convert_url_to_base64 should NOT be called for base64 images
+        mock_convert_url.assert_not_called()
+
+        # Check the image is unchanged
+        image_content = converted[0]["content"][1]
+        assert image_content["source"]["type"] == "base64"
+        assert image_content["source"]["media_type"] == "image/png"
+        assert image_content["source"]["data"] == "iVBORw0KGgo="
+
+    @patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+    )
+    def test_vertex_ai_messages_preserves_cache_control(
+        self, mock_convert_url: MagicMock
+    ):
+        """
+        Test that cache_control is preserved when converting image URLs.
+        """
+        mock_convert_url.return_value = (
+            "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQ=="
+        )
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "url",
+                            "url": "https://example.com/image.jpg",
+                        },
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                ],
+            }
+        ]
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        converted = config._convert_image_urls_to_base64(messages)
+
+        # Check cache_control is preserved
+        image_content = converted[0]["content"][0]
+        assert image_content["source"]["type"] == "base64"
+        assert image_content["cache_control"] == {"type": "ephemeral"}
+
+    @patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+    )
+    def test_vertex_ai_messages_handles_text_only_messages(
+        self, mock_convert_url: MagicMock
+    ):
+        """
+        Test that text-only messages are handled correctly.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello, how are you?"},
+                ],
+            }
+        ]
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        converted = config._convert_image_urls_to_base64(messages)
+
+        # convert_url_to_base64 should NOT be called for text-only messages
+        mock_convert_url.assert_not_called()
+
+        # Check the message is unchanged
+        assert converted[0]["content"][0]["type"] == "text"
+        assert converted[0]["content"][0]["text"] == "Hello, how are you?"
+
+    @patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+    )
+    def test_vertex_ai_messages_handles_string_content(
+        self, mock_convert_url: MagicMock
+    ):
+        """
+        Test that messages with string content are handled correctly.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": "Hello, how are you?",
+            }
+        ]
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        converted = config._convert_image_urls_to_base64(messages)
+
+        # convert_url_to_base64 should NOT be called for string content
+        mock_convert_url.assert_not_called()
+
+        # Check the message is unchanged
+        assert converted[0]["content"] == "Hello, how are you?"
+
+    @patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation.convert_url_to_base64"
+    )
+    def test_vertex_ai_messages_converts_multiple_images(
+        self, mock_convert_url: MagicMock
+    ):
+        """
+        Test that multiple image URLs in a message are all converted.
+        """
+        mock_convert_url.side_effect = [
+            "data:image/jpeg;base64,/9j/image1",
+            "data:image/png;base64,iVBORw0image2",
+        ]
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Compare these images"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "url",
+                            "url": "https://example.com/image1.jpg",
+                        },
+                    },
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "url",
+                            "url": "https://example.com/image2.png",
+                        },
+                    },
+                ],
+            }
+        ]
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        converted = config._convert_image_urls_to_base64(messages)
+
+        # Verify both URLs were converted
+        assert mock_convert_url.call_count == 2
+
+        # Check both images are converted to base64
+        image1 = converted[0]["content"][1]
+        assert image1["source"]["type"] == "base64"
+        assert image1["source"]["media_type"] == "image/jpeg"
+        assert image1["source"]["data"] == "/9j/image1"
+
+        image2 = converted[0]["content"][2]
+        assert image2["source"]["type"] == "base64"
+        assert image2["source"]["media_type"] == "image/png"
+        assert image2["source"]["data"] == "iVBORw0image2"


### PR DESCRIPTION
## Summary
Fixes #23016

## Problem
The `/v1/messages` endpoint with Vertex AI Anthropic returns `URL sources are not supported` error when sending images with URL sources. However, `/v1/chat/completions` works correctly because PR #18497 added URL-to-base64 conversion for that path.

## Root Cause
The `/v1/messages` endpoint uses the `experimental_pass_through` code path which forwards requests directly to Vertex AI without converting image URLs to base64. Since Vertex AI Anthropic doesn't support URL sources for images, this causes the error.

## Solution
Add the same URL-to-base64 conversion logic to the Vertex AI pass-through transformation layer:

1. Add `_convert_image_urls_to_base64()` method to `VertexAIPartnerModelsAnthropicMessagesConfig`
2. Detect Anthropic native image format: `{"type": "image", "source": {"type": "url", ...}}`
3. Convert to base64 format: `{"type": "image", "source": {"type": "base64", "media_type": "...", "data": "..."}}`
4. Call conversion in `transform_anthropic_messages_request()` before forwarding

## Changes
- `litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py`: Add image URL to base64 conversion
- `tests/test_litellm/.../test_vertex_ai_anthropic_image_url_handling.py`: Add 6 new test cases

## Testing
All tests pass:
```
15 passed, 2 warnings in 1.10s
```

New test cases cover:
- Single image URL conversion
- Multiple images conversion
- Preserving existing base64 images
- Preserving cache_control attributes
- Handling text-only messages
- Handling string content