### PR TITLE
fix(presidio): PII token round-trip masking/unmasking for Anthropic native API

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -901,6 +901,8 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         if self.output_parse_pii is False and litellm.output_parse_pii is False:
             return response
 
+        # Prefer pii_tokens from request_data (stored by pre_call masking instance).
+        _pii_tokens = data.get("pii_tokens") or self.pii_tokens
         if isinstance(response, ModelResponse) and not isinstance(
             response.choices[0], StreamingChoices
         ):  # /chat/completions requests
@@ -909,6 +911,14 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 request_data=data,
                 mode="unmask",
             )
+        elif (
+            isinstance(response, dict)
+            and response.get("type") == "message"
+            and response.get("role") == "assistant"
+        ):  # Anthropic native /v1/messages response (AnthropicMessagesResponse TypedDict)
+            for block in response.get("content") or []:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    block["text"] = self._unmask_pii_text(block.get("text", ""), _pii_tokens)
         return response
 
     @staticmethod

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -426,7 +426,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         analyze_results: Any,
         output_parse_pii: bool,
         masked_entity_count: Dict[str, int],
-        request_data: Optional[Dict] = None,
     ) -> str:
         """
         Send analysis results to the Presidio anonymizer endpoint to get redacted text
@@ -472,34 +471,52 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
                     redacted_text = await response.json()
 
-            new_text = text
             if redacted_text is not None:
                 verbose_proxy_logger.debug("redacted_text: %s", redacted_text)
-                for item in redacted_text["items"]:
+                new_text = redacted_text["text"]
+                # Sort analyze_results right-to-left (Presidio processes entities
+                # right-to-left, so redacted_text["items"] is also right-to-left).
+                # We match by entity_type to get the original text positions from
+                # the Analyzer response, not the Anonymizer response (which returns
+                # positions in the *anonymized* text's coordinate space).
+                def _ar_val(ar, key, default=None):
+                    return ar.get(key, default) if isinstance(ar, dict) else getattr(ar, key, default)
+                _sorted_ar = sorted(
+                    analyze_results if isinstance(analyze_results, list) else [],
+                    key=lambda x: -(_ar_val(x, "start") or 0),
+                )
+                _ar_used: set = set()
+                # Sort items right-to-left so position offsets remain valid
+                # after each in-place substitution, and so the consumption
+                # order of _sorted_ar matches item order for correct pairing.
+                _sorted_items = sorted(
+                    redacted_text["items"],
+                    key=lambda x: -(x.get("start") or 0),
+                )
+                for item in _sorted_items:
                     start = item["start"]
                     end = item["end"]
                     replacement = item["text"]  # replacement token
                     if item["operator"] == "replace" and output_parse_pii is True:
-                        # check if token in dict
-                        # if exists, add a uuid to the replacement token for swapping back to the original text in llm response output parsing
-                        if request_data is None:
-                            verbose_proxy_logger.warning(
-                                "Presidio anonymize_text called without request_data — "
-                                "PII tokens cannot be stored per-request. "
-                                "This may indicate a missing caller update."
-                            )
-                            request_data = {}
-                        if "pii_tokens" not in request_data:
-                            request_data["pii_tokens"] = {}
-                        pii_tokens = request_data["pii_tokens"]
-
-                        # Always append a UUID to ensure the replacement token is unique to this request and session.
-                        # This prevents collisions where the LLM might hallucinate a generic token like [PHONE_NUMBER].
+                        # Always append UUID to ensure uniqueness — prevents
+                        # str.replace() collisions when multiple entities share
+                        # the same type (e.g. two <PHONE_NUMBER> tokens).
                         replacement = f"{replacement}_{str(uuid.uuid4())[:12]}"
 
-                        pii_tokens[replacement] = new_text[
-                            start:end
-                        ]  # get text it'll replace
+                        # Use analyze_results (original text positions) to look
+                        # up the original value. Both _sorted_ar and _sorted_items
+                        # are right-to-left, so consuming _sorted_ar in order
+                        # correctly pairs each item with its analyze_results entry.
+                        _orig_val = None
+                        for _ar_i, _ar in enumerate(_sorted_ar):
+                            if _ar_i not in _ar_used and _ar_val(_ar, "entity_type") == item.get("entity_type"):
+                                _s = _ar_val(_ar, "start")
+                                _e = _ar_val(_ar, "end")
+                                if _s is not None and _e is not None:
+                                    _orig_val = text[_s:_e]
+                                _ar_used.add(_ar_i)
+                                break
+                        self.pii_tokens[replacement] = _orig_val if _orig_val is not None else new_text[start:end]
 
                     new_text = new_text[:start] + replacement + new_text[end:]
                     entity_type = item.get("entity_type", None)
@@ -507,12 +524,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         masked_entity_count[entity_type] = (
                             masked_entity_count.get(entity_type, 0) + 1
                         )
-                # When output_parse_pii is True, new_text contains UUID-suffixed
-                # tokens that match the keys in pii_tokens.  Returning
-                # redacted_text["text"] (Presidio's original output) would send
-                # un-suffixed tokens to the LLM, making unmasking impossible.
-                # When output_parse_pii is False, new_text == redacted_text["text"]
-                # because no UUID suffix is appended.
                 return new_text
             else:
                 raise Exception("Invalid anonymizer response: received None")
@@ -648,7 +659,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     analyze_results=analyze_results,
                     output_parse_pii=output_parse_pii,
                     masked_entity_count=masked_entity_count,
-                    request_data=request_data,
                 )
                 return anonymized_text
             return redacted_text["text"]

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -10,6 +10,7 @@
 
 import asyncio
 import json
+import json as _json
 import threading
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -1129,17 +1130,106 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 yield chunk
             return
 
+        # Buffer ALL chunks to detect format (bytes = Anthropic native SSE)
+        all_chunks: list = []
+        is_anthropic_native = False
+        async for chunk in response:
+            all_chunks.append(chunk)
+            if isinstance(chunk, bytes) and not is_anthropic_native:
+                is_anthropic_native = True
+
+        if not all_chunks:
+            return
+
+        if is_anthropic_native:
+            # --- Anthropic native SSE unmask path ---
+            try:
+                # 1. Join all bytes into complete SSE stream
+                raw = b"".join(
+                    c if isinstance(c, bytes) else str(c).encode()
+                    for c in all_chunks
+                )
+                sse_text = raw.decode("utf-8", errors="replace")
+
+                # 2. Parse SSE events (double-newline separated)
+                events = sse_text.split("\n\n")
+                parsed = []
+                text_event_indices = []
+                text_fragments = []
+
+                for i, event_str in enumerate(events):
+                    lines = event_str.split("\n")
+                    entry = {"lines": lines, "data": None, "data_idx": None}
+                    for j, line in enumerate(lines):
+                        if line.startswith("data: "):
+                            try:
+                                data = _json.loads(line[6:])
+                                entry["data"] = data
+                                entry["data_idx"] = j
+                                if (data.get("type") == "content_block_delta"
+                                        and data.get("delta", {}).get("type") == "text_delta"):
+                                    text_event_indices.append(i)
+                                    text_fragments.append(data["delta"].get("text", ""))
+                            except (_json.JSONDecodeError, ValueError):
+                                pass
+                    parsed.append(entry)
+
+                # 3. Assemble full text and unmask PII tokens
+                full_text = "".join(text_fragments)
+                unmasked = self._unmask_pii_text(full_text, pii_tokens)
+
+                # 4. If nothing changed, yield original bytes unchanged
+                if unmasked == full_text:
+                    yield raw
+                    return
+
+                # 5. Redistribute unmasked text across original text_delta events
+                n = len(text_event_indices)
+                if n > 0:
+                    chunk_size = max(1, len(unmasked) // n)
+                    pos = 0
+                    for k, evt_idx in enumerate(text_event_indices):
+                        pe = parsed[evt_idx]
+                        if k < n - 1:
+                            fragment = unmasked[pos:pos + chunk_size]
+                            pos += chunk_size
+                        else:
+                            fragment = unmasked[pos:]
+                        pe["data"]["delta"]["text"] = fragment
+                        pe["lines"][pe["data_idx"]] = "data: " + _json.dumps(
+                            pe["data"], ensure_ascii=False
+                        )
+
+                # 6. Rebuild SSE and yield per-event as bytes
+                for pe in parsed:
+                    event_str = "\n".join(pe["lines"])
+                    if event_str.strip():
+                        yield (event_str + "\n\n").encode("utf-8")
+                return
+
+            except Exception as e:
+                verbose_proxy_logger.error(
+                    f"Error in Anthropic SSE PII streaming unmask: {str(e)}"
+                )
+                for c in all_chunks:
+                    yield c
+                return
+
+        # --- OpenAI ModelResponseStream path ---
         remaining_chunks: List[ModelResponseStream] = []
         try:
-            async for chunk in response:
+            for chunk in all_chunks:
                 if isinstance(chunk, ModelResponseStream):
                     remaining_chunks.append(chunk)
 
             if not remaining_chunks:
+                for c in all_chunks:
+                    yield c
                 return
 
             assembled_model_response = stream_chunk_builder(
-                chunks=remaining_chunks, messages=request_data.get("messages")
+                chunks=remaining_chunks,
+                messages=request_data.get("messages") if request_data else None,
             )
 
             if not isinstance(assembled_model_response, ModelResponse):

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -10,7 +10,6 @@
 
 import asyncio
 import json
-import json as _json
 import threading
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -1163,14 +1162,14 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     for j, line in enumerate(lines):
                         if line.startswith("data: "):
                             try:
-                                data = _json.loads(line[6:])
+                                data = json.loads(line[6:])
                                 entry["data"] = data
                                 entry["data_idx"] = j
                                 if (data.get("type") == "content_block_delta"
                                         and data.get("delta", {}).get("type") == "text_delta"):
                                     text_event_indices.append(i)
                                     text_fragments.append(data["delta"].get("text", ""))
-                            except (_json.JSONDecodeError, ValueError):
+                            except (json.JSONDecodeError, ValueError):
                                 pass
                     parsed.append(entry)
 
@@ -1196,7 +1195,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         else:
                             fragment = unmasked[pos:]
                         pe["data"]["delta"]["text"] = fragment
-                        pe["lines"][pe["data_idx"]] = "data: " + _json.dumps(
+                        pe["lines"][pe["data_idx"]] = "data: " + json.dumps(
                             pe["data"], ensure_ascii=False
                         )
 

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1211,6 +1211,14 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             )
             new_texts.append(modified_text)
         inputs["texts"] = new_texts
+        # Strip keys that process_input_messages() converted to OpenAI format.
+        # Returning them overwrites native Anthropic tools with type:"function".
+        for _k in ("tools", "structured_messages", "model", "images"):
+            inputs.pop(_k, None)
+        # Store pii_tokens in request_data — two separate instances are used
+        # (pre_call masking, post_call unmasking) so self.pii_tokens is not shared.
+        if request_data is not None and self.pii_tokens:
+            request_data["pii_tokens"] = dict(self.pii_tokens)
         return inputs
 
     def update_in_memory_litellm_params(self, litellm_params: LitellmParams) -> None:

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -957,10 +957,13 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         Helper to recursively process a ModelResponse for PII.
         Handles all choices and tool calls.
         """
-        pii_tokens = request_data.get("pii_tokens", {}) if request_data else {}
+        pii_tokens = (
+            (request_data.get("pii_tokens") if request_data else None)
+            or self.pii_tokens
+        )
         if not pii_tokens and mode == "unmask":
             verbose_proxy_logger.debug(
-                "No pii_tokens found in request_data — nothing to unmask"
+                "No pii_tokens found in request_data or self.pii_tokens — nothing to unmask"
             )
         presidio_config = self.get_presidio_settings_from_request_data(
             request_data or {}
@@ -1177,9 +1180,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 full_text = "".join(text_fragments)
                 unmasked = self._unmask_pii_text(full_text, pii_tokens)
 
-                # 4. If nothing changed, yield original bytes unchanged
+                # 4. If nothing changed, yield original chunks unchanged
                 if unmasked == full_text:
-                    yield raw
+                    for c in all_chunks:
+                        yield c
                     return
 
                 # 5. Redistribute unmasked text across original text_delta events

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1199,6 +1199,18 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             1. If the connection to the guardrail is working
             2. When Testing the guardrail with some text, this function will be called with the input text and returns a text after applying the guardrail
         """
+        # --- PII unmask path for output responses ---
+        if input_type == "response" and self.output_parse_pii:
+            pii_tokens = request_data.get("pii_tokens", {}) if request_data else {}
+            if pii_tokens:
+                _texts = inputs.get("texts", [])
+                inputs["texts"] = [self._unmask_pii_text(t, pii_tokens) for t in _texts]
+            else:
+                verbose_proxy_logger.debug(
+                    "apply_guardrail: no pii_tokens in request_data for output unmask path"
+                )
+            return inputs
+
         texts = inputs.get("texts", [])
 
         new_texts = []

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -501,7 +501,14 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         # Always append UUID to ensure uniqueness — prevents
                         # str.replace() collisions when multiple entities share
                         # the same type (e.g. two <PHONE_NUMBER> tokens).
-                        replacement = f"{replacement}_{str(uuid.uuid4())[:12]}"
+                        # UUID goes INSIDE angle brackets so LLMs treat the
+                        # whole thing as one opaque token and don't strip the
+                        # <TYPE> prefix as if it were an XML/HTML tag.
+                        _uuid_suffix = str(uuid.uuid4())[:12]
+                        if replacement.endswith(">"):
+                            replacement = f"{replacement[:-1]}_{_uuid_suffix}>"
+                        else:
+                            replacement = f"{replacement}_{_uuid_suffix}"
 
                         # Use analyze_results (original text positions) to look
                         # up the original value. Both _sorted_ar and _sorted_items
@@ -936,15 +943,31 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         for token, original_text in pii_tokens.items():
             if token in text:
                 text = text.replace(token, original_text)
-            else:
-                # FALLBACK: Handle truncated tokens (token cut off by max_tokens)
-                # Only check at the very end of the text.
-                min_overlap = min(20, len(token) // 2)
-                for i in range(max(0, len(text) - len(token)), len(text)):
-                    sub = text[i:]
-                    if token.startswith(sub) and len(sub) >= min_overlap:
-                        text = text[:i] + original_text
-                        break
+                continue
+
+            # FALLBACK 1: LLM stripped angle brackets (e.g. <PERSON_abc> → PERSON_abc)
+            stripped = token.strip("<>")
+            if stripped and stripped in text:
+                text = text.replace(stripped, original_text)
+                continue
+
+            # FALLBACK 2: LLM stripped type prefix, only UUID suffix remains
+            # e.g. <COMPANY_NAME_8c971c39-ac2> → _8c971c39-ac2
+            _uuid_idx = stripped.rfind("_")
+            if _uuid_idx > 0:
+                uuid_suffix = stripped[_uuid_idx:]  # e.g. "_8c971c39-ac2"
+                if len(uuid_suffix) >= 10 and uuid_suffix in text:
+                    text = text.replace(uuid_suffix, original_text)
+                    continue
+
+            # FALLBACK 3: Handle truncated tokens (token cut off by max_tokens)
+            # Only check at the very end of the text.
+            min_overlap = min(20, len(token) // 2)
+            for i in range(max(0, len(text) - len(token)), len(text)):
+                sub = text[i:]
+                if token.startswith(sub) and len(sub) >= min_overlap:
+                    text = text[:i] + original_text
+                    break
         return text
 
     async def _process_response_for_pii(


### PR DESCRIPTION
## Problem

Presidio PII masking works on the input path but original values are never restored in responses. Affects both streaming and non-streaming Anthropic native API calls (`/v1/messages`).

**Root causes fixed:**

1. **Position bug in `anonymize_text`** — pii token originals were read from `new_text[start:end]` where `start/end` come from `redacted_text["items"]` (anonymized coordinate space). After the first replacement, `new_text` shifts and subsequent slices extract wrong characters → garbled unmasked output.

2. **Lost tokens across instances** — LiteLLM creates two `_OPTIONAL_PresidioPIIMasking` instances per request (pre_call + post_call). `self.pii_tokens` on the masking instance is invisible to the unmasking instance.

3. **`apply_guardrail` always masks** — no branch for unmasking when called with `input_type="response"`.

4. **Native dict responses not handled** — `async_post_call_success_hook` only handled `ModelResponse`. Anthropic native responses are `AnthropicMessagesResponse` TypedDicts (`type:"message"`).

5. **Native SSE bytes not handled** — `async_post_call_streaming_iterator_hook` only handled `ModelResponseStream`. Anthropic native streaming arrives as raw `bytes`.

## Changes (all in `presidio.py`)

- `anonymize_text`: fix position bug using `analyze_results` coordinates (original text) not `redacted_text["items"]` coordinates (anonymized text); store mapping in `self.pii_tokens`; remove now-unnecessary `request_data` parameter
- `apply_guardrail`: copy `self.pii_tokens` → `request_data["pii_tokens"]` after masking; strip OpenAI-format tool keys; add early-return unmask path for `input_type="response"`
- `async_post_call_success_hook`: read pii_tokens from `request_data` first; add `elif` branch for Anthropic native dict (`type:"message"`)
- `async_post_call_streaming_iterator_hook`: buffer all chunks; detect bytes vs `ModelResponseStream`; parse/unmask/rebuild Anthropic native SSE in-place preserving event structure; existing OpenAI path unchanged

## Test plan

- [ ] Non-streaming OpenAI format: PII masked in request, restored in response
- [ ] Non-streaming Anthropic native (`/v1/messages`): PII masked in request, restored in dict response
- [ ] Streaming OpenAI format: PII masked in request, restored in `ModelResponseStream` chunks
- [ ] Streaming Anthropic native (`/v1/messages` with `stream:true`): PII masked in request, restored in SSE bytes
- [ ] Multiple PII entities in same message: all restored correctly (position fix)