### PR TITLE
fix(hosted_vllm): convert thinking blocks to text for vLLM compatibility

### DIFF
--- a/litellm/llms/hosted_vllm/chat/transformation.py
+++ b/litellm/llms/hosted_vllm/chat/transformation.py
@@ -139,18 +139,29 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
         """
         Support translating:
         - video files from file_id or file_data to video_url
-        - thinking_blocks on assistant messages to content blocks
+        - thinking_blocks on assistant messages to text content blocks
+
+        Thinking blocks are converted to standard text content blocks because
+        vLLM/sglang only accept standard OpenAI content types (text, image_url,
+        video_url, audio_url). Redacted thinking blocks are dropped since they
+        contain opaque data with no value for the downstream model.
+
+        Relevant issue: https://github.com/BerriAI/litellm/issues/22997
         """
         for message in messages:
             if message["role"] == "assistant":
                 thinking_blocks = message.pop("thinking_blocks", None)  # type: ignore
                 if thinking_blocks:
-                    new_content: list = [
-                        {"type": block["type"], "thinking": block.get("thinking", "")}
-                        if block.get("type") == "thinking"
-                        else {"type": block["type"], "data": block.get("data", "")}
-                        for block in thinking_blocks
-                    ]
+                    new_content: list = []
+                    for block in thinking_blocks:
+                        if block.get("type") == "thinking":
+                            thinking_text = block.get("thinking", "")
+                            if thinking_text:
+                                new_content.append(
+                                    {"type": "text", "text": thinking_text}
+                                )
+                        # Drop redacted_thinking blocks — opaque data,
+                        # no value for non-Anthropic providers
                     existing_content = message.get("content")
                     if isinstance(existing_content, str):
                         new_content.append(
@@ -158,7 +169,8 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
                         )
                     elif isinstance(existing_content, list):
                         new_content.extend(existing_content)
-                    message["content"] = new_content  # type: ignore
+                    if new_content:
+                        message["content"] = new_content  # type: ignore
             elif message["role"] == "user":
                 message_content = message.get("content")
                 if message_content and isinstance(message_content, list):

--- a/litellm/llms/hosted_vllm/chat/transformation.py
+++ b/litellm/llms/hosted_vllm/chat/transformation.py
@@ -171,9 +171,9 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
                         new_content.extend(existing_content)
                     if new_content:
                         message["content"] = new_content  # type: ignore
-                    elif message.get("content") is None:
-                        # All thinking blocks were filtered out and no
-                        # existing content — ensure a valid content field
+                    elif not isinstance(message.get("content"), (str, list)):
+                        # All thinking blocks were filtered out and content
+                        # is missing or invalid — ensure a valid content field
                         # since thinking_blocks was already popped.
                         message["content"] = ""  # type: ignore
             elif message["role"] == "user":

--- a/litellm/llms/hosted_vllm/chat/transformation.py
+++ b/litellm/llms/hosted_vllm/chat/transformation.py
@@ -160,8 +160,14 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
                                 new_content.append(
                                     {"type": "text", "text": thinking_text}
                                 )
-                        # Drop redacted_thinking blocks — opaque data,
-                        # no value for non-Anthropic providers
+                        elif block.get("type") == "redacted_thinking":
+                            # Drop redacted_thinking blocks — opaque data,
+                            # no value for non-Anthropic providers
+                            pass
+                        else:
+                            # Pass through unknown block types so future
+                            # additions are not silently dropped
+                            new_content.append(block)
                     existing_content = message.get("content")
                     if isinstance(existing_content, str):
                         new_content.append(

--- a/litellm/llms/hosted_vllm/chat/transformation.py
+++ b/litellm/llms/hosted_vllm/chat/transformation.py
@@ -171,6 +171,11 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
                         new_content.extend(existing_content)
                     if new_content:
                         message["content"] = new_content  # type: ignore
+                    elif message.get("content") is None:
+                        # All thinking blocks were filtered out and no
+                        # existing content — ensure a valid content field
+                        # since thinking_blocks was already popped.
+                        message["content"] = ""  # type: ignore
             elif message["role"] == "user":
                 message_content = message.get("content")
                 if message_content and isinstance(message_content, list):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -377,9 +377,6 @@ from litellm.proxy.management_endpoints.internal_user_endpoints import user_upda
 from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
     router as jwt_key_mapping_router,
 )
-from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
-    router as jwt_key_mapping_router,
-)
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     delete_verification_tokens,
     duration_in_seconds,

--- a/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_chat_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_chat_transformation.py
@@ -167,10 +167,15 @@ def test_hosted_vllm_supports_thinking():
     assert optional_params["reasoning_effort"] == "low"
 
 
-def test_hosted_vllm_thinking_blocks_prepended_to_assistant_content():
+def test_hosted_vllm_thinking_blocks_converted_to_text():
     """
-    Test that thinking_blocks on assistant messages are converted to content
-    blocks prepended before the existing content.
+    Test that thinking_blocks on assistant messages are converted to standard
+    text content blocks prepended before the existing content.
+
+    vLLM/sglang only accept standard OpenAI content types (text, image_url,
+    video_url, audio_url), so thinking blocks must be converted to text.
+
+    Relevant issue: https://github.com/BerriAI/litellm/issues/22997
     """
     config = HostedVLLMChatConfig()
     messages = [
@@ -204,9 +209,10 @@ def test_hosted_vllm_thinking_blocks_prepended_to_assistant_content():
     assistant_msg = transformed["messages"][1]
     assert assistant_msg["role"] == "assistant"
     assert isinstance(assistant_msg["content"], list)
+    # Thinking content is converted to standard text blocks
     assert assistant_msg["content"][0] == {
-        "type": "thinking",
-        "thinking": "Let me reason about this...",
+        "type": "text",
+        "text": "Let me reason about this...",
     }
     assert assistant_msg["content"][1] == {
         "type": "text",
@@ -217,7 +223,8 @@ def test_hosted_vllm_thinking_blocks_prepended_to_assistant_content():
 
 def test_hosted_vllm_thinking_blocks_with_list_content():
     """
-    Test thinking_blocks prepended when assistant content is already a list.
+    Test thinking_blocks converted to text and prepended when assistant
+    content is already a list.
     """
     config = HostedVLLMChatConfig()
     messages = [
@@ -247,13 +254,58 @@ def test_hosted_vllm_thinking_blocks_with_list_content():
     )
     assistant_msg = transformed["messages"][0]
     assert len(assistant_msg["content"]) == 3
+    # All content blocks are standard text type
     assert assistant_msg["content"][0] == {
-        "type": "thinking",
-        "thinking": "Step 1 reasoning",
+        "type": "text",
+        "text": "Step 1 reasoning",
     }
     assert assistant_msg["content"][1] == {
-        "type": "thinking",
-        "thinking": "Step 2 reasoning",
+        "type": "text",
+        "text": "Step 2 reasoning",
     }
     assert assistant_msg["content"][2] == {"type": "text", "text": "Response text"}
+    assert "thinking_blocks" not in assistant_msg
+
+
+def test_hosted_vllm_redacted_thinking_blocks_dropped():
+    """
+    Test that redacted_thinking blocks are dropped since they contain
+    opaque data with no value for non-Anthropic providers.
+    """
+    config = HostedVLLMChatConfig()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Final answer.",
+            "thinking_blocks": [
+                {
+                    "type": "redacted_thinking",
+                    "data": "opaque_signature_data_abc123",
+                },
+                {
+                    "type": "thinking",
+                    "thinking": "Useful reasoning here",
+                    "signature": "sig1",
+                },
+            ],
+        },
+    ]
+    transformed = config.transform_request(
+        model="hosted_vllm/llama-3.1-70b-instruct",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    assistant_msg = transformed["messages"][0]
+    # Redacted thinking is dropped, only real thinking + original content remain
+    assert len(assistant_msg["content"]) == 2
+    assert assistant_msg["content"][0] == {
+        "type": "text",
+        "text": "Useful reasoning here",
+    }
+    assert assistant_msg["content"][1] == {
+        "type": "text",
+        "text": "Final answer.",
+    }
     assert "thinking_blocks" not in assistant_msg

--- a/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_chat_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_chat_transformation.py
@@ -309,3 +309,39 @@ def test_hosted_vllm_redacted_thinking_blocks_dropped():
         "text": "Final answer.",
     }
     assert "thinking_blocks" not in assistant_msg
+
+
+def test_hosted_vllm_all_thinking_blocks_filtered_no_content():
+    """
+    When all thinking blocks are redacted and the message has no existing
+    content, the message must still have a valid content field (empty string)
+    since thinking_blocks was already popped.
+    """
+    config = HostedVLLMChatConfig()
+    messages = [
+        {
+            "role": "assistant",
+            "thinking_blocks": [
+                {
+                    "type": "redacted_thinking",
+                    "data": "opaque_data_1",
+                },
+                {
+                    "type": "redacted_thinking",
+                    "data": "opaque_data_2",
+                },
+            ],
+        },
+    ]
+    transformed = config.transform_request(
+        model="hosted_vllm/llama-3.1-70b-instruct",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    assistant_msg = transformed["messages"][0]
+    # thinking_blocks removed, content set to empty string as fallback
+    assert "thinking_blocks" not in assistant_msg
+    assert "content" in assistant_msg
+    assert assistant_msg["content"] == ""

--- a/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
@@ -42,11 +42,12 @@ async def test_invoke_agent_a2a_adds_litellm_data():
 
     # Mock agent
     mock_agent = MagicMock()
+    mock_agent.agent_id = "test-agent"
     mock_agent.agent_card_params = {
         "url": "http://backend-agent:10001",
         "name": "Test Agent",
     }
-    mock_agent.litellm_params = None
+    mock_agent.litellm_params = {}
 
     # Mock request
     mock_request = MagicMock()

--- a/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
@@ -46,6 +46,7 @@ async def test_invoke_agent_a2a_adds_litellm_data():
         "url": "http://backend-agent:10001",
         "name": "Test Agent",
     }
+    mock_agent.litellm_params = None
 
     # Mock request
     mock_request = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #22997 — Thinking content blocks sent from Claude Code to a hosted_vllm backend (kimi-k2.5 via sglang) cause validation errors because vLLM only accepts standard OpenAI content types (`text`, `image_url`, `video_url`, `audio_url`).

## Root Cause

The `_transform_messages` method in `HostedVLLMChatConfig` (introduced in #21557) converts `thinking_blocks` from assistant messages into inline content blocks with `{"type": "thinking", "thinking": "..."}`. The downstream vLLM/sglang server rejects these because `thinking` is not a valid content type in the OpenAI-compatible API.

## Fix

- Convert `thinking` blocks to standard `{"type": "text", "text": "..."}` content blocks — preserves the thinking content for multi-turn context while using a content type that vLLM understands
- Drop `redacted_thinking` blocks entirely — they contain opaque Anthropic-specific signature data with no value for non-Anthropic providers
- Added a new test (`test_hosted_vllm_redacted_thinking_blocks_dropped`) verifying redacted blocks are properly dropped

## Before / After

**Before (broken):**
```json
{"role": "assistant", "content": [{"type": "thinking", "thinking": "Let me reason..."}]}
```
→ vLLM rejects: `Input should be 'text'`

**After (fixed):**
```json
{"role": "assistant", "content": [{"type": "text", "text": "Let me reason..."}]}
```
→ vLLM accepts standard text content

## Tests

All 7 hosted_vllm transformation tests pass:
- `test_hosted_vllm_thinking_blocks_converted_to_text` (updated)
- `test_hosted_vllm_thinking_blocks_with_list_content` (updated)
- `test_hosted_vllm_redacted_thinking_blocks_dropped` (new)
- `test_hosted_vllm_supports_thinking` (unchanged)
- `test_hosted_vllm_supports_reasoning_effort` (unchanged)
- `test_hosted_vllm_chat_transformation_file_url` (unchanged)
- `test_hosted_vllm_chat_transformation_with_audio_url` (unchanged)