### PR TITLE
fix(zai): map thinking/reasoning_effort params to Z.ai format

### DIFF
--- a/litellm/llms/zai/chat/transformation.py
+++ b/litellm/llms/zai/chat/transformation.py
@@ -49,8 +49,61 @@ class ZAIChatConfig(OpenAIGPTConfig):
 
         try:
             if litellm.supports_reasoning(model=model, custom_llm_provider=self.custom_llm_provider):
-                base_params.append("thinking")
+                base_params.extend(["thinking", "reasoning_effort"])
         except Exception:
             pass
 
         return base_params
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        """
+        Map Anthropic-style thinking params to Z.ai's thinking format.
+
+        Z.ai supports a ``thinking`` dict with ``type`` and ``clear_thinking``::
+
+            {"type": "enabled", "clear_thinking": false}
+
+        This translates LiteLLM's standardized ``thinking`` param (Anthropic
+        format with ``budget_tokens``) and ``reasoning_effort`` into Z.ai's
+        format.  ``budget_tokens`` is ignored since Z.ai does not support it.
+
+        ``clear_thinking`` controls Preserved Thinking mode — when false, the
+        model retains reasoning across turns instead of re-deriving from
+        scratch.  It defaults to false on the Coding Plan endpoint.
+
+        Reference: https://docs.z.ai/guides/capabilities/thinking-mode
+        """
+        optional_params = super().map_openai_params(
+            non_default_params, optional_params, model, drop_params
+        )
+
+        thinking_value = optional_params.pop("thinking", None)
+        reasoning_effort = optional_params.pop("reasoning_effort", None)
+
+        if thinking_value is not None:
+            if isinstance(thinking_value, dict):
+                thinking_type = thinking_value.get("type")
+                if thinking_type in ("enabled", "disabled"):
+                    zai_thinking: dict = {"type": thinking_type}
+                    if "clear_thinking" in thinking_value:
+                        zai_thinking["clear_thinking"] = thinking_value[
+                            "clear_thinking"
+                        ]
+                    optional_params["thinking"] = zai_thinking
+            elif isinstance(thinking_value, bool):
+                optional_params["thinking"] = {
+                    "type": "enabled" if thinking_value else "disabled"
+                }
+        elif reasoning_effort is not None:
+            if reasoning_effort == "none":
+                optional_params["thinking"] = {"type": "disabled"}
+            else:
+                optional_params["thinking"] = {"type": "enabled"}
+
+        return optional_params

--- a/tests/test_litellm/llms/zai/test_zai_provider.py
+++ b/tests/test_litellm/llms/zai/test_zai_provider.py
@@ -179,3 +179,95 @@ def test_zai_sync_completion(respx_mock, zai_response, monkeypatch):
 
     assert response.choices[0].message.content == "Hello! How can I help you today?"
     assert response.usage.total_tokens == 25
+
+
+class TestZaiThinkingParamMapping:
+    """Test that Anthropic-style thinking params are mapped to Z.ai format."""
+
+    def _get_config(self):
+        from litellm.llms.zai.chat.transformation import ZAIChatConfig
+
+        return ZAIChatConfig()
+
+    def test_thinking_enabled(self):
+        config = self._get_config()
+        result = config.map_openai_params(
+            non_default_params={"thinking": {"type": "enabled"}},
+            optional_params={},
+            model="glm-4.7",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "enabled"}
+
+    def test_thinking_disabled(self):
+        config = self._get_config()
+        result = config.map_openai_params(
+            non_default_params={"thinking": {"type": "disabled"}},
+            optional_params={},
+            model="glm-4.7",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "disabled"}
+
+    def test_thinking_budget_tokens_stripped(self):
+        """Z.ai does not support budget_tokens — it should be ignored."""
+        config = self._get_config()
+        result = config.map_openai_params(
+            non_default_params={"thinking": {"type": "enabled", "budget_tokens": 1024}},
+            optional_params={},
+            model="glm-4.7",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "enabled"}
+        assert "budget_tokens" not in result["thinking"]
+
+    def test_thinking_clear_thinking_passthrough(self):
+        """clear_thinking controls Preserved Thinking and should be passed through."""
+        config = self._get_config()
+        result = config.map_openai_params(
+            non_default_params={"thinking": {"type": "enabled", "clear_thinking": False}},
+            optional_params={},
+            model="glm-4.7",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "enabled", "clear_thinking": False}
+
+    def test_reasoning_effort_maps_to_thinking(self):
+        config = self._get_config()
+        result = config.map_openai_params(
+            non_default_params={"reasoning_effort": "high"},
+            optional_params={},
+            model="glm-4.7",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "enabled"}
+
+    def test_reasoning_effort_none_disables(self):
+        config = self._get_config()
+        result = config.map_openai_params(
+            non_default_params={"reasoning_effort": "none"},
+            optional_params={},
+            model="glm-4.7",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "disabled"}
+
+    def test_thinking_bool_true(self):
+        config = self._get_config()
+        result = config.map_openai_params(
+            non_default_params={"thinking": True},
+            optional_params={},
+            model="glm-4.7",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "enabled"}
+
+    def test_thinking_bool_false(self):
+        config = self._get_config()
+        result = config.map_openai_params(
+            non_default_params={"thinking": False},
+            optional_params={},
+            model="glm-4.7",
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "disabled"}


### PR DESCRIPTION
## Summary

- Z.ai's GLM-4.7 supports a thinking mode with format `{"type": "enabled"|"disabled", "clear_thinking": bool}`, but the existing ZAI provider passes LiteLLM's standardized Anthropic-style `thinking` param (with `budget_tokens`) through unmodified, causing `AsyncCompletions.create() got an unexpected keyword argument 'thinking'` errors from the OpenAI client.
- This PR adds a `map_openai_params` override to `ZAIChatConfig` that properly translates the standardized params to Z.ai's format:
  - `thinking: {type: "enabled", budget_tokens: N}` → `{type: "enabled"}` (strips unsupported `budget_tokens`)
  - `thinking: {type: "enabled", clear_thinking: false}` → passed through (Preserved Thinking support)
  - `reasoning_effort: "high"/"medium"/"low"` → `{type: "enabled"}`
  - `reasoning_effort: "none"` → `{type: "disabled"}`
  - `thinking: true/false` → `{type: "enabled"}/{type: "disabled"}`
- Adds `reasoning_effort` to `get_supported_openai_params` for reasoning-capable models

## Test plan

- [x] `test_thinking_enabled` — dict with `type: "enabled"` passes through correctly
- [x] `test_thinking_disabled` — dict with `type: "disabled"` passes through correctly
- [x] `test_thinking_budget_tokens_stripped` — `budget_tokens` is removed (Z.ai doesn't support it)
- [x] `test_thinking_clear_thinking_passthrough` — `clear_thinking` is preserved for Preserved Thinking mode
- [x] `test_reasoning_effort_maps_to_thinking` — `reasoning_effort: "high"` maps to `{type: "enabled"}`
- [x] `test_reasoning_effort_none_disables` — `reasoning_effort: "none"` maps to `{type: "disabled"}`
- [x] `test_thinking_bool_true` — `thinking: True` maps to `{type: "enabled"}`
- [x] `test_thinking_bool_false` — `thinking: False` maps to `{type: "disabled"}`

## References

- [Z.ai Thinking Mode docs](https://docs.z.ai/guides/capabilities/thinking-mode)
- Pattern follows existing DeepSeek provider's `map_openai_params` approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)