### PR TITLE
Don't pin to exact versions of optional deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ fastapi-sso = { version = "^0.16.0", optional = true }
 PyJWT = { version = "^2.10.1", optional = true, python = ">=3.9" }
 python-multipart = { version = ">=0.0.20", optional = true}
 cryptography = {version = "*", optional = true}
-prisma = {version = "0.11.0", optional = true}
+prisma = {version = "^0.11.0", optional = true}
 azure-identity = {version = "^1.15.0", optional = true, python = ">=3.9"}
 azure-keyvault-secrets = {version = "^4.8.0", optional = true}
 azure-storage-blob = {version="^12.25.1", optional=true}
@@ -57,13 +57,13 @@ google-cloud-aiplatform = {version = ">=1.38.0", optional = true}
 resend = {version = ">=0.8.0", optional = true}
 pynacl = {version = "^1.5.0", optional = true}
 websockets = {version = "^15.0.1", optional = true}
-boto3 = { version = "1.40.76", optional = true }
+boto3 = { version = "^1.40.76", optional = true }
 redisvl = {version = "^0.4.1", optional = true, markers = "python_version >= '3.9' and python_version < '3.14'"}
 mcp = {version = ">=1.25.0,<2.0.0", optional = true, python = ">=3.10"}
 a2a-sdk = {version = "^0.3.22", optional = true, python = ">=3.10"}
-litellm-proxy-extras = {version = "0.4.52", optional = true}
-rich = {version = "13.7.1", optional = true}
-litellm-enterprise = {version = "0.1.33", optional = true}
+litellm-proxy-extras = {version = "^0.4.52", optional = true}
+rich = {version = "^13.7.1", optional = true}
+litellm-enterprise = {version = "^0.1.33", optional = true}
 diskcache = {version = "^5.6.1", optional = true}
 polars = {version = "^1.31.0", optional = true, python = ">=3.10"}
 semantic-router = {version = ">=0.1.12", optional = true, python = ">=3.9,<3.14"}


### PR DESCRIPTION
Libraries pinning to exact versions (even of optional deps) makes it more likely that consumers will hit dependency conflicts when they try to install.

This becomes still more likely when these dependency specifications are translated into other package ecosystems, such as conda's. For example, because of the current pin to [rich 13.7.1](https://github.com/BerriAI/litellm/blob/cfd0e2cf9924c7cf0c64cd37298710f7b125a8d1/pyproject.toml#L65), the [litellm conda package ends up with `rich =13.7.1` in its run_constrained section](https://github.com/m-rossi/litellm-feedstock/blob/ce953a95b17c6961f9518b8dad87496ddcc81171/recipe/meta.yaml#L61) (correctly treated as optional). Since the `mcp` dependency (which is a direct dependency of `litellm`) requires `rich >=13.9.4`, the `run_constrained` constraint of `rich =13.7.1` kicks in (because `mcp` pulls in `rich`), leading to a dependency conflict:
```
❯ mamba create -p /tmp/repro 'litellm>=1.82.0' 'notebook_intelligence>=4.3.1'
...
error    libmamba Could not solve for environment specs
    The following packages are incompatible
    ├─ litellm >=1.82.0 * is installable and it requires
    │  ├─ mcp >=1.25.0,<2.0.0 *, which can be installed;
    │  └─ rich =13.7.1 *, which can be installed;
    └─ notebook_intelligence >=4.3.1 * is not installable because it requires
       └─ mcp =* * but there are no viable options
          ├─ mcp [1.10.0|1.10.1|...|1.9.4] conflicts with any installable versions previously reported;
          └─ mcp [1.25.0|1.26.0] would require
             └─ rich >=13.9.4 *, which conflicts with any installable versions previously reported.
```