### PR TITLE
fix: scoping virtual keys in the teams view to be applying the team filter

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -4345,8 +4345,6 @@ def _build_key_filter_conditions(
     user_condition: Dict[str, Any] = {}
     if user_id and isinstance(user_id, str):
         user_condition["user_id"] = user_id
-    if team_id and isinstance(team_id, str):
-        user_condition["team_id"] = team_id
     if key_alias and isinstance(key_alias, str):
         user_condition["key_alias"] = key_alias
     if exclude_team_id and isinstance(exclude_team_id, str):
@@ -4414,8 +4412,10 @@ def _build_key_filter_conditions(
     elif len(or_conditions) == 1:
         where.update(or_conditions[0])
 
-    # Apply project_id and access_group_id as global AND filters so they
+    # Apply team_id, project_id and access_group_id as global AND filters so they
     # narrow results across all visibility conditions (own keys, team keys, etc.)
+    if team_id and isinstance(team_id, str):
+        where = {"AND": [where, {"team_id": team_id}]}
     if project_id:
         where = {"AND": [where, {"project_id": project_id}]}
     if access_group_id:

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6366,21 +6366,13 @@ async def test_build_key_filter_team_id_scoped():
         include_created_by_keys=True,
     )
 
-    def _collect_team_id_filters(d):
-        results = []
-        if isinstance(d, dict):
-            for k, v in d.items():
-                if k == "team_id":
-                    results.append(v)
-                else:
-                    results.extend(_collect_team_id_filters(v))
-        elif isinstance(d, list):
-            for item in d:
-                results.extend(_collect_team_id_filters(item))
-        return results
-
-    team_id_filters = _collect_team_id_filters(where)
-    assert "team-A" in team_id_filters, f"Expected global team_id='team-A' AND filter, got: {where}"
+    # The team_id filter must be a direct child of the outermost AND,
+    # not buried inside an OR branch (which was the bug).
+    assert "AND" in where, f"Expected top-level AND, got: {where}"
+    outer_and = where["AND"]
+    assert {"team_id": "team-A"} in outer_and, (
+        f"Expected {{'team_id': 'team-A'}} as a direct AND condition, got: {outer_and}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6345,6 +6345,45 @@ async def test_build_key_filter_project_id_and_access_group_id():
 
 
 @pytest.mark.asyncio
+async def test_build_key_filter_team_id_scoped():
+    """
+    When team_id is provided, it should act as a global AND filter so keys
+    from other teams are excluded — even when the user is admin of multiple teams.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    where = _build_key_filter_conditions(
+        user_id="multi-team-user",
+        team_id="team-A",
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=["team-A", "team-B"],
+        member_team_ids=["team-A", "team-B"],
+        include_created_by_keys=True,
+    )
+
+    def _collect_team_id_filters(d):
+        results = []
+        if isinstance(d, dict):
+            for k, v in d.items():
+                if k == "team_id":
+                    results.append(v)
+                else:
+                    results.extend(_collect_team_id_filters(v))
+        elif isinstance(d, list):
+            for item in d:
+                results.extend(_collect_team_id_filters(item))
+        return results
+
+    team_id_filters = _collect_team_id_filters(where)
+    assert "team-A" in team_id_filters, f"Expected global team_id='team-A' AND filter, got: {where}"
+
+
+@pytest.mark.asyncio
 async def test_get_member_team_ids():
     """
     Test that get_member_team_ids returns all teams where user is a member


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

<img width="1710" height="537" alt="Screenshot 2026-03-07 at 4 32 37 PM" src="https://github.com/user-attachments/assets/bee96f17-07cf-4f51-ab0e-73db15cdc13e" />

<img width="871" height="585" alt="Screenshot 2026-03-07 at 4 31 55 PM" src="https://github.com/user-attachments/assets/a58f111d-cb22-4f7c-ac29-bbdb3a2b2e85" />

Internal users were seeing all the keys from all teams they were apart of when opening up the teams info to look at the virtual keys for a specific team

Query wasn't attaching the team filter globally as an AND filter and was attaching it an OR branch with a bunch of other things. Moved it to be applied as a top level AND just like the project/access groups filters 
