### PR TITLE
fix(ci): image variation openai sdk 2.24.0 compat + swap bedrock nova-premier to nova-pro

### DIFF
--- a/tests/image_gen_tests/test_image_variation.py
+++ b/tests/image_gen_tests/test_image_variation.py
@@ -45,10 +45,15 @@ def image_url():
 
     # Load the image into a file-like object
     image_file = BytesIO(response.content)
+    image_file.name = "litellm_logo.png"
 
     return image_file
 
 
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set",
+)
 def test_openai_image_variation_openai_sdk(image_url):
     from openai import OpenAI
 

--- a/tests/image_gen_tests/test_image_variation.py
+++ b/tests/image_gen_tests/test_image_variation.py
@@ -50,10 +50,6 @@ def image_url():
     return image_file
 
 
-@pytest.mark.skipif(
-    not os.environ.get("OPENAI_API_KEY"),
-    reason="OPENAI_API_KEY not set",
-)
 def test_openai_image_variation_openai_sdk(image_url):
     from openai import OpenAI
 

--- a/tests/proxy_e2e_anthropic_messages_tests/test_claude_agent_sdk.py
+++ b/tests/proxy_e2e_anthropic_messages_tests/test_claude_agent_sdk.py
@@ -4,7 +4,7 @@ E2E tests for Claude Agent SDK with LiteLLM Proxy using Bedrock models.
 Tests streaming messages across different Bedrock models:
 - Regular Bedrock Claude Sonnet 4.5
 - Bedrock Converse Claude Sonnet 4.5
-- AWS Nova Premier
+- AWS Nova Pro
 """
 
 import os
@@ -14,14 +14,14 @@ from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
 
 
 # Test models from test_config.yaml
-# Note: bedrock-converse-claude-sonnet-4.5 removed temporarily as the Bedrock Converse API 
+# Note: bedrock-converse-claude-sonnet-4.5 removed temporarily as the Bedrock Converse API
 # for Claude Sonnet 4.5 may not be available in all regions/accounts
-# Note: bedrock-nova-premier requires an inference profile for on-demand throughput
-# https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles.html
+# Note: bedrock-nova-premier requires provisioned throughput (not standard cross-region
+# inference profile) and is not reliably available in CI accounts. Using nova-pro instead.
 TEST_MODELS = [
     ("bedrock-claude-sonnet-4.5", "Bedrock Invoke API"),
     ("bedrock-converse-claude-sonnet-4.5", "Bedrock Converse API"),
-    ("bedrock-nova-premier", "AWS Nova Premier"),
+    ("bedrock-nova-pro", "AWS Nova Pro"),
 ]
 
 

--- a/tests/proxy_e2e_anthropic_messages_tests/test_config.yaml
+++ b/tests/proxy_e2e_anthropic_messages_tests/test_config.yaml
@@ -24,9 +24,9 @@ model_list:
       model: "bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0"
       aws_region_name: "us-east-1"
 
-  - model_name: bedrock-nova-premier
+  - model_name: bedrock-nova-pro
     litellm_params:
-      model: "bedrock/us.amazon.nova-premier-v1:0"
+      model: "bedrock/us.amazon.nova-pro-v1:0"
       aws_region_name: "us-east-1"
 
   # Converse API models


### PR DESCRIPTION
## Relevant issues

Fixes 2 failing CI jobs.

## Changes

**image_gen_testing: `test_openai_image_variation_openai_sdk`**

`openai==2.24.0` was pinned in `requirements.txt` on Feb 25 (bumped from 2.9.0). This version requires file-like objects passed to `create_variation` to have a `.name` attribute — the SDK uses it for MIME type detection in multipart uploads. `BytesIO` doesn't have `.name` by default, so the test started failing after the bump.

Fix: `image_file.name = "litellm_logo.png"` in the fixture.

**proxy_e2e_anthropic_messages_tests: `test_claude_agent_sdk_streaming[bedrock-nova-premier]`**

`us.amazon.nova-premier-v1:0` requires provisioned throughput — it's not available via standard on-demand cross-region inference profiles on the CI account. Every call got `ValidationException: Invocation of model ID ... with on-demand throughput isn't supported`.

Fix: swap to `us.amazon.nova-pro-v1:0` which works with standard on-demand access.

## Pre-Submission checklist

- [x] I am not breaking any existing functionality
- [x] Tests pass (these are the failing tests being fixed)