### PR TITLE
[Fix] Flaky E2E Tests for Create Key and Auth Redirect

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/tests/auth/unauthenticatedRedirect.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/auth/unauthenticatedRedirect.spec.ts
@@ -3,9 +3,8 @@ import { test, expect } from "@playwright/test";
 test.describe("Authentication Checks", () => {
   test("should redirect unauthenticated user from a protected page", async ({ page }) => {
     const protectedPageUrl = "http://localhost:4000/ui?page=llm-playground";
-    const expectedRedirectUrl = "http://localhost:4000/ui/login/";
     await page.goto(protectedPageUrl, { waitUntil: "domcontentloaded" });
-    await expect(page).toHaveURL(expectedRedirectUrl);
+    await expect(page).toHaveURL(/\/ui\/login/);
     await expect(page.getByRole("heading", { name: "Login" })).toBeVisible();
   });
 });

--- a/ui/litellm-dashboard/e2e_tests/tests/keys/createKey.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/keys/createKey.spec.ts
@@ -14,7 +14,7 @@ test.describe("Create Key", () => {
     await page.getByTestId("base-input").fill("e2eUITestingCreateKeyAllTeamModels");
     await page.locator(".ant-select-selection-overflow").click();
     await page.getByText("All Team Models").click();
-    await page.getByRole("combobox", { name: "* Models info-circle :" }).press("Escape");
+    await page.getByRole("combobox", { name: /models/i }).press("Escape");
     await page.getByRole("button", { name: "Create Key" }).click();
     await page.keyboard.press("Escape");
     await expect(page.getByText("e2eUITestingCreateKeyAllTeamModels")).toBeVisible();


### PR DESCRIPTION
## Relevant issues

Fixes CI e2e test failures for `createKey.spec.ts` and `unauthenticatedRedirect.spec.ts`.

## Summary

### Failure Path (Before Fix)

- `createKey.spec.ts` used an exact string selector `"* Models info-circle :"` for the Models combobox. After PR #22826 made the Models field optional, the asterisk was removed from the label, breaking the selector.
- `unauthenticatedRedirect.spec.ts` expected an exact URL `http://localhost:4000/ui/login/` but the redirect now includes a `redirect_to` query parameter.

### Fix

Both tests now use regex selectors (`/models/i` and `/\/ui\/login/`) instead of exact strings, making them resilient to label and URL changes.

## Testing

- Verified selectors match current UI state

## Type

🐛 Bug Fix
✅ Test