### PR TITLE
fix(streaming/logging): fix audio usage and message redaction bugs

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -476,13 +476,15 @@ class ChunkProcessor:
             "prompt_tokens_details": prompt_tokens_details,
         }
 
-    def count_reasoning_tokens(self, response: ModelResponse) -> int:
-        reasoning_tokens = 0
+    def count_reasoning_tokens(self, response: ModelResponse) -> Optional[int]:
+        reasoning_tokens: Optional[int] = None
         for choice in response.choices:
             if (
                 hasattr(cast(Choices, choice).message, "reasoning_content")
                 and cast(Choices, choice).message.reasoning_content is not None
             ):
+                if reasoning_tokens is None:
+                    reasoning_tokens = 0
                 reasoning_tokens += token_counter(
                     text=cast(Choices, choice).message.reasoning_content,
                     count_response_tokens=True,


### PR DESCRIPTION
## Relevant issues

Fixes 4 failing tests related to audio model handling and message redaction.

## Changes

### 1. `fix(streaming)`: `count_reasoning_tokens` returns `Optional[int]`

`count_reasoning_tokens` always returned `int` (defaulting to 0), so the `if reasoning_tokens is not None:` guard in `calculate_usage` always fired and injected `reasoning_tokens=0` into `completion_tokens_details` for non-reasoning models like `gpt-4o-audio-preview`.

Result: `stream_chunk_builder` produced `{'audio_tokens': X, 'reasoning_tokens': 0}` but the original streaming chunk had `{'audio_tokens': X}`, breaking the equality assertion.

Fix: return `Optional[int]` — `None` = no reasoning content seen, `0` = reasoning_content present but zero tokens. Using `> 0` was considered but rejected since it would silently drop a legitimate `reasoning_tokens: 0`.

### 2. `fix(logging)`: fix `turn_off_message_logging` redaction for standard logging payload

Two bugs in the redaction path for `standard_logging_object["response"]`:

**Bug A**: `get_final_response_obj` passed a plain `dict` (from `model_dump()`) into `redact_message_input_output_from_logging`. `perform_redaction` only handles `ModelResponse`/`EmbeddingResponse`/`ResponsesAPIResponse` — a plain dict hits the `else` branch and returns `{"text": "redacted-by-litellm"}`, destroying the `choices` structure entirely. Fix: pass `init_response_obj` (the original `BaseModel`) to redaction so `isinstance` checks work correctly, then call `model_dump()` on the result.

**Bug B**: `_redact_choice_content` never nulled `choice.message.audio`, so audio model responses kept the full audio blob in the logged payload even with `turn_off_message_logging=True`. Fix: set `choice.message.audio = None`.

## Tests fixed

- `test_stream_chunk_builder_openai_audio_output_usage`
- `test_standard_logging_payload[True-ft:gpt-3.5-turbo:my-org:custom_suffix:id]`
- `test_standard_logging_payload_audio[True-False]`
- `test_standard_logging_payload_audio[True-True]`

## Pre-Submission checklist

- [x] Existing tests cover these paths (live API tests, marked flaky)

## Type

- [x] Bug fix