### PR TITLE
fix(pass_through): cost injection for Anthropic passthrough streaming

### DIFF
--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -67,6 +67,14 @@ class PassThroughStreamingHandler:
                             )
                             if modified_chunk is not None:
                                 chunk = modified_chunk
+                    elif endpoint_type == EndpointType.ANTHROPIC:
+                        modified_chunk = (
+                            ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(
+                                chunk, model_name
+                            )
+                        )
+                        if modified_chunk is not None:
+                            chunk = modified_chunk
 
                 yield chunk
 

--- a/tests/pass_through_tests/test_anthropic_passthrough.py
+++ b/tests/pass_through_tests/test_anthropic_passthrough.py
@@ -337,41 +337,46 @@ async def test_anthropic_messages_streaming_cost_injection():
     
     async with aiohttp.ClientSession() as session:
         async with session.post(
-            "http://0.0.0.0:4000/v1/messages", 
-            json=payload, 
-            headers=headers
+            "http://0.0.0.0:4000/v1/messages",
+            json=payload,
+            headers=headers,
         ) as response:
             assert response.status == 200
-            
-            # Collect all SSE events
+
+            # Collect all SSE events.
+            # Split each chunk by newlines to handle both:
+            # - Anthropic direct path: chunks arrive as individual lines
+            # - OpenAI/Responses API path: chunks are full multi-line SSE events
             events = []
-            async for line in response.content:
-                line_str = line.decode('utf-8').strip()
-                if line_str.startswith('data: '):
-                    try:
-                        data = json.loads(line_str[6:])  # Remove 'data: ' prefix
-                        events.append(data)
-                    except json.JSONDecodeError:
-                        continue
-            
+            async for chunk in response.content:
+                chunk_str = chunk.decode("utf-8")
+                for line in chunk_str.split("\n"):
+                    line = line.strip()
+                    if line.startswith("data: "):
+                        try:
+                            data = json.loads(line[6:])  # Remove 'data: ' prefix
+                            events.append(data)
+                        except json.JSONDecodeError:
+                            continue
+
             # Find message_delta event with usage
             message_delta_events = [
-                event for event in events 
-                if event.get('type') == 'message_delta' and 'usage' in event
+                event for event in events
+                if event.get("type") == "message_delta" and "usage" in event
             ]
-            
+
             assert len(message_delta_events) > 0, "No message_delta events with usage found"
-            
+
             # Check that cost is included in usage
             for event in message_delta_events:
-                usage = event.get('usage', {})
-                assert 'cost' in usage, f"Cost not found in usage: {usage}"
-                assert isinstance(usage['cost'], (int, float)), f"Cost should be numeric: {usage['cost']}"
-                assert usage['cost'] >= 0, f"Cost should be non-negative: {usage['cost']}"
-                
-                print(f"✅ Found message_delta with cost: {usage}")
-            
-            print(f"✅ Test passed: Found {len(message_delta_events)} message_delta events with cost")
+                usage = event.get("usage", {})
+                assert "cost" in usage, f"Cost not found in usage: {usage}"
+                assert isinstance(usage["cost"], (int, float)), f"Cost should be numeric: {usage['cost']}"
+                assert usage["cost"] >= 0, f"Cost should be non-negative: {usage['cost']}"
+
+                print(f"Found message_delta with cost: {usage}")
+
+            print(f"Test passed: Found {len(message_delta_events)} message_delta events with cost")
 
 
 @pytest.mark.asyncio
@@ -381,54 +386,61 @@ async def test_anthropic_messages_openai_model_streaming_cost_injection():
     Test that cost is injected into message_delta usage for OpenAI model via Anthropic Messages API
     """
     print("Testing cost injection in Anthropic Messages API with OpenAI model")
-    
+
     headers = {
         "Authorization": "Bearer sk-1234",
         "Content-Type": "application/json",
         "anthropic-version": "2023-06-01",
     }
-    
+
     payload = {
         "model": "openai/gpt-4o",
         "max_tokens": 10,
         "stream": True,
         "messages": [{"role": "user", "content": "Say 'Hi'"}],
     }
-    
+
     async with aiohttp.ClientSession() as session:
         async with session.post(
-            "http://0.0.0.0:4000/v1/messages", 
-            json=payload, 
-            headers=headers
+            "http://0.0.0.0:4000/v1/messages",
+            json=payload,
+            headers=headers,
         ) as response:
             assert response.status == 200
-            
-            # Collect all SSE events
+
+            # Collect all SSE events.
+            # Split each chunk by newlines to handle both:
+            # - Direct API paths: chunks arrive as individual lines
+            # - OpenAI/Responses API path: AnthropicResponsesStreamWrapper yields
+            #   full multi-line SSE events as single bytes objects, so a naive
+            #   startswith('data: ') check on the whole chunk misses them.
             events = []
-            async for line in response.content:
-                line_str = line.decode('utf-8').strip()
-                if line_str.startswith('data: '):
-                    try:
-                        data = json.loads(line_str[6:])  # Remove 'data: ' prefix
-                        events.append(data)
-                    except json.JSONDecodeError:
-                        continue
-            
+            async for chunk in response.content:
+                chunk_str = chunk.decode("utf-8")
+                for line in chunk_str.split("\n"):
+                    line = line.strip()
+                    if line.startswith("data: "):
+                        try:
+                            data = json.loads(line[6:])  # Remove 'data: ' prefix
+                            events.append(data)
+                        except json.JSONDecodeError:
+                            continue
+
             # Find message_delta event with usage
             message_delta_events = [
-                event for event in events 
-                if event.get('type') == 'message_delta' and 'usage' in event
+                event for event in events
+                if event.get("type") == "message_delta" and "usage" in event
             ]
-            
+
             assert len(message_delta_events) > 0, "No message_delta events with usage found"
-            
+
             # Check that cost is included in usage
             for event in message_delta_events:
-                usage = event.get('usage', {})
-                assert 'cost' in usage, f"Cost not found in usage: {usage}"
-                assert isinstance(usage['cost'], (int, float)), f"Cost should be numeric: {usage['cost']}"
-                assert usage['cost'] >= 0, f"Cost should be non-negative: {usage['cost']}"
-                
-                print(f"✅ Found message_delta with cost: {usage}")
-            
-            print(f"✅ Test passed: Found {len(message_delta_events)} message_delta events with cost")
+                usage = event.get("usage", {})
+                assert "cost" in usage, f"Cost not found in usage: {usage}"
+                assert isinstance(usage["cost"], (int, float)), f"Cost should be numeric: {usage['cost']}"
+                assert usage["cost"] >= 0, f"Cost should be non-negative: {usage['cost']}"
+
+                print(f"Found message_delta with cost: {usage}")
+
+            print(f"Test passed: Found {len(message_delta_events)} message_delta events with cost")


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Two fixes for the Anthropic passthrough streaming path:

**1. `streaming_handler.py` — missing `ANTHROPIC` branch in cost injection**

`EndpointType.ANTHROPIC` was not in the cost injection block inside `chunk_processor`. Only `VERTEX_AI` (streamRawPredict) was handled. So with `include_cost_in_streaming_usage: true`, Anthropic passthrough streaming never injected cost into `message_delta` chunks.

**2. `test_anthropic_passthrough.py` — SSE parsing was silently skipping events**

`AnthropicResponsesStreamWrapper.async_anthropic_sse_wrapper()` (used when routing OpenAI models through `/v1/messages`) yields full multi-line SSE frames as a single `bytes` object:

```
b"event: message_delta\ndata: {...}\n\n"
```

The tests were iterating `async for line in response.content` and checking `if line_str.startswith('data: ')` on the whole chunk. Since the chunk starts with `event:` not `data:`, every `message_delta` event was silently missed and the test failed asserting no cost was found.

Fix: split each chunk by `\n` before checking for `data: ` prefix. Works for both paths — Anthropic direct (individual line chunks) and OpenAI/Responses API (full multi-line frames as single bytes objects).

Also removes the `@pytest.mark.skip` that was added with wrong diagnosis ("Responses API doesn't reliably emit usage") — the streaming was fine, only the test parsing was broken.