### PR TITLE
[Feature] UI - Internal Users: Allow Org Admins to View and Invite Users

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1502,10 +1502,11 @@ async def get_users(
     sort_order: str = fastapi.Query(
         default="asc", description="Sort order ('asc' or 'desc')"
     ),
-    organization_id: Optional[str] = fastapi.Query(
+    organization_id: Optional[List[str]] = fastapi.Query(
         default=None,
-        description="Filter users by organization membership. Comma-separated for multiple orgs.",
+        description="Filter users by organization membership. Pass multiple values for multiple orgs.",
     ),
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
     Get a paginated list of users with filtering and sorting options.
@@ -1534,13 +1535,78 @@ async def get_users(
         sort_order: Optional[str]
             Sort order ('asc' or 'desc')
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
 
     if prisma_client is None:
         raise HTTPException(
             status_code=500,
             detail={"error": f"No db connected. prisma client={prisma_client}"},
         )
+
+    # Server-side authorization: proxy admins see all, org admins see only their org(s)
+    is_proxy_admin = _user_has_admin_view(user_api_key_dict)
+    allowed_org_ids: Optional[List[str]] = None
+    if not is_proxy_admin:
+        if user_api_key_dict.user_id is None:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "Only proxy admins and organization admins can list users."
+                },
+            )
+        try:
+            caller_user = await get_user_object(
+                user_id=user_api_key_dict.user_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                user_id_upsert=False,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except ValueError:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "Only proxy admins and organization admins can list users."
+                },
+            )
+        if caller_user is None:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "Only proxy admins and organization admins can list users."
+                },
+            )
+        allowed_org_ids = [
+            m.organization_id
+            for m in (caller_user.organization_memberships or [])
+            if m.user_role == LitellmUserRoles.ORG_ADMIN.value
+        ]
+        if not allowed_org_ids:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "Only proxy admins and organization admins can list users."
+                },
+            )
+        # If client also sent organization_id, intersect with allowed orgs
+        if organization_id:
+            requested = set(organization_id)
+            allowed = set(allowed_org_ids)
+            intersection = list(requested & allowed)
+            if not intersection:
+                raise HTTPException(
+                    status_code=403,
+                    detail={
+                        "error": "You do not have org_admin access to the requested organization(s)."
+                    },
+                )
+            allowed_org_ids = intersection
+        # For org admins, always enforce org scoping
+        organization_id = allowed_org_ids
 
     # Calculate skip and take for pagination
     skip = (page - 1) * page_size
@@ -1580,12 +1646,9 @@ async def get_users(
             "in": sso_id_list,
         }
 
-    if organization_id is not None and isinstance(organization_id, str):
-        org_id_list = [
-            oid.strip() for oid in organization_id.split(",") if oid.strip()
-        ]
+    if organization_id:
         where_conditions["organization_memberships"] = {
-            "some": {"organization_id": {"in": org_id_list}}
+            "some": {"organization_id": {"in": organization_id}}
         }
 
     ## Filter any none fastapi.Query params - e.g. where_conditions: {'user_email': {'contains': Query(None), 'mode': 'insensitive'}, 'teams': {'has': Query(None)}}

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1502,6 +1502,10 @@ async def get_users(
     sort_order: str = fastapi.Query(
         default="asc", description="Sort order ('asc' or 'desc')"
     ),
+    organization_id: Optional[str] = fastapi.Query(
+        default=None,
+        description="Filter users by organization membership. Comma-separated for multiple orgs.",
+    ),
 ):
     """
     Get a paginated list of users with filtering and sorting options.
@@ -1574,6 +1578,14 @@ async def get_users(
         sso_id_list = [sid.strip() for sid in sso_user_ids.split(",") if sid.strip()]
         where_conditions["sso_user_id"] = {
             "in": sso_id_list,
+        }
+
+    if organization_id is not None and isinstance(organization_id, str):
+        org_id_list = [
+            oid.strip() for oid in organization_id.split(",") if oid.strip()
+        ]
+        where_conditions["organization_memberships"] = {
+            "some": {"organization_id": {"in": org_id_list}}
         }
 
     ## Filter any none fastapi.Query params - e.g. where_conditions: {'user_email': {'contains': Query(None), 'mode': 'insensitive'}, 'teams': {'has': Query(None)}}

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1502,9 +1502,9 @@ async def get_users(
     sort_order: str = fastapi.Query(
         default="asc", description="Sort order ('asc' or 'desc')"
     ),
-    organization_id: Optional[List[str]] = fastapi.Query(
+    organization_ids: Optional[str] = fastapi.Query(
         default=None,
-        description="Filter users by organization membership. Pass multiple values for multiple orgs.",
+        description="Filter users by organization membership. Comma-separated list of org IDs.",
     ),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
@@ -1592,9 +1592,9 @@ async def get_users(
                     "error": "Only proxy admins and organization admins can list users."
                 },
             )
-        # If client also sent organization_id, intersect with allowed orgs
-        if organization_id:
-            requested = set(organization_id)
+        # If client also sent organization_ids, intersect with allowed orgs
+        if organization_ids:
+            requested = set(oid.strip() for oid in organization_ids.split(",") if oid.strip())
             allowed = set(allowed_org_ids)
             intersection = list(requested & allowed)
             if not intersection:
@@ -1605,8 +1605,8 @@ async def get_users(
                     },
                 )
             allowed_org_ids = intersection
-        # For org admins, always enforce org scoping
-        organization_id = allowed_org_ids
+        # For org admins, always enforce org scoping via comma-separated string
+        organization_ids = ",".join(allowed_org_ids)
 
     # Calculate skip and take for pagination
     skip = (page - 1) * page_size
@@ -1646,10 +1646,12 @@ async def get_users(
             "in": sso_id_list,
         }
 
-    if organization_id:
-        where_conditions["organization_memberships"] = {
-            "some": {"organization_id": {"in": organization_id}}
-        }
+    if organization_ids:
+        org_id_list = [oid.strip() for oid in organization_ids.split(",") if oid.strip()]
+        if org_id_list:
+            where_conditions["organization_memberships"] = {
+                "some": {"organization_id": {"in": org_id_list}}
+            }
 
     ## Filter any none fastapi.Query params - e.g. where_conditions: {'user_email': {'contains': Query(None), 'mode': 'insensitive'}, 'teams': {'has': Query(None)}}
     where_conditions = {k: v for k, v in where_conditions.items() if v is not None}

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/page.tsx
@@ -13,13 +13,19 @@ const UsersPage = () => {
   const [keys, setKeys] = useState<null | any[]>([]);
 
   const { teams } = useTeams();
-  const { data: organizations } = useOrganizations();
+  const { data: organizations, isLoading: isOrgsLoading } = useOrganizations();
 
-  // Compute org IDs where the user is an org_admin, but only if they're NOT a proxy admin
-  const orgAdminOrgIds = useMemo(() => {
-    if (!userId || !organizations || !userRole) return null;
+  // Three states:
+  // - undefined: org data still loading (non-proxy-admin) — query should wait
+  // - null: proxy admin or no org filtering needed — query runs unfiltered
+  // - string[]: org admin org IDs — query runs filtered
+  const orgAdminOrgIds = useMemo((): string[] | null | undefined => {
+    if (!userId || !userRole) return null;
     // Proxy admins see all users — no org filtering
     if (isProxyAdminRole(userRole)) return null;
+
+    // Still loading org data — signal "not ready yet"
+    if (isOrgsLoading || !organizations) return undefined;
 
     const adminOrgIds = organizations
       .filter((org: Organization) =>
@@ -28,7 +34,7 @@ const UsersPage = () => {
       .map((org: Organization) => org.organization_id);
 
     return adminOrgIds.length > 0 ? adminOrgIds : null;
-  }, [userId, organizations, userRole]);
+  }, [userId, organizations, userRole, isOrgsLoading]);
 
   return (
     <ViewUserDashboard

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/page.tsx
@@ -3,13 +3,32 @@
 import ViewUserDashboard from "@/components/view_users";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import useTeams from "@/app/(dashboard)/hooks/useTeams";
-import { useState } from "react";
+import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
+import { isProxyAdminRole } from "@/utils/roles";
+import { useState, useMemo } from "react";
+import { Organization } from "@/components/networking";
 
 const UsersPage = () => {
   const { accessToken, userRole, userId, token } = useAuthorized();
   const [keys, setKeys] = useState<null | any[]>([]);
 
   const { teams } = useTeams();
+  const { data: organizations } = useOrganizations();
+
+  // Compute org IDs where the user is an org_admin, but only if they're NOT a proxy admin
+  const orgAdminOrgIds = useMemo(() => {
+    if (!userId || !organizations || !userRole) return null;
+    // Proxy admins see all users — no org filtering
+    if (isProxyAdminRole(userRole)) return null;
+
+    const adminOrgIds = organizations
+      .filter((org: Organization) =>
+        org.members?.some((member) => member.user_id === userId && member.user_role === "org_admin")
+      )
+      .map((org: Organization) => org.organization_id);
+
+    return adminOrgIds.length > 0 ? adminOrgIds : null;
+  }, [userId, organizations, userRole]);
 
   return (
     <ViewUserDashboard
@@ -20,6 +39,7 @@ const UsersPage = () => {
       userID={userId}
       teams={teams as any}
       setKeys={setKeys}
+      orgAdminOrgIds={orgAdminOrgIds}
     />
   );
 };

--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -45,7 +45,7 @@ interface CreateuserProps {
   possibleUIRoles: null | Record<string, Record<string, string>>;
   onUserCreated?: (userId: string) => void;
   isEmbedded?: boolean;
-  organizationId?: string | null;
+  organizationIds?: string[] | null;
 }
 
 // Define an interface for the UI settings
@@ -57,7 +57,7 @@ interface UISettings {
 }
 
 export const CreateUserButton: React.FC<CreateuserProps> = ({
-  userID, accessToken, teams, possibleUIRoles, onUserCreated, isEmbedded = false, organizationId }) => {
+  userID, accessToken, teams, possibleUIRoles, onUserCreated, isEmbedded = false, organizationIds }) => {
   const queryClient = useQueryClient();
   const [uiSettings, setUISettings] = useState<UISettings | null>(null);
   const [form] = Form.useForm();
@@ -100,7 +100,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
     form.resetFields();
   };
 
-  const handleCreate = async (formValues: { user_id: string; models?: string[]; user_role: string }) => {
+  const handleCreate = async (formValues: { user_id: string; models?: string[]; user_role: string; organization_id?: string }) => {
     try {
       NotificationsManager.info("Making API Call");
       if (!isEmbedded) {
@@ -114,15 +114,17 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
       setApiuser(true);
       const user_id = response.data?.user_id || response.user_id;
 
-      // Auto-add user to the org admin's organization
-      if (organizationId && user_id) {
+      // Auto-add user to the selected organization (org admin flow)
+      const targetOrgId = formValues.organization_id || (organizationIds?.length === 1 ? organizationIds[0] : null);
+      if (targetOrgId && user_id) {
         try {
-          await organizationMemberAddCall(accessToken, organizationId, {
+          await organizationMemberAddCall(accessToken, targetOrgId, {
             role: "internal_user",
             user_id: user_id,
           });
         } catch (orgError) {
           console.error("Failed to add user to organization:", orgError);
+          NotificationsManager.fromBackend("User created but failed to add to organization. Please add them manually.");
         }
       }
 
@@ -292,6 +294,21 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
           >
             <TeamDropdown teams={teams} />
           </Form.Item>
+
+          {organizationIds && organizationIds.length > 1 && (
+            <Form.Item
+              label="Organization"
+              name="organization_id"
+              initialValue={organizationIds[0]}
+              help="The user will be added to this organization."
+            >
+              <Select placeholder="Select Organization" style={{ width: "100%" }}>
+                {organizationIds.map((orgId) => (
+                  <Option key={orgId} value={orgId}>{orgId}</Option>
+                ))}
+              </Select>
+            </Form.Item>
+          )}
 
           <Form.Item label="Metadata" name="metadata">
             <Input.TextArea rows={4} placeholder="Enter metadata as JSON" />

--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -19,6 +19,7 @@ import {
   getProxyUISettings,
   invitationCreateCall,
   modelAvailableCall,
+  organizationMemberAddCall,
   userCreateCall,
 } from "./networking";
 import OnboardingModal, { InvitationLink } from "./onboarding_link";
@@ -44,6 +45,7 @@ interface CreateuserProps {
   possibleUIRoles: null | Record<string, Record<string, string>>;
   onUserCreated?: (userId: string) => void;
   isEmbedded?: boolean;
+  organizationId?: string | null;
 }
 
 // Define an interface for the UI settings
@@ -55,7 +57,7 @@ interface UISettings {
 }
 
 export const CreateUserButton: React.FC<CreateuserProps> = ({
-  userID, accessToken, teams, possibleUIRoles, onUserCreated, isEmbedded = false }) => {
+  userID, accessToken, teams, possibleUIRoles, onUserCreated, isEmbedded = false, organizationId }) => {
   const queryClient = useQueryClient();
   const [uiSettings, setUISettings] = useState<UISettings | null>(null);
   const [form] = Form.useForm();
@@ -111,6 +113,18 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
       await queryClient.invalidateQueries({ queryKey: ["userList"] });
       setApiuser(true);
       const user_id = response.data?.user_id || response.user_id;
+
+      // Auto-add user to the org admin's organization
+      if (organizationId && user_id) {
+        try {
+          await organizationMemberAddCall(accessToken, organizationId, {
+            role: "internal_user",
+            user_id: user_id,
+          });
+        } catch (orgError) {
+          console.error("Failed to add user to organization:", orgError);
+        }
+      }
 
       if (onUserCreated && isEmbedded) {
         onUserCreated(user_id);

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -443,8 +443,8 @@ const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapse
         children: item.children ? filterItemsByRole(item.children) : undefined,
       }))
       .filter((item) => {
-        // Special handling for organizations menu item - allow org_admins
-        if (item.key === "organizations") {
+        // Special handling for organizations and users menu items - allow org_admins
+        if (item.key === "organizations" || item.key === "users") {
           const hasRoleAccess = !item.roles || item.roles.includes(userRole) || isOrgAdmin;
           if (!hasRoleAccess) return false;
 

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1153,7 +1153,9 @@ export const userListCall = async (
     }
 
     if (organizationIds && organizationIds.length > 0) {
-      queryParams.append("organization_id", organizationIds.join(","));
+      for (const orgId of organizationIds) {
+        queryParams.append("organization_id", orgId);
+      }
     }
 
     const queryString = queryParams.toString();

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1104,6 +1104,7 @@ export const userListCall = async (
   sso_user_id: string | null = null,
   sortBy: string | null = null,
   sortOrder: "asc" | "desc" | null = null,
+  organizationIds: string[] | null = null,
 ) => {
   /**
    * Get all available teams on proxy
@@ -1149,6 +1150,10 @@ export const userListCall = async (
 
     if (sortOrder) {
       queryParams.append("sort_order", sortOrder);
+    }
+
+    if (organizationIds && organizationIds.length > 0) {
+      queryParams.append("organization_id", organizationIds.join(","));
     }
 
     const queryString = queryParams.toString();

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1153,9 +1153,7 @@ export const userListCall = async (
     }
 
     if (organizationIds && organizationIds.length > 0) {
-      for (const orgId of organizationIds) {
-        queryParams.append("organization_id", orgId);
-      }
+      queryParams.append("organization_ids", organizationIds.join(","));
     }
 
     const queryString = queryParams.toString();

--- a/ui/litellm-dashboard/src/components/view_users.tsx
+++ b/ui/litellm-dashboard/src/components/view_users.tsx
@@ -265,7 +265,7 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, toke
         orgAdminOrgIds ?? null,
       );
     },
-    enabled: Boolean(accessToken && token && userRole && userID),
+    enabled: Boolean(accessToken && token && userRole && userID && orgAdminOrgIds !== undefined),
     placeholderData: (previousData) => previousData,
   });
   const userListResponse = userListQuery.data;
@@ -304,7 +304,7 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, toke
             </>
           ) : userID && accessToken ? (
             <>
-              <CreateUserButton userID={userID} accessToken={accessToken} teams={teams} possibleUIRoles={possibleUIRoles} organizationId={orgAdminOrgIds?.[0] ?? null} />
+              <CreateUserButton userID={userID} accessToken={accessToken} teams={teams} possibleUIRoles={possibleUIRoles} organizationIds={orgAdminOrgIds ?? null} />
 
               {isProxyAdmin && (
                 <Button

--- a/ui/litellm-dashboard/src/components/view_users.tsx
+++ b/ui/litellm-dashboard/src/components/view_users.tsx
@@ -16,7 +16,7 @@ import {
 import OnboardingModal, { InvitationLink } from "./onboarding_link";
 
 import { updateExistingKeys } from "@/utils/dataUtils";
-import { isAdminRole } from "@/utils/roles";
+import { isAdminRole, isProxyAdminRole } from "@/utils/roles";
 import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Typography } from "antd";
@@ -39,6 +39,7 @@ interface ViewUserDashboardProps {
   userID: string | null;
   teams: any[] | null;
   setKeys: React.Dispatch<React.SetStateAction<object[] | null>>;
+  orgAdminOrgIds?: string[] | null;
 }
 
 interface FilterState {
@@ -69,7 +70,8 @@ const initialFilters: FilterState = {
   sort_order: "desc",
 };
 
-const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, token, userRole, userID, teams }) => {
+const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, token, userRole, userID, teams, orgAdminOrgIds }) => {
+  const isProxyAdmin = userRole ? isProxyAdminRole(userRole) : false;
   const queryClient = useQueryClient();
   const [currentPage, setCurrentPage] = useState(1);
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -245,7 +247,7 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, toke
   };
 
   const userListQuery = useQuery({
-    queryKey: ["userList", { debouncedFilter: debouncedFilters, currentPage }],
+    queryKey: ["userList", { debouncedFilter: debouncedFilters, currentPage, orgAdminOrgIds }],
     queryFn: async () => {
       if (!accessToken) throw new Error("Access token required");
 
@@ -260,6 +262,7 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, toke
         debouncedFilters.sso_user_id || null,
         debouncedFilters.sort_by,
         debouncedFilters.sort_order,
+        orgAdminOrgIds ?? null,
       );
     },
     enabled: Boolean(accessToken && token && userRole && userID),
@@ -301,17 +304,19 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, toke
             </>
           ) : userID && accessToken ? (
             <>
-              <CreateUserButton userID={userID} accessToken={accessToken} teams={teams} possibleUIRoles={possibleUIRoles} />
+              <CreateUserButton userID={userID} accessToken={accessToken} teams={teams} possibleUIRoles={possibleUIRoles} organizationId={orgAdminOrgIds?.[0] ?? null} />
 
-              <Button
-                onClick={handleToggleSelectionMode}
-                variant={selectionMode ? "primary" : "secondary"}
-                className="flex items-center"
-              >
-                {selectionMode ? "Cancel Selection" : "Select Users"}
-              </Button>
+              {isProxyAdmin && (
+                <Button
+                  onClick={handleToggleSelectionMode}
+                  variant={selectionMode ? "primary" : "secondary"}
+                  className="flex items-center"
+                >
+                  {selectionMode ? "Cancel Selection" : "Select Users"}
+                </Button>
+              )}
 
-              {selectionMode && (
+              {isProxyAdmin && selectionMode && (
                 <Button onClick={handleBulkEdit} disabled={selectedUsers.length === 0} className="flex items-center">
                   Bulk Edit ({selectedUsers.length} selected)
                 </Button>
@@ -321,61 +326,93 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, toke
         </div>
       </div>
 
-      <TabGroup defaultIndex={0} onIndexChange={(index) => setActiveTab(index === 0 ? "users" : "settings")}>
-        <TabList className="mb-4">
-          <Tab>Users</Tab>
-          <Tab>Default User Settings</Tab>
-        </TabList>
+      {isProxyAdmin ? (
+        <TabGroup defaultIndex={0} onIndexChange={(index) => setActiveTab(index === 0 ? "users" : "settings")}>
+          <TabList className="mb-4">
+            <Tab>Users</Tab>
+            <Tab>Default User Settings</Tab>
+          </TabList>
 
-        <TabPanels>
-          <TabPanel>
-            <UserDataTable
-              data={userListQuery.data?.users || []}
-              columns={tableColumns}
-              isLoading={userListQuery.isLoading}
-              accessToken={accessToken}
-              userRole={userRole}
-              onSortChange={handleSortChange}
-              currentSort={{
-                sortBy: filters.sort_by,
-                sortOrder: filters.sort_order,
-              }}
-              possibleUIRoles={possibleUIRoles}
-              handleEdit={(user) => {
-                setSelectedUser(user);
-                setEditModalVisible(true);
-              }}
-              handleDelete={handleDelete}
-              handleResetPassword={handleResetPassword}
-              enableSelection={selectionMode}
-              selectedUsers={selectedUsers}
-              onSelectionChange={handleSelectionChange}
-              filters={filters}
-              updateFilters={updateFilters}
-              initialFilters={initialFilters}
-              teams={teams}
-              userListResponse={userListResponse}
-              currentPage={currentPage}
-              handlePageChange={handlePageChange}
-            />
-          </TabPanel>
-
-          <TabPanel>
-            {!userID || !userRole || !accessToken ? (
-              <div className="flex justify-center items-center h-64">
-                <Skeleton active paragraph={{ rows: 4 }} />
-              </div>
-            ) : (
-              <DefaultUserSettings
+          <TabPanels>
+            <TabPanel>
+              <UserDataTable
+                data={userListQuery.data?.users || []}
+                columns={tableColumns}
+                isLoading={userListQuery.isLoading}
                 accessToken={accessToken}
-                possibleUIRoles={possibleUIRoles}
-                userID={userID}
                 userRole={userRole}
+                onSortChange={handleSortChange}
+                currentSort={{
+                  sortBy: filters.sort_by,
+                  sortOrder: filters.sort_order,
+                }}
+                possibleUIRoles={possibleUIRoles}
+                handleEdit={(user) => {
+                  setSelectedUser(user);
+                  setEditModalVisible(true);
+                }}
+                handleDelete={handleDelete}
+                handleResetPassword={handleResetPassword}
+                enableSelection={selectionMode}
+                selectedUsers={selectedUsers}
+                onSelectionChange={handleSelectionChange}
+                filters={filters}
+                updateFilters={updateFilters}
+                initialFilters={initialFilters}
+                teams={teams}
+                userListResponse={userListResponse}
+                currentPage={currentPage}
+                handlePageChange={handlePageChange}
               />
-            )}
-          </TabPanel>
-        </TabPanels>
-      </TabGroup>
+            </TabPanel>
+
+            <TabPanel>
+              {!userID || !userRole || !accessToken ? (
+                <div className="flex justify-center items-center h-64">
+                  <Skeleton active paragraph={{ rows: 4 }} />
+                </div>
+              ) : (
+                <DefaultUserSettings
+                  accessToken={accessToken}
+                  possibleUIRoles={possibleUIRoles}
+                  userID={userID}
+                  userRole={userRole}
+                />
+              )}
+            </TabPanel>
+          </TabPanels>
+        </TabGroup>
+      ) : (
+        <UserDataTable
+          data={userListQuery.data?.users || []}
+          columns={tableColumns}
+          isLoading={userListQuery.isLoading}
+          accessToken={accessToken}
+          userRole={userRole}
+          onSortChange={handleSortChange}
+          currentSort={{
+            sortBy: filters.sort_by,
+            sortOrder: filters.sort_order,
+          }}
+          possibleUIRoles={possibleUIRoles}
+          handleEdit={(user) => {
+            setSelectedUser(user);
+            setEditModalVisible(true);
+          }}
+          handleDelete={handleDelete}
+          handleResetPassword={handleResetPassword}
+          enableSelection={false}
+          selectedUsers={[]}
+          onSelectionChange={handleSelectionChange}
+          filters={filters}
+          updateFilters={updateFilters}
+          initialFilters={initialFilters}
+          teams={teams}
+          userListResponse={userListResponse}
+          currentPage={currentPage}
+          handlePageChange={handlePageChange}
+        />
+      )}
 
       {/* Existing Modals */}
       <EditUserModal


### PR DESCRIPTION
## Summary

### Problem
Org admins cannot see the "Internal Users" page in the left nav, preventing them from managing users within their organization.

### Fix
- Show "Internal Users" nav item to org admins (same pattern as "Organizations")
- Add `organization_id` filter to `/user/list` backend endpoint so org admins only see users in their org(s)
- Pass org admin context through the frontend so the user table is scoped to their organizations
- Auto-add newly invited users to the org admin's organization
- Hide admin-only controls (Select Users, Bulk Edit, Default User Settings) for non-proxy-admin org admins
- Proxy admins are unaffected — they continue to see all users with full controls

## Testing
1. Log in as org admin — "Internal Users" appears in left nav under Access Control
2. Click "Internal Users" — only users in the org admin's org(s) appear
3. Click "Invite User" — new user is auto-added to the org
4. Log in as proxy admin — all users show with full controls (no org filtering)
5. Log in as proxy admin who is also an org admin — proxy admin takes precedence, sees all users

## Type

🆕 New Feature