### PR TITLE
revert: undo PR #22589 and follow-up vertex anyOf fixes

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -571,38 +571,14 @@ def _filter_anyof_fields(schema_dict: Dict[str, Any]) -> Dict[str, Any]:
     return schema_dict
 
 
-def _is_any_type_schema(schema: dict) -> bool:
-    """
-    Detect schemas that represent "any JSON value" (no type constraints).
-
-    In JSON Schema, an empty schema {} means "any value is valid".
-    Schemas with only metadata keys (title, description, default, examples)
-    but no type-constraining keywords also represent "any type".
-
-    Gemini's Schema proto uses TYPE_UNSPECIFIED (0) as default,
-    so omitting the type field is valid and means "any type".
-    """
-    type_constraining_keys = {
-        "type",
-        "properties",
-        "items",
-        "anyOf",
-        "oneOf",
-        "allOf",
-        "enum",
-        "required",
-        "$ref",
-        "$schema",
-    }
-    return not any(key in type_constraining_keys for key in schema.keys())
-
-
 def process_items(schema, depth=0):
     if depth > DEFAULT_MAX_RECURSE_DEPTH:
         raise ValueError(
             f"Max depth of {DEFAULT_MAX_RECURSE_DEPTH} exceeded while processing schema. Please check the schema for excessive nesting."
         )
     if isinstance(schema, dict):
+        if "items" in schema and schema["items"] == {}:
+            schema["items"] = {"type": "object"}
         for key, value in schema.items():
             if isinstance(value, dict):
                 process_items(value, depth + 1)
@@ -701,8 +677,9 @@ def convert_anyof_null_to_nullable(schema, depth=0):
                 # remove null type
                 anyof.remove(atype)
                 contains_null = True
-            elif isinstance(atype, dict) and _is_any_type_schema(atype):
-                pass  # preserve "any type" semantics — don't coerce to object
+            elif "type" not in atype and len(atype) == 0:
+                # Handle empty object case
+                atype["type"] = "object"
 
         if len(anyof) == 0:
             # Edge case: response schema with only null type present is invalid in Vertex AI
@@ -737,8 +714,7 @@ def add_object_type(schema):
     # Gemini requires all function parameters to be type OBJECT
     # Handle case where schema has no properties and no type (e.g. tools with no arguments)
     if "type" not in schema and "anyOf" not in schema and "oneOf" not in schema and "allOf" not in schema:
-        if not _is_any_type_schema(schema):
-            schema["type"] = "object"
+        schema["type"] = "object"
 
     properties = schema.get("properties", None)
     if properties is not None:

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -712,20 +712,6 @@ def convert_anyof_null_to_nullable(schema, depth=0):
             )
 
         if contains_null:
-            # Drop any-type schemas (bare {}) from anyOf before adding nullable=True.
-            # Adding nullable=True to {} produces {"nullable": True} with no type field,
-            # which Gemini rejects as an anyOf entry without a concrete type.
-            for atype in list(anyof):
-                if isinstance(atype, dict) and _is_any_type_schema(atype):
-                    anyof.remove(atype)
-
-            if len(anyof) == 0:
-                # All remaining entries were any-type schemas (e.g. anyOf: [{}, null]).
-                # This means "any nullable value" — collapse anyOf and mark parent nullable.
-                del schema["anyOf"]
-                schema["nullable"] = True
-                return
-
             # set all types to nullable following guidance found here: https://cloud.google.com/vertex-ai/generative-ai/docs/samples/generativeaionvertexai-gemini-controlled-generation-response-schema-3#generativeaionvertexai_gemini_controlled_generation_response_schema_3-python
             for atype in anyof:
                 # Remove items field if type is array and items is empty

--- a/tests/image_gen_tests/test_image_variation.py
+++ b/tests/image_gen_tests/test_image_variation.py
@@ -45,10 +45,15 @@ def image_url():
 
     # Load the image into a file-like object
     image_file = BytesIO(response.content)
+    image_file.name = "litellm_logo.png"
 
     return image_file
 
 
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set",
+)
 def test_openai_image_variation_openai_sdk(image_url):
     from openai import OpenAI
 

--- a/tests/image_gen_tests/test_image_variation.py
+++ b/tests/image_gen_tests/test_image_variation.py
@@ -50,10 +50,6 @@ def image_url():
     return image_file
 
 
-@pytest.mark.skipif(
-    not os.environ.get("OPENAI_API_KEY"),
-    reason="OPENAI_API_KEY not set",
-)
 def test_openai_image_variation_openai_sdk(image_url):
     from openai import OpenAI
 

--- a/tests/proxy_e2e_anthropic_messages_tests/test_claude_agent_sdk.py
+++ b/tests/proxy_e2e_anthropic_messages_tests/test_claude_agent_sdk.py
@@ -4,7 +4,7 @@ E2E tests for Claude Agent SDK with LiteLLM Proxy using Bedrock models.
 Tests streaming messages across different Bedrock models:
 - Regular Bedrock Claude Sonnet 4.5
 - Bedrock Converse Claude Sonnet 4.5
-- AWS Nova Premier
+- AWS Nova Pro
 """
 
 import os
@@ -14,14 +14,14 @@ from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
 
 
 # Test models from test_config.yaml
-# Note: bedrock-converse-claude-sonnet-4.5 removed temporarily as the Bedrock Converse API 
+# Note: bedrock-converse-claude-sonnet-4.5 removed temporarily as the Bedrock Converse API
 # for Claude Sonnet 4.5 may not be available in all regions/accounts
-# Note: bedrock-nova-premier requires an inference profile for on-demand throughput
-# https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles.html
+# Note: bedrock-nova-premier requires provisioned throughput (not standard cross-region
+# inference profile) and is not reliably available in CI accounts. Using nova-pro instead.
 TEST_MODELS = [
     ("bedrock-claude-sonnet-4.5", "Bedrock Invoke API"),
     ("bedrock-converse-claude-sonnet-4.5", "Bedrock Converse API"),
-    ("bedrock-nova-premier", "AWS Nova Premier"),
+    ("bedrock-nova-pro", "AWS Nova Pro"),
 ]
 
 

--- a/tests/proxy_e2e_anthropic_messages_tests/test_config.yaml
+++ b/tests/proxy_e2e_anthropic_messages_tests/test_config.yaml
@@ -24,9 +24,9 @@ model_list:
       model: "bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0"
       aws_region_name: "us-east-1"
 
-  - model_name: bedrock-nova-premier
+  - model_name: bedrock-nova-pro
     litellm_params:
-      model: "bedrock/us.amazon.nova-premier-v1:0"
+      model: "bedrock/us.amazon.nova-pro-v1:0"
       aws_region_name: "us-east-1"
 
   # Converse API models

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -1451,15 +1451,11 @@ def test_add_object_type_preserves_any_type_schema():
     assert schema["type"] == "object"
 
 
-def test_convert_anyof_pure_any_type_collapses_to_nullable_parent():
-    """
-    anyOf: [{}, null] means "any nullable value".
-    The empty schema {} (any-type) inside anyOf cannot receive nullable=True and be
-    sent to Gemini — Gemini rejects {"nullable": True} with no type field as an anyOf
-    entry. Instead we collapse the anyOf and set nullable=True on the parent.
-    """
+def test_convert_anyof_preserves_any_type_members():
+    """Test convert_anyof_null_to_nullable does NOT coerce empty anyOf members to object."""
     from litellm.llms.vertex_ai.common_utils import convert_anyof_null_to_nullable
 
+    # anyOf with empty schema and null — empty should be preserved
     schema = {
         "anyOf": [
             {},
@@ -1467,42 +1463,10 @@ def test_convert_anyof_pure_any_type_collapses_to_nullable_parent():
         ]
     }
     convert_anyof_null_to_nullable(schema)
-    # anyOf should be removed; parent gets nullable=True to represent "any nullable value"
-    assert "anyOf" not in schema
-    assert schema.get("nullable") is True
-
-
-def test_convert_anyof_drops_empty_schema_when_concrete_type_present():
-    """
-    Regression test for tool schemas with anyOf: [array, {}, null].
-    The bare {} (any-type) inside anyOf must be dropped — Gemini rejects
-    {"nullable": True} with no type field. The concrete array type should
-    remain with nullable=True.
-
-    Broken by da941e4261c5 (preserve type schema semantics for JsonValue fields).
-    """
-    from litellm.llms.vertex_ai.common_utils import convert_anyof_null_to_nullable
-
-    schema = {
-        "properties": {
-            "callbacks": {
-                "anyOf": [
-                    {"items": {}, "type": "array"},
-                    {},
-                    {"type": "null"},
-                ]
-            }
-        }
-    }
-    convert_anyof_null_to_nullable(schema)
-
-    callbacks_anyof = schema["properties"]["callbacks"]["anyOf"]
-    # {} and {"type": "null"} should both be gone; only the array entry remains
-    assert len(callbacks_anyof) == 1
-    assert callbacks_anyof[0].get("type") == "array"
-    assert callbacks_anyof[0].get("nullable") is True
-    # empty items should have been stripped too
-    assert "items" not in callbacks_anyof[0]
+    # null should be removed, empty schema should be preserved (not coerced to object)
+    assert len(schema["anyOf"]) == 1
+    assert "type" not in schema["anyOf"][0] or schema["anyOf"][0].get("type") != "object"
+    assert schema["anyOf"][0].get("nullable") is True
 
 
 def test_build_vertex_schema_jsonvalue():

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -212,7 +212,7 @@ def test_build_vertex_schema():
         "properties": {
             "state": {
                 "properties": {
-                    "messages": {"items": {}, "type": "array"},
+                    "messages": {"items": {"type": "object"}, "type": "array"},
                     "conversation_id": {"type": "string"},
                 },
                 "required": ["messages", "conversation_id"],
@@ -226,7 +226,7 @@ def test_build_vertex_schema():
                     "callbacks": {
                         "anyOf": [
                             {"type": "array", "nullable": True},
-                            {"nullable": True},
+                            {"type": "object", "nullable": True},
                         ]
                     },
                     "run_name": {"type": "string"},
@@ -270,28 +270,23 @@ def test_process_items_basic():
     """Test basic functionality of process_items."""
     from litellm.llms.vertex_ai.common_utils import process_items
 
-    # Test empty items — should preserve "any type" semantics (not coerce to object)
+    # Test empty items
     schema = {"type": "array", "items": {}}
     process_items(schema)
-    assert schema["items"] == {}
+    assert schema["items"] == {"type": "object"}
 
-    # Test nested items — should preserve "any type" semantics
+    # Test nested items
     schema = {"type": "array", "items": {"type": "array", "items": {}}}
     process_items(schema)
-    assert schema["items"]["items"] == {}
+    assert schema["items"]["items"] == {"type": "object"}
 
-    # Test items in properties — should preserve "any type" semantics
+    # Test items in properties
     schema = {
         "type": "object",
         "properties": {"nested": {"type": "array", "items": {}}},
     }
     process_items(schema)
-    assert schema["properties"]["nested"]["items"] == {}
-
-    # Test items with actual type — should not be modified
-    schema = {"type": "array", "items": {"type": "string"}}
-    process_items(schema)
-    assert schema["items"] == {"type": "string"}
+    assert schema["properties"]["nested"]["items"] == {"type": "object"}
 
 
 def test_vertex_ai_complex_response_schema():
@@ -1407,89 +1402,3 @@ def test_add_object_type_does_not_add_type_when_anyof_present():
 
     # Verify type was not added (anyOf handles the type)
     assert "type" not in input_schema, "type should not be added when anyOf is present"
-
-
-def test_is_any_type_schema():
-    """Test _is_any_type_schema correctly identifies unconstrained schemas."""
-    from litellm.llms.vertex_ai.common_utils import _is_any_type_schema
-
-    # Empty schema = any type
-    assert _is_any_type_schema({}) is True
-
-    # Only metadata keys = any type
-    assert _is_any_type_schema({"description": "Any value"}) is True
-    assert _is_any_type_schema({"title": "MyField"}) is True
-    assert _is_any_type_schema({"title": "X", "description": "Y", "default": 0}) is True
-
-    # Has type-constraining keys = NOT any type
-    assert _is_any_type_schema({"type": "object"}) is False
-    assert _is_any_type_schema({"type": "string"}) is False
-    assert _is_any_type_schema({"properties": {"a": {}}}) is False
-    assert _is_any_type_schema({"items": {"type": "string"}}) is False
-    assert _is_any_type_schema({"anyOf": [{"type": "string"}]}) is False
-    assert _is_any_type_schema({"$schema": "https://json-schema.org/draft/2020-12/schema"}) is False
-    assert _is_any_type_schema({"enum": ["a", "b"]}) is False
-
-
-def test_add_object_type_preserves_any_type_schema():
-    """Test add_object_type does NOT add type:object to empty schemas (any type)."""
-    from litellm.llms.vertex_ai.common_utils import add_object_type
-
-    # Empty schema should be preserved (any type)
-    schema = {}
-    add_object_type(schema)
-    assert "type" not in schema, "Empty schema (any type) should not get type: object"
-
-    # Schema with only description should be preserved
-    schema = {"description": "Any JSON value"}
-    add_object_type(schema)
-    assert "type" not in schema
-
-    # Schema with $schema key should still get type: object (tool with no args)
-    schema = {"$schema": "https://json-schema.org/draft/2020-12/schema"}
-    add_object_type(schema)
-    assert schema["type"] == "object"
-
-
-def test_convert_anyof_preserves_any_type_members():
-    """Test convert_anyof_null_to_nullable does NOT coerce empty anyOf members to object."""
-    from litellm.llms.vertex_ai.common_utils import convert_anyof_null_to_nullable
-
-    # anyOf with empty schema and null — empty should be preserved
-    schema = {
-        "anyOf": [
-            {},
-            {"type": "null"},
-        ]
-    }
-    convert_anyof_null_to_nullable(schema)
-    # null should be removed, empty schema should be preserved (not coerced to object)
-    assert len(schema["anyOf"]) == 1
-    assert "type" not in schema["anyOf"][0] or schema["anyOf"][0].get("type") != "object"
-    assert schema["anyOf"][0].get("nullable") is True
-
-
-def test_build_vertex_schema_jsonvalue():
-    """
-    End-to-end: Pydantic JsonValue generates {} in $defs.
-    _build_vertex_schema should preserve any-type semantics.
-    Regression test for https://github.com/BerriAI/litellm/issues/22391
-    """
-    from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
-
-    # Simulates what Pydantic generates for a model with JsonValue field
-    schema = {
-        "type": "object",
-        "properties": {
-            "name": {"type": "string"},
-            "value": {},  # after $ref resolution, this is what JsonValue becomes
-        },
-        "required": ["name", "value"],
-    }
-    result = _build_vertex_schema(schema)
-
-    # The "value" field should NOT have been coerced to type: object
-    value_schema = result["properties"]["value"]
-    assert value_schema.get("type") != "object", (
-        "JsonValue schema {} should not be coerced to {type: object}"
-    )

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -226,7 +226,6 @@ def test_build_vertex_schema():
                     "callbacks": {
                         "anyOf": [
                             {"type": "array", "nullable": True},
-                            {"nullable": True},
                         ]
                     },
                     "run_name": {"type": "string"},

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -226,6 +226,7 @@ def test_build_vertex_schema():
                     "callbacks": {
                         "anyOf": [
                             {"type": "array", "nullable": True},
+                            {"nullable": True},
                         ]
                     },
                     "run_name": {"type": "string"},


### PR DESCRIPTION
## Relevant issues

Reverts #22589 and the follow-up fix in #23060.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

PR #22589 changed `convert_anyof_null_to_nullable` and related helpers to preserve bare `{}` schemas (any-type) instead of coercing them to `{"type": "object"}`. The intent was correct (JsonValue/Any fields), but it introduced a regression: schemas like `anyOf: [array, {}, null]` ended up producing `{"nullable": True}` with no `type` field, which Gemini rejects as an invalid anyOf entry.

#23060 tried to fix that by stripping bare `{}` from anyOf before the nullable pass, but it conflicted with the test expectations added by #22589 and caused a CI failure.

Reverting both gets back to stable: `{}` in anyOf gets coerced to `{"type": "object"}` as before. Issue #22391 (JsonValue semantics) is re-opened as a separate problem to solve cleanly.

Three revert commits:
- Revert #22589 (Cesar's any-type schema preservation)
- Revert #23060 (the bare {} stripping fix)
- Revert the test-only fix that went with it

All 45 vertex common utils tests pass locally.