### PR TITLE
[Fix] UI - Team: TeamInfo Virtual Keys Test Assertions

### DIFF
--- a/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
@@ -634,7 +634,7 @@ describe("TeamInfoView", () => {
     await user.click(virtualKeysTab);
 
     await waitFor(() => {
-      expect(screen.getByText("5 Members")).toBeInTheDocument();
+      expect(screen.getByText("Page 1 of 1")).toBeInTheDocument();
     });
   });
 
@@ -679,9 +679,8 @@ describe("TeamInfoView", () => {
     await user.click(virtualKeysTab);
 
     await waitFor(() => {
-      expect(screen.getByText("1 Member")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Filters" })).toBeInTheDocument();
     });
-    expect(screen.getByRole("button", { name: "Filters" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Reset Filters" })).toBeInTheDocument();
     expect(screen.getByText("Page 1 of 1")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Previous" })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Fixes regression in TeamInfo.test.tsx where two tests were asserting for "X Members" text that was removed from the TeamVirtualKeysTable component.

Commit ec4ef9c924 removed the member count display from the Virtual Keys tab but only updated tests in TeamVirtualKeysTable.test.tsx. This PR updates the two related tests in TeamInfo.test.tsx that were still checking for the removed text.

## Changes

- Test "should display X Members in Virtual Keys tab when navigated to": Changed assertion from "5 Members" to "Page 1 of 1" pagination text
- Test "should show Filters and pagination controls in Virtual Keys tab": Removed assertion for "1 Member" text, now waits for Filters button instead

## Testing

All 29 tests in TeamInfo.test.tsx pass after these changes.