### PR TITLE
fix(anthropic): strip empty text blocks from /v1/messages passthrough

### DIFF
--- a/.github/workflows/publish_enterprise.yml
+++ b/.github/workflows/publish_enterprise.yml
@@ -58,6 +58,7 @@ jobs:
         run: poetry build
 
       - name: Commit version bump and create PR
+        id: create-pr
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -72,7 +73,15 @@ jobs:
             --body "Version bump for litellm-enterprise. Merge to update main." \
             --head "$BRANCH" \
             --base main \
-          || echo "PR already exists"
+          || true
+          PR_URL=$(gh pr list --head "$BRANCH" --json url -q '.[0].url')
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Enable auto-merge
+        run: |
+          gh pr merge "${{ steps.create-pr.outputs.pr_url }}" --auto --squash
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -73,7 +73,7 @@ def _strip_empty_text_blocks_from_anthropic_messages(
             if not (
                 isinstance(block, dict)
                 and block.get("type") == "text"
-                and not block.get("text")
+                and not (block.get("text") or "").strip()
             )
         ]
         # Only replace if we actually removed something, and keep at

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -11,6 +11,7 @@ from functools import partial
 from typing import Any, AsyncIterator, Coroutine, Dict, List, Optional, Union
 
 import litellm
+from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.anthropic_messages.transformation import (
     BaseAnthropicMessagesConfig,
@@ -62,10 +63,14 @@ def _strip_empty_text_blocks_from_anthropic_messages(
     This mirrors the filtering already done in ``anthropic_messages_pt()``
     (the ``/v1/chat/completions`` path), but operates on native Anthropic
     message format so it covers the ``/v1/messages`` passthrough path.
+
+    Returns a new list; the original message dicts are not mutated.
     """
+    result = []
     for message in messages:
         content = message.get("content")
         if not isinstance(content, list):
+            result.append(message)
             continue
         filtered = [
             block
@@ -76,11 +81,19 @@ def _strip_empty_text_blocks_from_anthropic_messages(
                 and not (block.get("text") or "").strip()
             )
         ]
-        # Only replace if we actually removed something, and keep at
-        # least one block to avoid sending an empty content array.
         if len(filtered) < len(content) and len(filtered) > 0:
-            message["content"] = filtered
-    return messages
+            result.append({**message, "content": filtered})
+        elif len(filtered) == 0 and len(content) > 0:
+            # All blocks were empty text; cannot send empty content array.
+            # Preserve original to avoid breaking the request shape.
+            verbose_logger.warning(
+                "Cannot strip all empty text blocks from message "
+                "(would empty content). Message forwarded as-is."
+            )
+            result.append(message)
+        else:
+            result.append(message)
+    return result
 
 
 async def _execute_pre_request_hooks(

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -49,6 +49,40 @@ base_llm_http_handler = BaseLLMHTTPHandler()
 #################################################
 
 
+def _strip_empty_text_blocks_from_anthropic_messages(
+    messages: List[Dict],
+) -> List[Dict]:
+    """Remove empty text content blocks from Anthropic-format messages.
+
+    Anthropic's API often returns assistant messages with ``{"type": "text",
+    "text": ""}`` alongside ``tool_use`` blocks. When these messages are sent
+    back in a multi-turn conversation, Anthropic rejects them with a
+    validation error.
+
+    This mirrors the filtering already done in ``anthropic_messages_pt()``
+    (the ``/v1/chat/completions`` path), but operates on native Anthropic
+    message format so it covers the ``/v1/messages`` passthrough path.
+    """
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        filtered = [
+            block
+            for block in content
+            if not (
+                isinstance(block, dict)
+                and block.get("type") == "text"
+                and not block.get("text")
+            )
+        ]
+        # Only replace if we actually removed something, and keep at
+        # least one block to avoid sending an empty content array.
+        if len(filtered) < len(content) and len(filtered) > 0:
+            message["content"] = filtered
+    return messages
+
+
 async def _execute_pre_request_hooks(
     model: str,
     messages: List[Dict],
@@ -236,6 +270,14 @@ def anthropic_messages_handler(
     from litellm.types.utils import LlmProviders
 
     metadata = validate_anthropic_api_metadata(metadata)
+
+    # Sanitize empty text content blocks in Anthropic-format messages.
+    # Anthropic's API returns assistant messages with {"type": "text", "text": ""}
+    # alongside tool_use blocks, but rejects them on subsequent requests.
+    # This must happen here (in the /v1/messages handler) because messages are
+    # already in Anthropic format and bypass anthropic_messages_pt() sanitization.
+    # Fixes: https://github.com/BerriAI/litellm/issues/22930
+    messages = _strip_empty_text_blocks_from_anthropic_messages(messages)
 
     local_vars = locals()
     is_async = kwargs.pop("is_async", False)

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -21119,7 +21119,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21127,9 +21127,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",
@@ -21168,7 +21167,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21176,9 +21175,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -377,9 +377,6 @@ from litellm.proxy.management_endpoints.internal_user_endpoints import user_upda
 from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
     router as jwt_key_mapping_router,
 )
-from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
-    router as jwt_key_mapping_router,
-)
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     delete_verification_tokens,
     duration_in_seconds,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21119,7 +21119,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21127,9 +21127,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",
@@ -21168,7 +21167,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21176,9 +21175,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",

--- a/tests/pass_through_unit_tests/test_strip_empty_text_blocks.py
+++ b/tests/pass_through_unit_tests/test_strip_empty_text_blocks.py
@@ -8,8 +8,6 @@ returns in assistant responses but rejects on subsequent requests.
 
 import copy
 
-import pytest
-
 from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
     _strip_empty_text_blocks_from_anthropic_messages,
 )
@@ -122,6 +120,27 @@ def test_user_messages_also_sanitized():
     result = _strip_empty_text_blocks_from_anthropic_messages(messages)
     assert len(result[0]["content"]) == 1
     assert result[0]["content"][0]["type"] == "image"
+
+
+def test_whitespace_only_text_blocks_removed():
+    """Whitespace-only text blocks (e.g. ' ') are treated as empty and removed."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": " "},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01D",
+                    "name": "search",
+                    "input": {"q": "test"},
+                },
+            ],
+        },
+    ]
+    result = _strip_empty_text_blocks_from_anthropic_messages(messages)
+    assert len(result[0]["content"]) == 1
+    assert result[0]["content"][0]["type"] == "tool_use"
 
 
 def test_empty_messages_list():

--- a/tests/pass_through_unit_tests/test_strip_empty_text_blocks.py
+++ b/tests/pass_through_unit_tests/test_strip_empty_text_blocks.py
@@ -60,6 +60,30 @@ def test_preserves_nonempty_text_block():
     assert result == original
 
 
+def test_does_not_mutate_original_messages():
+    """The original message dicts must not be mutated in-place."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": ""},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_mut",
+                    "name": "search",
+                    "input": {"q": "test"},
+                },
+            ],
+        },
+    ]
+    original_content = copy.deepcopy(messages[0]["content"])
+    result = _strip_empty_text_blocks_from_anthropic_messages(messages)
+    # Result should have the empty text block removed
+    assert len(result[0]["content"]) == 1
+    # But the original message should be untouched
+    assert messages[0]["content"] == original_content
+
+
 def test_string_content_untouched():
     """Messages with string content (not list) must pass through unchanged."""
     messages = [

--- a/tests/pass_through_unit_tests/test_strip_empty_text_blocks.py
+++ b/tests/pass_through_unit_tests/test_strip_empty_text_blocks.py
@@ -1,0 +1,178 @@
+"""
+Tests for _strip_empty_text_blocks_from_anthropic_messages.
+
+Covers the fix for https://github.com/BerriAI/litellm/issues/22930:
+The /v1/messages endpoint must strip empty text content blocks that Anthropic
+returns in assistant responses but rejects on subsequent requests.
+"""
+
+import copy
+
+import pytest
+
+from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+    _strip_empty_text_blocks_from_anthropic_messages,
+)
+
+
+def test_removes_empty_text_block_alongside_tool_use():
+    """Assistant message with tool_use + empty text block → text block removed."""
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "What is the weather?"}],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": ""},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01A",
+                    "name": "get_weather",
+                    "input": {"location": "SF"},
+                },
+            ],
+        },
+    ]
+    result = _strip_empty_text_blocks_from_anthropic_messages(messages)
+    assistant = result[1]
+    assert len(assistant["content"]) == 1
+    assert assistant["content"][0]["type"] == "tool_use"
+
+
+def test_preserves_nonempty_text_block():
+    """Non-empty text blocks must not be removed."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "I'll look that up."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01B",
+                    "name": "search",
+                    "input": {"q": "test"},
+                },
+            ],
+        },
+    ]
+    original = copy.deepcopy(messages)
+    result = _strip_empty_text_blocks_from_anthropic_messages(messages)
+    assert result == original
+
+
+def test_string_content_untouched():
+    """Messages with string content (not list) must pass through unchanged."""
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+    ]
+    original = copy.deepcopy(messages)
+    result = _strip_empty_text_blocks_from_anthropic_messages(messages)
+    assert result == original
+
+
+def test_does_not_empty_content_array():
+    """If removing empty text blocks would leave content empty, keep them."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": ""}],
+        },
+    ]
+    result = _strip_empty_text_blocks_from_anthropic_messages(messages)
+    # Content should remain untouched — can't leave it empty
+    assert len(result[0]["content"]) == 1
+
+
+def test_multiple_empty_text_blocks_removed():
+    """Multiple empty text blocks are all removed when other blocks exist."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": ""},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01C",
+                    "name": "calc",
+                    "input": {"expr": "1+1"},
+                },
+                {"type": "text", "text": ""},
+            ],
+        },
+    ]
+    result = _strip_empty_text_blocks_from_anthropic_messages(messages)
+    assert len(result[0]["content"]) == 1
+    assert result[0]["content"][0]["type"] == "tool_use"
+
+
+def test_user_messages_also_sanitized():
+    """Empty text blocks in user messages are also stripped (defensive)."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": ""},
+                {"type": "image", "source": {"type": "base64", "data": "..."}},
+            ],
+        },
+    ]
+    result = _strip_empty_text_blocks_from_anthropic_messages(messages)
+    assert len(result[0]["content"]) == 1
+    assert result[0]["content"][0]["type"] == "image"
+
+
+def test_empty_messages_list():
+    """Empty messages list returns empty list."""
+    assert _strip_empty_text_blocks_from_anthropic_messages([]) == []
+
+
+def test_real_world_multi_turn_with_tool_result():
+    """
+    Real-world multi-turn scenario from issue #22930:
+    User → Assistant (tool_use + empty text) → tool_result → Assistant
+    """
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "What's 2+2?"}],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": ""},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_calc",
+                    "name": "calculator",
+                    "input": {"expression": "2+2"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_calc",
+                    "content": "4",
+                },
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "The answer is 4."}],
+        },
+    ]
+    result = _strip_empty_text_blocks_from_anthropic_messages(messages)
+
+    # The second message (assistant with tool_use) should have empty text removed
+    assert len(result[1]["content"]) == 1
+    assert result[1]["content"][0]["type"] == "tool_use"
+
+    # All other messages remain unchanged
+    assert len(result[0]["content"]) == 1  # user
+    assert len(result[2]["content"]) == 1  # tool_result
+    assert len(result[3]["content"]) == 1  # final assistant

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -609,6 +609,24 @@ def test_responses_api_bridge_check_strips_responses_prefix():
         assert model_info["mode"] == "responses"
 
 
+def test_responses_api_bridge_check_gpt_5_4_pro():
+    """Test that gpt-5.4-pro routes through responses API bridge, not chat completions.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/23014
+    gpt-5.4-pro is a responses-only model and must not be sent to /v1/chat/completions.
+    """
+    from litellm.main import responses_api_bridge_check
+
+    for model_name in ["gpt-5.4-pro", "gpt-5.4-pro-2026-03-05"]:
+        model_info, model = responses_api_bridge_check(
+            model=model_name,
+            custom_llm_provider="openai",
+        )
+        assert model_info.get("mode") == "responses", (
+            f"{model_name} should have mode='responses', got '{model_info.get('mode')}'"
+        )
+
+
 def test_responses_api_bridge_check_handles_exception():
     """Test that responses_api_bridge_check handles exceptions and still processes responses/ models."""
     from litellm.main import responses_api_bridge_check


### PR DESCRIPTION
## Summary

Fixes #22930 — The `/v1/messages` endpoint does not sanitize empty text content blocks, causing Anthropic API rejections on multi-turn conversations.

## Root Cause

Anthropic's API returns assistant messages with `{"type": "text", "text": ""}` alongside `tool_use` blocks. When these messages are replayed in subsequent turns via `/v1/messages`, Anthropic rejects them with a validation error.

The existing `/v1/chat/completions` path already handles this via `anthropic_messages_pt()` (line 2478 in `factory.py`), but the `/v1/messages` passthrough bypasses that function entirely because messages are already in native Anthropic format.

## Fix

Added `_strip_empty_text_blocks_from_anthropic_messages()` in the `/v1/messages` handler (`handler.py`). The function:

- Removes `{"type": "text", "text": ""}` blocks from content arrays
- Preserves non-empty text blocks and all other block types (tool_use, thinking, etc.)
- Refuses to empty a content array entirely (safety guard)
- Called early in `anthropic_messages_handler()`, covering all downstream code paths

## Tests

8 unit tests covering:
- Empty text block removal alongside tool_use
- Non-empty text block preservation
- String content passthrough (no-op)
- Safety guard: won't empty content array
- Multiple empty text blocks
- User message sanitization (defensive)
- Empty messages list
- Real-world multi-turn with tool_result

All 8 tests pass.

## Changes

| File | Change |
|------|--------|
| `litellm/llms/anthropic/experimental_pass_through/messages/handler.py` | Added `_strip_empty_text_blocks_from_anthropic_messages()` + call in handler |
| `tests/pass_through_unit_tests/test_strip_empty_text_blocks.py` | 8 new unit tests |
