### PR TITLE
test(vertex_ai): pin gemini-3.1-flash-lite reasoning mapping

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2082,7 +2082,10 @@ def test_reasoning_effort_maps_to_thinking_level_gemini_3():
     "reasoning_effort,expected_include_thoughts",
     [
         ("minimal", True),
+        ("low", True),
         ("medium", True),
+        ("high", True),
+        ("disable", False),
         ("none", False),
     ],
 )

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2094,14 +2094,17 @@ def test_reasoning_effort_maps_to_thinking_level_gemini_31_flash_lite(
     expected_thinking_level: str,
     expected_include_thoughts: bool,
 ):
-    result = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
-        reasoning_effort=reasoning_effort,
+    v = VertexGeminiConfig()
+    result = v.map_openai_params(
+        non_default_params={"reasoning_effort": reasoning_effort},
+        optional_params={},
         model="gemini-3.1-flash-lite-preview",
+        drop_params=False,
     )
 
-    assert result["thinkingLevel"] == expected_thinking_level
-    assert result["includeThoughts"] is expected_include_thoughts
-    assert "thinkingBudget" not in result
+    assert result["thinkingConfig"]["thinkingLevel"] == expected_thinking_level
+    assert result["thinkingConfig"]["includeThoughts"] is expected_include_thoughts
+    assert "thinkingBudget" not in result["thinkingConfig"]
 
 
 def test_reasoning_effort_dict_format_gemini_3():

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2079,18 +2079,19 @@ def test_reasoning_effort_maps_to_thinking_level_gemini_3():
 
 
 @pytest.mark.parametrize(
-    "reasoning_effort,expected_include_thoughts",
+    "reasoning_effort,expected_thinking_level,expected_include_thoughts",
     [
-        ("minimal", True),
-        ("low", True),
-        ("medium", True),
-        ("high", True),
-        ("disable", False),
-        ("none", False),
+        ("minimal", "minimal", True),
+        ("low", "low", True),
+        ("medium", "medium", True),
+        ("high", "high", True),
+        ("disable", "minimal", False),
+        ("none", "minimal", False),
     ],
 )
 def test_reasoning_effort_maps_to_thinking_level_gemini_31_flash_lite(
     reasoning_effort: str,
+    expected_thinking_level: str,
     expected_include_thoughts: bool,
 ):
     result = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
@@ -2098,7 +2099,7 @@ def test_reasoning_effort_maps_to_thinking_level_gemini_31_flash_lite(
         model="gemini-3.1-flash-lite-preview",
     )
 
-    assert "thinkingLevel" in result
+    assert result["thinkingLevel"] == expected_thinking_level
     assert result["includeThoughts"] is expected_include_thoughts
     assert "thinkingBudget" not in result
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2078,6 +2078,33 @@ def test_reasoning_effort_maps_to_thinking_level_gemini_3():
     assert result["thinkingConfig"]["includeThoughts"] is False
 
 
+@pytest.mark.parametrize(
+    "reasoning_effort,expected_thinking_level,expected_include_thoughts",
+    [
+        ("minimal", "minimal", True),
+        ("medium", "medium", True),
+        ("none", "minimal", False),
+    ],
+)
+def test_reasoning_effort_maps_to_thinking_level_gemini_31_flash_lite(
+    reasoning_effort: str,
+    expected_thinking_level: str,
+    expected_include_thoughts: bool,
+):
+    v = VertexGeminiConfig()
+
+    result = v.map_openai_params(
+        non_default_params={"reasoning_effort": reasoning_effort},
+        optional_params={},
+        model="gemini-3.1-flash-lite-preview",
+        drop_params=False,
+    )
+
+    assert result["thinkingConfig"]["thinkingLevel"] == expected_thinking_level
+    assert result["thinkingConfig"]["includeThoughts"] is expected_include_thoughts
+    assert "thinkingBudget" not in result["thinkingConfig"]
+
+
 def test_reasoning_effort_dict_format_gemini_3():
     """
     Test that reasoning_effort works when passed as dict format from OpenAI Agents SDK.
@@ -3723,4 +3750,3 @@ def test_vertex_ai_usage_metadata_video_tokens_with_caching():
         "Prompt video tokens should be 10240 - 5120 (cached) = 5120"
     assert result.prompt_tokens_details.text_tokens == 9
     assert result.prompt_tokens_details.audio_tokens == 200
-

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2079,30 +2079,25 @@ def test_reasoning_effort_maps_to_thinking_level_gemini_3():
 
 
 @pytest.mark.parametrize(
-    "reasoning_effort,expected_thinking_level,expected_include_thoughts",
+    "reasoning_effort,expected_include_thoughts",
     [
-        ("minimal", "minimal", True),
-        ("medium", "medium", True),
-        ("none", "minimal", False),
+        ("minimal", True),
+        ("medium", True),
+        ("none", False),
     ],
 )
 def test_reasoning_effort_maps_to_thinking_level_gemini_31_flash_lite(
     reasoning_effort: str,
-    expected_thinking_level: str,
     expected_include_thoughts: bool,
 ):
-    v = VertexGeminiConfig()
-
-    result = v.map_openai_params(
-        non_default_params={"reasoning_effort": reasoning_effort},
-        optional_params={},
+    result = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
+        reasoning_effort=reasoning_effort,
         model="gemini-3.1-flash-lite-preview",
-        drop_params=False,
     )
 
-    assert result["thinkingConfig"]["thinkingLevel"] == expected_thinking_level
-    assert result["thinkingConfig"]["includeThoughts"] is expected_include_thoughts
-    assert "thinkingBudget" not in result["thinkingConfig"]
+    assert "thinkingLevel" in result
+    assert result["includeThoughts"] is expected_include_thoughts
+    assert "thinkingBudget" not in result
 
 
 def test_reasoning_effort_dict_format_gemini_3():


### PR DESCRIPTION
## Relevant issues

Related: #22674, #22920

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

✅ Test

## Changes

- Add explicit `tests/test_litellm/` regression coverage for `gemini-3.1-flash-lite-preview`
- Cover all six supported `reasoning_effort` values for this model: `minimal`, `low`, `medium`, `high`, `disable`, `none`
- Assert the model stays on the `thinkingLevel` path and does not regress to `thinkingBudget`
- Assert `includeThoughts` stays aligned with the enabled vs disabled effort cases

## Validation

- `PYTEST_XDIST_WORKER=gw0 uv run pytest tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py -k gemini_31_flash_lite -q`
  - `6 passed, 87 deselected`
- `uv run ruff check tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py`
  - still blocked by pre-existing lint violations in this file unrelated to this diff

## Reference

- https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-flash-lite
