### PR TITLE
fix: preserve thinking block order with multiple web searches

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2445,74 +2445,242 @@ def anthropic_messages_pt(  # noqa: PLR0915
                     assistant_content.extend(_compaction_blocks)  # type: ignore
 
             thinking_blocks = assistant_content_block.get("thinking_blocks", None)
+
+            # Check if tool_calls contain server tool calls (web search, etc.)
+            # If so, we need to interleave thinking blocks with tool call groups
+            # to preserve the original content block ordering.
+            # Fixes: https://github.com/BerriAI/litellm/issues/23047
+            assistant_tool_calls = assistant_content_block.get("tool_calls")
+            _has_server_tool_calls = False
+            if assistant_tool_calls is not None:
+                for _tc in assistant_tool_calls:
+                    _tc_id = (
+                        _tc.get("id")
+                        if isinstance(_tc, dict)
+                        else getattr(_tc, "id", None)
+                    )
+                    if _tc_id and isinstance(_tc_id, str) and _tc_id.startswith("srvtoolu_"):
+                        _has_server_tool_calls = True
+                        break
+
             if (
                 thinking_blocks is not None
-            ):  # IMPORTANT: ADD THIS FIRST, ELSE ANTHROPIC WILL RAISE AN ERROR
-                assistant_content.extend(thinking_blocks)
-            if "content" in assistant_content_block and isinstance(
-                assistant_content_block["content"], list
+                and _has_server_tool_calls
+                and isinstance(
+                    assistant_content_block.get("content", None), (str, type(None))
+                )
             ):
-                for m in assistant_content_block["content"]:
-                    # handle thinking blocks
-                    thinking_block = cast(str, m.get("thinking", ""))
-                    text_block = cast(str, m.get("text", ""))
-                    if (
-                        m.get("type", "") == "thinking" and len(thinking_block) > 0
-                    ):  # don't pass empty text blocks. anthropic api raises errors.
-                        anthropic_message: Union[
-                            ChatCompletionThinkingBlock,
-                            AnthropicMessagesTextParam,
-                        ] = cast(ChatCompletionThinkingBlock, m)
-                        assistant_content.append(anthropic_message)
-                    # handle text
-                    elif (
-                        m.get("type", "") == "text" and len(text_block) > 0
-                    ):  # don't pass empty text blocks. anthropic api raises errors.
-                        anthropic_message = AnthropicMessagesTextParam(
-                            type="text", text=text_block
-                        )
-                        _cached_message = add_cache_control_to_content(
-                            anthropic_content_element=anthropic_message,
-                            original_content_element=dict(m),
-                        )
+                # INTERLEAVED MODE: When we have both thinking blocks and server
+                # tool calls (e.g. web search), Anthropic's original response
+                # interleaves them: [thinking_1, server_tool_use_1, result_1,
+                # thinking_2, text, server_tool_use_2, result_2, ...].
+                # We must preserve this interleaved order because Anthropic
+                # verifies thinking block signatures based on position.
 
-                        assistant_content.append(
-                            cast(AnthropicMessagesTextParam, _cached_message)
-                        )
-                    # handle server_tool_use blocks (tool search, web search, etc.)
-                    # Pass through as-is since these are Anthropic-native content types
-                    elif m.get("type", "") == "server_tool_use":
-                        assistant_content.append(m)  # type: ignore
-                    # handle all *_tool_result blocks (tool_search_tool_result,
-                    # web_search_tool_result, bash_code_execution_tool_result, etc.)
-                    # Pass through as-is since these are Anthropic-native content types
-                    elif m.get("type", "").endswith("_tool_result"):
-                        assistant_content.append(m)  # type: ignore
-            elif (
-                "content" in assistant_content_block
-                and isinstance(assistant_content_block["content"], str)
-                and assistant_content_block[
-                    "content"
-                ]  # don't pass empty text blocks. anthropic api raises errors.
-            ):
-                _anthropic_text_content_element = AnthropicMessagesTextParam(
-                    type="text",
-                    text=assistant_content_block["content"],
+                # Build the tool call groups (server_tool_use + its result)
+                _provider_specific_fields_raw_tc = assistant_content_block.get(
+                    "provider_specific_fields"
+                )
+                _provider_specific_fields_tc: Dict[str, Any] = {}
+                if isinstance(_provider_specific_fields_raw_tc, dict):
+                    _provider_specific_fields_tc = cast(
+                        Dict[str, Any], _provider_specific_fields_raw_tc
+                    )
+                _web_search_results_tc = _provider_specific_fields_tc.get(
+                    "web_search_results"
+                )
+                _tool_results_tc = _provider_specific_fields_tc.get("tool_results")
+                tool_invoke_results = convert_to_anthropic_tool_invoke(
+                    assistant_tool_calls,  # type: ignore
+                    web_search_results=_web_search_results_tc,
+                    tool_results=_tool_results_tc,
                 )
 
-                _content_element = add_cache_control_to_content(
-                    anthropic_content_element=_anthropic_text_content_element,
-                    original_content_element=dict(assistant_content_block),
-                )
+                # Group tool invoke results into (server_tool_use, result) pairs
+                # and separate regular tool_use blocks
+                server_tool_groups: List[List[Any]] = []
+                regular_tool_uses: List[Any] = []
+                _current_group: List[Any] = []
+                for item in tool_invoke_results:
+                    item_type = (
+                        item.get("type", "")
+                        if isinstance(item, dict)
+                        else getattr(item, "type", "")
+                    )
+                    if item_type == "server_tool_use":
+                        if _current_group:
+                            server_tool_groups.append(_current_group)
+                        _current_group = [item]
+                    elif item_type.endswith("_tool_result"):
+                        _current_group.append(item)
+                    elif item_type == "tool_use":
+                        regular_tool_uses.append(item)
+                    else:
+                        _current_group.append(item)
+                if _current_group:
+                    server_tool_groups.append(_current_group)
 
-                if "cache_control" in _content_element:
-                    _anthropic_text_content_element["cache_control"] = _content_element[
-                        "cache_control"
-                    ]
+                # Build the text block if content is a non-empty string
+                text_element = None
+                if (
+                    isinstance(assistant_content_block.get("content"), str)
+                    and assistant_content_block["content"]
+                ):
+                    _anthropic_text_content_element = AnthropicMessagesTextParam(
+                        type="text",
+                        text=assistant_content_block["content"],
+                    )
+                    _content_element = add_cache_control_to_content(
+                        anthropic_content_element=_anthropic_text_content_element,
+                        original_content_element=dict(assistant_content_block),
+                    )
+                    if "cache_control" in _content_element:
+                        _anthropic_text_content_element["cache_control"] = (
+                            _content_element["cache_control"]
+                        )
+                    text_element = _anthropic_text_content_element
 
-                assistant_content.append(_anthropic_text_content_element)
+                # Interleave: each thinking block precedes its server tool group.
+                # Pattern: thinking[0], group[0], thinking[1], group[1], ...
+                # Any remaining thinking blocks (after all groups) go before text.
+                # Any remaining groups (after all thinking blocks) go after.
+                tb_idx = 0
+                grp_idx = 0
+                num_tb = len(thinking_blocks) if thinking_blocks else 0
+                num_grp = len(server_tool_groups)
 
-            assistant_tool_calls = assistant_content_block.get("tool_calls")
+                while tb_idx < num_tb or grp_idx < num_grp:
+                    if tb_idx < num_tb and grp_idx < num_grp:
+                        # Emit thinking block then its tool group
+                        assistant_content.append(thinking_blocks[tb_idx])
+                        tb_idx += 1
+                        for block in server_tool_groups[grp_idx]:
+                            item_id = (
+                                block.get("id")
+                                if isinstance(block, dict)
+                                else getattr(block, "id", None)
+                            )
+                            if item_id and item_id in unique_tool_ids:
+                                continue
+                            if item_id:
+                                unique_tool_ids.add(item_id)
+                            assistant_content.append(
+                                cast(AnthropicMessagesAssistantMessageValues, block)
+                            )
+                        grp_idx += 1
+                    elif tb_idx < num_tb:
+                        # More thinking blocks than tool groups - emit before text
+                        assistant_content.append(thinking_blocks[tb_idx])
+                        tb_idx += 1
+                    else:
+                        # More tool groups than thinking blocks - emit remaining
+                        for block in server_tool_groups[grp_idx]:
+                            item_id = (
+                                block.get("id")
+                                if isinstance(block, dict)
+                                else getattr(block, "id", None)
+                            )
+                            if item_id and item_id in unique_tool_ids:
+                                continue
+                            if item_id:
+                                unique_tool_ids.add(item_id)
+                            assistant_content.append(
+                                cast(AnthropicMessagesAssistantMessageValues, block)
+                            )
+                        grp_idx += 1
+
+                # Add text block (if any)
+                if text_element is not None:
+                    assistant_content.append(text_element)
+
+                # Add regular (non-server) tool calls at the end
+                for item in regular_tool_uses:
+                    item_id = (
+                        item.get("id")
+                        if isinstance(item, dict)
+                        else getattr(item, "id", None)
+                    )
+                    if item_id and item_id in unique_tool_ids:
+                        continue
+                    if item_id:
+                        unique_tool_ids.add(item_id)
+                    assistant_content.append(
+                        cast(AnthropicMessagesAssistantMessageValues, item)
+                    )
+
+                # Mark tool_calls as already processed so they are not added again
+                assistant_tool_calls = None
+
+            else:
+                # SEQUENTIAL MODE: No server tool calls, or no thinking blocks,
+                # or content is a list. Use the original sequential approach.
+                if (
+                    thinking_blocks is not None
+                ):  # IMPORTANT: ADD THIS FIRST, ELSE ANTHROPIC WILL RAISE AN ERROR
+                    assistant_content.extend(thinking_blocks)
+                if "content" in assistant_content_block and isinstance(
+                    assistant_content_block["content"], list
+                ):
+                    for m in assistant_content_block["content"]:
+                        # handle thinking blocks
+                        thinking_block = cast(str, m.get("thinking", ""))
+                        text_block = cast(str, m.get("text", ""))
+                        if (
+                            m.get("type", "") == "thinking" and len(thinking_block) > 0
+                        ):  # don't pass empty text blocks. anthropic api raises errors.
+                            anthropic_message: Union[
+                                ChatCompletionThinkingBlock,
+                                AnthropicMessagesTextParam,
+                            ] = cast(ChatCompletionThinkingBlock, m)
+                            assistant_content.append(anthropic_message)
+                        # handle text
+                        elif (
+                            m.get("type", "") == "text" and len(text_block) > 0
+                        ):  # don't pass empty text blocks. anthropic api raises errors.
+                            anthropic_message = AnthropicMessagesTextParam(
+                                type="text", text=text_block
+                            )
+                            _cached_message = add_cache_control_to_content(
+                                anthropic_content_element=anthropic_message,
+                                original_content_element=dict(m),
+                            )
+
+                            assistant_content.append(
+                                cast(AnthropicMessagesTextParam, _cached_message)
+                            )
+                        # handle server_tool_use blocks (tool search, web search, etc.)
+                        # Pass through as-is since these are Anthropic-native content types
+                        elif m.get("type", "") == "server_tool_use":
+                            assistant_content.append(m)  # type: ignore
+                        # handle all *_tool_result blocks (tool_search_tool_result,
+                        # web_search_tool_result, bash_code_execution_tool_result, etc.)
+                        # Pass through as-is since these are Anthropic-native content types
+                        elif m.get("type", "").endswith("_tool_result"):
+                            assistant_content.append(m)  # type: ignore
+                elif (
+                    "content" in assistant_content_block
+                    and isinstance(assistant_content_block["content"], str)
+                    and assistant_content_block[
+                        "content"
+                    ]  # don't pass empty text blocks. anthropic api raises errors.
+                ):
+                    _anthropic_text_content_element = AnthropicMessagesTextParam(
+                        type="text",
+                        text=assistant_content_block["content"],
+                    )
+
+                    _content_element = add_cache_control_to_content(
+                        anthropic_content_element=_anthropic_text_content_element,
+                        original_content_element=dict(assistant_content_block),
+                    )
+
+                    if "cache_control" in _content_element:
+                        _anthropic_text_content_element["cache_control"] = _content_element[
+                            "cache_control"
+                        ]
+
+                    assistant_content.append(_anthropic_text_content_element)
+
             if (
                 assistant_tool_calls is not None
             ):  # support assistant tool invoke conversion

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2626,7 +2626,7 @@ def anthropic_messages_pt(  # noqa: PLR0915
                 _list_has_thinking = False
                 if _content_is_list:
                     for _item in assistant_content_block["content"]:
-                        if isinstance(_item, dict) and _item.get("type") == "thinking":
+                        if isinstance(_item, dict) and _item.get("type") in ("thinking", "redacted_thinking"):
                             _list_has_thinking = True
                             break
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2614,13 +2614,28 @@ def anthropic_messages_pt(  # noqa: PLR0915
             else:
                 # SEQUENTIAL MODE: No server tool calls, or no thinking blocks,
                 # or content is a list. Use the original sequential approach.
+
+                # When content is a list, check if it already contains thinking
+                # blocks inline. If so, skip prepending thinking_blocks to avoid
+                # duplication and preserve the original interleaved order.
+                # Fixes the gap where list-content messages bypass INTERLEAVED
+                # MODE and still get thinking blocks prepended out of order.
+                _content_is_list = "content" in assistant_content_block and isinstance(
+                    assistant_content_block["content"], list
+                )
+                _list_has_thinking = False
+                if _content_is_list:
+                    for _item in assistant_content_block["content"]:
+                        if isinstance(_item, dict) and _item.get("type") == "thinking":
+                            _list_has_thinking = True
+                            break
+
                 if (
                     thinking_blocks is not None
+                    and not _list_has_thinking
                 ):  # IMPORTANT: ADD THIS FIRST, ELSE ANTHROPIC WILL RAISE AN ERROR
                     assistant_content.extend(thinking_blocks)
-                if "content" in assistant_content_block and isinstance(
-                    assistant_content_block["content"], list
-                ):
+                if _content_is_list:
                     for m in assistant_content_block["content"]:
                         # handle thinking blocks
                         thinking_block = cast(str, m.get("thinking", ""))

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -1847,3 +1847,100 @@ def test_anthropic_messages_pt_interleave_more_thinking_than_tool_groups():
         "thinking",            # extra - before text
         "text",
     ], f"Expected order but got: {types}"
+
+
+def test_anthropic_messages_pt_list_content_with_thinking_preserves_order():
+    """
+    Test that when assistant content is already a list containing interleaved
+    thinking blocks and server tool blocks, the thinking_blocks from
+    provider_specific_fields are NOT duplicated/prepended.
+
+    This covers the gap identified by Greptile where list-content messages
+    bypass INTERLEAVED MODE and fall into SEQUENTIAL MODE, which previously
+    would prepend all thinking_blocks again, causing duplication and
+    breaking Anthropic's position-dependent signature verification.
+
+    Fixes: https://github.com/BerriAI/litellm/issues/23047
+    """
+    messages = [
+        {"role": "user", "content": "Search for AI news"},
+        {
+            "role": "assistant",
+            # Content is already a list with interleaved thinking + server tool blocks
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "Let me search for AI news.",
+                    "signature": "sig_1",
+                },
+                {
+                    "type": "server_tool_use",
+                    "id": "srvtoolu_01SEARCH1",
+                    "name": "web_search",
+                    "input": {"query": "AI news"},
+                },
+                {
+                    "type": "web_search_tool_result",
+                    "tool_use_id": "srvtoolu_01SEARCH1",
+                    "content": [
+                        {
+                            "type": "web_search_result",
+                            "url": "https://example.com",
+                            "title": "AI News",
+                            "snippet": "Latest AI news",
+                        }
+                    ],
+                },
+                {
+                    "type": "thinking",
+                    "thinking": "Now let me summarize.",
+                    "signature": "sig_2",
+                },
+                {
+                    "type": "text",
+                    "text": "Here is the AI news summary.",
+                },
+            ],
+            # thinking_blocks also present in provider_specific_fields
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": "Let me search for AI news.",
+                    "signature": "sig_1",
+                },
+                {
+                    "type": "thinking",
+                    "thinking": "Now let me summarize.",
+                    "signature": "sig_2",
+                },
+            ],
+        },
+        {"role": "user", "content": "Tell me more"},
+    ]
+
+    result = anthropic_messages_pt(
+        messages, model="claude-sonnet-4-5", llm_provider="anthropic"
+    )
+
+    assistant_msg = next(m for m in result if m["role"] == "assistant")
+    content = assistant_msg["content"]
+    types = [c.get("type") for c in content]
+
+    # The list content already has the correct interleaved order.
+    # thinking_blocks should NOT be prepended again (which would cause
+    # duplication and break signature verification).
+    assert types == [
+        "thinking",
+        "server_tool_use",
+        "web_search_tool_result",
+        "thinking",
+        "text",
+    ], f"Expected preserved list order without duplicate thinking blocks, but got: {types}"
+
+    # Verify no duplicate thinking blocks
+    thinking_count = sum(1 for t in types if t == "thinking")
+    assert thinking_count == 2, f"Expected 2 thinking blocks, got {thinking_count} (duplication detected)"
+
+    # Verify signatures preserved in correct positions
+    assert content[0]["signature"] == "sig_1"
+    assert content[3]["signature"] == "sig_2"

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -1601,3 +1601,249 @@ def test_parse_tool_call_arguments_still_raises_for_unrepairable():
     error_msg = str(exc_info.value)
     assert "test_tool" in error_msg
     assert "test context" in error_msg
+
+
+
+def test_anthropic_messages_pt_interleave_thinking_with_server_tool_calls():
+    """
+    Test that thinking blocks are interleaved with server tool calls (web search)
+    instead of being prepended all at once.
+
+    When Anthropic returns a response with extended thinking + multiple web searches,
+    the content blocks are interleaved:
+    [thinking_1, server_tool_use_1, result_1, thinking_2, server_tool_use_2, result_2]
+
+    On round-trip through OpenAI format, thinking_blocks and tool_calls are separate
+    fields. anthropic_messages_pt must reconstruct the interleaved order, otherwise
+    Anthropic rejects the request because thinking block signatures are position-dependent.
+
+    Fixes: https://github.com/BerriAI/litellm/issues/23047
+    """
+    messages = [
+        {"role": "user", "content": "Search for news about fast.ai and answer.ai"},
+        {
+            "role": "assistant",
+            "content": "Here is what I found.",
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": "I need to search for fast.ai news.",
+                    "signature": "sig_thinking_1",
+                },
+                {
+                    "type": "thinking",
+                    "thinking": "Now I should also search for answer.ai.",
+                    "signature": "sig_thinking_2",
+                },
+            ],
+            "tool_calls": [
+                {
+                    "id": "srvtoolu_01SEARCH1",
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": '{"query": "fast.ai news"}',
+                    },
+                },
+                {
+                    "id": "srvtoolu_01SEARCH2",
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": '{"query": "answer.ai news"}',
+                    },
+                },
+            ],
+            "provider_specific_fields": {
+                "web_search_results": [
+                    {
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "srvtoolu_01SEARCH1",
+                        "content": [
+                            {
+                                "type": "web_search_result",
+                                "url": "https://fast.ai",
+                                "title": "fast.ai",
+                                "snippet": "fast.ai news",
+                            }
+                        ],
+                    },
+                    {
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "srvtoolu_01SEARCH2",
+                        "content": [
+                            {
+                                "type": "web_search_result",
+                                "url": "https://answer.ai",
+                                "title": "answer.ai",
+                                "snippet": "answer.ai news",
+                            }
+                        ],
+                    },
+                ]
+            },
+        },
+        {"role": "user", "content": "Now search for news about solveit"},
+    ]
+
+    result = anthropic_messages_pt(
+        messages, model="claude-sonnet-4-5", llm_provider="anthropic"
+    )
+
+    # Find the assistant message
+    assistant_msg = next(m for m in result if m["role"] == "assistant")
+    content = assistant_msg["content"]
+
+    # Extract types in order
+    types = [c.get("type") for c in content]
+
+    # The correct interleaved order should be:
+    # thinking_1, server_tool_use_1, web_search_tool_result_1,
+    # thinking_2, server_tool_use_2, web_search_tool_result_2,
+    # text
+    assert types == [
+        "thinking",
+        "server_tool_use",
+        "web_search_tool_result",
+        "thinking",
+        "server_tool_use",
+        "web_search_tool_result",
+        "text",
+    ], f"Expected interleaved order but got: {types}"
+
+    # Verify thinking blocks preserved their content and signatures
+    thinking_1 = content[0]
+    assert thinking_1["thinking"] == "I need to search for fast.ai news."
+    assert thinking_1["signature"] == "sig_thinking_1"
+
+    thinking_2 = content[3]
+    assert thinking_2["thinking"] == "Now I should also search for answer.ai."
+    assert thinking_2["signature"] == "sig_thinking_2"
+
+    # Verify server_tool_use blocks preserved their IDs
+    assert content[1]["id"] == "srvtoolu_01SEARCH1"
+    assert content[4]["id"] == "srvtoolu_01SEARCH2"
+
+    # Verify web_search_tool_result blocks are paired correctly
+    assert content[2]["tool_use_id"] == "srvtoolu_01SEARCH1"
+    assert content[5]["tool_use_id"] == "srvtoolu_01SEARCH2"
+
+    # Verify text block is present at the end
+    assert content[6]["text"] == "Here is what I found."
+
+
+def test_anthropic_messages_pt_thinking_blocks_no_server_tools_unchanged():
+    """
+    Test that the existing behavior is preserved when thinking blocks exist
+    but there are no server tool calls (only regular tool_use).
+
+    Thinking blocks should still be prepended first in this case.
+    """
+    messages = [
+        {"role": "user", "content": "What is the weather?"},
+        {
+            "role": "assistant",
+            "content": "Let me check.",
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": "I should check the weather.",
+                    "signature": "sig_1",
+                },
+            ],
+            "tool_calls": [
+                {
+                    "id": "toolu_01REG",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"location": "SF"}',
+                    },
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "toolu_01REG",
+            "content": "72F and sunny",
+        },
+    ]
+
+    result = anthropic_messages_pt(
+        messages, model="claude-sonnet-4-5", llm_provider="anthropic"
+    )
+
+    assistant_msg = next(m for m in result if m["role"] == "assistant")
+    content = assistant_msg["content"]
+    types = [c.get("type") for c in content]
+
+    # Original behavior: thinking first, then text, then tool_use
+    assert types == ["thinking", "text", "tool_use"], f"Expected sequential order but got: {types}"
+
+
+def test_anthropic_messages_pt_interleave_more_thinking_than_tool_groups():
+    """
+    Test interleaving when there are more thinking blocks than server tool groups.
+    Extra thinking blocks should appear before the text block.
+    """
+    messages = [
+        {"role": "user", "content": "Search for something"},
+        {
+            "role": "assistant",
+            "content": "Found it.",
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": "First thought",
+                    "signature": "sig_1",
+                },
+                {
+                    "type": "thinking",
+                    "thinking": "Second thought",
+                    "signature": "sig_2",
+                },
+                {
+                    "type": "thinking",
+                    "thinking": "Third thought after search",
+                    "signature": "sig_3",
+                },
+            ],
+            "tool_calls": [
+                {
+                    "id": "srvtoolu_01ONLY",
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": '{"query": "something"}',
+                    },
+                },
+            ],
+            "provider_specific_fields": {
+                "web_search_results": [
+                    {
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "srvtoolu_01ONLY",
+                        "content": [{"type": "web_search_result", "url": "https://example.com", "title": "Test", "snippet": "result"}],
+                    },
+                ]
+            },
+        },
+    ]
+
+    result = anthropic_messages_pt(
+        messages, model="claude-sonnet-4-5", llm_provider="anthropic"
+    )
+
+    assistant_msg = next(m for m in result if m["role"] == "assistant")
+    content = assistant_msg["content"]
+    types = [c.get("type") for c in content]
+
+    # thinking_1 paired with tool group, thinking_2 and thinking_3 before text
+    assert types == [
+        "thinking",            # paired with tool group
+        "server_tool_use",
+        "web_search_tool_result",
+        "thinking",            # extra - before text
+        "thinking",            # extra - before text
+        "text",
+    ], f"Expected order but got: {types}"


### PR DESCRIPTION
**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

## Summary

Fixes #23047

When using Claude with extended thinking and web search, if the model performs 2+ web searches in a single turn, the next `completion()` call fails with:

```
thinking or redacted_thinking blocks in the latest assistant message cannot be modified
```

### Root cause

In `anthropic_messages_pt`, assistant content was reconstructed by:
1. Prepending **all** `thinking_blocks` first
2. Then appending text blocks
3. Then appending `server_tool_use` + `web_search_tool_result` blocks

But Anthropic's original response interleaves thinking blocks *between* tool use/result blocks:
```
[thinking_1, server_tool_use_1, web_search_result_1, thinking_2, text, server_tool_use_2, web_search_result_2]
```

The reconstructed order differs, which breaks Anthropic's thinking block signature verification.

### Fix

When both `thinking_blocks` and server tool calls (`srvtoolu_*`) are present on an assistant message, the code now **interleaves** them instead of separating them:

- Each thinking block is paired with its corresponding server tool use group (server_tool_use + tool_result)
- Extra thinking blocks (if more than tool groups) are emitted before the text block
- Extra tool groups (if more than thinking blocks) are emitted without a preceding thinking block
- Regular (non-server) tool calls are appended at the end
- When no server tool calls are present, the existing sequential behavior is preserved

### Changes

- `litellm/litellm_core_utils/prompt_templates/factory.py`: Added interleaved mode for thinking blocks + server tool calls in `anthropic_messages_pt`
- `tests/llm_translation/test_prompt_factory.py`: Added 3 tests covering the interleaving fix, backward compatibility, and edge cases

## Test plan

- [x] `test_anthropic_messages_pt_interleave_thinking_with_server_tool_calls` — verifies correct interleaved order with 2 web searches
- [x] `test_anthropic_messages_pt_thinking_blocks_no_server_tools_unchanged` — verifies existing behavior preserved when only regular tool_use
- [x] `test_anthropic_messages_pt_interleave_more_thinking_than_tool_groups` — verifies handling of more thinking blocks than tool groups