### PR TITLE
fix: forward store param to OpenAI for gpt-5.1/5.2 models

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -407,6 +407,7 @@ async def acompletion(  # noqa: PLR0915
     verbosity: Optional[Literal["low", "medium", "high"]] = None,
     safety_identifier: Optional[str] = None,
     service_tier: Optional[str] = None,
+    store: Optional[bool] = None,
     # set api_base, api_version, api_key
     base_url: Optional[str] = None,
     api_version: Optional[str] = None,
@@ -557,6 +558,7 @@ async def acompletion(  # noqa: PLR0915
         "reasoning_effort": reasoning_effort,
         "safety_identifier": safety_identifier,
         "service_tier": service_tier,
+        "store": store,
         "extra_headers": extra_headers,
         "acompletion": True,  # assuming this is a required parameter
         "thinking": thinking,
@@ -1035,6 +1037,7 @@ def completion(  # type: ignore # noqa: PLR0915
     extra_headers: Optional[dict] = None,
     safety_identifier: Optional[str] = None,
     service_tier: Optional[str] = None,
+    store: Optional[bool] = None,
     # soon to be deprecated params by OpenAI
     functions: Optional[List] = None,
     function_call: Optional[str] = None,
@@ -1463,6 +1466,7 @@ def completion(  # type: ignore # noqa: PLR0915
             "web_search_options": web_search_options,
             "safety_identifier": safety_identifier,
             "service_tier": service_tier,
+            "store": store,
             "allowed_openai_params": kwargs.get("allowed_openai_params"),
         }
         optional_params = get_optional_params(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3864,6 +3864,7 @@ def get_optional_params(  # noqa: PLR0915
     thinking: Optional[AnthropicThinkingParam] = None,
     web_search_options: Optional[OpenAIWebSearchOptions] = None,
     safety_identifier: Optional[str] = None,
+    store: Optional[bool] = None,
     **kwargs,
 ):
     passed_params = locals().copy()

--- a/tests/test_litellm/llms/openai/chat/test_store_param.py
+++ b/tests/test_litellm/llms/openai/chat/test_store_param.py
@@ -1,0 +1,111 @@
+"""
+Tests for the `store` parameter being correctly forwarded to OpenAI.
+
+Related issue: https://github.com/BerriAI/litellm/issues/23087
+
+When users pass `store=True` in a completion request, it must be forwarded
+to OpenAI so that `metadata` (which the proxy may attach) is accepted by
+the API.  Previously `store` was listed as a supported param but was never
+threaded through `completion()` -> `get_optional_params()` -> `transform_request()`.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.utils import get_optional_params
+
+
+class TestStoreParamForwarding:
+    """Tests that `store` flows through the parameter processing pipeline."""
+
+    def test_store_true_forwarded_for_openai(self):
+        """store=True should appear in optional_params for OpenAI models."""
+        result = get_optional_params(
+            model="gpt-5.1",
+            custom_llm_provider="openai",
+            store=True,
+        )
+        assert result.get("store") is True
+
+    def test_store_false_forwarded_for_openai(self):
+        """store=False should appear in optional_params for OpenAI models."""
+        result = get_optional_params(
+            model="gpt-4o",
+            custom_llm_provider="openai",
+            store=False,
+        )
+        assert result.get("store") is False
+
+    def test_store_none_not_forwarded(self):
+        """When store is None (default), it should not appear in optional_params."""
+        result = get_optional_params(
+            model="gpt-4o",
+            custom_llm_provider="openai",
+        )
+        assert "store" not in result
+
+    def test_store_with_gpt5_model(self):
+        """store=True should work with GPT-5 models (the exact models from the bug report)."""
+        for model in ["gpt-5.1", "gpt-5.2"]:
+            result = get_optional_params(
+                model=model,
+                custom_llm_provider="openai",
+                store=True,
+            )
+            assert result.get("store") is True, f"store not forwarded for {model}"
+
+    def test_store_in_supported_params(self):
+        """Verify store is listed as a supported OpenAI param for relevant models."""
+        from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+
+        config = OpenAIGPTConfig()
+        for model in ["gpt-4o", "gpt-5.1", "gpt-5.2"]:
+            supported = config.get_supported_openai_params(model)
+            assert "store" in supported, f"store not in supported params for {model}"
+
+    def test_store_in_transform_request(self):
+        """Verify store appears in the final transformed request dict."""
+        from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+
+        config = OpenAIGPTConfig()
+        messages = [{"role": "user", "content": "Hello"}]
+        optional_params = {"store": True}
+        result = config.transform_request(
+            model="gpt-5.1",
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+        assert result.get("store") is True
+
+    def test_store_true_with_metadata(self):
+        """When store=True and metadata is also set, both should be in the request."""
+        from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+
+        config = OpenAIGPTConfig()
+        messages = [{"role": "user", "content": "Hello"}]
+        optional_params = {"store": True, "metadata": {"key": "value"}}
+        result = config.transform_request(
+            model="gpt-5.1",
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+        assert result.get("store") is True
+        assert result.get("metadata") == {"key": "value"}
+
+    def test_store_param_in_gpt5_search_model(self):
+        """store should be supported for GPT-5 search models."""
+        from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
+
+        config = OpenAIGPT5Config()
+        supported = config.get_supported_openai_params("gpt-5-search-api")
+        assert "store" in supported


### PR DESCRIPTION
Fixes #23087

## Summary
- The `store` parameter was listed as a supported OpenAI param but was never threaded through `completion()` -> `get_optional_params()`, so it was silently dropped
- This caused OpenAI to reject requests that included `metadata` (added by the proxy for internal tracking) with: `"The 'metadata' parameter is only allowed when 'store' is enabled."`
- Root cause: `store` was in `OPENAI_CHAT_COMPLETION_PARAMS` and `DEFAULT_CHAT_COMPLETION_PARAM_VALUES` but was not a named parameter of `completion()`, `acompletion()`, or `get_optional_params()`, so it was excluded from the parameter pipeline

## Changes
- Add `store` as a named parameter to `acompletion()` in `litellm/main.py`
- Add `store` to `completion_kwargs` dict in `acompletion()` so it gets forwarded to `completion()`
- Add `store` as a named parameter to `completion()` in `litellm/main.py`
- Add `store` to `optional_param_args` dict in `completion()` so it gets passed to `get_optional_params()`
- Add `store` as a named parameter to `get_optional_params()` in `litellm/utils.py`

## Testing
- Added 8 new unit tests in `tests/test_litellm/llms/openai/chat/test_store_param.py` covering:
  - `store=True` forwarded correctly for OpenAI models
  - `store=False` forwarded correctly
  - `store=None` (default) is not included in params
  - `store=True` works with GPT-5.1/5.2 models specifically
  - `store` is in supported params for relevant models
  - `store` appears in the final `transform_request()` output
  - `store=True` coexists correctly with `metadata`
  - `store` supported for GPT-5 search models
- All 44 existing GPT-5 transformation tests continue to pass
- All 16 existing OpenAI GPT transformation tests continue to pass