### PR TITLE
[Fix] UI - Agents: fix stale test assertions after AgentsPanel table refactor

### DIFF
--- a/ui/litellm-dashboard/src/components/agents.test.tsx
+++ b/ui/litellm-dashboard/src/components/agents.test.tsx
@@ -20,6 +20,8 @@ vi.mock("./agents/agent_card_grid", () => ({
   ),
 }));
 
+// Note: agents.tsx no longer uses AgentCardGrid — it renders a Table directly.
+
 vi.mock("./agents/agent_info", () => ({
   default: () => <div data-testid="agent-info" />,
 }));
@@ -54,19 +56,19 @@ describe("AgentsPanel", () => {
     expect(screen.queryByText("+ Add New Agent")).not.toBeInTheDocument();
   });
 
-  it("should pass isAdmin=true to AgentCardGrid for admin role", async () => {
+  it("should show Actions column header for admin role", async () => {
     render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
     await waitFor(() => {
-      const grid = screen.getByTestId("agent-card-grid");
-      expect(grid).toHaveAttribute("data-is-admin", "true");
+      expect(screen.getByRole("columnheader", { name: /actions/i })).toBeInTheDocument();
     });
   });
 
-  it("should pass isAdmin=false to AgentCardGrid for internal user role", async () => {
+  it("should not show Actions column header for internal user role", async () => {
     render(<AgentsPanel accessToken="test-token" userRole="Internal User" />);
     await waitFor(() => {
-      const grid = screen.getByTestId("agent-card-grid");
-      expect(grid).toHaveAttribute("data-is-admin", "false");
+      expect(screen.queryByRole("columnheader", { name: /actions/i })).not.toBeInTheDocument();
+      // confirm table is rendered (not still loading)
+      expect(screen.getByRole("table")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Summary

### Failure Path (Before Fix)

Two tests in `agents.test.tsx` were asserting the presence of `agent-card-grid` (via `data-testid`), which came from the `AgentCardGrid` component. `AgentsPanel` was refactored to render a `Table` directly instead of delegating to `AgentCardGrid`, leaving these tests looking for an element that no longer exists.

### Fix

Updated the two stale tests to assert on the `Actions` column header in the rendered table — present for admin roles, absent for non-admin roles. Added `waitFor` to handle the loading skeleton that renders before the table appears.

## Testing

Ran `npx vitest run src/components/agents.test.tsx` — all 11 tests pass.

## Type

🐛 Bug Fix
✅ Test