### PR TITLE
fix: handle month overflow in duration_in_seconds for multi-month durations

### DIFF
--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -64,12 +64,10 @@ def duration_in_seconds(duration: str) -> int:
         now = time.time()
         current_time = datetime.fromtimestamp(now)
 
-        if current_time.month == 12:
-            target_year = current_time.year + 1
-            target_month = 1
-        else:
-            target_year = current_time.year
-            target_month = current_time.month + value
+        # Calculate target month and year, handling overflow past December
+        total_months = current_time.month - 1 + value  # 0-indexed months
+        target_year = current_time.year + total_months // 12
+        target_month = total_months % 12 + 1  # back to 1-indexed
 
         # Determine the day to set for next month
         target_day = current_time.day


### PR DESCRIPTION
## Summary

`duration_in_seconds("Nmo")` crashes with `ValueError: month must be in 1..12` when `current_month + N > 12` and `current_month != 12`.

The existing code only handles the year rollover for `current_month == 12`, but not for cases like November + 2 months = month 13. This affects any multi-month budget duration (e.g., `"2mo"`, `"3mo"`) used in Router provider budget routing or Proxy key/team generation.

**Before:** `month=11, value=2` → `target_month=13` → `ValueError`
**After:** Uses modular arithmetic: `target_month = (total_months % 12) + 1`, `target_year += total_months // 12`

## Test plan
- Verify `duration_in_seconds("2mo")` works correctly in November (month 11)
- Verify `duration_in_seconds("3mo")` works correctly in October (month 10) 
- Verify single-month `duration_in_seconds("1mo")` behavior is unchanged
- Verify December rollover still works correctly
