### PR TITLE
fix: use correct divisor when averaging TTFT in lowest-latency routing

### DIFF
--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -490,20 +490,22 @@ class LowestLatencyLoggingHandler(CustomLogger):
 
             # get average latency or average ttft (depending on streaming/non-streaming)
             total: float = 0.0
-            if (
+            use_ttft = (
                 request_kwargs is not None
                 and request_kwargs.get("stream", None) is not None
                 and request_kwargs["stream"] is True
                 and len(item_ttft_latency) > 0
-            ):
+            )
+            if use_ttft:
                 for _call_latency in item_ttft_latency:
                     if isinstance(_call_latency, float):
                         total += _call_latency
+                item_latency = total / len(item_ttft_latency)
             else:
                 for _call_latency in item_latency:
                     if isinstance(_call_latency, float):
                         total += _call_latency
-            item_latency = total / len(item_latency)
+                item_latency = total / len(item_latency)
 
             # -------------- #
             # Debugging Logic


### PR DESCRIPTION
## Summary

In `LowestLatencyLoggingHandler._get_available_deployments`, when computing the average latency for streaming requests, the code sums values from `item_ttft_latency` but divides by `len(item_latency)` instead of `len(item_ttft_latency)`.

These two lists can have different lengths (TTFT is only recorded for streaming requests, while latency is recorded for all requests). Using the wrong divisor produces an incorrect average, which skews lowest-latency routing decisions for streaming requests.

**Before:** `item_latency = total_of_ttft_values / len(item_latency)` — wrong divisor
**After:** `item_latency = total_of_ttft_values / len(item_ttft_latency)` — correct divisor

## Test plan
- Verify routing with `stream=True` when deployments have different numbers of TTFT vs total latency entries
- Verify non-streaming routing behavior is unchanged
