### PR TITLE
fix: complexity_router routes to default model when no messages provided

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -349,9 +349,12 @@ class ComplexityRouter(CustomLogger):
         
         if messages is None or len(messages) == 0:
             verbose_router_logger.debug(
-                "ComplexityRouter: No messages provided, skipping routing"
+                "ComplexityRouter: No messages provided, routing to default model"
             )
-            return None
+            return PreRoutingHookResponse(
+                model=self.config.default_model or self.get_model_for_tier(ComplexityTier.MEDIUM),
+                messages=messages,
+            )
         
         # Extract the last user message and the last system prompt
         user_message: Optional[str] = None

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -339,23 +339,33 @@ class TestPreRoutingHook:
 
     @pytest.mark.asyncio
     async def test_pre_routing_hook_no_messages(self, complexity_router):
-        """Test pre-routing hook returns None when no messages."""
+        """Test pre-routing hook routes to MEDIUM tier when no messages provided.
+
+        Returning None would cause the raw auto_router/complexity_router deployment
+        to be selected, resulting in LiteLLMUnknownProvider errors.
+        """
         result = await complexity_router.async_pre_routing_hook(
             model="test-model",
             request_kwargs={},
             messages=None,
         )
-        assert result is None
+        assert result is not None
+        assert result.model == "gpt-4o"  # MEDIUM tier fallback (no default_model configured)
 
     @pytest.mark.asyncio
     async def test_pre_routing_hook_empty_messages(self, complexity_router):
-        """Test pre-routing hook returns None when messages empty."""
+        """Test pre-routing hook routes to MEDIUM tier when messages list is empty.
+
+        Returning None would cause the raw auto_router/complexity_router deployment
+        to be selected, resulting in LiteLLMUnknownProvider errors.
+        """
         result = await complexity_router.async_pre_routing_hook(
             model="test-model",
             request_kwargs={},
             messages=[],
         )
-        assert result is None
+        assert result is not None
+        assert result.model == "gpt-4o"  # MEDIUM tier fallback (no default_model configured)
 
     @pytest.mark.asyncio
     async def test_pre_routing_hook_with_system_prompt(self, complexity_router):


### PR DESCRIPTION
## Problem

When `async_pre_routing_hook` is called with `messages=None` or an empty messages list, the complexity router cannot classify the request complexity and previously returned `None`. This caused the caller to skip the hook result and select the raw `auto_router/complexity_router` deployment, which was then passed directly to `litellm.acompletion`, resulting in:

```
litellm.BadRequestError: Unmapped LLM provider for this endpoint.
You passed model=complexity_router, custom_llm_provider=auto_router
```

## Fix

When no messages are provided, route to the configured `default_model` (or MEDIUM tier fallback) instead of returning `None` — consistent with the existing behaviour when messages are present but contain no user message.

## Relation to #22761

PR #22761 fixed the case where messages are present but contain no extractable user message. This PR fixes the remaining `return None` path: when `messages` itself is `None` or empty — same root cause, same fix pattern.

## Changes

- `litellm/router_strategy/complexity_router/complexity_router.py`: replace `return None` with `return PreRoutingHookResponse(default_model or MEDIUM tier)` for the empty messages case
- `tests/test_litellm/router_strategy/test_complexity_router.py`: update two tests that previously asserted `result is None` to assert the correct fallback behaviour

## Test plan

- [x] `poetry run pytest tests/test_litellm/router_strategy/test_complexity_router.py` — 56/56 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)