### PR TITLE
fix(anthropic): enforce type:"object" on tool input schemas in _map_tool_helper

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -395,6 +395,14 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 },
             )
 
+            # Anthropic requires input_schema.type to be "object". Normalize
+            # schemas from external sources (MCP servers, OpenAI callers) that
+            # may omit the type field or use a non-object type.
+            if _input_schema.get("type") != "object":
+                _input_schema["type"] = "object"
+                if "properties" not in _input_schema:
+                    _input_schema["properties"] = {}
+
             _allowed_properties = set(AnthropicInputSchema.__annotations__.keys())
             input_schema_filtered = {
                 k: v for k, v in _input_schema.items() if k in _allowed_properties

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -399,6 +399,13 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             # schemas from external sources (MCP servers, OpenAI callers) that
             # may omit the type field or use a non-object type.
             if _input_schema.get("type") != "object":
+                litellm.verbose_logger.debug(
+                    "_map_tool_helper: coercing input_schema type from %r to "
+                    "'object' for Anthropic compatibility (tool: %s)",
+                    _input_schema.get("type"),
+                    tool["function"].get("name"),
+                )
+                _input_schema = dict(_input_schema)  # avoid mutating caller's dict
                 _input_schema["type"] = "object"
                 if "properties" not in _input_schema:
                     _input_schema["properties"] = {}

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3208,11 +3208,16 @@ def test_map_tool_helper_enforces_object_type_when_missing():
         },
     }
 
+    original_params = tool["function"]["parameters"].copy()
     result, _ = config._map_tool_helper(tool)
     assert result is not None
     assert result["input_schema"]["type"] == "object"
     assert "properties" in result["input_schema"]
     assert "query" in result["input_schema"]["properties"]
+    # Original parameters dict must not be modified in place
+    assert tool["function"]["parameters"] == original_params, (
+        "parameters dict was mutated; _map_tool_helper should not modify caller data"
+    )
 
 
 def test_map_tool_helper_enforces_object_type_when_wrong_type():
@@ -3234,9 +3239,17 @@ def test_map_tool_helper_enforces_object_type_when_wrong_type():
         },
     }
 
+    original_params = tool["function"]["parameters"].copy()
     result, _ = config._map_tool_helper(tool)
     assert result is not None
     assert result["input_schema"]["type"] == "object"
+    assert result["input_schema"].get("properties") == {}, (
+        "properties should be injected as {} when schema has non-object type and no properties key"
+    )
+    # Original parameters dict must not be modified in place
+    assert tool["function"]["parameters"] == original_params, (
+        "parameters dict was mutated; _map_tool_helper should not modify caller data"
+    )
 
 
 def test_map_tool_helper_preserves_valid_object_schema():

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3175,3 +3175,115 @@ def test_map_openai_params_max_tokens_normalized_to_int():
 
     assert "max_tokens" in result
     assert result["max_tokens"] == 1
+
+
+# ========================================================================
+# Tool schema normalization tests
+# ========================================================================
+
+
+def test_map_tool_helper_enforces_object_type_when_missing():
+    """
+    Anthropic requires input_schema.type to be "object". When an OpenAI tool
+    has parameters without a 'type' field (common with MCP servers), LiteLLM
+    should inject type:"object" before forwarding to Anthropic.
+
+    Without this fix, Anthropic rejects with:
+        tools.N.custom.input_schema.type: Input should be 'object'
+    """
+    config = AnthropicConfig()
+
+    # Tool with parameters that has properties but no 'type' field
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "search_code",
+            "description": "Search for code patterns",
+            "parameters": {
+                "properties": {
+                    "query": {"type": "string", "description": "Search query"}
+                },
+                "required": ["query"],
+            },
+        },
+    }
+
+    result, _ = config._map_tool_helper(tool)
+    assert result is not None
+    assert result["input_schema"]["type"] == "object"
+    assert "properties" in result["input_schema"]
+    assert "query" in result["input_schema"]["properties"]
+
+
+def test_map_tool_helper_enforces_object_type_when_wrong_type():
+    """
+    If a tool schema has type:"string" or type:"array" at the root level,
+    LiteLLM should normalize it to type:"object" for Anthropic compatibility.
+    """
+    config = AnthropicConfig()
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "echo",
+            "description": "Echo input",
+            "parameters": {
+                "type": "string",
+                "description": "The input to echo",
+            },
+        },
+    }
+
+    result, _ = config._map_tool_helper(tool)
+    assert result is not None
+    assert result["input_schema"]["type"] == "object"
+
+
+def test_map_tool_helper_preserves_valid_object_schema():
+    """
+    When a tool schema already has type:"object", it should be preserved
+    without modification.
+    """
+    config = AnthropicConfig()
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                },
+                "required": ["city"],
+            },
+        },
+    }
+
+    result, _ = config._map_tool_helper(tool)
+    assert result is not None
+    assert result["input_schema"]["type"] == "object"
+    assert "city" in result["input_schema"]["properties"]
+    assert result["input_schema"]["required"] == ["city"]
+
+
+def test_map_tool_helper_empty_parameters_get_default():
+    """
+    When parameters is entirely missing, the existing default should still
+    produce a valid {type:"object", properties:{}} schema.
+    """
+    config = AnthropicConfig()
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "no_params_tool",
+            "description": "Tool with no parameters",
+        },
+    }
+
+    result, _ = config._map_tool_helper(tool)
+    assert result is not None
+    assert result["input_schema"]["type"] == "object"
+    assert result["input_schema"].get("properties") == {}


### PR DESCRIPTION
## Related Issues

Fixes #21584 — Gemini CLI tool schemas without `type: "object"` rejected by Anthropic
Related to #22312 — VertexAI Claude errors in Codex CLI (same tool schema path)
Related to #16679 — `tools.N.custom.input_schema` errors with Claude Code

## What this PR does

Fixes `_map_tool_helper()` in the Anthropic transformation layer to enforce `type: "object"` on tool input schemas before forwarding to the Anthropic API.

Anthropic requires all tool `input_schema` to have `type: "object"` at the root level. When tools arrive from MCP servers or other sources without a `type` field (or with a non-`"object"` type like `"string"` or `"array"`), the API rejects with:

```
tools.N.custom.input_schema.type: Input should be 'object'
```

### Root Cause

`_map_tool_helper()` resolves `parameters` from the OpenAI tool definition and passes it through to `AnthropicInputSchema`, but never validates or normalizes the `type` field. MCP servers commonly emit tool schemas without explicit `type` fields.

### Fix

After resolving `_input_schema` from `tool["function"].get("parameters", ...)`:

1. Check if `_input_schema.get("type") != "object"`
2. If so, **shallow copy** the dict (to avoid mutating the caller's original tool definition)
3. Set `type = "object"` on the copy
4. Inject `properties: {}` if absent (Anthropic requires this field)
5. Log the coercion via `verbose_logger.debug()` for observability

The shallow copy is critical — without it, repeated `litellm.completion()` calls with the same tools list would see progressive in-place mutations of the caller's data.

### Tests

5 unit tests (no network calls):

- `test_map_tool_helper` — pre-existing test, still passing
- `test_map_tool_helper_enforces_object_type_when_missing` — missing type field, injected as "object", with mutation-guard assertion
- `test_map_tool_helper_enforces_object_type_when_wrong_type` — wrong type ("string"), coerced to "object", with mutation-guard assertion and `properties: {}` injection check
- `test_map_tool_helper_preserves_valid_object_schema` — already-valid schema passes through unchanged
- `test_map_tool_helper_empty_parameters_get_default` — no parameters at all, default `{type: "object", properties: {}}`

### Files Changed

| File | Change |
|------|--------|
| `litellm/llms/anthropic/chat/transformation.py` | Schema normalization in `_map_tool_helper()` with shallow copy + debug logging |
| `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py` | 4 new test functions with mutation guards |
