### PR TITLE
fix(fireworks): remove duplicate /v1 in get_models URL

### DIFF
--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -427,7 +427,7 @@ class FireworksAIConfig(OpenAIGPTConfig):
             )
 
         response = litellm.module_level_client.get(
-            url=f"{api_base}/v1/accounts/{account_id}/models",
+            url=f"{api_base}/accounts/{account_id}/models",
             headers={"Authorization": f"Bearer {api_key}"},
         )
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -377,9 +377,6 @@ from litellm.proxy.management_endpoints.internal_user_endpoints import user_upda
 from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
     router as jwt_key_mapping_router,
 )
-from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
-    router as jwt_key_mapping_router,
-)
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     delete_verification_tokens,
     duration_in_seconds,

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -137,3 +137,75 @@ def test_transform_messages_helper_removes_provider_specific_fields():
     out = config._transform_messages_helper(messages, model="fireworks/test", litellm_params={})
     for msg in out:
         assert "provider_specific_fields" not in msg
+
+
+class TestGetModelsUrl:
+    """Regression tests for get_models URL construction.
+
+    Ensures the /v1 path segment from api_base is not duplicated when
+    building the Fireworks AI models endpoint URL.
+    Fixes: https://github.com/BerriAI/litellm/issues/23106
+    """
+
+    @patch("litellm.llms.fireworks_ai.chat.transformation.get_secret_str")
+    @patch("litellm.module_level_client")
+    def test_get_models_url_no_v1_duplication(self, mock_client, mock_secret):
+        """Default api_base (…/inference/v1) must not produce /v1/v1/ in URL."""
+        mock_secret.side_effect = lambda key: {
+            "FIREWORKS_API_KEY": None,
+            "FIREWORKS_API_BASE": None,
+            "FIREWORKS_AI_API_KEY": None,
+            "FIREWORKSAI_API_KEY": None,
+            "FIREWORKS_AI_TOKEN": None,
+            "FIREWORKS_ACCOUNT_ID": "my-account",
+        }.get(key)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "models": [{"name": "accounts/my-account/models/llama-v3p1-8b-instruct"}]
+        }
+        mock_client.get.return_value = mock_response
+
+        config = FireworksAIConfig()
+        models = config.get_models(api_key="test-key")
+
+        called_url = mock_client.get.call_args.kwargs.get(
+            "url", mock_client.get.call_args[1].get("url", "")
+        )
+        assert "/v1/v1/" not in called_url, (
+            f"URL contains duplicated /v1/v1/: {called_url}"
+        )
+        assert "/v1/accounts/my-account/models" in called_url
+        assert models == [
+            "fireworks_ai/accounts/my-account/models/llama-v3p1-8b-instruct"
+        ]
+
+    @patch("litellm.llms.fireworks_ai.chat.transformation.get_secret_str")
+    @patch("litellm.module_level_client")
+    def test_get_models_url_with_custom_api_base(self, mock_client, mock_secret):
+        """Custom api_base ending with /v1 must not produce /v1/v1/."""
+        mock_secret.side_effect = lambda key: {
+            "FIREWORKS_ACCOUNT_ID": "acme",
+        }.get(key)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "models": [{"name": "accounts/acme/models/mixtral-8x7b"}]
+        }
+        mock_client.get.return_value = mock_response
+
+        config = FireworksAIConfig()
+        config.get_models(
+            api_key="test-key",
+            api_base="https://custom.fireworks.ai/inference/v1",
+        )
+
+        called_url = mock_client.get.call_args.kwargs.get(
+            "url", mock_client.get.call_args[1].get("url", "")
+        )
+        assert "/v1/v1/" not in called_url
+        assert called_url == (
+            "https://custom.fireworks.ai/inference/v1/accounts/acme/models"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes [#23106](https://github.com/BerriAI/litellm/issues/23106) — the Fireworks AI `get_models()` method constructs a malformed URL with a duplicated `/v1` path segment.

### Root Cause

`_get_openai_compatible_provider_info()` sets `api_base` to `https://api.fireworks.ai/inference/v1`, but `get_models()` then builds the URL as:

```python
url = f"{api_base}/v1/accounts/{account_id}/models"
#                  ^^^^ duplicate
```

Producing: `https://api.fireworks.ai/inference/v1/v1/accounts/fireworks/models` → **404**

### Fix

Remove the extra `/v1` from the URL template:

```python
url = f"{api_base}/accounts/{account_id}/models"
```

### Tests

Added `TestGetModelsUrl` with 2 regression tests:
- `test_get_models_url_no_v1_duplication` — default api_base
- `test_get_models_url_with_custom_api_base` — custom api_base ending with `/v1`

Both verify `/v1/v1/` does not appear in the constructed URL.

### All Tests Pass

```
tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py: 6 passed
```