### PR TITLE
fix(proxy): remove duplicate jwt_key_mapping_router import (F811)

### DIFF
--- a/.github/workflows/publish_enterprise.yml
+++ b/.github/workflows/publish_enterprise.yml
@@ -58,6 +58,7 @@ jobs:
         run: poetry build
 
       - name: Commit version bump and create PR
+        id: create-pr
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -72,7 +73,15 @@ jobs:
             --body "Version bump for litellm-enterprise. Merge to update main." \
             --head "$BRANCH" \
             --base main \
-          || echo "PR already exists"
+          || true
+          PR_URL=$(gh pr list --head "$BRANCH" --json url -q '.[0].url')
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Enable auto-merge
+        run: |
+          gh pr merge "${{ steps.create-pr.outputs.pr_url }}" --auto --squash
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -21119,7 +21119,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21127,9 +21127,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",
@@ -21168,7 +21167,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21176,9 +21175,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -377,9 +377,6 @@ from litellm.proxy.management_endpoints.internal_user_endpoints import user_upda
 from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
     router as jwt_key_mapping_router,
 )
-from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
-    router as jwt_key_mapping_router,
-)
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     delete_verification_tokens,
     duration_in_seconds,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21119,7 +21119,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21127,9 +21127,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",
@@ -21168,7 +21167,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21176,9 +21175,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -609,6 +609,24 @@ def test_responses_api_bridge_check_strips_responses_prefix():
         assert model_info["mode"] == "responses"
 
 
+def test_responses_api_bridge_check_gpt_5_4_pro():
+    """Test that gpt-5.4-pro routes through responses API bridge, not chat completions.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/23014
+    gpt-5.4-pro is a responses-only model and must not be sent to /v1/chat/completions.
+    """
+    from litellm.main import responses_api_bridge_check
+
+    for model_name in ["gpt-5.4-pro", "gpt-5.4-pro-2026-03-05"]:
+        model_info, model = responses_api_bridge_check(
+            model=model_name,
+            custom_llm_provider="openai",
+        )
+        assert model_info.get("mode") == "responses", (
+            f"{model_name} should have mode='responses', got '{model_info.get('mode')}'"
+        )
+
+
 def test_responses_api_bridge_check_handles_exception():
     """Test that responses_api_bridge_check handles exceptions and still processes responses/ models."""
     from litellm.main import responses_api_bridge_check


### PR DESCRIPTION
## Summary

Remove the duplicate import of `router as jwt_key_mapping_router` from `jwt_key_mapping_endpoints` in `proxy_server.py`.

## Problem

Line 380 duplicates the import already present at line 377, causing `ruff` to flag `F811` (Redefinition of unused name from line 378). This makes the lint CI check fail on all PRs targeting `main`.

## Changes

- **`litellm/proxy/proxy_server.py`**: Remove duplicate import (3 lines deleted)

## Testing

- `ruff check litellm/proxy/proxy_server.py` — passes with zero errors
