### PR TITLE
ci: reduce CircleCI costs ~$2,500/mo — Phase 1 quick wins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-
       - run:
           name: Install Dependencies
           command: |
@@ -187,7 +188,6 @@ jobs:
             pip install argon2-cffi
             pip install "pytest-mock==3.12.0"
             pip install python-multipart
-            pip install google-cloud-aiplatform
             pip install prometheus-client==0.20.0
             pip install "pydantic==2.10.2"
             pip install "diskcache==5.6.1"
@@ -202,8 +202,8 @@ jobs:
       - setup_litellm_enterprise_pip
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - ~/.cache/pip
+          key: v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -241,7 +241,7 @@ jobs:
                 -n 4 \
                 --timeout=300 \
                 --timeout_method=thread"
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -274,7 +274,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-
       - run:
           name: Install Dependencies
           command: |
@@ -315,7 +316,6 @@ jobs:
             pip install argon2-cffi
             pip install "pytest-mock==3.12.0"
             pip install python-multipart
-            pip install google-cloud-aiplatform
             pip install prometheus-client==0.20.0
             pip install "pydantic==2.10.2"
             pip install "diskcache==5.6.1"
@@ -330,8 +330,8 @@ jobs:
       - setup_litellm_enterprise_pip
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - ~/.cache/pip
+          key: v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -339,14 +339,6 @@ jobs:
             chmod +x docker/entrypoint.sh
             ./docker/entrypoint.sh
             set -e
-      - run:
-          name: Black Formatting
-          command: |
-            cd litellm
-            python -m pip install black
-            python -m black .
-            cd ..
-
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests (Part 2 - N-Z)
@@ -369,7 +361,7 @@ jobs:
                 -n 4 \
                 --timeout=300 \
                 --timeout_method=thread"
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -402,7 +394,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-
       - run:
           name: Install Dependencies
           command: |
@@ -443,7 +436,6 @@ jobs:
             pip install argon2-cffi
             pip install "pytest-mock==3.12.0"
             pip install python-multipart
-            pip install google-cloud-aiplatform
             pip install prometheus-client==0.20.0
             pip install "pydantic==2.10.2"
             pip install "diskcache==5.6.1"
@@ -453,8 +445,8 @@ jobs:
       - setup_litellm_enterprise_pip
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - ~/.cache/pip
+          key: v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -470,7 +462,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/local_testing --cov=litellm --cov-report=xml -x --junitxml=test-results/junit.xml --durations=5 -k "langfuse"
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -509,7 +501,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-
       - run:
           name: Install Dependencies
           command: |
@@ -550,7 +543,6 @@ jobs:
             pip install argon2-cffi
             pip install "pytest-mock==3.12.0"
             pip install python-multipart
-            pip install google-cloud-aiplatform
             pip install prometheus-client==0.20.0
             pip install "pydantic==2.10.2"
             pip install "diskcache==5.6.1"
@@ -560,8 +552,8 @@ jobs:
       - setup_litellm_enterprise_pip
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - ~/.cache/pip
+          key: v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -577,7 +569,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/local_testing --cov=litellm --cov-report=xml -x --junitxml=test-results/junit.xml --durations=5 -k "caching or cache"
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -603,6 +595,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - restore_cache:
+          keys:
+            - v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-
       - run:
           name: Install Dependencies
           command: |
@@ -614,8 +610,8 @@ jobs:
             pip install "pytest-cov==5.0.0"
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - ~/.cache/pip
+          key: v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -630,7 +626,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/proxy_admin_ui_tests -x --cov=litellm --cov-report=xml --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
 
       - run:
           name: Rename the coverage files
@@ -679,7 +675,7 @@ jobs:
             pwd
             ls
             python -m pytest tests/local_testing --cov=litellm --cov-report=xml -vv -k "router" -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -727,7 +723,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/router_unit_tests --cov=litellm --cov-report=xml -x -s --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -760,17 +756,28 @@ jobs:
             curl -fsSL https://get.docker.com | sh
             sudo usermod -aG docker $USER
             docker version
+      - restore_cache:
+          keys:
+            - v1-miniconda-py313-{{ arch }}
       - run:
-          name: Install Python 3.13
+          name: Install Python 3.13 via Miniconda
           command: |
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-            bash miniconda.sh -b -p $HOME/miniconda
+            if [ ! -d "$HOME/miniconda" ]; then
+              curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
+              bash miniconda.sh -b -p $HOME/miniconda
+            fi
             export PATH="$HOME/miniconda/bin:$PATH"
+            source $HOME/miniconda/etc/profile.d/conda.sh
             conda init bash
-            source ~/.bashrc
-            conda create -n myenv python=3.13 -y
+            if ! conda env list | grep -q "^myenv "; then
+              conda create -n myenv python=3.13 -y
+            fi
             conda activate myenv
             python --version
+      - save_cache:
+          key: v1-miniconda-py313-{{ arch }}
+          paths:
+            - ~/miniconda
       - run:
           name: Install Dependencies
           command: |
@@ -898,7 +905,8 @@ jobs:
             sudo apt-get install -y postgresql-14 postgresql-contrib-14
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-
       - run:
           name: Install Dependencies
           command: |
@@ -942,7 +950,6 @@ jobs:
             pip install argon2-cffi
             pip install "pytest-mock==3.12.0"
             pip install python-multipart
-            pip install google-cloud-aiplatform
             pip install prometheus-client==0.20.0
             pip install "pydantic==2.10.2"
             pip install "diskcache==5.6.1"
@@ -953,8 +960,8 @@ jobs:
       - setup_litellm_enterprise_pip
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - ~/.cache/pip
+          key: v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -969,7 +976,7 @@ jobs:
             ls
             # Run without -n flag to avoid pytest-xdist event loop conflicts with logging worker
             python -m pytest tests/proxy_unit_tests/test_key_generate_prisma.py --cov=litellm --cov-report=xml --junitxml=test-results/junit-key-generation.xml --durations=10 --timeout=300 -vv --log-cli-level=INFO
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1004,7 +1011,8 @@ jobs:
             sudo apt-get install -y postgresql-14 postgresql-contrib-14
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-
       - run:
           name: Install Dependencies
           command: |
@@ -1048,7 +1056,6 @@ jobs:
             pip install argon2-cffi
             pip install "pytest-mock==3.12.0"
             pip install python-multipart
-            pip install google-cloud-aiplatform
             pip install prometheus-client==0.20.0
             pip install "pydantic==2.10.2"
             pip install "diskcache==5.6.1"
@@ -1060,8 +1067,8 @@ jobs:
       - setup_litellm_enterprise_pip
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - ~/.cache/pip
+          key: v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -1076,7 +1083,7 @@ jobs:
             ls
             # Run auth tests with parallel execution (test_key_generate_prisma moved to separate job to avoid event loop issues)
             python -m pytest tests/proxy_unit_tests/test_auth_checks.py tests/proxy_unit_tests/test_user_api_key_auth.py --cov=litellm --cov-report=xml --junitxml=test-results/junit-part1.xml --durations=10 -n 8 --timeout=300 -vv --log-cli-level=INFO
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1111,7 +1118,8 @@ jobs:
             sudo apt-get install -y postgresql-14 postgresql-contrib-14
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - v2-dependencies-
       - run:
           name: Install Dependencies
           command: |
@@ -1155,7 +1163,6 @@ jobs:
             pip install argon2-cffi
             pip install "pytest-mock==3.12.0"
             pip install python-multipart
-            pip install google-cloud-aiplatform
             pip install prometheus-client==0.20.0
             pip install "pydantic==2.10.2"
             pip install "diskcache==5.6.1"
@@ -1167,8 +1174,8 @@ jobs:
       - setup_litellm_enterprise_pip
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+            - ~/.cache/pip
+          key: v2-dependencies-{{ checksum ".circleci/requirements.txt" }}
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -1182,7 +1189,7 @@ jobs:
             pwd
             ls
             python -m pytest tests/proxy_unit_tests --ignore=tests/proxy_unit_tests/test_key_generate_prisma.py --ignore=tests/proxy_unit_tests/test_auth_checks.py --ignore=tests/proxy_unit_tests/test_user_api_key_auth.py --cov=litellm --cov-report=xml --junitxml=test-results/junit-part2.xml --durations=10 -n 4 --timeout=300 -vv --log-cli-level=INFO
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1226,7 +1233,7 @@ jobs:
             pwd
             ls
             python -m pytest tests/local_testing/ -vv -k "assistants" --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1280,7 +1287,7 @@ jobs:
               IGNORE_ARGS="$IGNORE_ARGS --ignore=$dir"
             done
             python -m pytest -vv tests/llm_translation $IGNORE_ARGS --cov=litellm --cov-report=xml -v --junitxml=test-results/junit.xml --durations=20 -n 4 --timeout=120 --timeout_method=thread
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1328,7 +1335,7 @@ jobs:
             # Add --timeout to kill hanging tests after 120s (2 min)
             # Add --durations=20 to show 20 slowest tests for debugging
             python -m pytest -vv tests/llm_translation/realtime --cov=litellm --cov-report=xml -v --junitxml=test-results/junit.xml --durations=20 -n 4 --timeout=120 --timeout_method=thread
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1373,7 +1380,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/mcp_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1418,7 +1425,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/agent_tests --ignore=tests/agent_tests/local_only_agent_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1464,7 +1471,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/guardrails_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1509,7 +1516,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/unified_google_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1553,7 +1560,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/llm_responses_api_testing --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1596,7 +1603,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/ocr_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1639,7 +1646,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/search_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1727,7 +1734,7 @@ jobs:
           name: Run LLM provider tests
           command: |
             python -m pytest tests/test_litellm/llms --cov=litellm --cov-report=xml --junitxml=test-results/junit-llms.xml --durations=10 -n 16 --maxfail=5 --timeout=300 -vv --log-cli-level=WARNING
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1754,7 +1761,7 @@ jobs:
           name: Run core tests
           command: |
             python -m pytest tests/test_litellm --ignore=tests/test_litellm/proxy --ignore=tests/test_litellm/llms --ignore=tests/test_litellm/integrations --ignore=tests/test_litellm/litellm_core_utils --ignore=tests/test_litellm/experimental_mcp_client --cov=litellm --cov-report=xml --junitxml=test-results/junit-core.xml --durations=10 -n 16 --maxfail=5 --timeout=300 -vv --log-cli-level=WARNING
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1781,7 +1788,7 @@ jobs:
           name: Run litellm_core_utils tests
           command: |
             python -m pytest tests/test_litellm/litellm_core_utils --cov=litellm --cov-report=xml --junitxml=test-results/junit-litellm-core-utils.xml --durations=10 -n 16 --maxfail=5 --timeout=300 -vv --log-cli-level=WARNING
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1808,7 +1815,7 @@ jobs:
           name: Run MCP client tests
           command: |
             python -m pytest tests/test_litellm/experimental_mcp_client --cov=litellm --cov-report=xml --junitxml=test-results/junit-mcps.xml --durations=10 -n 4 --maxfail=5 --timeout=300 -vv --log-cli-level=WARNING
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1835,7 +1842,7 @@ jobs:
           name: Run integrations tests
           command: |
             python -m pytest tests/test_litellm/integrations --cov=litellm --cov-report=xml --junitxml=test-results/junit-integrations.xml --durations=10 -n 16 --maxfail=5 --timeout=300 -vv --log-cli-level=WARNING
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1886,7 +1893,7 @@ jobs:
             ls
             prisma generate
             python -m pytest -vv tests/enterprise --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit-enterprise.xml --durations=10 -n 8
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1931,7 +1938,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/batches_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -1978,7 +1985,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/litellm_utils_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -2022,7 +2029,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/pass_through_unit_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -2066,7 +2073,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/image_gen_tests -n 4 --cov=litellm --cov-report=xml -x -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -2117,7 +2124,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/logging_callback_tests --cov=litellm -n 4 --cov-report=xml -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -2160,7 +2167,7 @@ jobs:
             pwd
             ls
             python -m pytest -vv tests/audio_tests --cov=litellm --cov-report=xml -x -s -v --junitxml=test-results/junit.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
       - run:
           name: Rename the coverage files
           command: |
@@ -2451,7 +2458,7 @@ jobs:
           name: Run Basic Proxy Startup Tests (Health Readiness and Chat Completion)
           command: |
             python -m pytest -vv tests/basic_proxy_startup_tests -x --junitxml=test-results/junit-2.xml --durations=5
-          no_output_timeout: 120m
+          no_output_timeout: 60m
 
   build_and_test:
     machine:
@@ -4485,19 +4492,6 @@ workflows:
               only:
                 - main
                 - /litellm_.*/
-      - e2e_ui_testing:
-          name: e2e_ui_testing_firefox
-          browser: firefox
-          context: e2e_ui_tests
-          requires:
-            - ui_build
-            - build_docker_database_image
-            - prisma_schema_sync
-          filters:
-            branches:
-              only:
-                - main
-                - /litellm_.*/
       - build_and_test:
           filters:
             branches:
@@ -4824,7 +4818,6 @@ workflows:
             - auth_ui_unit_tests
             - db_migration_disable_update_check
             - e2e_ui_testing_chromium
-            - e2e_ui_testing_firefox
             - litellm_proxy_unit_testing_key_generation
             - litellm_proxy_unit_testing_part1
             - litellm_proxy_unit_testing_part2
@@ -4840,3 +4833,22 @@ workflows:
             - check_code_and_doc_quality
             - publish_proxy_extras
             - guardrails_testing
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 3 * * *"  # 3:00 AM UTC daily
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - ui_build
+      - build_docker_database_image
+      - e2e_ui_testing:
+          name: e2e_ui_testing_firefox
+          browser: firefox
+          context: e2e_ui_tests
+          requires:
+            - ui_build
+            - build_docker_database_image


### PR DESCRIPTION
## Summary

Phase 1 of a [CircleCI cost optimization analysis](https://github.com/jquinter/litellm/blob/analysis/circleci-cost-optimization/docs/circleci-cost-analysis.md) targeting the \$15k/month pipeline. No test logic was changed — only build configuration.

- **Fix broken pip cache** — 8 jobs were saving `./venv` (empty dir) instead of `~/.cache/pip`. Cache was never hitting. Bumped key to `v2` to invalidate stale entries. Also added missing `restore_cache` to `auth_ui_unit_tests`.
- **Remove duplicate Black step** — `local_testing_part2` ran `black .` redundantly; it already runs in `part1` on the same commit.
- **Remove duplicate pip installs** — 7 jobs installed `google-cloud-aiplatform==1.43.0` then immediately reinstalled it unversioned. Removed the 7 unversioned duplicates.
- **Reduce job timeouts** — Changed `no_output_timeout: 120m → 60m` on 33 test jobs. Kept 120m only for Docker build/E2E jobs (`build_and_test`, `proxy_*`, `e2e_*`). Halves worst-case cost of a hung test.
- **Firefox E2E → nightly** — Moved `e2e_ui_testing_firefox` from per-commit CI to a new `nightly` workflow (3 AM UTC). Saves ~\$1.50/run on every commit.
- **Cache Miniconda** — `litellm_security_tests` now restores `~/miniconda` from cache; skips the ~8-min download + conda env creation on cache hits.

## Estimated savings

~\$2,500/month (Phase 1 of 3). Phases 2 (resource right-sizing) and 3 (structural: PR vs full-CI split, machine→Docker executor) can follow once this is validated.

## Test plan

- [ ] Verify `local_testing_part1` and `local_testing_part2` pass (cache fix, Black removal, duplicate pip removal)
- [ ] Verify `auth_ui_unit_tests` passes with new `restore_cache` step
- [ ] Verify `litellm_security_tests` passes with Miniconda cache
- [ ] Confirm `e2e_ui_testing_firefox` no longer appears in per-commit workflow
- [ ] Confirm nightly workflow appears in CircleCI schedules

🤖 Generated with [Claude Code](https://claude.com/claude-code)