### PR TITLE
fix fkey violation on deleting user in Internal Users Section

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1844,7 +1844,13 @@ async def delete_user(
 
     ## DELETE ASSOCIATED INVITATION LINKS
     await prisma_client.db.litellm_invitationlink.delete_many(
-        where={"user_id": {"in": data.user_ids}}
+        where={
+            "OR": [
+                {"user_id": {"in": data.user_ids}},
+                {"created_by": {"in": data.user_ids}},
+                {"updated_by": {"in": data.user_ids}},
+            ]
+        }
     )
 
     ## DELETE ASSOCIATED ORGANIZATION MEMBERSHIPS

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -1644,3 +1644,88 @@ async def test_get_user_daily_activity_aggregated_admin_global_view(monkeypatch)
         api_key=None,
         timezone_offset_minutes=480,
     )
+
+
+@pytest.mark.asyncio
+async def test_delete_user_cleans_up_created_by_invitation_links(mocker):
+    """
+    Test that delete_user removes invitation links where the deleted user is the
+    creator (created_by) or updater (updated_by), not just the invited person (user_id).
+
+    This prevents FK constraint violations when deleting a user who created pending invites.
+    """
+    from litellm.proxy._types import DeleteUserRequest, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.internal_user_endpoints import delete_user
+
+    mock_prisma_client = mocker.MagicMock()
+
+    # Mock user lookup
+    mock_user_row = mocker.MagicMock()
+    mock_user_row.user_id = "admin-creator"
+    mock_user_row.user_email = "admin@example.com"
+    mock_user_row.teams = []
+    mock_user_row.json.return_value = "{}"
+    mock_user_row.model_dump.return_value = {
+        "user_id": "admin-creator",
+        "user_email": "admin@example.com",
+        "teams": [],
+    }
+
+    async def mock_find_unique(*args, **kwargs):
+        return mock_user_row
+
+    mock_prisma_client.db.litellm_usertable.find_unique = mocker.AsyncMock(
+        side_effect=mock_find_unique
+    )
+
+    # Mock find_many for teams (no teams)
+    mock_prisma_client.db.litellm_teamtable.find_many = mocker.AsyncMock(
+        return_value=[]
+    )
+
+    # Mock all delete_many calls
+    mock_prisma_client.db.litellm_verificationtoken.delete_many = mocker.AsyncMock(
+        return_value=0
+    )
+    mock_prisma_client.db.litellm_invitationlink.delete_many = mocker.AsyncMock(
+        return_value=1
+    )
+    mock_prisma_client.db.litellm_organizationmembership.delete_many = mocker.AsyncMock(
+        return_value=0
+    )
+    mock_prisma_client.db.litellm_teammembership.delete_many = mocker.AsyncMock(
+        return_value=0
+    )
+    mock_prisma_client.db.litellm_usertable.delete_many = mocker.AsyncMock(
+        return_value=1
+    )
+
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    # Call delete_user
+    data = DeleteUserRequest(user_ids=["admin-creator"])
+    user_api_key_dict = UserAPIKeyAuth(
+        user_id="proxy-admin", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+
+    await delete_user(data=data, user_api_key_dict=user_api_key_dict)
+
+    # Verify invitation link deletion uses OR with user_id, created_by, updated_by
+    mock_prisma_client.db.litellm_invitationlink.delete_many.assert_called_once()
+    call_kwargs = mock_prisma_client.db.litellm_invitationlink.delete_many.call_args
+    where_clause = call_kwargs.kwargs.get("where") or call_kwargs[1].get("where")
+
+    assert "OR" in where_clause, "Should use OR to match user_id, created_by, and updated_by"
+    or_conditions = where_clause["OR"]
+    assert len(or_conditions) == 3, "Should have 3 OR conditions"
+
+    # Verify all three FK fields are covered
+    condition_keys = [list(c.keys())[0] for c in or_conditions]
+    assert "user_id" in condition_keys
+    assert "created_by" in condition_keys
+    assert "updated_by" in condition_keys
+
+    # Verify each condition uses {"in": ["admin-creator"]}
+    for condition in or_conditions:
+        field = list(condition.keys())[0]
+        assert condition[field] == {"in": ["admin-creator"]}


### PR DESCRIPTION
## Relevant issues

Fixes #23114 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix


## Changes
- Fix delete_user endpoint to clean up invitation links where the deleted user is the creator (created_by) or updater (updated_by), not just the invited person (user_id)
- Uses a single OR query to cover all three FK relations on LiteLLM_InvitationLink
- Add unit test verifying the OR clause covers all three FK fields