### PR TITLE
fix(tests): use AsyncMock for prisma find_unique in agent get-by-id test

### DIFF
--- a/tests/test_litellm/proxy/agent_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_endpoints.py
@@ -295,6 +295,9 @@ class TestAgentRBACInternalUser:
             return_value=_sample_agent_response()
         )
         with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_prisma.db.litellm_agentstable.find_unique = AsyncMock(
+                return_value=None
+            )
             resp = self.internal_client.get(
                 "/v1/agents/agent-123", headers={"Authorization": "Bearer k"}
             )


### PR DESCRIPTION
## Summary
- Fixes `test_should_allow_internal_user_to_get_agent_by_id` which was returning 500 instead of 200
- The `GET /v1/agents/{agent_id}` endpoint calls `await prisma_client.db.litellm_agentstable.find_unique(...)` even when the agent is found in the registry
- The test patched `prisma_client` with a plain `MagicMock`, but `find_unique` must be an `AsyncMock` — awaiting a plain `MagicMock` raises `TypeError`, caught by the endpoint's `except Exception` block and re-raised as HTTP 500
- Fix: set `mock_prisma.db.litellm_agentstable.find_unique = AsyncMock(return_value=None)` inside the patch block

Note: `test (proxy-misc)` will still show 1 failure (`test_invoke_agent_a2a_adds_litellm_data`) which is a separate root cause being fixed in a follow-up PR.

## Test plan
- [ ] `test_should_allow_internal_user_to_get_agent_by_id` passes