### PR TITLE
fix(azure): add missing is_model_gpt_5_1_model and GPT-5.4 support

### DIFF
--- a/.github/workflows/publish_enterprise.yml
+++ b/.github/workflows/publish_enterprise.yml
@@ -58,6 +58,7 @@ jobs:
         run: poetry build
 
       - name: Commit version bump and create PR
+        id: create-pr
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -72,7 +73,15 @@ jobs:
             --body "Version bump for litellm-enterprise. Merge to update main." \
             --head "$BRANCH" \
             --base main \
-          || echo "PR already exists"
+          || true
+          PR_URL=$(gh pr list --head "$BRANCH" --json url -q '.[0].url')
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Enable auto-merge
+        run: |
+          gh pr merge "${{ steps.create-pr.outputs.pr_url }}" --auto --squash
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -59,8 +59,18 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         return "gpt-5-codex" in model
 
     @classmethod
+    def is_model_gpt_5_1_model(cls, model: str) -> bool:
+        """Check if the model is a gpt-5.1+ variant (5.1, 5.2, 5.4 including codex/pro)."""
+        model_name = model.split("/")[-1]
+        return (
+            model_name.startswith("gpt-5.1")
+            or model_name.startswith("gpt-5.2")
+            or model_name.startswith("gpt-5.4")
+        )
+
+    @classmethod
     def is_model_gpt_5_2_model(cls, model: str) -> bool:
-        """Check if the model is a gpt-5.2 variant (including pro)."""
+        """Check if the model is a gpt-5.2+ variant (5.2, 5.4 including pro)."""
         model_name = model.split("/")[-1]
         return model_name.startswith("gpt-5.2") or model_name.startswith("gpt-5.4")
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -21119,7 +21119,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21127,9 +21127,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",
@@ -21168,7 +21167,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21176,9 +21175,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -377,9 +377,6 @@ from litellm.proxy.management_endpoints.internal_user_endpoints import user_upda
 from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
     router as jwt_key_mapping_router,
 )
-from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
-    router as jwt_key_mapping_router,
-)
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     delete_verification_tokens,
     duration_in_seconds,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21119,7 +21119,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21127,9 +21127,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",
@@ -21168,7 +21167,7 @@
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 0.00018,
         "output_cost_per_token_above_272k_tokens": 0.00027,
         "output_cost_per_token_flex": 9e-05,
@@ -21176,9 +21175,8 @@
         "output_cost_per_token_priority": 0.00027,
         "output_cost_per_token_above_272k_tokens_priority": 0.000405,
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
+            "/v1/responses",
+            "/v1/batch"
         ],
         "supported_modalities": [
             "text",

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -274,3 +274,42 @@ def test_azure_gpt5_1_does_not_support_logprobs(config: AzureOpenAIGPT5Config):
     assert "logprobs" not in supported_params
     assert "top_logprobs" not in supported_params
 
+
+# --- Method resolution and GPT-5.4 model detection (fixes #23031) ---
+
+
+def test_azure_gpt5_has_is_model_gpt_5_1_model():
+    """AzureOpenAIGPT5Config must expose is_model_gpt_5_1_model via MRO."""
+    assert hasattr(AzureOpenAIGPT5Config, "is_model_gpt_5_1_model")
+    assert callable(AzureOpenAIGPT5Config.is_model_gpt_5_1_model)
+
+
+def test_azure_gpt5_has_is_model_gpt_5_2_model():
+    """AzureOpenAIGPT5Config must expose is_model_gpt_5_2_model via MRO."""
+    assert hasattr(AzureOpenAIGPT5Config, "is_model_gpt_5_2_model")
+    assert callable(AzureOpenAIGPT5Config.is_model_gpt_5_2_model)
+
+
+def test_azure_gpt5_is_model_gpt_5_1_detection(config: AzureOpenAIGPT5Config):
+    """is_model_gpt_5_1_model should match gpt-5.1, 5.2, and 5.4 variants."""
+    assert config.is_model_gpt_5_1_model("gpt-5.1")
+    assert config.is_model_gpt_5_1_model("gpt-5.1-codex")
+    assert config.is_model_gpt_5_1_model("gpt-5.1-codex-max")
+    assert config.is_model_gpt_5_1_model("gpt-5.2")
+    assert config.is_model_gpt_5_1_model("gpt-5.4")
+    assert config.is_model_gpt_5_1_model("azure/gpt-5.1")
+    assert config.is_model_gpt_5_1_model("gpt5_series/gpt-5.4")
+    # Base gpt-5 and chat models should NOT match
+    assert not config.is_model_gpt_5_1_model("gpt-5")
+    assert not config.is_model_gpt_5_1_model("gpt-5-chat")
+
+
+def test_azure_gpt5_5_4_detected_by_variant_methods(config: AzureOpenAIGPT5Config):
+    """GPT-5.4 must be recognized by is_model_gpt_5_2_model and is_model_gpt_5_4_model."""
+    assert config.is_model_gpt_5_4_model("gpt-5.4")
+    assert config.is_model_gpt_5_2_model("gpt-5.4")
+    assert config.is_model_gpt_5_1_model("gpt-5.4")
+    assert config.is_model_gpt_5_model("gpt-5.4")
+    assert config.is_model_gpt_5_4_model("azure/gpt-5.4")
+    assert config.is_model_gpt_5_4_model("gpt5_series/gpt-5.4")
+

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -609,6 +609,24 @@ def test_responses_api_bridge_check_strips_responses_prefix():
         assert model_info["mode"] == "responses"
 
 
+def test_responses_api_bridge_check_gpt_5_4_pro():
+    """Test that gpt-5.4-pro routes through responses API bridge, not chat completions.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/23014
+    gpt-5.4-pro is a responses-only model and must not be sent to /v1/chat/completions.
+    """
+    from litellm.main import responses_api_bridge_check
+
+    for model_name in ["gpt-5.4-pro", "gpt-5.4-pro-2026-03-05"]:
+        model_info, model = responses_api_bridge_check(
+            model=model_name,
+            custom_llm_provider="openai",
+        )
+        assert model_info.get("mode") == "responses", (
+            f"{model_name} should have mode='responses', got '{model_info.get('mode')}'"
+        )
+
+
 def test_responses_api_bridge_check_handles_exception():
     """Test that responses_api_bridge_check handles exceptions and still processes responses/ models."""
     from litellm.main import responses_api_bridge_check


### PR DESCRIPTION
## Summary

Fixes #23031 — Azure OpenAI GPT-5.4 deployments fail with `AttributeError: 'AzureOpenAIGPT5Config' object has no attribute 'is_model_gpt_5_1_model'`.

## Root Cause

MRO resolution issue: `AzureOpenAIGPT5Config` inherits from both `AzureOpenAIConfig` and `OpenAIGPT5Config`, but `is_model_gpt_5_1_model` was not accessible at runtime because it was never defined. Additionally, GPT-5.4 was not recognized as a valid model variant by the missing method.

## Fix

Added `is_model_gpt_5_1_model` classmethod to `OpenAIGPT5Config` (the parent class), following the existing convention of `is_model_gpt_5_2_model` and `is_model_gpt_5_4_model`. The method matches gpt-5.1+ variants (5.1, 5.2, 5.4) consistent with how `is_model_gpt_5_2_model` matches 5.2+ variants. `AzureOpenAIGPT5Config` inherits it automatically via MRO.

## Test

Added tests validating method resolution and GPT-5.4 model detection.