### PR TITLE
fix(tests): restore litellm_params=None on mock agent in a2a invoke test

### DIFF
--- a/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
@@ -46,6 +46,7 @@ async def test_invoke_agent_a2a_adds_litellm_data():
         "url": "http://backend-agent:10001",
         "name": "Test Agent",
     }
+    mock_agent.litellm_params = None
 
     # Mock request
     mock_request = MagicMock()


### PR DESCRIPTION
## Summary
- Fixes `test_invoke_agent_a2a_adds_litellm_data` which was failing with `HTTPException: 400: Agent '<MagicMock name='mock.agent_id'>` requires x-litellm-trace-id header`
- `mock_agent.litellm_params` was unset, so `agent.litellm_params or {}` returned the truthy `MagicMock` instead of `{}`
- `MagicMock.get("require_trace_id_on_calls_to_agent")` returns another truthy `MagicMock`, causing trace-id enforcement to trigger with no header present → 400
- Fix: set `mock_agent.litellm_params = None` so `None or {}` resolves to `{}` and enforcement is skipped

This fix was previously added in `a9f040dd43` and accidentally dropped in `caf7f1ccda` (perplexity integration update) while updating the patch path for `add_litellm_data_to_request`.

This is a follow-up to #23122 which fixed the other failing test in `test (proxy-misc)`. Together these two PRs should turn `test (proxy-misc)` green.

## Test plan
- [ ] `test_invoke_agent_a2a_adds_litellm_data` passes
- [ ] `test (proxy-misc)` goes green once both #23122 and this PR are merged