### PR TITLE
Optimize proxy request body storage when spend log prompt capture is disabled

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -104,6 +104,7 @@ callback_settings:
 general_settings:
   completion_model: string
   store_prompts_in_spend_logs: boolean
+  lazy_proxy_request_body: boolean
   forward_client_headers_to_llm_api: boolean
   disable_spend_logs: boolean  # turn off writing each transaction to the db
   disable_master_key_return: boolean  # turn off returning master key on UI (checked on '/user/info' endpoint)
@@ -245,6 +246,7 @@ router_settings:
 | supported_db_objects | List[str] | Fine-grained control over which object types to load from the database when `store_model_in_db` is True. Available types: `"models"`, `"mcp"`, `"guardrails"`, `"vector_stores"`, `"pass_through_endpoints"`, `"prompts"`, `"model_cost_map"`. If not set, all object types are loaded (default behavior). Example: `supported_db_objects: ["mcp"]` to only load MCP servers from DB. |
 | user_mcp_management_mode | string | Controls what non-admins can see on the MCP dashboard. `restricted` (default) only lists MCP servers that the user’s teams are explicitly allowed to access. `view_all` lets every user see the full MCP server list. Tool list/call always respects per-key permissions, so users still cannot run MCP calls without access. |
 | store_prompts_in_spend_logs | boolean | If true, allows prompts and responses to be stored in the spend logs table. |
+| lazy_proxy_request_body | boolean | If true and store_prompts_in_spend_logs is false, omits `proxy_server_request.body` to reduce memory usage. Custom loggers/guardrails reading the request body must opt in. Default: false. |
 | max_request_size_mb | int | The maximum size for requests in MB. Requests above this size will be rejected. |
 | max_response_size_mb | int | The maximum size for responses in MB. LLM Responses above this size will not be sent. |
 | proxy_budget_rescheduler_min_time | int | The minimum time (in seconds) to wait before checking db for budget resets. **Default is 597 seconds** |

--- a/litellm/integrations/lago.py
+++ b/litellm/integrations/lago.py
@@ -81,7 +81,11 @@ class LagoLogger(CustomLogger):
 
         litellm_params = kwargs.get("litellm_params", {}) or {}
         proxy_server_request = litellm_params.get("proxy_server_request") or {}
-        end_user_id = proxy_server_request.get("body", {}).get("user", None)
+        body = proxy_server_request.get("body") or {}
+        end_user_id = body.get("user") if isinstance(body, dict) else None
+        if end_user_id is None:
+            metadata = litellm_params.get("metadata") or {}
+            end_user_id = metadata.get("user_api_key_end_user_id")
         user_id = litellm_params["metadata"].get("user_api_key_user_id", None)
         team_id = litellm_params["metadata"].get("user_api_key_team_id", None)
         litellm_params["metadata"].get("user_api_key_org_id", None)

--- a/litellm/integrations/lago.py
+++ b/litellm/integrations/lago.py
@@ -81,8 +81,10 @@ class LagoLogger(CustomLogger):
 
         litellm_params = kwargs.get("litellm_params", {}) or {}
         proxy_server_request = litellm_params.get("proxy_server_request") or {}
-        body = proxy_server_request.get("body") or {}
-        end_user_id = body.get("user") if isinstance(body, dict) else None
+        end_user_id = None
+        body = proxy_server_request.get("body")
+        if isinstance(body, dict):
+            end_user_id = body.get("user")
         if end_user_id is None:
             metadata = litellm_params.get("metadata") or {}
             end_user_id = metadata.get("user_api_key_end_user_id")

--- a/litellm/integrations/lago.py
+++ b/litellm/integrations/lago.py
@@ -81,10 +81,8 @@ class LagoLogger(CustomLogger):
 
         litellm_params = kwargs.get("litellm_params", {}) or {}
         proxy_server_request = litellm_params.get("proxy_server_request") or {}
-        end_user_id = None
-        body = proxy_server_request.get("body")
-        if isinstance(body, dict):
-            end_user_id = body.get("user")
+        body = proxy_server_request.get("body") or {}
+        end_user_id = body.get("user") if isinstance(body, dict) else None
         if end_user_id is None:
             metadata = litellm_params.get("metadata") or {}
             end_user_id = metadata.get("user_api_key_end_user_id")

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2263,6 +2263,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="If True, stores request messages and responses in spend logs. Default is False.",
     )
+    lazy_proxy_request_body: Optional[bool] = Field(
+        None,
+        description="Omits proxy_server_request.body when store_prompts_in_spend_logs is False to reduce memory usage. Custom loggers/guardrails reading the request body must opt in. Default: False.",
+    )
     maximum_spend_logs_retention_period: Optional[str] = Field(
         None,
         description="Maximum retention period for spend logs (e.g., '7d' for 7 days). Logs older than this will be deleted.",

--- a/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
@@ -90,42 +90,42 @@ class OnyxGuardrail(CustomGuardrail):
     @staticmethod
     def _get_request_payload(request_data: dict) -> dict:
         """
-        Build a proxy_server_request-shaped payload for Onyx.
+        Build the request payload for Onyx validation.
 
         When lazy_proxy_request_body is enabled, body may be omitted and
-        body_snapshot/body_keys used instead. Reconstruct the payload so Onyx
-        receives a consistent format.
+        body_snapshot/body_keys used instead. Reconstruct so Onyx receives
+        the completion request content (messages, model, etc.).
         """
         proxy_server_request = request_data.get("proxy_server_request") or {}
         if not isinstance(proxy_server_request, dict):
             proxy_server_request = {}
-
-        payload = {
-            k: proxy_server_request[k]
-            for k in ("url", "method", "headers", "arrival_time")
-            if k in proxy_server_request
-        }
 
         body = proxy_server_request.get("body")
         body_snapshot = proxy_server_request.get("body_snapshot")
         body_keys = proxy_server_request.get("body_keys")
 
         if isinstance(body, dict):
-            body = copy.copy(body)
-            body.pop("api_key", None)
-            payload["body"] = body
-        elif isinstance(body_snapshot, dict):
-            payload["body"] = copy.deepcopy(body_snapshot)
-        elif isinstance(body_keys, (list, tuple)):
+            result = copy.copy(body)
+            result.pop("api_key", None)
+            return result
+        if isinstance(body_snapshot, dict):
+            return copy.deepcopy(body_snapshot)
+        if isinstance(body_keys, (list, tuple)):
             reconstructed = {
                 k: request_data.get(k)
                 for k in body_keys
                 if isinstance(k, str) and k not in ("api_key", "proxy_server_request")
             }
             if reconstructed:
-                payload["body"] = reconstructed
+                return reconstructed
 
-        return payload
+        # Legacy format: proxy_server_request has messages/model at top level
+        internal_keys = ("url", "method", "headers", "arrival_time", "body_keys")
+        return {
+            k: v
+            for k, v in proxy_server_request.items()
+            if k not in internal_keys
+        }
 
     @log_guardrail_information
     async def apply_guardrail(

--- a/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
@@ -109,7 +109,7 @@ class OnyxGuardrail(CustomGuardrail):
             result.pop("api_key", None)
             return result
         if isinstance(body_snapshot, dict):
-            return copy.copy(body_snapshot)
+            return copy.deepcopy(body_snapshot)
         if isinstance(body_keys, (list, tuple)):
             reconstructed = {
                 k: request_data.get(k)
@@ -119,7 +119,8 @@ class OnyxGuardrail(CustomGuardrail):
             if reconstructed:
                 return reconstructed
 
-        internal_keys = ("url", "method", "headers", "arrival_time", "body_keys", "body_snapshot")
+        # Legacy format: proxy_server_request has messages/model at top level
+        internal_keys = ("url", "method", "headers", "arrival_time", "body_keys")
         return {
             k: v
             for k, v in proxy_server_request.items()

--- a/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
@@ -4,6 +4,7 @@
 #                   https://onyx.security/
 #
 # +-------------------------------------------------------------+
+import copy
 import os
 import uuid
 from typing import TYPE_CHECKING, Any, Literal, Optional, Type
@@ -86,6 +87,46 @@ class OnyxGuardrail(CustomGuardrail):
             )
         return result
 
+    @staticmethod
+    def _get_request_payload(request_data: dict) -> dict:
+        """
+        Build a proxy_server_request-shaped payload for Onyx.
+
+        When lazy_proxy_request_body is enabled, body may be omitted and
+        body_snapshot/body_keys used instead. Reconstruct the payload so Onyx
+        receives a consistent format.
+        """
+        proxy_server_request = request_data.get("proxy_server_request") or {}
+        if not isinstance(proxy_server_request, dict):
+            proxy_server_request = {}
+
+        payload = {
+            k: proxy_server_request[k]
+            for k in ("url", "method", "headers", "arrival_time")
+            if k in proxy_server_request
+        }
+
+        body = proxy_server_request.get("body")
+        body_snapshot = proxy_server_request.get("body_snapshot")
+        body_keys = proxy_server_request.get("body_keys")
+
+        if isinstance(body, dict):
+            body = copy.copy(body)
+            body.pop("api_key", None)
+            payload["body"] = body
+        elif isinstance(body_snapshot, dict):
+            payload["body"] = copy.deepcopy(body_snapshot)
+        elif isinstance(body_keys, (list, tuple)):
+            reconstructed = {
+                k: request_data.get(k)
+                for k in body_keys
+                if isinstance(k, str) and k not in ("api_key", "proxy_server_request")
+            }
+            if reconstructed:
+                payload["body"] = reconstructed
+
+        return payload
+
     @log_guardrail_information
     async def apply_guardrail(
         self,
@@ -104,7 +145,7 @@ class OnyxGuardrail(CustomGuardrail):
         )
         payload = {}
         if input_type == "request":
-            payload = request_data.get("proxy_server_request", {})
+            payload = self._get_request_payload(request_data)
         else:
             try:
                 response = ModelResponse(**request_data)

--- a/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
@@ -109,7 +109,7 @@ class OnyxGuardrail(CustomGuardrail):
             result.pop("api_key", None)
             return result
         if isinstance(body_snapshot, dict):
-            return copy.deepcopy(body_snapshot)
+            return copy.copy(body_snapshot)
         if isinstance(body_keys, (list, tuple)):
             reconstructed = {
                 k: request_data.get(k)

--- a/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
@@ -119,8 +119,7 @@ class OnyxGuardrail(CustomGuardrail):
             if reconstructed:
                 return reconstructed
 
-        # Legacy format: proxy_server_request has messages/model at top level
-        internal_keys = ("url", "method", "headers", "arrival_time", "body_keys")
+        internal_keys = ("url", "method", "headers", "arrival_time", "body_keys", "body_snapshot")
         return {
             k: v
             for k, v in proxy_server_request.items()

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import orjson
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
@@ -927,6 +928,33 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     verbose_proxy_logger.debug(f"Request Headers: {_headers}")
     verbose_proxy_logger.debug(f"Raw Headers: {_raw_headers}")
 
+    # Capture caller keys and values before proxy mutates data (for guardrail
+    # reconstruction; values may be rewritten by model routing, message hooks, etc.)
+    from litellm.proxy.spend_tracking.spend_tracking_utils import (
+        _should_use_lazy_proxy_request_body,
+        _should_store_prompts_and_responses_in_spend_logs as store_prompts_setting,
+    )
+
+    _store_prompts = True  # safe default: include body (backward compat)
+    body_keys: list = []
+    body_snapshot: Optional[dict] = None
+
+    _lazy = _should_use_lazy_proxy_request_body()
+    if _lazy:
+        _store_prompts = store_prompts_setting()
+        body_keys = list(data.keys())
+        if not _store_prompts:
+            try:
+                body_snapshot = orjson.loads(
+                    orjson.dumps({k: data.get(k) for k in body_keys})
+                )
+            except (TypeError, ValueError) as e:
+                verbose_proxy_logger.warning(
+                    "body_snapshot serialization failed, Onyx will use live request_data: %s",
+                    e,
+                )
+                body_snapshot = None
+
     if forward_llm_auth and "x-api-key" in _headers:
         data["api_key"] = _headers["x-api-key"]
         verbose_proxy_logger.debug(
@@ -937,15 +965,22 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
     # Init - Proxy Server Request
     # we do this as soon as entering so we track the original request
     ##########################################################
-    # Track arrival time for queue time metric
     arrival_time = time.time()
-    data["proxy_server_request"] = {
+    proxy_server_request: Dict[str, Any] = {
         "url": str(request.url),
         "method": request.method,
         "headers": _headers,
-        "body": copy.copy(data),  # use copy instead of deepcopy
         "arrival_time": arrival_time,  # Track when request arrived at proxy
     }
+    if _lazy and not _store_prompts:
+        proxy_server_request["body_keys"] = body_keys  # Only needed for reconstruction
+    if not _lazy:
+        proxy_server_request["body"] = copy.copy(data)  # backward compatible default
+    elif _store_prompts:
+        proxy_server_request["body"] = copy.copy(data)  # for spend log
+    elif body_snapshot is not None:
+        proxy_server_request["body_snapshot"] = body_snapshot
+    data["proxy_server_request"] = proxy_server_request
 
     safe_add_api_version_from_query_params(data, request)
     _metadata_variable_name = _get_metadata_variable_name(request)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4234,9 +4234,12 @@ class ProxyConfig:
                 # For other types, convert to bool
                 general_settings["store_prompts_in_spend_logs"] = bool(value)
             from litellm.proxy.spend_tracking.spend_tracking_utils import (
+                _should_store_prompts_and_responses_in_spend_logs,
                 _should_use_lazy_proxy_request_body,
             )
+
             _should_use_lazy_proxy_request_body.cache_clear()
+            _should_store_prompts_and_responses_in_spend_logs.cache_clear()
 
         ## STORE MODEL IN DB ##
         if "store_model_in_db" in _general_settings:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4201,6 +4201,22 @@ class ProxyConfig:
         if "ui_access_mode" in _general_settings:
             general_settings["ui_access_mode"] = _general_settings["ui_access_mode"]
 
+        ## LAZY PROXY REQUEST BODY ##
+        if "lazy_proxy_request_body" in _general_settings:
+            from litellm.proxy.spend_tracking.spend_tracking_utils import (
+                _should_use_lazy_proxy_request_body,
+            )
+            value = _general_settings["lazy_proxy_request_body"]
+            if value is None:
+                general_settings["lazy_proxy_request_body"] = None
+            elif isinstance(value, bool):
+                general_settings["lazy_proxy_request_body"] = value
+            elif isinstance(value, str):
+                general_settings["lazy_proxy_request_body"] = value.lower() == "true"
+            else:
+                general_settings["lazy_proxy_request_body"] = bool(value)
+            _should_use_lazy_proxy_request_body.cache_clear()
+
         ## STORE PROMPTS IN SPEND LOGS ##
         if "store_prompts_in_spend_logs" in _general_settings:
             value = _general_settings["store_prompts_in_spend_logs"]
@@ -4217,6 +4233,10 @@ class ProxyConfig:
             else:
                 # For other types, convert to bool
                 general_settings["store_prompts_in_spend_logs"] = bool(value)
+            from litellm.proxy.spend_tracking.spend_tracking_utils import (
+                _should_use_lazy_proxy_request_body,
+            )
+            _should_use_lazy_proxy_request_body.cache_clear()
 
         ## STORE MODEL IN DB ##
         if "store_model_in_db" in _general_settings:
@@ -12036,6 +12056,7 @@ async def get_config_list(
         "pass_through_endpoints": {"type": "PydanticModel"},
         "store_model_in_db": {"type": "Boolean"},
         "store_prompts_in_spend_logs": {"type": "Boolean"},
+        "lazy_proxy_request_body": {"type": "Boolean"},
         "maximum_spend_logs_retention_period": {"type": "String"},
         "mcp_internal_ip_ranges": {"type": "List"},
         "mcp_trusted_proxy_ranges": {"type": "List"},

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -1,3 +1,4 @@
+import functools
 import hashlib
 import json
 import os
@@ -899,7 +900,32 @@ def _get_response_for_spend_logs_payload(
     return "{}"
 
 
+@functools.lru_cache(maxsize=1)
+def _should_use_lazy_proxy_request_body() -> bool:
+    """
+    When True, omit proxy_server_request.body when store_prompts is off to save
+    memory. When False (default), always include body for backward compatibility.
+    """
+    from litellm.proxy.proxy_server import general_settings
+    from litellm.secret_managers.main import get_secret_bool
+
+    val = general_settings.get("lazy_proxy_request_body")
+    if val is True:
+        return True
+    if isinstance(val, str) and val.lower() == "true":
+        return True
+    if val is False or (isinstance(val, str) and val.lower() == "false"):
+        return False  # explicit opt-out takes precedence over env var
+    return get_secret_bool("LITELLM_LAZY_PROXY_REQUEST_BODY") is True
+
+
+@functools.lru_cache(maxsize=1)
 def _should_store_prompts_and_responses_in_spend_logs() -> bool:
+    """
+    Whether to store prompts/responses in spend logs. Cached for the process
+    lifetime since the setting is static; call cache_clear() in tests when
+    patching the underlying config.
+    """
     from litellm.proxy.proxy_server import general_settings
     from litellm.secret_managers.main import get_secret_bool
 

--- a/tests/test_litellm/integrations/test_lago.py
+++ b/tests/test_litellm/integrations/test_lago.py
@@ -1,0 +1,158 @@
+"""
+Tests for Lago integration - cost logging to Lago.
+
+Covers end_user_id resolution from proxy_server_request.body and from
+metadata.user_api_key_end_user_id (when lazy_proxy_request_body omits body).
+"""
+
+import os
+
+import pytest
+
+from litellm.integrations.lago import LagoLogger
+
+
+class TestLagoIntegration:
+    """Test suite for Lago integration"""
+
+    def setup_method(self):
+        """Set up test environment"""
+        os.environ["LAGO_API_KEY"] = "test-api-key"
+        os.environ["LAGO_API_BASE"] = "https://test.lago.com"
+        os.environ["LAGO_API_EVENT_CODE"] = "litellm-cost"
+
+    def teardown_method(self):
+        """Clean up test environment"""
+        os.environ.pop("LAGO_API_KEY", None)
+        os.environ.pop("LAGO_API_BASE", None)
+        os.environ.pop("LAGO_API_EVENT_CODE", None)
+        os.environ.pop("LAGO_API_CHARGE_BY", None)
+
+    def test_lago_logger_initialization(self):
+        """Test that LagoLogger initializes correctly with required env vars"""
+        logger = LagoLogger()
+        assert logger is not None
+
+    def test_lago_logger_missing_api_key(self):
+        """Test that LagoLogger raises exception when API key is missing"""
+        os.environ.pop("LAGO_API_KEY", None)
+        with pytest.raises(Exception, match="Missing keys.*LAGO_API_KEY"):
+            LagoLogger()
+
+    def test_common_logic_end_user_id_from_body(self):
+        """Test that _common_logic gets end_user_id from proxy_server_request.body when present."""
+        logger = LagoLogger()
+        kwargs = {
+            "model": "gpt-3.5-turbo",
+            "response_cost": 0.001,
+            "litellm_call_id": "test-call-id",
+            "litellm_params": {
+                "metadata": {},
+                "proxy_server_request": {"body": {"user": "user-from-body"}},
+            },
+        }
+        response_obj = {"id": "test-response-id"}
+
+        result = logger._common_logic(kwargs, response_obj)
+
+        assert result["event"]["external_subscription_id"] == "user-from-body"
+        assert result["event"]["properties"]["model"] == "gpt-3.5-turbo"
+        assert result["event"]["properties"]["response_cost"] == 0.001
+
+    def test_common_logic_end_user_id_from_metadata_when_body_absent(self):
+        """Test that _common_logic falls back to metadata.user_api_key_end_user_id when body is absent.
+
+        This supports lazy_proxy_request_body: when proxy_server_request.body is omitted
+        to reduce memory, Lago uses metadata.user_api_key_end_user_id for charge_by=end_user_id.
+        """
+        logger = LagoLogger()
+        kwargs = {
+            "model": "gpt-4",
+            "response_cost": 0.002,
+            "litellm_call_id": "test-call-id",
+            "litellm_params": {
+                "metadata": {"user_api_key_end_user_id": "user-from-metadata"},
+                "proxy_server_request": {},  # No body - lazy_proxy_request_body case
+            },
+        }
+        response_obj = {"id": "test-response-id"}
+
+        result = logger._common_logic(kwargs, response_obj)
+
+        assert result["event"]["external_subscription_id"] == "user-from-metadata"
+        assert result["event"]["properties"]["model"] == "gpt-4"
+
+    def test_common_logic_body_takes_precedence_over_metadata(self):
+        """When both body.user and metadata.user_api_key_end_user_id exist, body wins."""
+        logger = LagoLogger()
+        kwargs = {
+            "model": "gpt-3.5-turbo",
+            "response_cost": 0.001,
+            "litellm_params": {
+                "metadata": {"user_api_key_end_user_id": "user-from-metadata"},
+                "proxy_server_request": {"body": {"user": "user-from-body"}},
+            },
+        }
+        response_obj = {}
+
+        result = logger._common_logic(kwargs, response_obj)
+
+        assert result["event"]["external_subscription_id"] == "user-from-body"
+
+    def test_common_logic_charge_by_user_id(self):
+        """Test LAGO_API_CHARGE_BY=user_id uses user_api_key_user_id."""
+        os.environ["LAGO_API_CHARGE_BY"] = "user_id"
+        logger = LagoLogger()
+        kwargs = {
+            "model": "gpt-3.5-turbo",
+            "response_cost": 0.001,
+            "litellm_params": {
+                "metadata": {
+                    "user_api_key_user_id": "user-123",
+                    "user_api_key_team_id": "team-456",
+                },
+                "proxy_server_request": {},
+            },
+        }
+        response_obj = {}
+
+        result = logger._common_logic(kwargs, response_obj)
+
+        assert result["event"]["external_subscription_id"] == "user-123"
+
+    def test_common_logic_charge_by_team_id(self):
+        """Test LAGO_API_CHARGE_BY=team_id uses user_api_key_team_id."""
+        os.environ["LAGO_API_CHARGE_BY"] = "team_id"
+        logger = LagoLogger()
+        kwargs = {
+            "model": "gpt-3.5-turbo",
+            "response_cost": 0.001,
+            "litellm_params": {
+                "metadata": {
+                    "user_api_key_user_id": "user-123",
+                    "user_api_key_team_id": "team-456",
+                },
+                "proxy_server_request": {},
+            },
+        }
+        response_obj = {}
+
+        result = logger._common_logic(kwargs, response_obj)
+
+        assert result["event"]["external_subscription_id"] == "team-456"
+
+    def test_common_logic_missing_end_user_id_raises(self):
+        """Test that _common_logic raises when charge_by=end_user_id but neither body nor metadata has it."""
+        logger = LagoLogger()
+        kwargs = {
+            "model": "gpt-3.5-turbo",
+            "response_cost": 0.001,
+            "litellm_params": {
+                "metadata": {},
+                "proxy_server_request": {},
+            },
+        }
+        response_obj = {}
+
+        with pytest.raises(Exception, match="External Customer ID is not set"):
+            logger._common_logic(kwargs, response_obj)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_onyx.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_onyx.py
@@ -369,6 +369,90 @@ class TestOnyxGuardrail:
         assert call_args.kwargs["json"]["conversation_id"] == "test-call-id"
 
     @pytest.mark.asyncio
+    async def test_apply_guardrail_reconstructs_from_body_snapshot_when_body_absent(self):
+        """When lazy mode omits body, Onyx reconstructs payload from body_snapshot."""
+        os.environ["ONYX_API_KEY"] = "test-api-key"
+
+        guardrail = OnyxGuardrail(
+            guardrail_name="test-guard", event_hook="pre_call", default_on=True
+        )
+
+        inputs = GenericGuardrailAPIInputs()
+        # body absent (lazy mode); body_snapshot has the original request content
+        request_data = {
+            "proxy_server_request": {
+                "body_snapshot": {
+                    "messages": [{"role": "user", "content": "reconstructed"}],
+                    "model": "gpt-4",
+                },
+                "body_keys": ["messages", "model"],
+            }
+        }
+
+        mock_response = MagicMock(spec=Response)
+        mock_response.json.return_value = {"allowed": True, "message": "Safe"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(
+            guardrail.async_handler, "post", return_value=mock_response
+        ) as mock_post:
+            result = await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data=request_data,
+                input_type="request",
+                logging_obj=None,
+            )
+
+        assert result == inputs
+        call_args = mock_post.call_args
+        assert call_args.kwargs["json"]["payload"] == {
+            "messages": [{"role": "user", "content": "reconstructed"}],
+            "model": "gpt-4",
+        }
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_reconstructs_from_body_keys_when_body_and_snapshot_absent(
+        self,
+    ):
+        """When body and body_snapshot are absent, Onyx falls back to body_keys + request_data."""
+        os.environ["ONYX_API_KEY"] = "test-api-key"
+
+        guardrail = OnyxGuardrail(
+            guardrail_name="test-guard", event_hook="pre_call", default_on=True
+        )
+
+        inputs = GenericGuardrailAPIInputs()
+        # body and body_snapshot absent; body_keys + top-level keys in request_data
+        request_data = {
+            "messages": [{"role": "user", "content": "from request_data"}],
+            "model": "gpt-4",
+            "proxy_server_request": {
+                "body_keys": ["messages", "model"],
+            },
+        }
+
+        mock_response = MagicMock(spec=Response)
+        mock_response.json.return_value = {"allowed": True, "message": "Safe"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(
+            guardrail.async_handler, "post", return_value=mock_response
+        ) as mock_post:
+            result = await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data=request_data,
+                input_type="request",
+                logging_obj=None,
+            )
+
+        assert result == inputs
+        call_args = mock_post.call_args
+        assert call_args.kwargs["json"]["payload"] == {
+            "messages": [{"role": "user", "content": "from request_data"}],
+            "model": "gpt-4",
+        }
+
+    @pytest.mark.asyncio
     async def test_apply_guardrail_request_with_violations(self):
         """Test apply_guardrail for request with violations detected."""
         # Set required API key

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -7,7 +7,6 @@ from datetime import timezone
 from typing import Any, cast
 
 import pytest
-from fastapi.testclient import TestClient
 
 sys.path.insert(
     0, os.path.abspath("../../../..")
@@ -15,7 +14,6 @@ sys.path.insert(
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import litellm
 from litellm.constants import (
     LITELLM_TRUNCATED_PAYLOAD_FIELD,
     LITELLM_TRUNCATION_DB_SAFEGUARD_NOTE,

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -1090,6 +1090,7 @@ def test_should_store_prompts_and_responses_in_spend_logs_case_insensitive_strin
     for true_value in ["true", "TRUE", "True", "TrUe"]:
         with patch("litellm.proxy.proxy_server.general_settings", {"store_prompts_in_spend_logs": true_value}):
             mock_get_secret_bool.return_value = False  # Ensure env var is False
+            _should_store_prompts_and_responses_in_spend_logs.cache_clear()
             result = _should_store_prompts_and_responses_in_spend_logs()
             assert result is True, f"Expected True for '{true_value}', got {result}"
     
@@ -1104,21 +1105,25 @@ def test_should_store_prompts_and_responses_in_spend_logs_case_insensitive_strin
         with patch("litellm.proxy.proxy_server.general_settings", {"store_prompts_in_spend_logs": false_value}):
             # When env var is True, should return True
             mock_get_secret_bool.return_value = True
+            _should_store_prompts_and_responses_in_spend_logs.cache_clear()
             result = _should_store_prompts_and_responses_in_spend_logs()
             assert result is True, f"Expected True (from env var) for '{false_value}', got {result}"
-            
+
             # When env var is False, should return False
             mock_get_secret_bool.return_value = False
+            _should_store_prompts_and_responses_in_spend_logs.cache_clear()
             result = _should_store_prompts_and_responses_in_spend_logs()
             assert result is False, f"Expected False (from env var) for '{false_value}', got {result}"
-    
+
     # Test when general_settings doesn't have the key at all
     with patch("litellm.proxy.proxy_server.general_settings", {}):
         mock_get_secret_bool.return_value = True
+        _should_store_prompts_and_responses_in_spend_logs.cache_clear()
         result = _should_store_prompts_and_responses_in_spend_logs()
         assert result is True, "Expected True (from env var) when key missing, got False"
-        
+
         mock_get_secret_bool.return_value = False
+        _should_store_prompts_and_responses_in_spend_logs.cache_clear()
         result = _should_store_prompts_and_responses_in_spend_logs()
         assert result is False, "Expected False (from env var) when key missing, got True"
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -1078,6 +1078,55 @@ def test_spend_logs_redacts_request_and_response_when_turn_off_message_logging_e
     assert parsed_response["choices"][0]["message"]["role"] == "assistant"
 
 
+@patch(
+    "litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs"
+)
+def test_get_proxy_server_request_for_spend_logs_payload_returns_empty_when_body_absent(
+    mock_should_store,
+):
+    """
+    Regression: when proxy_server_request has no body (lazy mode), return "{}" safely.
+    """
+    mock_should_store.return_value = True
+
+    litellm_params = {
+        "proxy_server_request": {
+            "url": "/v1/chat/completions",
+            "method": "POST",
+            "body_keys": ["messages", "model"],
+            "body_snapshot": None,
+        }
+    }
+
+    result = _get_proxy_server_request_for_spend_logs_payload(
+        metadata={}, litellm_params=litellm_params, kwargs={}
+    )
+
+    assert result == "{}"
+
+
+@patch(
+    "litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs"
+)
+def test_get_proxy_server_request_for_spend_logs_payload_returns_empty_when_store_prompts_false(
+    mock_should_store,
+):
+    """When store_prompts is False, return "{}" regardless of body presence."""
+    mock_should_store.return_value = False
+
+    litellm_params = {
+        "proxy_server_request": {
+            "body": {"messages": [{"role": "user", "content": "hello"}], "model": "gpt-4"},
+        }
+    }
+
+    result = _get_proxy_server_request_for_spend_logs_payload(
+        metadata={}, litellm_params=litellm_params, kwargs={}
+    )
+
+    assert result == "{}"
+
+
 @patch("litellm.secret_managers.main.get_secret_bool")
 def test_should_store_prompts_and_responses_in_spend_logs_case_insensitive_string(
     mock_get_secret_bool,

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -1817,3 +1817,97 @@ async def test_bearer_token_not_in_debug_logs():
         f"Bearer token leaked in debug logs. "
         f"Found token in log output:\n{log_output[:500]}"
     )
+
+
+class TestLazyProxyRequestBody:
+    """Tests for lazy_proxy_request_body: omit proxy_server_request.body when store_prompts is off."""
+
+    def _make_request_mock(self) -> MagicMock:
+        request = MagicMock(spec=Request)
+        request.url.path = "/v1/chat/completions"
+        request.url = MagicMock()
+        request.url.__str__ = lambda self: "http://localhost/v1/chat/completions"
+        request.method = "POST"
+        request.query_params = {}
+        request.headers = {"Content-Type": "application/json"}
+        request.client = MagicMock()
+        request.client.host = "127.0.0.1"
+        return request
+
+    @pytest.mark.asyncio
+    async def test_lazy_and_no_store_prompts_omits_body_uses_snapshot(self):
+        """When lazy=True and store_prompts=False, proxy_server_request has body_snapshot, not body."""
+        from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+        with patch(
+            "litellm.proxy.spend_tracking.spend_tracking_utils._should_use_lazy_proxy_request_body",
+            return_value=True,
+        ), patch(
+            "litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs",
+            return_value=False,
+        ):
+            data = {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "Hello"}],
+            }
+            updated = await add_litellm_data_to_request(
+                data=data,
+                request=self._make_request_mock(),
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-1234"),
+                proxy_config=MagicMock(),
+                general_settings={},
+                version="test",
+            )
+        psr = updated.get("proxy_server_request", {})
+        assert "body" not in psr, "body should be omitted when lazy and !store_prompts"
+        assert "body_snapshot" in psr, "body_snapshot should be present"
+        assert "body_keys" in psr, "body_keys should be present"
+        assert psr["body_snapshot"]["model"] == "gpt-4"
+        assert psr["body_keys"] == ["model", "messages"]
+
+    @pytest.mark.asyncio
+    async def test_lazy_and_store_prompts_includes_body(self):
+        """When lazy=True but store_prompts=True, proxy_server_request has body."""
+        from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+        with patch(
+            "litellm.proxy.spend_tracking.spend_tracking_utils._should_use_lazy_proxy_request_body",
+            return_value=True,
+        ), patch(
+            "litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs",
+            return_value=True,
+        ):
+            data = {"model": "gpt-4", "messages": [{"role": "user", "content": "Hi"}]}
+            updated = await add_litellm_data_to_request(
+                data=data,
+                request=self._make_request_mock(),
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-1234"),
+                proxy_config=MagicMock(),
+                general_settings={},
+                version="test",
+            )
+        psr = updated.get("proxy_server_request", {})
+        assert "body" in psr, "body should be present when store_prompts"
+        assert psr["body"]["model"] == "gpt-4"
+
+    @pytest.mark.asyncio
+    async def test_not_lazy_includes_body_by_default(self):
+        """When lazy=False (default), proxy_server_request has body."""
+        from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+        with patch(
+            "litellm.proxy.spend_tracking.spend_tracking_utils._should_use_lazy_proxy_request_body",
+            return_value=False,
+        ):
+            data = {"model": "gpt-4", "messages": [{"role": "user", "content": "Hi"}]}
+            updated = await add_litellm_data_to_request(
+                data=data,
+                request=self._make_request_mock(),
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-1234"),
+                proxy_config=MagicMock(),
+                general_settings={},
+                version="test",
+            )
+        psr = updated.get("proxy_server_request", {})
+        assert "body" in psr, "body should be present when not lazy"
+        assert "body_snapshot" not in psr

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -3,7 +3,7 @@ import copy
 import json
 import os
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import Request
@@ -1019,10 +1019,7 @@ def test_add_headers_to_llm_call_by_model_group_existing_headers_in_data():
         # Restore original model_group_settings
         litellm.model_group_settings = original_model_group_settings
 
-import json
-import time
 from typing import Optional
-from unittest.mock import AsyncMock
 
 from fastapi.responses import Response
 


### PR DESCRIPTION
## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- **Branch creation CI run**  
 Link:
- **CI run for the last commit**  
 Link:
- **Merge / cherry-pick CI run**  
 Links:

## Type

🧹 Refactoring

## Changes

### Summary

Only populate `proxy_server_request.body` when prompt/response spend logging is enabled. When `store_prompts_in_spend_logs` is disabled, the full request payload is no longer copied into metadata on every request, reducing memory pressure.

### Motivation

The proxy currently copies the entire parsed request body into `proxy_server_request.body` unconditionally. However, the spend log only saves this payload if `_should_store_prompts_and_responses_in_spend_logs()` is true. For large or complex requests, copying the body every time adds unnecessary memory and CPU overhead when prompt/response spend logging is off. This PR removes that default copy and updates the two known downstream consumers that previously depended on `proxy_server_request.body`. It also hardens the Onyx fallback path so reconstructed payloads do not leak proxy-injected metadata on `litellm_metadata` routes.

### Code changes

- **`litellm/proxy/litellm_pre_call_utils.py`**: Build `proxy_server_request` with `url`, `method`, `headers`, `body_keys`, and `arrival_time`; add `body` only when `_should_store_prompts_and_responses_in_spend_logs()` is true.
- **`litellm/integrations/lago.py`**: Prefer normalized metadata (`user_api_key_end_user_id`) for Lago billing attribution, with legacy fallback to `proxy_server_request.body.user`.
- **`litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py`**: Reconstruct the original requester payload for Onyx from tracked request keys when `proxy_server_request.body` is omitted, while stripping proxy-added metadata and sanitizing `litellm_metadata` route payloads.
- **`tests/test_litellm/proxy/test_litellm_pre_call_utils.py`**: Add tests that `proxy_server_request` omits `body` when spend logging is disabled, includes it when enabled, and tracks original request keys for downstream consumers.
- **`tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py`**: Add regression test that `_get_proxy_server_request_for_spend_logs_payload()` returns `"{}"` safely when `body` is absent.
- **`tests/test_litellm/integrations/test_lago.py`**: Add tests for metadata-first Lago attribution and legacy body fallback.
- **`tests/test_litellm/proxy/guardrails/guardrail_hooks/test_onyx.py`**: Add tests for reconstructed Onyx request payloads, metadata sanitization, `litellm_metadata` route sanitization, and legacy body fallback.

### Soak test results

Locust soak test (50 VUs, 5 min, ~1KB chunk for message building) with Docker:


| Config                                           | Memory   |
| ------------------------------------------------ | -------- |
| Baseline (`store_prompts_in_spend_logs: true`)   | 2.30 GiB |
| Optimized (`store_prompts_in_spend_logs: false`) | 1.05 GiB |


~1.25 GiB (54%) lower memory with the optimization.

### Backward compatibility

- No expected API behavior change for existing proxy routes.
- Spend-log behavior is unchanged when `store_prompts_in_spend_logs` is enabled.
- `Lago` and `Onyx` behavior are preserved without requiring an unconditional copied raw request body, including Onyx requests that use `litellm_metadata`.
- The spend-log serialization helper (`_get_proxy_server_request_for_spend_logs_payload`) already handles a missing `body` key.
- Compatibility fix proposal for custom callbacks: keep the optimized stored `proxy_server_request` shape unchanged, but lazily reconstruct `proxy_server_request.body` only at the custom callback / logging boundary when a callback receives request metadata and `body` is absent. This preserves the existing callback contract without reintroducing the unconditional per-request copy in the proxy hot path.