### PR TITLE
feat: add LITELLM_ENFORCE_STREAMED_USAGE env var for automatic stream…

### DIFF
--- a/docs/my-website/docs/completion/usage.md
+++ b/docs/my-website/docs/completion/usage.md
@@ -64,6 +64,12 @@ general_settings:
   always_include_stream_usage: true
 ```
 
+Or set the environment variable (no config file change needed):
+
+```bash
+LITELLM_ENFORCE_STREAMED_USAGE=true
+```
+
 Alternatively, configure it through the UI:
 
 1. Navigate to the LiteLLM Proxy UI

--- a/docs/my-website/docs/completion/usage.md
+++ b/docs/my-website/docs/completion/usage.md
@@ -70,6 +70,8 @@ Or set the environment variable (no config file change needed):
 LITELLM_ENFORCE_STREAMED_USAGE=true
 ```
 
+> **Note:** This value is read once at server startup. Changing it at runtime has no effect — a server restart is required.
+
 Alternatively, configure it through the UI:
 
 1. Navigate to the LiteLLM Proxy UI

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -53,7 +53,8 @@ StreamChunkSerializer = Callable[[Any], str]
 # Type alias for streaming error serializer (ProxyException -> wire format)
 StreamErrorSerializer = Callable[[ProxyException], str]
 
-# Cached at module load time to avoid repeated env var lookups on every request
+# Cached at module load time to avoid repeated env var lookups on every request.
+# NOTE: changing this env var at runtime has no effect; a server restart is required.
 _ENFORCE_STREAMED_USAGE = (
     os.environ.get("LITELLM_ENFORCE_STREAMED_USAGE", "false").lower() == "true"
 )

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 import time
 import traceback
 from datetime import datetime
@@ -655,8 +656,9 @@ class ProxyBaseLLMRequestProcessing:
         # automatically add stream_options={'include_usage': True} if not already set
         if (
             general_settings.get("always_include_stream_usage", False) is True
-            and self.data.get("stream", False) is True
-        ):
+            or os.environ.get("LITELLM_ENFORCE_STREAMED_USAGE", "false").lower()
+            == "true"
+        ) and self.data.get("stream", False) is True:
             # Only set if stream_options is not already provided by the client
             if "stream_options" not in self.data:
                 self.data["stream_options"] = {"include_usage": True}

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -53,6 +53,11 @@ StreamChunkSerializer = Callable[[Any], str]
 # Type alias for streaming error serializer (ProxyException -> wire format)
 StreamErrorSerializer = Callable[[ProxyException], str]
 
+# Cached at module load time to avoid repeated env var lookups on every request
+_ENFORCE_STREAMED_USAGE = (
+    os.environ.get("LITELLM_ENFORCE_STREAMED_USAGE", "false").lower() == "true"
+)
+
 if TYPE_CHECKING:
     from litellm.proxy.proxy_server import ProxyConfig as _ProxyConfig
 
@@ -656,8 +661,7 @@ class ProxyBaseLLMRequestProcessing:
         # automatically add stream_options={'include_usage': True} if not already set
         if (
             general_settings.get("always_include_stream_usage", False) is True
-            or os.environ.get("LITELLM_ENFORCE_STREAMED_USAGE", "false").lower()
-            == "true"
+            or _ENFORCE_STREAMED_USAGE
         ) and self.data.get("stream", False) is True:
             # Only set if stream_options is not already provided by the client
             if "stream_options" not in self.data:

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -766,6 +766,11 @@ class TestProxyBaseLLMRequestProcessing:
         automatically get stream_options={'include_usage': True}.
         """
         monkeypatch.setenv("LITELLM_ENFORCE_STREAMED_USAGE", "true")
+        # Also patch the cached module-level constant, since it is evaluated at
+        # import time and monkeypatch.setenv alone cannot update it.
+        monkeypatch.setattr(
+            litellm.proxy.common_request_processing, "_ENFORCE_STREAMED_USAGE", True
+        )
 
         processing_obj = ProxyBaseLLMRequestProcessing(
             data={
@@ -822,6 +827,11 @@ class TestProxyBaseLLMRequestProcessing:
         non-streaming requests.
         """
         monkeypatch.setenv("LITELLM_ENFORCE_STREAMED_USAGE", "true")
+        # Also patch the cached module-level constant, since it is evaluated at
+        # import time and monkeypatch.setenv alone cannot update it.
+        monkeypatch.setattr(
+            litellm.proxy.common_request_processing, "_ENFORCE_STREAMED_USAGE", True
+        )
 
         processing_obj = ProxyBaseLLMRequestProcessing(
             data={

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -759,6 +759,115 @@ class TestProxyBaseLLMRequestProcessing:
             metadata["queue_time_seconds"] >= 0.5
         ), f"queue_time_seconds should be at least 0.5, got {metadata['queue_time_seconds']}"
 
+    @pytest.mark.asyncio
+    async def test_enforce_streamed_usage_env_var(self, monkeypatch):
+        """
+        When LITELLM_ENFORCE_STREAMED_USAGE=true, streaming requests should
+        automatically get stream_options={'include_usage': True}.
+        """
+        monkeypatch.setenv("LITELLM_ENFORCE_STREAMED_USAGE", "true")
+
+        processing_obj = ProxyBaseLLMRequestProcessing(
+            data={
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            }
+        )
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {}
+
+        async def mock_add_litellm_data_to_request(*args, **kwargs):
+            return kwargs.get("data", {})
+
+        async def mock_pre_call_hook(user_api_key_dict, data, call_type):
+            return copy.deepcopy(data)
+
+        mock_logging_obj = MagicMock()
+        mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+        mock_user_api_key_dict.aliases = None
+
+        mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+        mock_proxy_logging_obj.pre_call_hook = AsyncMock(
+            side_effect=mock_pre_call_hook
+        )
+        monkeypatch.setattr(
+            litellm.proxy.common_request_processing,
+            "add_litellm_data_to_request",
+            mock_add_litellm_data_to_request,
+        )
+        monkeypatch.setattr(
+            litellm.utils,
+            "function_setup",
+            lambda *args, **kwargs: (mock_logging_obj, kwargs),
+        )
+
+        returned_data, _ = await processing_obj.common_processing_pre_call_logic(
+            request=mock_request,
+            general_settings={},
+            user_api_key_dict=mock_user_api_key_dict,
+            proxy_logging_obj=mock_proxy_logging_obj,
+            proxy_config=MagicMock(spec=ProxyConfig),
+            route_type="acompletion",
+        )
+
+        assert returned_data["stream_options"] == {"include_usage": True}
+
+    @pytest.mark.asyncio
+    async def test_enforce_streamed_usage_env_var_no_effect_on_non_streaming(
+        self, monkeypatch
+    ):
+        """
+        LITELLM_ENFORCE_STREAMED_USAGE should not add stream_options to
+        non-streaming requests.
+        """
+        monkeypatch.setenv("LITELLM_ENFORCE_STREAMED_USAGE", "true")
+
+        processing_obj = ProxyBaseLLMRequestProcessing(
+            data={
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "Hello"}],
+            }
+        )
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {}
+
+        async def mock_add_litellm_data_to_request(*args, **kwargs):
+            return kwargs.get("data", {})
+
+        async def mock_pre_call_hook(user_api_key_dict, data, call_type):
+            return copy.deepcopy(data)
+
+        mock_logging_obj = MagicMock()
+        mock_user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+        mock_user_api_key_dict.aliases = None
+
+        mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+        mock_proxy_logging_obj.pre_call_hook = AsyncMock(
+            side_effect=mock_pre_call_hook
+        )
+        monkeypatch.setattr(
+            litellm.proxy.common_request_processing,
+            "add_litellm_data_to_request",
+            mock_add_litellm_data_to_request,
+        )
+        monkeypatch.setattr(
+            litellm.utils,
+            "function_setup",
+            lambda *args, **kwargs: (mock_logging_obj, kwargs),
+        )
+
+        returned_data, _ = await processing_obj.common_processing_pre_call_logic(
+            request=mock_request,
+            general_settings={},
+            user_api_key_dict=mock_user_api_key_dict,
+            proxy_logging_obj=mock_proxy_logging_obj,
+            proxy_config=MagicMock(spec=ProxyConfig),
+            route_type="acompletion",
+        )
+
+        assert "stream_options" not in returned_data
+
 
 @pytest.mark.asyncio
 class TestCommonRequestProcessingHelpers:


### PR DESCRIPTION
## Relevant issues
Fixes #22280

## Pre-Submission checklist
- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)
- [ ] Branch creation CI run
      Link:
- [ ] CI run for the last commit
      Link:
- [ ] Merge / cherry-pick CI run
      Links:

## Type
🆕 New Feature

## Changes
- Added `LITELLM_ENFORCE_STREAMED_USAGE` environment variable support
- When set to `true`, automatically injects `stream_options: {"include_usage": true}` into streaming requests without requiring config YAML changes
- Reuses existing `always_include_stream_usage` logic rather than duplicating it
- Updated `docs/my-website/docs/completion/usage.md` to document the new env var
- Added 2 tests: one confirming streaming requests get `stream_options` injected, one confirming non-streaming requests are unaffected

### Why
Issue #22280 requested an `ENFORCE_STREAMED_USAGE` config flag. During implementation, discovered that `always_include_stream_usage` in `general_settings` already handles this behavior. Rather than duplicating logic, this PR exposes the same functionality via the `LITELLM_ENFORCE_STREAMED_USAGE` env var which useful for Docker and CI/CD environments where editing config YAML isn't practical.