### PR TITLE
fix(anthropic): preserve interleaved thinking block order on round-trip (#23047)

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2444,124 +2444,165 @@ def anthropic_messages_pt(  # noqa: PLR0915
                     # Add compaction blocks at the beginning of assistant content : https://platform.claude.com/docs/en/build-with-claude/compaction
                     assistant_content.extend(_compaction_blocks)  # type: ignore
 
-            thinking_blocks = assistant_content_block.get("thinking_blocks", None)
-            if (
-                thinking_blocks is not None
-            ):  # IMPORTANT: ADD THIS FIRST, ELSE ANTHROPIC WILL RAISE AN ERROR
-                assistant_content.extend(thinking_blocks)
-            if "content" in assistant_content_block and isinstance(
-                assistant_content_block["content"], list
-            ):
-                for m in assistant_content_block["content"]:
-                    # handle thinking blocks
-                    thinking_block = cast(str, m.get("thinking", ""))
-                    text_block = cast(str, m.get("text", ""))
-                    if (
-                        m.get("type", "") == "thinking" and len(thinking_block) > 0
-                    ):  # don't pass empty text blocks. anthropic api raises errors.
-                        anthropic_message: Union[
-                            ChatCompletionThinkingBlock,
-                            AnthropicMessagesTextParam,
-                        ] = cast(ChatCompletionThinkingBlock, m)
-                        assistant_content.append(anthropic_message)
-                    # handle text
-                    elif (
-                        m.get("type", "") == "text" and len(text_block) > 0
-                    ):  # don't pass empty text blocks. anthropic api raises errors.
-                        anthropic_message = AnthropicMessagesTextParam(
-                            type="text", text=text_block
+            # Check for preserved original content block ordering.
+            # When responses have interleaved thinking and server tool use
+            # blocks (e.g. web search), the original interleaving must be
+            # preserved on round-trip or Anthropic's thinking block signature
+            # verification fails.
+            # See: https://github.com/BerriAI/litellm/issues/23047
+            _original_content = None
+            if isinstance(_provider_specific_fields_raw, dict):
+                _original_content = _provider_specific_fields_raw.get(
+                    "_original_content"
+                )
+
+            if _original_content is not None and isinstance(_original_content, list):
+                for _oc_block in _original_content:
+                    _oc_type = _oc_block.get("type", "")
+                    if _oc_type == "text":
+                        _oc_text = _oc_block.get("text", "")
+                        if _oc_text:  # skip empty text blocks
+                            _oc_msg = AnthropicMessagesTextParam(
+                                type="text", text=_oc_text
+                            )
+                            _oc_cached = add_cache_control_to_content(
+                                anthropic_content_element=_oc_msg,
+                                original_content_element=dict(_oc_block),
+                            )
+                            assistant_content.append(
+                                cast(AnthropicMessagesTextParam, _oc_cached)
+                            )
+                    elif _oc_type in ("tool_use", "server_tool_use"):
+                        _oc_id = _oc_block.get("id")
+                        if _oc_id:
+                            if _oc_id in unique_tool_ids:
+                                continue
+                            unique_tool_ids.add(_oc_id)
+                        assistant_content.append(_oc_block)  # type: ignore
+                    else:
+                        # thinking, redacted_thinking, *_tool_result, compaction
+                        assistant_content.append(_oc_block)  # type: ignore
+            else:
+                thinking_blocks = assistant_content_block.get("thinking_blocks", None)
+                if (
+                    thinking_blocks is not None
+                ):  # IMPORTANT: ADD THIS FIRST, ELSE ANTHROPIC WILL RAISE AN ERROR
+                    assistant_content.extend(thinking_blocks)
+                if "content" in assistant_content_block and isinstance(
+                    assistant_content_block["content"], list
+                ):
+                    for m in assistant_content_block["content"]:
+                        # handle thinking blocks
+                        thinking_block = cast(str, m.get("thinking", ""))
+                        text_block = cast(str, m.get("text", ""))
+                        if (
+                            m.get("type", "") == "thinking" and len(thinking_block) > 0
+                        ):  # don't pass empty text blocks. anthropic api raises errors.
+                            anthropic_message: Union[
+                                ChatCompletionThinkingBlock,
+                                AnthropicMessagesTextParam,
+                            ] = cast(ChatCompletionThinkingBlock, m)
+                            assistant_content.append(anthropic_message)
+                        # handle text
+                        elif (
+                            m.get("type", "") == "text" and len(text_block) > 0
+                        ):  # don't pass empty text blocks. anthropic api raises errors.
+                            anthropic_message = AnthropicMessagesTextParam(
+                                type="text", text=text_block
+                            )
+                            _cached_message = add_cache_control_to_content(
+                                anthropic_content_element=anthropic_message,
+                                original_content_element=dict(m),
+                            )
+
+                            assistant_content.append(
+                                cast(AnthropicMessagesTextParam, _cached_message)
+                            )
+                        # handle server_tool_use blocks (tool search, web search, etc.)
+                        # Pass through as-is since these are Anthropic-native content types
+                        elif m.get("type", "") == "server_tool_use":
+                            assistant_content.append(m)  # type: ignore
+                        # handle all *_tool_result blocks (tool_search_tool_result,
+                        # web_search_tool_result, bash_code_execution_tool_result, etc.)
+                        # Pass through as-is since these are Anthropic-native content types
+                        elif m.get("type", "").endswith("_tool_result"):
+                            assistant_content.append(m)  # type: ignore
+                elif (
+                    "content" in assistant_content_block
+                    and isinstance(assistant_content_block["content"], str)
+                    and assistant_content_block[
+                        "content"
+                    ]  # don't pass empty text blocks. anthropic api raises errors.
+                ):
+                    _anthropic_text_content_element = AnthropicMessagesTextParam(
+                        type="text",
+                        text=assistant_content_block["content"],
+                    )
+
+                    _content_element = add_cache_control_to_content(
+                        anthropic_content_element=_anthropic_text_content_element,
+                        original_content_element=dict(assistant_content_block),
+                    )
+
+                    if "cache_control" in _content_element:
+                        _anthropic_text_content_element["cache_control"] = (
+                            _content_element["cache_control"]
                         )
-                        _cached_message = add_cache_control_to_content(
-                            anthropic_content_element=anthropic_message,
-                            original_content_element=dict(m),
+
+                    assistant_content.append(_anthropic_text_content_element)
+
+                assistant_tool_calls = assistant_content_block.get("tool_calls")
+                if (
+                    assistant_tool_calls is not None
+                ):  # support assistant tool invoke conversion
+                    # Get web_search_results and tool_results from provider_specific_fields
+                    # for server_tool_use reconstruction.
+                    # Fixes: https://github.com/BerriAI/litellm/issues/17737
+                    _provider_specific_fields_raw = assistant_content_block.get(
+                        "provider_specific_fields"
+                    )
+                    _provider_specific_fields: Dict[str, Any] = {}
+                    if isinstance(_provider_specific_fields_raw, dict):
+                        _provider_specific_fields = cast(
+                            Dict[str, Any], _provider_specific_fields_raw
                         )
+                    _web_search_results = _provider_specific_fields.get(
+                        "web_search_results"
+                    )
+                    _tool_results = _provider_specific_fields.get("tool_results")
+                    tool_invoke_results = convert_to_anthropic_tool_invoke(
+                        assistant_tool_calls,
+                        web_search_results=_web_search_results,
+                        tool_results=_tool_results,
+                    )
+
+                    # Prevent "tool_use ids must be unique" errors by filtering duplicates
+                    # This can happen when merging history that already contains the tool calls
+                    for item in tool_invoke_results:
+                        # tool_use items are typically dicts, but handle objects just in case
+                        item_id = (
+                            item.get("id")
+                            if isinstance(item, dict)
+                            else getattr(item, "id", None)
+                        )
+
+                        if item_id:
+                            if item_id in unique_tool_ids:
+                                continue
+                            unique_tool_ids.add(item_id)
 
                         assistant_content.append(
-                            cast(AnthropicMessagesTextParam, _cached_message)
+                            cast(AnthropicMessagesAssistantMessageValues, item)
                         )
-                    # handle server_tool_use blocks (tool search, web search, etc.)
-                    # Pass through as-is since these are Anthropic-native content types
-                    elif m.get("type", "") == "server_tool_use":
-                        assistant_content.append(m)  # type: ignore
-                    # handle all *_tool_result blocks (tool_search_tool_result,
-                    # web_search_tool_result, bash_code_execution_tool_result, etc.)
-                    # Pass through as-is since these are Anthropic-native content types
-                    elif m.get("type", "").endswith("_tool_result"):
-                        assistant_content.append(m)  # type: ignore
-            elif (
-                "content" in assistant_content_block
-                and isinstance(assistant_content_block["content"], str)
-                and assistant_content_block[
-                    "content"
-                ]  # don't pass empty text blocks. anthropic api raises errors.
-            ):
-                _anthropic_text_content_element = AnthropicMessagesTextParam(
-                    type="text",
-                    text=assistant_content_block["content"],
-                )
 
-                _content_element = add_cache_control_to_content(
-                    anthropic_content_element=_anthropic_text_content_element,
-                    original_content_element=dict(assistant_content_block),
-                )
+                assistant_function_call = assistant_content_block.get("function_call")
 
-                if "cache_control" in _content_element:
-                    _anthropic_text_content_element["cache_control"] = _content_element[
-                        "cache_control"
-                    ]
-
-                assistant_content.append(_anthropic_text_content_element)
-
-            assistant_tool_calls = assistant_content_block.get("tool_calls")
-            if (
-                assistant_tool_calls is not None
-            ):  # support assistant tool invoke conversion
-                # Get web_search_results and tool_results from provider_specific_fields
-                # for server_tool_use reconstruction.
-                # Fixes: https://github.com/BerriAI/litellm/issues/17737
-                _provider_specific_fields_raw = assistant_content_block.get(
-                    "provider_specific_fields"
-                )
-                _provider_specific_fields: Dict[str, Any] = {}
-                if isinstance(_provider_specific_fields_raw, dict):
-                    _provider_specific_fields = cast(
-                        Dict[str, Any], _provider_specific_fields_raw
+                if assistant_function_call is not None:
+                    assistant_content.extend(
+                        convert_function_to_anthropic_tool_invoke(
+                            assistant_function_call
+                        )
                     )
-                _web_search_results = _provider_specific_fields.get(
-                    "web_search_results"
-                )
-                _tool_results = _provider_specific_fields.get("tool_results")
-                tool_invoke_results = convert_to_anthropic_tool_invoke(
-                    assistant_tool_calls,
-                    web_search_results=_web_search_results,
-                    tool_results=_tool_results,
-                )
-
-                # Prevent "tool_use ids must be unique" errors by filtering duplicates
-                # This can happen when merging history that already contains the tool calls
-                for item in tool_invoke_results:
-                    # tool_use items are typically dicts, but handle objects just in case
-                    item_id = (
-                        item.get("id")
-                        if isinstance(item, dict)
-                        else getattr(item, "id", None)
-                    )
-
-                    if item_id:
-                        if item_id in unique_tool_ids:
-                            continue
-                        unique_tool_ids.add(item_id)
-
-                    assistant_content.append(
-                        cast(AnthropicMessagesAssistantMessageValues, item)
-                    )
-
-            assistant_function_call = assistant_content_block.get("function_call")
-
-            if assistant_function_call is not None:
-                assistant_content.extend(
-                    convert_function_to_anthropic_tool_invoke(assistant_function_call)
-                )
 
             msg_i += 1
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2480,7 +2480,11 @@ def anthropic_messages_pt(  # noqa: PLR0915
                             unique_tool_ids.add(_oc_id)
                         assistant_content.append(_oc_block)  # type: ignore
                     else:
-                        # thinking, redacted_thinking, *_tool_result, compaction
+                        # thinking, redacted_thinking, *_tool_result
+                        # Skip compaction — already prepended above.
+                        # Skip tool_search_tool_result — internal metadata.
+                        if _oc_type in ("compaction", "tool_search_tool_result"):
+                            continue
                         assistant_content.append(_oc_block)  # type: ignore
             else:
                 thinking_blocks = assistant_content_block.get("thinking_blocks", None)
@@ -2551,60 +2555,51 @@ def anthropic_messages_pt(  # noqa: PLR0915
 
                     assistant_content.append(_anthropic_text_content_element)
 
-                assistant_tool_calls = assistant_content_block.get("tool_calls")
-                if (
-                    assistant_tool_calls is not None
-                ):  # support assistant tool invoke conversion
-                    # Get web_search_results and tool_results from provider_specific_fields
-                    # for server_tool_use reconstruction.
-                    # Fixes: https://github.com/BerriAI/litellm/issues/17737
-                    _provider_specific_fields_raw = assistant_content_block.get(
-                        "provider_specific_fields"
-                    )
-                    _provider_specific_fields: Dict[str, Any] = {}
-                    if isinstance(_provider_specific_fields_raw, dict):
-                        _provider_specific_fields = cast(
-                            Dict[str, Any], _provider_specific_fields_raw
-                        )
-                    _web_search_results = _provider_specific_fields.get(
-                        "web_search_results"
-                    )
-                    _tool_results = _provider_specific_fields.get("tool_results")
-                    tool_invoke_results = convert_to_anthropic_tool_invoke(
-                        assistant_tool_calls,
-                        web_search_results=_web_search_results,
-                        tool_results=_tool_results,
-                    )
-
-                    # Prevent "tool_use ids must be unique" errors by filtering duplicates
-                    # This can happen when merging history that already contains the tool calls
-                    for item in tool_invoke_results:
-                        # tool_use items are typically dicts, but handle objects just in case
-                        item_id = (
-                            item.get("id")
-                            if isinstance(item, dict)
-                            else getattr(item, "id", None)
-                        )
-
-                        if item_id:
-                            if item_id in unique_tool_ids:
-                                continue
-                            unique_tool_ids.add(item_id)
-
-                        assistant_content.append(
-                            cast(AnthropicMessagesAssistantMessageValues, item)
-                        )
-
-                assistant_function_call = assistant_content_block.get("function_call")
-
-                if assistant_function_call is not None:
-                    assistant_content.extend(
-                        convert_function_to_anthropic_tool_invoke(
-                            assistant_function_call
-                        )
-                    )
-
             msg_i += 1
+
+            # Process tool_calls outside the _original_content / else branches
+            # so they are included regardless of which path was taken.
+            # unique_tool_ids prevents duplication with tools already in content.
+            assistant_tool_calls = assistant_content_block.get("tool_calls")
+            if (
+                assistant_tool_calls is not None
+            ):  # support assistant tool invoke conversion
+                _psf_raw = assistant_content_block.get("provider_specific_fields")
+                _psf: Dict[str, Any] = {}
+                if isinstance(_psf_raw, dict):
+                    _psf = cast(Dict[str, Any], _psf_raw)
+                _web_search_results = _psf.get("web_search_results")
+                _tool_results = _psf.get("tool_results")
+                tool_invoke_results = convert_to_anthropic_tool_invoke(
+                    assistant_tool_calls,
+                    web_search_results=_web_search_results,
+                    tool_results=_tool_results,
+                )
+
+                for item in tool_invoke_results:
+                    item_id = (
+                        item.get("id")
+                        if isinstance(item, dict)
+                        else getattr(item, "id", None)
+                    )
+
+                    if item_id:
+                        if item_id in unique_tool_ids:
+                            continue
+                        unique_tool_ids.add(item_id)
+
+                    assistant_content.append(
+                        cast(AnthropicMessagesAssistantMessageValues, item)
+                    )
+
+            assistant_function_call = assistant_content_block.get("function_call")
+
+            if assistant_function_call is not None:
+                assistant_content.extend(
+                    convert_function_to_anthropic_tool_invoke(
+                        assistant_function_call
+                    )
+                )
 
         if assistant_content:
             new_messages.append({"role": "assistant", "content": assistant_content})

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1745,7 +1745,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     for content in completion_response.get("content", [])
                 )
                 if _has_server_tools:
-                    provider_specific_fields["_original_content"] = (
+                    provider_specific_fields["_original_content"] = list(
                         completion_response["content"]
                     )
 

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1734,6 +1734,21 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             if compaction_blocks is not None:
                 provider_specific_fields["compaction_blocks"] = compaction_blocks
 
+            # When the response has both thinking blocks and server tool use
+            # (e.g. web search), the content blocks are interleaved in an order
+            # that Anthropic's signature verification depends on.  Store the
+            # original content so the round-trip reconstruction can preserve
+            # the exact block ordering.  (Fixes #23047)
+            if thinking_blocks and tool_calls:
+                _has_server_tools = any(
+                    content.get("type") == "server_tool_use"
+                    for content in completion_response.get("content", [])
+                )
+                if _has_server_tools:
+                    provider_specific_fields["_original_content"] = (
+                        completion_response["content"]
+                    )
+
             _message = litellm.Message(
                 tool_calls=tool_calls,
                 content=text_content or None,

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1739,7 +1739,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             # that Anthropic's signature verification depends on.  Store the
             # original content so the round-trip reconstruction can preserve
             # the exact block ordering.  (Fixes #23047)
-            if thinking_blocks and tool_calls:
+            if thinking_blocks:
                 _has_server_tools = any(
                     content.get("type") == "server_tool_use"
                     for content in completion_response.get("content", [])

--- a/tests/litellm_core_utils/test_thinking_blocks_round_trip_ordering.py
+++ b/tests/litellm_core_utils/test_thinking_blocks_round_trip_ordering.py
@@ -1,0 +1,367 @@
+"""
+Tests for thinking block ordering preservation on round-trip with
+multiple web searches.
+
+Fixes: https://github.com/BerriAI/litellm/issues/23047
+
+When an assistant response contains interleaved thinking blocks and
+server_tool_use / web_search_tool_result blocks, the round-trip
+conversion (Anthropic → OpenAI → Anthropic) must preserve the original
+content block order.  Anthropic's API verifies thinking block signatures
+and rejects requests where the blocks have been reordered.
+"""
+
+import json
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.prompt_templates.factory import anthropic_messages_pt
+from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+
+# Simulated Anthropic response with interleaved thinking and 2 web searches.
+# This is the content array from the raw Anthropic API response.
+INTERLEAVED_CONTENT: List[Dict[str, Any]] = [
+    {
+        "type": "thinking",
+        "thinking": "I should search for fast.ai news first.",
+        "signature": "sig_thinking_1",
+    },
+    {
+        "type": "server_tool_use",
+        "id": "srvtoolu_001",
+        "name": "web_search",
+        "input": {"query": "fast.ai news"},
+    },
+    {
+        "type": "web_search_tool_result",
+        "tool_use_id": "srvtoolu_001",
+        "content": [
+            {"url": "https://fast.ai", "title": "fast.ai", "snippet": "Fast AI news"}
+        ],
+    },
+    {
+        "type": "thinking",
+        "thinking": "Now let me search for answer.ai as well.",
+        "signature": "sig_thinking_2",
+    },
+    {
+        "type": "text",
+        "text": "Here are the results from my searches.",
+    },
+    {
+        "type": "server_tool_use",
+        "id": "srvtoolu_002",
+        "name": "web_search",
+        "input": {"query": "answer.ai news"},
+    },
+    {
+        "type": "web_search_tool_result",
+        "tool_use_id": "srvtoolu_002",
+        "content": [
+            {
+                "url": "https://answer.ai",
+                "title": "Answer.AI",
+                "snippet": "Answer AI news",
+            }
+        ],
+    },
+]
+
+
+def _make_anthropic_response(content: List[Dict]) -> dict:
+    """Build a minimal Anthropic Messages API response dict."""
+    return {
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "content": content,
+        "model": "claude-sonnet-4-6",
+        "stop_reason": "end_turn",
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+    }
+
+
+def _parse_response_to_openai(content: List[Dict]) -> litellm.ModelResponse:
+    """Run the Anthropic → OpenAI response transformation."""
+    config = AnthropicConfig()
+    completion_response = _make_anthropic_response(content)
+    model_response = litellm.ModelResponse()
+
+    raw_response = MagicMock(spec=httpx.Response)
+    raw_response.headers = {}
+    raw_response.status_code = 200
+
+    return config.transform_parsed_response(
+        completion_response=completion_response,
+        raw_response=raw_response,
+        model_response=model_response,
+    )
+
+
+class TestThinkingBlocksRoundTripOrdering:
+    """Round-trip: Anthropic response → OpenAI message → Anthropic request."""
+
+    def test_original_content_stored_when_interleaved(self):
+        """
+        transform_parsed_response should store _original_content in
+        provider_specific_fields when both thinking blocks and server_tool_use
+        are present.
+        """
+        resp = _parse_response_to_openai(INTERLEAVED_CONTENT)
+        msg = resp.choices[0].message
+        psf = msg.provider_specific_fields or {}
+
+        assert "_original_content" in psf, (
+            "_original_content must be stored for interleaved thinking + server tools"
+        )
+        assert psf["_original_content"] == INTERLEAVED_CONTENT
+
+    def test_original_content_not_stored_without_server_tools(self):
+        """No _original_content when there are no server_tool_use blocks."""
+        content = [
+            {"type": "thinking", "thinking": "hmm", "signature": "sig1"},
+            {"type": "text", "text": "Hello!"},
+        ]
+        resp = _parse_response_to_openai(content)
+        msg = resp.choices[0].message
+        psf = msg.provider_specific_fields or {}
+
+        assert "_original_content" not in psf
+
+    def test_original_content_not_stored_without_thinking(self):
+        """No _original_content when there are no thinking blocks."""
+        content = [
+            {
+                "type": "server_tool_use",
+                "id": "srvtoolu_001",
+                "name": "web_search",
+                "input": {"query": "test"},
+            },
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_001",
+                "content": [],
+            },
+            {"type": "text", "text": "Result"},
+        ]
+        resp = _parse_response_to_openai(content)
+        msg = resp.choices[0].message
+        psf = msg.provider_specific_fields or {}
+
+        assert "_original_content" not in psf
+
+    def test_round_trip_preserves_block_order(self):
+        """
+        Core test: the Anthropic → OpenAI → Anthropic round-trip must
+        produce the same content block type sequence as the original.
+        """
+        resp = _parse_response_to_openai(INTERLEAVED_CONTENT)
+        msg = resp.choices[0].message
+
+        # Build the messages list as a user would for a follow-up call
+        openai_messages = [
+            {"role": "user", "content": "Search for fast.ai and answer.ai news"},
+            msg.model_dump(),
+            {"role": "user", "content": "Now search for solveit"},
+        ]
+
+        # Run the OpenAI → Anthropic conversion
+        anthropic_messages = anthropic_messages_pt(
+            openai_messages,
+            model="claude-sonnet-4-6",
+            llm_provider="anthropic",
+        )
+
+        # Find the assistant message
+        assistant_msg = next(
+            m for m in anthropic_messages if m["role"] == "assistant"
+        )
+        reconstructed = assistant_msg["content"]
+
+        # Extract type sequences
+        original_types = [b["type"] for b in INTERLEAVED_CONTENT]
+        reconstructed_types = [
+            b.get("type") or ("thinking" if "thinking" in b else "unknown")
+            for b in reconstructed
+        ]
+
+        assert reconstructed_types == original_types, (
+            f"Block ordering must be preserved on round-trip.\n"
+            f"  Original:      {original_types}\n"
+            f"  Reconstructed: {reconstructed_types}"
+        )
+
+    def test_round_trip_preserves_thinking_block_content(self):
+        """Thinking block text and signatures must survive round-trip."""
+        resp = _parse_response_to_openai(INTERLEAVED_CONTENT)
+        msg = resp.choices[0].message
+        openai_messages = [
+            {"role": "user", "content": "test"},
+            msg.model_dump(),
+            {"role": "user", "content": "follow up"},
+        ]
+
+        anthropic_messages = anthropic_messages_pt(
+            openai_messages,
+            model="claude-sonnet-4-6",
+            llm_provider="anthropic",
+        )
+
+        assistant_msg = next(
+            m for m in anthropic_messages if m["role"] == "assistant"
+        )
+        thinking_blocks = [
+            b for b in assistant_msg["content"] if b.get("type") == "thinking"
+        ]
+
+        assert len(thinking_blocks) == 2
+        assert thinking_blocks[0]["thinking"] == "I should search for fast.ai news first."
+        assert thinking_blocks[0]["signature"] == "sig_thinking_1"
+        assert thinking_blocks[1]["thinking"] == "Now let me search for answer.ai as well."
+        assert thinking_blocks[1]["signature"] == "sig_thinking_2"
+
+    def test_round_trip_preserves_server_tool_use_blocks(self):
+        """server_tool_use and web_search_tool_result must survive round-trip."""
+        resp = _parse_response_to_openai(INTERLEAVED_CONTENT)
+        msg = resp.choices[0].message
+        openai_messages = [
+            {"role": "user", "content": "test"},
+            msg.model_dump(),
+            {"role": "user", "content": "follow up"},
+        ]
+
+        anthropic_messages = anthropic_messages_pt(
+            openai_messages,
+            model="claude-sonnet-4-6",
+            llm_provider="anthropic",
+        )
+
+        assistant_msg = next(
+            m for m in anthropic_messages if m["role"] == "assistant"
+        )
+        content = assistant_msg["content"]
+
+        # Verify server_tool_use blocks
+        server_tools = [b for b in content if b.get("type") == "server_tool_use"]
+        assert len(server_tools) == 2
+        assert server_tools[0]["id"] == "srvtoolu_001"
+        assert server_tools[1]["id"] == "srvtoolu_002"
+
+        # Verify web_search_tool_result blocks
+        ws_results = [
+            b for b in content if b.get("type") == "web_search_tool_result"
+        ]
+        assert len(ws_results) == 2
+        assert ws_results[0]["tool_use_id"] == "srvtoolu_001"
+        assert ws_results[1]["tool_use_id"] == "srvtoolu_002"
+
+    def test_round_trip_preserves_text_block(self):
+        """Text blocks must survive round-trip."""
+        resp = _parse_response_to_openai(INTERLEAVED_CONTENT)
+        msg = resp.choices[0].message
+        openai_messages = [
+            {"role": "user", "content": "test"},
+            msg.model_dump(),
+            {"role": "user", "content": "follow up"},
+        ]
+
+        anthropic_messages = anthropic_messages_pt(
+            openai_messages,
+            model="claude-sonnet-4-6",
+            llm_provider="anthropic",
+        )
+
+        assistant_msg = next(
+            m for m in anthropic_messages if m["role"] == "assistant"
+        )
+        text_blocks = [
+            b for b in assistant_msg["content"] if b.get("type") == "text"
+        ]
+
+        assert len(text_blocks) == 1
+        assert text_blocks[0]["text"] == "Here are the results from my searches."
+
+    def test_fallback_to_normal_path_without_original_content(self):
+        """
+        Messages without _original_content (e.g. single web search or no web
+        search) should use the existing reconstruction logic.
+        """
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": "Hi there!",
+                "thinking_blocks": [
+                    {
+                        "type": "thinking",
+                        "thinking": "greeting",
+                        "signature": "sig1",
+                    }
+                ],
+            },
+            {"role": "user", "content": "Follow up"},
+        ]
+
+        result = anthropic_messages_pt(
+            messages, model="claude-sonnet-4-6", llm_provider="anthropic"
+        )
+
+        assistant_msg = next(m for m in result if m["role"] == "assistant")
+        types = [b.get("type") for b in assistant_msg["content"]]
+
+        # Normal path: thinking first, then text
+        assert types == ["thinking", "text"]
+
+    def test_single_web_search_with_thinking_preserves_order(self):
+        """Even a single web search with thinking should preserve order."""
+        single_search_content = [
+            {
+                "type": "thinking",
+                "thinking": "Let me search.",
+                "signature": "sig1",
+            },
+            {
+                "type": "server_tool_use",
+                "id": "srvtoolu_001",
+                "name": "web_search",
+                "input": {"query": "test"},
+            },
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_001",
+                "content": [{"url": "https://example.com", "title": "Test", "snippet": "ok"}],
+            },
+            {"type": "text", "text": "Here you go."},
+        ]
+
+        resp = _parse_response_to_openai(single_search_content)
+        msg = resp.choices[0].message
+        openai_messages = [
+            {"role": "user", "content": "test"},
+            msg.model_dump(),
+            {"role": "user", "content": "follow up"},
+        ]
+
+        anthropic_messages = anthropic_messages_pt(
+            openai_messages,
+            model="claude-sonnet-4-6",
+            llm_provider="anthropic",
+        )
+
+        assistant_msg = next(
+            m for m in anthropic_messages if m["role"] == "assistant"
+        )
+        original_types = [b["type"] for b in single_search_content]
+        reconstructed_types = [b.get("type") for b in assistant_msg["content"]]
+
+        assert reconstructed_types == original_types

--- a/tests/litellm_core_utils/test_thinking_blocks_round_trip_ordering.py
+++ b/tests/litellm_core_utils/test_thinking_blocks_round_trip_ordering.py
@@ -11,7 +11,6 @@ content block order.  Anthropic's API verifies thinking block signatures
 and rejects requests where the blocks have been reordered.
 """
 
-import json
 from typing import Any, Dict, List
 from unittest.mock import MagicMock
 


### PR DESCRIPTION
## Summary

Fixes #23047 — thinking blocks corrupted on round-trip when assistant performs multiple web searches.

## Root Cause

When an Anthropic response has interleaved thinking blocks and `server_tool_use` blocks (e.g. from 2+ web searches):

```
[thinking_1, server_tool_use_1, web_search_result_1, thinking_2, text, server_tool_use_2, web_search_result_2]
```

`anthropic_messages_pt` was reconstructing the content with all thinking blocks first:

```
[thinking_1, thinking_2, text, server_tool_use_1, web_search_result_1, server_tool_use_2, web_search_result_2]
```

Anthropic verifies thinking block signatures against their original positions and rejects reordered content with:
> `thinking blocks in the latest assistant message cannot be modified`

## Fix

**`transformation.py`**: During response parsing, when both thinking blocks and `server_tool_use` are present, store the original content block array in `provider_specific_fields['_original_content']`.

**`factory.py`**: During reconstruction in `anthropic_messages_pt`, if `_original_content` is available, replay the preserved block order instead of the separate thinking → text → tool ordering. Cache control is still applied to text blocks. Messages without interleaved thinking+tools fall through to the existing path unchanged.

## Tests

9 new tests covering:
- `_original_content` storage (set when interleaved, not set without server tools or thinking)
- Full round-trip block order preservation
- Thinking block content/signature integrity
- Server tool use and web search result survival
- Fallback to normal path for non-interleaved messages
- Single web search case

All 181 existing related tests pass (prompt factory + anthropic transformation + dedup).