### PR TITLE
fix: add missing indexes for top CPU-consuming queries

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260309115809_add_missing_indexes/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260309115809_add_missing_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "LiteLLM_VerificationToken_key_alias_idx" ON "LiteLLM_VerificationToken"("key_alias");
+
+-- CreateIndex
+CREATE INDEX "LiteLLM_SpendLogs_user_startTime_idx" ON "LiteLLM_SpendLogs"("user", "startTime");

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260309115809_add_missing_indexes/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260309115809_add_missing_indexes/migration.sql
@@ -1,5 +1,13 @@
--- CreateIndex
-CREATE INDEX "LiteLLM_VerificationToken_key_alias_idx" ON "LiteLLM_VerificationToken"("key_alias");
+-- SkipTransactionBlock
+
+-- Drop invalid indexes left behind by failed CONCURRENTLY builds
+DROP INDEX CONCURRENTLY IF EXISTS "LiteLLM_VerificationToken_key_alias_idx";
 
 -- CreateIndex
-CREATE INDEX "LiteLLM_SpendLogs_user_startTime_idx" ON "LiteLLM_SpendLogs"("user", "startTime");
+CREATE INDEX CONCURRENTLY "LiteLLM_VerificationToken_key_alias_idx" ON "LiteLLM_VerificationToken"("key_alias");
+
+-- Drop invalid indexes left behind by failed CONCURRENTLY builds
+DROP INDEX CONCURRENTLY IF EXISTS "LiteLLM_SpendLogs_user_startTime_idx";
+
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "LiteLLM_SpendLogs_user_startTime_idx" ON "LiteLLM_SpendLogs"("user", "startTime");

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -388,6 +388,9 @@ model LiteLLM_VerificationToken {
 
     // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE (("public"."LiteLLM_VerificationToken"."expires" IS NULL OR "public"."LiteLLM_VerificationToken"."expires" > $1) AND "public"."LiteLLM_VerificationToken"."budget_reset_at" < $2) OFFSET $3
     @@index([budget_reset_at, expires])
+
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE (...) ORDER BY "public"."LiteLLM_VerificationToken"."key_alias" ASC
+    @@index([key_alias])
 }
 
 model LiteLLM_JWTKeyMapping {
@@ -553,6 +556,9 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+
+  // SELECT ... FROM "LiteLLM_SpendLogs" WHERE ("startTime" >= $1 AND "startTime" <= $2 AND "user" = $3) GROUP BY ...
+  @@index([user, startTime])
 }
 
 // View spend, model, api_key per request

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -388,6 +388,9 @@ model LiteLLM_VerificationToken {
 
     // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE (("public"."LiteLLM_VerificationToken"."expires" IS NULL OR "public"."LiteLLM_VerificationToken"."expires" > $1) AND "public"."LiteLLM_VerificationToken"."budget_reset_at" < $2) OFFSET $3
     @@index([budget_reset_at, expires])
+
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE (...) ORDER BY "public"."LiteLLM_VerificationToken"."key_alias" ASC
+    @@index([key_alias])
 }
 
 model LiteLLM_JWTKeyMapping {
@@ -553,6 +556,9 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+
+  // SELECT ... FROM "LiteLLM_SpendLogs" WHERE ("startTime" >= $1 AND "startTime" <= $2 AND "user" = $3) GROUP BY ...
+  @@index([user, startTime])
 }
 
 // View spend, model, api_key per request

--- a/schema.prisma
+++ b/schema.prisma
@@ -388,6 +388,9 @@ model LiteLLM_VerificationToken {
 
     // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE (("public"."LiteLLM_VerificationToken"."expires" IS NULL OR "public"."LiteLLM_VerificationToken"."expires" > $1) AND "public"."LiteLLM_VerificationToken"."budget_reset_at" < $2) OFFSET $3
     @@index([budget_reset_at, expires])
+
+    // SELECT ... FROM "public"."LiteLLM_VerificationToken" WHERE (...) ORDER BY "public"."LiteLLM_VerificationToken"."key_alias" ASC
+    @@index([key_alias])
 }
 
 model LiteLLM_JWTKeyMapping {
@@ -553,6 +556,9 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+
+  // SELECT ... FROM "LiteLLM_SpendLogs" WHERE ("startTime" >= $1 AND "startTime" <= $2 AND "user" = $3) GROUP BY ...
+  @@index([user, startTime])
 }
 
 // View spend, model, api_key per request


### PR DESCRIPTION
## Summary
- Two of the top 5 queries by CPU usage on our database are doing full table scans due to missing indexes.
- **`LiteLLM_VerificationToken(key_alias)`**: The virtual keys listing query filters on `team_id` and sorts by `key_alias ASC`. The `team_id` index exists but there's no index to support the `ORDER BY`, forcing a sort on every request.
- **`LiteLLM_SpendLogs(user, startTime)`**: The spend summary query filters on `user = $1 AND startTime BETWEEN $2 AND $3` and groups by multiple columns. There's a `startTime` index but no composite index with `user` as the leading column, so Postgres can't efficiently seek to the right user's rows.
- Includes the Prisma migration file.

## Test plan
- [x] Schema changes are consistent across all three schema.prisma copies
- [x] Migration SQL matches the schema index definitions
- [ ] Verify indexes are created on deploy via `\di` in psql

🤖 Generated with [Claude Code](https://claude.com/claude-code)