### PR TITLE
[Fix] Remove duplicate jwt_key_mapping_router import

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -377,9 +377,6 @@ from litellm.proxy.management_endpoints.internal_user_endpoints import user_upda
 from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
     router as jwt_key_mapping_router,
 )
-from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
-    router as jwt_key_mapping_router,
-)
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     delete_verification_tokens,
     duration_in_seconds,


### PR DESCRIPTION
## Relevant issues

Fixes CI lint failure: https://app.circleci.com/pipelines/github/BerriAI/litellm/67031/workflows/0d8d9af2-50d1-47c0-9ffa-96f21b8b9b63/jobs/1363818

## Summary

### Failure Path (Before Fix)

Ruff lint check fails with `F811` (redefinition of unused import) because `jwt_key_mapping_router` is imported twice from the same module in `proxy_server.py`.

### Fix

Removed the duplicate import on lines 380-382.

## Testing

`make lint-ruff` passes locally.

## Type

🐛 Bug Fix