### PR TITLE
[Fix] Chocolatey v2.5.1 Interactive Prompt Blocking Windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,11 @@ jobs:
       - run:
           name: Install Python
           command: |
-            choco install python --version=3.11.0 -y
+            choco install python --version=3.11.0 -y --no-progress --force
             refreshenv
             python --version
+          environment:
+            CHOCOLATEY_CONFIRM_ALL: "true"
       - run:
           name: Install Dependencies
           command: |


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)

Chocolatey v2.5.1 introduced interactive prompts that require user input during `choco install`. This blocks the `using_litellm_on_windows` CI job since there's no TTY to respond.

### Fix

Added `--no-progress`, `--force` flags and `CHOCOLATEY_CONFIRM_ALL=true` environment variable to the `choco install python` step to fully suppress interactive behavior in CI.

## Testing

- Verified the flags are valid for Chocolatey v2.5.1
- CI job should now pass without hanging on user input

## Type

🚄 Infrastructure