### PR TITLE
Fix Langfuse callback skipping for Anthropic streaming passthrough

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -218,6 +218,9 @@ class AnthropicPassthroughLoggingHandler:
             logging_obj=litellm_logging_obj,
         )
 
+        # Add complete_streaming_response to kwargs so callbacks like Langfuse can access it
+        kwargs["complete_streaming_response"] = complete_streaming_response
+
         return {
             "result": complete_streaming_response,
             "kwargs": kwargs,


### PR DESCRIPTION
Fixes #17476

## Summary
When using Anthropic pass-through endpoints with streaming and Langfuse callbacks, streaming requests were completing successfully but failing to log to Langfuse. Non-streaming requests worked correctly.

## Root Cause
- `_handle_logging_anthropic_collected_chunks()` successfully builds the complete response from chunks
- However, kwargs only included `response_cost` and `model`, missing the `complete_streaming_response` key
- In `litellm_logging.py:2167`, Langfuse callback checks `if complete_streaming_response is None: continue`, causing it to skip logging

## Solution
- Add `complete_streaming_response` to kwargs dict before returning from `_handle_logging_anthropic_collected_chunks()`
- This ensures callbacks like Langfuse can access the complete response and properly log streaming requests

## Changes
- Modified `litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py`
- Added one line (222) to include `complete_streaming_response` in kwargs

## Testing
- Existing test suite covers the handler logic
- The fix aligns with how non-streaming paths set `complete_streaming_response` in `model_call_details`
- Matches the pattern used by other callbacks (OpenMeter, Greenscale, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)