### PR TITLE
Feat add token totals

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
@@ -249,6 +249,8 @@ vi.mock("@ant-design/icons", async () => {
     CalendarOutlined: Icon,
     InfoCircleOutlined: Icon,
     UserOutlined: Icon,
+    DownOutlined: Icon,
+    RightOutlined: Icon,
     LoadingOutlined,
   };
 });

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -631,12 +631,6 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                             </Text>
                           </Card>
                           <Card>
-                            <Title>Total Tokens</Title>
-                            <Text className="text-2xl font-bold mt-2">
-                              {userSpendData.metadata?.total_tokens?.toLocaleString() || 0}
-                            </Text>
-                          </Card>
-                          <Card>
                             <Title>Average Cost per Request</Title>
                             <Text className="text-2xl font-bold mt-2">
                               $
@@ -646,39 +640,47 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                               )}
                             </Text>
                           </Card>
-                        </Grid>
-                      </Card>
-                    </Col>
-
-                    <Col numColSpan={2}>
-                      <Card>
-                        <Title>Token Breakdown</Title>
-                        <Grid numItems={4} className="gap-4 mt-4">
                           <Card>
-                            <Title>Input Tokens</Title>
-                            <Text className="text-2xl font-bold mt-2 text-blue-600">
-                              {userSpendData.metadata?.total_prompt_tokens?.toLocaleString() || 0}
-                            </Text>
-                          </Card>
-                          <Card>
-                            <Title>Output Tokens</Title>
-                            <Text className="text-2xl font-bold mt-2 text-cyan-600">
-                              {userSpendData.metadata?.total_completion_tokens?.toLocaleString() || 0}
-                            </Text>
-                          </Card>
-                          <Card>
-                            <Title>Cache Read Tokens</Title>
-                            <Text className="text-2xl font-bold mt-2 text-green-600">
-                              {userSpendData.metadata?.total_cache_read_input_tokens?.toLocaleString() || 0}
-                            </Text>
-                          </Card>
-                          <Card>
-                            <Title>Cache Write Tokens</Title>
-                            <Text className="text-2xl font-bold mt-2 text-purple-600">
-                              {userSpendData.metadata?.total_cache_creation_input_tokens?.toLocaleString() || 0}
+                            <Title>Total Tokens</Title>
+                            <Text className="text-2xl font-bold mt-2">
+                              {userSpendData.metadata?.total_tokens?.toLocaleString() || 0}
                             </Text>
                           </Card>
                         </Grid>
+                        <div className="flex justify-center gap-4 mt-4">
+                          <div className="flex-1 max-w-[20%]">
+                            <Card>
+                              <Title>Input Tokens</Title>
+                              <Text className="text-2xl font-bold mt-2 text-blue-600">
+                                {userSpendData.metadata?.total_prompt_tokens?.toLocaleString() || 0}
+                              </Text>
+                            </Card>
+                          </div>
+                          <div className="flex-1 max-w-[20%]">
+                            <Card>
+                              <Title>Output Tokens</Title>
+                              <Text className="text-2xl font-bold mt-2 text-cyan-600">
+                                {userSpendData.metadata?.total_completion_tokens?.toLocaleString() || 0}
+                              </Text>
+                            </Card>
+                          </div>
+                          <div className="flex-1 max-w-[20%]">
+                            <Card>
+                              <Title>Cache Read Tokens</Title>
+                              <Text className="text-2xl font-bold mt-2 text-green-600">
+                                {userSpendData.metadata?.total_cache_read_input_tokens?.toLocaleString() || 0}
+                              </Text>
+                            </Card>
+                          </div>
+                          <div className="flex-1 max-w-[20%]">
+                            <Card>
+                              <Title>Cache Write Tokens</Title>
+                              <Text className="text-2xl font-bold mt-2 text-purple-600">
+                                {userSpendData.metadata?.total_cache_creation_input_tokens?.toLocaleString() || 0}
+                              </Text>
+                            </Card>
+                          </div>
+                        </div>
                       </Card>
                     </Col>
 

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -6,7 +6,7 @@
  * Works at 1m+ spend logs, by querying an aggregate table instead.
  */
 
-import { InfoCircleOutlined, LoadingOutlined } from "@ant-design/icons";
+import { DownOutlined, InfoCircleOutlined, LoadingOutlined, RightOutlined } from "@ant-design/icons";
 import {
   BarChart,
   Card,
@@ -148,6 +148,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
   const [showCredentialBanner, setShowCredentialBanner] = useState(true);
   const [topKeysLimit, setTopKeysLimit] = useState<number>(5);
   const [topModelsLimit, setTopModelsLimit] = useState<number>(5);
+  const [showTokenBreakdown, setShowTokenBreakdown] = useState(false);
   const getAllTags = async () => {
     if (!accessToken) {
       return;
@@ -640,47 +641,59 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                               )}
                             </Text>
                           </Card>
-                          <Card>
-                            <Title>Total Tokens</Title>
+                          <Card
+                            className="cursor-pointer hover:bg-gray-50 transition-colors"
+                            onClick={() => setShowTokenBreakdown(!showTokenBreakdown)}
+                          >
+                            <div className="flex items-center gap-2">
+                              <Title>Total Tokens</Title>
+                              {showTokenBreakdown ? (
+                                <DownOutlined className="text-gray-400 text-xs" />
+                              ) : (
+                                <RightOutlined className="text-gray-400 text-xs" />
+                              )}
+                            </div>
                             <Text className="text-2xl font-bold mt-2">
                               {userSpendData.metadata?.total_tokens?.toLocaleString() || 0}
                             </Text>
                           </Card>
                         </Grid>
-                        <div className="flex justify-center gap-4 mt-4">
-                          <div className="flex-1 max-w-[20%]">
-                            <Card>
-                              <Title>Input Tokens</Title>
-                              <Text className="text-2xl font-bold mt-2 text-blue-600">
-                                {userSpendData.metadata?.total_prompt_tokens?.toLocaleString() || 0}
-                              </Text>
-                            </Card>
+                        {showTokenBreakdown && (
+                          <div className="flex justify-center gap-4 mt-4">
+                            <div className="flex-1 max-w-[20%]">
+                              <Card>
+                                <Title>Input Tokens</Title>
+                                <Text className="text-2xl font-bold mt-2 text-blue-600">
+                                  {userSpendData.metadata?.total_prompt_tokens?.toLocaleString() || 0}
+                                </Text>
+                              </Card>
+                            </div>
+                            <div className="flex-1 max-w-[20%]">
+                              <Card>
+                                <Title>Output Tokens</Title>
+                                <Text className="text-2xl font-bold mt-2 text-cyan-600">
+                                  {userSpendData.metadata?.total_completion_tokens?.toLocaleString() || 0}
+                                </Text>
+                              </Card>
+                            </div>
+                            <div className="flex-1 max-w-[20%]">
+                              <Card>
+                                <Title>Cache Read Tokens</Title>
+                                <Text className="text-2xl font-bold mt-2 text-green-600">
+                                  {userSpendData.metadata?.total_cache_read_input_tokens?.toLocaleString() || 0}
+                                </Text>
+                              </Card>
+                            </div>
+                            <div className="flex-1 max-w-[20%]">
+                              <Card>
+                                <Title>Cache Write Tokens</Title>
+                                <Text className="text-2xl font-bold mt-2 text-purple-600">
+                                  {userSpendData.metadata?.total_cache_creation_input_tokens?.toLocaleString() || 0}
+                                </Text>
+                              </Card>
+                            </div>
                           </div>
-                          <div className="flex-1 max-w-[20%]">
-                            <Card>
-                              <Title>Output Tokens</Title>
-                              <Text className="text-2xl font-bold mt-2 text-cyan-600">
-                                {userSpendData.metadata?.total_completion_tokens?.toLocaleString() || 0}
-                              </Text>
-                            </Card>
-                          </div>
-                          <div className="flex-1 max-w-[20%]">
-                            <Card>
-                              <Title>Cache Read Tokens</Title>
-                              <Text className="text-2xl font-bold mt-2 text-green-600">
-                                {userSpendData.metadata?.total_cache_read_input_tokens?.toLocaleString() || 0}
-                              </Text>
-                            </Card>
-                          </div>
-                          <div className="flex-1 max-w-[20%]">
-                            <Card>
-                              <Title>Cache Write Tokens</Title>
-                              <Text className="text-2xl font-bold mt-2 text-purple-600">
-                                {userSpendData.metadata?.total_cache_creation_input_tokens?.toLocaleString() || 0}
-                              </Text>
-                            </Card>
-                          </div>
-                        </div>
+                        )}
                       </Card>
                     </Col>
 

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -404,6 +404,10 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
           aggregatedMetadata.total_successful_requests += pageData.metadata.total_successful_requests || 0;
           aggregatedMetadata.total_failed_requests += pageData.metadata.total_failed_requests || 0;
           aggregatedMetadata.total_tokens += pageData.metadata.total_tokens || 0;
+          aggregatedMetadata.total_prompt_tokens += pageData.metadata.total_prompt_tokens || 0;
+          aggregatedMetadata.total_completion_tokens += pageData.metadata.total_completion_tokens || 0;
+          aggregatedMetadata.total_cache_read_input_tokens += pageData.metadata.total_cache_read_input_tokens || 0;
+          aggregatedMetadata.total_cache_creation_input_tokens += pageData.metadata.total_cache_creation_input_tokens || 0;
         }
       }
 
@@ -640,6 +644,38 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                                 (totalSpend || 0) / (userSpendData.metadata?.total_api_requests || 1),
                                 4,
                               )}
+                            </Text>
+                          </Card>
+                        </Grid>
+                      </Card>
+                    </Col>
+
+                    <Col numColSpan={2}>
+                      <Card>
+                        <Title>Token Breakdown</Title>
+                        <Grid numItems={4} className="gap-4 mt-4">
+                          <Card>
+                            <Title>Input Tokens</Title>
+                            <Text className="text-2xl font-bold mt-2 text-blue-600">
+                              {userSpendData.metadata?.total_prompt_tokens?.toLocaleString() || 0}
+                            </Text>
+                          </Card>
+                          <Card>
+                            <Title>Output Tokens</Title>
+                            <Text className="text-2xl font-bold mt-2 text-cyan-600">
+                              {userSpendData.metadata?.total_completion_tokens?.toLocaleString() || 0}
+                            </Text>
+                          </Card>
+                          <Card>
+                            <Title>Cache Read Tokens</Title>
+                            <Text className="text-2xl font-bold mt-2 text-green-600">
+                              {userSpendData.metadata?.total_cache_read_input_tokens?.toLocaleString() || 0}
+                            </Text>
+                          </Card>
+                          <Card>
+                            <Title>Cache Write Tokens</Title>
+                            <Text className="text-2xl font-bold mt-2 text-purple-600">
+                              {userSpendData.metadata?.total_cache_creation_input_tokens?.toLocaleString() || 0}
                             </Text>
                           </Card>
                         </Grid>

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -400,15 +400,15 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
         const pageData = await userDailyActivityCall(accessToken, startTime, endTime, page, effectiveUserId);
         allResults.push(...pageData.results);
         if (pageData.metadata) {
-          aggregatedMetadata.total_spend += pageData.metadata.total_spend || 0;
-          aggregatedMetadata.total_api_requests += pageData.metadata.total_api_requests || 0;
-          aggregatedMetadata.total_successful_requests += pageData.metadata.total_successful_requests || 0;
-          aggregatedMetadata.total_failed_requests += pageData.metadata.total_failed_requests || 0;
-          aggregatedMetadata.total_tokens += pageData.metadata.total_tokens || 0;
-          aggregatedMetadata.total_prompt_tokens += pageData.metadata.total_prompt_tokens || 0;
-          aggregatedMetadata.total_completion_tokens += pageData.metadata.total_completion_tokens || 0;
-          aggregatedMetadata.total_cache_read_input_tokens += pageData.metadata.total_cache_read_input_tokens || 0;
-          aggregatedMetadata.total_cache_creation_input_tokens += pageData.metadata.total_cache_creation_input_tokens || 0;
+          aggregatedMetadata.total_spend = (aggregatedMetadata.total_spend || 0) + (pageData.metadata.total_spend || 0);
+          aggregatedMetadata.total_api_requests = (aggregatedMetadata.total_api_requests || 0) + (pageData.metadata.total_api_requests || 0);
+          aggregatedMetadata.total_successful_requests = (aggregatedMetadata.total_successful_requests || 0) + (pageData.metadata.total_successful_requests || 0);
+          aggregatedMetadata.total_failed_requests = (aggregatedMetadata.total_failed_requests || 0) + (pageData.metadata.total_failed_requests || 0);
+          aggregatedMetadata.total_tokens = (aggregatedMetadata.total_tokens || 0) + (pageData.metadata.total_tokens || 0);
+          aggregatedMetadata.total_prompt_tokens = (aggregatedMetadata.total_prompt_tokens || 0) + (pageData.metadata.total_prompt_tokens || 0);
+          aggregatedMetadata.total_completion_tokens = (aggregatedMetadata.total_completion_tokens || 0) + (pageData.metadata.total_completion_tokens || 0);
+          aggregatedMetadata.total_cache_read_input_tokens = (aggregatedMetadata.total_cache_read_input_tokens || 0) + (pageData.metadata.total_cache_read_input_tokens || 0);
+          aggregatedMetadata.total_cache_creation_input_tokens = (aggregatedMetadata.total_cache_creation_input_tokens || 0) + (pageData.metadata.total_cache_creation_input_tokens || 0);
         }
       }
 
@@ -659,40 +659,32 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                           </Card>
                         </Grid>
                         {showTokenBreakdown && (
-                          <div className="flex justify-center gap-4 mt-4">
-                            <div className="flex-1 max-w-[20%]">
-                              <Card>
-                                <Title>Input Tokens</Title>
-                                <Text className="text-2xl font-bold mt-2 text-blue-600">
-                                  {userSpendData.metadata?.total_prompt_tokens?.toLocaleString() || 0}
-                                </Text>
-                              </Card>
-                            </div>
-                            <div className="flex-1 max-w-[20%]">
-                              <Card>
-                                <Title>Output Tokens</Title>
-                                <Text className="text-2xl font-bold mt-2 text-cyan-600">
-                                  {userSpendData.metadata?.total_completion_tokens?.toLocaleString() || 0}
-                                </Text>
-                              </Card>
-                            </div>
-                            <div className="flex-1 max-w-[20%]">
-                              <Card>
-                                <Title>Cache Read Tokens</Title>
-                                <Text className="text-2xl font-bold mt-2 text-green-600">
-                                  {userSpendData.metadata?.total_cache_read_input_tokens?.toLocaleString() || 0}
-                                </Text>
-                              </Card>
-                            </div>
-                            <div className="flex-1 max-w-[20%]">
-                              <Card>
-                                <Title>Cache Write Tokens</Title>
-                                <Text className="text-2xl font-bold mt-2 text-purple-600">
-                                  {userSpendData.metadata?.total_cache_creation_input_tokens?.toLocaleString() || 0}
-                                </Text>
-                              </Card>
-                            </div>
-                          </div>
+                          <Grid numItems={4} className="gap-4 mt-4">
+                            <Card>
+                              <Title>Input Tokens</Title>
+                              <Text className="text-2xl font-bold mt-2 text-blue-600">
+                                {userSpendData.metadata?.total_prompt_tokens?.toLocaleString() || 0}
+                              </Text>
+                            </Card>
+                            <Card>
+                              <Title>Output Tokens</Title>
+                              <Text className="text-2xl font-bold mt-2 text-cyan-600">
+                                {userSpendData.metadata?.total_completion_tokens?.toLocaleString() || 0}
+                              </Text>
+                            </Card>
+                            <Card>
+                              <Title>Cache Read Tokens</Title>
+                              <Text className="text-2xl font-bold mt-2 text-green-600">
+                                {userSpendData.metadata?.total_cache_read_input_tokens?.toLocaleString() || 0}
+                              </Text>
+                            </Card>
+                            <Card>
+                              <Title>Cache Write Tokens</Title>
+                              <Text className="text-2xl font-bold mt-2 text-purple-600">
+                                {userSpendData.metadata?.total_cache_creation_input_tokens?.toLocaleString() || 0}
+                              </Text>
+                            </Card>
+                          </Grid>
                         )}
                       </Card>
                     </Col>


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes
<img width="1710" height="964" alt="Screenshot 2026-03-09 at 2 08 04 PM" src="https://github.com/user-attachments/assets/aa73d99b-9c61-4b1f-8c38-1dca817293a8" />

<img width="1710" height="958" alt="Screenshot 2026-03-09 at 2 07 56 PM" src="https://github.com/user-attachments/assets/b84db733-6beb-4b74-a9d8-872660ef6e4f" />

Adds Input Tokens, Output Tokens, Cache Read Tokens, and Cache Write Tokens cards to the Usage Metrics section on the Usage page. Data was already returned by the `/user/daily/activity/aggregated` API in the `metadata` response, this is a UI-only change

Fixes paginated fallback aggregation to include the 4 token fields (`total_prompt_tokens`, `total_completion_tokens`, `total_cache_read_input_tokens`, `total_cache_creation_input_tokens`)

