### PR TITLE
[Fix] Batch retrieve missing model_id causing raw output_file_id

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -26,6 +26,7 @@ from litellm.proxy.openai_files_endpoints.common_utils import (
     encode_file_id_with_model,
     get_batch_from_database,
     get_credentials_for_model,
+    get_model_id_from_unified_batch_id,
     get_models_from_unified_file_id,
     get_original_file_id,
     prepare_data_with_credentials,
@@ -455,6 +456,10 @@ async def retrieve_batch( # noqa: PLR0915
 
             response = await llm_router.aretrieve_batch(**data)  # type: ignore
             response._hidden_params["unified_batch_id"] = unified_batch_id
+            if unified_batch_id:
+                model_id_from_batch = get_model_id_from_unified_batch_id(unified_batch_id)
+                if model_id_from_batch:
+                    response._hidden_params["model_id"] = model_id_from_batch
         
         # SCENARIO 3: Fallback to custom_llm_provider (uses env variables)
         else:


### PR DESCRIPTION
## Relevant issues

Fixes failing CI: https://app.circleci.com/pipelines/github/BerriAI/litellm/67092/workflows/d48f5f17-c373-47b9-9a5e-d76284b73843/jobs/1364595

## Summary

### Failure Path (Before Fix)

When retrieving a batch via the unified batch ID path in `retrieve_batch`, only `unified_batch_id` was set on `response._hidden_params` but `model_id` was not. The downstream managed files hook checks `(unified_batch_id or unified_file_id) and model_id` — since `model_id` was `None`, the hook skipped encoding `output_file_id` into a managed ID, returning the raw provider ID instead.

### Fix

Extract `model_id` from the `unified_batch_id` string (which already contains it in the format `litellm_proxy;model_id:{model_id};llm_batch_id:{batch_id}`) using the existing `get_model_id_from_unified_batch_id()` helper, and set it on `_hidden_params`.

## Testing

- Existing unit tests pass (`test_batch_retrieve_input_file_id.py`, `test_batch_retrieve_returns_unified_input_file_id.py`)
- Fixes the E2E test `test_e2e_managed_batch[azure_fake_gpt_5_batch_2025_08_07]`

## Type

🐛 Bug Fix