### PR TITLE
docs: add DB query performance guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,13 @@ LiteLLM is a unified interface for 100+ LLM providers with two main components:
 ### Proxy database access
 - **Do not write raw SQL** for proxy DB operations. Use Prisma model methods instead of `execute_raw` / `query_raw`.
 - Use the generated client: `prisma_client.db.<model>` (e.g. `litellm_tooltable`, `litellm_usertable`) with `.upsert()`, `.find_many()`, `.find_unique()`, `.update()`, `.update_many()` as appropriate. This avoids schema/client drift, keeps code testable with simple mocks, and matches patterns used in spend logs and other proxy code.
+- **No N+1 queries.** Never query the DB inside a loop. Batch-fetch with `{"in": ids}` and distribute in-memory.
+- **Batch writes.** Use `create_many`/`update_many`/`delete_many` instead of individual calls (these return counts only; `update_many`/`delete_many` no-op silently on missing rows). When multiple separate writes target the same table (e.g. in `batch_()`), order by primary key to avoid deadlocks.
+- **Push work to the DB.** Filter, sort, group, and aggregate in SQL, not Python. Verify Prisma generates the expected SQL — e.g. prefer `group_by` over `find_many(distinct=...)` which does client-side processing.
+- **Bound large result sets.** Prisma materializes full results in memory. For results over ~10 MB, paginate with `take`/`skip` or `cursor`/`take`, always with an explicit `order`. Prefer cursor-based pagination (`skip` is O(n)). Don't paginate naturally small result sets.
+- **Limit fetched columns on wide tables.** Use `select` to fetch only needed fields — returns a partial object, so downstream code must not access unselected fields.
+- **Check index coverage.** For new or modified queries, check `schema.prisma` for a supporting index. Prefer extending an existing index (e.g. `@@index([a])` → `@@index([a, b])`) over adding a new one, unless it's a `@@unique`. Only add indexes for large/frequent queries.
+- **Keep schema files in sync.** Apply schema changes to all `schema.prisma` copies (`schema.prisma`, `litellm/proxy/`, `litellm-proxy-extras/`, `litellm-js/spend-logs/` for SpendLogs) with a migration under `litellm-proxy-extras/litellm_proxy_extras/migrations/`.
 
 ### Enterprise Features
 - Enterprise-specific code in `enterprise/` directory


### PR DESCRIPTION
## Summary

- Extend the "Proxy database access" section in CLAUDE.md with database query performance guidelines, tailored to actual Prisma Client Python usage patterns in the litellm codebase
- Guidelines cover: N+1 queries, pushing work to the database (e.g. `group_by` over `distinct`), bounding large result sets with cursor-based pagination, using `select` on wide tables, batching writes with deadlock-safe ordering, preferring `update_many`/`delete_many` when return values aren't needed, index coverage considerations, and schema file sync requirements
- Motivated by recurring production issues across multiple PRs:
  - #23136 — Prisma `distinct` causing full table scan on 3M+ rows
  - #23152 — N+1 key queries in team listing
  - #23147, #20736, #20040 — Missing database indexes
  - #17073 — Unoptimized date filtering on spend logs
  - #15281, #16343 — Deadlocks from unordered writes

## Test plan

- [x] N/A — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)