### PR TITLE
feat(images): support input_fidelity parameter for image edit API

### DIFF
--- a/litellm/llms/openai/image_edit/transformation.py
+++ b/litellm/llms/openai/image_edit/transformation.py
@@ -40,6 +40,7 @@ class OpenAIImageEditConfig(BaseImageEditConfig):
             "image",
             "prompt",
             "background",
+            "input_fidelity",
             "mask",
             "model",
             "n",

--- a/litellm/types/images/main.py
+++ b/litellm/types/images/main.py
@@ -13,6 +13,7 @@ class ImageEditOptionalRequestParams(TypedDict, total=False):
     """
 
     background: Optional[Literal["transparent", "opaque", "auto"]]
+    input_fidelity: Optional[Literal["high", "low"]]
     mask: Optional[str]
     n: Optional[int]
     quality: Optional[Literal["high", "medium", "low", "standard", "auto"]]

--- a/tests/test_litellm/llms/openai/test_openai_image_edit_transformation.py
+++ b/tests/test_litellm/llms/openai/test_openai_image_edit_transformation.py
@@ -4,6 +4,7 @@ from typing import Dict
 import pytest
 
 from litellm import image_edit
+from litellm.images.utils import ImageEditRequestUtils
 from litellm.llms.openai.image_edit.transformation import OpenAIImageEditConfig
 from litellm.types.router import GenericLiteLLMParams
 
@@ -253,4 +254,51 @@ def test_transform_image_edit_request_with_mask_list(image_edit_config: OpenAIIm
     
     mask_file = next(f for f in files if f[0] == "mask")
     assert mask_file[1][1] == mask1  # Should be the first mask, not the second
+
+
+def test_transform_image_edit_request_with_input_fidelity(
+    image_edit_config: OpenAIImageEditConfig,
+):
+    """Test that input_fidelity is included in the data dict when provided"""
+    model = "gpt-image-1"
+    prompt = "Make the background blue"
+    image = b"fake_image_data"
+    image_edit_optional_request_params = {"input_fidelity": "high"}
+    litellm_params = GenericLiteLLMParams()
+    headers = {}
+
+    data, files = image_edit_config.transform_image_edit_request(
+        model=model,
+        prompt=prompt,
+        image=image,
+        image_edit_optional_request_params=image_edit_optional_request_params,
+        litellm_params=litellm_params,
+        headers=headers,
+    )
+
+    assert data["input_fidelity"] == "high"
+    assert data["model"] == model
+    assert data["prompt"] == prompt
+    assert "image" not in data
+
+
+def test_get_supported_openai_params_includes_input_fidelity(
+    image_edit_config: OpenAIImageEditConfig,
+):
+    """Test that input_fidelity is in the supported params list"""
+    supported = image_edit_config.get_supported_openai_params(model="gpt-image-1")
+    assert "input_fidelity" in supported
+
+
+def test_input_fidelity_passes_through_optional_param_filter():
+    """Test that input_fidelity is not dropped by get_requested_image_edit_optional_param"""
+    params = {
+        "input_fidelity": "low",
+        "quality": "high",
+        "unknown_param": "should_be_dropped",
+    }
+    filtered = ImageEditRequestUtils.get_requested_image_edit_optional_param(params)
+    assert filtered["input_fidelity"] == "low"
+    assert filtered["quality"] == "high"
+    assert "unknown_param" not in filtered
 


### PR DESCRIPTION
## Relevant issues

Fixes #22813

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai`

## Type

🆕 New Feature

## Changes

Add `input_fidelity` parameter support to the image edit API.

**Values:** `"high"` or `"low"` (defaults to `"low"`)
**Supported models:** `gpt-image-1`, `gpt-image-1.5`

### Usage

```python
import litellm

response = litellm.image_edit(
    model="gpt-image-1",
    image=open("photo.png", "rb"),
    prompt="Add a hat to the person",
    input_fidelity="high",
)
```

Ref: [OpenAI image edit API docs](https://platform.openai.com/docs/api-reference/images/createEdit)